### PR TITLE
make contentsDeltaUri optional

### DIFF
--- a/mmv1/products/vertexai/Index.yaml
+++ b/mmv1/products/vertexai/Index.yaml
@@ -95,7 +95,6 @@ properties:
           Index field can be also updated as part of the same call.
           The expected structure and format of the files this URI points to is
           described at https://cloud.google.com/vertex-ai/docs/matching-engine/using-matching-engine#input-data-format
-        required: true
         custom_flatten: 'templates/terraform/custom_flatten/vertex_ai_index_ignore_contents_delta_uri.go.tmpl'
       - name: 'isCompleteOverwrite'
         type: Boolean


### PR DESCRIPTION
## Summary
Deleted `required: true` from `contentsDeltaUri` because it is not required property.

## Background
- `contentsDeltaUri`, which is supposed to be optional, is currently required.
  - the official documentation states that it is possible to create an index without specifying `contentsDeltaUri`.
  - ref: https://cloud.google.com/vertex-ai/docs/vector-search/create-manage-index?hl=en#create-empty-index-batch
- It seems that the field was changed from optional to required in the following issue and pull request
  - issue: https://github.com/hashicorp/terraform-provider-google/issues/15962
  - pull request: https://github.com/GoogleCloudPlatform/magic-modules/pull/9066
  - above issue mentions that the error occurs during `terraform apply` (without `contentsDeltaUri`).
  - when I switched to the version at that time (google-beta = "4.76.0") and ran `terraform apply` (without `contentsDeltaUri`), the error did not occur.
    - additionally, i confirmed that it is possible to create an index by making a request to the Vertex AI API without specifying `contentsDeltaUri`.
  - it seems likely that there was a bug in the Vertex API at the time.


## Release Note
```release-note:bug
vertexai: made `contents_delta_uri` a optional field in `google_vertex_ai_index`
```