### PR TITLE
Make resource_google_storage_bucket_object generate diff for md5hash, generation, crc32c if content changes

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -4,6 +4,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"context"
 	"io"
 	"log"
 	"os"
@@ -28,6 +29,7 @@ func ResourceStorageBucketObject() *schema.Resource {
 		Read:   resourceStorageBucketObjectRead,
 		Update: resourceStorageBucketObjectUpdate,
 		Delete: resourceStorageBucketObjectDelete,
+		CustomizeDiff: resourceStorageBucketObjectCustomizeDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(4 * time.Minute),
@@ -602,4 +604,36 @@ func flattenObjectRetention(objectRetention *storage.ObjectRetention) []map[stri
 
 	retentions = append(retentions, retention)
 	return retentions
+}
+
+func resourceStorageBucketObjectCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	localMd5Hash := ""
+	if source, ok := d.GetOkExists("source"); ok {
+		localMd5Hash = tpgresource.GetFileMd5Hash(source.(string))
+	}
+	if content, ok := d.GetOkExists("content"); ok {
+		localMd5Hash = tpgresource.GetContentMd5Hash([]byte(content.(string)))
+	}
+	if localMd5Hash == "" {
+		return nil
+	}
+
+	oldMd5Hash, ok := d.GetOkExists("md5hash")
+	if ok && oldMd5Hash == localMd5Hash {
+		return nil
+	}
+
+	err := d.SetNewComputed("md5hash")
+	if err != nil {
+		return fmt.Errorf("Error re-setting md5hash: %s", err)
+	}
+	err = d.SetNewComputed("crc32c")
+	if err != nil {
+		return fmt.Errorf("Error re-setting crc32c: %s", err)
+	}
+	err = d.SetNewComputed("generation")
+	if err != nil {
+		return fmt.Errorf("Error re-setting generation: %s", err)
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_object.go
@@ -3,8 +3,8 @@ package storage
 
 import (
 	"bytes"
-	"fmt"
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -25,10 +25,10 @@ import (
 
 func ResourceStorageBucketObject() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceStorageBucketObjectCreate,
-		Read:   resourceStorageBucketObjectRead,
-		Update: resourceStorageBucketObjectUpdate,
-		Delete: resourceStorageBucketObjectDelete,
+		Create:        resourceStorageBucketObjectCreate,
+		Read:          resourceStorageBucketObjectRead,
+		Update:        resourceStorageBucketObjectUpdate,
+		Delete:        resourceStorageBucketObjectDelete,
 		CustomizeDiff: resourceStorageBucketObjectCustomizeDiff,
 
 		Timeouts: &schema.ResourceTimeout{


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20552

```release-note:bug
storage: Make `resource_google_storage_bucket_object` generate diff for `md5hash`, `generation`, `crc32c` if content changes
```
