### PR TITLE
Promote Cloud Armor Security Policies for Regional Backend Services from Beta to GA

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1146,7 +1146,6 @@ properties:
     type: String
     description: |
       The security policy associated with this backend service.
-    min_version: 'beta'
     update_url: 'projects/{{project}}/regions/{{region}}/backendServices/{{name}}/setSecurityPolicy'
     update_verb: 'POST'
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'

--- a/mmv1/templates/terraform/post_create/compute_region_backend_service_security_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_create/compute_region_backend_service_security_policy.go.tmpl
@@ -1,4 +1,3 @@
-{{- if ne $.TargetVersionName "ga" }}
 // security_policy isn't set by Create
 if v, ok := d.GetOkExists("security_policy"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, securityPolicyProp)) {
   err = resourceComputeRegionBackendServiceRead(d, meta)
@@ -36,4 +35,3 @@ if v, ok := d.GetOkExists("security_policy"); !tpgresource.IsEmptyValue(reflect.
     return err
   }
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -1174,7 +1174,6 @@ resource "google_compute_health_check" "health_check" {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeRegionBackendService_withSecurityPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -1223,4 +1222,3 @@ resource "google_compute_region_security_policy" "policy" {
 }
 `, serviceName, polLink, polName)
 }
-{{- end }}


### PR DESCRIPTION
Promote Cloud Armor Security Policies for Regional Backend Services from Beta to GA

```release-note: note
compute:  promoted `security_policy` for `google_compute_region_backend_service`  from Beta to GA
```