### PR TITLE
Add properties field to apigee environment resource

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -191,8 +191,6 @@ properties:
     type: NestedObject
     description: |
       Key-value pairs that may be used for customizing the environment.
-    immutable: false
-    required: false
     properties:
       - name: 'property'
         type: Array

--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -79,6 +79,16 @@ examples:
       # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
+  - name: 'apigee_environment_basic_properties_test'
+    primary_resource_id: 'apigee_environment'
+    primary_resource_name: 'fmt.Sprintf("organizations/tf-test%s", context["random_suffix"]), fmt.Sprintf("tf-test%s", context["random_suffix"])'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    # Resource creation race
+    skip_vcr: true
+    external_providers: ["time"]
   - name: 'apigee_environment_patch_update_test'
     primary_resource_id: 'apigee_environment'
     primary_resource_name: 'fmt.Sprintf("organizations/tf-test%s", context["random_suffix"]), fmt.Sprintf("tf-test%s", context["random_suffix"])'

--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -187,3 +187,25 @@ properties:
     description: |
       Optional. URI of the forward proxy to be applied to the runtime instances in this environment. Must be in the format of {scheme}://{hostname}:{port}. Note that the scheme must be one of "http" or "https", and the port must be supplied.
     required: false
+  - name: 'properties'
+    type: NestedObject
+    description: |
+      Key-value pairs that may be used for customizing the environment.
+    immutable: false
+    required: false
+    properties:
+      - name: 'property'
+        type: Array
+        description: |
+          List of all properties in the object.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                The property key.
+            - name: 'value'
+              type: String
+              description: |
+                The property value.

--- a/mmv1/templates/terraform/examples/apigee_environment_basic_properties_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_basic_properties_test.tf.tmpl
@@ -1,0 +1,75 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [google_project_service.compute]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "{{$.PrimaryResourceId}}" {
+  org_id   = google_apigee_organization.apigee_org.id
+  name         = "tf-test%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "environment-1"
+  properties {
+  	property {
+  		name  = "property-1-key"
+        value = "property-1-value"
+  	}
+  }
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_update_test.go
@@ -118,6 +118,12 @@ resource "google_apigee_environment" "apigee_environment" {
   name         = "tf-test%{random_suffix}"
   description  = "Updated Apigee Environment Description"
   display_name = "environment-1-updated"
+  properties {
+	property {
+		name  = "property-1-key"
+        value = "property-1-value"
+	}
+  }
 }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Added `properties` field to Apigee environment resource as described in the Apigee API docs: https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
apigee: added `properties` field to `google_apigee_environment` resource
```