### PR TITLE
refactor: resolve downstream gosimple warnings

### DIFF
--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -26,7 +26,7 @@ func TestAccUniverseDomainDisk(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccUniverseDomain_basic_disk(universeDomain),
 			},
 		},
@@ -41,7 +41,7 @@ func TestAccDefaultUniverseDomainDisk(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeDiskDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccUniverseDomain_basic_disk(universeDomain),
 			},
 		},
@@ -55,7 +55,7 @@ func TestAccDefaultUniverseDomain_doesNotMatchExplicit(t *testing.T) {
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      testAccUniverseDomain_basic_disk(universeDomainFake),
 				ExpectError: regexp.MustCompile("Universe domain mismatch"),
 			},

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_pubsub_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_pubsub_test.go
@@ -27,7 +27,7 @@ func TestAccUniverseDomainPubSub(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckPubsubSubscriptionDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccUniverseDomain_basic_pubsub(universeDomain, topic, subscription),
 			},
 		},

--- a/mmv1/third_party/terraform/provider/universe/universe_domain_storage_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_storage_test.go
@@ -24,7 +24,7 @@ func TestAccUniverseDomainStorage(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccUniverseDomain_bucket(universeDomain, bucketName),
 			},
 		},

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_authorized_view_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_authorized_view_internal_test.go
@@ -18,7 +18,7 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 		"empty subset view": {
 			sv: bigtable.SubsetViewInfo{},
 			want: []map[string]interface{}{
-				map[string]interface{}{},
+				{},
 			},
 			orWant: nil,
 		},
@@ -27,7 +27,7 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				RowPrefixes: [][]byte{[]byte("row1"), []byte("row2")},
 			},
 			want: []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"row_prefixes": []string{"cm93MQ==", "cm93Mg=="},
 				},
 			},
@@ -45,12 +45,12 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				},
 			},
 			want: []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"family_subsets": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"family_name":        "fam1",
 							"qualifier_prefixes": []string{"Y29s"},
-						}, map[string]interface{}{
+						}, {
 							"family_name": "fam2",
 							"qualifiers":  []string{"Y29sMQ==", "Y29sMg=="},
 						},
@@ -58,13 +58,13 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				},
 			},
 			orWant: []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"family_subsets": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"family_name": "fam2",
 							"qualifiers":  []string{"Y29sMQ==", "Y29sMg=="},
 						},
-						map[string]interface{}{
+						{
 							"family_name":        "fam1",
 							"qualifier_prefixes": []string{"Y29s"},
 						},
@@ -81,9 +81,9 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				},
 			},
 			want: []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"family_subsets": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"family_name": "fam",
 							"qualifiers":  []string{"Y29s"},
 						},
@@ -101,9 +101,9 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				},
 			},
 			want: []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"family_subsets": []map[string]interface{}{
-						map[string]interface{}{
+						{
 							"family_name":        "fam",
 							"qualifier_prefixes": []string{"Y29s"},
 						},
@@ -118,7 +118,7 @@ func TestUnitBigtable_flattenSubsetViewInfo(t *testing.T) {
 				FamilySubsets: map[string]bigtable.FamilySubset{},
 			},
 			want: []map[string]interface{}{
-				map[string]interface{}{},
+				{},
 			},
 			orWant: nil,
 		},

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_gc_policy.go
@@ -402,7 +402,6 @@ func GcPolicyToGCRuleString(gc bigtable.GCPolicy, topLevel bool) (map[string]int
 		} else {
 			result["max_version"] = version
 		}
-		break
 	case bigtable.PolicyUnion:
 		result["mode"] = "union"
 		rules := []interface{}{}
@@ -414,7 +413,6 @@ func GcPolicyToGCRuleString(gc bigtable.GCPolicy, topLevel bool) (map[string]int
 			rules = append(rules, gcRuleString)
 		}
 		result["rules"] = rules
-		break
 	case bigtable.PolicyIntersection:
 		result["mode"] = "intersection"
 		rules := []interface{}{}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -160,7 +160,7 @@ func TestUnitBigtable_flattenBigtableCluster(t *testing.T) {
 				"kms_key_name": "KMS",
 				"state":        "CREATING",
 				"autoscaling_config": []map[string]interface{}{
-					map[string]interface{}{
+					{
 						"min_nodes":      3,
 						"max_nodes":      7,
 						"cpu_target":     50,

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
@@ -457,7 +457,7 @@ func resourceBigtableTableUpdate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error creating column family %q: %s", cfn, err)
 		}
 	}
-	for cfn, _ := range familyMapDiffKeys(oMap, nMap) {
+	for cfn := range familyMapDiffKeys(oMap, nMap) {
 		log.Printf("[DEBUG] removing column family %q", cfn)
 		if err := c.DeleteColumnFamily(ctx, name, cfn); err != nil {
 			return fmt.Errorf("Error deleting column family %q: %s", cfn, err)

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1601,10 +1601,8 @@ func flattenResourceManagerTags(c *container.ResourceManagerTags) map[string]int
 
 	rmt := make(map[string]interface{})
 
-	if c != nil {
-		for k, v := range c.Tags {
-			rmt[k] = v
-		}
+	for k, v := range c.Tags {
+		rmt[k] = v
 	}
 
 	return rmt

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go
@@ -618,7 +618,7 @@ func testAccNetappVolume_volumeBasicExample_cleanupScheduledBackup(t *testing.T,
 			createTime time.Time
 		}
 		var backupDataList []BackupData
-		for i, _ := range backups {
+		for i := range backups {
 			backup := backups[i].(map[string]interface{})
 			backupName := backup["name"].(string)
 			backupCreateTimeStr := backup["createTime"].(string)
@@ -635,7 +635,7 @@ func testAccNetappVolume_volumeBasicExample_cleanupScheduledBackup(t *testing.T,
 		sort.Slice(backupDataList, func(i, j int) bool {
 			return backupDataList[i].createTime.After(backupDataList[j].createTime)
 		})
-		for i, _ := range backupDataList {
+		for i := range backupDataList {
 			baseUrl, err := tpgresource.ReplaceVarsForTest(config, rs, "{{NetappBasePath}}")
 			if err != nil {
 				return fmt.Errorf("Error : %v", err)

--- a/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_bindings.go.tmpl
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_bindings.go.tmpl
@@ -352,7 +352,6 @@ func flattenNestedTagsLocationTagBinding(d *schema.ResourceData, meta interface{
 	switch v.(type) {
 	case []interface{}:
 		log.Printf("[DEBUG] Hey it's in break = %#v,)", v)
-		break
 	case map[string]interface{}:
 		// Construct list out of single nested resource
 		v = []interface{}{v}

--- a/tpgtools/documentation.go
+++ b/tpgtools/documentation.go
@@ -69,7 +69,7 @@ func mergeProperties(ga, beta []Property) []Property {
 		betaProps[p.title] = p
 	}
 	inOrder := make([]string, 0)
-	for k, _ := range betaProps {
+	for k := range betaProps {
 		inOrder = append(inOrder, k)
 	}
 	sort.Strings(inOrder)

--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -161,7 +161,7 @@ func findDCLReferencePackage(product SnakeCaseProductName) (DCLPackageName, erro
 
 	// Otherwise, just return an error.
 	var productOverrideKeys []Filepath
-	for k, _ := range productOverrides {
+	for k := range productOverrides {
 		productOverrideKeys = append(productOverrideKeys, k)
 	}
 	return DCLPackageName(""), fmt.Errorf("can't find %q in the overrides map, which contains %v", product, productOverrideKeys)

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -792,7 +792,7 @@ func flatten{{$.PathType}}Labels(v map[string]string, d *schema.ResourceData) in
 
 	transformed := make(map[string]interface{})
 	if l, ok := d.Get("labels").(map[string]interface{}); ok {
-		for k, _ := range l {
+		for k := range l {
 			transformed[k] = v[k]
 		}
 	}
@@ -807,7 +807,7 @@ func flatten{{$.PathType}}TerraformLabels(v map[string]string, d *schema.Resourc
 
 	transformed := make(map[string]interface{})
 	if l, ok := d.Get("terraform_labels").(map[string]interface{}); ok {
-		for k, _ := range l {
+		for k := range l {
 			transformed[k] = v[k]
 		}
 	}
@@ -824,7 +824,7 @@ func flatten{{$.PathType}}Annotations(v map[string]string, d *schema.ResourceDat
 
 	transformed := make(map[string]interface{})
 	if l, ok := d.Get("annotations").(map[string]interface{}); ok {
-		for k, _ := range l {
+		for k := range l {
 			transformed[k] = v[k]
 		}
 	}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**
Resolve some `gofmt` (missing `-s`) and `gosimple` findings in downstream provider.

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
