### PR TITLE
Support apigee environment properties update

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -23,9 +23,6 @@ docs:
 base_url: 'environments'
 self_link: '{{org_id}}/environments/{{name}}'
 create_url: '{{org_id}}/environments'
-update_url: '{{org_id}}/environments/{{name}}'
-update_verb: 'PATCH'
-update_mask: true
 import_format:
   - '{{org_id}}/environments/{{name}}'
   - '{{org_id}}/{{name}}'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Update google_apigee_environment update operation's http verb from `PATCH` ([modifyEnvironment](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments/modifyEnvironment)) to `PUT` ([update](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments/update)). 

Note from the update operation's API doc: `Note: Both PUT and POST methods are supported for updating an existing environment.` 

Partially Fixes: https://github.com/hashicorp/terraform-provider-google/issues/20931

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
apigee: fixed `properties` field update on `google_apigee_environment` resource
```
