### PR TITLE
Add Terraform Support for GKE Auto-Monitoring

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1267,14 +1267,30 @@ func ResourceContainerCluster() *schema.Resource {
 							MaxItems:    1,
 							Description: `Configuration for Google Cloud Managed Services for Prometheus.`,
 							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type:        schema.TypeBool,
-										Required:    true,
-										Description: `Whether or not the managed collection is enabled.`,
-									},
-								},
-							},
+									        	Schema: map[string]*schema.Schema{
+						            		"enabled": {
+						                		Type:        schema.TypeBool,
+						                		Required:    true,
+						                		Description: `Whether or not the managed collection is enabled.`,
+						            		},
+						            		"auto_monitoring_config": {
+						                		Type:        schema.TypeSet,
+						                		Optional:    true,
+						                		MaxItems:    1,
+						                		Description: `Configuration for GKE Workload Auto-Monitoring.`,
+						                		Elem: &schema.Resource{
+						                    			Schema: map[string]*schema.Schema{
+						                       				"scope": {
+						                            				Type:         schema.TypeString,
+						                            				Required:     true,
+						                            				Description:  `The scope of auto-monitoring.`,
+						                            				ValidateFunc: validation.StringInSlice([]string{"ALL", "NONE"}, false),
+						                        			},
+						                    			},
+						                		},
+						           		},
+						        	},
+						    	},
 						},
 						"advanced_datapath_observability_config": {
 							Type:        schema.TypeList,
@@ -5894,6 +5910,14 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
+		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok && len(autoMonitoring.([]interface{})) > 0 {
+			autoMonitoringConfig := autoMonitoring.([]interface{})[0].(map[string]interface{})
+			if scope, ok := autoMonitoringConfig["scope"].(string); ok {
+				mc.ManagedPrometheusConfig.AutoMonitoringConfig = &container.AutoMonitoringConfig {
+					Scope: scope,
+				}
+			}
+		}
 	}
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
@@ -6871,11 +6895,23 @@ func flattenAdvancedDatapathObservabilityConfig(c *container.AdvancedDatapathObs
 }
 
 func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[string]interface{} {
-	return []map[string]interface{}{
-		{
-			"enabled": c != nil && c.Enabled,
-		},
-	}
+        if c == nil {
+                return nil
+        }
+
+        result := make(map[string]interface{})
+
+        result["enabled"] = c.Enabled
+
+        if c.AutoMonitoringConfig != nil {
+                autoMonitoringMap := make(map[string]interface{})
+                if c.AutoMonitoringConfig.Scope != "" {
+                        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
+                }
+                result["auto_monitoring_config"] = autoMonitoringMap
+        }
+
+        return []map[string]interface{}{result}
 }
 
 func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6913,13 +6913,18 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
         result["enabled"] = c.Enabled
 
 	{{- if ne $.TargetVersionName "ga" }}								
-        if c.AutoMonitoringConfig != nil {
-                autoMonitoringMap := make(map[string]interface{})
-                if c.AutoMonitoringConfig.Scope != "" {
-                        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
-                }
-                result["auto_monitoring_config"] = autoMonitoringMap
-        }
+	if c.AutoMonitoringConfig != nil {
+	    autoMonitoringMap := make(map[string]interface{})
+	    if c.AutoMonitoringConfig.Scope != "" {
+	        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
+	    }
+	
+	    if set, ok := c.AutoMonitoringConfig.(*schema.Set); ok {
+	        result["auto_monitoring_config"] = set
+	    } else {
+	        result["auto_monitoring_config"] = autoMonitoringMap
+	    }
+	}
 	{{- end }}
 
         return []map[string]interface{}{result}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5913,13 +5913,18 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
 		{{- if ne $.TargetVersionName "ga" }}
-		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok && len(autoMonitoring.([]interface{})) > 0 {
-			autoMonitoringConfig := autoMonitoring.([]interface{})[0].(map[string]interface{})
-			if scope, ok := autoMonitoringConfig["scope"].(string); ok {
-				mc.ManagedPrometheusConfig.AutoMonitoringConfig = &container.AutoMonitoringConfig {
-					Scope: scope,
-				}
-			}
+		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok {
+		    if autoMonitoringSet, ok := autoMonitoring.(*schema.Set); ok {
+		        autoMonitoringList := autoMonitoringSet.List()
+		        if len(autoMonitoringList) > 0 {
+		            autoMonitoringConfig := autoMonitoringList[0].(map[string]interface{})
+		            if scope, ok := autoMonitoringConfig["scope"].(string); ok {
+		                mc.ManagedPrometheusConfig.AutoMonitoringConfig = &container.AutoMonitoringConfig{
+		                    Scope: scope,
+		                }
+		            }
+		        }
+		    }
 		}
 		{{- end }}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6912,21 +6912,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
 
         result["enabled"] = c.Enabled
 
-	{{- if ne $.TargetVersionName "ga" }}								
-	if c.AutoMonitoringConfig != nil {
-	    autoMonitoringMap := make(map[string]interface{})
-	    if c.AutoMonitoringConfig.Scope != "" {
-	        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
-	    }
-	
-	    if set, ok := c.AutoMonitoringConfig.(*schema.Set); ok {
-	        result["auto_monitoring_config"] = set
-	    } else {
-	        result["auto_monitoring_config"] = autoMonitoringMap
-	    }
-	}
-	{{- end }}
-
 	{{- if ne $.TargetVersionName "ga" }}
 	if c.AutoMonitoringConfig != nil {
 	    autoMonitoringMap := make(map[string]interface{})

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6927,6 +6927,23 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
 	}
 	{{- end }}
 
+	{{- if ne $.TargetVersionName "ga" }}
+	if c.AutoMonitoringConfig != nil {
+	    autoMonitoringMap := make(map[string]interface{})
+	    if c.AutoMonitoringConfig.Scope != "" {
+	        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
+	    }
+	
+	    // Constructing a schema.Set using NewSet 
+	    set := schema.NewSet(schema.HashString, []interface{}{})
+	    if c.AutoMonitoringConfig.Scope != "" {
+	        set.Add(c.AutoMonitoringConfig.Scope)
+	    }
+	
+	    result["auto_monitoring_config"] = set
+	}
+	{{- end }}
+
         return []map[string]interface{}{result}
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1273,6 +1273,7 @@ func ResourceContainerCluster() *schema.Resource {
 						                		Required:    true,
 						                		Description: `Whether or not the managed collection is enabled.`,
 						            		},
+									{{- if ne $.TargetVersionName "ga" }}
 						            		"auto_monitoring_config": {
 						                		Type:        schema.TypeSet,
 						                		Optional:    true,
@@ -1289,6 +1290,7 @@ func ResourceContainerCluster() *schema.Resource {
 						                    			},
 						                		},
 						           		},
+									{{- end }}
 						        	},
 						    	},
 						},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6904,32 +6904,23 @@ func flattenAdvancedDatapathObservabilityConfig(c *container.AdvancedDatapathObs
 }
 
 func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[string]interface{} {
-        if c == nil {
-                return nil
+    if c == nil {
+        return nil
+    }
+
+    result := make(map[string]interface{})
+    result["enabled"] = c.Enabled
+
+    {{- if ne $.TargetVersionName "ga" }}
+    if c.AutoMonitoringConfig != nil && c.AutoMonitoringConfig.Scope != "" {
+        autoMonitoringMap := map[string]interface{}{
+            "scope": c.AutoMonitoringConfig.Scope,
         }
+        result["auto_monitoring_config"] = []interface{}{autoMonitoringMap}
+    }
+    {{- end }}
 
-        result := make(map[string]interface{})
-
-        result["enabled"] = c.Enabled
-
-	{{- if ne $.TargetVersionName "ga" }}
-	if c.AutoMonitoringConfig != nil {
-	    autoMonitoringMap := make(map[string]interface{})
-	    if c.AutoMonitoringConfig.Scope != "" {
-	        autoMonitoringMap["scope"] = c.AutoMonitoringConfig.Scope
-	    }
-	
-	    // Constructing a schema.Set using NewSet 
-	    set := schema.NewSet(schema.HashString, []interface{}{})
-	    if c.AutoMonitoringConfig.Scope != "" {
-	        set.Add(c.AutoMonitoringConfig.Scope)
-	    }
-	
-	    result["auto_monitoring_config"] = set
-	}
-	{{- end }}
-
-        return []map[string]interface{}{result}
+    return []map[string]interface{}{result}
 }
 
 func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5915,11 +5915,10 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		}
 		{{- if ne $.TargetVersionName "ga" }}
 		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok {
-		    if autoMonitoringSet, ok := autoMonitoring.(*schema.Set); ok {
-		        autoMonitoringList := autoMonitoringSet.List()
+		    if autoMonitoringList, ok := autoMonitoring.([]interface{}); ok {
 		        if len(autoMonitoringList) > 0 {
 		            autoMonitoringConfig := autoMonitoringList[0].(map[string]interface{})
-		            if scope, ok := autoMonitoringConfig["scope"].(string); ok {
+		            if scope, ok := autoMonitoringConfig["scope"].(string); ok && scope != "" {
 		                mc.ManagedPrometheusConfig.AutoMonitoringConfig = &container.AutoMonitoringConfig{
 		                    Scope: scope,
 		                }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6912,12 +6912,15 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
     result["enabled"] = c.Enabled
 
     {{- if ne $.TargetVersionName "ga" }}
+    autoMonitoringList := []map[string]interface{}{}
     if c.AutoMonitoringConfig != nil && c.AutoMonitoringConfig.Scope != "" {
         autoMonitoringMap := map[string]interface{}{
             "scope": c.AutoMonitoringConfig.Scope,
         }
-        result["auto_monitoring_config"] = []interface{}{autoMonitoringMap}
+        autoMonitoringList = append(autoMonitoringList, autoMonitoringMap)
     }
+
+    result["auto_monitoring_config"] = autoMonitoringList
     {{- end }}
 
     return []map[string]interface{}{result}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1268,31 +1268,31 @@ func ResourceContainerCluster() *schema.Resource {
 							Description: `Configuration for Google Cloud Managed Services for Prometheus.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-						            		"enabled": {
-						                		Type:        schema.TypeBool,
-						                		Required:    true,
-						                		Description: `Whether or not the managed collection is enabled.`,
-						            		},
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether or not the managed collection is enabled.`,
+									},
 									{{- if ne $.TargetVersionName "ga" }}
-						            		"auto_monitoring_config": {
-						                		Type:        schema.TypeSet,
-						                		Optional:    true,
-						                		MaxItems:    1,
-						                		Description: `Configuration for GKE Workload Auto-Monitoring.`,
-						                		Elem: &schema.Resource{
-						                    			Schema: map[string]*schema.Schema{
-						                       				"scope": {
-						                            				Type:         schema.TypeString,
-						                            				Required:     true,
-						                            				Description:  `The scope of auto-monitoring.`,
-						                            				ValidateFunc: validation.StringInSlice([]string{"ALL", "NONE"}, false),
-						                        			},
-						                    			},
-						                		},
-						           		},
+									"auto_monitoring_config": {
+										Type:        schema.TypeSet,
+										Optional:    true,
+										MaxItems:    1,
+										Description: `Configuration for GKE Workload Auto-Monitoring.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"scope": {
+													Type:         schema.TypeString,
+													Required:     true,
+													Description:  `The scope of auto-monitoring.`,
+													ValidateFunc: validation.StringInSlice([]string{"ALL", "NONE"}, false),
+												},
+											},
+										},
+									},
 									{{- end }}
-						        	},
-						    	},
+								},
+							},
 						},
 						"advanced_datapath_observability_config": {
 							Type:        schema.TypeList,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1267,7 +1267,7 @@ func ResourceContainerCluster() *schema.Resource {
 							MaxItems:    1,
 							Description: `Configuration for Google Cloud Managed Services for Prometheus.`,
 							Elem: &schema.Resource{
-									        	Schema: map[string]*schema.Schema{
+								Schema: map[string]*schema.Schema{
 						            		"enabled": {
 						                		Type:        schema.TypeBool,
 						                		Required:    true,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5912,6 +5912,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
+		{{- if ne $.TargetVersionName "ga" }}
 		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok && len(autoMonitoring.([]interface{})) > 0 {
 			autoMonitoringConfig := autoMonitoring.([]interface{})[0].(map[string]interface{})
 			if scope, ok := autoMonitoringConfig["scope"].(string); ok {
@@ -5920,6 +5921,7 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 				}
 			}
 		}
+		{{- end }}
 	}
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
@@ -6905,6 +6907,7 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
 
         result["enabled"] = c.Enabled
 
+	{{- if ne $.TargetVersionName "ga" }}								
         if c.AutoMonitoringConfig != nil {
                 autoMonitoringMap := make(map[string]interface{})
                 if c.AutoMonitoringConfig.Scope != "" {
@@ -6912,6 +6915,7 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
                 }
                 result["auto_monitoring_config"] = autoMonitoringMap
         }
+	{{- end }}
 
         return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1275,8 +1275,9 @@ func ResourceContainerCluster() *schema.Resource {
 									},
 									{{- if ne $.TargetVersionName "ga" }}
 									"auto_monitoring_config": {
-										Type:        schema.TypeSet,
+										Type:        schema.TypeList,
 										Optional:    true,
+										Computed:    true,
 										MaxItems:    1,
 										Description: `Configuration for GKE Workload Auto-Monitoring.`,
 										Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3966,6 +3966,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
+			{{- if ne $.TargetVersionName "ga" }}
 			{
 				Config: testAccContainerCluster_withMonitoringConfigScopeAll(clusterName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
@@ -3990,6 +3991,7 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
+			{{- end }}
 			// Back to basic settings to test setting Prometheus on its own
 			{
 				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
@@ -10810,6 +10812,7 @@ resource "google_container_cluster" "primary" {
 `, name, networkName, subnetworkName)
 }
 
+{{- if ne $.TargetVersionName "ga" }}								
 func testAccContainerCluster_withMonitoringConfigScopeAll(name, networkName, subnetworkName string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -10851,6 +10854,7 @@ resource "google_container_cluster" "primary" {
 }
 `, name, networkName, subnetworkName)
 }
+{{- end }}
 
 func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigEnabled(name string) string {
        return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -10740,9 +10740,6 @@ resource "google_container_cluster" "primary" {
     enable_components = ["SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER"]
     managed_prometheus {
       enabled = true
-      auto_monitoring_config {
-        scope = "ALL" 
-      }
     }
   }
   deletion_protection = false
@@ -10762,9 +10759,6 @@ resource "google_container_cluster" "primary" {
     enable_components = []
     managed_prometheus {
       enabled = true
-      auto_monitoring_config {
-        scope = "ALL"
-      }
     }
   }
   deletion_protection = false
@@ -10783,8 +10777,47 @@ resource "google_container_cluster" "primary" {
   monitoring_config {
     managed_prometheus {
       enabled = true
+    }
+  }
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+`, name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withMonitoringConfigScopeAll(name, networkName, subnetworkName string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+    managed_prometheus {
+      enabled = true
       auto_monitoring_config {
         scope = "ALL"
+      }
+    }
+  }
+  deletion_protection = false
+  network             = "%s"
+  subnetwork          = "%s"
+}
+`, name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withMonitoringConfigScopeNone(name, networkName, subnetworkName string) string {
+       return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  monitoring_config {
+    managed_prometheus {
+      enabled = true
+      auto_monitoring_config {
+        scope = "NONE"
       }
     }
   }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -10783,6 +10783,9 @@ resource "google_container_cluster" "primary" {
   monitoring_config {
     managed_prometheus {
       enabled = true
+      auto_monitoring_config {
+        scope = "ALL"
+      }
     }
   }
   deletion_protection = false

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -10740,6 +10740,9 @@ resource "google_container_cluster" "primary" {
     enable_components = ["SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER"]
     managed_prometheus {
       enabled = true
+      auto_monitoring_config {
+        scope = "ALL" 
+      }
     }
   }
   deletion_protection = false
@@ -10759,6 +10762,9 @@ resource "google_container_cluster" "primary" {
     enable_components = []
     managed_prometheus {
       enabled = true
+      auto_monitoring_config {
+        scope = "ALL"
+      }
     }
   }
   deletion_protection = false

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3966,6 +3966,30 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigScopeAll(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "monitoring_config.0.managed_prometheus.0.auto_monitoring_config.0.scope", "ALL"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withMonitoringConfigScopeNone(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "monitoring_config.0.managed_prometheus.0.auto_monitoring_config.0.scope", "NONE"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
+			},
 			// Back to basic settings to test setting Prometheus on its own
 			{
 				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -663,6 +663,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
+* `auto_monitoring_config` - (Optional) Configuration for Auto-Monitoring which includes a `Scope` field (string). Supported values include: `ALL` and `NONE`.
 
 <a name="nested_advanced_datapath_observability_config"></a>The `advanced_datapath_observability_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -663,7 +663,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
-* `auto_monitoring_config` - (Optional) Configuration for Auto-Monitoring which includes a `Scope` field (string). Supported values include: `ALL` and `NONE`.
+* `auto_monitoring_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for GKE Auto-Monitoring which includes a `Scope` field (string). Supported values include: `ALL` and `NONE`.
 
 <a name="nested_advanced_datapath_observability_config"></a>The `advanced_datapath_observability_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -663,7 +663,11 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
-* `auto_monitoring_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for GKE Auto-Monitoring which includes a `Scope` field (string). Supported values include: `ALL` and `NONE`.
+* `auto_monitoring_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for GKE Auto-Monitoring.
+
+<a name="auto_monitoring_config"></a>The `auto_monitoring_config` block supports:
+
+* `scope` - (Required) Whether or not to enable GKE Auto-Monitoring. Supported values include: `ALL`, `NONE`.  
 
 <a name="nested_advanced_datapath_observability_config"></a>The `advanced_datapath_observability_config` block supports:
 


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
container: added `auto_monitoring_config` field and subfields to the `google_container_cluster` resource to allow auto-monitoring scope to be configured.)
```

Enable Terraform support for GKE Auto-Monitoring for `google_container_resource`.