### PR TITLE
Add field-level metadata generation for mmv1 resources

### DIFF
--- a/docs/content/reference/metadata.md
+++ b/docs/content/reference/metadata.md
@@ -30,3 +30,11 @@ The version of the API used for this resource e.g., "v2".
 ### `api_resource_type_kind`
 
 The API "resource type kind" used for this resource e.g., "Function".
+
+### `fields`
+
+The list of fields used by this resource. Each field can contain the following attributes:
+
+- `field`: The name of the field in Terraform, including the path e.g., "build_config.source.storage_source.bucket"
+- `api_field`: The name of the field in the API, including the path e.g., "build_config.source.storage_source.bucket". Defaults to the value of `field`.
+- `provider_only`: If true, the field is only present in the provider. This primarily applies for virtual fields and url-only parameters. When set to true, `api_field` should be left empty, as it will be ignored. Default: `false`.

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -626,7 +626,7 @@ func (r Resource) RootProperties() []*Type {
 func (r Resource) LeafProperties() []*Type {
 	types := r.AllNestedProperties(google.Concat(r.RootProperties(), r.UserVirtualFields()))
 
-	// Remove types that have children, becasue we only want "leaf" fields
+	// Remove types that have children, because we only want "leaf" fields
 	types = slices.DeleteFunc(types, func(t *Type) bool {
 		nestedProperties := t.NestedProperties()
 		return len(nestedProperties) > 0

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -500,6 +500,12 @@ func (r Resource) UserParameters() []*Type {
 	})
 }
 
+func (r Resource) UserVirtualFields() []*Type {
+	return google.Reject(r.VirtualFields, func(p *Type) bool {
+		return p.Exclude
+	})
+}
+
 func (r Resource) ServiceVersion() string {
 	if r.CaiBaseUrl != "" {
 		return extractVersionFromBaseUrl(r.CaiBaseUrl)
@@ -613,6 +619,28 @@ func (r Resource) RootProperties() []*Type {
 		}
 	}
 	return props
+}
+
+// Returns a sorted list of all "leaf" properties, meaning properties that have
+// no children.
+func (r Resource) LeafProperties() []*Type {
+	types := r.AllNestedProperties(google.Concat(r.RootProperties(), r.UserVirtualFields()))
+
+	// Remove types that have children, becasue we only want "leaf" fields
+	types = slices.DeleteFunc(types, func(t *Type) bool {
+		nestedProperties := t.NestedProperties()
+		return len(nestedProperties) > 0
+	})
+
+	// Sort types by lineage
+	slices.SortFunc(types, func(a, b *Type) int {
+		if a.MetadataLineage() < b.MetadataLineage() {
+			return -1
+		}
+		return 1
+	})
+
+	return types
 }
 
 // Return the product-level async object, or the resource-specific one

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -208,6 +208,21 @@ func TestLeafProperties(t *testing.T) {
 		expected    Type
 	}{
 		{
+			description: "non-nested type",
+			obj: Resource{
+				BaseUrl: "test",
+				Properties: []*Type{
+					{
+						Name: "basic",
+						Type: "String",
+					},
+				},
+			},
+			expected: Type{
+				Name: "basic",
+			},
+		},
+		{
 			description: "nested type",
 			obj: Resource{
 				BaseUrl: "test",

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -198,3 +198,105 @@ func TestResourceServiceVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestLeafProperties(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		description string
+		obj         Resource
+		expected    Type
+	}{
+		{
+			description: "nested type",
+			obj: Resource{
+				BaseUrl: "test",
+				Properties: []*Type{
+					{
+						Name: "root",
+						Type: "NestedObject",
+						Properties: []*Type{
+							{
+								Name: "foo",
+								Type: "NestedObject",
+								Properties: []*Type{
+									{
+										Name: "bars",
+										Type: "Array",
+										ItemType: &Type{
+											Type: "NestedObject",
+											Properties: []*Type{
+												{
+													Name: "fooBar",
+													Type: "String",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: Type{
+				Name: "fooBar",
+			},
+		},
+		{
+			description: "nested virtual",
+			obj: Resource{
+				BaseUrl: "test",
+				VirtualFields: []*Type{
+					{
+						Name: "root",
+						Type: "NestedObject",
+						Properties: []*Type{
+							{
+								Name: "foo",
+								Type: "String",
+							},
+						},
+					},
+				},
+			},
+			expected: Type{
+				Name: "foo",
+			},
+		},
+		{
+			description: "nested param",
+			obj: Resource{
+				BaseUrl: "test",
+				Parameters: []*Type{
+					{
+						Name: "root",
+						Type: "NestedObject",
+						Properties: []*Type{
+							{
+								Name: "foo",
+								Type: "String",
+							},
+						},
+					},
+				},
+			},
+			expected: Type{
+				Name: "foo",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			tc.obj.SetDefault(nil)
+			if got, want := tc.obj.LeafProperties(), tc.expected; got[0].Name != want.Name {
+				t.Errorf("expected %q to be %q", got[0].Name, want.Name)
+			}
+		})
+	}
+}

--- a/mmv1/api/type_test.go
+++ b/mmv1/api/type_test.go
@@ -184,3 +184,244 @@ func TestTypeExcludeIfNotInVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestMetadataLineage(t *testing.T) {
+	t.Parallel()
+
+	root := Type{
+		Name: "root",
+		Type: "NestedObject",
+		Properties: []*Type{
+			{
+				Name: "foo",
+				Type: "NestedObject",
+				Properties: []*Type{
+					{
+						Name: "bars",
+						Type: "Array",
+						ItemType: &Type{
+							Type: "NestedObject",
+							Properties: []*Type{
+								{
+									Name: "fooBar",
+									Type: "String",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	root.SetDefault(&Resource{})
+
+	cases := []struct {
+		description string
+		obj         Type
+		expected    string
+	}{
+		{
+			description: "root type",
+			obj:         root,
+			expected:    "root",
+		},
+		{
+			description: "sub type",
+			obj:         *root.Properties[0],
+			expected:    "root.foo",
+		},
+		{
+			description: "array",
+			obj:         *root.Properties[0].Properties[0],
+			expected:    "root.foo.bars",
+		},
+		{
+			description: "array of objects",
+			obj:         *root.Properties[0].Properties[0].ItemType.Properties[0],
+			expected:    "root.foo.bars.foo_bar",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.obj.MetadataLineage()
+			if got != tc.expected {
+				t.Errorf("expected %q to be %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMetadataApiLineage(t *testing.T) {
+	t.Parallel()
+
+	root := Type{
+		Name: "root",
+		Type: "NestedObject",
+		Properties: []*Type{
+			{
+				Name: "foo",
+				Type: "NestedObject",
+				Properties: []*Type{
+					{
+						Name: "bars",
+						Type: "Array",
+						ItemType: &Type{
+							Type: "NestedObject",
+							Properties: []*Type{
+								{
+									Name: "fooBar",
+									Type: "String",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Name:    "baz",
+				ApiName: "bazbaz",
+				Type:    "String",
+			},
+		},
+	}
+	root.SetDefault(&Resource{})
+
+	cases := []struct {
+		description string
+		obj         Type
+		expected    string
+	}{
+		{
+			description: "root type",
+			obj:         root,
+			expected:    "root",
+		},
+		{
+			description: "sub type",
+			obj:         *root.Properties[0],
+			expected:    "root.foo",
+		},
+		{
+			description: "array",
+			obj:         *root.Properties[0].Properties[0],
+			expected:    "root.foo.bars",
+		},
+		{
+			description: "array of objects",
+			obj:         *root.Properties[0].Properties[0].ItemType.Properties[0],
+			expected:    "root.foo.bars.foo_bar",
+		},
+		{
+			description: "with api name",
+			obj:         *root.Properties[1],
+			expected:    "root.bazbaz",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.obj.MetadataApiLineage()
+			if got != tc.expected {
+				t.Errorf("expected %q to be %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestProviderOnly(t *testing.T) {
+	t.Parallel()
+
+	nested := Type{
+		Name:       "foo",
+		ClientSide: true,
+		Type:       "NestedObject",
+		Properties: []*Type{
+			{
+				Name: "bar",
+			},
+		},
+	}
+	nested.SetDefault(&Resource{})
+
+	labeled := Resource{
+		BaseUrl: "test",
+		Properties: []*Type{
+			{
+				Name: "labels",
+				Type: "KeyValueLabels",
+			},
+		},
+	}
+	labeled.Properties = labeled.AddLabelsRelatedFields(labeled.PropertiesWithExcluded(), nil)
+	labeled.SetDefault(nil)
+
+	cases := []struct {
+		description string
+		obj         Type
+		expected    bool
+	}{
+		{
+			description: "normal",
+			obj: Type{
+				Name: "foo",
+			},
+			expected: false,
+		},
+		{
+			description: "url param",
+			obj: Type{
+				Name:         "foo",
+				UrlParamOnly: true,
+			},
+			expected: true,
+		},
+		{
+			description: "virtual",
+			obj: Type{
+				Name: "foo",
+				// Virtual fields will have this field set during SetDefault()
+				ClientSide: true,
+			},
+			expected: true,
+		},
+		{
+			description: "child of virtual",
+			obj:         *nested.Properties[0],
+			expected:    true,
+		},
+		{
+			description: "terraform labels",
+			// Terraform labels are added first
+			obj:      *labeled.Properties[1],
+			expected: true,
+		},
+		{
+			description: "effective labels",
+			// Effective labels are added second
+			obj:      *labeled.Properties[2],
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.description, func(t *testing.T) {
+			t.Parallel()
+
+			got := tc.obj.ProviderOnly()
+			if got != tc.expected {
+				t.Errorf("expected %t to be %t", got, tc.expected)
+			}
+		})
+	}
+}

--- a/mmv1/templates/terraform/metadata.yaml.tmpl
+++ b/mmv1/templates/terraform/metadata.yaml.tmpl
@@ -5,8 +5,7 @@ api_version: '{{ or $.ProductMetadata.ServiceVersion $.ServiceVersion }}'
 api_resource_type_kind: '{{ or $.ApiResourceTypeKind $.Name }}'
 fields:
 {{- range $p := $.LeafProperties }}
-  -
-    field: '{{ $p.MetadataLineage }}'
+  - field: '{{ $p.MetadataLineage }}'
     {{- if and (ne $p.MetadataLineage $p.MetadataApiLineage) (not $p.ProviderOnly) }}
     api_field: '{{ $p.MetadataApiLineage }}'
     {{- end }}

--- a/mmv1/templates/terraform/metadata.yaml.tmpl
+++ b/mmv1/templates/terraform/metadata.yaml.tmpl
@@ -3,3 +3,14 @@ generation_type: 'mmv1'
 api_service_name: '{{ $.ProductMetadata.ServiceName }}'
 api_version: '{{ or $.ProductMetadata.ServiceVersion $.ServiceVersion }}'
 api_resource_type_kind: '{{ or $.ApiResourceTypeKind $.Name }}'
+fields:
+{{- range $p := $.LeafProperties }}
+  -
+    field: '{{ $p.MetadataLineage }}'
+    {{- if and (ne $p.MetadataLineage $p.MetadataApiLineage) (not $p.ProviderOnly) }}
+    api_field: '{{ $p.MetadataApiLineage }}'
+    {{- end }}
+    {{- if $p.ProviderOnly }}
+    provider_only: true
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is the initial pass at adding field metadata to all mmv1 resources. I was able to check a small set of resources for accuracy, but further accuracy improvements are expected to come after we have the data ingested and can more clearly run checks.

Notable decisions:
* I chose to have the `api_field` default to the value of `field` when it isn't specified, so that it does not need to be included for the vast majority of fields. This massively reduces the size and visual noise in metadata files, which will be helpful for handwritten resources later.
* We do not generate explicit `key`/`value` metadata fields for maps, even though that is how they are described in the API, because it isn't meaningful for coverage. Maps are treated like a single field.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
