### PR TITLE
Add post-create/post-update sleep to KMS AutokeyConfig

### DIFF
--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -51,6 +51,8 @@ custom_code:
   pre_read: 'templates/terraform/pre_read/kms_autokey_config_folder.go.tmpl'
   pre_update: 'templates/terraform/pre_update/kms_autokey_config_folder.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/kms_autokey_config_folder.go.tmpl'
+  post_create: 'templates/terraform/post_create/sleep.go.tmpl'
+  post_update: 'templates/terraform/post_create/sleep.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/kms_autokey_config.go.tmpl'
 # Using a handwritten sweeper because of pre_delete.
 exclude_sweeper: true

--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -67,9 +67,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     external_providers: ["random", "time"]
-    # Need the time_sleep resource
-    # Currently failing
-    skip_vcr: true
 parameters:
   - name: 'folder'
     type: String


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Attempts to fix https://github.com/hashicorp/terraform-provider-google/issues/18935

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
kms: added 5 second sleep post-create / post-update to `google_kms_autokey_config`
```
