### PR TITLE
container: fixed resourceManagerTags tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -62,6 +62,7 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	t.Parallel()
 
 	pid := envvar.GetTestProjectFromEnv()
+	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
@@ -69,7 +70,8 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) {
+	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
+		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -3636,13 +3638,15 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	t.Parallel()
 
 	pid := envvar.GetTestProjectFromEnv()
+	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
 	clusterNetName := fmt.Sprintf("tf-test-container-net-%s", randomSuffix)
 	clusterSubnetName := fmt.Sprintf("tf-test-container-subnet-%s", randomSuffix)
 
-	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) {
+	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
+		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -3672,7 +3676,7 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Small sleep first, to avoid condition where cluster is ready but underlying GCE
 					// resources apparently aren't.
-					acctest.SleepInSecondsForTest(30),
+					acctest.SleepInSecondsForTest(15),
 					resource.TestCheckResourceAttrSet("google_container_cluster.with_autopilot", "node_pool_auto_config.0.resource_manager_tags.%"),
 				),
 			},
@@ -11776,20 +11780,6 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tag_user" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tag_user,
-  ]
-}
-
 resource "google_tags_tag_key" "key1" {
   parent      = data.google_project.project.id
   short_name  = "foobarbaz-%[2]s"
@@ -11844,8 +11834,6 @@ resource "google_container_cluster" "primary" {
   deletion_protection = false
   network             = "%[4]s"
   subnetwork          = "%[5]s"
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName, tagResourceNumber)
 }
@@ -11854,20 +11842,6 @@ func testAccContainerCluster_withAutopilotResourceManagerTags(projectID, cluster
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%[1]s"
-}
-
-resource "google_project_iam_member" "tag_user" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tag_user,
-  ]
 }
 
 resource "google_tags_tag_key" "key1" {
@@ -11964,8 +11938,6 @@ resource "google_container_cluster" "with_autopilot" {
   vertical_pod_autoscaling {
     enabled = true
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName)
 }
@@ -11974,20 +11946,6 @@ func testAccContainerCluster_withAutopilotResourceManagerTagsUpdate1(projectID, 
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%[1]s"
-}
-
-resource "google_project_iam_member" "tag_user" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tag_user,
-  ]
 }
 
 resource "google_tags_tag_key" "key1" {
@@ -12085,8 +12043,6 @@ resource "google_container_cluster" "with_autopilot" {
   vertical_pod_autoscaling {
     enabled = true
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName)
 }
@@ -12095,20 +12051,6 @@ func testAccContainerCluster_withAutopilotResourceManagerTagsUpdate2(projectID, 
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%[1]s"
-}
-
-resource "google_project_iam_member" "tag_user" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tag_user,
-  ]
 }
 
 resource "google_tags_tag_key" "key1" {
@@ -12199,8 +12141,6 @@ resource "google_container_cluster" "with_autopilot" {
   vertical_pod_autoscaling {
     enabled = true
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 `, projectID, randomSuffix, clusterName, networkName, subnetworkName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,7 +69,8 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") 
+		|| acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -11767,12 +11768,6 @@ func testAccContainerCluster_resourceManagerTags(projectID, clusterName, network
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%[1]s"
-}
-
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
 
 resource "google_project_iam_member" "tagUser1" {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,9 +69,7 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagUser") {
+	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -3644,9 +3642,7 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	clusterNetName := fmt.Sprintf("tf-test-container-net-%s", randomSuffix)
 	clusterSubnetName := fmt.Sprintf("tf-test-container-subnet-%s", randomSuffix)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagUser") {
+	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3676,7 +3676,7 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Small sleep first, to avoid condition where cluster is ready but underlying GCE
 					// resources apparently aren't.
-					acctest.SleepInSecondsForTest(15),
+					acctest.SleepInSecondsForTest(30),
 					resource.TestCheckResourceAttrSet("google_container_cluster.with_autopilot", "node_pool_auto_config.0.resource_manager_tags.%"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3643,6 +3643,11 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	clusterNetName := fmt.Sprintf("tf-test-container-net-%s", randomSuffix)
 	clusterSubnetName := fmt.Sprintf("tf-test-container-subnet-%s", randomSuffix)
 
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -11774,23 +11779,18 @@ resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagHoldAdmin,
     google_project_iam_member.tagUser1,
     google_project_iam_member.tagUser2,
   ]
@@ -11862,33 +11862,22 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagHoldAdmin,
     google_project_iam_member.tagUser1,
     google_project_iam_member.tagUser2,
   ]
@@ -12000,33 +11989,22 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagHoldAdmin,
     google_project_iam_member.tagUser1,
     google_project_iam_member.tagUser2,
   ]
@@ -12139,33 +12117,22 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
 resource "google_project_iam_member" "tagUser1" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "google_project_iam_member" "tagUser2" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
 }
 
 resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagHoldAdmin,
     google_project_iam_member.tagUser1,
     google_project_iam_member.tagUser2,
   ]

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -15,6 +15,27 @@ import (
 	cloudkms "google.golang.org/api/cloudkms/v1"
 )
 
+func bootstrapGkeTagManagerServiceAgents(t *testing.T) {
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role:   "roles/resourcemanager.tagAdmin",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role:   "roles/resourcemanager.tagHoldAdmin",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role:   "roles/resourcemanager.tagUser",
+		},
+		{
+			Member: "serviceAccount:{project_number}@cloudservices.gserviceaccount.com",
+			Role:   "roles/resourcemanager.tagUser",
+		},
+	})
+}
+
 func TestAccContainerCluster_basic(t *testing.T) {
 	t.Parallel()
 
@@ -62,19 +83,14 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	t.Parallel()
 
 	pid := envvar.GetTestProjectFromEnv()
-	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
-
-	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
-		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
-		t.Fatal("Stopping the test because a role was added to the policy.")
-	}
-
+	
+	bootstrapGkeTagManagerServiceAgents(t)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -3638,17 +3654,13 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	t.Parallel()
 
 	pid := envvar.GetTestProjectFromEnv()
-	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
 	clusterNetName := fmt.Sprintf("tf-test-container-net-%s", randomSuffix)
 	clusterSubnetName := fmt.Sprintf("tf-test-container-subnet-%s", randomSuffix)
 
-	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
-		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
-		t.Fatal("Stopping the test because a role was added to the policy.")
-	}
+	bootstrapGkeTagManagerServiceAgents(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,8 +69,9 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagUser") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -3643,8 +3644,9 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 	clusterNetName := fmt.Sprintf("tf-test-container-net-%s", randomSuffix)
 	clusterSubnetName := fmt.Sprintf("tf-test-container-subnet-%s", randomSuffix)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
-		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagUser") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 
@@ -3672,6 +3674,9 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 			{
 				Config: testAccContainerCluster_withAutopilotResourceManagerTagsUpdate1(pid, clusterName, clusterNetName, clusterSubnetName, randomSuffix),
 				Check: resource.ComposeTestCheckFunc(
+					// Small sleep first, to avoid condition where cluster is ready but underlying GCE
+					// resources apparently aren't.
+					acctest.SleepInSecondsForTest(30),
 					resource.TestCheckResourceAttrSet("google_container_cluster.with_autopilot", "node_pool_auto_config.0.resource_manager_tags.%"),
 				),
 			},
@@ -11775,13 +11780,7 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser2" {
+resource "google_project_iam_member" "tag_user" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
@@ -11791,8 +11790,7 @@ resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
+    google_project_iam_member.tag_user,
   ]
 }
 
@@ -11862,13 +11860,7 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser2" {
+resource "google_project_iam_member" "tag_user" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
@@ -11878,8 +11870,7 @@ resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
+    google_project_iam_member.tag_user,
   ]
 }
 
@@ -11989,13 +11980,7 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser2" {
+resource "google_project_iam_member" "tag_user" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
@@ -12005,8 +11990,7 @@ resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
+    google_project_iam_member.tag_user,
   ]
 }
 
@@ -12117,13 +12101,7 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser2" {
+resource "google_project_iam_member" "tag_user" {
   project = "%[1]s"
   role    = "roles/resourcemanager.tagUser"
   member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
@@ -12133,8 +12111,7 @@ resource "time_sleep" "wait_120_seconds" {
   create_duration = "120s"
 
   depends_on = [
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
+    google_project_iam_member.tag_user,
   ]
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -3674,8 +3674,9 @@ func TestAccContainerCluster_withAutopilotResourceManagerTags(t *testing.T) {
 			{
 				Config: testAccContainerCluster_withAutopilotResourceManagerTagsUpdate1(pid, clusterName, clusterNetName, clusterSubnetName, randomSuffix),
 				Check: resource.ComposeTestCheckFunc(
-					// Small sleep first, to avoid condition where cluster is ready but underlying GCE
+					// Small sleep, to avoid case where cluster is ready but underlying GCE
 					// resources apparently aren't.
+					// b/390456348
 					acctest.SleepInSecondsForTest(30),
 					resource.TestCheckResourceAttrSet("google_container_cluster.with_autopilot", "node_pool_auto_config.0.resource_manager_tags.%"),
 				),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -69,8 +69,8 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") 
-		|| acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
+	if acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagHoldAdmin") ||
+		acctest.BootstrapPSARole(t, "service-", "container-engine-robot", "roles/resourcemanager.tagAdmin") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
 	}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -40,12 +40,18 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 func TestAccContainerNodePool_resourceManagerTags(t *testing.T) {
 	t.Parallel()
 	pid := envvar.GetTestProjectFromEnv()
+	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
+		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
+		t.Fatal("Stopping the test because a role was added to the policy.")
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -4479,38 +4485,6 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "google_project_iam_member" "tagUser2" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tagHoldAdmin,
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
-  ]
-}
-
 resource "google_tags_tag_key" "key1" {
   parent      = "projects/%[1]s"
   short_name  = "foobarbaz1-%[2]s"
@@ -4568,8 +4542,6 @@ resource "google_container_cluster" "primary" {
     create = "30m"
     update = "40m"
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 
 # Separately Managed Node Pool
@@ -4599,38 +4571,6 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "google_project_iam_member" "tagUser2" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tagHoldAdmin,
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
-  ]
-}
-
 resource "google_tags_tag_key" "key1" {
   parent      = "projects/%[1]s"
   short_name  = "foobarbaz1-%[2]s"
@@ -4688,8 +4628,6 @@ resource "google_container_cluster" "primary" {
     create = "30m"
     update = "40m"
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 
 # Separately Managed Node Pool
@@ -4720,38 +4658,6 @@ data "google_project" "project" {
   project_id = "%[1]s"
 }
 
-resource "google_project_iam_member" "tagHoldAdmin" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagHoldAdmin"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "tagUser1" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "google_project_iam_member" "tagUser2" {
-  project = "%[1]s"
-  role    = "roles/resourcemanager.tagUser"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudservices.gserviceaccount.com"
-
-  depends_on = [google_project_iam_member.tagHoldAdmin]
-}
-
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
-
-  depends_on = [
-    google_project_iam_member.tagHoldAdmin,
-    google_project_iam_member.tagUser1,
-    google_project_iam_member.tagUser2,
-  ]
-}
-
 resource "google_tags_tag_key" "key1" {
   parent      = "projects/%[1]s"
   short_name  = "foobarbaz1-%[2]s"
@@ -4809,8 +4715,6 @@ resource "google_container_cluster" "primary" {
     create = "30m"
     update = "40m"
   }
-
-  depends_on = [time_sleep.wait_120_seconds]
 }
 
 # Separately Managed Node Pool

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -40,7 +40,6 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 func TestAccContainerNodePool_resourceManagerTags(t *testing.T) {
 	t.Parallel()
 	pid := envvar.GetTestProjectFromEnv()
-	project := envvar.GetTestProjectNumberFromEnv()
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
@@ -48,10 +47,7 @@ func TestAccContainerNodePool_resourceManagerTags(t *testing.T) {
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
-	if acctest.BootstrapPSARoles(t, "service-", "container-engine-robot", []string{"roles/resourcemanager.tagAdmin", "roles/resourcemanager.tagHoldAdmin", "roles/resourcemanager.tagUser"}) ||
-		acctest.BootstrapPSARole(t, project, "@cloudservices", "roles/resourcemanager.tagUser") {
-		t.Fatal("Stopping the test because a role was added to the policy.")
-	}
+	bootstrapGkeTagManagerServiceAgents(t)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
Rework of #12376 by @MaChenhao

This fixes some tests that may have started failing after my #12014.

Turned out to be a bigger can of worms than I expected, and is now updated to include autopilot and nodepool variants as well.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19997
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20252
Closes #12376

**Release Note Template for Downstream PRs (will be copied)**
```release-note:none

```