### PR TITLE
Fix failing test: "TestAccComputeInstance_bootAndAttachedDisk_interface"

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -11252,10 +11252,10 @@ func TestAccComputeInstance_bootAndAttachedDisk_interface(t *testing.T) {
                 ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
                 Steps: []resource.TestStep{
                         {
-                                Config:    testAccComputeInstance_bootAndAttachedDisk_interface(instanceName1, diskName1, envvar.GetTestZoneFromEnv(), "h3-standard-88", "NVME", false),
+                                Config:    testAccComputeInstance_bootAndAttachedDisk_interface(instanceName1, diskName1, envvar.GetTestZoneFromEnv(), "c3-standard-22", "NVME", false),
                                 Check: resource.ComposeTestCheckFunc(
                                         resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.interface", "NVME"),
-                                        resource.TestCheckResourceAttr("google_compute_instance.foobar", "machine_type", "h3-standard-88"),
+                                        resource.TestCheckResourceAttr("google_compute_instance.foobar", "machine_type", "c3-standard-22"),
                                 ),
                         },
                         //computeInstanceImportStep("us-central1-a", instanceName1, []string{"desired_status","allow_stopping_for_update"}),


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Resolves: https://github.com/hashicorp/terraform-provider-google/issues/20573  
This PR resolves a failing test error for the `TestAccComputeInstance_bootAndAttachedDisk_interface` test.

### Related Issues

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/20573

### Release Note

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a failing test for `TestAccComputeInstance_bootAndAttachedDisk_interface` in `google_compte_instance`.
```