### PR TITLE
Fix diff suppress function ignoring additive_vpc_scope_dns_domain in Autopilot clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -113,6 +113,14 @@ var (
 
 	suppressDiffForAutopilot = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 		if v, _ := d.Get("enable_autopilot").(bool); v {
+			if k == "dns_config.0.additive_vpc_scope_dns_domain" {
+				return false
+			}
+			if k == "dns_config.#" {
+				if avpcDomain, _ := d.Get("dns_config.0.additive_vpc_scope_dns_domain").(string); avpcDomain != "" || d.HasChange("dns_config.0.additive_vpc_scope_dns_domain") {
+					return false
+				}
+			}
 			return true
 		}
 		return false
@@ -7073,6 +7081,9 @@ func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.Resourc
 		if err := d.SetNew("networking_mode", "VPC_NATIVE"); err != nil {
 			return err
 		}
+	}
+	if d.Get("enable_autopilot").(bool) && d.HasChange("dns_config.0.additive_vpc_scope_dns_domain") {
+		return d.ForceNew("dns_config.0.additive_vpc_scope_dns_domain")
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5798,6 +5798,169 @@ func TestAccContainerCluster_autopilot_minimal(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, false, ""),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, true, ""),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, true, ""),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
+	t.Parallel()
+
+	domain := "additive.autopilot.example"
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, false, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, true, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, true, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
+	t.Parallel()
+
+	domain := "additive-mutating.autopilot.example"
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionReplace)}},
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{PreApply: []plancheck.PlanCheck{plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionReplace)}},
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_autopilot_net_admin(t *testing.T) {
 	t.Parallel()
 
@@ -11033,6 +11196,42 @@ resource "google_container_cluster" "primary" {
   enable_autopilot    = true
   deletion_protection = false
 }`, name)
+}
+
+func testAccContainerCluster_autopilot_withDNSConfig(name string, dnsConfigSectionPresent, clusterDnsPresent, clusterDnsScopePresent bool, additiveVpcDnsDomain string) string {
+	config := fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1"
+  enable_autopilot    = true
+  deletion_protection = false
+`, name)
+	if dnsConfigSectionPresent {
+		config += `
+  dns_config {
+`
+		if clusterDnsPresent {
+			config += `
+    cluster_dns = "CLOUD_DNS"
+`
+		}
+		if clusterDnsScopePresent {
+			config += `
+    cluster_dns_scope = "CLUSTER_SCOPE"
+`
+		}
+		if additiveVpcDnsDomain != "" {
+			config += fmt.Sprintf(`
+    additive_vpc_scope_dns_domain = "%s"
+`, additiveVpcDnsDomain)
+		}
+		config += `
+  }
+`
+	}
+	config += `
+}`
+	return config
 }
 
 func testAccContainerCluster_autopilot_net_admin(name, networkName, subnetworkName string, enabled bool) string {


### PR DESCRIPTION
self-appointed successor to #11744

GKE Autopilot allows setting additive VPC scope domain on creation only. However, current implementation of the diff suppress function for Autopilot clusters removes any values in dns_config of Autopilot clusters, all the time.

This change permits setting additive VPC scope domain.

Remaining action items:
- [x] validate that allowing `dns_config.#` doesn't cause issues (it seems necessary for `dns_config.0.additive_vpc_scope_dns_domain` to exist
- [ ] revise test coverage to look for other gaps
- [x] verify that the change in #11744 to ForceNew when domain changes is exactly the behavior we want and copy it over
- [x] write the release note below

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed `additive_vpc_scope_dns_domain` being ignored in Autopilot cluster definition
```
