### PR TITLE
Add post_read custom_code

### DIFF
--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -89,6 +89,10 @@ type CustomCode struct {
 	// in the Read function.
 	PreRead string `yaml:"pre_read"`
 
+	// This code is run after Read calls happen.  It's placed
+	// in the Read function and also after the nested_query read call.
+	PostRead string `yaml:"post_read"`
+
 	// This code is run before the Update call happens.  It's placed
 	// in the Update function, just after the encoder call, before
 	// the Update call.  Just like the encoder, it is only used if

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -89,8 +89,8 @@ type CustomCode struct {
 	// in the Read function.
 	PreRead string `yaml:"pre_read"`
 
-	// This code is run after Read calls happen.  It's placed
-	// in the Read function and also after the nested_query read call.
+	// This code is run after Read calls happen.  It's placed in the
+	// Read function and also after the nested_query read call.
 	PostRead string `yaml:"post_read"`
 
 	// This code is run before the Update call happens.  It's placed

--- a/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
@@ -68,6 +68,7 @@ nested_query:
   modify_by_patch: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
 exclude_sweeper: true

--- a/mmv1/templates/terraform/nested_query.go.tmpl
+++ b/mmv1/templates/terraform/nested_query.go.tmpl
@@ -243,6 +243,9 @@ func resource{{ $.ResourceName }}ListForPatch(d *schema.ResourceData, meta inter
     return nil, err
   }
 
+{{- if $.CustomCode.PostRead }}
+  {{ $.CustomTemplate $.CustomCode.PostRead false -}}
+{{- end }}
   var v interface{}
   var ok bool
 {{- range $i, $k := $.NestedQuery.Keys }}

--- a/mmv1/templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl
+++ b/mmv1/templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl
@@ -1,0 +1,4 @@
+// post_read template for access_context_manager_service_perimeter_resource
+
+// this is a placeholder for now but in the future we can use this to access
+// the etag from the read response

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -567,9 +567,6 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
         ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorAbortPredicates "," -}}{{"}"}},
 {{- end}}
     })
-{{- if $.CustomCode.PostRead }}
-    {{ $.CustomTemplate $.CustomCode.PostRead false -}}
-{{- end }}
     if err != nil {
 {{- if $.ReadErrorTransform -}}
         return transport_tpg.HandleNotFoundError({{ $.ReadErrorTransform }}(err), d, fmt.Sprintf("{{ $.ResourceName }} %q", d.Id()))
@@ -577,6 +574,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
         return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("{{ $.ResourceName }} %q", d.Id()))
 {{- end}}
     }
+{{- if $.CustomCode.PostRead }}
+    {{ $.CustomTemplate $.CustomCode.PostRead false -}}
+{{- end }}
 
 {{if $.NestedQuery -}}
     res, err = flattenNested{{ $.ResourceName -}}(d, meta, res)

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -567,6 +567,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
         ErrorAbortPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorAbortPredicates "," -}}{{"}"}},
 {{- end}}
     })
+{{- if $.CustomCode.PostRead }}
+    {{ $.CustomTemplate $.CustomCode.PostRead false -}}
+{{- end }}
     if err != nil {
 {{- if $.ReadErrorTransform -}}
         return transport_tpg.HandleNotFoundError({{ $.ReadErrorTransform }}(err), d, fmt.Sprintf("{{ $.ResourceName }} %q", d.Id()))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is to unblock a future PR for etags in `access_context_manager` resources. We'll need to access the etag in the GET response that's made from the nested_query code. For consistency, I also added the `post_read` to the normal resource read function as well, but that's not strictly required for our use case.

I'm also not sure what the params `false -` are for in the template, so would appreciate a check to ensure those are correct. Thanks!

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
