### PR TITLE
Test Failure Ticket Creation Job Config

### DIFF
--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -18,5 +18,5 @@ availableSecrets:
     # needed for ticket creator
     # - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
     #   env: GITHUB_TOKEN
-    - versionName: projects/673497134629/secrets/ci-test-teamcity/versions/latest
+    - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
       env: TEAMCITY_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -15,8 +15,5 @@ options:
 logsBucket: 'gs://cloudbuild-test-failure-ticket-logs'
 availableSecrets:
   secretManager:
-    # needed for ticket creator
-    # - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
-    #   env: GITHUB_TOKEN
     - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
       env: TEAMCITY_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -1,13 +1,12 @@
 ---
 steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
-      id: collect-test-status
+      id: gcb-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN", "TEAMCITY_TOKEN"]
-      env:
-        - CUSTOM_DATE=$_CUSTOM_DATE
       args:
         - 'collect-nightly-test-status'
+        - $_CUSTOM_DATE
 
 timeout: 3600s
 options:
@@ -18,5 +17,5 @@ availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN
-    - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
+    - versionName: projects/673497134629/secrets/ci-test-teamcity/versions/latest
       env: TEAMCITY_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -18,5 +18,5 @@ availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN
-    - versionName: projects/673497134629/secrets/ci-test-teamcity/versions/latest
+    - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
       env: TEAMCITY_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -1,0 +1,22 @@
+---
+steps:
+    - name: 'gcr.io/graphite-docker-images/go-plus'
+      id: collect-test-status
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      secretEnv: ["GITHUB_TOKEN", "TEAMCITY_TOKEN"]
+      env:
+        - CUSTOM_DATE=$_CUSTOM_DATE
+      args:
+        - 'collect-nightly-test-status'
+
+timeout: 3600s
+options:
+    machineType: 'N1_HIGHCPU_32'
+
+logsBucket: 'gs://cloudbuild-test-failure-ticket-logs'
+availableSecrets:
+  secretManager:
+    - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
+      env: GITHUB_TOKEN
+    - versionName: projects/673497134629/secrets/ci-test-teamcity/versions/latest
+      env: TEAMCITY_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -3,7 +3,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: gcb-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["GITHUB_TOKEN", "TEAMCITY_TOKEN"]
+      secretEnv: ["TEAMCITY_TOKEN"]
       args:
         - 'collect-nightly-test-status'
         - $_CUSTOM_DATE
@@ -15,7 +15,8 @@ options:
 logsBucket: 'gs://cloudbuild-test-failure-ticket-logs'
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
-      env: GITHUB_TOKEN
+    # needed for ticket creator
+    # - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
+    #   env: GITHUB_TOKEN
     - versionName: projects/673497134629/secrets/ci-test-teamcity/versions/latest
       env: TEAMCITY_TOKEN


### PR DESCRIPTION
Part 2 of **Automated Nightly Test Failure Ticket Creation**

This PR adds the configuration file for the automated gcb job for ticket creation. Currently, this only contains the step of collecting test status.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
