### PR TITLE
suppressing Project id vs project number diff in forwardingRule.target

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -492,7 +492,7 @@ properties:
       For Private Service Connect forwarding rules that forward traffic to managed services, the target must be a service attachment.
     update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'
     update_verb: 'POST'
-    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePathsIgnoreProjectId'
     custom_expand: 'templates/terraform/custom_expand/self_link_from_name.tmpl'
   - name: 'labelFingerprint'
     type: Fingerprint

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
@@ -93,8 +93,20 @@ func DurationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 // has the project number instead of the project name
 func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	var a2, b2 string
-	reN := regexp.MustCompile("projects/\\d+")
+	re := regexp.MustCompile("projects/\\d+")
+	reN := regexp.MustCompile("projects/[^/]+")
+	replacement := []byte("projects/equal")
+	a2 = string(re.ReplaceAll([]byte(old), replacement))
+	b2 = string(reN.ReplaceAll([]byte(new), replacement))
+	return a2 == b2
+}
+
+// Suppress diffs when the value read from api
+// has the project ID instead of the project number
+func ProjectIDDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	var a2, b2 string
 	re := regexp.MustCompile("projects/[^/]+")
+	reN := regexp.MustCompile("projects/\\d+")
 	replacement := []byte("projects/equal")
 	a2 = string(re.ReplaceAll([]byte(old), replacement))
 	b2 = string(reN.ReplaceAll([]byte(new), replacement))

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
@@ -96,8 +96,8 @@ func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool 
 	reN := regexp.MustCompile("projects/\\d+")
 	re := regexp.MustCompile("projects/[^/]+")
 	replacement := []byte("projects/equal")
-	a2 = string(reN.ReplaceAll([]byte(old), replacement))
-	b2 = string(re.ReplaceAll([]byte(new), replacement))
+	a2 = string(re.ReplaceAll([]byte(old), replacement))
+	b2 = string(reN.ReplaceAll([]byte(new), replacement))
 	return a2 == b2
 }
 

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
@@ -101,6 +101,18 @@ func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool 
 	return a2 == b2
 }
 
+// Suppress diffs when the value read from api
+// has the project id instead of the project number
+func ProjectIDDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	var a2, b2 string
+	re := regexp.MustCompile("projects/\\d+")
+	reN := regexp.MustCompile("projects/[^/]+")
+	replacement := []byte("projects/equal")
+	a2 = string(reN.ReplaceAll([]byte(old), replacement))
+	b2 = string(re.ReplaceAll([]byte(new), replacement))
+	return a2 == b2
+}
+
 func IsNewResource(diff TerraformResourceDiff) bool {
 	name := diff.Get("name")
 	return name.(string) == ""

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go.tmpl
@@ -101,18 +101,6 @@ func ProjectNumberDiffSuppress(_, old, new string, _ *schema.ResourceData) bool 
 	return a2 == b2
 }
 
-// Suppress diffs when the value read from api
-// has the project id instead of the project number
-func ProjectIDDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	var a2, b2 string
-	re := regexp.MustCompile("projects/\\d+")
-	reN := regexp.MustCompile("projects/[^/]+")
-	replacement := []byte("projects/equal")
-	a2 = string(reN.ReplaceAll([]byte(old), replacement))
-	b2 = string(re.ReplaceAll([]byte(new), replacement))
-	return a2 == b2
-}
-
 func IsNewResource(diff TerraformResourceDiff) bool {
 	name := diff.Get("name")
 	return name.(string) == ""

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -67,6 +67,53 @@ func TestDurationDiffSuppress(t *testing.T) {
 	}
 }
 
+func TestProjectNumberDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"different project identifiers": {
+			Old:                "projects/1234/locations/abc/serviceAttachments/xyz",
+			New:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			ExpectDiffSuppress: true,
+		},
+		"different resources": {
+			Old:                "projects/1234/locations/abc/serviceAttachments/jkl",
+			New:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if ProjectNumberDiffSuppress("diffSuppress", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
+func TestProjectIDDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"different project identifiers": {
+			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			New:                "projects/1234/locations/abc/serviceAttachments/xyz",
+			ExpectDiffSuppress: true,
+		},
+		"different resources": {
+			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			New:                "projects/1234/locations/abc/serviceAttachments/jkl",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if ProjectIDDiffSuppress("diffSuppress", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
 func TestEmptyOrUnsetBlockDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Key, Old, New      string

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -67,6 +67,35 @@ func TestDurationDiffSuppress(t *testing.T) {
 	}
 }
 
+func TestProjectIDDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"different project identifiers": {
+			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			New:                "projects/1234/locations/abc/serviceAttachments/xyz",
+			ExpectDiffSuppress: yes,
+		},
+		"same values": {
+			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			New:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			ExpectDiffSuppress: true,
+		},
+		"different resources": {
+			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
+			New:                "projects/1234/locations/abc/serviceAttachments/jkl",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if ProjectIDDiffSuppress(tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
 func TestEmptyOrUnsetBlockDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Key, Old, New      string

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -75,7 +75,7 @@ func TestProjectIDDiffSuppress(t *testing.T) {
 		"different project identifiers": {
 			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
 			New:                "projects/1234/locations/abc/serviceAttachments/xyz",
-			ExpectDiffSuppress: yes,
+			ExpectDiffSuppress: true,
 		},
 		"same values": {
 			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -67,30 +67,6 @@ func TestDurationDiffSuppress(t *testing.T) {
 	}
 }
 
-func TestProjectIDDiffSuppress(t *testing.T) {
-	cases := map[string]struct {
-		Old, New           string
-		ExpectDiffSuppress bool
-	}{
-		"different project identifiers": {
-			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
-			New:                "projects/1234/locations/abc/serviceAttachments/xyz",
-			ExpectDiffSuppress: true,
-		},
-		"different resources": {
-			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
-			New:                "projects/1234/locations/abc/serviceAttachments/jkl",
-			ExpectDiffSuppress: false,
-		},
-	}
-
-	for tn, tc := range cases {
-		if ProjectIDDiffSuppress("diffSuppress", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
-			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
-		}
-	}
-}
-
 func TestEmptyOrUnsetBlockDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Key, Old, New      string

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -90,7 +90,7 @@ func TestProjectIDDiffSuppress(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		if ProjectIDDiffSuppress(tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+		if ProjectIDDiffSuppress("diffSuppress", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
 			t.Fatalf("bad: %s, '%s' => '%s' expect %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
 		}
 	}

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -77,11 +77,6 @@ func TestProjectIDDiffSuppress(t *testing.T) {
 			New:                "projects/1234/locations/abc/serviceAttachments/xyz",
 			ExpectDiffSuppress: true,
 		},
-		"same values": {
-			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
-			New:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
-			ExpectDiffSuppress: true,
-		},
 		"different resources": {
 			Old:                "projects/ten-tp/locations/abc/serviceAttachments/xyz",
 			New:                "projects/1234/locations/abc/serviceAttachments/jkl",

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -31,7 +31,7 @@ func CompareSelfLinkRelativePathsIgnoreProjectId(unused1, old, new string, unuse
 	if oldStripped == newStripped {
 		return true
 	}
-	return ProjectNumberDiffSuppress(unused1, oldStripped, newStripped, unused2)
+	return ProjectIDDiffSuppress(unused1, oldStripped, newStripped, unused2)
 }
 
 // Compare only the relative path of two self links.

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -17,7 +17,7 @@ func CompareResourceNames(_, old, new string, _ *schema.ResourceData) bool {
 }
 
 // Compare only the relative path of two self links.
-func CompareSelfLinkRelativePathsIgnoreProjectId(_, old, new string, r *schema.ResourceData) bool {
+func CompareSelfLinkRelativePathsIgnoreProjectId(unused1, old, new string, unused2 *schema.ResourceData) bool {
 	oldStripped, err := GetRelativePath(old)
 	if err != nil {
 		return false
@@ -31,7 +31,7 @@ func CompareSelfLinkRelativePathsIgnoreProjectId(_, old, new string, r *schema.R
 	if oldStripped == newStripped {
 		return true
 	}
-	return ProjectIDDiffSuppress(oldStripped, newStripped, r)
+	return ProjectIDDiffSuppress(unused1, oldStripped, newStripped, unused2)
 }
 
 // Compare only the relative path of two self links.

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -17,6 +17,24 @@ func CompareResourceNames(_, old, new string, _ *schema.ResourceData) bool {
 }
 
 // Compare only the relative path of two self links.
+func CompareSelfLinkRelativePathsIgnoreProjectId(_, old, new string, r *schema.ResourceData) bool {
+	oldStripped, err := GetRelativePath(old)
+	if err != nil {
+		return false
+	}
+
+	newStripped, err := GetRelativePath(new)
+	if err != nil {
+		return false
+	}
+
+	if oldStripped == newStripped {
+		return true
+	}
+	return ProjectIDDiffSuppress(oldStripped, newStripped, r)
+}
+
+// Compare only the relative path of two self links.
 func CompareSelfLinkRelativePaths(_, old, new string, _ *schema.ResourceData) bool {
 	oldStripped, err := GetRelativePath(old)
 	if err != nil {
@@ -31,7 +49,6 @@ func CompareSelfLinkRelativePaths(_, old, new string, _ *schema.ResourceData) bo
 	if oldStripped == newStripped {
 		return true
 	}
-
 	return false
 }
 

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -31,7 +31,7 @@ func CompareSelfLinkRelativePathsIgnoreProjectId(unused1, old, new string, unuse
 	if oldStripped == newStripped {
 		return true
 	}
-	return ProjectIDDiffSuppress(unused1, oldStripped, newStripped, unused2)
+	return ProjectNumberDiffSuppress(unused1, oldStripped, newStripped, unused2)
 }
 
 // Compare only the relative path of two self links.

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -124,7 +124,7 @@ func TestCompareSelfLinkRelativePathsIgnoreProjectId(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
-		if CompareSelfLinkOrResourceName("", tc.Old, tc.New, nil) != tc.Expect {
+		if CompareSelfLinkRelativePathsIgnoreProjectId("", tc.Old, tc.New, nil) != tc.Expect {
 			t.Errorf("bad: %s, expected %t for old = %q and new = %q", tn, tc.Expect, tc.Old, tc.New)
 		}
 	}

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -66,7 +66,7 @@ func TestCompareSelfLinkOrResourceName(t *testing.T) {
 	}
 }
 
-func CompareSelfLinkRelativePathsIgnoreProjectId(t *testing.T) {
+func TestCompareSelfLinkRelativePathsIgnoreProjectId(t *testing.T) {
 	cases := map[string]struct {
 		Old, New string
 		Expect   bool

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -66,6 +66,70 @@ func TestCompareSelfLinkOrResourceName(t *testing.T) {
 	}
 }
 
+func CompareSelfLinkRelativePathsIgnoreProjectId(t *testing.T) {
+	cases := map[string]struct {
+		Old, New string
+		Expect   bool
+	}{
+		"full path, project number": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/v1/projects/1234/global/networks/a-network",
+			Expect: true,
+		},
+		"partial path, project number": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/1234/global/networks/a-network",
+			Expect: true,
+		},
+		"partial path, same": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/your-project/global/networks/a-network",
+			Expect: true,
+		},
+		"partial path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"partial path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+		"full path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"full path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/v1/projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+		"beta full path, same": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/your-project/global/networks/a-network",
+			Expect: true,
+		},
+		"beta full path, different name": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/your-project/global/networks/another-network",
+			Expect: false,
+		},
+		"beta full path, different project": {
+			Old:    "https://www.googleapis.com/compute/v1/projects/your-project/global/networks/a-network",
+			New:    "https://www.googleapis.com/compute/beta/projects/another-project/global/networks/a-network",
+			Expect: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if CompareSelfLinkOrResourceName("", tc.Old, tc.New, nil) != tc.Expect {
+			t.Errorf("bad: %s, expected %t for old = %q and new = %q", tn, tc.Expect, tc.Old, tc.New)
+		}
+	}
+}
+
 func TestGetResourceNameFromSelfLink(t *testing.T) {
 	cases := map[string]struct {
 		SelfLink, ExpectedName string


### PR DESCRIPTION
suppressing Project id vs project number diff in forwardingRule.target

This is to unblock
[https://github.com/GoogleCloudPlatform/magic-modules/pull/12548/files](https://www.google.com/url?sa=D&q=https%3A%2F%2Fgithub.com%2FGoogleCloudPlatform%2Fmagic-modules%2Fpull%2F12548%2Ffiles)

The chan

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: Allowed Service attachment with Project Number to be used as ForwardingRule.Target 
```
