### PR TITLE
Add post update 5s sleep to Topic update

### DIFF
--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -29,6 +29,7 @@ timeouts:
   delete_minutes: 20
 custom_code:
   post_create: 'templates/terraform/post_create/sleep.go.tmpl'
+  post_update: 'templates/terraform/post_create/sleep.go.tmpl'
 examples:
   - name: 'managedkafka_topic_basic'
     primary_resource_id: 'example'


### PR DESCRIPTION
Description: Adding a post_update sleep time of 5 seconds to the Managed Service for Apache Kafka terraform Topic resource.

Issue: https://github.com/hashicorp/terraform-provider-google/issues/18949

```release-note:none
managedkafka: added 5 second wait post `google_managed_kafka_topic` update to fix eventual consistency errors 
```