### PR TITLE
give meaningful names to rrsets in routing policy tests

### DIFF
--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -296,7 +296,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyWRR(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:      "google_dns_record_set.foobar",
+				ResourceName:      "google_dns_record_set.wrr",
 				ImportStateId:     fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -305,7 +305,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyGEO(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.geo",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -314,7 +314,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyPrimaryBackup(networkName, backendName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.failover",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -323,7 +323,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyRegionalL7PrimaryBackup(networkName, proxySubnetName, httpHealthCheckName, backendName, urlMapName, httpProxyName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.rl7_failover",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -332,7 +332,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyRegionalL7PrimaryBackupMultipleNoLbType(networkName, proxySubnetName, httpHealthCheckName, backendName, urlMapName, httpProxyName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.implicit_rl7_failover",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -341,7 +341,7 @@ func TestAccDNSRecordSet_routingPolicy(t *testing.T) {
 				Config: testAccDnsRecordSet_routingPolicyCrossRegionL7PrimaryBackup(networkName, backendSubnetName, proxySubnetName, httpHealthCheckName, backendName, urlMapName, httpProxyName, forwardingRuleName, zoneName, 300),
 			},
 			{
-				ResourceName:  "google_dns_record_set.foobar",
+				ResourceName:  "google_dns_record_set.gl7_failover",
 				ImportStateId: fmt.Sprintf("%s/%s/test-record.%s.hashicorptest.com./A", envvar.GetTestProjectFromEnv(), zoneName, zoneName),
 				ImportState:   true,
 				ImportStateVerify: true,
@@ -801,7 +801,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "wrr" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"
@@ -867,7 +867,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "geo" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"
@@ -935,7 +935,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "failover" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"
@@ -1036,7 +1036,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "rl7_failover" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"
@@ -1149,7 +1149,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "implicit_rl7_failover" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"
@@ -1260,7 +1260,7 @@ resource "google_dns_managed_zone" "parent-zone" {
   visibility = "private"
 }
 
-resource "google_dns_record_set" "foobar" {
+resource "google_dns_record_set" "gl7_failover" {
   managed_zone = google_dns_managed_zone.parent-zone.name
   name         = "test-record.%s.hashicorptest.com."
   type         = "A"


### PR DESCRIPTION
Fix routing policy tests for `google_dns_record_set`

These tests were failing during development of #12684. 

There's no changes here to the actual resource.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
