### PR TITLE
Add Intercept Endpoint Group Association resource to Network Security.

### DIFF
--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -1,0 +1,132 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterceptEndpointGroupAssociation'
+description: Creates an association between a VPC and an Intercept Endpoint Group in order to intercept traffic in that VPC.
+min_version: 'beta'
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations'
+self_link: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations?interceptEndpointGroupAssociationId={{intercept_endpoint_group_association_id}}'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: true
+  error:
+    path: 'error'
+    message: 'message'
+custom_code:
+examples:
+  - name: 'network_security_intercept_endpoint_group_association_basic'
+    config_path: 'templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    vars:
+      producer_network_name: 'example-prod-network'
+      consumer_network_name: 'example-cons-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
+      endpoint_group_association_id: 'example-ega'
+parameters:
+  - name: 'location'
+    type: String
+    description: 'The location of the Intercept Endpoint Group Association, currently restricted to `global`.'
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interceptEndpointGroupAssociationId'
+    type: String
+    description: 'ID of the Intercept Endpoint Group Association.'
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: 'Identifier. The name of the Intercept Endpoint Group Association.'
+    min_version: 'beta'
+    output: true
+  - name: 'createTime'
+    type: String
+    description: 'Create time stamp.'
+    min_version: 'beta'
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: 'Update time stamp.'
+    min_version: 'beta'
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: 'Optional. Labels as key value pairs.'
+    min_version: 'beta'
+  - name: 'interceptEndpointGroup'
+    type: String
+    description: "Immutable. The Intercept Endpoint Group that this resource
+    is connected to. Format\nis:\n`projects/{project}/locations/global/interceptEndpointGroups/{interceptEndpointGroup}`."
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'network'
+    type: String
+    description: "Immutable. The VPC network associated. Format:\n`projects/{project}/global/networks/{network}`."
+    min_version: 'beta'
+    required: true
+    immutable: true
+  - name: 'locationsDetails'
+    type: Array
+    description: 'The list of locations that are currently supported by the associated Intercept Deployment Group and their state.'
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'location'
+          type: String
+          min_version: 'beta'
+          description: 'Location supported by the Intercept Deployment Group, for example `us-central1-a`'
+          output: true
+        - name: 'state'
+          type: String
+          description: "The association state in this location. \n Possible
+            values:\n STATE_UNSPECIFIED\nACTIVE\nOUT_OF_SYNC"
+          min_version: 'beta'
+          output: true
+  - name: 'state'
+    type: String
+    description: "Current state of the Intercept Endpoint Group Association. \n Possible
+      values:\n STATE_UNSPECIFIED\nACTIVE\nCREATING\nDELETING\nCLOSED\nOUT_OF_SYNC\nDELETE_FAILED"
+    min_version: 'beta'
+    output: true
+  - name: 'reconciling'
+    type: Boolean
+    description: "Whether reconciling is in progress."
+    min_version: 'beta'
+    output: true

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -1,0 +1,36 @@
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "producer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "consumer_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "{{$.PrimaryResourceId}}" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_generated_test.go.tmpl
@@ -1,0 +1,133 @@
+package networksecurity_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context),
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_intercept_endpoint_group_association.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_intercept_endpoint_group_association.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "producer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-prod-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network" "consumer_network" {
+  provider                = google-beta
+  name                    = "tf-test-example-cons-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.producer_network.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+}
+
+resource "google_network_security_intercept_endpoint_group_association" "default" {
+  provider                                = google-beta
+  intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
+  location                                = "global"
+  network                                 = google_compute_network.consumer_network.id
+  intercept_endpoint_group                = google_network_security_intercept_endpoint_group.endpoint_group.id
+  labels = {
+    foo = "goo"
+  }
+}
+`, context)
+}
+
+{{ end }}


### PR DESCRIPTION
This PR is a promotion from google-private provider.
Removal CL: https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/49230

```release-note:new-resource
`google_network_security_intercept_endpoint_group_association` (beta)
```
