### PR TITLE
Cloud Router Standard BPS Terraform Beta to GA support

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -60,21 +60,18 @@ examples:
       project: 'PROJECT_NAME'
   - name: 'network_bgp_best_path_selection_mode'
     primary_resource_id: 'vpc_network'
-    min_version: 'beta'
     vars:
       network_name: 'vpc-network'
     test_env_vars:
       project: 'PROJECT_NAME'
   - name: 'network_bgp_best_path_selection_mode_standard'
     primary_resource_id: 'vpc_network'
-    min_version: 'beta'
     vars:
       network_name: 'vpc-network'
     test_env_vars:
       project: 'PROJECT_NAME'
   - name: 'network_bgp_best_path_selection_mode_standard_custom_fields'
     primary_resource_id: 'vpc_network'
-    min_version: 'beta'
     vars:
       network_name: 'vpc-network'
     test_env_vars:
@@ -168,7 +165,6 @@ properties:
         type: Enum
         description: |
          The BGP best selection algorithm to be employed. MODE can be LEGACY or STANDARD.
-        min_version: 'beta'
         default_from_api: true
         update_url: 'projects/{{project}}/global/networks/{{name}}'
         update_verb: 'PATCH'
@@ -180,7 +176,6 @@ properties:
         description: |
          Enables/disables the comparison of MED across routes with different Neighbor ASNs.
          This value can only be set if the --bgp-best-path-selection-mode is STANDARD
-        min_version: 'beta'
         required: false
         default_from_api: true
         update_url: 'projects/{{project}}/global/networks/{{name}}'
@@ -189,7 +184,6 @@ properties:
         type: Enum
         description: |
          Choice of the behavior of inter-regional cost and MED in the BPS algorithm.
-        min_version: 'beta'
         required: false
         default_from_api: true
         update_url: 'projects/{{project}}/global/networks/{{name}}'

--- a/mmv1/products/compute/Route.yaml
+++ b/mmv1/products/compute/Route.yaml
@@ -225,19 +225,16 @@ properties:
     type: String
     description: |
       Indicates the origin of the route. Can be IGP (Interior Gateway Protocol), EGP (Exterior Gateway Protocol), or INCOMPLETE.
-    min_version: 'beta'
     output: true
   - name: 'nextHopMed'
     type: String
     description: |
       Multi-Exit Discriminator, a BGP route metric that indicates the desirability of a particular route in a network.
-    min_version: 'beta'
     output: true
   - name: 'nextHopInterRegionCost'
     type: String
     description: |
       Internal fixed region-to-region cost that Google Cloud calculates based on factors such as network performance, distance, and available bandwidth between regions.
-    min_version: 'beta'
     output: true
   - name: 'nextHopIlb'
     type: String

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
-  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
-  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"

--- a/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_bgp_best_path_selection_mode_standard_custom_fields.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_network" "{{$.PrimaryResourceId}}" {
-  provider                                  = google-beta
   project                                   = "{{index $.TestEnvVars "project"}}"
   name                                      = "{{index $.Vars "network_name"}}"
   routing_mode                              = "GLOBAL"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -112,7 +112,6 @@ func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
    t.Parallel()
 
@@ -122,7 +121,7 @@ func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -157,7 +156,7 @@ func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -193,7 +192,7 @@ func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -219,6 +218,7 @@ func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
    })
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeNetwork_networkProfile(t *testing.T) {
    t.Parallel()
 
@@ -303,7 +303,6 @@ func TestAccComputeNetwork_default_routing_mode(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeNetwork_default_bgp_best_path_selection_mode(t *testing.T) {
 	t.Parallel()
 
@@ -315,11 +314,11 @@ func TestAccComputeNetwork_default_bgp_best_path_selection_mode(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBetaNetwork_basic(networkName),
+				Config: testAccComputeNetwork_basic(networkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.bar", &network),
@@ -342,7 +341,7 @@ func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-       ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+       ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
        CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
        Steps: []resource.TestStep{
            {
@@ -357,7 +356,6 @@ func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
        },
    })
 }
-{{- end }}
 
 func TestAccComputeNetwork_networkDeleteDefaultRoute(t *testing.T) {
 	t.Parallel()
@@ -564,7 +562,6 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 	}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t *testing.T, n string, network *compute.Network, bgpBestPathSelectionMode string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -652,6 +649,7 @@ func testAccCheckComputeNetworkHasBgpInterRegionCost(t *testing.T, n string, net
    }
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
 func testAccCheckComputeNetworkHasNetworkProfile(t *testing.T, n string, network *compute.Network, networkProfile string) resource.TestCheckFunc {
    return func(s *terraform.State) error {
        config := acctest.GoogleProviderConfig(t)
@@ -747,21 +745,10 @@ resource "google_compute_network" "acc_network_routing_mode" {
 `, networkName, routingMode)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
-func testAccComputeBetaNetwork_basic(networkName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "bar" {
-  provider 				  = google-beta
-  name                    = "%s"
-  auto_create_subnetworks = true
-}
-`, networkName)
-}
 
 func testAccComputeNetwork_best_bgp_path_selection_mode(networkName, bgpBestPathSelection string) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_best_path_selection_mode" {
- provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "%s"
@@ -772,7 +759,6 @@ resource "google_compute_network" "acc_network_bgp_best_path_selection_mode" {
 func testAccComputeNetwork_bgp_always_compare_med(networkName string, bgpAlwaysCompareMed bool) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_always_compare_med" {
- provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "STANDARD"
@@ -784,7 +770,6 @@ resource "google_compute_network" "acc_network_bgp_always_compare_med" {
 func testAccComputeNetwork_bgp_inter_region_cost(networkName, bgpInterRegionCost string) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_bgp_inter_region_cost" {
- provider     = google-beta
  name         = "%s"
  routing_mode = "GLOBAL"
  bgp_best_path_selection_mode = "STANDARD"
@@ -793,6 +778,7 @@ resource "google_compute_network" "acc_network_bgp_inter_region_cost" {
 `, networkName, bgpInterRegionCost)
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeNetwork_network_profile(networkName, networkProfile string) string {
    return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_network_profile" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -129,7 +129,7 @@ func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
-					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, "LEGACY"),
+					resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_best_path_selection_mode", "bgp_best_path_selection_mode", "LEGACY"),
 				),
 			},
 			// Test updating the best bgp path selection field (only updatable field).
@@ -138,7 +138,7 @@ func TestAccComputeNetwork_bgpBestPathSelectionModeAndUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
-					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, "STANDARD"),
+					resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_best_path_selection_mode", "bgp_best_path_selection_mode", "STANDARD"),
 				),
 			},
            },
@@ -164,8 +164,7 @@ func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
                Check: resource.ComposeTestCheckFunc(
                    testAccCheckComputeNetworkExists(
                        t, "google_compute_network.acc_network_bgp_always_compare_med", &network),
-                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
-                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network, false),
+                   resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_always_compare_med", "bgp_always_compare_med", "false"),
                ),
            },
            // Test updating the bgpAlwaysCompareMed field (only updatable field).
@@ -174,8 +173,7 @@ func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
                Check: resource.ComposeTestCheckFunc(
                    testAccCheckComputeNetworkExists(
                        t, "google_compute_network.acc_network_bgp_always_compare_med", &network),
-                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
-                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network, true),
+                   resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_always_compare_med", "bgp_always_compare_med", "true"),
                ),
            },
        },
@@ -200,8 +198,7 @@ func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
                Check: resource.ComposeTestCheckFunc(
                    testAccCheckComputeNetworkExists(
                        t, "google_compute_network.acc_network_bgp_inter_region_cost", &network),
-                   testAccCheckComputeNetworkHasBgpInterRegionCost(
-                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network, "DEFAULT"),
+                      resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_inter_region_cost", "bgp_inter_region_cost", "DEFAULT"),
                ),
            },
            // Test updating the bgpInterRegionCost field (only updatable field).
@@ -210,8 +207,7 @@ func TestAccComputeNetwork_bgpInterRegionCostAndUpdate(t *testing.T) {
                Check: resource.ComposeTestCheckFunc(
                    testAccCheckComputeNetworkExists(
                        t, "google_compute_network.acc_network_bgp_inter_region_cost", &network),
-                   testAccCheckComputeNetworkHasBgpInterRegionCost(
-                       t, "google_compute_network.acc_network_bgp_inter_region_cost", &network, "ADD_COST_TO_MED"),
+                   resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_inter_region_cost", "bgp_inter_region_cost", "ADD_COST_TO_MED"),
                ),
            },
        },
@@ -322,7 +318,7 @@ func TestAccComputeNetwork_default_bgp_best_path_selection_mode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeNetworkExists(
 						t, "google_compute_network.bar", &network),
-					testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t, "google_compute_network.bar", &network, expectedBgpBestPathSelection),
+					resource.TestCheckResourceAttr("google_compute_network.bar", "bgp_best_path_selection_mode", expectedBgpBestPathSelection),
 				),
 			},
 		},
@@ -337,7 +333,7 @@ func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
    suffixName := acctest.RandString(t, 10)
    networkName := fmt.Sprintf("tf-test-bgp-always-compare-med-default-routes-%s", suffixName)
 
-   expectedBgpAlwaysCompareMed := false
+   expectedBgpAlwaysCompareMed := "false"
 
    acctest.VcrTest(t, resource.TestCase{
        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -349,8 +345,7 @@ func TestAccComputeNetwork_default_bgp_always_compare_med(t *testing.T) {
                Check: resource.ComposeTestCheckFunc(
                    testAccCheckComputeNetworkExists(
                        t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network),
-                   testAccCheckComputeNetworkHasBgpAlwaysCompareMed(
-                       t, "google_compute_network.acc_network_bgp_best_path_selection_mode", &network, expectedBgpAlwaysCompareMed),
+                   	resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_best_path_selection_mode", "bgp_always_compare_med", expectedBgpAlwaysCompareMed),
                ),
            },
        },
@@ -562,92 +557,6 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 	}
 }
 
-func testAccCheckComputeNetworkHasBgpBestPathSelectionMode(t *testing.T, n string, network *compute.Network, bgpBestPathSelectionMode string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := acctest.GoogleProviderConfig(t)
-
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.Attributes["bgp_always_compare_med"] == "" {
-			return fmt.Errorf("BGP always compare med  not found on resource")
-		}
-
-		found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
-			config.Project, network.Name).Do()
-		if err != nil {
-			return err
-		}
-
-		foundBgpBestPathSelectionMode := found.RoutingConfig.BgpBestPathSelectionMode
-
-		if bgpBestPathSelectionMode != foundBgpBestPathSelectionMode {
-			return fmt.Errorf("Expected BGP always compare med %s to match actual BGP always compare med %s", bgpBestPathSelectionMode, foundBgpBestPathSelectionMode)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckComputeNetworkHasBgpAlwaysCompareMed(t *testing.T, n string, network *compute.Network, bgpAlwaysCompareMed bool) resource.TestCheckFunc {
-   return func(s *terraform.State) error {
-       config := acctest.GoogleProviderConfig(t)
-
-       rs, ok := s.RootModule().Resources[n]
-       if !ok {
-           return fmt.Errorf("Not found: %s", n)
-       }
-
-       if rs.Primary.Attributes["bgp_always_compare_med"] == "" {
-           return fmt.Errorf("BGP always compare med  not found on resource")
-       }
-
-       found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
-           config.Project, network.Name).Do()
-       if err != nil {
-           return err
-       }
-
-       foundBgpAlwaysCompareMed := found.RoutingConfig.BgpAlwaysCompareMed
-
-       if foundBgpAlwaysCompareMed != bgpAlwaysCompareMed {
-           return fmt.Errorf("Expected BGP always compare med %t to match actual BGP always compare med %t", bgpAlwaysCompareMed, foundBgpAlwaysCompareMed)
-       }
-
-       return nil
-   }
-}
-
-func testAccCheckComputeNetworkHasBgpInterRegionCost(t *testing.T, n string, network *compute.Network, bgpInterRegionCost string) resource.TestCheckFunc {
-   return func(s *terraform.State) error {
-       config := acctest.GoogleProviderConfig(t)
-
-       rs, ok := s.RootModule().Resources[n]
-       if !ok {
-           return fmt.Errorf("Not found: %s", n)
-       }
-
-       if rs.Primary.Attributes["bgp_inter_region_cost"] == "" {
-           return fmt.Errorf("BGP inter region cost  not found on resource")
-       }
-
-       found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
-           config.Project, network.Name).Do()
-       if err != nil {
-           return err
-       }
-
-       foundBgpInterRegionCost := found.RoutingConfig.BgpInterRegionCost
-
-       if foundBgpInterRegionCost != bgpInterRegionCost {
-           return fmt.Errorf("Expected BGP always compare med %s to match actual BGP always compare med %s", bgpInterRegionCost, foundBgpInterRegionCost)
-       }
-
-       return nil
-   }
-}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccCheckComputeNetworkHasNetworkProfile(t *testing.T, n string, network *compute.Network, networkProfile string) resource.TestCheckFunc {


### PR DESCRIPTION
b/387318596
Cloud Router Standard BPS Terraform Beta => GA support

**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
compute: promoted `bgp_best_path_selection_mode `,`bgp_bps_always_compare_med` and `bgp_bps_inter_region_cost ` fields in `google_compute_network` from Beta to Ga
```
```release-note:enhancement
compute: promoted `next_hop_origin `,`next_hop_med ` and `next_hop_inter_region_cost ` output fields in `google_compute_route` form Beta to GA
```
