### PR TITLE
Allow AUTH_TYPE_UNSPECIFIED in connectors

### DIFF
--- a/mmv1/products/integrationconnectors/Connection.yaml
+++ b/mmv1/products/integrationconnectors/Connection.yaml
@@ -236,6 +236,7 @@ properties:
           authType of the Connection
         required: true
         enum_values:
+          - 'AUTH_TYPE_UNSPECIFIED'
           - 'USER_PASSWORD'
           - 'OAUTH2_JWT_BEARER'
           - 'OAUTH2_CLIENT_CREDENTIALS'

--- a/mmv1/products/integrationconnectors/Connection.yaml
+++ b/mmv1/products/integrationconnectors/Connection.yaml
@@ -487,6 +487,7 @@ properties:
         type: Boolean
         description: |
           Indicates whether or not the connection is locked.
+        default_from_api: false
         required: true
       - name: 'reason'
         type: String
@@ -564,6 +565,7 @@ properties:
       Log configuration for the connection.
     properties:
       - name: 'enabled'
+        default_from_api: false
         type: Boolean
         description: |
           Enabled represents whether logging is enabled or not for a connection.


### PR DESCRIPTION
Auth config does not allow AUTH_TYPE_UNSPECIFIED currently. There are auth types like Private Key in Hubspot which are added as additional auth type and make use of AUTH_TYPE_UNSPECIFIED
