### PR TITLE
Add etag to service perimeter dry run resource

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
@@ -71,6 +71,7 @@ custom_code:
   pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
   pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
@@ -106,3 +107,8 @@ properties:
       The name of the Access Policy this resource belongs to.
     ignore_read: true
     output: true
+  - name: 'etag'
+    type: String
+    output: true
+    description: |
+      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunResource.yaml
@@ -68,9 +68,9 @@ nested_query:
   modify_by_patch: true
 custom_code:
   encoder: 'templates/terraform/encoders/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
-  pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
-  pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
-  pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
+  pre_update: 'templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
+  pre_delete: 'templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
   post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_dry_run_resource.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.tmpl'
 exclude_tgc: true

--- a/mmv1/templates/terraform/post_read/access_context_manager_service_perimeter_dry_run_resource.go.tmpl
+++ b/mmv1/templates/terraform/post_read/access_context_manager_service_perimeter_dry_run_resource.go.tmpl
@@ -1,0 +1,3 @@
+if err := d.Set("etag", res["etag"]); err != nil {
+	log.Printf("[ERROR] Unable to set etag: %s", err)
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl
@@ -1,1 +1,17 @@
 obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.resources", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl
@@ -1,17 +1,1 @@
 obj["use_explicit_dry_run_spec"] = true
-
-etag := d.Get("etag").(string)
-
-if etag == "" {
-	log.Printf("[ERROR] Unable to get etag: %s", err)
-	return nil
-}
-obj["etag"] = etag
-
-// updateMask is a URL parameter but not present in the schema, so ReplaceVars
-// won't set it
-updateMask := []string{"spec.resources", "etag"}
-url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
-if err != nil {
-	return err
-}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_resource.go.tmpl
@@ -1,1 +1,17 @@
 obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.resources", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Same as #12736 except for adding etags to the dry run version of the resource.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
accesscontextmanager: added `etag` to `google_access_context_manager_service_perimeter_dry_run_resource` to prevent overriding list of resources
```
