### PR TITLE
updated DataStore.yaml to add 'advancedSiteSearchConfig'

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -71,7 +71,6 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
       data_store_id: 'data-store-id'
-    exclude_docs: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -66,6 +66,12 @@ examples:
     vars:
       data_store_id: 'data-store-id'
     exclude_docs: true
+  - name: 'discoveryengine_datastore_advanced_site_search_config'
+    primary_resource_id: 'advanced_site_search_config'
+    primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
+    vars:
+      data_store_id: 'data-store-id'
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String
@@ -157,6 +163,21 @@ properties:
       - 'NO_CONTENT'
       - 'CONTENT_REQUIRED'
       - 'PUBLIC_WEBSITE'
+  - name: 'advancedSiteSearchConfig'
+    type: NestedObject
+    description: |
+      Configuration data for advance site search.
+    required: false
+    immutable: true
+    properties:
+      - name: 'disableInitialIndex'
+        type: Boolean
+        description: If set true, initial indexing is disabled for the DataStore.
+        required: false
+      - name: 'disableAutomaticRefresh'
+        type: Boolean
+        description: If set true, automatic refresh is disabled for the DataStore.
+        required: false
   - name: 'documentProcessingConfig'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_advanced_site_search_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_advanced_site_search_config.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_discovery_engine_data_store" "advanced_site_search_config" {
+  location                     = "global"
+  data_store_id                = "{{index $.Vars "data_store_id"}}"
+  display_name                 = "tf-test-advanced-site-search-config-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "PUBLIC_WEBSITE"
+  solution_types               = ["SOLUTION_TYPE_CHAT"]
+  create_advanced_site_search  = true
+  skip_default_schema_creation = false
+
+  advanced_site_search_config {
+    disable_initial_index = true
+    disable_automatic_refresh = true
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

In order to submit a sitemap to a datastore, one must create must create a new data store by turning off initial indexing and automatic refresh using the [AdvancedSiteSearchConfig](https://cloud.google.com/generative-ai-app-builder/docs/reference/rpc/google.cloud.discoveryengine.v1alpha#advancedsitesearchconfig) configuration.

This functionality is not yet available in the Terraform provider. Hence, this PR updates the fields as required. 

This is also required to enable https://github.com/hashicorp/terraform-provider-google/issues/20554.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
discoveryengine: added `advanced_site_search_config` field to `google_discovery_engine_data_store` resource
```
