### PR TITLE
CodeRepositoryIndex cascade deletion

### DIFF
--- a/mmv1/products/gemini/CodeRepositoryIndex.yaml
+++ b/mmv1/products/gemini/CodeRepositoryIndex.yaml
@@ -51,6 +51,8 @@ async:
   result:
     resource_inside_response: true
   include_project: false
+custom_code:
+  pre_delete: templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
 error_retry_predicates:
   - 'transport_tpg.IsCodeRepositoryIndexUnreadyError'
   - 'transport_tpg.IsRepositoryGroupQueueError'

--- a/mmv1/products/gemini/CodeRepositoryIndex.yaml
+++ b/mmv1/products/gemini/CodeRepositoryIndex.yaml
@@ -59,7 +59,8 @@ error_retry_predicates:
 virtual_fields:
   - name: 'force_destroy'
     description:
-      If set to true, any RepositoryGroups for this CodeRepositoryIndex will also be deleted.
+      If set to true, will allow deletion of the CodeRepositoryIndex even if there are existing
+      RepositoryGroups for the resource. These RepositoryGroups will also be deleted.
     type: Boolean
     default_value: false
 parameters:

--- a/mmv1/products/gemini/CodeRepositoryIndex.yaml
+++ b/mmv1/products/gemini/CodeRepositoryIndex.yaml
@@ -56,6 +56,12 @@ custom_code:
 error_retry_predicates:
   - 'transport_tpg.IsCodeRepositoryIndexUnreadyError'
   - 'transport_tpg.IsRepositoryGroupQueueError'
+virtual_fields:
+  - name: 'force_destroy'
+    description:
+      If set to true, any RepositoryGroups for this CodeRepositoryIndex will also be deleted.
+    type: Boolean
+    default_value: false
 parameters:
   - name: location
     type: String

--- a/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
@@ -1,0 +1,4 @@
+{{- if ne $.TargetVersionName "ga" -}}
+obj = make(map[string]interface{})
+obj["force"] = true
+{{- end }}

--- a/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
@@ -1,4 +1,8 @@
 {{- if ne $.TargetVersionName "ga" -}}
 obj = make(map[string]interface{})
-obj["force"] = true
+if v, ok := d.GetOk("force_destroy"); ok {
+	if v == true {
+		obj["force"] = true
+	}
+}
 {{- end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_code_repository_index_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_code_repository_index_test.go.tmpl
@@ -70,7 +70,7 @@ func TestAccGeminiCodeRepositoryIndex_delete(t *testing.T) {
 				ResourceName:            "google_gemini_code_repository_index.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"code_repository_index_id", "labels", "location", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"code_repository_index_id", "labels", "location", "terraform_labels", "force_destroy"},
 			},
 			{
 				Config: testAccGeminiCodeRepositoryIndex_withChildren_delete(context),
@@ -88,6 +88,7 @@ resource "google_gemini_code_repository_index" "example" {
   labels = {"ccfe_debug_note": "terraform_e2e_should_be_deleted"}
   location = "us-central1"
   code_repository_index_id = "%{cri_id}"
+  force_destroy = true
 }
 
 resource "google_gemini_repository_group" "example" {
@@ -100,6 +101,9 @@ resource "google_gemini_repository_group" "example" {
     branch_pattern = "main"
   }
   labels = {"label1": "value1"}
+  depends_on = [
+    google_gemini_code_repository_index.example
+  ]
 }
 
 resource "google_developer_connect_git_repository_link" "conn" {
@@ -129,6 +133,7 @@ resource "google_developer_connect_connection" "github_conn" {
 `, context)
 }
 
+// Removed depends_on to not break plan test
 func testAccGeminiCodeRepositoryIndex_withChildren_delete(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_gemini_repository_group" "example" {

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_code_repository_index_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_code_repository_index_test.go.tmpl
@@ -2,6 +2,7 @@ package gemini_test
 {{- if ne $.TargetVersionName "ga" }}
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -42,6 +43,131 @@ func TestAccGeminiCodeRepositoryIndex_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccGeminiCodeRepositoryIndex_delete checks if there is no error in deleting CRI along with children resource
+// note: this is an example of a bad usage, where RGs refer to the CRI using a string id, not a reference, as they
+// will be force-removed upon CRI deletion, because the CRI provider uses --force option by default
+// The plan after the _delete function should not be empty due to the child resource in plan
+func TestAccGeminiCodeRepositoryIndex_delete(t *testing.T) {
+	bootstrappedKMS := acctest.BootstrapKMSKeyInLocation(t, "us-central1")
+	randomSuffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix": randomSuffix,
+		"project_id": os.Getenv("GOOGLE_PROJECT"),
+		"kms_key": bootstrappedKMS.CryptoKey.Name,
+		"cri_id": fmt.Sprintf("tf-test-cri-index-delete-example-%s", randomSuffix),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck: func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiCodeRepositoryIndex_withChildren_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_code_repository_index.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"code_repository_index_id", "labels", "location", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiCodeRepositoryIndex_withChildren_delete(context),
+        ExpectNonEmptyPlan: true,
+        PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccGeminiCodeRepositoryIndex_withChildren_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_code_repository_index" "example" {
+  provider = google-beta
+  labels = {"ccfe_debug_note": "terraform_e2e_should_be_deleted"}
+  location = "us-central1"
+  code_repository_index_id = "%{cri_id}"
+}
+
+resource "google_gemini_repository_group" "example" {
+  provider = google-beta
+  location = "us-central1"
+  code_repository_index = "%{cri_id}"
+  repository_group_id = "tf-test-rg-repository-group-id-%{random_suffix}"
+  repositories {
+    resource = "projects/%{project_id}/locations/us-central1/connections/${google_developer_connect_connection.github_conn.connection_id}/gitRepositoryLinks/${google_developer_connect_git_repository_link.conn.git_repository_link_id}"
+    branch_pattern = "main"
+  }
+  labels = {"label1": "value1"}
+}
+
+resource "google_developer_connect_git_repository_link" "conn" {
+  provider = google-beta
+  git_repository_link_id = "tf-test-repository-conn-delete"
+  parent_connection = google_developer_connect_connection.github_conn.connection_id
+  clone_uri = "https://github.com/CC-R-github-robot/tf-test.git"
+  location = "us-central1"
+  annotations = {}
+}
+
+resource "google_developer_connect_connection" "github_conn" {
+  provider = google-beta
+  location = "us-central1"
+  connection_id = "tf-test-cloudaicompanion-delete-%{random_suffix}"
+  disabled = false
+
+  github_config {
+    github_app = "DEVELOPER_CONNECT"
+    app_installation_id = 54180648
+
+    authorizer_credential {
+      oauth_token_secret_version = "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1"
+    }
+  }
+}
+`, context)
+}
+
+func testAccGeminiCodeRepositoryIndex_withChildren_delete(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_repository_group" "example" {
+  provider = google-beta
+  location = "us-central1"
+  code_repository_index = "%{cri_id}"
+  repository_group_id = "tf-test-rg-repository-group-id-%{random_suffix}"
+  repositories {
+    resource = "projects/%{project_id}/locations/us-central1/connections/${google_developer_connect_connection.github_conn.connection_id}/gitRepositoryLinks/${google_developer_connect_git_repository_link.conn.git_repository_link_id}"
+    branch_pattern = "main"
+  }
+  labels = {"label1": "value1"}
+}
+
+resource "google_developer_connect_git_repository_link" "conn" {
+  provider = google-beta
+  git_repository_link_id = "tf-test-repository-conn-delete"
+  parent_connection = google_developer_connect_connection.github_conn.connection_id
+  clone_uri = "https://github.com/CC-R-github-robot/tf-test.git"
+  location = "us-central1"
+  annotations = {}
+}
+
+resource "google_developer_connect_connection" "github_conn" {
+  provider = google-beta
+  location = "us-central1"
+  connection_id = "tf-test-cloudaicompanion-delete-%{random_suffix}"
+  disabled = false
+
+  github_config {
+    github_app = "DEVELOPER_CONNECT"
+    app_installation_id = 54180648
+
+    authorizer_credential {
+      oauth_token_secret_version = "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1"
+    }
+  }
+}
+`, context)
 }
 
 func testAccGeminiCodeRepositoryIndex_basic(context map[string]interface{}) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
gemini: added `force_destroy` field to resource `google_code_repository_index`, enabling deletion of the resource even when it has dependent RepositoryGroups
```
