### PR TITLE
Modify the doc templates to generate the unique anchor name for nested properties

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -399,6 +399,15 @@ func (t Type) Lineage() string {
 	return fmt.Sprintf("%s.%s", t.ParentMetadata.Lineage(), google.Underscore(t.Name))
 }
 
+// Returns the lineage in snake case
+func (t Type) LineageAsSnakeCase() string {
+	if t.ParentMetadata == nil {
+		return google.Underscore(t.Name)
+	}
+
+	return fmt.Sprintf("%s_%s", t.ParentMetadata.LineageAsSnakeCase(), google.Underscore(t.Name))
+}
+
 // Prints the access path of the field in the configration eg: metadata.0.labels
 // The only intended purpose is to get the value of the labes field by calling d.Get().
 func (t Type) TerraformLineage() string {

--- a/mmv1/templates/terraform/nested_property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/nested_property_documentation.html.markdown.tmpl
@@ -4,7 +4,7 @@
 {{- trimTemplate "nested_property_documentation.html.markdown.tmpl" $np -}}
   {{- end -}}
 {{- else if $.NestedProperties }}
-<a name="nested_{{ underscore $.Name }}"></a>The `{{ underscore $.Name }}` block {{ if $.Output }}contains{{ else }}supports{{ end }}:
+<a name="nested_{{$.LineageAsSnakeCase}}"></a>The `{{ underscore $.Name }}` block {{ if $.Output }}contains{{ else }}supports{{ end }}:
 {{ "" }}
   {{- if $.IsA "Map" }}
 * `{{ underscore $.KeyName }}` - (Required) The identifier for this object. Format specified above.

--- a/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
+++ b/mmv1/templates/terraform/property_documentation.html.markdown.tmpl
@@ -37,7 +37,7 @@
   **Note**: This property is sensitive and will not be displayed in the plan.
   {{- end }}
   {{- if and (not $.FlattenObject) $.NestedProperties }}
-  Structure is [documented below](#nested_{{ underscore $.Name }}).
+  Structure is [documented below](#nested_{{ $.LineageAsSnakeCase}}).
   {{- end }}
   {{- if $.DeprecationMessage }}
 


### PR DESCRIPTION
Modify the doc templates to generate the unique anchor name for nested properties, especially for the properties with the  same name

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
