### PR TITLE
Fix autofilling values in `initialize_params.resource_policies` causing instance to recreate

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -325,6 +325,7 @@ func ResourceComputeInstance() *schema.Resource {
 										Elem:             &schema.Schema{Type: schema.TypeString},
 										Optional:         true,
 										ForceNew:         true,
+										Computed:         true,
 										AtLeastOneOf:     initializeParamsKeys,
 										DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
 										MaxItems:         1,
@@ -3203,7 +3204,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 
 	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
 	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
-	if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == "" {
+	if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == nil || d.Get("boot_disk.0.initialize_params.0.resource_policies") == nil {
 		diskDetails.ResourcePolicies = nil
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -325,7 +325,6 @@ func ResourceComputeInstance() *schema.Resource {
 										Elem:             &schema.Schema{Type: schema.TypeString},
 										Optional:         true,
 										ForceNew:         true,
-										Computed:         true,
 										AtLeastOneOf:     initializeParamsKeys,
 										DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
 										MaxItems:         1,
@@ -3201,6 +3200,13 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
         }
 
 	diskDetails, err := getDisk(disk.Source, d, config)
+
+	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
+	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
+	if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == "" {
+		diskDetails.ResourcePolicies = nil
+	}
+
 	if err != nil {
 		log.Printf("[WARN] Cannot retrieve boot disk details: %s", err)
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -305,7 +305,7 @@ is desired, you will need to modify your state file manually using
 
 * `resource_manager_tags` - (Optional) A tag is a key-value pair that can be attached to a Google Cloud resource. You can use tags to conditionally allow or deny policies based on whether a resource has a specific tag. This value is not returned by the API. In Terraform, this value cannot be updated and changing it will recreate the resource.
 
-* `resource_policies` - (Optional) A list of self_links of resource policies to attach to the instance's boot disk. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.
+* `resource_policies` - (Optional) A list of self_links of resource policies to attach to the instance's boot disk. Modifying this list will cause the instance to recreate, so any external values are not set until the user specifies this field. Currently a max of 1 resource policy is supported.
 
 * `provisioned_iops` - (Optional) Indicates how many IOPS to provision for the disk.
     This sets the number of I/O operations per second that the disk can handle.


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/19735

This field will no longer take API values if the field is not set causing an instance recreation.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: Setting resource policies for `google_compute_instance` outside of terraform or using `google_compute_disk_resource_policy_attachment` will no longer affect the `boot_disk.initialize_params.resource_policies` field
```
