### PR TITLE
Add google_compute_instance to v6 cai2hcl

### DIFF
--- a/mmv1/templates/tgc_v6/cai2hcl/resource_converters.go.tmpl
+++ b/mmv1/templates/tgc_v6/cai2hcl/resource_converters.go.tmpl
@@ -29,6 +29,7 @@ package converters
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/services/compute"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/services/resourcemanager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,4 +41,5 @@ var provider *schema.Provider = tpg_provider.Provider()
 // ConverterMap is a collection of converters instances, indexed by cai asset type.
 var ConverterMap = map[string]models.Converter{
 	resourcemanager.ProjectAssetType: resourcemanager.NewProjectConverter(provider),
+	compute.ComputeInstanceAssetType: compute.NewComputeInstanceConverter(provider),
 }

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/services/compute/compute_instance.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/services/compute/compute_instance.go
@@ -1,0 +1,216 @@
+package compute
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/utils"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	compute "google.golang.org/api/compute/v0.beta"
+)
+
+// ComputeInstanceAssetType is the CAI asset type name for compute instance.
+const ComputeInstanceAssetType string = "compute.googleapis.com/Instance"
+
+// ComputeInstanceSchemaName is the TF resource schema name for compute instance.
+const ComputeInstanceSchemaName string = "google_compute_instance"
+
+// ComputeInstanceConverter for compute instance resource.
+type ComputeInstanceConverter struct {
+	name   string
+	schema map[string]*schema.Schema
+}
+
+// NewComputeInstanceConverter returns an HCL converter for compute instance.
+func NewComputeInstanceConverter(provider *schema.Provider) models.Converter {
+	schema := provider.ResourcesMap[ComputeInstanceSchemaName].Schema
+
+	return &ComputeInstanceConverter{
+		name:   ComputeInstanceSchemaName,
+		schema: schema,
+	}
+}
+
+// Convert converts asset to HCL resource blocks.
+func (c *ComputeInstanceConverter) Convert(asset *caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
+	if asset == nil || asset.Resource == nil && asset.Resource.Data == nil {
+		return nil, nil
+	}
+	var blocks []*models.TerraformResourceBlock
+	block, err := c.convertResourceData(asset)
+	if err != nil {
+		return nil, err
+	}
+	blocks = append(blocks, block)
+	return blocks, nil
+}
+
+func (c *ComputeInstanceConverter) convertResourceData(asset *caiasset.Asset) (*models.TerraformResourceBlock, error) {
+	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+		return nil, fmt.Errorf("asset resource data is nil")
+	}
+
+	project := utils.ParseFieldValue(asset.Name, "projects")
+
+	var instance *compute.Instance
+	if err := utils.DecodeJSON(asset.Resource.Data, &instance); err != nil {
+		return nil, err
+	}
+
+	hclData := make(map[string]interface{})
+
+	if instance.CanIpForward {
+		hclData["can_ip_forward"] = instance.CanIpForward
+	}
+	hclData["machine_type"] = tpgresource.GetResourceNameFromSelfLink(instance.MachineType)
+	hclData["network_performance_config"] = flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)
+
+	// Set the networks
+	networkInterfaces, _, _, err := flattenNetworkInterfaces(instance.NetworkInterfaces, project)
+	if err != nil {
+		return nil, err
+	}
+	hclData["network_interface"] = networkInterfaces
+
+	if instance.Tags != nil {
+		hclData["tags"] = tpgresource.ConvertStringArrToInterface(instance.Tags.Items)
+	}
+
+	hclData["labels"] = utils.RemoveTerraformAttributionLabel(instance.Labels)
+	hclData["service_account"] = flattenServiceAccounts(instance.ServiceAccounts)
+	hclData["resource_policies"] = instance.ResourcePolicies
+
+	bootDisk, ads, scratchDisks := flattenDisks(instance.Disks, instance.Name)
+	hclData["boot_disk"] = bootDisk
+	hclData["attached_disk"] = ads
+	hclData["scratch_disk"] = scratchDisks
+
+	hclData["scheduling"] = flattenScheduling(instance.Scheduling)
+	hclData["guest_accelerator"] = flattenGuestAccelerators(instance.GuestAccelerators)
+	hclData["shielded_instance_config"] = flattenShieldedVmConfig(instance.ShieldedInstanceConfig)
+	hclData["enable_display"] = flattenEnableDisplay(instance.DisplayDevice)
+	hclData["min_cpu_platform"] = instance.MinCpuPlatform
+
+	// Only convert the field when its value is not default false
+	if instance.DeletionProtection {
+		hclData["deletion_protection"] = instance.DeletionProtection
+	}
+	hclData["zone"] = tpgresource.GetResourceNameFromSelfLink(instance.Zone)
+	hclData["name"] = instance.Name
+	hclData["description"] = instance.Description
+	hclData["hostname"] = instance.Hostname
+	hclData["confidential_instance_config"] = flattenConfidentialInstanceConfig(instance.ConfidentialInstanceConfig)
+	hclData["advanced_machine_features"] = flattenAdvancedMachineFeatures(instance.AdvancedMachineFeatures)
+	hclData["reservation_affinity"] = flattenReservationAffinity(instance.ReservationAffinity)
+	hclData["key_revocation_action_type"] = instance.KeyRevocationActionType
+
+	// TODO: convert details from the boot disk assets (separate disk assets) into initialize_params in cai2hcl?
+	// It needs to integrate the disk assets into instance assets with the resolver.
+
+	ctyVal, err := utils.MapToCtyValWithSchema(hclData, c.schema)
+	if err != nil {
+		return nil, err
+	}
+	return &models.TerraformResourceBlock{
+		Labels: []string{c.name, instance.Name},
+		Value:  ctyVal,
+	}, nil
+
+}
+
+func flattenDisks(disks []*compute.AttachedDisk, instanceName string) ([]map[string]interface{}, []map[string]interface{}, []map[string]interface{}) {
+	attachedDisks := []map[string]interface{}{}
+	bootDisk := []map[string]interface{}{}
+	scratchDisks := []map[string]interface{}{}
+	for _, disk := range disks {
+		if disk.Boot {
+			bootDisk = flattenBootDisk(disk, instanceName)
+		} else if disk.Type == "SCRATCH" {
+			scratchDisks = append(scratchDisks, flattenScratchDisk(disk))
+		} else {
+			di := map[string]interface{}{
+				"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
+				"device_name": disk.DeviceName,
+				"mode":        disk.Mode,
+			}
+			if key := disk.DiskEncryptionKey; key != nil {
+				if key.KmsKeyName != "" {
+					// The response for crypto keys often includes the version of the key which needs to be removed
+					// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+					di["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
+				}
+			}
+			attachedDisks = append(attachedDisks, di)
+		}
+	}
+
+	// Remove nils from map in case there were disks in the config that were not present on read;
+	// i.e. a disk was detached out of band
+	ads := []map[string]interface{}{}
+	for _, d := range attachedDisks {
+		if d != nil {
+			ads = append(ads, d)
+		}
+	}
+	return bootDisk, ads, scratchDisks
+}
+
+func flattenBootDisk(disk *compute.AttachedDisk, instanceName string) []map[string]interface{} {
+	result := map[string]interface{}{}
+
+	if !disk.AutoDelete {
+		result["auto_delete"] = false
+	}
+
+	if !strings.Contains(disk.DeviceName, "persistent-disk-") {
+		result["device_name"] = disk.DeviceName
+	}
+
+	if disk.Mode != "READ_WRITE" {
+		result["mode"] = disk.Mode
+	}
+
+	if disk.DiskEncryptionKey != nil {
+		if disk.DiskEncryptionKey.KmsKeyName != "" {
+			// The response for crypto keys often includes the version of the key which needs to be removed
+			// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+			result["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
+		}
+	}
+
+	// Don't convert the field with the default value
+	if disk.Interface != "SCSI" {
+		result["interface"] = disk.Interface
+	}
+
+	if !strings.HasSuffix(disk.Source, instanceName) {
+		result["source"] = tpgresource.ConvertSelfLinkToV1(disk.Source)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{result}
+}
+
+func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
+	result := map[string]interface{}{
+		"size": disk.DiskSizeGb,
+	}
+
+	if !strings.Contains(disk.DeviceName, "persistent-disk-") {
+		result["device_name"] = disk.DeviceName
+	}
+
+	// Don't convert the field with the default value
+	if disk.Interface != "SCSI" {
+		result["interface"] = disk.Interface
+	}
+
+	return result
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/services/compute/compute_instance_helpers.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/services/compute/compute_instance_helpers.go
@@ -1,0 +1,330 @@
+package compute
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/utils"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+
+	compute "google.golang.org/api/compute/v0.beta"
+)
+
+func flattenAliasIpRange(ranges []*compute.AliasIpRange) []map[string]interface{} {
+	rangesSchema := make([]map[string]interface{}, 0, len(ranges))
+	for _, ipRange := range ranges {
+		rangesSchema = append(rangesSchema, map[string]interface{}{
+			"ip_cidr_range":         ipRange.IpCidrRange,
+			"subnetwork_range_name": ipRange.SubnetworkRangeName,
+		})
+	}
+	return rangesSchema
+}
+
+func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
+	schedulingMap := make(map[string]interface{}, 0)
+
+	if resp.InstanceTerminationAction != "" {
+		schedulingMap["instance_termination_action"] = resp.InstanceTerminationAction
+	}
+
+	if resp.MinNodeCpus != 0 {
+		schedulingMap["min_node_cpus"] = resp.MinNodeCpus
+	}
+
+	if resp.OnHostMaintenance != "MIGRATE" {
+		schedulingMap["on_host_maintenance"] = resp.OnHostMaintenance
+	}
+
+	if resp.AutomaticRestart != nil && !*resp.AutomaticRestart {
+		schedulingMap["automatic_restart"] = *resp.AutomaticRestart
+	}
+
+	if resp.Preemptible {
+		schedulingMap["preemptible"] = resp.Preemptible
+	}
+
+	if resp.NodeAffinities != nil && len(resp.NodeAffinities) > 0 {
+		nodeAffinities := []map[string]interface{}{}
+		for _, na := range resp.NodeAffinities {
+			nodeAffinities = append(nodeAffinities, map[string]interface{}{
+				"key":      na.Key,
+				"operator": na.Operator,
+				"values":   tpgresource.ConvertStringArrToInterface(na.Values),
+			})
+		}
+		schedulingMap["node_affinities"] = nodeAffinities
+	}
+
+	if resp.ProvisioningModel != "STANDARD" {
+		schedulingMap["provisioning_model"] = resp.ProvisioningModel
+	}
+
+	if resp.AvailabilityDomain != 0 {
+		schedulingMap["availability_domain"] = resp.AvailabilityDomain
+	}
+
+	if resp.MaxRunDuration != nil {
+		schedulingMap["max_run_duration"] = flattenComputeMaxRunDuration(resp.MaxRunDuration)
+	}
+
+	if resp.OnInstanceStopAction != nil {
+		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(resp.OnInstanceStopAction)
+	}
+
+	if resp.HostErrorTimeoutSeconds != 0 {
+		schedulingMap["host_error_timeout_seconds"] = resp.HostErrorTimeoutSeconds
+	}
+
+	if resp.MaintenanceInterval != "" {
+		schedulingMap["maintenance_interval"] = resp.MaintenanceInterval
+	}
+
+	if resp.LocalSsdRecoveryTimeout != nil {
+		schedulingMap["local_ssd_recovery_timeout"] = flattenComputeLocalSsdRecoveryTimeout(resp.LocalSsdRecoveryTimeout)
+	}
+
+	if len(schedulingMap) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{schedulingMap}
+}
+
+func flattenComputeMaxRunDuration(v *compute.Duration) []interface{} {
+	if v == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["nanos"] = v.Nanos
+	transformed["seconds"] = v.Seconds
+	return []interface{}{transformed}
+}
+
+func flattenOnInstanceStopAction(v *compute.SchedulingOnInstanceStopAction) []interface{} {
+	if v == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["discard_local_ssd"] = v.DiscardLocalSsd
+	return []interface{}{transformed}
+}
+
+func flattenComputeLocalSsdRecoveryTimeout(v *compute.Duration) []interface{} {
+	if v == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["nanos"] = v.Nanos
+	transformed["seconds"] = v.Seconds
+	return []interface{}{transformed}
+}
+
+func flattenAccessConfigs(accessConfigs []*compute.AccessConfig) ([]map[string]interface{}, string) {
+	flattened := make([]map[string]interface{}, len(accessConfigs))
+	natIP := ""
+	for i, ac := range accessConfigs {
+		flattened[i] = map[string]interface{}{
+			"nat_ip":       ac.NatIP,
+			"network_tier": ac.NetworkTier,
+		}
+		if ac.SetPublicPtr {
+			flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
+		}
+		if natIP == "" {
+			natIP = ac.NatIP
+		}
+		if ac.SecurityPolicy != "" {
+			flattened[i]["security_policy"] = ac.SecurityPolicy
+		}
+	}
+	return flattened, natIP
+}
+
+func flattenIpv6AccessConfigs(ipv6AccessConfigs []*compute.AccessConfig) []map[string]interface{} {
+	flattened := make([]map[string]interface{}, len(ipv6AccessConfigs))
+	for i, ac := range ipv6AccessConfigs {
+		flattened[i] = map[string]interface{}{
+			"network_tier": ac.NetworkTier,
+		}
+		flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
+		flattened[i]["external_ipv6"] = ac.ExternalIpv6
+		flattened[i]["external_ipv6_prefix_length"] = strconv.FormatInt(ac.ExternalIpv6PrefixLength, 10)
+		flattened[i]["name"] = ac.Name
+		if ac.SecurityPolicy != "" {
+			flattened[i]["security_policy"] = ac.SecurityPolicy
+		}
+	}
+	return flattened
+}
+
+func flattenNetworkInterfaces(networkInterfaces []*compute.NetworkInterface, project string) ([]map[string]interface{}, string, string, error) {
+	flattened := make([]map[string]interface{}, len(networkInterfaces))
+	var internalIP, externalIP string
+
+	for i, iface := range networkInterfaces {
+		var ac []map[string]interface{}
+		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
+
+		flattened[i] = map[string]interface{}{
+			"network_ip":         iface.NetworkIP,
+			"access_config":      ac,
+			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
+			"nic_type":           iface.NicType,
+			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
+			"ipv6_address":       iface.Ipv6Address,
+		}
+
+		if !strings.HasSuffix(iface.Network, "/default") {
+			flattened[i]["network"] = tpgresource.ConvertSelfLinkToV1(iface.Network)
+		}
+
+		if !strings.HasSuffix(iface.Subnetwork, "/default") {
+			flattened[i]["subnetwork"] = tpgresource.ConvertSelfLinkToV1(iface.Subnetwork)
+		}
+
+		subnetProject := utils.ParseFieldValue(iface.Subnetwork, "projects")
+		if subnetProject != project {
+			flattened[i]["subnetwork_project"] = subnetProject
+		}
+
+		if iface.StackType != "IPV4_ONLY" {
+			flattened[i]["stack_type"] = iface.StackType
+		}
+
+		if iface.QueueCount != 0 {
+			flattened[i]["queue_count"] = iface.QueueCount
+		}
+
+		if internalIP == "" {
+			internalIP = iface.NetworkIP
+		}
+
+		if iface.NetworkAttachment != "" {
+			networkAttachment, err := tpgresource.GetRelativePath(iface.NetworkAttachment)
+			if err != nil {
+				return nil, "", "", err
+			}
+			flattened[i]["network_attachment"] = networkAttachment
+		}
+
+		// the security_policy for a network_interface is found in one of its accessConfigs.
+		if len(iface.AccessConfigs) > 0 && iface.AccessConfigs[0].SecurityPolicy != "" {
+			flattened[i]["security_policy"] = iface.AccessConfigs[0].SecurityPolicy
+		} else if len(iface.Ipv6AccessConfigs) > 0 && iface.Ipv6AccessConfigs[0].SecurityPolicy != "" {
+			flattened[i]["security_policy"] = iface.Ipv6AccessConfigs[0].SecurityPolicy
+		}
+	}
+	return flattened, internalIP, externalIP, nil
+}
+
+func flattenServiceAccounts(serviceAccounts []*compute.ServiceAccount) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(serviceAccounts))
+	for i, serviceAccount := range serviceAccounts {
+		result[i] = map[string]interface{}{
+			"email":  serviceAccount.Email,
+			"scopes": serviceAccount.Scopes,
+		}
+	}
+	return result
+}
+
+func flattenGuestAccelerators(accelerators []*compute.AcceleratorConfig) []map[string]interface{} {
+	acceleratorsSchema := make([]map[string]interface{}, len(accelerators))
+	for i, accelerator := range accelerators {
+		acceleratorsSchema[i] = map[string]interface{}{
+			"count": accelerator.AcceleratorCount,
+			"type":  accelerator.AcceleratorType,
+		}
+	}
+	return acceleratorsSchema
+}
+
+func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *compute.ConfidentialInstanceConfig) []map[string]interface{} {
+	if ConfidentialInstanceConfig == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{{
+		"enable_confidential_compute": ConfidentialInstanceConfig.EnableConfidentialCompute,
+		"confidential_instance_type":  ConfidentialInstanceConfig.ConfidentialInstanceType,
+	}}
+}
+
+func flattenAdvancedMachineFeatures(AdvancedMachineFeatures *compute.AdvancedMachineFeatures) []map[string]interface{} {
+	if AdvancedMachineFeatures == nil {
+		return nil
+	}
+	return []map[string]interface{}{{
+		"enable_nested_virtualization": AdvancedMachineFeatures.EnableNestedVirtualization,
+		"threads_per_core":             AdvancedMachineFeatures.ThreadsPerCore,
+		"turbo_mode":                   AdvancedMachineFeatures.TurboMode,
+		"visible_core_count":           AdvancedMachineFeatures.VisibleCoreCount,
+		"performance_monitoring_unit":  AdvancedMachineFeatures.PerformanceMonitoringUnit,
+		"enable_uefi_networking":       AdvancedMachineFeatures.EnableUefiNetworking,
+	}}
+}
+
+func flattenShieldedVmConfig(shieldedVmConfig *compute.ShieldedInstanceConfig) []map[string]bool {
+	if shieldedVmConfig == nil {
+		return nil
+	}
+
+	shieldedInstanceConfig := map[string]bool{}
+
+	if shieldedVmConfig.EnableSecureBoot {
+		shieldedInstanceConfig["enable_secure_boot"] = shieldedVmConfig.EnableSecureBoot
+	}
+
+	if !shieldedVmConfig.EnableVtpm {
+		shieldedInstanceConfig["enable_vtpm"] = shieldedVmConfig.EnableVtpm
+	}
+
+	if !shieldedVmConfig.EnableIntegrityMonitoring {
+		shieldedInstanceConfig["enable_integrity_monitoring"] = shieldedVmConfig.EnableIntegrityMonitoring
+	}
+
+	if len(shieldedInstanceConfig) == 0 {
+		return nil
+	}
+
+	return []map[string]bool{shieldedInstanceConfig}
+}
+
+func flattenEnableDisplay(displayDevice *compute.DisplayDevice) interface{} {
+	if displayDevice == nil {
+		return nil
+	}
+
+	return displayDevice.EnableDisplay
+}
+
+func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[string]interface{} {
+	if affinity == nil {
+		return nil
+	}
+
+	flattened := map[string]interface{}{
+		"type": affinity.ConsumeReservationType,
+	}
+
+	if affinity.ConsumeReservationType == "SPECIFIC_RESERVATION" {
+		flattened["specific_reservation"] = []map[string]interface{}{{
+			"key":    affinity.Key,
+			"values": affinity.Values,
+		}}
+	}
+
+	return []map[string]interface{}{flattened}
+}
+
+func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"total_egress_bandwidth_tier": c.TotalEgressBandwidthTier,
+		},
+	}
+}

--- a/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils.go
+++ b/mmv1/third_party/tgc_v6/cai2hcl/converters/utils/utils.go
@@ -24,13 +24,22 @@ func ParseFieldValue(url string, name string) string {
 }
 
 // Remove the Terraform attribution label "goog-terraform-provisioned" from labels
-func RemoveTerraformAttributionLabel(raw interface{}) map[string]interface{} {
+func RemoveTerraformAttributionLabel(raw interface{}) interface{} {
 	if raw == nil {
 		return nil
 	}
-	labels := raw.(map[string]interface{})
-	delete(labels, "goog-terraform-provisioned")
-	return labels
+
+	if labels, ok := raw.(map[string]string); ok {
+		delete(labels, "goog-terraform-provisioned")
+		return labels
+	}
+
+	if labels, ok := raw.(map[string]interface{}); ok {
+		delete(labels, "goog-terraform-provisioned")
+		return labels
+	}
+
+	return nil
 }
 
 // DecodeJSON decodes the map object into the target struct.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
1. The cai2hcl  conversion workflow for `google_compute_instance` is cai asset -> API object -> tfplan. In this way, the flatten functions in the provider, which convert API object into Terraform resource,  can be reused. To handle the inconsistency between cai asset and API object, some modification is needed for the flatten functions.
2. The fields with default value in provider are only converted when their values are not default.
3. Testing:

In magic modules, generate tgc
```
make tgc  OUTPUT_PATH="$GOPATH/src/github.com/GoogleCloudPlatform/terraform-google-conversion"
```

In terraform-google-conversion

make build
./bin/tgc cai2hcl convert [full_compute_instance.json](https://paste.googleplex.com/5853163819892736) > [full_compute_instance.tf](https://paste.googleplex.com/5591232353665024)


The automatic testing will come soon.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
