### PR TITLE
Add support for the metricsGcpServiceAccountEmail field in ConfigManagement Fleet-level default config

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -283,6 +283,9 @@ properties:
               - name: 'preventDrift'
                 type: Boolean
                 description: 'Set to true to enable the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts.'
+              - name: 'metricsGcpServiceAccountEmail'
+                type: String
+                description: 'The Email of the Google Cloud Service Account (GSA) used for exporting Config Sync metrics to Cloud Monitoring. The GSA should have the Monitoring Metric Writer(roles/monitoring.metricWriter) IAM role. The Kubernetes ServiceAccount `default` in the namespace `config-management-monitoring` should be bound to the GSA.'
               - name: 'git'
                 type: NestedObject
                 description: 'Git repo configuration for the cluster'

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
@@ -579,6 +579,7 @@ resource "google_gke_hub_feature" "feature" {
         enabled = true
         prevent_drift = true
         source_format = "unstructured"
+        metrics_gcp_service_account_email = "gke-cluster-metrics@gke-foo-nonprod.iam.gserviceaccount.com"
         oci {
           sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"
           policy_dir = "/acm/nonprod-root/"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
gkehub2: added support for `fleet_default_member_config.config_management.config_sync.metrics_gcp_service_account_email` field to `google_gke_hub_feature` resource
```
