### PR TITLE
b/383149651 - Make export ranges fields immutable

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -292,13 +292,11 @@ properties:
       - name: includeExportRanges
         type: Array
         description: IP ranges allowed to be included from peering.
-        immutable: true
         item_type:
           type: String
       - name: excludeExportRanges
         type: Array
         description: IP ranges encompassing the subnets to be excluded from peering.
-        immutable: true
         item_type:
           type: String
   - name: 'uniqueId'

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -256,13 +256,11 @@ properties:
       - name: 'excludeExportRanges'
         type: Array
         description: IP ranges encompassing the subnets to be excluded from peering.
-        immutable: true
         item_type:
           type: String
       - name: 'includeExportRanges'
         type: Array
         description: IP ranges allowed to be included from peering.
-        immutable: true
         item_type:
           type: String
   - name: linkedProducerVpcNetwork


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkconnectivity: made `includeExportRanges`, `excludeExportRanges` mutable in `google_network_connectivity_spoke` to avoid recreation of resources (b/383149651)
```
