### PR TITLE
convert databaseVersion enum to string

### DIFF
--- a/mmv1/products/sql/SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/SourceRepresentationInstance.yaml
@@ -66,20 +66,10 @@ properties:
     required: false
     default_from_api: true
   - name: 'databaseVersion'
-    type: Enum
+    type: String
     description: |
-      The MySQL version running on your source database server.
+      The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.
     required: true
-    enum_values:
-      - 'MYSQL_5_6'
-      - 'MYSQL_5_7'
-      - 'MYSQL_8_0'
-      - 'POSTGRES_9_6'
-      - 'POSTGRES_10'
-      - 'POSTGRES_11'
-      - 'POSTGRES_12'
-      - 'POSTGRES_13'
-      - 'POSTGRES_14'
   - name: 'onPremisesConfiguration'
     type: NestedObject
     description: |

--- a/mmv1/products/sql/SourceRepresentationInstance.yaml
+++ b/mmv1/products/sql/SourceRepresentationInstance.yaml
@@ -68,7 +68,7 @@ properties:
   - name: 'databaseVersion'
     type: String
     description: |
-      The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.
+      The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17. Database Version Policies includes an up-to-date reference of supported versions.
     required: true
   - name: 'onPremisesConfiguration'
     type: NestedObject


### PR DESCRIPTION
This change updates the `databaseVersion` field to accept strings instead of enums. This allows users to specify new database versions that are available in the cloud but not yet defined in the provider.

## With this change:

The databaseVersion field will use string values (keeping the user interface the same). Users will be able to utilize the latest database versions available in the cloud without waiting for provider updates.

## Addresses:

 - [#18896](https://github.com/hashicorp/terraform-provider-google/issues/18896)
 - [#14928](https://github.com/hashicorp/terraform-provider-google/issues/14928)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: `sql_source_representation_instance` now uses `string` representation of `databaseVersion`
```
