### PR TITLE
chore: Move Traffic Extensions example server image

### DIFF
--- a/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
@@ -262,7 +262,7 @@ resource "google_compute_instance" "callouts_instance" {
 
   # Initialize an Envoy's Ext Proc gRPC API based on a docker container
   metadata = {
-    gce-container-declaration = "# DISCLAIMER:\n# This container declaration format is not a public API and may change without\n# notice. Please use gcloud command-line tool or Google Cloud Console to run\n# Containers on Google Compute Engine.\n\nspec:\n  containers:\n  - image: us-docker.pkg.dev/service-extensions/ext-proc/service-callout-basic-example-python:latest\n    name: callouts-vm\n    securityContext:\n      privileged: false\n    stdin: false\n    tty: false\n    volumeMounts: []\n  restartPolicy: Always\n  volumes: []\n"
+    gce-container-declaration = "# DISCLAIMER:\n# This container declaration format is not a public API and may change without\n# notice. Please use gcloud command-line tool or Google Cloud Console to run\n# Containers on Google Compute Engine.\n\nspec:\n  containers:\n  - image: us-docker.pkg.dev/service-extensions-samples/callouts/python-example-basic:main\n    name: callouts-vm\n    securityContext:\n      privileged: false\n    stdin: false\n    tty: false\n    volumeMounts: []\n  restartPolicy: Always\n  volumes: []\n"
     google-logging-enabled = "true"
   }
 


### PR DESCRIPTION
Move an example Docker image used as a Traffic Extensions callouts backend

```release-note:none
```
