### PR TITLE
Add support for source_workstation in workstations_workstation resource.

### DIFF
--- a/mmv1/products/workstations/Workstation.yaml
+++ b/mmv1/products/workstations/Workstation.yaml
@@ -153,3 +153,9 @@ properties:
       - 'STATE_RUNNING'
       - 'STATE_STOPPING'
       - 'STATE_STOPPED'
+  - name: 'source_workstation'
+    type: String
+    description: |
+      Full resource name of the source workstation from which the workstation's persistent
+      directories will be cloned from during creation.
+    immutable: true


### PR DESCRIPTION
This adds support for workstation PD cloning using `source_workstation`. It can only be set during workstation resource creation and cannot be updated afterwards: https://cloud.google.com/workstations/docs/reference/rest/v1beta/projects.locations.workstationClusters.workstationConfigs.workstations#Workstation.FIELDS.source_workstation

The primary use case of this field is for recovery, so it doesn't seem possible to write an automated test for it. This is because a workstation must be started manually before it can be cloned, else its PD is not created. If there is a way to write a test that can send API calls outside of Terraform, please let me know.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19730.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
workstations: add `source_workstation` field to `google_workstations_workstation` resource
```