### PR TITLE
Failing test(s): TestAccComputeInterconnect_computeInterconnectBasicTestExample

### DIFF
--- a/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.tmpl
+++ b/mmv1/templates/terraform/examples/interconnect_attachment_dedicated.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_interconnect" "foobar" {
   interconnect_type    = "DEDICATED"
   link_type            = "LINK_TYPE_ETHERNET_10G_LR"
   requested_link_count = 1
-  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
+  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-nciadf-a" # Special location only available for Google testing.
 }
 
 resource "google_compute_interconnect_attachment" "{{$.PrimaryResourceId}}" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_macsec_test.go
@@ -51,7 +51,7 @@ resource "google_compute_interconnect" "example-interconnect" {
   customer_name        = "internal_customer" # Special customer only available for Google testing.
   interconnect_type    = "DEDICATED"
   link_type            = "LINK_TYPE_ETHERNET_100G_LR"
-  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
+  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-z" # Special location only available for Google testing.
   requested_link_count = 1
   admin_enabled        = true
   description          = "example description"
@@ -74,7 +74,7 @@ resource "google_compute_interconnect" "example-interconnect" {
   customer_name        = "internal_customer" # Special customer only available for Google testing.
   interconnect_type    = "DEDICATED"
   link_type            = "LINK_TYPE_ETHERNET_100G_LR"
-  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-a" # Special location only available for Google testing.
+  location             = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/global/interconnectLocations/z2z-us-east4-zone1-lciadl-z" # Special location only available for Google testing.
   requested_link_count = 1
   admin_enabled        = true
   description          = "example description"


### PR DESCRIPTION
b/362278333

fixes https://github.com/hashicorp/terraform-provider-google/issues/19229

Fix for the interconnect test cases by adding different interconnect locations `z2z-us-east4-zone1-lciadl-z ` and ```z2z-us-east4-zone1-nciadf-a``` while creating interconnect.

**Release Note Template for Downstream PRs (will be copied)**


```release-note: none
```
