### PR TITLE
Network peering routes config updates

### DIFF
--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -106,3 +106,17 @@ properties:
       Whether to import the custom routes to the peer network.
     required: true
     send_empty_value: true
+  - name: 'exportSubnetRoutesWithPublicIp'
+    description: |
+      Whether subnet routes with public IP range are exported.
+      IPv4 special-use ranges are always exported to peers and
+      are not controlled by this field.
+    send_empty_value: true
+    default_from_api: true
+  - name: 'importSubnetRoutesWithPublicIp'
+    description: |
+      Whether subnet routes with public IP range are imported.
+      IPv4 special-use ranges are always imported from peers and
+      are not controlled by this field.
+    send_empty_value: true
+    default_from_api: true

--- a/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
+++ b/mmv1/products/compute/NetworkPeeringRoutesConfig.yaml
@@ -107,6 +107,7 @@ properties:
     required: true
     send_empty_value: true
   - name: 'exportSubnetRoutesWithPublicIp'
+    type: Boolean
     description: |
       Whether subnet routes with public IP range are exported.
       IPv4 special-use ranges are always exported to peers and
@@ -114,6 +115,7 @@ properties:
     send_empty_value: true
     default_from_api: true
   - name: 'importSubnetRoutesWithPublicIp'
+    type: Boolean
     description: |
       Whether subnet routes with public IP range are imported.
       IPv4 special-use ranges are always imported from peers and

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
@@ -15,6 +15,8 @@ resource "google_compute_network_peering" "peering_primary" {
 
   import_custom_routes = true
   export_custom_routes = true
+  import_subnet_routes_with_public_ip = true
+  export_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network_peering" "peering_secondary" {

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
@@ -4,6 +4,8 @@ resource "google_compute_network_peering_routes_config" "{{$.PrimaryResourceId}}
 
   import_custom_routes = true
   export_custom_routes = true
+  import_subnet_routes_with_public_ip = true
+  export_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network_peering" "peering_primary" {

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_basic.tf.tmpl
@@ -2,8 +2,8 @@ resource "google_compute_network_peering_routes_config" "{{$.PrimaryResourceId}}
   peering = google_compute_network_peering.peering_primary.name
   network = google_compute_network.network_primary.name
 
-  import_custom_routes = true
-  export_custom_routes = true
+  import_custom_routes                = true
+  export_custom_routes                = true
   import_subnet_routes_with_public_ip = true
   export_subnet_routes_with_public_ip = true
 }

--- a/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_peering_routes_config_gke.tf.tmpl
@@ -2,8 +2,10 @@ resource "google_compute_network_peering_routes_config" "{{$.PrimaryResourceId}}
   peering = google_container_cluster.private_cluster.private_cluster_config[0].peering_name
   network = google_compute_network.container_network.name
 
-  import_custom_routes = true
-  export_custom_routes = true
+  import_custom_routes                = true
+  export_custom_routes                = true
+  import_subnet_routes_with_public_ip = true
+  export_subnet_routes_with_public_ip = true
 }
 
 resource "google_compute_network" "container_network" {


### PR DESCRIPTION
This PR adds the import_subnet_routes_with_public_ip and export_subnet_routes_with_public_ip fields to the compute resource google_compute_network_peering_routes_config.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/11573

Although there is an API side default, I set these fields as required without defaults as people may have this resource already in state, and it is undesirable to change without explicitly choosing to.

This mirrors the approach of import_custom_routes and export_custom_routes. Please let me know if there is a better approach.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
compute: added `import_subnet_routes_with_public_ip` and `export_subnet_routes_with_public_ip` fields to `google_compute_network_peering_routes_config` resource
```
