### PR TITLE
Fix permadiff when Access Context Manager returns a different order for ingress / egress rule identities

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
@@ -116,6 +116,8 @@ properties:
           https://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.
         item_type:
           type: String
+        diff_suppress_func: AccessContextManagerServicePerimeterDryRunEgressPolicyEgressFromIdentitiesDiffSuppressFunc
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_egress_policy_from_identities_custom_flatten.go.tmpl
       - name: 'sources'
         type: Array
         description: 'Sources that this EgressPolicy authorizes access from.'

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
@@ -118,6 +118,8 @@ properties:
           https://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.
         item_type:
           type: String
+        diff_suppress_func: AccessContextManagerServicePerimeterDryRunIngressPolicyIngressFromIdentitiesDiffSuppressFunc
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_from_identities_custom_flatten.go.tmpl
       - name: 'sources'
         type: Array
         description: |

--- a/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
@@ -113,6 +113,8 @@ properties:
           https://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.
         item_type:
           type: String
+        diff_suppress_func: AccessContextManagerServicePerimeterEgressPolicyEgressFromIdentitiesDiffSuppressFunc
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_egress_policy_from_identities_custom_flatten.go.tmpl
       - name: 'sources'
         type: Array
         description: 'Sources that this EgressPolicy authorizes access from.'

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -115,6 +115,8 @@ properties:
           https://cloud.google.com/iam/docs/principal-identifiers#v1 are supported.
         item_type:
           type: String
+        diff_suppress_func: AccessContextManagerServicePerimeterIngressPolicyIngressFromIdentitiesDiffSuppressFunc
+        custom_flatten: templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_from_identities_custom_flatten.go.tmpl
       - name: 'sources'
         type: Array
         description: |

--- a/mmv1/templates/terraform/constants/access_context_manager.go.tmpl
+++ b/mmv1/templates/terraform/constants/access_context_manager.go.tmpl
@@ -40,6 +40,48 @@ func {{$.ResourceName}}IngressToResourcesDiffSuppressFunc(_, _, _ string, d *sch
     return slices.Equal(oldResources, newResources)
 }
 
+func {{$.ResourceName}}EgressFromIdentitiesDiffSuppressFunc(_, _, _ string, d *schema.ResourceData) bool {
+    old, new := d.GetChange("egress_from.0.identities")
+
+    oldResources, err := tpgresource.InterfaceSliceToStringSlice(old)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert egress from identities config value: %s", err)
+        return false
+    }
+
+    newResources, err := tpgresource.InterfaceSliceToStringSlice(new)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert egress from identities api value: %s", err)
+        return false
+    }
+
+    sort.Strings(oldResources)
+    sort.Strings(newResources)
+
+    return slices.Equal(oldResources, newResources)
+}
+
+func {{$.ResourceName}}IngressFromIdentitiesDiffSuppressFunc(_, _, _ string, d *schema.ResourceData) bool {
+    old, new := d.GetChange("ingress_from.0.identities")
+
+    oldResources, err := tpgresource.InterfaceSliceToStringSlice(old)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert ingress from identities config value: %s", err)
+        return false
+    }
+
+    newResources, err := tpgresource.InterfaceSliceToStringSlice(new)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert ingress from identities api value: %s", err)
+        return false
+    }
+
+    sort.Strings(oldResources)
+    sort.Strings(newResources)
+
+    return slices.Equal(oldResources, newResources)
+}
+
 func {{$.ResourceName}}IdentityTypeDiffSuppressFunc(_, old, new string, _ *schema.ResourceData) bool {
     if old == "" && new == "IDENTITY_TYPE_UNSPECIFIED" {
        return true

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_from_identities_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_egress_policy_from_identities_custom_flatten.go.tmpl
@@ -1,0 +1,26 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("egress_from.0.identities")
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert egress from identities config value: %s", err)
+        return v
+    }
+    sortedConfigValue := append([]string{}, configValue...)
+    sort.Strings(sortedConfigValue)
+
+    // Convert v to []string
+    apiValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert egress from identities API value: %s", err)
+        return v
+    }
+    sortedApiValue := append([]string{}, apiValue...)
+    sort.Strings(sortedApiValue)
+
+    if (slices.Equal(sortedApiValue, sortedConfigValue)) {
+        return configValue
+    }
+
+    return apiValue
+}

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_from_identities_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_ingress_policy_from_identities_custom_flatten.go.tmpl
@@ -1,0 +1,26 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    rawConfigValue := d.Get("ingress_from.0.identities")
+    // Convert config value to []string
+    configValue, err := tpgresource.InterfaceSliceToStringSlice(rawConfigValue)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert ingress from identities config value: %s", err)
+        return v
+    }
+    sortedConfigValue := append([]string{}, configValue...)
+    sort.Strings(sortedConfigValue)
+
+    // Convert v to []string
+    apiValue, err := tpgresource.InterfaceSliceToStringSlice(v)
+    if err != nil {
+        log.Printf("[ERROR] Failed to convert ingress from identities API value: %s", err)
+        return v
+    }
+    sortedApiValue := append([]string{}, apiValue...)
+    sort.Strings(sortedApiValue)
+
+    if (slices.Equal(sortedApiValue, sortedConfigValue)) {
+        return configValue
+    }
+
+    return apiValue
+}


### PR DESCRIPTION
Adds a diff suppress func to ignore ordering for identities in ingress / egress rule resources. The order does not matter and sometimes the API changes it.

Addresses [#19203](https://github.com/hashicorp/terraform-provider-google/issues/19203) and [#20519](https://github.com/hashicorp/terraform-provider-google/issues/20519)

```release-note:bug
accesscontextmanager: fixed permadiff due to reordering on `google_access_context_manager_service_perimeter_dry_run_egress_policy` `egress_from.identities`
```

```release-note:bug
accesscontextmanager: fixed permadiff due to reordering on `google_access_context_manager_service_perimeter_dry_run_ingress_policy` `ingress_from.identities`
```

```release-note:bug
accesscontextmanager: fixed permadiff due to reordering on `google_access_context_manager_service_perimeter_egress_policy` `egress_from.identities`
```
```release-note:bug
accesscontextmanager: fixed permadiff due to reordering on `google_access_context_manager_service_perimeter_ingress_policy` `ingress_from.identities`
```
