### PR TITLE
Marked RegionNetworkEndpointGroup psc_data as default_from_api 

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -167,7 +167,7 @@ properties:
     type: NestedObject
     description: |
       This field is only used for PSC NEGs.
-
+    default_from_api: true
     properties:
       - name: 'producerPort'
         type: String


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/20576

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed perma-destroy for `psc_data` in `google_compute_region_network_endpoint_group` resource
```
