### PR TITLE
add support for internet IP health checking to routing policies

### DIFF
--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -915,6 +915,9 @@ func flattenDnsRecordSetRoutingPolicy(policy *dns.RRSetRoutingPolicy) []interfac
 	if policy.PrimaryBackup != nil {
 		p["primary_backup"] = flattenDnsRecordSetRoutingPolicyPrimaryBackup(policy.PrimaryBackup)
 	}
+	if policy.HealthCheck != "" {
+		p["health_check"] = policy.HealthCheck
+	}
 	return append(ps, p)
 }
 
@@ -949,6 +952,7 @@ func flattenDnsRecordSetHealthCheckedTargets(targets *dns.RRSetRoutingPolicyHeal
 
 	data := map[string]interface{}{
 		"internal_load_balancers": flattenDnsRecordSetInternalLoadBalancers(targets.InternalLoadBalancers),
+		"external_endpoints":      flattenDnsRecordSetExternalEndpoints(targets.ExternalEndpoints),
 	}
 
 	return []map[string]interface{}{data}
@@ -969,6 +973,10 @@ func flattenDnsRecordSetInternalLoadBalancers(ilbs []*dns.RRSetRoutingPolicyLoad
 		ilbsSchema = append(ilbsSchema, data)
 	}
 	return ilbsSchema
+}
+
+func flattenDnsRecordSetExternalEndpoints(externalEndpoints []string) []string {
+	return externalEndpoints
 }
 
 func flattenDnsRecordSetRoutingPolicyPrimaryBackup(primaryBackup *dns.RRSetRoutingPolicyPrimaryBackupPolicy) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -260,12 +260,11 @@ var geoPolicySchema *schema.Resource = &schema.Resource{
 			},
 		},
 		"health_checked_targets": {
-			Type:         schema.TypeList,
-			Optional:     true,
-			Description:  "For A and AAAA types only. The list of targets to be health checked. These can be specified along with `rrdatas` within this item.",
-			MaxItems:     1,
-			Elem:         healthCheckedTargetSchema,
-			ExactlyOneOf: []string{"routing_policy.0.wrr", "routing_policy.0.geo", "routing_policy.0.primary_backup"},
+			Type:        schema.TypeList,
+			Optional:    true,
+			Description: "For A and AAAA types only. The list of targets to be health checked. These can be specified along with `rrdatas` within this item.",
+			MaxItems:    1,
+			Elem:        healthCheckedTargetSchema,
 		},
 	},
 }

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -354,9 +354,7 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 	t.Parallel()
 
 	httpHealthCheckName := fmt.Sprintf("tf-test-http-health-check-%s", acctest.RandString(t, 10))
-	failoverZoneName := fmt.Sprintf("failover-dnszone-test-%s", acctest.RandString(t, 10))
-    wrrZoneName := fmt.Sprintf("wrr-dnszone-test-%s", acctest.RandString(t, 10))
-    geoZoneName := fmt.Sprintf("geo-dnszone-test-%s", acctest.RandString(t, 10))
+	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -366,29 +364,29 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, failoverZoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_failover",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), failoverZoneName, failoverZoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, failoverZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
             {
-				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, wrrZoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_wrr",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), wrrZoneName, wrrZoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, wrrZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
             {
-				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, geoZoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_geo",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), geoZoneName, geoZoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, geoZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
@@ -1347,7 +1345,7 @@ func testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(healthCheckName, zon
 	return fmt.Sprintf(`
 
 resource "google_compute_health_check" "health_check" {
-  name                = "%s"
+  name                = "failover-%s"
   description         = "Resource created for Terraform acceptance testing"
   check_interval_sec  = 30
   source_regions      = ["us-central1", "us-east1", "asia-south1"]
@@ -1363,8 +1361,8 @@ resource "time_sleep" "wait_4_minutes" {
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
-  name        = "%s"
-  dns_name    = "%s.hashicorptest-com."
+  name        = "failover-%s"
+  dns_name    = "failover-%s.hashicorptest-com."
   description = "Test Description"
   visibility  = "public"
 }
@@ -1373,7 +1371,7 @@ resource "google_dns_record_set" "ihc_failover" {
   depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
-  name         = "test-record.%s.hashicorptest-com."
+  name         = "test-record.failover-%s.hashicorptest-com."
   type         = "A"
   ttl          = %d
 
@@ -1413,7 +1411,7 @@ func testAccDnsRecordSet_routingPolicyInternetWRR(healthCheckName, zoneName stri
 	return fmt.Sprintf(`
 
 resource "google_compute_health_check" "health_check" {
-    name                = "%s"
+    name                = "wrr-%s"
     description         = "Resource created for Terraform acceptance testing"
     check_interval_sec  = 30
     source_regions      = ["us-central1", "us-east1", "asia-south1"]
@@ -1429,8 +1427,8 @@ resource "time_sleep" "wait_4_minutes" {
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
-  name        = "%s"
-  dns_name    = "%s.hashicorptest-com."
+  name        = "wrr-%s"
+  dns_name    = "wrr-%s.hashicorptest-com."
   description = "Test Description"
   visibility  = "public"
 }
@@ -1439,7 +1437,7 @@ resource "google_dns_record_set" "ihc_wrr" {
   depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
-  name         = "test-record.%s.hashicorptest-com."
+  name         = "test-record.wrr-%s.hashicorptest-com."
   type         = "A"
   ttl          = %d
 
@@ -1470,7 +1468,7 @@ func testAccDnsRecordSet_routingPolicyInternetGEO(healthCheckName, zoneName stri
 	return fmt.Sprintf(`
 
 resource "google_compute_health_check" "health_check" {
-    name                = "%s"
+    name                = "geo-%s"
     description         = "Resource created for Terraform acceptance testing"
     check_interval_sec  = 30
     source_regions      = ["us-central1", "us-east1", "asia-south1"]
@@ -1486,8 +1484,8 @@ resource "time_sleep" "wait_4_minutes" {
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
-  name        = "%s"
-  dns_name    = "%s.hashicorptest-com."
+  name        = "geo-%s"
+  dns_name    = "geo-%s.hashicorptest-com."
   description = "Test Description"
   visibility  = "public"
 }
@@ -1496,7 +1494,7 @@ resource "google_dns_record_set" "ihc_geo" {
   depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
-  name         = "test-record.%s.hashicorptest-com."
+  name         = "test-record.geo-%s.hashicorptest-com."
   type         = "A"
   ttl          = %d
 

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -1356,10 +1356,10 @@ resource "google_compute_health_check" "health_check" {
   }
 }
 
-resource "time_sleep" "wait_2_minutes" {
+resource "time_sleep" "wait_4_minutes" {
   depends_on = [google_compute_health_check.health_check]
   # need to wait for destruction due to 'still in use' error from api
-  destroy_duration = "2m"
+  destroy_duration = "4m"
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
@@ -1370,7 +1370,7 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_failover" {
-  depends_on = [time_sleep.wait_2_minutes]
+  depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
@@ -1422,10 +1422,10 @@ resource "google_compute_health_check" "health_check" {
     }
 }
 
-resource "time_sleep" "wait_2_minutes" {
+resource "time_sleep" "wait_4_minutes" {
   depends_on = [google_compute_health_check.health_check]
   # need to wait for destruction due to 'still in use' error from api
-  destroy_duration = "2m"
+  destroy_duration = "4m"
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
@@ -1436,7 +1436,7 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_wrr" {
-  depends_on = [time_sleep.wait_2_minutes]
+  depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
@@ -1479,10 +1479,10 @@ resource "google_compute_health_check" "health_check" {
     }
 }
 
-resource "time_sleep" "wait_2_minutes" {
+resource "time_sleep" "wait_4_minutes" {
   depends_on = [google_compute_health_check.health_check]
   # need to wait for destruction due to 'still in use' error from api
-  destroy_duration = "2m"
+  destroy_duration = "4m"
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
@@ -1493,7 +1493,7 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_geo" {
-  depends_on = [time_sleep.wait_2_minutes]
+  depends_on = [time_sleep.wait_4_minutes]
 
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -360,6 +360,9 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+        ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -354,36 +354,38 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 	t.Parallel()
 
 	httpHealthCheckName := fmt.Sprintf("tf-test-http-health-check-%s", acctest.RandString(t, 10))
-	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
+	failoverZoneName := fmt.Sprintf("failover-dnszone-test-%s", acctest.RandString(t, 10))
+    wrrZoneName := fmt.Sprintf("wrr-dnszone-test-%s", acctest.RandString(t, 10))
+    geoZoneName := fmt.Sprintf("geo-dnszone-test-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, zoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, failoverZoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_failover",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), failoverZoneName, failoverZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
             {
-				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, zoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, wrrZoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_wrr",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), wrrZoneName, wrrZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
             {
-				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, zoneName, 300),
+				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, geoZoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.ihc_geo",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), geoZoneName, geoZoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -346,6 +346,15 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, zoneName, 300),
+			},
+			{
+				ResourceName:  "google_dns_record_set.foobar",
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:   true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1295,6 +1304,57 @@ resource "google_dns_record_set" "foobar" {
   }
 }
 `, networkName, backendSubnetName, proxySubnetName, healthCheckName, backendName, urlMapName, httpProxyName, forwardingRuleName, zoneName, zoneName, zoneName, ttl)
+}
+
+func testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(healthCheckName, zoneName string, ttl int) string {
+	return fmt.Sprintf(`
+
+resource "google_compute_health_check" "health_check" {
+    name                = "%s"
+    description         = "Resource created for Terraform acceptance testing"
+    check_interval_sec  = 30
+    source_regions      = ["us-central1", "us-east1", "asia-south1"]
+    http_health_check {
+        port          = "80"
+    }
+}
+
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest-com."
+  description = "Test Description"
+  visibility  = "public"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest-com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    health_check = google_compute_health_check.health_check.self_link
+    primary_backup {
+      trickle_ratio                  = 0.1
+      enable_geo_fencing_for_backups = true
+
+      primary {
+        external_endpoints = ["8.8.8.8"]
+      }
+
+      backup_geo {
+        location = "us-west1"
+        rrdatas  = ["1.2.3.4"]
+      }
+
+      backup_geo {
+        location = "asia-east1"
+        rrdatas  = ["5.6.7.8"]
+      }
+    }
+  }
+}
+`, healthCheckName, zoneName, zoneName, zoneName, ttl)
 }
 
 func testAccDnsRecordSet_interpolated(zoneName string) string {

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -1377,9 +1377,7 @@ resource "google_dns_record_set" "ihc_failover" {
       backup_geo {
         location = "us-central1"
         health_checked_targets {
-          internal_load_balancers {
-            external_endpoints = ["8.8.4.4"]
-          }
+          external_endpoints = ["8.8.4.4"]
         }
       }
 

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -1344,13 +1344,19 @@ func testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(healthCheckName, zon
 	return fmt.Sprintf(`
 
 resource "google_compute_health_check" "health_check" {
-    name                = "%s"
-    description         = "Resource created for Terraform acceptance testing"
-    check_interval_sec  = 30
-    source_regions      = ["us-central1", "us-east1", "asia-south1"]
-    http_health_check {
-        port          = "80"
-    }
+  name                = "%s"
+  description         = "Resource created for Terraform acceptance testing"
+  check_interval_sec  = 30
+  source_regions      = ["us-central1", "us-east1", "asia-south1"]
+  http_health_check {
+    port              = "80"
+  }
+}
+
+resource "time_sleep" "wait_2_minutes" {
+  depends_on = [google_compute_health_check.health_check]
+  # need to wait for destruction due to 'still in use' error from api
+  destroy_duration = "2m"
 }
 
 resource "google_dns_managed_zone" "parent-zone" {
@@ -1361,6 +1367,8 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_failover" {
+  depends_on = [time_sleep.wait_2_minutes]
+
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"
@@ -1411,6 +1419,12 @@ resource "google_compute_health_check" "health_check" {
     }
 }
 
+resource "time_sleep" "wait_2_minutes" {
+  depends_on = [google_compute_health_check.health_check]
+  # need to wait for destruction due to 'still in use' error from api
+  destroy_duration = "2m"
+}
+
 resource "google_dns_managed_zone" "parent-zone" {
   name        = "%s"
   dns_name    = "%s.hashicorptest-com."
@@ -1419,6 +1433,8 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_wrr" {
+  depends_on = [time_sleep.wait_2_minutes]
+
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"
@@ -1460,6 +1476,12 @@ resource "google_compute_health_check" "health_check" {
     }
 }
 
+resource "time_sleep" "wait_2_minutes" {
+  depends_on = [google_compute_health_check.health_check]
+  # need to wait for destruction due to 'still in use' error from api
+  destroy_duration = "2m"
+}
+
 resource "google_dns_managed_zone" "parent-zone" {
   name        = "%s"
   dns_name    = "%s.hashicorptest-com."
@@ -1468,6 +1490,8 @@ resource "google_dns_managed_zone" "parent-zone" {
 }
 
 resource "google_dns_record_set" "ihc_geo" {
+  depends_on = [time_sleep.wait_2_minutes]
+
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -346,12 +346,44 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
+
+func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	httpHealthCheckName := fmt.Sprintf("tf-test-http-health-check-%s", acctest.RandString(t, 10))
+	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, zoneName, 300),
 			},
 			{
 				ResourceName:  "google_dns_record_set.foobar",
-				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:   true,
+				ImportStateVerify: true,
+			},
+            {
+				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, zoneName, 300),
+			},
+			{
+				ResourceName:  "google_dns_record_set.foobar",
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
+				ImportState:   true,
+				ImportStateVerify: true,
+			},
+            {
+				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, zoneName, 300),
+			},
+			{
+				ResourceName:  "google_dns_record_set.foobar",
+				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
 			},
@@ -1343,6 +1375,15 @@ resource "google_dns_record_set" "foobar" {
       }
 
       backup_geo {
+        location = "us-central1"
+        health_checked_targets {
+          internal_load_balancers {
+            external_endpoints = ["8.8.4.4"]
+          }
+        }
+      }
+
+      backup_geo {
         location = "us-west1"
         rrdatas  = ["1.2.3.4"]
       }
@@ -1350,6 +1391,104 @@ resource "google_dns_record_set" "foobar" {
       backup_geo {
         location = "asia-east1"
         rrdatas  = ["5.6.7.8"]
+      }
+    }
+  }
+}
+`, healthCheckName, zoneName, zoneName, zoneName, ttl)
+}
+
+func testAccDnsRecordSet_routingPolicyInternetWRR(healthCheckName, zoneName string, ttl int) string {
+	return fmt.Sprintf(`
+
+resource "google_compute_health_check" "health_check" {
+    name                = "%s"
+    description         = "Resource created for Terraform acceptance testing"
+    check_interval_sec  = 30
+    source_regions      = ["us-central1", "us-east1", "asia-south1"]
+    http_health_check {
+        port          = "80"
+    }
+}
+
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest-com."
+  description = "Test Description"
+  visibility  = "public"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest-com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    health_check = google_compute_health_check.health_check.self_link
+
+    wrr {
+      weight = 1.0
+
+      health_checked_targets {
+        external_endpoints = ["8.8.8.8"]
+      }
+    }
+
+    wrr {
+      weight = 0.5
+
+      health_checked_targets {
+        external_endpoints = ["8.8.4.4"]
+      }
+    }
+  }
+}
+`, healthCheckName, zoneName, zoneName, zoneName, ttl)
+}
+
+func testAccDnsRecordSet_routingPolicyInternetGEO(healthCheckName, zoneName string, ttl int) string {
+	return fmt.Sprintf(`
+
+resource "google_compute_health_check" "health_check" {
+    name                = "%s"
+    description         = "Resource created for Terraform acceptance testing"
+    check_interval_sec  = 30
+    source_regions      = ["us-central1", "us-east1", "asia-south1"]
+    http_health_check {
+        port          = "80"
+    }
+}
+
+resource "google_dns_managed_zone" "parent-zone" {
+  name        = "%s"
+  dns_name    = "%s.hashicorptest-com."
+  description = "Test Description"
+  visibility  = "public"
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.parent-zone.name
+  name         = "test-record.%s.hashicorptest-com."
+  type         = "A"
+  ttl          = %d
+
+  routing_policy {
+    health_check = google_compute_health_check.health_check.self_link
+
+    geo {
+      location = "us-east1"
+
+      health_checked_targets {
+        external_endpoints = ["8.8.8.8"]
+      }
+    }
+
+    geo {
+      location = "us-west1"
+
+      health_checked_targets {
+        external_endpoints = ["8.8.4.4"]
       }
     }
   }

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -364,7 +364,7 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyInternetPrimaryBackup(httpHealthCheckName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.ihc_failover",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -373,7 +373,7 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyInternetWRR(httpHealthCheckName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.ihc_wrr",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -382,7 +382,7 @@ func TestAccDNSRecordSet_routingPolicyInternetHealthCheck(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyInternetGEO(httpHealthCheckName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.ihc_geo",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest-com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -1358,7 +1358,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility  = "public"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "ihc_failover" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"
@@ -1418,7 +1418,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility  = "public"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "ihc_wrr" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"
@@ -1467,7 +1467,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility  = "public"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "ihc_geo" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest-com."
   type         = "A"

--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -279,7 +279,6 @@ resource "google_dns_managed_zone" "zone" {
 }
 
 resource "google_compute_health_check" "health_check" {
-  provider            = "google-beta"
   name                = "health-check"
   check_interval_sec  = 30
   source_regions      = ["us-central1", "us-east1", "asia-south1"]


### PR DESCRIPTION
Adds support for internet IP address health checking to routing policies in public managed zones.

b/384932633 b/352032481

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dns: added `routing_policy.health_check` and `health_checked_targets.external_endpoints` to `google_dns_record_set`
```
