### PR TITLE
GetProjectFromRegionalSelfLink: Accept projects with a colon in the name

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -172,7 +172,7 @@ func GetRegionFromRegionalSelfLink(selfLink string) string {
 }
 
 func GetProjectFromRegionalSelfLink(selfLink string) string {
-	re := regexp.MustCompile("projects/([a-zA-Z0-9-]*)/(?:locations|regions)/[a-zA-Z0-9-]*")
+	re := regexp.MustCompile("projects/([a-zA-Z0-9-:]*)/(?:locations|regions)/[a-zA-Z0-9-:]*")
 	switch {
 	case re.MatchString(selfLink):
 		if res := re.FindStringSubmatch(selfLink); len(res) == 2 && res[1] != "" {

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -125,8 +125,9 @@ func TestGetRegionFromRegionalSelfLink(t *testing.T) {
 
 func TestGetProjectFromRegionalSelfLink(t *testing.T) {
 	cases := map[string]string{
-		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar":        "foo",
-		"projects/REDACTED/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8": "REDACTED",
+		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar":            "foo",
+		"projects/REDACTED/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8":     "REDACTED",
+		"projects/REDA:CT-ED09/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8": "REDA:CT-ED09",
 	}
 	for input, expected := range cases {
 		if result := GetProjectFromRegionalSelfLink(input); result != expected {


### PR DESCRIPTION
Some internal projects may have a colon in their name. This fix modifies the regex pattern to accept such project names.

Closes: https://issuetracker.google.com/issues/378500886

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: GetProjectFromRegionalSelfLink accepts projects with a colon in the name
```
