### PR TITLE
Promote Cloud Armor regional Security Policies Resources (Policy, Rules and Edge) from Beta to GA

### DIFF
--- a/mmv1/products/compute/NetworkEdgeSecurityService.yaml
+++ b/mmv1/products/compute/NetworkEdgeSecurityService.yaml
@@ -16,7 +16,6 @@ name: 'NetworkEdgeSecurityService'
 kind: 'compute#networkEdgeSecurityService'
 description: |
   Google Cloud Armor network edge security service resource.
-min_version: 'beta'
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/armor/docs/advanced-network-ddos'
@@ -55,7 +54,6 @@ parameters:
     type: ResourceRef
     description: |
       The region of the gateway security policy.
-    min_version: 'beta'
     url_param_only: true
     required: false
     immutable: true
@@ -66,49 +64,41 @@ properties:
     type: String
     description: |
       Name of the resource. Provided by the client when the resource is created.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'description'
     type: String
     description: |
       Free-text description of the resource.
-    min_version: 'beta'
   - name: 'serviceId'
     type: String
     description: |
       The unique identifier for the resource. This identifier is defined by the server.
     api_name: id
-    min_version: 'beta'
     output: true
   - name: 'creationTimestamp'
     type: String
     description: |
       Creation timestamp in RFC3339 text format.
-    min_version: 'beta'
     output: true
   - name: 'selfLink'
     type: String
     description: |
       Server-defined URL for the resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLinkWithServiceId'
     type: String
     description: |
       Server-defined URL for this resource with the resource id.
     api_name: selfLinkWithId
-    min_version: 'beta'
     output: true
   - name: 'fingerprint'
     type: Fingerprint
     description: |
       Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a NetworkEdgeSecurityService.
       An up-to-date fingerprint must be provided in order to update the NetworkEdgeSecurityService, otherwise the request will fail with error 412 conditionNotMet.
-    min_version: 'beta'
     output: true
   - name: 'securityPolicy'
     type: String
     description: |
       The resource URL for the network edge security service associated with this network edge security service.
-    min_version: 'beta'

--- a/mmv1/products/compute/RegionSecurityPolicy.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicy.yaml
@@ -16,7 +16,6 @@ name: 'RegionSecurityPolicy'
 api_resource_type_kind: SecurityPolicy
 description: |
   Represents a Region Cloud Armor Security Policy resource.
-min_version: 'beta'
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/armor/docs/security-policy-concepts'
@@ -63,7 +62,6 @@ parameters:
     description: |
       The Region in which the created Region Security Policy should reside.
       If it is not provided, the provider region is used.
-    min_version: 'beta'
     required: false
     immutable: true
     default_from_api: true
@@ -76,27 +74,23 @@ properties:
     description: |
       The unique identifier for the resource. This identifier is defined by the server.
     api_name: id
-    min_version: 'beta'
     output: true
   - name: 'name'
     type: String
     description: |
       Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035.
       Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'description'
     type: String
     description: |
       An optional description of this resource. Provide this property when you create the resource.
-    min_version: 'beta'
   - name: 'fingerprint'
     type: Fingerprint
     description: |
       Fingerprint of this resource. This field is used internally during
       updates of this resource.
-    min_version: 'beta'
     output: true
   - name: 'type'
     type: Enum
@@ -106,7 +100,6 @@ properties:
       - CLOUD_ARMOR_EDGE: Cloud Armor edge security policies can be configured to filter incoming HTTP requests targeting backend services (including Cloud CDN-enabled) as well as backend buckets (Cloud Storage). They filter requests before the request is served from Google's cache.
       - CLOUD_ARMOR_NETWORK: Cloud Armor network policies can be configured to filter packets targeting network load balancing resources such as backend services, target pools, target instances, and instances with external IPs. They filter requests before the request is served from the application.
       This field can be set only at resource creation time.
-    min_version: 'beta'
     immutable: true
     enum_values:
       - 'CLOUD_ARMOR'
@@ -116,7 +109,6 @@ properties:
     type: NestedObject
     description: |
       Configuration for Google Cloud Armor DDOS Proctection Config.
-    min_version: 'beta'
     properties:
       - name: 'ddosProtection'
         type: Enum
@@ -125,7 +117,6 @@ properties:
           - STANDARD: basic always-on protection for network load balancers, protocol forwarding, or VMs with public IP addresses.
           - ADVANCED: additional protections for Managed Protection Plus subscribers who use network load balancers, protocol forwarding, or VMs with public IP addresses.
           - ADVANCED_PREVIEW: flag to enable the security policy in preview mode.
-        min_version: 'beta'
         required: true
         enum_values:
           - 'ADVANCED'
@@ -135,14 +126,12 @@ properties:
     type: String
     description: |
       Server-defined URL for the resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLinkWithPolicyId'
     type: String
     description: |
       Server-defined URL for this resource with the resource id.
     api_name: selfLinkWithId
-    min_version: 'beta'
     output: true
   - name: 'userDefinedFields'
     type: Array
@@ -150,7 +139,6 @@ properties:
       Definitions of user-defined fields for CLOUD_ARMOR_NETWORK policies.
       A user-defined field consists of up to 4 bytes extracted from a fixed offset in the packet, relative to the IPv4, IPv6, TCP, or UDP header, with an optional mask to select certain bits.
       Rules may then specify matching values for these fields.
-    min_version: 'beta'
     item_type:
       type: NestedObject
       properties:
@@ -158,7 +146,6 @@ properties:
           type: String
           description: |
             The name of this field. Must be unique within the policy.
-          min_version: 'beta'
         - name: 'base'
           type: Enum
           description: |
@@ -167,7 +154,6 @@ properties:
             - IPV6: Points to the beginning of the IPv6 header.
             - TCP: Points to the beginning of the TCP header, skipping over any IPv4 options or IPv6 extension headers. Not present for non-first fragments.
             - UDP: Points to the beginning of the UDP header, skipping over any IPv4 options or IPv6 extension headers. Not present for non-first fragments.
-          min_version: 'beta'
           required: true
           enum_values:
             - 'IPV4'
@@ -178,24 +164,20 @@ properties:
           type: Integer
           description: |
             Offset of the first byte of the field (in network byte order) relative to 'base'.
-          min_version: 'beta'
         - name: 'size'
           type: Integer
           description: |
             Size of the field in bytes. Valid values: 1-4.
-          min_version: 'beta'
         - name: 'mask'
           type: String
           description: |
             If specified, apply this mask (bitwise AND) to the field to ignore bits before matching.
             Encoded as a hexadecimal number (starting with "0x").
             The last byte of the field (in network byte order) corresponds to the least significant byte of the mask.
-          min_version: 'beta'
   - name: 'rules'
     type: Array
     description: |
       The set of rules that belong to this policy. There must always be a default rule (rule with priority 2147483647 and match "*"). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
-    min_version: 'beta'
     default_from_api: true
     item_type:
       type: NestedObject
@@ -204,54 +186,46 @@ properties:
           type: String
           description: |
             An optional description of this resource. Provide this property when you create the resource.
-          min_version: 'beta'
         - name: 'priority'
           type: Integer
           description: |
             An integer indicating the priority of a rule in the list.
             The priority must be a positive value between 0 and 2147483647.
             Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           required: true
         - name: 'match'
           type: NestedObject
           description: |
             A match condition that incoming traffic is evaluated against.
             If it evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           properties:
             - name: 'versionedExpr'
               type: Enum
               description: |
                 Preconfigured versioned expression. If this field is specified, config must also be specified.
                 Available preconfigured expressions along with their requirements are: SRC_IPS_V1 - must specify the corresponding srcIpRange field in config.
-              min_version: 'beta'
               enum_values:
                 - 'SRC_IPS_V1'
             - name: 'expr'
               type: NestedObject
               description: |
                 User defined CEVAL expression. A CEVAL expression is used to specify match criteria such as origin.ip, source.region_code and contents in the request header. See [Sample expressions](https://cloud.google.com/armor/docs/configure-security-policies#sample-expressions) for examples.
-              min_version: 'beta'
               properties:
                 - name: 'expression'
                   type: String
                   description: |
                     Textual representation of an expression in Common Expression Language syntax. The application context of the containing message determines which well-known feature set of CEL is supported.
-                  min_version: 'beta'
                   required: true
             - name: 'config'
               type: NestedObject
               description: |
                 The configuration options available when specifying versionedExpr.
                 This field must be specified if versionedExpr is specified and cannot be specified if versionedExpr is not specified.
-              min_version: 'beta'
               properties:
                 - name: 'srcIpRanges'
                   type: Array
                   description: |
                     CIDR IP address range. Maximum number of srcIpRanges allowed is 10.
-                  min_version: 'beta'
                   max_size: 10
                   item_type:
                     type: String
@@ -260,14 +234,12 @@ properties:
           description: |
             Preconfigured WAF configuration to be applied for the rule.
             If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect.
-          min_version: 'beta'
           properties:
             - name: 'exclusion'
               type: Array
               description: |
                 An exclusion to apply during preconfigured WAF evaluation.
               api_name: exclusions
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -275,14 +247,12 @@ properties:
                     type: String
                     description: |
                       Target WAF rule set to apply the preconfigured WAF exclusion.
-                    min_version: 'beta'
                     required: true
                   - name: 'targetRuleIds'
                     type: Array
                     description: |
                       A list of target rule IDs under the WAF rule set to apply the preconfigured WAF exclusion.
                       If omitted, it refers to all the rule IDs under the WAF rule set.
-                    min_version: 'beta'
                     item_type:
                       type: String
                   - name: 'requestHeader'
@@ -290,7 +260,6 @@ properties:
                     description: |
                       Request header whose value will be excluded from inspection during preconfigured WAF evaluation.
                     api_name: requestHeadersToExclude
-                    min_version: 'beta'
                     item_type:
                       type: NestedObject
                       properties:
@@ -305,7 +274,6 @@ properties:
                             CONTAINS: The operator matches if the field value contains the specified value.
                             EQUALS_ANY: The operator matches if the field value is any value.
                           api_name: op
-                          min_version: 'beta'
                           required: true
                           enum_values:
                             - 'CONTAINS'
@@ -319,13 +287,11 @@ properties:
                             A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                             The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                           api_name: val
-                          min_version: 'beta'
                   - name: 'requestCookie'
                     type: Array
                     description: |
                       Request cookie whose value will be excluded from inspection during preconfigured WAF evaluation.
                     api_name: requestCookiesToExclude
-                    min_version: 'beta'
                     item_type:
                       type: NestedObject
                       properties:
@@ -340,7 +306,6 @@ properties:
                             CONTAINS: The operator matches if the field value contains the specified value.
                             EQUALS_ANY: The operator matches if the field value is any value.
                           api_name: op
-                          min_version: 'beta'
                           required: true
                           enum_values:
                             - 'CONTAINS'
@@ -354,14 +319,12 @@ properties:
                             A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                             The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                           api_name: val
-                          min_version: 'beta'
                   - name: 'requestUri'
                     type: Array
                     description: |
                       Request URI from the request line to be excluded from inspection during preconfigured WAF evaluation.
                       When specifying this field, the query or fragment part should be excluded.
                     api_name: requestUrisToExclude
-                    min_version: 'beta'
                     item_type:
                       type: NestedObject
                       properties:
@@ -376,7 +339,6 @@ properties:
                             CONTAINS: The operator matches if the field value contains the specified value.
                             EQUALS_ANY: The operator matches if the field value is any value.
                           api_name: op
-                          min_version: 'beta'
                           required: true
                           enum_values:
                             - 'CONTAINS'
@@ -390,14 +352,12 @@ properties:
                             A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                             The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                           api_name: val
-                          min_version: 'beta'
                   - name: 'requestQueryParam'
                     type: Array
                     description: |
                       Request query parameter whose value will be excluded from inspection during preconfigured WAF evaluation.
                       Note that the parameter can be in the query string or in the POST body.
                     api_name: requestQueryParamsToExclude
-                    min_version: 'beta'
                     item_type:
                       type: NestedObject
                       properties:
@@ -412,7 +372,6 @@ properties:
                             CONTAINS: The operator matches if the field value contains the specified value.
                             EQUALS_ANY: The operator matches if the field value is any value.
                           api_name: op
-                          min_version: 'beta'
                           required: true
                           enum_values:
                             - 'CONTAINS'
@@ -426,7 +385,6 @@ properties:
                             A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                             The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                           api_name: val
-                          min_version: 'beta'
         - name: 'action'
           type: String
           description: |
@@ -441,13 +399,11 @@ properties:
             * redirect: redirect to a different target. This can either be an internal reCAPTCHA redirect, or an external URL-based redirect via a 302 response. Parameters for this action can be configured via redirectOptions. This action is only supported in Global Security Policies of type CLOUD_ARMOR.
 
             * throttle: limit client traffic to the configured threshold. Configure parameters for this action in rateLimitOptions. Requires rateLimitOptions to be set for this.
-          min_version: 'beta'
           required: true
         - name: 'rateLimitOptions'
           type: NestedObject
           description: |
             Must be specified if the action is "rate_based_ban" or "throttle". Cannot be specified for any other actions.
-          min_version: 'beta'
           update_mask_fields:
             - 'rateLimitOptions.rateLimitThreshold'
             - 'rateLimitOptions.conformAction'
@@ -462,30 +418,25 @@ properties:
               type: NestedObject
               description: |
                 Threshold at which to begin ratelimiting.
-              min_version: 'beta'
               properties:
                 - name: 'count'
                   type: Integer
                   description: |
                     Number of HTTP(S) requests for calculating the threshold.
-                  min_version: 'beta'
                 - name: 'intervalSec'
                   type: Integer
                   description: |
                     Interval over which the threshold is computed.
-                  min_version: 'beta'
             - name: 'conformAction'
               type: String
               description: |
                 Action to take for requests that are under the configured rate limit threshold.
                 Valid option is "allow" only.
-              min_version: 'beta'
             - name: 'exceedAction'
               type: String
               description: |
                 Action to take for requests that are above the configured rate limit threshold, to deny with a specified HTTP response code.
                 Valid options are deny(STATUS), where valid values for STATUS are 403, 404, 429, and 502.
-              min_version: 'beta'
             - name: 'enforceOnKey'
               type: Enum
               description: |
@@ -500,7 +451,6 @@ properties:
                 * REGION_CODE: The country/region from which the request originates.
                 * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                 * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
-              min_version: 'beta'
               enum_values:
                 - 'ALL'
                 - 'IP'
@@ -518,14 +468,12 @@ properties:
                 Rate limit key name applicable only for the following key types:
                 HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
                 HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
-              min_version: 'beta'
             - name: 'enforceOnKeyConfigs'
               type: Array
               description: |
                 If specified, any combination of values of enforceOnKeyType/enforceOnKeyName is treated as the key on which ratelimit threshold/action is enforced.
                 You can specify up to 3 enforceOnKeyConfigs.
                 If enforceOnKeyConfigs is specified, enforceOnKey must not be specified.
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -543,7 +491,6 @@ properties:
                       * REGION_CODE: The country/region from which the request originates.
                       * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                       * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
-                    min_version: 'beta'
                     enum_values:
                       - 'ALL'
                       - 'IP'
@@ -561,35 +508,29 @@ properties:
                       Rate limit key name applicable only for the following key types:
                       HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
                       HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
-                    min_version: 'beta'
             - name: 'banThreshold'
               type: NestedObject
               description: |
                 Can only be specified if the action for the rule is "rate_based_ban".
                 If specified, the key will be banned for the configured 'banDurationSec' when the number of requests that exceed the 'rateLimitThreshold' also exceed this 'banThreshold'.
-              min_version: 'beta'
               properties:
                 - name: 'count'
                   type: Integer
                   description: |
                     Number of HTTP(S) requests for calculating the threshold.
-                  min_version: 'beta'
                 - name: 'intervalSec'
                   type: Integer
                   description: |
                     Interval over which the threshold is computed.
-                  min_version: 'beta'
             - name: 'banDurationSec'
               type: Integer
               description: |
                 Can only be specified if the action for the rule is "rate_based_ban".
                 If specified, determines the time (in seconds) the traffic will continue to be banned by the rate limit after the rate falls below the threshold.
-              min_version: 'beta'
         - name: 'preview'
           type: Boolean
           description: |
             If set to true, the specified action is not enforced.
-          min_version: 'beta'
         - name: 'networkMatch'
           type: NestedObject
           description: |
@@ -601,7 +542,6 @@ properties:
             Example:
             networkMatch: srcIpRanges: - "192.0.2.0/24" - "198.51.100.0/24" userDefinedFields: - name: "ipv4_fragment_offset" values: - "1-0x1fff"
             The above match condition matches packets with a source IP in 192.0.2.0/24 or 198.51.100.0/24 and a user-defined field named "ipv4_fragment_offset" with a value between 1 and 0x1fff inclusive
-          min_version: 'beta'
           update_mask_fields:
             - 'network_match.userDefinedFields'
             - 'network_match.srcIpRanges'
@@ -616,7 +556,6 @@ properties:
               type: Array
               description: |
                 User-defined fields. Each element names a defined field and lists the matching values for that field.
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -624,60 +563,51 @@ properties:
                     type: String
                     description: |
                       Name of the user-defined field, as given in the definition.
-                    min_version: 'beta'
                   - name: 'values'
                     type: Array
                     description: |
                       Matching values of the field. Each element can be a 32-bit unsigned decimal or hexadecimal (starting with "0x") number (e.g. "64") or range (e.g. "0x400-0x7ff").
-                    min_version: 'beta'
                     item_type:
                       type: String
             - name: 'srcIpRanges'
               type: Array
               description: |
                 Source IPv4/IPv6 addresses or CIDR prefixes, in standard text format.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destIpRanges'
               type: Array
               description: |
                 Destination IPv4/IPv6 addresses or CIDR prefixes, in standard text format.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'ipProtocols'
               type: Array
               description: |
                 IPv4 protocol / IPv6 next header (after extension headers). Each element can be an 8-bit unsigned decimal number (e.g. "6"), range (e.g. "253-254"), or one of the following protocol names: "tcp", "udp", "icmp", "esp", "ah", "ipip", or "sctp".
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcPorts'
               type: Array
               description: |
                 Source port numbers for TCP/UDP/SCTP. Each element can be a 16-bit unsigned decimal number (e.g. "80") or range (e.g. "0-1023").
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destPorts'
               type: Array
               description: |
                 Destination port numbers for TCP/UDP/SCTP. Each element can be a 16-bit unsigned decimal number (e.g. "80") or range (e.g. "0-1023").
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcRegionCodes'
               type: Array
               description: |
                 Two-letter ISO 3166-1 alpha-2 country code associated with the source IP address.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcAsns'
               type: Array
               description: |
                 BGP Autonomous System Number associated with the source IP address.
-              min_version: 'beta'
               item_type:
                 type: Integer

--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -16,7 +16,6 @@ name: 'RegionSecurityPolicyRule'
 api_resource_type_kind: SecurityPolicy
 description: |
   A rule for the RegionSecurityPolicy.
-min_version: 'beta'
 references:
   guides:
     'Creating region security policy rules': 'https://cloud.google.com/armor/docs/configure-security-policies'
@@ -50,27 +49,22 @@ custom_code:
 examples:
   - name: 'region_security_policy_rule_basic'
     primary_resource_id: 'policy_rule'
-    min_version: 'beta'
     vars:
       sec_policy_name: 'policyruletest'
   - name: 'region_security_policy_rule_multiple_rules'
     primary_resource_id: 'policy_rule_one'
-    min_version: 'beta'
     vars:
       sec_policy_name: 'policywithmultiplerules'
   - name: 'region_security_policy_rule_default_rule'
     primary_resource_id: 'policy_rule'
-    min_version: 'beta'
     vars:
       sec_policy_name: 'policywithdefaultrule'
   - name: 'region_security_policy_rule_with_preconfigured_waf_config'
     primary_resource_id: 'policy_rule'
-    min_version: 'beta'
     vars:
       sec_policy_name: 'policyruletest'
   - name: 'region_security_policy_rule_with_network_match'
     primary_resource_id: 'policy_rule_network_match'
-    min_version: 'beta'
     vars:
       sec_policy_name: 'policyfornetworkmatch'
     # it needs to run synchronously because a region can have only one google_compute_network_edge_security_service.
@@ -81,7 +75,6 @@ parameters:
     type: String
     description: |
       The Region in which the created Region Security Policy rule should reside.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -89,7 +82,6 @@ parameters:
     type: String
     description: |
       The name of the security policy this rule belongs to.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -98,14 +90,12 @@ properties:
     type: String
     description: |
       An optional description of this resource. Provide this property when you create the resource.
-    min_version: 'beta'
   - name: 'priority'
     type: Integer
     description: |
       An integer indicating the priority of a rule in the list.
       The priority must be a positive value between 0 and 2147483647.
       Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest priority.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'match'
@@ -113,40 +103,34 @@ properties:
     description: |
       A match condition that incoming traffic is evaluated against.
       If it evaluates to true, the corresponding 'action' is enforced.
-    min_version: 'beta'
     properties:
       - name: 'versionedExpr'
         type: Enum
         description: |
           Preconfigured versioned expression. If this field is specified, config must also be specified.
           Available preconfigured expressions along with their requirements are: SRC_IPS_V1 - must specify the corresponding srcIpRange field in config.
-        min_version: 'beta'
         enum_values:
           - 'SRC_IPS_V1'
       - name: 'expr'
         type: NestedObject
         description: |
           User defined CEVAL expression. A CEVAL expression is used to specify match criteria such as origin.ip, source.region_code and contents in the request header.
-        min_version: 'beta'
         properties:
           - name: 'expression'
             type: String
             description: |
               Textual representation of an expression in Common Expression Language syntax. The application context of the containing message determines which well-known feature set of CEL is supported.
-            min_version: 'beta'
             required: true
       - name: 'config'
         type: NestedObject
         description: |
           The configuration options available when specifying versionedExpr.
           This field must be specified if versionedExpr is specified and cannot be specified if versionedExpr is not specified.
-        min_version: 'beta'
         properties:
           - name: 'srcIpRanges'
             type: Array
             description: |
               CIDR IP address range. Maximum number of srcIpRanges allowed is 10.
-            min_version: 'beta'
             item_type:
               type: String
   - name: 'preconfiguredWafConfig'
@@ -154,14 +138,12 @@ properties:
     description: |
       Preconfigured WAF configuration to be applied for the rule.
       If the rule does not evaluate preconfigured WAF rules, i.e., if evaluatePreconfiguredWaf() is not used, this field will have no effect.
-    min_version: 'beta'
     properties:
       - name: 'exclusion'
         type: Array
         description: |
           An exclusion to apply during preconfigured WAF evaluation.
         api_name: exclusions
-        min_version: 'beta'
         item_type:
           type: NestedObject
           properties:
@@ -169,14 +151,12 @@ properties:
               type: String
               description: |
                 Target WAF rule set to apply the preconfigured WAF exclusion.
-              min_version: 'beta'
               required: true
             - name: 'targetRuleIds'
               type: Array
               description: |
                 A list of target rule IDs under the WAF rule set to apply the preconfigured WAF exclusion.
                 If omitted, it refers to all the rule IDs under the WAF rule set.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'requestHeader'
@@ -184,7 +164,6 @@ properties:
               description: |
                 Request header whose value will be excluded from inspection during preconfigured WAF evaluation.
               api_name: requestHeadersToExclude
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -199,7 +178,6 @@ properties:
                       CONTAINS: The operator matches if the field value contains the specified value.
                       EQUALS_ANY: The operator matches if the field value is any value.
                     api_name: op
-                    min_version: 'beta'
                     required: true
                     enum_values:
                       - 'CONTAINS'
@@ -213,13 +191,11 @@ properties:
                       A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                       The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                     api_name: val
-                    min_version: 'beta'
             - name: 'requestCookie'
               type: Array
               description: |
                 Request cookie whose value will be excluded from inspection during preconfigured WAF evaluation.
               api_name: requestCookiesToExclude
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -234,7 +210,6 @@ properties:
                       CONTAINS: The operator matches if the field value contains the specified value.
                       EQUALS_ANY: The operator matches if the field value is any value.
                     api_name: op
-                    min_version: 'beta'
                     required: true
                     enum_values:
                       - 'CONTAINS'
@@ -248,14 +223,12 @@ properties:
                       A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                       The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                     api_name: val
-                    min_version: 'beta'
             - name: 'requestUri'
               type: Array
               description: |
                 Request URI from the request line to be excluded from inspection during preconfigured WAF evaluation.
                 When specifying this field, the query or fragment part should be excluded.
               api_name: requestUrisToExclude
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -270,7 +243,6 @@ properties:
                       CONTAINS: The operator matches if the field value contains the specified value.
                       EQUALS_ANY: The operator matches if the field value is any value.
                     api_name: op
-                    min_version: 'beta'
                     required: true
                     enum_values:
                       - 'CONTAINS'
@@ -284,14 +256,12 @@ properties:
                       A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                       The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                     api_name: val
-                    min_version: 'beta'
             - name: 'requestQueryParam'
               type: Array
               description: |
                 Request query parameter whose value will be excluded from inspection during preconfigured WAF evaluation.
                 Note that the parameter can be in the query string or in the POST body.
               api_name: requestQueryParamsToExclude
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -306,7 +276,6 @@ properties:
                       CONTAINS: The operator matches if the field value contains the specified value.
                       EQUALS_ANY: The operator matches if the field value is any value.
                     api_name: op
-                    min_version: 'beta'
                     required: true
                     enum_values:
                       - 'CONTAINS'
@@ -320,7 +289,6 @@ properties:
                       A request field matching the specified value will be excluded from inspection during preconfigured WAF evaluation.
                       The field value must be given if the field operator is not EQUALS_ANY, and cannot be given if the field operator is EQUALS_ANY.
                     api_name: val
-                    min_version: 'beta'
   - name: 'action'
     type: String
     description: |
@@ -335,13 +303,11 @@ properties:
       * redirect: redirect to a different target. This can either be an internal reCAPTCHA redirect, or an external URL-based redirect via a 302 response. Parameters for this action can be configured via redirectOptions. This action is only supported in Global Security Policies of type CLOUD_ARMOR.
 
       * throttle: limit client traffic to the configured threshold. Configure parameters for this action in rateLimitOptions. Requires rateLimitOptions to be set for this.
-    min_version: 'beta'
     required: true
   - name: 'rateLimitOptions'
     type: NestedObject
     description: |
       Must be specified if the action is "rate_based_ban" or "throttle". Cannot be specified for any other actions.
-    min_version: 'beta'
     update_mask_fields:
       - 'rateLimitOptions.rateLimitThreshold'
       - 'rateLimitOptions.conformAction'
@@ -356,30 +322,25 @@ properties:
         type: NestedObject
         description: |
           Threshold at which to begin ratelimiting.
-        min_version: 'beta'
         properties:
           - name: 'count'
             type: Integer
             description: |
               Number of HTTP(S) requests for calculating the threshold.
-            min_version: 'beta'
           - name: 'intervalSec'
             type: Integer
             description: |
               Interval over which the threshold is computed.
-            min_version: 'beta'
       - name: 'conformAction'
         type: String
         description: |
           Action to take for requests that are under the configured rate limit threshold.
           Valid option is "allow" only.
-        min_version: 'beta'
       - name: 'exceedAction'
         type: String
         description: |
           Action to take for requests that are above the configured rate limit threshold, to deny with a specified HTTP response code.
           Valid options are deny(STATUS), where valid values for STATUS are 403, 404, 429, and 502.
-        min_version: 'beta'
       - name: 'enforceOnKey'
         type: Enum
         description: |
@@ -394,7 +355,6 @@ properties:
           * REGION_CODE: The country/region from which the request originates.
           * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
           * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
-        min_version: 'beta'
         enum_values:
           - 'ALL'
           - 'IP'
@@ -412,14 +372,12 @@ properties:
           Rate limit key name applicable only for the following key types:
           HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
           HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
-        min_version: 'beta'
       - name: 'enforceOnKeyConfigs'
         type: Array
         description: |
           If specified, any combination of values of enforceOnKeyType/enforceOnKeyName is treated as the key on which ratelimit threshold/action is enforced.
           You can specify up to 3 enforceOnKeyConfigs.
           If enforceOnKeyConfigs is specified, enforceOnKey must not be specified.
-        min_version: 'beta'
         item_type:
           type: NestedObject
           properties:
@@ -437,7 +395,6 @@ properties:
                 * REGION_CODE: The country/region from which the request originates.
                 * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                 * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
-              min_version: 'beta'
               enum_values:
                 - 'ALL'
                 - 'IP'
@@ -455,35 +412,29 @@ properties:
                 Rate limit key name applicable only for the following key types:
                 HTTP_HEADER -- Name of the HTTP header whose value is taken as the key value.
                 HTTP_COOKIE -- Name of the HTTP cookie whose value is taken as the key value.
-              min_version: 'beta'
       - name: 'banThreshold'
         type: NestedObject
         description: |
           Can only be specified if the action for the rule is "rate_based_ban".
           If specified, the key will be banned for the configured 'banDurationSec' when the number of requests that exceed the 'rateLimitThreshold' also exceed this 'banThreshold'.
-        min_version: 'beta'
         properties:
           - name: 'count'
             type: Integer
             description: |
               Number of HTTP(S) requests for calculating the threshold.
-            min_version: 'beta'
           - name: 'intervalSec'
             type: Integer
             description: |
               Interval over which the threshold is computed.
-            min_version: 'beta'
       - name: 'banDurationSec'
         type: Integer
         description: |
           Can only be specified if the action for the rule is "rate_based_ban".
           If specified, determines the time (in seconds) the traffic will continue to be banned by the rate limit after the rate falls below the threshold.
-        min_version: 'beta'
   - name: 'preview'
     type: Boolean
     description: |
       If set to true, the specified action is not enforced.
-    min_version: 'beta'
   - name: 'networkMatch'
     type: NestedObject
     description: |
@@ -495,7 +446,6 @@ properties:
       Example:
       networkMatch: srcIpRanges: - "192.0.2.0/24" - "198.51.100.0/24" userDefinedFields: - name: "ipv4_fragment_offset" values: - "1-0x1fff"
       The above match condition matches packets with a source IP in 192.0.2.0/24 or 198.51.100.0/24 and a user-defined field named "ipv4_fragment_offset" with a value between 1 and 0x1fff inclusive
-    min_version: 'beta'
     update_mask_fields:
       - 'network_match.userDefinedFields'
       - 'network_match.srcIpRanges'
@@ -510,7 +460,6 @@ properties:
         type: Array
         description: |
           User-defined fields. Each element names a defined field and lists the matching values for that field.
-        min_version: 'beta'
         item_type:
           type: NestedObject
           properties:
@@ -518,60 +467,51 @@ properties:
               type: String
               description: |
                 Name of the user-defined field, as given in the definition.
-              min_version: 'beta'
             - name: 'values'
               type: Array
               description: |
                 Matching values of the field. Each element can be a 32-bit unsigned decimal or hexadecimal (starting with "0x") number (e.g. "64") or range (e.g. "0x400-0x7ff").
-              min_version: 'beta'
               item_type:
                 type: String
       - name: 'srcIpRanges'
         type: Array
         description: |
           Source IPv4/IPv6 addresses or CIDR prefixes, in standard text format.
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'destIpRanges'
         type: Array
         description: |
           Destination IPv4/IPv6 addresses or CIDR prefixes, in standard text format.
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'ipProtocols'
         type: Array
         description: |
           IPv4 protocol / IPv6 next header (after extension headers). Each element can be an 8-bit unsigned decimal number (e.g. "6"), range (e.g. "253-254"), or one of the following protocol names: "tcp", "udp", "icmp", "esp", "ah", "ipip", or "sctp".
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'srcPorts'
         type: Array
         description: |
           Source port numbers for TCP/UDP/SCTP. Each element can be a 16-bit unsigned decimal number (e.g. "80") or range (e.g. "0-1023").
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'destPorts'
         type: Array
         description: |
           Destination port numbers for TCP/UDP/SCTP. Each element can be a 16-bit unsigned decimal number (e.g. "80") or range (e.g. "0-1023").
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'srcRegionCodes'
         type: Array
         description: |
           Two-letter ISO 3166-1 alpha-2 country code associated with the source IP address.
-        min_version: 'beta'
         item_type:
           type: String
       - name: 'srcAsns'
         type: Array
         description: |
           BGP Autonomous System Number associated with the source IP address.
-        min_version: 'beta'
         item_type:
           type: Integer

--- a/mmv1/templates/terraform/examples/compute_network_edge_security_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_network_edge_security_service_basic.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_network_edge_security_service" "{{$.PrimaryResourceId}}" {
-  provider     = google-beta  
-
   name         = "{{index $.Vars "resource_name"}}"
   region       = "us-east1"
   description  = "My basic resource"

--- a/mmv1/templates/terraform/examples/region_security_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_basic.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
-
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
   type        = "CLOUD_ARMOR"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_basic.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "default" {
-  provider    = google-beta
-  
   region      = "us-west2"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
@@ -8,8 +6,6 @@ resource "google_compute_region_security_policy" "default" {
 }
 
 resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
-  
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_default_rule.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_security_policy" "default" {
-  provider    = google-beta
   region      = "us-west2"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
@@ -7,7 +6,6 @@ resource "google_compute_region_security_policy" "default" {
 }
 
 resource "google_compute_region_security_policy_rule" "default_rule" {
-  provider        = google-beta
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"
@@ -22,7 +20,6 @@ resource "google_compute_region_security_policy_rule" "default_rule" {
 }
 
 resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
-  provider        = google-beta
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_multiple_rules.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_multiple_rules.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "default" {
-  provider    = google-beta
-  
   region      = "us-west2"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
@@ -8,8 +6,6 @@ resource "google_compute_region_security_policy" "default" {
 }
 
 resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
-  
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule one"
@@ -25,8 +21,6 @@ resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" 
 }
 
 resource "google_compute_region_security_policy_rule" "policy_rule_two" {
-  provider = google-beta
-  
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule two"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_with_network_match.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_with_network_match.tf.tmpl
@@ -1,7 +1,5 @@
 # First activate advanced network DDoS protection for the desired region
 resource "google_compute_region_security_policy" "policyddosprotection" {
-  provider    = google-beta
-
   region      = "us-west2"
   name        = "policyddosprotection"
   description = "policy for activating network DDoS protection for the desired region"
@@ -12,8 +10,6 @@ resource "google_compute_region_security_policy" "policyddosprotection" {
 }
 
 resource "google_compute_network_edge_security_service" "edge_sec_service" {
-  provider        = google-beta
-
   region          = "us-west2"
   name            = "edgesecservice"
   description     = "linking policy to edge security service"
@@ -22,8 +18,6 @@ resource "google_compute_network_edge_security_service" "edge_sec_service" {
 
 # Add the desired policy and custom rule.
 resource "google_compute_region_security_policy" "policynetworkmatch" {
-  provider    = google-beta
-
   region      = "us-west2"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "region security policy for network match"
@@ -39,8 +33,6 @@ resource "google_compute_region_security_policy" "policynetworkmatch" {
 }
 
 resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
-  provider        = google-beta
-
   region          = "us-west2"
   security_policy = google_compute_region_security_policy.policynetworkmatch.name
   description     = "custom rule for network match"

--- a/mmv1/templates/terraform/examples/region_security_policy_rule_with_preconfigured_waf_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_rule_with_preconfigured_waf_config.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "default" {
-  provider    = google-beta
-
   region      = "asia-southeast1"
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy"
@@ -8,8 +6,6 @@ resource "google_compute_region_security_policy" "default" {
 }
 
 resource "google_compute_region_security_policy_rule" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
-
   region          = "asia-southeast1"
   security_policy = google_compute_region_security_policy.default.name
   description     = "new rule"

--- a/mmv1/templates/terraform/examples/region_security_policy_with_ddos_protection_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_with_ddos_protection_config.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta  
-
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "with ddos protection config"
   type        = "CLOUD_ARMOR_NETWORK"

--- a/mmv1/templates/terraform/examples/region_security_policy_with_rules.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_with_rules.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
-
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "basic region security policy with multiple rules"
   type        = "CLOUD_ARMOR"

--- a/mmv1/templates/terraform/examples/region_security_policy_with_user_defined_fields.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_with_user_defined_fields.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_compute_region_security_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta  
-
   name        = "{{index $.Vars "sec_policy_name"}}"
   description = "with user defined fields"
   type        = "CLOUD_ARMOR_NETWORK"

--- a/mmv1/templates/terraform/examples/target_instance_with_security_policy.tf.tmpl
+++ b/mmv1/templates/terraform/examples/target_instance_with_security_policy.tf.tmpl
@@ -43,7 +43,6 @@ resource "google_compute_instance" "target-vm" {
 }
 
 resource "google_compute_region_security_policy" "policyddosprotection" {
-  provider    = google-beta
   region      = "southamerica-west1"
   name        = "tf-test-policyddos%{random_suffix}"
   description = "ddos protection security policy to set target instance"
@@ -54,14 +53,12 @@ resource "google_compute_region_security_policy" "policyddosprotection" {
 }
 
 resource "google_compute_network_edge_security_service" "edge_sec_service" {
-  provider        = google-beta
   region          = "southamerica-west1"
   name            = "tf-test-edgesec%{random_suffix}"
   security_policy = google_compute_region_security_policy.policyddosprotection.self_link
 }
 
 resource "google_compute_region_security_policy" "regionsecuritypolicy" {
-  provider    = google-beta
   name        = "{{index $.Vars "region_sec_policy"}}"
   region      = "southamerica-west1"
   description = "basic security policy for target instance"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -3819,7 +3819,6 @@ func TestAccComputeInstance_keyRevocationActionType(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 const errorDeleteAccessConfigWithSecPolicy = "Cannot delete an access config with a security policy set. Please remove the security policy first"
 
 // The tests related to security_policy use network_edge_security_service resource
@@ -4146,7 +4145,6 @@ func testAccComputeInstance_nic_securityPolicyCreateWithoutAccessConfig(t *testi
 	})
 }
 
-{{ end }}
 
 func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -10203,7 +10201,6 @@ resource "google_compute_disk" "debian" {
 `, instance, diskName, suffix, suffix, suffix)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeInstance_nic_securityPolicyCreateWithOneNicAndTwoAccessConfigs(suffix, policy, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -11000,7 +10997,6 @@ resource "google_compute_instance" "foobar" {
 `, suffix, suffix, suffix, suffix, suffix, suffix, suffix, policy, instance)
 }
 
-{{ end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeInstance_networkAttachment(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_edge_security_service_sweeper.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_edge_security_service_sweeper.go.tmpl
@@ -1,5 +1,4 @@
 package compute
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"context"
@@ -61,4 +60,3 @@ func testSweepComputeNetworkEdgeSecurityService(region string) error {
 
 	return nil
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_edge_security_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_edge_security_service_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"fmt"
@@ -76,4 +75,3 @@ resource "google_compute_network_edge_security_service" "foobar" {
 }
 `, pName, nesName)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
   "fmt"
@@ -1114,4 +1113,3 @@ resource "google_compute_region_security_policy_rule" "policy_rule" {
 }
 `, spName)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -941,5 +940,3 @@ func testAccComputeRegionSecurityPolicy_withNetworkMatch_update(context map[stri
 	}
 	`, context)
 }
-
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_instance_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -109,7 +108,6 @@ resource "google_compute_instance" "target-vm" {
 }
 
 resource "google_compute_region_security_policy" "policyddosprotection" {
-  provider    = google-beta
   region      = "southamerica-east1"
   name        = "tf-test-up-pol-policyddos%{random_suffix}"
   description = "ddos protection security policy to set target instance"
@@ -127,7 +125,6 @@ resource "google_compute_network_edge_security_service" "edge_sec_service" {
 }
 
 resource "google_compute_region_security_policy" "regionsecuritypolicy1" {
-  provider    = google-beta
   name        = "tf-test-up-pol-region-secpolicy1%{random_suffix}"
   region      = "southamerica-east1"
   description = "basic security policy one for target instance"
@@ -136,7 +133,6 @@ resource "google_compute_region_security_policy" "regionsecuritypolicy1" {
 }
 
 resource "google_compute_region_security_policy" "regionsecuritypolicy2" {
-  provider    = google-beta
   name        = "tf-test-up-pol-region-secpolicy2%{random_suffix}"
   region      = "southamerica-east1"
   description = "basic security policy two for target instance"
@@ -154,4 +150,3 @@ resource "google_compute_target_instance" "default" {
 }
 `, context)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
@@ -82,7 +82,6 @@ func TestAccComputeTargetPool_update(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeTargetPool_withSecurityPolicy(t *testing.T) {
 	tpname := fmt.Sprintf("tf-tp-test-%s", acctest.RandString(t, 10))
 	ddosPolicy := fmt.Sprintf("tf-tp-ddos-pol-test-%s", acctest.RandString(t, 10))
@@ -137,7 +136,6 @@ func TestAccComputeTargetPool_withSecurityPolicy(t *testing.T) {
 	})
 }
 
-{{ end }}
 func testAccCheckComputeTargetPoolDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -296,7 +294,6 @@ resource "google_compute_instance" "bar" {
 `, tpname, instances, name1, name2)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeTargetPool_withSecurityPolicy(ddosPolicy, edgeSecService, pol1, pol2, tpname, polToSet string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_security_policy" "policyddosprotection" {
@@ -317,6 +314,8 @@ resource "google_compute_network_edge_security_service" "edge_sec_service" {
 }
 
 resource "google_compute_region_security_policy" "policytargetpool1" {
+  provider        = google-beta
+  
   region      = "us-south1"
   name        = "%s"
   description = "region security policy one"
@@ -340,5 +339,3 @@ resource "google_compute_target_pool" "foo" {
 }
 `, ddosPolicy, edgeSecService, pol1, pol2, tpname, polToSet)
 }
-
-{{ end }}


### PR DESCRIPTION
Promote Cloud Armor regional Security Policies Resources (Policy, Rules and Edge) from Beta to GA

```release-note:note
compute:  promoted `NetworkEdgeSecurityService`, `RegionSecurityPolicy` and `RegionSecurityPolicyRules` from Beta to GA
```
