### PR TITLE
Implement the v6 cai2hcl Convert function

### DIFF
--- a/mmv1/templates/tgc_v6/cai2hcl/resource_converters.go.tmpl
+++ b/mmv1/templates/tgc_v6/cai2hcl/resource_converters.go.tmpl
@@ -26,3 +26,11 @@
 //
 // ----------------------------------------------------------------------------
 package converters
+
+import (
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
+)
+
+// ConverterMap is a collection of converters instances, indexed by cai asset type.
+var ConverterMap = map[string]models.Converter{
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/convert.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/convert.go
@@ -1,0 +1,43 @@
+package cai2hcl
+
+import (
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+	"go.uber.org/zap"
+)
+
+// Struct for options so that adding new options does not
+// require updating function signatures all along the pipe.
+type Options struct {
+	ErrorLogger *zap.Logger
+}
+
+// Converts CAI Assets into HCL string.
+func Convert(assets []*caiasset.Asset, options *Options) ([]byte, error) {
+	if options == nil || options.ErrorLogger == nil {
+		return nil, fmt.Errorf("logger is not initialized")
+	}
+
+	// TODO: add resolvers to resolve the assets into single resource assets
+
+	allBlocks := []*models.TerraformResourceBlock{}
+	for _, asset := range assets {
+		newBlocks, err := converters.ConvertResource(asset)
+		if err != nil {
+			return nil, err
+		}
+
+		if newBlocks != nil {
+			allBlocks = append(allBlocks, newBlocks...)
+		}
+	}
+
+	t, err := models.HclWriteBlocks(allBlocks)
+
+	options.ErrorLogger.Debug(string(t))
+
+	return t, err
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/convert_resource.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/convert_resource.go
@@ -1,0 +1,14 @@
+package converters
+
+import (
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+)
+
+func ConvertResource(asset *caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
+	converter, ok := ConverterMap[asset.Type]
+	if !ok {
+		return nil, nil
+	}
+	return converter.Convert(asset)
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils.go
@@ -1,0 +1,128 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	hashicorpcty "github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+	"github.com/zclconf/go-cty/cty"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
+)
+
+// ParseFieldValue extracts named part from resource url.
+func ParseFieldValue(url string, name string) string {
+	fragments := strings.Split(url, "/")
+	for ix, item := range fragments {
+		if item == name && ix+1 < len(fragments) {
+			return fragments[ix+1]
+		}
+	}
+	return ""
+}
+
+// DecodeJSON decodes the map object into the target struct.
+func DecodeJSON(data map[string]interface{}, v interface{}) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MapToCtyValWithSchema normalizes and converts resource from untyped map format to TF JSON.
+//
+// Normalization is a post-processing of the output map, which does the following:
+// * Converts unmarshallable "schema.Set" to marshallable counterpart.
+// * Strips out properties, which are not part ofthe resource TF schema.
+func MapToCtyValWithSchema(m map[string]interface{}, s map[string]*schema.Schema) (cty.Value, error) {
+	m = normalizeFlattenedObj(m, s).(map[string]interface{})
+
+	b, err := json.Marshal(&m)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("error marshaling map as JSON: %v", err)
+	}
+
+	ty, err := hashicorpCtyTypeToZclconfCtyType(schema.InternalMap(s).CoreConfigSchema().ImpliedType())
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("error casting type: %v", err)
+	}
+	ret, err := ctyjson.Unmarshal(b, ty)
+	if err != nil {
+		return cty.NilVal, fmt.Errorf("error unmarshaling JSON as cty.Value: %v", err)
+	}
+	return ret, nil
+}
+
+func hashicorpCtyTypeToZclconfCtyType(t hashicorpcty.Type) (cty.Type, error) {
+	b, err := json.Marshal(t)
+	if err != nil {
+		return cty.NilType, err
+	}
+	var ret cty.Type
+	if err := json.Unmarshal(b, &ret); err != nil {
+		return cty.NilType, err
+	}
+	return ret, nil
+}
+
+func NewConfig() *transport_tpg.Config {
+	return &transport_tpg.Config{}
+}
+
+// normalizeFlattenedObj traverses the output map recursively, removes fields which are
+// not a part of TF schema and converts unmarshallable "schema.Set" objects to arrays.
+func normalizeFlattenedObj(obj interface{}, schemaPerProp map[string]*schema.Schema) interface{} {
+	obj = convertToMarshallableObj(obj)
+
+	if schemaPerProp == nil {
+		// Schema for leaf nodes was already checked.
+		return obj
+	}
+
+	switch obj.(type) {
+	case map[string]interface{}:
+		objMap := obj.(map[string]interface{})
+		objMapNew := map[string]interface{}{}
+
+		for property, propertySchema := range schemaPerProp {
+			propertyValue := objMap[property]
+
+			switch propertySchema.Elem.(type) {
+			case *schema.Resource:
+				objMapNew[property] = normalizeFlattenedObj(propertyValue, propertySchema.Elem.(*schema.Resource).Schema)
+			case *schema.ValueType:
+			default:
+				objMapNew[property] = normalizeFlattenedObj(propertyValue, nil)
+			}
+		}
+		return objMapNew
+	case []interface{}:
+		arr := obj.([]interface{})
+		arrNew := make([]interface{}, len(arr))
+
+		for i := range arr {
+			arrNew[i] = normalizeFlattenedObj(arr[i], schemaPerProp)
+		}
+
+		return arrNew
+	default:
+		return obj
+	}
+}
+
+func convertToMarshallableObj(node interface{}) interface{} {
+	switch node.(type) {
+	case *schema.Set:
+		nodeSet := node.(*schema.Set)
+
+		return nodeSet.List()
+	default:
+		return node
+	}
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils_test.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils_test.go
@@ -1,0 +1,187 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	tpg_provider "github.com/hashicorp/terraform-provider-google-beta/google-beta/provider"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestSubsetOfFieldsMapsToCtyValue(t *testing.T) {
+	schema := createSchema("google_compute_forwarding_rule")
+
+	outputMap := map[string]interface{}{
+		"name": "forwarding-rule-1",
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, schema)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "forwarding-rule-1", val.GetAttr("name").AsString())
+}
+
+func TestWrongFieldTypeBreaksConversion(t *testing.T) {
+	resourceSchema := createSchema("google_compute_backend_service")
+	outputMap := map[string]interface{}{
+		"name":        "fr-1",
+		"description": []string{"unknownValue"}, // string is required, not array.
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	assert.True(t, val.IsNull())
+	assert.Contains(t, err.Error(), "string is required")
+}
+
+func TestNilValue(t *testing.T) {
+	resourceSchema := createSchema("google_compute_forwarding_rule")
+	outputMap := map[string]interface{}{
+		"name":        "fr-1",
+		"description": nil,
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	assert.Nil(t, err)
+	assert.Equal(t, cty.Value(cty.StringVal("fr-1")), val.GetAttr("name"))
+	assert.Equal(t, cty.Value(cty.NullVal(cty.String)), val.GetAttr("description"))
+}
+
+func TestNilValueInRequiredField(t *testing.T) {
+	resourceSchema := createSchema("google_compute_forwarding_rule")
+	outputMap := map[string]interface{}{
+		"name": nil,
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	// In future we may want to fail in this case.
+	assert.Nil(t, err)
+	assert.Equal(t, cty.Value(cty.NullVal(cty.String)), val.GetAttr("name"))
+}
+
+func TestFieldsWithTypeSlice(t *testing.T) {
+	resourceSchema := createSchema("google_compute_forwarding_rule")
+	outputMap := map[string]interface{}{
+		"name":  "fr-1",
+		"ports": []string{"80"},
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, []cty.Value{cty.StringVal("80")}, val.GetAttr("ports").AsValueSlice())
+}
+
+func TestMissingFieldDoesNotBreakConversionConversion(t *testing.T) {
+	resourceSchema := createSchema("google_compute_forwarding_rule")
+	outputMap := map[string]interface{}{
+		"name":         "fr-1",
+		"unknownField": "unknownValue",
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	assert.Nil(t, err)
+
+	assert.True(t, val.Type().HasAttribute("name"))
+	assert.Equal(t, "fr-1", val.GetAttr("name").AsString())
+}
+
+func TestFieldWithTypeSchemaSet(t *testing.T) {
+	resourceSchema := createSchema("google_compute_forwarding_rule")
+	outputMap := map[string]interface{}{
+		"name":  "fr-1",
+		"ports": schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface([]string{"80"})),
+	}
+
+	val, err := MapToCtyValWithSchema(outputMap, resourceSchema)
+
+	assert.Nil(t, err)
+	assert.Equal(t, []cty.Value{cty.StringVal("80")}, val.GetAttr("ports").AsValueSlice())
+}
+
+func TestFieldWithTypeSchemaListAndNestedObject(t *testing.T) {
+	resourceSchema := map[string]*schema.Schema{
+		"list": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"nested_key": {
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+	flattenedMap := map[string]interface{}{
+		"list": []interface{}{
+			map[string]interface{}{
+				"nested_key":         "value",
+				"nested_unknown_key": "unknown_key_value",
+			},
+		},
+	}
+
+	val, err := MapToCtyValWithSchema(flattenedMap, resourceSchema)
+
+	assert.Nil(t, err)
+	assert.Equal(t,
+		[]cty.Value{
+			cty.ObjectVal(
+				map[string]cty.Value{
+					"nested_key": cty.StringVal("value"),
+				},
+			),
+		},
+		val.GetAttr("list").AsValueSlice(),
+	)
+}
+
+func TestFieldWithTypeSchemaSetAndNestedObject(t *testing.T) {
+	nestedResource := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"nested_key": {
+				Type: schema.TypeString,
+			},
+		},
+	}
+	resourceSchema := map[string]*schema.Schema{
+		"list": {
+			Type: schema.TypeSet,
+			Elem: nestedResource,
+		},
+	}
+
+	flattenedMap := map[string]interface{}{
+		"list": schema.NewSet(schema.HashResource(nestedResource), []interface{}{
+			map[string]interface{}{
+				"nested_key":         "value",
+				"nested_unknown_key": "unknown_key_value",
+			},
+		}),
+	}
+
+	val, err := MapToCtyValWithSchema(flattenedMap, resourceSchema)
+
+	assert.Nil(t, err)
+	assert.Equal(t,
+		[]cty.Value{
+			cty.ObjectVal(
+				map[string]cty.Value{
+					"nested_key": cty.StringVal("value"),
+				},
+			)},
+		val.GetAttr("list").AsValueSlice())
+}
+
+func createSchema(name string) map[string]*schema.Schema {
+	provider := tpg_provider.Provider()
+
+	return provider.ResourcesMap[name].Schema
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/models/converter.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/models/converter.go
@@ -1,0 +1,11 @@
+package models
+
+import (
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+)
+
+// Converter interface for resources.
+type Converter interface {
+	// Convert turns asset into hcl blocks.
+	Convert(asset *caiasset.Asset) ([]*TerraformResourceBlock, error)
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/models/hcl_block.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/models/hcl_block.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TerraformResourceBlock identifies the HCL block's labels and content.
+type TerraformResourceBlock struct {
+	Labels []string
+	Value  cty.Value
+}
+
+func HclWriteBlocks(blocks []*TerraformResourceBlock) ([]byte, error) {
+	f := hclwrite.NewFile()
+	rootBody := f.Body()
+
+	for _, resourceBlock := range blocks {
+		hclBlock := rootBody.AppendNewBlock("resource", resourceBlock.Labels)
+		if err := hclWriteBlock(resourceBlock.Value, hclBlock.Body()); err != nil {
+			return nil, err
+		}
+	}
+
+	return printer.Format(f.Bytes())
+}
+
+func hclWriteBlock(val cty.Value, body *hclwrite.Body) error {
+	if val.IsNull() {
+		return nil
+	}
+	if !val.Type().IsObjectType() {
+		return fmt.Errorf("expect object type only, but type = %s", val.Type().FriendlyName())
+	}
+	it := val.ElementIterator()
+	for it.Next() {
+		objKey, objVal := it.Element()
+		if objVal.IsNull() {
+			continue
+		}
+		objValType := objVal.Type()
+		switch {
+		case objValType.IsObjectType():
+			newBlock := body.AppendNewBlock(objKey.AsString(), nil)
+			if err := hclWriteBlock(objVal, newBlock.Body()); err != nil {
+				return err
+			}
+		case objValType.IsCollectionType():
+			if objVal.LengthInt() == 0 {
+				continue
+			}
+			// Presumes map should not contain object type.
+			if !objValType.IsMapType() && objValType.ElementType().IsObjectType() {
+				listIterator := objVal.ElementIterator()
+				for listIterator.Next() {
+					_, listVal := listIterator.Element()
+					subBlock := body.AppendNewBlock(objKey.AsString(), nil)
+					if err := hclWriteBlock(listVal, subBlock.Body()); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+			fallthrough
+		default:
+			if objValType.FriendlyName() == "string" && objVal.AsString() == "" {
+				continue
+			}
+			body.SetAttributeValue(objKey.AsString(), objVal)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
1. Copy v5 cai2hcl convert and utils functions to v6 cai2hcl.

  * Move cai2hcl/common/converter.go to tgc_v6/cai2hcl/models/converter.go
  * Move cai2hcl/common/hcl_write.go to tgc_v6/cai2hcl/models/hcl_block.go
  * Move mmv1/third_party/cai2hcl/common/utils.go to tgc_v6/cai2hcl/converters/utils/utils.go

2. Add single resource convert function `ConvertResource`

TODO: add resolvers to resolve multiple cai assets to the same asset

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
