### PR TITLE
Add Terraform support for the Security Gateway resource

### DIFF
--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -1,0 +1,124 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: SecurityGateway
+description: Deployment of Security Gateway.
+base_url: projects/{{project}}/locations/{{location}}/securityGateways
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+create_url: projects/{{project}}/locations/{{location}}/securityGateways?securityGatewayId={{security_gateway_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+import_format:
+- projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+examples:
+- name: beyondcorp_security_gateway_basic
+  primary_resource_id: example
+  vars:
+    security_gateway_name: default
+autogen_async: true
+async:
+  operation:
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
+    base_url: '{{op_id}}'
+  actions:
+  - create
+  - delete
+  - update
+  type: OpAsync
+  result:
+    resource_inside_response: true
+  error: {}
+  include_project: false
+autogen_status: U2VjdXJpdHlHYXRld2F5
+parameters:
+- name: location
+  type: String
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+  required: true
+- name: securityGatewayId
+  type: String
+  description: |-
+    Optional. User-settable SecurityGateway resource ID.
+    * Must start with a letter.
+    * Must contain between 4-63 characters from `/a-z-/`.
+    * Must end with a number or letter.
+  immutable: true
+  url_param_only: true
+  required: true
+properties:
+- name: state
+  type: String
+  description: |-
+    Output only. The operational state of the SecurityGateway.
+    Possible values:
+    STATE_UNSPECIFIED
+    CREATING
+    UPDATING
+    DELETING
+    RUNNING
+    DOWN
+    ERROR
+  output: true
+- name: updateTime
+  type: String
+  description: Output only. Timestamp when the resource was last modified.
+  output: true
+- name: createTime
+  type: String
+  description: Output only. Timestamp when the resource was created.
+  output: true
+- name: hubs
+  type: Map
+  description: |-
+    Optional. Map of Hubs that represents regional data path deployment with GCP region
+    as a key.
+  key_name: region
+  key_description: The region to deploy the hub in.
+  value_type:
+    name: Hub
+    type: NestedObject
+    properties:
+      - name: internet_gateway
+        type: NestedObject
+        description: Internet Gateway configuration.
+        properties:
+          - name: assigned_ips
+            type: Array
+            description: Output only. List of IP addresses assigned to the Cloud NAT.
+            output: true
+            item_type:
+              type: String
+- name: displayName
+  type: String
+  description: |-
+    Optional. An arbitrary user-provided name for the SecurityGateway.
+    Cannot exceed 64 characters.
+- name: externalIps
+  type: Array
+  description: |-
+    Output only. IP addresses that will be used for establishing
+    connection to the endpoints.
+  output: true
+  item_type:
+    type: String
+- name: name
+  type: String
+  description: Identifier. Name of the resource.
+  output: true

--- a/mmv1/templates/terraform/examples/beyondcorp_security_gateway_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/beyondcorp_security_gateway_basic.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_beyondcorp_security_gateway" "{{$.PrimaryResourceId}}" {
+  security_gateway_id = "{{index $.Vars "security_gateway_name"}}"
+  location = "global"
+  display_name = "My Security Gateway resource"
+  hubs { region = "us-central1" }
+}

--- a/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_security_gateway_test.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_security_gateway_test.go
@@ -1,0 +1,70 @@
+package beyondcorp_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_beyondcorp_security_gateway.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "security_gateway_id"},
+			},
+			{
+				Config: testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_beyondcorp_security_gateway.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_beyondcorp_security_gateway.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "security_gateway_id"},
+			},
+		},
+	})
+}
+
+func testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_beyondcorp_security_gateway" "example" {
+  security_gateway_id = "default%{random_suffix}"
+  location = "global"
+  display_name = "My Security Gateway resource"
+  hubs { region = "us-central1" }
+}
+`, context)
+}
+
+func testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_beyondcorp_security_gateway" "example" {
+  security_gateway_id = "default%{random_suffix}"
+  location = "global"
+  display_name = "My Security Gateway resource"
+  hubs { region = "us-east1" }
+}
+`, context)
+}


### PR DESCRIPTION
Adding support for the Security Gateway resource from the Beyondcorp API.

```release-note:REPLACEME
`google_beyondcorp_security_gateway`
```
