### PR TITLE
Add properties field to apigee environment resource

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -187,3 +187,25 @@ properties:
     description: |
       Optional. URI of the forward proxy to be applied to the runtime instances in this environment. Must be in the format of {scheme}://{hostname}:{port}. Note that the scheme must be one of "http" or "https", and the port must be supplied.
     required: false
+  - name: 'properties'
+    type: NestedObject
+    description: |
+      Key-value pairs that may be used for customizing the environment.
+    immutable: false
+    required: false
+    properties:
+      - name: 'property'
+        type: Array
+        description: |
+          List of all properties in the object.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                The property key.
+            - name: 'value'
+              type: String
+              description: |
+                The property value.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Added `properties` field to Apigee environment resource as described in the Apigee API docs: https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
apigee: added `properties` field to `google_apigee_environment` resource (ga)
```
