### PR TITLE
Fixed cluster resource limits maximum to be marked as required in docs.

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -620,9 +620,10 @@ func ResourceContainerCluster() *schema.Resource {
 										Description: `Minimum amount of the resource in the cluster.`,
 									},
 									"maximum": {
-										Type:        schema.TypeInt,
-										Optional:    true,
-										Description: `Maximum amount of the resource in the cluster.`,
+										Type:         schema.TypeInt,
+										Description:  `Maximum amount of the resource in the cluster.`,
+										Required:     true,
+										ValidateFunc: validation.IntAtLeast(1),
 									},
 								},
 							},

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -582,7 +582,7 @@ for a list of types.
 
 * `minimum` - (Optional) Minimum amount of the resource in the cluster.
 
-* `maximum` - (Optional) Maximum amount of the resource in the cluster.
+* `maximum` - (Required) Maximum amount of the resource in the cluster.
 
 <a name="nested_auto_provisioning_defaults"></a>The `auto_provisioning_defaults` block supports:
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR patches parameter [cluster. cluster_autoscaling.resource_limits.maximum](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#maximum-1) to be marked as required and sets a minimum value for it.

Current docs indicate that users are able to configure resource limits like so:

```terraform
resource_limits {
    resource_type = "cpu"
}
```

This is not a valid configuration and it's getting rejected while attempting to create a cluster with the following error:

`Error: googleapi: Error 400: Resource_limit.maximum must be greater than 0.`

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: marked `cluster_autoscaling.resource_limits.maximum` as required as requests would fail if it was not set
```
