### PR TITLE
Fixed TestAccNetworkServicesGateway_update

### DIFF
--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -147,7 +147,6 @@ properties:
       The proxy binds to the specified ports. Gateways of type 'SECURE_WEB_GATEWAY' are
       limited to 1 port. Gateways of type 'OPEN_MESH' listen on 0.0.0.0 and support multiple ports.
     required: true
-    immutable: true
     item_type:
       type: Integer
   - name: 'scope'

--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -48,7 +48,7 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/network_services_gateway.go.tmpl'
   post_delete: 'templates/terraform/post_delete/network_services_gateway.go.tmpl'
-  pre_update: 'templates/terraform/pre_update/network_services_gateway.go.tmpl'
+  update_encoder: 'templates/terraform/update_encoder/network_services_gateway.go.tmpl'
 examples:
   - name: 'network_services_gateway_basic'
     primary_resource_id: 'default'

--- a/mmv1/templates/terraform/pre_update/network_services_gateway.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/network_services_gateway.go.tmpl
@@ -1,5 +1,0 @@
-if d.Get("type") == "SECURE_WEB_GATEWAY" {
-    obj["name"] = d.Get("name")
-    obj["type"] = d.Get("type")
-    obj["routingMode"] = d.Get("routingMode")
-}

--- a/mmv1/templates/terraform/update_encoder/network_services_gateway.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/network_services_gateway.go.tmpl
@@ -1,0 +1,8 @@
+// Always force-send some attributes even if they were not modified. This works around extra API-side requirements.
+obj["scope"] = d.Get("scope")
+if d.Get("type") == "SECURE_WEB_GATEWAY" {
+    obj["name"] = d.Get("name")
+    obj["type"] = d.Get("type")
+    obj["routingMode"] = d.Get("routingMode")
+}
+return obj, nil

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
@@ -31,11 +31,11 @@ func TestAccNetworkServicesGateway_update(t *testing.T) {
 			},
 			{
 				Config: testAccNetworkServicesGateway_update(gatewayName),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
-           PreApply: []plancheck.PlanCheck{
-              plancheck.ExpectResourceAction("google_network_services_gateway.foobar", plancheck.ResourceActionUpdate),
-           },
-        },
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_services_gateway.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:            "google_network_services_gateway.foobar",

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNetworkServicesGateway_update(t *testing.T) {
@@ -30,6 +31,11 @@ func TestAccNetworkServicesGateway_update(t *testing.T) {
 			},
 			{
 				Config: testAccNetworkServicesGateway_update(gatewayName),
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+           PreApply: []plancheck.PlanCheck{
+              plancheck.ExpectResourceAction("google_network_services_gateway.foobar", plancheck.ResourceActionUpdate),
+           },
+        },
 			},
 			{
 				ResourceName:            "google_network_services_gateway.foobar",
@@ -59,7 +65,7 @@ resource "google_network_services_gateway" "foobar" {
   name        = "%s"
   scope       = "default-scope-update"
   type        = "OPEN_MESH"
-  ports       = [443]
+  ports       = [1000]
   description = "update description"
   labels      = {
     foo = "bar"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19742

Marked ports field as updatable. This should be the case anyway, and will ensure that the field gets included in update requests. See discussion on b/372764562 for more context.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added in-place update support for `ports` field on `google_network_services_gateway` resource
```

```release-note:bug
networkservices: fixed bug where `google_network_services_gateway` could not be updated in place
```
