### PR TITLE
Remove projects/ prefix if it exists

### DIFF
--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config.go
@@ -131,15 +131,16 @@ For example: jsonPayload.request.status`,
 }
 
 func projectBucketConfigID(d *schema.ResourceData, config *transport_tpg.Config) (string, error) {
-	project := d.Get("project").(string)
+	projectID := d.Get("project").(string)
 	location := d.Get("location").(string)
 	bucketID := d.Get("bucket_id").(string)
 
-	if !strings.HasPrefix(project, "project") {
-		project = "projects/" + project
+	if strings.HasPrefix(projectID, "projects/") {
+		// Remove "projects/" prefix if it exists
+		projectID = strings.TrimPrefix(projectID, "projects/")
 	}
 
-	id := fmt.Sprintf("%s/locations/%s/buckets/%s", project, location, bucketID)
+	id := fmt.Sprintf("projects/%s/locations/%s/buckets/%s", projectID, location, bucketID)
 	return id, nil
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudlogging: fixed bug in `google_logging_project_bucket_config` that if providing "project" in the format of `<project-id-only>` , the create url will contains "projects/" twice. 
```
