### PR TITLE
Fix usage of log.Fatalf() in main.go

### DIFF
--- a/mmv1/third_party/terraform/main.go.tmpl
+++ b/mmv1/third_party/terraform/main.go.tmpl
@@ -31,7 +31,7 @@ func main() {
 	// use the muxer
 	muxServer, err := tf5muxserver.NewMuxServer(context.Background(), providers...)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatal(err.Error())
 	}
 
 	var serveOpts []tf5server.ServeOpt


### PR DESCRIPTION
It's a simple fix that'll resolve following lint error on building provider

```
$ make build
==> Checking that code complies with gofmt requirements...
go vet
# github.com/hashicorp/terraform-provider-google-beta
# [github.com/hashicorp/terraform-provider-google-beta]
./main.go:36:14: non-constant format string in call to log.Fatalf
make: *** [GNUmakefile:29: vet] Error 1
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
