### PR TITLE
Add edgenetwork InterconnectAttachment resource.

### DIFF
--- a/mmv1/products/edgenetwork/InterconnectAttachment.yaml
+++ b/mmv1/products/edgenetwork/InterconnectAttachment.yaml
@@ -1,0 +1,135 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'InterconnectAttachment'
+description: |
+  A Distributed Cloud Edge interconnect attachment, which connects routers to the northbound network.
+references:
+  guides:
+    'Create and manage interconnect attachments': 'https://cloud.google.com/distributed-cloud/edge/latest/docs/attachments#api'
+  api: 'https://cloud.google.com/distributed-cloud/edge/latest/docs/reference/network/rest/v1/projects.locations.zones.interconnectAttachments'
+docs:
+base_url: 'projects/{{project}}/locations/{{location}}/zones/{{zone}}/interconnectAttachments'
+self_link: 'projects/{{project}}/locations/{{location}}/zones/{{zone}}/interconnectAttachments/{{interconnect_attachment_id}}'
+create_url: 'projects/{{project}}/locations/{{location}}/zones/{{zone}}/interconnectAttachments?interconnectAttachmentId={{interconnect_attachment_id}}'
+immutable: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/zones/{{zone}}/interconnectAttachment/{{interconnect_attachment_id}}'
+  - '{{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 30
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'response'
+    resource_inside_response: false
+  error:
+    path: 'error'
+    message: 'message'
+examples:
+  - name: 'edgenetwork_interconnect_attachment'
+    primary_resource_id: 'example_interconnect_attachment'
+    vars:
+      edgenetwork_interconnect_attachment_id: 'example-interconnect-attachment'
+      edgenetwork_network_id: 'example-network'
+    test_env_vars:
+      location: 'REGION'
+      zone: 'ZONE'
+    exclude_test: true
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The Google Cloud region to which the target Distributed Cloud Edge zone belongs.
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'zone'
+    type: String
+    description: |
+      The name of the target Distributed Cloud Edge zone.
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'interconnect_attachment_id'
+    type: String
+    description: |
+      A unique ID that identifies this interconnect attachment.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The canonical name of this resource, with format
+      `projects/{{project}}/locations/{{location}}/zones/{{zone}}/interconnectAttachments/{{interconnect_attachment_id}}`
+    output: true
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      Labels associated with this resource.
+    required: false
+  - name: 'description'
+    type: String
+    description: |
+      A free-text description of the resource. Max length 1024 characters.
+    required: false
+  - name: 'createTime'
+    type: String
+    description: |
+      The time when the resource was created.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: `2014-10-02T15:01:23Z` and `2014-10-02T15:01:23.045123456Z`.
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: |
+      The time when the resource was last updated.
+      A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+      fractional digits. Examples: `2014-10-02T15:01:23Z` and `2014-10-02T15:01:23.045123456Z`.
+    output: true
+  - name: 'interconnect'
+    type: String
+    description: |
+      The ID of the underlying interconnect that this attachment's traffic will traverse through.
+    required: true
+  - name: 'network'
+    type: ResourceRef
+    description: |
+      The ID of the network to which this interconnect attachment belongs.
+      Must be of the form: `projects/{{project}}/locations/{{location}}/zones/{{zone}}/networks/{{network_id}}`
+    required: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Network'
+    imports: 'name'
+  - name: 'vlanId'
+    type: Integer
+    description: |
+      VLAN ID provided by user. Must be site-wise unique.
+    required: true
+  - name: 'mtu'
+    type: Integer
+    description: |
+      IP (L3) MTU value of the virtual edge cloud. Default value is `1500`. Possible values are: `1500`, `9000`.
+    default_value: 1500
+

--- a/mmv1/templates/terraform/examples/edgenetwork_interconnect_attachment.tf.tmpl
+++ b/mmv1/templates/terraform/examples/edgenetwork_interconnect_attachment.tf.tmpl
@@ -1,0 +1,23 @@
+
+resource "google_edgenetwork_interconnect_attachment" "{{$.PrimaryResourceId}}" {
+  interconnect_attachment_id   = "{{index $.Vars "edgenetwork_interconnect_attachment_id"}}"
+  location     = "{{index $.TestEnvVars "location"}}"
+  zone         = "{{index $.TestEnvVars "zone"}}"
+  description  = "Example interconnect attachment."
+  network      = google_edgenetwork_network.example_network.id
+  interconnect = "11111111-2222-3333-4444-555555555555"
+  vlan_id      = 55
+  mtu          = 9000
+  labels       = {
+    "environment" : "dev"
+  }
+}
+
+resource "google_edgenetwork_network" "example_network" {
+  network_id  = "{{index $.Vars "edgenetwork_network_id"}}"
+  location    = "{{index $.TestEnvVars "location"}}"
+  zone        = "{{index $.TestEnvVars "zone"}}"
+  description = "Example network."
+  mtu         = 9000
+}
+


### PR DESCRIPTION
Create InterconnectAttachment resource in product edgenetwork.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15665

Tests are disabled for this resource for the same reason as other resources in `edgenetwork`. See: https://github.com/GoogleCloudPlatform/magic-modules/pull/8905

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_edgenetwork_interconnect_attachment`
```
