### PR TITLE
Add colab runtime permissions to test projects

### DIFF
--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -468,6 +468,13 @@ resource "google_project_iam_member" "compute_agent_encrypter_decrypter" {
   member  = "serviceAccount:service-${google_project.proj.number}@compute-system.iam.gserviceaccount.com"
 }
 
+# TestAccColabRuntime_colabRuntimeBasicExample
+# TestAccColabRuntime_colabRuntimeFullExample
+resource "google_project_iam_member" "colab_admin_permissions" {
+  project = google_project.proj.project_id
+  role    = "roles/aiplatform.colabEnterpriseAdmin"
+  member  = "user:gterraformtestuser@gmail.com"
+}
 
 data "google_organization" "org2" {
   organization = var.org2_id


### PR DESCRIPTION
Needed for google_colab_runtime tests, which need a permissioned user account.

/cc @bcreddy-gcp this will stop the stomping, we'll just bake the permission into our test environment. 

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
