### PR TITLE
Promoting namespace to the GA provider

### DIFF
--- a/mmv1/products/servicedirectory/Namespace.yaml
+++ b/mmv1/products/servicedirectory/Namespace.yaml
@@ -46,10 +46,6 @@ examples:
     primary_resource_id: 'example'
     vars:
       namespace_id: 'example-namespace'
-  - name: 'service_directory_namespace_ga'
-    primary_resource_id: 'example-ga'
-    vars:
-      namespace_id: 'example-namespace-ga'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/servicedirectory/Namespace.yaml
+++ b/mmv1/products/servicedirectory/Namespace.yaml
@@ -80,9 +80,3 @@ properties:
       Resource labels associated with this Namespace. No more than 64 user
       labels can be associated with a given resource. Label keys and values can
       be no longer than 63 characters.
-  - name: 'uid'
-    type: String
-    description: |
-      The unique identifier of the namespace.
-    output: true
-    exact_version: 'ga'

--- a/mmv1/products/servicedirectory/Namespace.yaml
+++ b/mmv1/products/servicedirectory/Namespace.yaml
@@ -16,7 +16,6 @@ name: 'Namespace'
 description: |
   A container for `services`. Namespaces allow administrators to group services
   together and define permissions for a collection of services.
-min_version: 'beta'
 references:
   guides:
     'Configuring a namespace': 'https://cloud.google.com/service-directory/docs/configuring-service-directory#configuring_a_namespace'
@@ -45,9 +44,12 @@ exclude_sweeper: true
 examples:
   - name: 'service_directory_namespace_basic'
     primary_resource_id: 'example'
-    min_version: 'beta'
     vars:
       namespace_id: 'example-namespace'
+  - name: 'service_directory_namespace_ga'
+    primary_resource_id: 'example-ga'
+    vars:
+      namespace_id: 'example-namespace-ga'
 parameters:
   - name: 'location'
     type: String
@@ -55,7 +57,6 @@ parameters:
       The location for the Namespace.
       A full list of valid locations can be found by running
       `gcloud beta service-directory locations list`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -65,7 +66,6 @@ parameters:
     description: |
       The Resource ID must be 1-63 characters long, including digits,
       lowercase letters or the hyphen character.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -77,7 +77,6 @@ properties:
     description: |
       The resource name for the namespace
       in the format `projects/*/locations/*/namespaces/*`.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
@@ -85,4 +84,9 @@ properties:
       Resource labels associated with this Namespace. No more than 64 user
       labels can be associated with a given resource. Label keys and values can
       be no longer than 63 characters.
-    min_version: 'beta'
+  - name: 'uid'
+    type: String
+    description: |
+      The unique identifier of the namespace.
+    output: true
+    exact_version: 'ga'

--- a/mmv1/products/servicedirectory/product.yaml
+++ b/mmv1/products/servicedirectory/product.yaml
@@ -17,5 +17,7 @@ display_name: 'Service Directory'
 versions:
   - name: 'beta'
     base_url: 'https://servicedirectory.googleapis.com/v1beta1/'
+  - name: 'ga'
+    base_url: 'https://servicedirectory.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
+++ b/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
@@ -4,7 +4,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   } else if strings.HasPrefix(v.(string), "https://") {
     return v, nil
   }
-  url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ServiceDirectoryBasePath{{"}}"}}" + v.(string))
+  url, err := tpgresource.ReplaceVars(d, config, "https://servicedirectory.googleapis.com/v1/" + v.(string))
   if err != nil {
     return "", err
   }

--- a/mmv1/templates/terraform/examples/service_directory_namespace_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/service_directory_namespace_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_service_directory_namespace" "{{$.PrimaryResourceId}}" {
-  provider     = google-beta
   namespace_id = "{{index $.Vars "namespace_id"}}"
   location     = "us-central1"
 

--- a/mmv1/templates/terraform/examples/service_directory_namespace_ga.tf.tmpl
+++ b/mmv1/templates/terraform/examples/service_directory_namespace_ga.tf.tmpl
@@ -1,9 +1,0 @@
-resource "google_service_directory_namespace" "{{$.PrimaryResourceId}}" {
-  namespace_id = "{{index $.Vars "namespace_id"}}"
-  location     = "us-central1"
-
-  labels = {
-    key = "value"
-    foo = "bar"
-  }
-}

--- a/mmv1/templates/terraform/examples/service_directory_namespace_ga.tf.tmpl
+++ b/mmv1/templates/terraform/examples/service_directory_namespace_ga.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_service_directory_namespace" "{{$.PrimaryResourceId}}" {
+  namespace_id = "{{index $.Vars "namespace_id"}}"
+  location     = "us-central1"
+
+  labels = {
+    key = "value"
+    foo = "bar"
+  }
+}


### PR DESCRIPTION
In an effort to promote the namespace to the GA provider we do the following:

1. Remove instances of `min_version` from `Namespace.yaml` and include the `uid` field within `properties`.
2. Include a test file, `service_directory_namespace_ga.tf.tmpl`, with the provider omitted.

```release-note:new-resource
`google_service_directory_namespace` (GA)
```