### PR TITLE
Revert "Etag support for ACM service perimeters"

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -65,7 +65,6 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   encoder: 'templates/terraform/encoders/access_level_never_send_parent.go.tmpl'
-  pre_update: 'templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl'
   custom_import: 'templates/terraform/custom_import/set_access_policy_parent_from_self_link.go.tmpl'
 # Skipping the sweeper due to the non-standard base_url
 exclude_sweeper: true
@@ -783,10 +782,3 @@ properties:
       actually enforcing them. This testing is done through analyzing the differences
       between currently enforced and suggested restrictions. useExplicitDryRunSpec must
       bet set to True if any of the fields in the spec are set to non-default values.
-  - name: 'etag'
-    type: Fingerprint
-    description: |
-      An opaque identifier for the current version of the ServicePerimeter. This
-      identifier does not follow any specific format. If an etag is not provided, the
-      operation will be performed as if a valid etag is provided.
-    output: true

--- a/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
@@ -94,13 +94,6 @@ properties:
           description: |
             Description of the ServicePerimeter and its use. Does not affect
             behavior.
-        - name: 'etag'
-          type: Fingerprint
-          description: |
-            An opaque identifier for the current version of the ServicePerimeter. This
-            identifier does not follow any specific format. If an etag is not provided, the
-            operation will be performed as if a valid etag is provided.
-          output: true
         - name: 'createTime'
           type: Time
           description: |

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
@@ -18,7 +18,6 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			"perimeter_type":            flattenAccessContextManagerServicePerimetersServicePerimetersPerimeterType(original["perimeterType"], d, config),
 			"status":                    flattenAccessContextManagerServicePerimetersServicePerimetersStatus(original["status"], d, config),
 			"spec":                      flattenAccessContextManagerServicePerimetersServicePerimetersSpec(original["spec"], d, config),
-			"etag":                      flattenAccessContextManagerServicePerimetersServicePerimetersEtag(original["etag"], d, config),
 			"use_explicit_dry_run_spec": flattenAccessContextManagerServicePerimetersServicePerimetersUseExplicitDryRunSpec(original["useExplicitDryRunSpec"], d, config),
 		})
 	}
@@ -36,10 +35,6 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 }
 
 func flattenAccessContextManagerServicePerimetersServicePerimetersName(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return v
-}
-
-func flattenAccessContextManagerServicePerimetersServicePerimetersEtag(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }
 

--- a/mmv1/templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/access_context_manager_service_perimeter.go.tmpl
@@ -1,5 +1,0 @@
-if _, ok := d.GetOkExists("etag"); ok {
-	updateMask = append(updateMask, "etag")
-
-	url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
-}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -26,7 +26,6 @@ func testAccAccessContextManagerServicePerimeter_basicTest(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccessContextManagerServicePerimeter_basic(org, "my policy", "level", "perimeter"),
-				Check: resource.TestCheckResourceAttrSet("google_access_context_manager_service_perimeter.test-access", "etag"),
 			},
 			{
 				ResourceName:      "google_access_context_manager_service_perimeter.test-access",


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#12363

Unfortunately, we'd like to revert this change and then try again probably in early January with a new approach for perimeter etags. We have ideas on this but for now we think reverting this change will ensure customers upgrading to the next released version aren't broken.

The broken scenario is when there are perimeters from the same policy in separate google_access_context_manager_service_perimeter resources. Customers with multiple perimeters in a single google_access_context_manager_service_perimeters resource would be fine.

Currently, perimeter etags are generated at the policy level (the parent entity). So, when the first PATCH request is sent for updating perimeter 1, then the etag saved in the Terraform plan for the other perimeters is no longer valid. Those updates will fail.

```release-note:enhancement
accesscontextmanager: added `etag` to `google_access_context_manager_service_perimeter` and `google_access_context_manager_service_perimeters` (reverts)
```
