### PR TITLE
Fix global_forwarding_rule labels

### DIFF
--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -41,6 +41,7 @@ async:
     resource_inside_response: false
 collection_url_key: 'items'
 custom_code:
+  pre_create: 'templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl'
   post_create: 'templates/terraform/post_create/labels.tmpl'
 legacy_long_form_project: true
 examples:

--- a/mmv1/templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl
@@ -1,8 +1,7 @@
 // Labels cannot be set in a create for PSC forwarding rules, so remove it from the CREATE request.
-
-if targetProp != nil &&
-  (strings.Contains(targetProp.(string), "/serviceAttachments/") ||
-    targetProp.(string) == "all-apis" || targetProp.(string) == "vpc-sc") {
+if strings.Contains(targetProp.(string), "/serviceAttachments/") ||
+    targetProp.(string) == "all-apis" ||
+    targetProp.(string) == "vpc-sc" {
   if _, ok := obj["labels"]; ok {
     delete(obj, "labels")
   }

--- a/mmv1/templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/compute_global_forwarding_rule.go.tmpl
@@ -1,0 +1,9 @@
+// Labels cannot be set in a create for PSC forwarding rules, so remove it from the CREATE request.
+
+if targetProp != nil &&
+  (strings.Contains(targetProp.(string), "/serviceAttachments/") ||
+    targetProp.(string) == "all-apis" || targetProp.(string) == "vpc-sc") {
+  if _, ok := obj["labels"]; ok {
+    delete(obj, "labels")
+  }
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -87,7 +87,6 @@ func TestAccComputeGlobalForwardingRule_ipv6(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeGlobalForwardingRule_labels(t *testing.T) {
 	t.Parallel()
 
@@ -123,7 +122,39 @@ func TestAccComputeGlobalForwardingRule_labels(t *testing.T) {
 		},
 	})
 }
-{{- end }}
+
+func TestAccComputeGlobalForwardingRule_pscLabels(t *testing.T) {
+	t.Parallel()
+
+	fr := fmt.Sprintf("frtest%s", acctest.RandString(t, 10))
+	address := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeGlobalForwardingRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeGlobalForwardingRule_pscLabels(fr, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"port_range", "target", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeGlobalForwardingRule_pscLabelsUpdated(fr, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"port_range", "target", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeGlobalForwardingRule_internalLoadBalancing(t *testing.T) {
@@ -361,7 +392,6 @@ resource "google_compute_url_map" "url_map" {
 `, fr, targetProxy, proxy, proxy2, backend, hc, urlmap)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeGlobalForwardingRule_labels(fr, proxy, backend, hc, urlmap string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
@@ -416,9 +446,7 @@ resource "google_compute_url_map" "urlmap" {
 }
 `, fr, proxy, backend, hc, urlmap)
 }
-{{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeGlobalForwardingRule_labelsUpdated(fr, proxy, backend, hc, urlmap string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
@@ -473,7 +501,56 @@ resource "google_compute_url_map" "urlmap" {
 }
 `, fr, proxy, backend, hc, urlmap)
 }
-{{- end }}
+
+func testAccComputeGlobalForwardingRule_pscLabels(fr, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  network               = "default"
+  target                = "all-apis"
+  ip_address            = google_compute_global_address.default.id
+  load_balancing_scheme = ""
+  labels = {
+    my-label          = "a-value"
+    a-different-label = "my-second-label-value"
+  }
+}
+
+resource "google_compute_global_address" "default" {
+  name          = "%s"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = "default"
+  address       = "100.100.100.105"
+}
+
+`, fr, address)
+}
+
+func testAccComputeGlobalForwardingRule_pscLabelsUpdated(fr, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  network               = "default"
+  target                = "all-apis"
+  ip_address            = google_compute_global_address.default.id
+  load_balancing_scheme = ""
+  labels = {
+    my-label          = "a-value"
+    a-different-label = "my-third-label-value"
+  }
+}
+
+resource "google_compute_global_address" "default" {
+  name          = "%s"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = "default"
+  address       = "100.100.100.105"
+}
+
+`, fr, address)
+}
 
 func testAccComputeGlobalForwardingRule_ipv6(fr, proxy, backend, hc, urlmap string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -123,7 +123,7 @@ func TestAccComputeGlobalForwardingRule_labels(t *testing.T) {
 	})
 }
 
-func TestAccComputeGlobalForwardingRule_pscLabels(t *testing.T) {
+func TestAccComputeGlobalForwardingRule_allApisLabels(t *testing.T) {
 	t.Parallel()
 
 	fr := fmt.Sprintf("frtest%s", acctest.RandString(t, 10))
@@ -135,7 +135,7 @@ func TestAccComputeGlobalForwardingRule_pscLabels(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeGlobalForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeGlobalForwardingRule_pscLabels(fr, address),
+				Config: testAccComputeGlobalForwardingRule_allApisLabels(fr, address),
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
@@ -144,13 +144,46 @@ func TestAccComputeGlobalForwardingRule_pscLabels(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"port_range", "target", "labels", "terraform_labels"},
 			},
 			{
-				Config: testAccComputeGlobalForwardingRule_pscLabelsUpdated(fr, address),
+				Config: testAccComputeGlobalForwardingRule_allApisLabelsUpdated(fr, address),
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"port_range", "target", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccComputeGlobalForwardingRule_vpcscLabels(t *testing.T) {
+	t.Parallel()
+
+	fr := fmt.Sprintf("frtest%s", acctest.RandString(t, 10))
+	address := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeGlobalForwardingRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeGlobalForwardingRule_vpcscLabels(fr, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"port_range", "target", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeGlobalForwardingRule_vpcscLabelsUpdated(fr, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"port_range", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -502,7 +535,7 @@ resource "google_compute_url_map" "urlmap" {
 `, fr, proxy, backend, hc, urlmap)
 }
 
-func testAccComputeGlobalForwardingRule_pscLabels(fr, address string) string {
+func testAccComputeGlobalForwardingRule_allApisLabels(fr, address string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   name                  = "%s"
@@ -527,7 +560,7 @@ resource "google_compute_global_address" "default" {
 `, fr, address)
 }
 
-func testAccComputeGlobalForwardingRule_pscLabelsUpdated(fr, address string) string {
+func testAccComputeGlobalForwardingRule_allApisLabelsUpdated(fr, address string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   name                  = "%s"
@@ -547,6 +580,56 @@ resource "google_compute_global_address" "default" {
   purpose       = "PRIVATE_SERVICE_CONNECT"
   network       = "default"
   address       = "100.100.100.105"
+}
+
+`, fr, address)
+}
+
+func testAccComputeGlobalForwardingRule_vpcscLabels(fr, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  network               = "default"
+  target                = "vpc-sc"
+  ip_address            = google_compute_global_address.default.id
+  load_balancing_scheme = ""
+  labels = {
+    my-label          = "a-value"
+    a-different-label = "my-second-label-value"
+  }
+}
+
+resource "google_compute_global_address" "default" {
+  name          = "%s"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = "default"
+  address       = "100.100.100.106"
+}
+
+`, fr, address)
+}
+
+func testAccComputeGlobalForwardingRule_vpcscLabelsUpdated(fr, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  network               = "default"
+  target                = "vpc-sc"
+  ip_address            = google_compute_global_address.default.id
+  load_balancing_scheme = ""
+  labels = {
+    my-label          = "a-value"
+    a-different-label = "my-third-label-value"
+  }
+}
+
+resource "google_compute_global_address" "default" {
+  name          = "%s"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = "default"
+  address       = "100.100.100.106"
 }
 
 `, fr, address)


### PR DESCRIPTION
- enable tests for global_forwarding_rule for `ga` provider
- add test for global_forwarding_rule for PSC target
- do not send labels for global_forwarding_rule for PSC target

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/20873

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fix failure when creating `google_compute_global_forwarding_rule` with labels targeting PSC endpoint
```
