### PR TITLE
`EphemeralWriteOnly`: Initial support for MMv1 Generation in schema & docs

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -547,10 +547,27 @@ func (r Resource) SensitiveProps() []*Type {
 	})
 }
 
+func (r Resource) WriteOnlyProps() []*Type {
+	props := r.AllNestedProperties(r.RootProperties())
+	return google.Select(props, func(p *Type) bool {
+		return p.WriteOnly
+	})
+}
+
 func (r Resource) SensitivePropsToString() string {
 	var props []string
 
 	for _, prop := range r.SensitiveProps() {
+		props = append(props, fmt.Sprintf("`%s`", prop.Lineage()))
+	}
+
+	return strings.Join(props, ", ")
+}
+
+func (r Resource) WriteOnlyPropsToString() string {
+	var props []string
+
+	for _, prop := range r.WriteOnlyProps() {
 		props = append(props, fmt.Sprintf("`%s`", prop.Lineage()))
 	}
 

--- a/mmv1/api/resource/docs.go
+++ b/mmv1/api/resource/docs.go
@@ -32,5 +32,7 @@ type Docs struct {
 
 	OptionalProperties string `yaml:"optional_properties"`
 
+	WriteOnlyProperties string `yaml:"write_only_properties"`
+
 	Attributes string
 }

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -363,6 +363,10 @@ func (t *Type) Validate(rName string) {
 		log.Fatalf("'default_value' and 'default_from_api' cannot be both set in resource %s", rName)
 	}
 
+	if t.WriteOnly && (t.DefaultFromApi || t.Output) {
+		log.Fatalf("Property %s cannot be write_only and computed at the same time in resource %s", t.Name, rName)
+	}
+
 	t.validateLabelsField()
 
 	switch {

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -171,6 +171,9 @@ type Type struct {
 
 	Sensitive bool `yaml:"sensitive,omitempty"` // Adds `Sensitive: true` to the schema
 
+	// If true, the field is write-only and should not be read from the API.
+	WriteOnly bool `yaml:"write_only,omitempty"`
+
 	// Does not set this value to the returned API value.  Useful for fields
 	// like secrets where the returned API value is not helpful.
 	IgnoreRead bool `yaml:"ignore_read,omitempty"`

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -364,7 +364,11 @@ func (t *Type) Validate(rName string) {
 	}
 
 	if t.WriteOnly && (t.DefaultFromApi || t.Output) {
-		log.Fatalf("Property %s cannot be write_only and computed at the same time in resource %s", t.Name, rName)
+		log.Fatalf("Property %s cannot be write_only and default_from_api or output at the same time in resource %s", t.Name, rName)
+	}
+
+	if t.WriteOnly && t.Sensitive {
+		log.Fatalf("Property %s cannot be write_only and sensitive at the same time in resource %s", t.Name, rName)
 	}
 
 	t.validateLabelsField()

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -84,6 +84,9 @@ examples:
     vars:
       disk_name: 'test-disk-features'
 parameters:
+  - name: 'rootWriteTest'
+    type: String
+    write_only: true
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the disk resides.'

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -176,6 +176,16 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        conflicts:
+          - diskEncryptionKey.0.raw_key_wo
+      - name: 'rawKey_wo'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        write_only: true
+        conflicts:
+          - diskEncryptionKey.0.raw_key
       - name: 'rsaEncryptedKey'
         type: String
         description: |

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -176,6 +176,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        write_only: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -176,7 +176,6 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
-        write_only: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -84,9 +84,6 @@ examples:
     vars:
       disk_name: 'test-disk-features'
 parameters:
-  - name: 'rootWriteTest'
-    type: String
-    write_only: true
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the disk resides.'
@@ -179,16 +176,6 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
-        conflicts:
-          - diskEncryptionKey.0.raw_key_wo
-      - name: 'rawKey_wo'
-        type: String
-        description: |
-          Specifies a 256-bit customer-supplied encryption key, encoded in
-          RFC 4648 base64 to either encrypt or decrypt this resource.
-        write_only: true
-        conflicts:
-          - diskEncryptionKey.0.raw_key
       - name: 'rsaEncryptedKey'
         type: String
         description: |

--- a/mmv1/templates/terraform/expand_property_method.go.tmpl
+++ b/mmv1/templates/terraform/expand_property_method.go.tmpl
@@ -26,7 +26,8 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
     original := raw.(map[string]interface{})
     transformed := make(map[string]interface{})
       {{- range $prop := $.NestedProperties }}
-        {{- if not (eq $prop.Name $prop.KeyName) }}
+        {{- if $prop.WriteOnly }}
+        {{- else if not (eq $prop.Name $prop.KeyName) }}
 
     transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ underscore $prop.Name }}"], d, config)
     if err != nil {
@@ -65,7 +66,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
   transformed := make(map[string]interface{})
       {{- range $prop := $.NestedProperties }}
-        {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
+        {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite (not $prop.WriteOnly)) }}
   transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}({{ if $prop.FlattenObject }}nil{{ else }}d.Get("{{ underscore $prop.Name }}"), d, config)
   if err != nil {
     return nil, err
@@ -83,6 +84,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   return transformed, nil
 }
     {{ else }}{{/* if $.IsA "Map" */}}
+    {{- if not $.WriteOnly }}
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
       {{- if $.IsSet }}
   v = v.(*schema.Set).List()
@@ -118,7 +120,8 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
         {{- end }}{{/* if $.IsA "Array */}}
     transformed := make(map[string]interface{})
         {{ range $prop := $.NestedProperties }}
-          {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
+          {{- if $prop.WriteOnly }}
+          {{- else if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
       transformed{{$prop.TitlelizeProperty}}, err := expand{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ underscore $prop.Name }}"], d, config)
       if err != nil {
         return nil, err
@@ -155,11 +158,12 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
       {{- else }}
   return v, nil
 }
+    {{ end }}{{/* if not $.WriteOnly */}}
       {{- end }}{{/* if $.NestedProperties */}}
     {{- end }}{{/* if $.IsA "Map" */}}
     {{ if $.NestedProperties }}
       {{- range $prop := $.NestedProperties }}
-        {{- if not (and (hasPrefix $prop.Type "KeyValue") $prop.IgnoreWrite) }}
+        {{- if not (and (hasPrefix $prop.Type "KeyValue") (not $prop.WriteOnly)) }}
           {{- template "expandPropertyMethod" $prop -}}
         {{- end }}
       {{- end }}

--- a/mmv1/templates/terraform/flatten_property_method.go.tmpl
+++ b/mmv1/templates/terraform/flatten_property_method.go.tmpl
@@ -13,7 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License. */ -}}
 {{- define "flattenPropertyMethod" }}
-{{- if $.CustomFlatten }}
+{{- if $.WriteOnly }}
+{{- else if $.CustomFlatten }}
     {{- $.CustomTemplate $.CustomFlatten false -}}
 {{- else -}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
@@ -33,7 +34,8 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     {{- end }}
   transformed := make(map[string]interface{})
     {{- range $prop := $.UserProperties }}
-      {{- if $prop.FlattenObject }}
+      {{- if $prop.WriteOnly }}
+      {{- else if $prop.FlattenObject }}
     if {{ $prop.ApiName }} := flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config); {{ $prop.ApiName }} != nil {
       obj := {{ $prop.ApiName }}.([]interface{})[0]
       for k, v := range obj.(map[string]interface{}) {
@@ -73,7 +75,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   {{- end }}
 
   {{- range $prop := $.ItemType.UserProperties }}
-    {{- if not $prop.IgnoreRead }}
+    {{- if not (or $prop.IgnoreRead $prop.WriteOnly) }}
       "{{ underscore $prop.Name }}": flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config),
     {{- end }}
   {{- end }}

--- a/mmv1/templates/terraform/nested_property_write_only_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/nested_property_write_only_documentation.html.markdown.tmpl
@@ -1,18 +1,11 @@
-{{ "" }}
-{{- if and $.FlattenObject (not $.WriteOnlyProperties) }}
-  {{- range $np := $.NestedProperties }}
-{{- trimTemplate "nested_property_documentation.html.markdown.tmpl" $np -}}
-  {{- end -}}
-{{- else if and $.NestedProperties (not $.WriteOnlyProperties) }}
+{{- if $.WriteOnlyProperties }}
 <a name="nested_{{ underscore $.Name }}"></a>The `{{ underscore $.Name }}` block {{ if $.Output }}contains{{ else }}supports{{ end }}:
 {{ "" }}
-  {{- if $.IsA "Map" }}
-* `{{ underscore $.KeyName }}` - (Required) The identifier for this object. Format specified above.
-{{ "" }}
-  {{- end -}}
   {{- if $.NestedProperties }}
     {{- range $np := $.NestedProperties }}
+      {{- if $np.WriteOnly }}
 {{- trimTemplate "property_documentation.html.markdown.tmpl" $np -}}
+      {{- end -}}
     {{- end -}}
 {{ "" }}
     {{- $innerNested := false }}
@@ -26,7 +19,7 @@
     {{- end }}
     {{- range $np := $.NestedProperties }}
       {{- if $np.NestedProperties }}
-{{- trimTemplate "nested_property_documentation.html.markdown.tmpl" $np -}}
+{{- trimTemplate "nested_property_write_only_documentation.html.markdown.tmpl" $np -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
@@ -36,6 +36,9 @@
   {{- if $.Sensitive }}
   **Note**: This property is sensitive and will not be displayed in the plan.
   {{- end }}
+  {{- if $.WriteOnly }}
+  **Note**: This property is write-only and will not be read from the API.
+  {{- end }}
   {{- if and (not $.FlattenObject) $.NestedProperties }}
   Structure is [documented below](#nested_{{ underscore $.Name }}).
   {{- end }}

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -70,6 +70,11 @@ To get more information about {{$.Name}}, see:
 values will be stored in the raw state as plain text: {{ $.SensitivePropsToString }}.
 [Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
 {{ end }}
+{{- if $.WriteOnlyProps }}
+~> **Warning:** All arguments including the following potentially write-only
+values will be stored in the raw state as plain text: {{ $.WriteOnlyPropsToString }}.
+[Read more about sensitive data in state](https://www.terraform.io/language/state/sensitive-data).
+{{ end }}
 {{- if $.Examples }}
 	{{- range $e := $.Examples }}
 		{{- if not $e.ExcludeDocs }}

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -101,7 +101,7 @@ The following arguments are supported:
 {{ "" }}
 {{ "" }}
 {{- range $p := $.RootProperties }}
-	{{- if $p.Required }}
+	{{- if and $p.Required (not $p.WriteOnly) }}
 {{- trimTemplate "property_documentation.html.markdown.tmpl" $p -}}
 	{{- end }}
 {{- end }}
@@ -115,7 +115,7 @@ The following arguments are supported:
 {{ "" }}
 {{ "" }}
 {{- range $p := $.RootProperties }}
-	{{- if and (not $p.Required) (not $p.Output) }}
+	{{- if and (not $p.Required) (not $p.Output) (not $p.WriteOnly) }}
 {{- trimTemplate "property_documentation.html.markdown.tmpl" $p -}}
 	{{- end }}
 {{- end }}
@@ -139,6 +139,21 @@ The following arguments are supported:
 	{{- end}}
 {{- end }}
 {{- "" }}
+
+{{- if $.WriteOnlyProps }}
+## Ephemeral Attributes Reference
+
+The following write-only attributes are supported:
+{{ range $p := $.RootProperties }}
+    {{- if $p.WriteOnly }}
+{{- trimTemplate "property_documentation.html.markdown.tmpl" $p }}
+    {{- end}}
+{{- end }}
+{{ range $p := $.AllUserProperties }}
+{{- trimTemplate "nested_property_write_only_documentation.html.markdown.tmpl" $p }}
+{{- end }}
+{{- end }}
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -40,9 +40,6 @@
 {{ if .IsForceNew -}}
   ForceNew: true,
 {{ end -}}
-{{ if .WriteOnly -}}
-  WriteOnly: true,
-{{ end -}}
 {{ if and (not .Output) .Validation -}}
 	{{ if .Validation.Regex -}}
   ValidateFunc: verify.ValidateRegexp(`{{ .Validation.Regex -}}`),
@@ -163,6 +160,9 @@ Default value: {{ .ItemType.DefaultValue -}}
 {{ end -}}
 {{ if .Sensitive -}}
     Sensitive: true,
+{{ end -}}
+{{ if .WriteOnly -}}
+  WriteOnly: true,
 {{ end -}}
 {{ if not (eq .DefaultValue nil ) -}}
     Default: {{ .GoLiteral .DefaultValue -}},

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -40,6 +40,9 @@
 {{ if .IsForceNew -}}
   ForceNew: true,
 {{ end -}}
+{{ if .WriteOnly -}}
+  WriteOnly: true,
+{{ end -}}
 {{ if and (not .Output) .Validation -}}
 	{{ if .Validation.Regex -}}
   ValidateFunc: verify.ValidateRegexp(`{{ .Validation.Regex -}}`),

--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -67,6 +67,7 @@ type Property struct {
 	Optional  bool
 	Computed  bool
 	Sensitive bool
+	WriteOnly bool
 
 	ForceNew    bool
 	Description string

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -117,6 +117,9 @@ func Resource{{$.PathType}}() *schema.Resource {
 	{{- if $p.Sensitive}}
 				Sensitive: true,
 	{{- end }}
+	{{- if $p.WriteOnly }}
+				WriteOnly: true,
+	{{- end }}
 	{{- if $p.DiffSuppressFunc }}
 				DiffSuppressFunc: {{$p.DiffSuppressFunc}},
 	{{- end }}
@@ -179,6 +182,9 @@ func {{$.PathType}}{{$v.PackagePath}}Schema() *schema.Resource {
 		{{- end }}
 		{{- if $p.Sensitive }}
 					Sensitive: true,
+		{{- end }}
+		{{- if $p.WriteOnly }}
+					WriteOnly: true,
 		{{- end }}
 		{{- if $p.DiffSuppressFunc }}
 					DiffSuppressFunc: {{$p.DiffSuppressFunc}},


### PR DESCRIPTION
Goal of this PR is to include `WriteOnly` property as part of generation to support the upcoming Ephemeral WriteOnly Attributes in Terraform 1.11

We add a new field titled `write_only` that includes `WriteOnly` in the schema of any field with `write_only: true`

Some things to know:

The generation will fail when `write_only: true` is set with any of the following:
- `sensitive` (write_only attributes are meant to replace sensitive values in the future)
- `default_from_api`/`output` set properties to be Computed + Optional which we do not support for ephemeral write-only attributes

It's also worth noting that `flatteners` are not needed as write-onlys will not be saved to state.

This PR also introduces `WriteOnlyProperties` that's needed to separate the Ephemeral Write-Only Attributes from a resource into it's own section when generation documentation (similar to how we have arguments and attributes. A new section will be introduced under the name `Ephemeral Attributes Reference`


```release-note:none

```