### PR TITLE
Inline post_create_failure custom code

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -291,7 +291,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     })
     if err != nil {
 {{- if and ($.CustomCode.PostCreateFailure) (not $.GetAsync) -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+        {{ $.CustomTemplate $.CustomCode.PostCreateFailure false -}}
 {{- end}}
         return fmt.Errorf("Error creating {{ $.Name -}}: %s", err)
     }
@@ -324,7 +324,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         d.Timeout(schema.TimeoutCreate))
     if err != nil {
 {{if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+    {{ $.CustomTemplate $.CustomCode.PostCreateFailure false -}}
 {{- end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
@@ -380,7 +380,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
     if err != nil {
 {{if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+    {{ $.CustomTemplate $.CustomCode.PostCreateFailure false -}}
 {{ end}}
 {{-          if not $.TaintResourceOnFailedCreate -}}
         // The resource didn't actually create
@@ -406,7 +406,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
 {{-        else }}
 {{- if $.CustomCode.PostCreateFailure -}}
-        resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
+    {{ $.CustomTemplate $.CustomCode.PostCreateFailure false -}}
 {{- end}}
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
 {{- end}}
@@ -1198,11 +1198,6 @@ func resource{{ $.ResourceName -}}UpdateEncoder(d *schema.ResourceData, meta int
 {{- end }}
 func resource{{ $.ResourceName -}}Decoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
     {{ $.CustomTemplate $.CustomCode.Decoder false -}}
-}
-{{- end }}
-{{- if $.CustomCode.PostCreateFailure }}
-func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta interface{}) {
-    {{- $.CustomTemplate $.CustomCode.PostCreateFailure false -}}
 }
 {{- end }}
 {{- if and $.SchemaVersion $.StateUpgraders }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Can we change `post_create_failure` to be inline instead of a function? I think that would be more consistent with the other pre/post custom code hooks I'm seeing.

Reasons for changing:
- Full access to the variables in the parent scope (not just limited to the few params passed to the function)
- Ability to modify control flow of the parent function.

Both of these will be useful for adding etags to `access_context_manager_service_perimeter_resource`. I'm trying to add custom error handling and was blocked by those limitations. I checked and only one other provider is using `post_create_failure` currently and I believe this change is a no-op for it. Thanks!

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
