### PR TITLE
Correct SecurityGateway to be global only

### DIFF
--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -14,14 +14,14 @@
 ---
 name: SecurityGateway
 description: Deployment of Security Gateway.
-base_url: projects/{{project}}/locations/global/securityGateways
+base_url: projects/{{project}}/locations/{{location}}/securityGateways
 update_mask: true
-self_link: projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
-create_url: projects/{{project}}/locations/global/securityGateways?securityGatewayId={{security_gateway_id}}
+self_link: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+create_url: projects/{{project}}/locations/{{location}}/securityGateways?securityGatewayId={{security_gateway_id}}
 update_verb: PATCH
-id_format: projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
+id_format: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
 import_format:
-  - projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
+  - projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
 examples:
   - name: beyondcorp_security_gateway_basic
     primary_resource_id: example
@@ -46,6 +46,15 @@ async:
   include_project: false
 autogen_status: U2VjdXJpdHlHYXRld2F5
 parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    default_value: 'global'
+    validation:
+      regex: '^global$'
+    required: false
   - name: securityGatewayId
     type: String
     description: |-

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -48,7 +48,7 @@ autogen_status: U2VjdXJpdHlHYXRld2F5
 parameters:
   - name: location
     type: String
-    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122. Must be omitted or set to `global`.
     immutable: true
     url_param_only: true
     default_value: 'global'

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -14,14 +14,14 @@
 ---
 name: SecurityGateway
 description: Deployment of Security Gateway.
-base_url: projects/{{project}}/locations/{{location}}/securityGateways
+base_url: projects/{{project}}/locations/global/securityGateways
 update_mask: true
-self_link: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
-create_url: projects/{{project}}/locations/{{location}}/securityGateways?securityGatewayId={{security_gateway_id}}
+self_link: projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
+create_url: projects/{{project}}/locations/global/securityGateways?securityGatewayId={{security_gateway_id}}
 update_verb: PATCH
-id_format: projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+id_format: projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
 import_format:
-  - projects/{{project}}/locations/{{location}}/securityGateways/{{security_gateway_id}}
+  - projects/{{project}}/locations/global/securityGateways/{{security_gateway_id}}
 examples:
   - name: beyondcorp_security_gateway_basic
     primary_resource_id: example
@@ -46,12 +46,6 @@ async:
   include_project: false
 autogen_status: U2VjdXJpdHlHYXRld2F5
 parameters:
-  - name: location
-    type: String
-    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
-    immutable: true
-    url_param_only: true
-    required: true
   - name: securityGatewayId
     type: String
     description: |-

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -49,6 +49,7 @@ parameters:
   - name: location
     type: String
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122. Must be omitted or set to `global`.
+    deprecation_message: '`location` is deprecated and will be removed in a future major release.'
     immutable: true
     url_param_only: true
     default_value: 'global'

--- a/mmv1/templates/terraform/examples/beyondcorp_security_gateway_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/beyondcorp_security_gateway_basic.tf.tmpl
@@ -1,6 +1,5 @@
 resource "google_beyondcorp_security_gateway" "{{$.PrimaryResourceId}}" {
   security_gateway_id = "{{index $.Vars "security_gateway_name"}}"
-  location = "global"
   display_name = "My Security Gateway resource"
   hubs { region = "us-central1" }
 }

--- a/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_security_gateway_test.go
+++ b/mmv1/third_party/terraform/services/beyondcorp/resource_beyondcorp_security_gateway_test.go
@@ -27,7 +27,7 @@ func TestAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_upda
 				ResourceName:            "google_beyondcorp_security_gateway.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "security_gateway_id"},
+				ImportStateVerifyIgnore: []string{"security_gateway_id"},
 			},
 			{
 				Config: testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_update(context),
@@ -41,7 +41,7 @@ func TestAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_upda
 				ResourceName:            "google_beyondcorp_security_gateway.example",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location", "security_gateway_id"},
+				ImportStateVerifyIgnore: []string{"security_gateway_id"},
 			},
 		},
 	})
@@ -51,7 +51,6 @@ func testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_basi
 	return acctest.Nprintf(`
 resource "google_beyondcorp_security_gateway" "example" {
   security_gateway_id = "default%{random_suffix}"
-  location = "global"
   display_name = "My Security Gateway resource"
   hubs { region = "us-central1" }
 }
@@ -62,7 +61,6 @@ func testAccBeyondcorpSecurityGateway_beyondcorpSecurityGatewayBasicExample_upda
 	return acctest.Nprintf(`
 resource "google_beyondcorp_security_gateway" "example" {
   security_gateway_id = "default%{random_suffix}"
-  location = "global"
   display_name = "My Security Gateway resource"
   hubs { region = "us-east1" }
 }


### PR DESCRIPTION
Change is for correcting a mistake in the original submission from last week: https://github.com/GoogleCloudPlatform/magic-modules/pull/12695 

```release-note:bug
beyondcorp: corrected `location` to always be global in `google_beyondcorp_security_gateway` 
```

```release-note:deprecation
beyondcorp: deprecated `location` on `google_beyondcorp_security_gateway`. The only valid value is `global`, which is now also the default value. The field will be removed in a future major release.
```
