### PR TITLE
Fix "non-constant format string in call to log.Fatalf" in main.go when running make build

### DIFF
--- a/mmv1/third_party/terraform/main.go.tmpl
+++ b/mmv1/third_party/terraform/main.go.tmpl
@@ -31,7 +31,7 @@ func main() {
 	// use the muxer
 	muxServer, err := tf5muxserver.NewMuxServer(context.Background(), providers...)
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%v", err.Error())
 	}
 
 	var serveOpts []tf5server.ServeOpt


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fix "non-constant format string in call to log.Fatalf" in main.go when running `make build` in the generated provider repository.

Error without fix:
```
$ make build
==> Checking that code complies with gofmt requirements...
go vet
# github.com/hashicorp/terraform-provider-google-beta
# [github.com/hashicorp/terraform-provider-google-beta]
./main.go:36:14: non-constant format string in call to log.Fatalf
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
