### PR TITLE
Fix breaking-change unit test

### DIFF
--- a/.github/workflows/unit-test-tools.yml
+++ b/.github/workflows/unit-test-tools.yml
@@ -5,6 +5,7 @@ permissions: read-all
 on:
   pull_request:
     paths:
+      - 'docs/**'
       - 'tools/**'
       - '.github/workflows/unit-test-tools.yml'
 

--- a/tools/diff-processor/breaking_changes/breaking_changes.go
+++ b/tools/diff-processor/breaking_changes/breaking_changes.go
@@ -14,7 +14,7 @@ type BreakingChange struct {
 	RuleName               string
 }
 
-const breakingChangesPath = "develop/breaking-changes/breaking-changes"
+const breakingChangesPath = "breaking-changes/breaking-changes"
 
 func NewBreakingChange(message, identifier string) BreakingChange {
 	return BreakingChange{

--- a/tools/diff-processor/breaking_changes/breaking_changes_test.go
+++ b/tools/diff-processor/breaking_changes/breaking_changes_test.go
@@ -94,7 +94,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Resource `google-x` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-map-resource-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-map-resource-removal-or-rename",
 				},
 			},
 		},
@@ -118,7 +118,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-b` within resource `google-x` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
 				},
 			},
 		},
@@ -143,7 +143,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a` changed from optional to required on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-optional-to-required",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-optional-to-required",
 				},
 			},
 		},
@@ -167,11 +167,11 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a` changed from optional to required on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-optional-to-required",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-optional-to-required",
 				},
 				{
 					Message:                "Field `field-b` within resource `google-x` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
 				},
 			},
 		},
@@ -200,15 +200,15 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a` changed from optional to required on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-optional-to-required",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-optional-to-required",
 				},
 				{
 					Message:                "Field `field-b` within resource `google-x` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
 				},
 				{
 					Message:                "Resource `google-y` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-map-resource-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-map-resource-removal-or-rename",
 				},
 			},
 		},
@@ -254,7 +254,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a.sub-field-2` within resource `google-x` was either removed or renamed",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#resource-schema-field-removal-or-rename",
 				},
 			},
 		},
@@ -299,7 +299,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a.sub-field-1` MinItems went from 100 to 25 on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-shrinking-max",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-shrinking-max",
 				},
 			},
 		},
@@ -344,7 +344,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a.sub-field-1` MinItems went from 100 to 25 on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-shrinking-max",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-shrinking-max",
 				},
 			},
 		},
@@ -375,7 +375,7 @@ func TestComputeBreakingChanges(t *testing.T) {
 			wantViolations: []BreakingChange{
 				{
 					Message:                "Field `field-a` MinItems went from 1 to 4 on `google-x`",
-					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/develop/breaking-changes/breaking-changes#field-growing-min",
+					DocumentationReference: "https://googlecloudplatform.github.io/magic-modules/breaking-changes/breaking-changes#field-growing-min",
 				},
 			},
 		},


### PR DESCRIPTION
File moved locations and broke this unit test.

https://github.com/GoogleCloudPlatform/magic-modules/commit/e831a6f681562d82794af71180e36fc9b568224a#diff-b30349d65d27b0d96a63a15ae2817c20b423cc8c2d9cf16cc6d43670da8810e2

unit test is needed because we link to relative locations in the breaking-change file. This test ensures those <a> tags exist with the appropriate id we index into. 


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
