### PR TITLE
Made reassign-reviewer correctly pass argument to the underlying command

### DIFF
--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -42,4 +42,4 @@ jobs:
           go build .
       - name: Run command
         if: steps.read-comment.outputs.match != ''
-        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.match.group1 }}
+        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.group1 }}


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/20649

According to the [action's docs](https://github.com/actions-ecosystem/action-regex-match?tab=readme-ov-file#outputs) `match` and `group1` are siblings, not nested.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
