### PR TITLE
Pin ubuntu version for all github workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     permissions:
       # required for all workflows

--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   reassign-reviewer:
     if: ${{ github.event.issue.pull_request }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     env:

--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   request-review:
     if: (github.event.action == 'created' && github.event.issue.state == 'open' && github.event.issue.draft == false && github.event.comment.user.login == github.event.issue.user.login) || (github.event.action != 'created' && github.event.pull_request.state == 'open' && github.event.pull_request.draft == false )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     env:

--- a/.github/workflows/scheduled-pr-reminders.yml
+++ b/.github/workflows/scheduled-pr-reminders.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   send-pr-reminders:
     if: github.repository == 'GoogleCloudPlatform/magic-modules'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     env:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -37,7 +37,7 @@ jobs:
   build-and-unit-test:
     permissions:
       statuses: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - name: Get Job URL

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -34,7 +34,7 @@ jobs:
   build-and-unit-test:
     permissions:
       statuses: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - name: Get Job URL


### PR DESCRIPTION

Pin ubuntu version -- removal of terraform is [resulting in tgc unit tests breakages](https://github.com/GoogleCloudPlatform/magic-modules/actions/workflows/test-tgc.yml?page=2).
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
