### PR TITLE
feat: added support for ssl_config support for postgresql_profile

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -91,6 +91,18 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
     exclude_test: true
+  - name: 'datastream_stream_postgresql_sslconfig_server_and_client_verification'
+    primary_resource_id: 'default'
+    vars:
+      connection_profile_id: 'profile-id'
+      deletion_protection: 'true'
+      database_instance_name: 'my-instance'
+    test_vars_overrides:
+      'deletion_protection': 'false'
+    oics_vars_overrides:
+      'deletion_protection': 'false'
+    external_providers: ["random"]
+    skip_vcr: true
 parameters:
   - name: 'connectionProfileId'
     type: String
@@ -324,6 +336,69 @@ properties:
         description: |
           Database for the PostgreSQL connection.
         required: true
+      - name: 'sslConfig'
+        type: NestedObject
+        description: |
+          SSL configuration for the PostgreSQL connection.
+        required: false
+        properties:
+          - name: 'serverVerification'
+            type: NestedObject
+            description: |
+              If this field is set, the communication will be encrypted with TLS encryption
+              and the server identity will be authenticated.
+            exactly_one_of:
+              - 'ssl_config.0.server_verification'
+              - 'ssl_config.0.server_and_client_verification'
+            properties:
+              - name: 'caCertificate'
+                type: String
+                description: PEM-encoded server root CA certificate.
+                required: true
+                immutable: true
+                sensitive: true
+                ignore_read: true
+          - name: 'serverAndClientVerification'
+            type: NestedObject
+            description: |
+              If this field is set, the communication will be encrypted with TLS encryption
+              and both the server identity and the client identity will be authenticated.
+            exactly_one_of:
+              - 'ssl_config.0.server_verification'
+              - 'ssl_config.0.server_and_client_verification'
+            properties:
+              - name: 'clientCertificate'
+                type: String
+                description: |
+                  PEM-encoded certificate used by the source database to authenticate the
+                  client identity (i.e., the Datastream's identity). This certificate is
+                  signed by either a root certificate trusted by the server or one or more
+                  intermediate certificates (which is stored with the leaf certificate) to
+                  link to this certificate to the trusted root certificate.
+                immutable: true
+                required: true
+                sensitive: true
+                ignore_read: true
+              - name: 'clientKey'
+                type: String
+                description: |
+                  PEM-encoded private key associated with the client certificate.
+                  This value will be used during the SSL/TLS handshake, allowing
+                  the PostgreSQL server to authenticate the client's identity,
+                  i.e. identity of the stream.
+                immutable: true
+                required: true
+                sensitive: true
+                ignore_read: true
+              - name: 'caCertificate'
+                type: String
+                description: |
+                  PEM-encoded server root CA certificate.
+                immutable: true
+                required: true
+                sensitive: true
+                ignore_read: true
+
   - name: 'sqlServerProfile'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_ca_certificate.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_ca_certificate.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+{{/* Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 */}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("postgresql_profile.0.ssl_config.0.server_and_client_verification.0.ca_certificate")
+}

--- a/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_client_certificate.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_client_certificate.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+{{/* Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 */}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("postgresql_profile.0.ssl_config.0.server_and_client_verification.0.client_certificate")
+}

--- a/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_client_key.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_and_client_verification_client_key.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+{{/* Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 */}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("postgresql_profile.0.ssl_config.0.server_and_client_verification.0.client_key")
+}

--- a/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_verification_ca_certificate.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/datastream_connection_profile_postgresql_profile_ssl_config_server_verification_ca_certificate.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+{{/* Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410 */}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return d.Get("postgresql_profile.0.ssl_config.0.server_verification.0.ca_certificate")
+}

--- a/mmv1/templates/terraform/examples/datastream_stream_postgresql_sslconfig_server_and_client_verification.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_stream_postgresql_sslconfig_server_and_client_verification.tf.tmpl
@@ -1,0 +1,69 @@
+data "google_datastream_static_ips" "datastream_ips" {
+  location           = "us-central1"
+}
+
+resource "google_sql_database_instance" "instance" {
+  name             = "{{index $.Vars "database_instance_name"}}"
+  database_version = "POSTGRES_15"
+  region           = "us-central1"
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled = true
+      ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
+      dynamic "authorized_networks" {
+        for_each = data.google_datastream_static_ips.datastream_ips.static_ips
+        iterator = ip
+
+        content {
+          name  = format("datastream-%d", ip.key)
+          value = ip.value
+        }
+      }
+    }
+  }
+
+  deletion_protection  = {{index $.Vars "deletion_protection"}}
+}
+
+resource "google_sql_database" "db" {
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "random_password" "pwd" {
+  length  = 16
+  special = false
+}
+
+resource "google_sql_user" "user" {
+    name = "user"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
+resource "google_sql_ssl_cert" "client_cert" {
+  common_name = "client-name"
+  instance    = google_sql_database_instance.instance.name
+}
+
+resource "google_datastream_connection_profile" "{{$.PrimaryResourceId}}" {
+    display_name          = "Connection Profile"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "connection_profile_id"}}"
+
+    postgresql_profile {
+        hostname = google_sql_database_instance.instance.public_ip_address
+        port     = 5432
+        username = "user"
+        password = random_password.pwd.result
+        database = google_sql_database.db.name
+        ssl_config {
+            server_and_client_verification {
+              client_certificate = google_sql_ssl_cert.client_cert.cert
+              client_key = google_sql_ssl_cert.client_cert.private_key
+              ca_certificate = google_sql_ssl_cert.client_cert.server_ca_cert
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added support for `ssl_config` for `postgresql_profile`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20929

**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
datastream: added `postgresql_profile.ssl_config` to `google_datastream_connection_profile`
```
