### PR TITLE
Add 5s to the billing project wait + network deletion retry wait in google_project

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -216,7 +216,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	// Sleep for 10s, letting the billing account settle before other resources
+	// Sleep to let the billing account settle before other resources
 	// try to use this project.
 	time.Sleep(15 * time.Second)
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -218,7 +218,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Sleep for 10s, letting the billing account settle before other resources
 	// try to use this project.
-	time.Sleep(10 * time.Second)
+	time.Sleep(15 * time.Second)
 
 	err = resourceGoogleProjectRead(d, meta)
 	if err != nil {
@@ -245,7 +245,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		err = forceDeleteComputeNetwork(d, config, project.ProjectId, "default")
 		// Retry if API is not yet enabled.
 		if err != nil && transport_tpg.IsGoogleApiErrorWithCode(err, 403) {
-			time.Sleep(10 * time.Second)
+			time.Sleep(15 * time.Second)
 			err = forceDeleteComputeNetwork(d, config, project.ProjectId, "default")
 		}
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20891

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
resourcemanager: added a slightly longer wait (two 10s checks bumped to 15s) for issues with billing associations in `google_project`. Default network deletion should succeed more often.
```
