### PR TITLE
add `external_credentials` support in provider block

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -19,12 +19,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 
 	// if this secret version is disabled, the api will return an error, as the value cannot be accessed, return what we have
 	if d.Get("enabled").(bool) == false {
-		if _, ok := d.GetOk("secret_data_wo"); ok {
-			v, _ := d.GetRawConfigAt(cty.GetAttrPath("secret_data_wo"))
-			transformed["secret_data"] = v
-		} else {
-			transformed["secret_data"] = d.Get("secret_data")
-		}
+		transformed["secret_data"] = d.Get("secret_data")
 		return []interface{}{transformed}
 	}
 

--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -19,7 +19,12 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 
 	// if this secret version is disabled, the api will return an error, as the value cannot be accessed, return what we have
 	if d.Get("enabled").(bool) == false {
-		transformed["secret_data"] = d.Get("secret_data")
+		if _, ok := d.GetOk("secret_data_wo"); ok {
+			v, _ := d.GetRawConfigAt(cty.GetAttrPath("secret_data_wo"))
+			transformed["secret_data"] = v
+		} else {
+			transformed["secret_data"] = d.Get("secret_data")
+		}
 		return []interface{}{transformed}
 	}
 

--- a/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
+++ b/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
@@ -8,7 +8,7 @@ import (
 type ExternalCredentialsModel struct {
 	Audience            types.String `tfsdk:"audience"`
 	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
-	IdentityTokenFile   types.String `tfsdk:"identity_token_file"`
+	IdentityToken       types.String `tfsdk:"identity_token"`
 }
 
 // ProviderModel maps provider schema data to a Go type.

--- a/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
+++ b/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
@@ -5,10 +5,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+type ExternalCredentialsModel struct {
+	Audience            types.String `tfsdk:"audience"`
+	ServiceAccountEmail types.String `tfsdk:"service_account_email"`
+	IdentityTokenFile   types.String `tfsdk:"identity_token_file"`
+}
+
 // ProviderModel maps provider schema data to a Go type.
 // When the plugin-framework provider is configured, the Configure function receives data about
 // the provider block in the configuration. That data is used to populate this struct.
 type ProviderModel struct {
+	ExternalCredentials                       []ExternalCredentialsModel `tfsdk:"external_credentials"`
 	Credentials                               types.String `tfsdk:"credentials"`
 	AccessToken                               types.String `tfsdk:"access_token"`
 	ImpersonateServiceAccount                 types.String `tfsdk:"impersonate_service_account"`

--- a/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
+++ b/mmv1/third_party/terraform/fwmodels/provider_model.go.tmpl
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
+// ExternalCredentialsModel contains the information necessary to retrieve external credentials (like Workload Identity Federation credentials) using the user-defined function retrieval method (https://pkg.go.dev/golang.org/x/oauth2/google/externalaccount)
 type ExternalCredentialsModel struct {
 	Audience            types.String `tfsdk:"audience"`
 	ServiceAccountEmail types.String `tfsdk:"service_account_email"`

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -21,7 +21,7 @@ import (
     "github.com/hashicorp/terraform-provider-google/google/functions"
     "github.com/hashicorp/terraform-provider-google/google/fwmodels"
     "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
-	"github.com/hashicorp/terraform-provider-google/version"
+    "github.com/hashicorp/terraform-provider-google/version"
     {{- if ne $.TargetVersionName "ga" }}
     "github.com/hashicorp/terraform-provider-google/google/services/firebase"
     {{- end }}
@@ -264,7 +264,7 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                         "service_account_email": schema.StringAttribute{
                             Required: true,
                             Validators: []validator.String{
-                                fwvalidators.ServiceAccountEmailValidator(),
+                                fwvalidators.ServiceAccountEmailValidator{},
                             },
                         },
                         "identity_token_file": schema.StringAttribute{

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -252,25 +252,25 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                     },
                 },
             },
-            			"external_credentials": schema.ListNestedBlock{
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"audience": schema.StringAttribute{
-							Required: true,
-							Validators: []validator.String{
-								fwvalidators.NonEmptyStringValidator(),
-							},
-						},
-						"service_account_email": schema.StringAttribute{
-							Required: true,
-							Validators: []validator.String{
-								fwvalidators.NonEmptyStringValidator(),
-							},
-						},
-						"identity_token_file": schema.StringAttribute{
-							Required: true,
-							Validators: []validator.String{
-								fwvalidators.NonEmptyStringValidator(),
+            "external_credentials": schema.ListNestedBlock{
+                NestedObject: schema.NestedBlockObject{
+                    Attributes: map[string]schema.Attribute{
+                        "audience": schema.StringAttribute{
+                            Required: true,
+                            Validators: []validator.String{
+                                fwvalidators.NonEmptyStringValidator(),
+                            },
+                        },
+                        "service_account_email": schema.StringAttribute{
+                            Required: true,
+                            Validators: []validator.String{
+                                fwvalidators.ServiceAccountEmailValidator(),
+                            },
+                        },
+                        "identity_token_file": schema.StringAttribute{
+                            Required: true,
+                            Validators: []validator.String{
+                                fwvalidators.JWTValidator(),
                             },
                         },
                     },

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -267,7 +267,7 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                                 fwvalidators.ServiceAccountEmailValidator{},
                             },
                         },
-                        "identity_token_file": schema.StringAttribute{
+                        "identity_token": schema.StringAttribute{
                             Required: true,
                             Validators: []validator.String{
                                 fwvalidators.JWTValidator(),

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -252,6 +252,30 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                     },
                 },
             },
+            			"external_credentials": schema.ListNestedBlock{
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"audience": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								fwvalidators.NonEmptyStringValidator(),
+							},
+						},
+						"service_account_email": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								fwvalidators.NonEmptyStringValidator(),
+							},
+						},
+						"identity_token_file": schema.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								fwvalidators.NonEmptyStringValidator(),
+                            },
+                        },
+                    },
+                },
+            },
         },
     }
 

--- a/mmv1/third_party/terraform/fwvalidators/framework_validators.go
+++ b/mmv1/third_party/terraform/fwvalidators/framework_validators.go
@@ -2,9 +2,11 @@ package fwvalidators
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"

--- a/mmv1/third_party/terraform/fwvalidators/framework_validators.go
+++ b/mmv1/third_party/terraform/fwvalidators/framework_validators.go
@@ -206,3 +206,57 @@ func (v BoundedDuration) ValidateString(ctx context.Context, req validator.Strin
 		)
 	}
 }
+
+type jwtValidator struct {
+}
+
+func (v jwtValidator) Description(_ context.Context) string {
+	return "value must be a valid JWT token"
+}
+
+func (v jwtValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v jwtValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if value == "" {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Invalid JWT Token",
+			"JWT token must not be empty",
+		)
+		return
+	}
+
+	// JWT consists of 3 parts separated by dots: header.payload.signature
+	parts := strings.Split(value, ".")
+	if len(parts) != 3 {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Invalid JWT Format",
+			"JWT token must have 3 parts separated by dots (header.payload.signature)",
+		)
+		return
+	}
+
+	// Check that each part is base64 encoded
+	for i, part := range parts {
+		if _, err := base64.RawURLEncoding.DecodeString(part); err != nil {
+			response.Diagnostics.AddAttributeError(
+				request.Path,
+				"Invalid JWT Encoding",
+				fmt.Sprintf("Part %d of JWT is not valid base64: %v", i+1, err),
+			)
+		}
+	}
+}
+
+func JWTValidator() validator.String {
+	return jwtValidator{}
+}

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -37,14 +37,37 @@ func Provider() *schema.Provider {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  ValidateCredentials,
-				ConflictsWith: []string{"access_token"},
+				ConflictsWith: []string{"access_token", "external_credentials"},
 			},
 
 			"access_token": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  ValidateEmptyStrings,
-				ConflictsWith: []string{"credentials"},
+				ConflictsWith: []string{"credentials", "external_credentials"},
+			},
+
+			"external_credentials": {
+				Type:          schema.TypeList,
+				MaxItems:      1,
+				Optional:      true,
+				ConflictsWith: []string{"credentials", "access_token"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"audience": {
+							Type:     schema.TypeString,
+							Required: true, // TODO: validate audience is non-empty string
+						},
+						"service_account_email": {
+							Type:     schema.TypeString, // TODO: validate service_account_email is non-empty string that is a valid email address
+							Required: true,
+						},
+						"identity_token_file": {
+							Type:     schema.TypeString, // TODO: validate identity_token is non-empty string that is a valid JWT
+							Required: true,
+						},
+					},
+				},
 			},
 
 			"impersonate_service_account": {
@@ -265,6 +288,15 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 
 	if v, ok := d.GetOk("credentials"); ok {
 		config.Credentials = v.(string)
+	}
+
+
+	if v, ok := d.GetOk("external_credentials"); ok {
+		externalCredentials, err := transport_tpg.ExpandExternalCredentials(v)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		config.ExternalCredentials = externalCredentials
 	}
 
 	// only check environment variables if neither value was set in config- this

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -56,15 +56,18 @@ func Provider() *schema.Provider {
 					Schema: map[string]*schema.Schema{
 						"audience": {
 							Type:     schema.TypeString,
-							Required: true, // TODO: validate audience is non-empty string
+							Required: true,
+							ValidateFunc: ValidateEmptyStrings,
 						},
 						"service_account_email": {
-							Type:     schema.TypeString, // TODO: validate service_account_email is non-empty string that is a valid email address
+							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: ValidateServiceAccountEmail,
 						},
 						"identity_token_file": {
-							Type:     schema.TypeString, // TODO: validate identity_token is non-empty string that is a valid JWT
+							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: ValidateJWT,
 						},
 					},
 				},

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -64,7 +64,7 @@ func Provider() *schema.Provider {
 							Required: true,
 							ValidateFunc: ValidateServiceAccountEmail,
 						},
-						"identity_token_file": {
+						"identity_token": {
 							Type:     schema.TypeString,
 							Required: true,
 							ValidateFunc: ValidateJWT,
@@ -286,11 +286,11 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	// Check for primary credentials in config. Note that if none of these values are set, ADCs
 	// will be used if available.
 	if v, ok := d.GetOk("external_credentials"); ok {
-		externalCredentials, err := transport_tpg.ExpandExternalCredentials(v)
+		external, err := transport_tpg.ExpandExternalCredentialsConfig(v)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
-		config.ExternalCredentials = externalCredentials
+		config.ExternalCredentials = external
 	} else {
 		if v, ok := d.GetOk("access_token"); ok {
 			config.AccessToken = v.(string)

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -283,28 +283,27 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		config.RequestReason = v.(string)
 	}
 
-	// Check for primary credentials in config. Note that if neither is set, ADCs
+	// Check for primary credentials in config. Note that if none of these values are set, ADCs
 	// will be used if available.
-	if v, ok := d.GetOk("access_token"); ok {
-		config.AccessToken = v.(string)
-	}
-
-	if v, ok := d.GetOk("credentials"); ok {
-		config.Credentials = v.(string)
-	}
-
-
 	if v, ok := d.GetOk("external_credentials"); ok {
 		externalCredentials, err := transport_tpg.ExpandExternalCredentials(v)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
 		config.ExternalCredentials = externalCredentials
+	} else {
+		if v, ok := d.GetOk("access_token"); ok {
+			config.AccessToken = v.(string)
+		}
+
+		if v, ok := d.GetOk("credentials"); ok {
+			config.Credentials = v.(string)
+		}
 	}
 
-	// only check environment variables if neither value was set in config- this
+	// only check environment variables if none of these values are set in config- this
 	// means config beats env var in all cases.
-	if config.AccessToken == "" && config.Credentials == "" {
+	if config.ExternalCredentials == nil && config.AccessToken == "" && config.Credentials == "" {
 		config.Credentials = transport_tpg.MultiEnvSearch([]string{
 			"GOOGLE_CREDENTIALS",
 			"GOOGLE_CLOUD_KEYFILE_JSON",

--- a/mmv1/third_party/terraform/provider/provider_internal_test.go
+++ b/mmv1/third_party/terraform/provider/provider_internal_test.go
@@ -85,6 +85,71 @@ func TestProvider_ValidateCredentials(t *testing.T) {
 	}
 }
 
+func TestProvider_ValidateJWT(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue      interface{}
+		ValueNotProvided bool
+		ExpectedWarnings []string
+		ExpectedErrors   []error
+	}{
+		"a valid JWT is accepted": {
+			ConfigValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+		},
+		"an empty JWT is rejected": {
+			ConfigValue: "",
+			ExpectedErrors: []error{
+				errors.New("\"\" cannot be empty"),
+			},
+		},
+		"a JWT with invalid base64 parts is rejected": {
+			ConfigValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.invalid-signature",
+			ExpectedErrors: []error{
+				errors.New("part 3 of JWT is not valid base64: illegal base64 data at input byte 16"),
+			},
+		},
+		"a JWT with incorrect format (not 3 parts) is rejected": {
+			ConfigValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ",
+			ExpectedErrors: []error{
+				errors.New("\"\" is not a valid JWT format"),
+			},
+		},
+		"unconfigured value is not valid": {
+			ValueNotProvided: true,
+			ExpectedErrors: []error{
+				errors.New("\"\" cannot be empty"),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+
+			// Arrange
+			var configValue interface{}
+			if !tc.ValueNotProvided {
+				configValue = tc.ConfigValue
+			}
+
+			// Act
+			ws, es := provider.ValidateJWT(configValue, "")
+
+			// Assert
+			if len(ws) != len(tc.ExpectedWarnings) {
+				t.Fatalf("Expected %d warnings, got %d: %v", len(tc.ExpectedWarnings), len(ws), ws)
+			}
+			if len(es) != len(tc.ExpectedErrors) {
+				t.Fatalf("Expected %d errors, got %d: %v", len(tc.ExpectedErrors), len(es), es)
+			}
+
+			for i := 0; i < len(tc.ExpectedErrors) && i < len(es); i++ {
+				if es[i].Error() != tc.ExpectedErrors[i].Error() {
+					t.Fatalf("Expected error %d to be \"%s\", got \"%s\"", i+1, tc.ExpectedErrors[i], es[i])
+				}
+			}
+		})
+	}
+}
+
 func TestProvider_ValidateEmptyStrings(t *testing.T) {
 	cases := map[string]struct {
 		ConfigValue      interface{}

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -200,10 +200,10 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 				},
 				ExternalProviders: oldVersion,
 				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
-					"access_token":  accessToken,
+					"access_token": accessToken,
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "access_token", accessToken),
+					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
 				),
 			},
 			{
@@ -231,7 +231,7 @@ provider "google" {
   access_token = "%{access_token}"
 }
 
-data "google_provider_config_sdk" "default" {}
+data "google_client_config" "default" {}
 `, context)
 }
 

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -192,6 +192,7 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		Steps: []resource.TestStep{
+			// old provider - access_token
 			{
 				PreConfig: func() {
 					for _, env := range envvar.CredsEnvVars {
@@ -206,8 +207,38 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
 				),
 			},
+			// old provider - credentials
 			{
-				// Step 2: Upgrade to new provider version
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+				ExternalProviders:        oldVersion,
+				PreConfig: func() {
+					for _, env := range envvar.CredsEnvVars {
+						t.Setenv(env, "")
+					}
+				},
+				Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(map[string]interface{}{
+					"credentials": credentials,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "credentials", credentials),
+				),
+			},
+			{
+				// new provider - access_token
+				PreConfig: func() {
+					for _, env := range envvar.CredsEnvVars {
+						t.Setenv(env, "")
+					}
+				},
+				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
+					"access_token": accessToken,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
+				),
+			},
+			{
+				// new provider - credentials
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 				PreConfig: func() {
 					for _, env := range envvar.CredsEnvVars {

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -216,11 +216,10 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 					}
 				},
 				Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(map[string]interface{}{
-					"credentials":   credentials,
-					"random_suffix": acctest.RandString(t, 10),
+					"credentials": credentials,
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "credentials", credentials),
 				),
 			},
 		},
@@ -246,10 +245,7 @@ provider "google" {
   credentials = "%{credentials}"
 }
 
-resource "google_service_account" "default" {
-  account_id   = "tf-test-%{random_suffix}"
-  display_name = "Test Service Account"
-}
+data "google_provider_config_sdk" "default" {}
 `, context)
 }
 

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -201,10 +201,9 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 				ExternalProviders: oldVersion,
 				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
 					"access_token":  accessToken,
-					"random_suffix": acctest.RandString(t, 10),
 				}),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "access_token", accessToken),
 				),
 			},
 			{
@@ -232,10 +231,7 @@ provider "google" {
   access_token = "%{access_token}"
 }
 
-resource "google_service_account" "default" {
-  account_id   = "tf-test-%{random_suffix}"
-  display_name = "Test Service Account"
-}
+data "google_provider_config_sdk" "default" {}
 `, context)
 }
 

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -197,11 +197,10 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 		preConfig func(*testing.T)
 	}{
 		"access_token still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(),
-			context: map[string]interface{}{
+			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
 				"access_token":  accessToken,
 				"random_suffix": acctest.RandString(t, 10),
-			},
+			}),
 			preConfig: func(t *testing.T) {
 				for _, env := range envvar.CredsEnvVars {
 					t.Setenv(env, "")
@@ -209,11 +208,10 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 			},
 		},
 		"credentials still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(),
-			context: map[string]interface{}{
+			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(map[string]interface{}{
 				"credentials":   credentials,
 				"random_suffix": acctest.RandString(t, 10),
-			},
+			}),
 			preConfig: func(t *testing.T) {
 				// Clear environment variables to ensure only config values are used
 				for _, env := range envvar.CredsEnvVars {
@@ -251,8 +249,8 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 	}
 }
 
-func testAccProviderExternalCredentialsUpgrade_AccessTokenConfig() string {
-	return `
+func testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 provider "google" {
   access_token = "%{access_token}"
 }
@@ -261,11 +259,11 @@ resource "google_service_account" "default" {
   account_id   = "tf-test-%{random_suffix}"
   display_name = "Test Service Account"
 }
-`
+`, context)
 }
 
-func testAccProviderExternalCredentialsUpgrade_CredentialsConfig() string {
-	return `
+func testAccProviderExternalCredentialsUpgrade_CredentialsConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 provider "google" {
   credentials = "%{credentials}"
 }
@@ -274,7 +272,7 @@ resource "google_service_account" "default" {
   account_id   = "tf-test-%{random_suffix}"
   display_name = "Test Service Account"
 }
-`
+`, context)
 }
 
 func testAccProviderBasePath_setBasePath(endpoint, name string) string {

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -172,6 +172,12 @@ func TestAccProviderEmptyStrings(t *testing.T) {
 func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 	acctest.SkipIfVcr(t) // Test doesn't interact with API
 
+	// Skip if not running in a acc test environment,
+	// as acc test environment variables needed to get accessToken 
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+
 	accessToken := acctest.GetAccessTokenFromTestCredsFromEnv(t)
 	credentials := envvar.GetTestCredsFromEnv()
 

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -174,13 +174,31 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 	acctest.SkipIfVcr(t) // Test doesn't interact with API
 
 	// Skip if not running in a acc test environment,
-	// as acc test environment variables needed to get accessToken 
+	// as acc test environment variables needed to get accessToken
 	if v := os.Getenv("TF_ACC"); v == "" {
 		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
 	}
 
 	accessToken := acctest.GetAccessTokenFromTestCredsFromEnv(t)
 	credentials := envvar.GetTestCredsFromEnv()
+
+	providerAccessTokenOnly := fmt.Sprintf(`
+	access_token = "%s"
+	`, accessToken)
+
+	providerCredentialsOnly := fmt.Sprintf(`
+	credentials = "%s"
+	`, credentials)
+
+	contextAccessTokenOnly := map[string]interface{}{
+		"fields":        providerAccessTokenOnly,
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	contextCredentialsOnly := map[string]interface{}{
+		"fields":        providerCredentialsOnly,
+		"random_suffix": acctest.RandString(t, 10),
+	}
 
 	// Define old version (without external_credentials)
 	oldVersion := map[string]resource.ExternalProvider{
@@ -197,10 +215,7 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 		preConfig func(*testing.T)
 	}{
 		"access_token still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
-				"access_token":  accessToken,
-				"random_suffix": acctest.RandString(t, 10),
-			}),
+			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(contextAccessTokenOnly),
 			preConfig: func(t *testing.T) {
 				for _, env := range envvar.CredsEnvVars {
 					t.Setenv(env, "")
@@ -208,10 +223,7 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 			},
 		},
 		"credentials still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(map[string]interface{}{
-				"credentials":   credentials,
-				"random_suffix": acctest.RandString(t, 10),
-			}),
+			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(contextCredentialsOnly),
 			preConfig: func(t *testing.T) {
 				// Clear environment variables to ensure only config values are used
 				for _, env := range envvar.CredsEnvVars {
@@ -252,7 +264,7 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 func testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {
-  access_token = "%{access_token}"
+%{fields}
 }
 
 resource "google_service_account" "default" {
@@ -265,7 +277,7 @@ resource "google_service_account" "default" {
 func testAccProviderExternalCredentialsUpgrade_CredentialsConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {
-  credentials = "%{credentials}"
+%{fields}
 }
 
 resource "google_service_account" "default" {

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -180,7 +180,7 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 	}
 
 	accessToken := acctest.GetAccessTokenFromTestCredsFromEnv(t)
-	credentials := envvar.GetTestCredsFromEnv()
+	credentials := transport_tpg.TestFakeCredentialsPath
 
 	// Define old version (without external_credentials)
 	oldVersion := map[string]resource.ExternalProvider{

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/provider"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -164,6 +165,109 @@ func TestAccProviderEmptyStrings(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccProvider_external_credentials_upgrade verifies that credentials and access_token
+// continue to function properly when upgrading to a version with external_credentials
+func TestAccProvider_external_credentials_upgrade(t *testing.T) {
+	acctest.SkipIfVcr(t) // Test doesn't interact with API
+
+	accessToken := acctest.GetAccessTokenFromTestCredsFromEnv(t)
+	credentials := envvar.GetTestCredsFromEnv()
+
+	// Define old version (without external_credentials)
+	oldVersion := map[string]resource.ExternalProvider{
+		"google": {
+			VersionConstraint: "6.10.0", // a version before external_credentials was added
+			Source:            "registry.terraform.io/hashicorp/google",
+		},
+	}
+
+	// Test cases
+	testCases := map[string]struct {
+		Config    string
+		context   map[string]interface{}
+		preConfig func(*testing.T)
+	}{
+		"access_token still works after upgrade": {
+			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(),
+			context: map[string]interface{}{
+				"access_token":  accessToken,
+				"random_suffix": acctest.RandString(t, 10),
+			},
+			preConfig: func(t *testing.T) {
+				for _, env := range envvar.CredsEnvVars {
+					t.Setenv(env, "")
+				}
+			},
+		},
+		"credentials still works after upgrade": {
+			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(),
+			context: map[string]interface{}{
+				"credentials":   credentials,
+				"random_suffix": acctest.RandString(t, 10),
+			},
+			preConfig: func(t *testing.T) {
+				// Clear environment variables to ensure only config values are used
+				for _, env := range envvar.CredsEnvVars {
+					t.Setenv(env, "")
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			acctest.VcrTest(t, resource.TestCase{
+				Steps: []resource.TestStep{
+					{
+						PreConfig:         func() { tc.preConfig(t) },
+						ExternalProviders: oldVersion,
+						Config:            acctest.Nprintf(tc.Config, tc.context),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+						),
+					},
+					{
+						// Step 2: Upgrade to new provider version
+						PreConfig:                func() { tc.preConfig(t) },
+						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+						Config:                   acctest.Nprintf(tc.Config, tc.context),
+						Check: resource.ComposeTestCheckFunc(
+							resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+						),
+					},
+				},
+			})
+		})
+	}
+}
+
+func testAccProviderExternalCredentialsUpgrade_AccessTokenConfig() string {
+	return `
+provider "google" {
+  access_token = "%{access_token}"
+}
+
+resource "google_service_account" "default" {
+  account_id   = "tf-test-%{random_suffix}"
+  display_name = "Test Service Account"
+}
+`
+}
+
+func testAccProviderExternalCredentialsUpgrade_CredentialsConfig() string {
+	return `
+provider "google" {
+  credentials = "%{credentials}"
+}
+
+resource "google_service_account" "default" {
+  account_id   = "tf-test-%{random_suffix}"
+  display_name = "Test Service Account"
+}
+`
 }
 
 func testAccProviderBasePath_setBasePath(endpoint, name string) string {

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -182,24 +182,6 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 	accessToken := acctest.GetAccessTokenFromTestCredsFromEnv(t)
 	credentials := envvar.GetTestCredsFromEnv()
 
-	providerAccessTokenOnly := fmt.Sprintf(`
-	access_token = "%s"
-	`, accessToken)
-
-	providerCredentialsOnly := fmt.Sprintf(`
-	credentials = "%s"
-	`, credentials)
-
-	contextAccessTokenOnly := map[string]interface{}{
-		"fields":        providerAccessTokenOnly,
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
-	contextCredentialsOnly := map[string]interface{}{
-		"fields":        providerCredentialsOnly,
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
 	// Define old version (without external_credentials)
 	oldVersion := map[string]resource.ExternalProvider{
 		"google": {
@@ -208,63 +190,47 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 		},
 	}
 
-	// Test cases
-	testCases := map[string]struct {
-		Config    string
-		context   map[string]interface{}
-		preConfig func(*testing.T)
-	}{
-		"access_token still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(contextAccessTokenOnly),
-			preConfig: func(t *testing.T) {
-				for _, env := range envvar.CredsEnvVars {
-					t.Setenv(env, "")
-				}
-			},
-		},
-		"credentials still works after upgrade": {
-			Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(contextCredentialsOnly),
-			preConfig: func(t *testing.T) {
-				// Clear environment variables to ensure only config values are used
-				for _, env := range envvar.CredsEnvVars {
-					t.Setenv(env, "")
-				}
-			},
-		},
-	}
-
-	for name, tc := range testCases {
-		tc := tc
-		t.Run(name, func(t *testing.T) {
-			acctest.VcrTest(t, resource.TestCase{
-				Steps: []resource.TestStep{
-					{
-						PreConfig:         func() { tc.preConfig(t) },
-						ExternalProviders: oldVersion,
-						Config:            acctest.Nprintf(tc.Config, tc.context),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
-						),
-					},
-					{
-						// Step 2: Upgrade to new provider version
-						PreConfig:                func() { tc.preConfig(t) },
-						ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-						Config:                   acctest.Nprintf(tc.Config, tc.context),
-						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
-						),
-					},
+	acctest.VcrTest(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					for _, env := range envvar.CredsEnvVars {
+						t.Setenv(env, "")
+					}
 				},
-			})
-		})
-	}
+				ExternalProviders: oldVersion,
+				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
+					"access_token":  accessToken,
+					"random_suffix": acctest.RandString(t, 10),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+				),
+			},
+			{
+				// Step 2: Upgrade to new provider version
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+				PreConfig: func() {
+					for _, env := range envvar.CredsEnvVars {
+						t.Setenv(env, "")
+					}
+				},
+				Config: testAccProviderExternalCredentialsUpgrade_CredentialsConfig(map[string]interface{}{
+					"credentials":   credentials,
+					"random_suffix": acctest.RandString(t, 10),
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_service_account.default", "email"),
+				),
+			},
+		},
+	})
 }
 
 func testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {
-%{fields}
+  access_token = "%{access_token}"
 }
 
 resource "google_service_account" "default" {
@@ -277,7 +243,7 @@ resource "google_service_account" "default" {
 func testAccProviderExternalCredentialsUpgrade_CredentialsConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 provider "google" {
-%{fields}
+  credentials = "%{credentials}"
 }
 
 resource "google_service_account" "default" {

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"fmt"
 	"regexp"
+	"os"
 	"strings"
 	"testing"
 

--- a/mmv1/third_party/terraform/provider/provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_test.go.tmpl
@@ -207,6 +207,20 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
 				),
 			},
+			{
+				// new provider - access_token
+				PreConfig: func() {
+					for _, env := range envvar.CredsEnvVars {
+						t.Setenv(env, "")
+					}
+				},
+				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
+					"access_token": accessToken,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
+				),
+			},
 			// old provider - credentials
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -221,20 +235,6 @@ func TestAccProvider_external_credentials_upgrade(t *testing.T) {
 				}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_provider_config_sdk.default", "credentials", credentials),
-				),
-			},
-			{
-				// new provider - access_token
-				PreConfig: func() {
-					for _, env := range envvar.CredsEnvVars {
-						t.Setenv(env, "")
-					}
-				},
-				Config: testAccProviderExternalCredentialsUpgrade_AccessTokenConfig(map[string]interface{}{
-					"access_token": accessToken,
-				}),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.google_client_config.default", "access_token", accessToken),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
@@ -2,8 +2,11 @@ package provider
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	googleoauth "golang.org/x/oauth2/google"
 )

--- a/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
@@ -45,3 +45,42 @@ func ValidateEmptyStrings(v interface{}, k string) (warnings []string, errors []
 
 	return
 }
+
+func ValidateJWT(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+	if value == "" {
+		errors = append(errors, fmt.Errorf("%q cannot be empty", k))
+		return
+	}
+
+	// JWT consists of 3 parts separated by dots: header.payload.signature
+	parts := strings.Split(value, ".")
+	if len(parts) != 3 {
+		errors = append(errors, fmt.Errorf("%q is not a valid JWT format", k))
+		return
+	}
+
+	// Check that each part is base64 encoded
+	for i, part := range parts {
+		if _, err := base64.RawURLEncoding.DecodeString(part); err != nil {
+			errors = append(errors, fmt.Errorf("part %d of JWT is not valid base64: %v", i+1, err))
+		}
+	}
+
+	return
+}
+
+func ValidateServiceAccountEmail(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+	if value == "" {
+		errors = append(errors, fmt.Errorf("%q cannot be empty", k))
+		return
+	}
+
+	serviceAccountRegex := regexp.MustCompile(`^[a-zA-Z0-9-]+@[a-zA-Z0-9-]+\.iam\.gserviceaccount\.com$`)
+	if !serviceAccountRegex.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q is not a valid service account email address (expected format: name@project-id.iam.gserviceaccount.com)", k))
+	}
+
+	return
+}

--- a/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_validators.go.tmpl
@@ -50,14 +50,13 @@ func ValidateEmptyStrings(v interface{}, k string) (warnings []string, errors []
 }
 
 func ValidateJWT(v interface{}, k string) (warnings []string, errors []error) {
-	value := v.(string)
-	if value == "" {
+	if v == nil || v.(string) == "" {
 		errors = append(errors, fmt.Errorf("%q cannot be empty", k))
 		return
 	}
 
 	// JWT consists of 3 parts separated by dots: header.payload.signature
-	parts := strings.Split(value, ".")
+	parts := strings.Split(v.(string), ".")
 	if len(parts) != 3 {
 		errors = append(errors, fmt.Errorf("%q is not a valid JWT format", k))
 		return

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	googleoauth "golang.org/x/oauth2/google"
+	googleoauthexternalaccount "golang.org/x/oauth2/google/externalaccount"
 	appengine "google.golang.org/api/appengine/v1"
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/bigtableadmin/v2"
@@ -182,6 +183,7 @@ type Config struct {
 	DCLConfig
 	AccessToken                               string
 	Credentials                               string
+	ExternalCredentials                       *googleoauthexternalaccount.Config
 	ImpersonateServiceAccount                 string
 	ImpersonateServiceAccountDelegates        []string
 	Project                                   string
@@ -520,6 +522,25 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	return nil
 }
 
+func ExpandExternalCredentials(v interface{}) (*googleoauthexternalaccount.Config, error) {
+	ls := v.([]interface{})
+	if len(ls) == 0 || ls[0] == nil {
+		return nil, fmt.Errorf("external_credentials must be a list with at least one element")
+	}
+	cfgV := ls[0].(map[string]interface{})
+	externalCredentialsConfig := &googleoauthexternalaccount.Config{
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+		TokenURL:         "https://sts.googleapis.com/v1/token",
+		Scopes:           []string{"https://www.googleapis.com/auth/cloud-platform"},
+		Audience:         cfgV["audience"].(string),
+		ServiceAccountImpersonationURL: fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", cfgV["service_account_email"].(string)),
+		CredentialSource: &googleoauthexternalaccount.CredentialSource{
+			File: cfgV["identity_token_file"].(string),
+		},
+	}
+	return externalCredentialsConfig, nil
+}
+
 func ExpandProviderBatchingConfig(v interface{}) (*BatchingConfig, error) {
 	config := &BatchingConfig{
 		SendAfter:      time.Second * DefaultBatchSendIntervalSec,
@@ -607,6 +628,16 @@ func (c *Config) logGoogleIdentities() error {
 // Get a TokenSource based on the Google Credentials configured.
 // If initialCredentialsOnly is true, don't follow the impersonation settings and return the initial set of creds.
 func (c *Config) getTokenSource(clientScopes []string, initialCredentialsOnly bool) (oauth2.TokenSource, error) {
+
+	if c.ExternalCredentials != nil {
+		log.Printf("[INFO] Using external credentials")
+		creds, err := googleoauthexternalaccount.NewTokenSource(c.Context, *c.ExternalCredentials)
+		if err != nil {
+			return nil, fmt.Errorf("error creating token source from external credentials: %s", err)
+		}
+		return creds, nil
+	}
+
 	creds, err := c.GetCredentials(clientScopes, initialCredentialsOnly)
 	if err != nil {
 		return nil, fmt.Errorf("%s", err)

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -579,10 +579,7 @@ func (c *Config) getExternalAccountConfig(clientScopes []string) externalaccount
 	eaConfig := externalaccount.Config{
 		Audience:         c.ExternalCredentials.Audience,
 		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
-		// Is ServiceAccountImpersonationURL affected by Universe Domain?
 		ServiceAccountImpersonationURL: fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", c.ExternalCredentials.ServiceAccountEmail),
-		// ServiceAccountImpersonationLifetimeSeconds ??
-		// QuotaProjectID ??
 		Scopes:               clientScopes,
 		SubjectTokenSupplier: c.ExternalCredentials,
 	}

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -632,7 +632,7 @@ func (c *Config) synchronousTimeout() time.Duration {
 func (c *Config) logGoogleIdentities(ctx context.Context) error {
 	if c.ImpersonateServiceAccount == "" {
 
-	tokenSource, err := c.getTokenSource(ctx, c.Scopes, false)
+	tokenSource, err := c.getTokenSource(ctx, c.Scopes, true)
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -30,7 +31,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	googleoauth "golang.org/x/oauth2/google"
-	googleoauthexternalaccount "golang.org/x/oauth2/google/externalaccount"
+	externalaccount "golang.org/x/oauth2/google/externalaccount"
 	appengine "google.golang.org/api/appengine/v1"
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/bigtableadmin/v2"
@@ -177,13 +178,63 @@ func (f *Formatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return []byte(output), nil
 }
 
+type ExternalCredentials struct {
+	Audience            string
+	ServiceAccountEmail string
+	IdentityToken    string
+}
+
+var _ externalaccount.SubjectTokenSupplier = ExternalCredentials{}
+
+// SubjectToken returns the identity token passed to the provider as an argument from the config.
+// We do not interact with an external system to get a token.
+func (e ExternalCredentials) SubjectToken(ctx context.Context, options externalaccount.SupplierOptions) (string, error) {
+	if e.IdentityToken != "" {
+		return e.IdentityToken, nil
+	}
+	return "", errors.New("identity token unavailable in Config when configuring the provider")
+}
+
+func ExpandExternalCredentialsConfig(v interface{}) (*ExternalCredentials, error) {
+	if v == nil {
+		return nil, nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 || ls[0] == nil {
+		return nil, nil
+	}
+
+	config := &ExternalCredentials{}
+	cfgV := ls[0].(map[string]interface{})
+
+	audience, ok := cfgV["audience"]
+	if !ok || audience.(string) == "" {
+		return nil, errors.New("missing value for external_credentials.audience")
+	}
+	config.Audience = audience.(string)
+
+	email, ok := cfgV["service_account_email"]
+	if !ok || email.(string) == "" {
+		return nil, errors.New("missing value for external_credentials.service_account_email")
+	}
+	config.ServiceAccountEmail = email.(string)
+
+	jwt, ok := cfgV["identity_token"]
+	if !ok || jwt.(string) == "" {
+		return nil, errors.New("missing value for external_credentials.identity_token")
+	}
+	config.IdentityToken = jwt.(string)
+
+	return config, nil
+}
+
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
 	DCLConfig
 	AccessToken                               string
 	Credentials                               string
-	ExternalCredentials                       *googleoauthexternalaccount.Config
+	ExternalCredentials                       *ExternalCredentials
 	ImpersonateServiceAccount                 string
 	ImpersonateServiceAccountDelegates        []string
 	Project                                   string
@@ -431,7 +482,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 
 	c.Context = ctx
 
-	tokenSource, err := c.getTokenSource(c.Scopes, false)
+	tokenSource, err := c.getTokenSource(ctx, c.Scopes, false)
 	if err != nil {
 		return err
 	}
@@ -456,7 +507,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	}
 
 	// Userinfo is fetched before request logging is enabled to reduce additional noise.
-	err = c.logGoogleIdentities()
+	err = c.logGoogleIdentities(ctx)
 	if err != nil {
 		return err
 	}
@@ -522,24 +573,26 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	return nil
 }
 
-func ExpandExternalCredentials(v interface{}) (*googleoauthexternalaccount.Config, error) {
-	ls := v.([]interface{})
-	if len(ls) == 0 || ls[0] == nil {
-		return nil, fmt.Errorf("external_credentials must be a list with at least one element")
-	}
-	cfgV := ls[0].(map[string]interface{})
-	externalCredentialsConfig := &googleoauthexternalaccount.Config{
+// getExternalAccountConfig returns an externalaccount.Config based on the Config object.
+// The external account config is intended to be used to create a token source.
+func (c *Config) getExternalAccountConfig(clientScopes []string) externalaccount.Config {
+	eaConfig := externalaccount.Config{
+		Audience:         c.ExternalCredentials.Audience,
 		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
-		TokenURL:         "https://sts.googleapis.com/v1/token",
-		Scopes:           []string{"https://www.googleapis.com/auth/cloud-platform"},
-		Audience:         cfgV["audience"].(string),
-		ServiceAccountImpersonationURL: fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", cfgV["service_account_email"].(string)),
-		CredentialSource: &googleoauthexternalaccount.CredentialSource{
-			File: cfgV["identity_token_file"].(string),
-		},
+		// Is ServiceAccountImpersonationURL affected by Universe Domain?
+		ServiceAccountImpersonationURL: fmt.Sprintf("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken", c.ExternalCredentials.ServiceAccountEmail),
+		// ServiceAccountImpersonationLifetimeSeconds ??
+		// QuotaProjectID ??
+		Scopes:               clientScopes,
+		SubjectTokenSupplier: c.ExternalCredentials,
 	}
-	return externalCredentialsConfig, nil
+	// If UniverseDomain is set, the externalaccount package will use it to set the TokenURL (https://sts.UNIVERSE_DOMAIN/v1/token). Otherwise TokenURL defaults to https://sts.googleapis.com/v1/token
+	if c.UniverseDomain != "" {
+		eaConfig.UniverseDomain = c.UniverseDomain
+	}
+	return eaConfig
 }
+
 
 func ExpandProviderBatchingConfig(v interface{}) (*BatchingConfig, error) {
 	config := &BatchingConfig{
@@ -579,10 +632,10 @@ func (c *Config) synchronousTimeout() time.Duration {
 }
 
 // Print Identities executing terraform API Calls.
-func (c *Config) logGoogleIdentities() error {
+func (c *Config) logGoogleIdentities(ctx context.Context) error {
 	if c.ImpersonateServiceAccount == "" {
 
-		tokenSource, err := c.getTokenSource(c.Scopes, true)
+	tokenSource, err := c.getTokenSource(ctx, c.Scopes, false)
 		if err != nil {
 			return err
 		}
@@ -601,7 +654,7 @@ func (c *Config) logGoogleIdentities() error {
 
 	// Drop Impersonated ClientOption from OAuth2 TokenSource to infer original identity
 
-	tokenSource, err := c.getTokenSource(c.Scopes, true)
+	tokenSource, err := c.getTokenSource(ctx, c.Scopes, true)
 	if err != nil {
 		return err
 	}
@@ -616,7 +669,7 @@ func (c *Config) logGoogleIdentities() error {
 
 	// Add the Impersonated ClientOption back in to the OAuth2 TokenSource
 
-	tokenSource, err = c.getTokenSource(c.Scopes, false)
+	tokenSource, err = c.getTokenSource(ctx, c.Scopes, false)
 	if err != nil {
 		return err
 	}
@@ -627,11 +680,12 @@ func (c *Config) logGoogleIdentities() error {
 
 // Get a TokenSource based on the Google Credentials configured.
 // If initialCredentialsOnly is true, don't follow the impersonation settings and return the initial set of creds.
-func (c *Config) getTokenSource(clientScopes []string, initialCredentialsOnly bool) (oauth2.TokenSource, error) {
+func (c *Config) getTokenSource(ctx context.Context, clientScopes []string, initialCredentialsOnly bool) (oauth2.TokenSource, error) {
 
 	if c.ExternalCredentials != nil {
 		log.Printf("[INFO] Using external credentials")
-		creds, err := googleoauthexternalaccount.NewTokenSource(c.Context, *c.ExternalCredentials)
+		eaConfig := c.getExternalAccountConfig(clientScopes)
+		creds, err := externalaccount.NewTokenSource(ctx, eaConfig)
 		if err != nil {
 			return nil, fmt.Errorf("error creating token source from external credentials: %s", err)
 		}

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -584,7 +584,7 @@ func (c *Config) getExternalAccountConfig(clientScopes []string) externalaccount
 		SubjectTokenSupplier: c.ExternalCredentials,
 	}
 	// If UniverseDomain is set, the externalaccount package will use it to set the TokenURL (https://sts.UNIVERSE_DOMAIN/v1/token). Otherwise TokenURL defaults to https://sts.googleapis.com/v1/token
-	if c.UniverseDomain != "" {
+	if c.UniverseDomain != "" && c.UniverseDomain != "googleapis.com" {
 		eaConfig.UniverseDomain = c.UniverseDomain
 	}
 	return eaConfig

--- a/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
@@ -25,8 +25,8 @@ In the case of Stacks, we need to create the both the workload identity pool and
 Required variables:
 
 - `project_id` - The GCP project ID
-- `tfc_organization` - The Terraform Cloud organization
-- `tfc_stacks_project` - The Terraform Cloud project
+- `hcp_tf_organization` - The HCP Terraform organization
+- `hcp_tf_stacks_project` - The HCP Terraform Stacks project
 
 ```hcl
 provider "google" {
@@ -38,14 +38,14 @@ variable "project_id" {
   description = "GCP Project ID"
 }
 
-variable "tfc_organization" {
+variable "hcp_tf_organization" {
   type        = string
-  description = "Terraform Cloud Organization"
+  description = "HCP Terraform Organization"
 }
 
-variable "tfc_stacks_project" {
+variable "hcp_tf_stacks_project" {
   type        = string
-  description = "Terraform Cloud Project"
+  description = "HCP Terraform Stacks Project"
 }
 
 # Create a service account for Terraform Stacks
@@ -104,7 +104,7 @@ resource "google_iam_workload_identity_pool_provider" "terraform_stacks_provider
     issuer_uri = "https://app.terraform.io"
     allowed_audiences = ["hcp.workload.identity"]
   }
-  attribute_condition = "assertion.sub.startsWith(\"organization:${var.tfc_organization}:project:${var.tfc_stacks_project}:stack\")"
+  attribute_condition = "assertion.sub.startsWith(\"organization:${var.hcp_tf_organization}:project:${var.hcp_tf_stacks_project}:stack\")"
 }
 
 # Switch from binding to member for service account IAM

--- a/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
@@ -1,0 +1,152 @@
+---
+page_title: "Use external credentials in the Google Cloud provider with Terraform Stacks"
+description: |-
+  How to use external credentials in the Google Cloud provider with Terraform Stacks
+---
+
+# External Credentials in the Google Cloud provider with Terraform Stacks
+
+Apart from using `access_token` and `credential` fields in the provider configuration, you can also use external credentials in the Google Cloud provider that are provided through a Workload Identity Federation (WIF) provider. This can be used to authenticate Terraform Stacks to provision resources in Google Cloud.
+
+## Setting up a Workload Identity Federation (WIF) credentials
+
+## Stacks Setup
+
+A Terraform Stacks Project requires the following:
+
+- A Workload Identity Federation (WIF) provider
+- Components - `components.tfstacks.hcl`
+- Deployment - `deployments.tfdeploy.hcl`
+
+## Generating the Workload Identity Federation (WIF) credentials
+
+```hcl
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.25.0"
+    }
+  }
+}
+
+provider "google" {
+  region = "global"
+}
+
+variable "project_id" {
+  type        = string
+  description = "GCP Project ID"
+}
+
+# Create a service account for Terraform Stacks
+resource "google_service_account" "terraform_stacks_sa" {
+  account_id   = "terraform-stacks-sa"
+  display_name = "Terraform Stacks Service Account"
+  description  = "Service account used by Terraform Stacks for GCP resources"
+}
+
+# Create Workload Identity Pool
+resource "google_iam_workload_identity_pool" "terraform_stacks_pool" {
+  workload_identity_pool_id = "terraform-stacks-pool"
+  display_name              = "Terraform Stacks Pool"
+  description               = "Identity pool for Terraform Stacks authentication"
+}
+
+# Create Workload Identity Pool Provider
+resource "google_iam_workload_identity_pool_provider" "terraform_stacks_provider" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.terraform_stacks_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "terraform-stacks-provider"
+  display_name                       = "Terraform Stacks Provider"
+  description                        = "OIDC identity pool provider for Terraform Stacks"
+  
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+    "attribute.aud"        = "assertion.aud"
+  }
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+    allowed_audiences = ["https://iam.googleapis.com/${google_iam_workload_identity_pool.terraform_stacks_pool.name}"]
+  }
+}
+
+# Allow the Workload Identity Pool to impersonate the service account
+resource "google_service_account_iam_binding" "workload_identity_binding" {
+  service_account_id = google_service_account.terraform_stacks_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+  
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.terraform_stacks_pool.name}/*"
+  ]
+}
+
+# Grant Storage Admin role to the service account (for bucket operations)
+resource "google_project_iam_member" "sa_storage_admin" {
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.terraform_stacks_sa.email}"
+}
+
+# Outputs to be used by Terraform Stacks
+output "service_account_email" {
+  value       = google_service_account.terraform_stacks_sa.email
+  description = "Email of the service account to be used by Terraform Stacks"
+}
+
+output "audience" {
+  value       = "https://iam.googleapis.com/${google_iam_workload_identity_pool.terraform_stacks_pool.name}"
+  description = "The audience value to use when generating OIDC tokens"
+}
+```
+
+## Terraform Stacks Setup with External Credentials
+
+`deployments.tfdeploy.hcl`
+```hcl
+identity_token "jwt" {
+  audience = ["hcp.workload.identity"]
+}
+
+deployment "staging" {
+  inputs = {
+    jwt = identity_token.jwt.jwt
+  }
+}
+```
+
+`components.tfstacks.hcl`
+```hcl
+required_providers {
+  google = {
+    source = "hashicorp/google"
+    version = "6.25.0"
+  }
+}
+
+provider "google" "this" {
+  external_credentials {
+    audience = "//iam.googleapis.com/projects/871647908372/locations/global/workloadIdentityPools/stacks-oidc-myz3/providers/stacks-oidc-myz3"
+    service_account_email = "stacks-oidc-myz3@hc-terraform-testing.iam.gserviceaccount.com"
+    identity_token_file = "./identity_token"
+  }
+}
+
+variable "jwt" {
+  type = string
+}
+
+component "storage_buckets" {
+    source = "./buckets"
+
+    inputs = {
+        jwt = var.jwt
+    }
+
+    providers = {
+        google    = provider.google.this
+    }
+}
+```

--- a/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/external_credentials_stacks.html.markdown
@@ -130,7 +130,7 @@ provider "google" "this" {
   external_credentials {
     audience = "//iam.googleapis.com/projects/871647908372/locations/global/workloadIdentityPools/stacks-oidc-myz3/providers/stacks-oidc-myz3"
     service_account_email = "stacks-oidc-myz3@hc-terraform-testing.iam.gserviceaccount.com"
-    identity_token_file = "./identity_token"
+    identity_token = var.jwt
   }
 }
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -191,7 +191,7 @@ variable.
 
     -> Terraform cannot renew these access tokens, and they will eventually
     expire (default `1 hour`). If Terraform needs access for longer than a token's
-    lifetime, use a service account key with `credentials` instead.
+    lifetime, supply a [credential configuration](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#create-credential-config) through the `credentials` field instead.
 
 ## Quota Management Configuration
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -116,20 +116,7 @@ impersonated service account regardless of the primary identity in use.
 
 ## Authentication Configuration
 
-* `external_credentials` - (Optional) A block to configure external credentials for the provider, such as Workload Identity Federation credentials. See [External Credentials](/website/docs/guides/external_credentials_stacks.html.markdown) for more information.
-
-`external_credentials` takes precedence over `credentials` and `access_token` as well as `GOOGLE_CREDENTIALS` and `GOOGLE_OAUTH_ACCESS_TOKEN` environment variables. It includes the following fields:
-
-* `audience` - (Required) The audience for the external credentials.
-* `service_account_email` - (Required) The email of the service account to impersonate.
-* `identity_token` - (Required) The identity token to use for authentication.
-
-    -> Terraform cannot renew these access tokens, and they will eventually
-    expire (default `2 hour`). If Terraform needs access for longer than a token's
-    lifetime, use a service account key with `credentials` instead.
-
----
-
+* `credentials` - (Optional) Either the path to or the contents of a
 [service account key file] in JSON format. You can
 [manage key files using the Cloud Console]. Your service account key file is
 used to complete a two-legged OAuth 2.0 flow to obtain access tokens to
@@ -191,6 +178,20 @@ Alternatively, this can be specified using the `GOOGLE_IMPERSONATE_SERVICE_ACCOU
 variable.
 
 * `impersonate_service_account_delegates` - (Optional) The delegation chain for an impersonating a service account as described [here](https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-delegated).
+
+---
+
+* `external_credentials` - (Optional) A block to configure external credentials for the provider, such as Workload Identity Federation credentials. See [External Credentials](/website/docs/guides/external_credentials_stacks.html.markdown) for more information.
+
+`external_credentials` takes precedence over `credentials` and `access_token` as well as `GOOGLE_CREDENTIALS` and `GOOGLE_OAUTH_ACCESS_TOKEN` environment variables. It includes the following fields:
+
+* `audience` - (Required) The audience for the external credentials.
+* `service_account_email` - (Required) The email of the service account to impersonate.
+* `identity_token` - (Required) The identity token to use for authentication.
+
+    -> Terraform cannot renew these access tokens, and they will eventually
+    expire (default `1 hour`). If Terraform needs access for longer than a token's
+    lifetime, use a service account key with `credentials` instead.
 
 ## Quota Management Configuration
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -187,7 +187,7 @@ variable.
 
 * `audience` - (Required) The Secure Token Service (STS) audience for the external credentials.
 * `service_account_email` - (Required) The email of the service account to impersonate when retrieving a Google access token.
-* `identity_token` - (Required) An identity token from the external identity provider to use for authentication.
+* `identity_token` - (Required) An identity token from the external identity provider to use for authentication with the external provider.
 
     -> Terraform cannot renew these access tokens, and they will eventually
     expire (default `1 hour`). If Terraform needs access for longer than a token's

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -116,7 +116,20 @@ impersonated service account regardless of the primary identity in use.
 
 ## Authentication Configuration
 
-* `credentials` - (Optional) Either the path to or the contents of a
+* `external_credentials` - (Optional) A block to configure external credentials for the provider, such as Workload Identity Federation credentials. See [External Credentials](/website/docs/guides/external_credentials_stacks.html.markdown) for more information.
+
+`external_credentials` takes precedence over `credentials` and `access_token` as well as `GOOGLE_CREDENTIALS` and `GOOGLE_OAUTH_ACCESS_TOKEN` environment variables. It includes the following fields:
+
+* `audience` - (Required) The audience for the external credentials.
+* `service_account_email` - (Required) The email of the service account to impersonate.
+* `identity_token` - (Required) The identity token to use for authentication.
+
+    -> Terraform cannot renew these access tokens, and they will eventually
+    expire (default `2 hour`). If Terraform needs access for longer than a token's
+    lifetime, use a service account key with `credentials` instead.
+
+---
+
 [service account key file] in JSON format. You can
 [manage key files using the Cloud Console]. Your service account key file is
 used to complete a two-legged OAuth 2.0 flow to obtain access tokens to

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -181,13 +181,13 @@ variable.
 
 ---
 
-* `external_credentials` - (Optional) A block to configure external credentials for the provider, such as Workload Identity Federation credentials. See [External Credentials](/website/docs/guides/external_credentials_stacks.html.markdown) for more information.
+* `external_credentials` - (Optional) Configuration of external credentials for the provider, such as Workload Identity Federation credentials. Terraform constructs a function as a [user-defined function credentials source](https://pkg.go.dev/golang.org/x/oauth2/google/externalaccount#hdr-Workload_Identity_Federation) based on the fixed (per execution) `identity_token` value. To use this with HCP Terraform, see the [External Credentials in Terraform Stacks](/website/docs/guides/external_credentials_stacks.html.markdown) guide.
 
 `external_credentials` takes precedence over `credentials` and `access_token` as well as `GOOGLE_CREDENTIALS` and `GOOGLE_OAUTH_ACCESS_TOKEN` environment variables. It includes the following fields:
 
-* `audience` - (Required) The audience for the external credentials.
-* `service_account_email` - (Required) The email of the service account to impersonate.
-* `identity_token` - (Required) The identity token to use for authentication.
+* `audience` - (Required) The Secure Token Service (STS) audience for the external credentials.
+* `service_account_email` - (Required) The email of the service account to impersonate when retrieving a Google access token.
+* `identity_token` - (Required) An identity token from the external identity provider to use for authentication.
 
     -> Terraform cannot renew these access tokens, and they will eventually
     expire (default `1 hour`). If Terraform needs access for longer than a token's


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

This adds external_credentials support allowing you to implement credentials such as WIF

screenshot shows successful apply with the previous error occurring when commenting out the external_credentials.

![image](https://github.com/user-attachments/assets/0ebaded9-2965-417d-a095-c572cb16d230)

provider that was used for testing this feature is found here: https://github.com/BBBmau/terraform-provider-google/commit/caadf43fe76c4fdc04c851e16ed659ede13f3d7d#diff-3f3fc7ca4bb3b70c74628fe4092a22f6540b4367b2ce9f57766def8093a38a07R1612

# Validation

## [Refer to this comment for the most up-to date validation video](https://github.com/GoogleCloudPlatform/magic-modules/pull/12714#issuecomment-2741600948)

https://github.com/user-attachments/assets/5c09fe37-221a-4ed6-8a24-8f02e9dd0da2


See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
`external_credentials` block in provider
```
