### PR TITLE
Fixes boolean fields in the ShieldedInstanceConfig struct for dataproc clusters

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -2241,6 +2241,7 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.shielded_instance_config"); ok {
 		cfgSic := v.([]interface{})[0].(map[string]interface{})
 		conf.ShieldedInstanceConfig = &dataproc.ShieldedInstanceConfig{}
+		conf.ShieldedInstanceConfig.ForceSendFields = []string{"EnableIntegrityMonitoring", "EnableSecureBoot", "EnableVtpm"}
 		if v, ok := cfgSic["enable_integrity_monitoring"]; ok {
 			conf.ShieldedInstanceConfig.EnableIntegrityMonitoring = v.(bool)
 		}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -254,6 +254,31 @@ func TestAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(t *testing.T
 	})
 }
 
+func TestAccDataprocCluster_withShieldedConfig(t *testing.T) {
+	t.Parallel()
+
+	var cluster dataproc.Cluster
+	rnd := acctest.RandString(t, 10)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withShieldedConfig(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
+
+					// Testing behavior for Dataproc to use only internal IP addresses
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_integrity_monitoring", "false"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_secure_boot", "false"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_vtpm", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataprocCluster_withConfidentialCompute(t *testing.T) {
     t.Parallel()
 
@@ -1579,6 +1604,25 @@ resource "google_dataproc_cluster" "basic" {
   }
 }
 `, rnd, rnd, rnd, rnd)
+}
+
+func testAccDataprocCluster_withShieldedConfig(rnd string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_cluster" "basic" {
+  name   = "tf-test-dproc-%s"
+  region = "us-central1"
+
+  cluster_config {
+    gce_cluster_config {
+      shielded_instance_config {
+        enable_integrity_monitoring = false
+        enable_secure_boot          = false
+        enable_vtpm                 = false
+      }
+    }
+  }
+}
+`, rnd)
 }
 
 func testAccDataprocCluster_withConfidentialCompute(rnd, subnetworkName string, imageUri string) string {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20203

```release-note:bug
dataproc: fixed boolean fields in the `shielded_instance_config` 
```