### PR TITLE
Fix nodeConfigDefaults on cluster create.

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -870,6 +870,7 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 	if v, ok := config["insecure_kubelet_readonly_port_enabled"]; ok {
 		nodeConfigDefaults.NodeKubeletConfig = &container.NodeKubeletConfig{
 			InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(v),
+			ForceSendFields:                    []string{"InsecureKubeletReadonlyPortEnabled"},
 		}
 	}
 	if variant, ok := config["logging_variant"]; ok {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1861,6 +1861,7 @@ func TestAccContainerCluster_withInsecureKubeletReadonlyPortEnabledInNodePool(t 
 	})
 }
 
+
 // This is for `node_pool_defaults.node_config_defaults` - the default settings
 // for newly created nodepools
 func TestAccContainerCluster_withInsecureKubeletReadonlyPortEnabledDefaultsUpdates(t *testing.T) {
@@ -3574,7 +3575,10 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
+// func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
+// nodePoolDefaults is not allowed on GKE Autopilot clusters, error from GKE is:
+// `Setting node_pool_defaults.node_config_defaults.node_kubelet_config is not allowed on GKE Autopilot clusters.`
+func TestAccContainerCluster_withAutopilot_withNodePoolAutoConfig(t *testing.T) {
 	t.Parallel()
 
 	randomSuffix := acctest.RandString(t, 10)
@@ -3588,7 +3592,7 @@ func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAutopilot_withNodePoolDefaults(clusterName, networkName, subnetworkName),
+				Config: testAccContainerCluster_withAutopilot_withNodePoolAutoConfig(clusterName, networkName, subnetworkName, "FALSE"),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -3599,6 +3603,33 @@ func TestAccContainerCluster_withAutopilot_withNodePoolDefaults(t *testing.T) {
 		},
 	})
 }
+
+func TestAccContainerCluster_withStandard_withNodePoolDefaults(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withStandard_withNodePoolDefaults(clusterName, networkName, subnetworkName, "FALSE"),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 
 
 func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
@@ -11480,8 +11511,8 @@ resource "google_container_cluster" "primary" {
   location         = "us-central1"
   enable_autopilot = true
 
-  node_pool_defaults {
-    node_config_defaults {
+	node_pool_defaults {
+    node_kubelet_config {
     }
   }
 
@@ -11490,6 +11521,47 @@ resource "google_container_cluster" "primary" {
   subnetwork          = "%s"
 }
 `, name, networkName, subnetworkName)
+}
+
+
+func testAccContainerCluster_withAutopilot_withNodePoolAutoConfig(name, networkName, subnetworkName string, insecureKubeletReadonlyPortEnabled string) string {
+  return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name             = "%s"
+  location         = "us-central1"
+  enable_autopilot = true
+
+	node_pool_auto_config {
+    node_kubelet_config {
+      insecure_kubelet_readonly_port_enabled = "%s"
+    }
+  }
+
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+`, name, insecureKubeletReadonlyPortEnabled, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withStandard_withNodePoolDefaults(name, networkName, subnetworkName string, insecureKubeletReadonlyPortEnabled string) string {
+  return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name             = "%s"
+  location         = "us-central1-a"
+	initial_node_count = 1
+
+  node_pool_defaults {
+    node_config_defaults {
+      insecure_kubelet_readonly_port_enabled = "%s"
+    }
+  }
+
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+`, name, insecureKubeletReadonlyPortEnabled, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_resourceManagerTags(projectID, clusterName, networkName, subnetworkName, randomSuffix string, tagResourceNumber int) string {
@@ -12880,5 +12952,4 @@ resource "google_container_cluster" "with_enterprise_config" {
   deletion_protection = false
 }
 `, projectID, clusterName, networkName, subnetworkName)
-}  
-
+}


### PR DESCRIPTION
The expansion of
`node_pool_defaults.node_config_defaults.insecure_kubelet_readonly_port_enabled` should have a ForceSendFields to allow `FALSE` values to be propagated.

Without this "FALSE" values are not included in the request.

This is not an issue in nodePoolAutoConfig, or during updates. ForceSendFields is set in those cases.

An alternative fix is to use expandNodeKubeletConfig function here as well. The server will reject any values other than the readonly port field.

```release-note:bug
container: fixed propagation of `node_pool_defaults.node_config_defaults.insecure_kubelet_readonly_port_enabled` in node config.
```
