### PR TITLE
Fixes PermaDiff Issue in `google_storage_transfer_job.aws_s3_data_source.aws_access_key` field

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
@@ -1150,7 +1150,7 @@ func flattenAwsS3Data(awsS3Data *storagetransfer.AwsS3Data, d *schema.ResourceDa
 		"path":        awsS3Data.Path,
 		"role_arn":    awsS3Data.RoleArn,
 	}
-	if _, exist := d.GetOkExists("transfer_spec.0.aws_s3_data_source.0.aws_access_key"); exist{
+	if _, exist := d.GetOk("transfer_spec.0.aws_s3_data_source.0.aws_access_key"); exist{
 		data["aws_access_key"] = flattenAwsAccessKeys(d)
 	}
 	return []map[string]interface{}{data}


### PR DESCRIPTION
Fixes permadiff issue in `google_storage_transfer_job` resource.  Ticket: b/386174536

Cause: It appears that the issue is happening because of `GetOkExists` used to obtain value of `aws_s3_data_source.aws_access_key` in the flattener. `GetOkExists` checks for the presence of the value regardless of zero value of the field. So here, In this case, we are always getting zero value of the field `aws_s3_data_source.aws_access_key` which empty list, `[]`, and true for it's existence even though it's not specified in the config. 

Solution: We can use `GetOk` to obtain value of the field from the config. `GetOk` treats zero value as absent which is use case here like other `TypeList` field.

Alternative: Continue using `GetOkExists` and checking empty vs unset each time, 
```
aws_access_key, exist := d.GetOkExists("transfer_spec.0.aws_s3_data_source.0.aws_access_key")
if !tpgresource.IsEmptyValue(reflect.ValueOf(aws_access_key)) && exist {
data["aws_access_key"] = flattenAwsAccessKeys(d)
}
```
As `GetOkExists` is deprecated, [reference](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema#ResourceData.GetOkExists), and discouraged to use, I prefer `GetOk` and didn't see any problem with that as all the nested fields within `aws_access_key` are required. So there won't be a case of empty block(without any nested field specified) and we need to separate from unset nested fields.

Testing: Currently `storagetransfer` service lacks acceptance tests for third-party cloud providers so there is no way to add acceptance tests. 


```release-note:bug
storagetransfer: fixed a permadiff with `transfer_spec.aws_s3_data_source.aws_access_key` in `google_storage_transfer_job`
```