### PR TITLE
add enforce_in_transit field in google_pubsub_topic

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -129,6 +129,14 @@ properties:
         required: true
         item_type:
           type: String
+      - name: "enforceInTransit"
+        type: Boolean
+        description: |
+          If true, `allowedPersistenceRegions` is also used to enforce in-transit
+          guarantees for messages. That is, Pub/Sub will fail topics.publish
+          operations on this topic and subscribe operations on any subscription
+          attached to this topic in any region that is not in `allowedPersistenceRegions`.
+        required: false
   - name: 'schemaSettings'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/pubsub_topic_geo_restricted.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_topic_geo_restricted.tf.tmpl
@@ -5,5 +5,6 @@ resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
     allowed_persistence_regions = [
       "europe-west3",
     ]
+    enforce_in_transit = true
   }
 }

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -230,6 +230,7 @@ resource "google_pubsub_topic" "foo" {
     allowed_persistence_regions = [
       "%s",
     ]
+    enforce_in_transit = false
   }
 }
 `, topic, key, value, region)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19448

**Release Note Template for Downstream PRs (will be copied)**


```release-note: enhancement
pubsub: added `enforce_in_transit` fields to `google_pubsub_topic` resource
```
