### PR TITLE
Implemented simpler IAM bootstrapping logic

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
@@ -3,6 +3,8 @@ package acctest
 import (
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,7 +45,7 @@ func BootstrapIamMembers(t *testing.T, members []IamMember) {
 	for _, member := range members {
 		newBindings = append(newBindings, &cloudresourcemanager.Binding{
 			Role:    member.role,
-			Members: []string{strings.Replace(member.member, "{project_number}", project.ProjectNumber)},
+			Members: []string{strings.ReplaceAll(member.member, "{project_number}", strconv.FormatInt(project.ProjectNumber, 10))},
 		})
 	}
 
@@ -80,7 +82,7 @@ func BootstrapIamMembers(t *testing.T, members []IamMember) {
 // Return whether the bindings changed.
 func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []string) bool {
 	var members []IamMember
-	for i, agentName := range agentNames {
+	for _, agentName := range agentNames {
 		member := fmt.Sprintf("serviceAccount:%s{project_number}@%s.iam.gserviceaccount.com", prefix, agentName)
 		for _, role := range roles {
 			members = append(members, IamMember{

--- a/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 type IamMember struct {
-	member, role string
+	Member, Role string
 }
 
 // BootstrapIamMembers ensures that a given set of member/role pairs exist in the default
@@ -44,8 +44,8 @@ func BootstrapIamMembers(t *testing.T, members []IamMember) {
 	var newBindings []*cloudresourcemanager.Binding
 	for _, member := range members {
 		newBindings = append(newBindings, &cloudresourcemanager.Binding{
-			Role:    member.role,
-			Members: []string{strings.ReplaceAll(member.member, "{project_number}", strconv.FormatInt(project.ProjectNumber, 10))},
+			Role:    member.Role,
+			Members: []string{strings.ReplaceAll(member.Member, "{project_number}", strconv.FormatInt(project.ProjectNumber, 10))},
 		})
 	}
 
@@ -86,8 +86,8 @@ func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []strin
 		member := fmt.Sprintf("serviceAccount:%s{project_number}@%s.iam.gserviceaccount.com", prefix, agentName)
 		for _, role := range roles {
 			members = append(members, IamMember{
-				member: member,
-				role:   role,
+				Member: member,
+				Role:   role,
 			})
 		}
 	}

--- a/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
@@ -4,20 +4,22 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/tpgiamresource"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 )
 
-// BootstrapAllPSARoles ensures that the given project's IAM
-// policy grants the given service agents the given roles.
-// prefix is usually "service-" and indicates the service agent should have the
-// given prefix before the project number.
-// This is important to bootstrap because using iam policy resources means that
-// deleting them removes permissions for concurrent tests.
-// Return whether the bindings changed.
-func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []string) bool {
+type IamMember struct {
+	member, role string
+}
+
+// BootstrapIamMembers ensures that a given set of member/role pairs exist in the default
+// test project. This should be used to avoid race conditions that can happen on the
+// default project due to parallel tests managing the same member/role pairings. Members
+// will have `{project_number}` replaced with the default test project's project number.
+func BootstrapIamMembers(t *testing.T, members []IamMember) {
 	config := BootstrapConfig(t)
 	if config == nil {
 		t.Fatal("Could not bootstrap a config for BootstrapAllPSARoles.")
@@ -36,17 +38,12 @@ func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []strin
 		t.Fatalf("Error getting project iam policy: %v", err)
 	}
 
-	members := make([]string, len(agentNames))
-	for i, agentName := range agentNames {
-		members[i] = fmt.Sprintf("serviceAccount:%s%d@%s.iam.gserviceaccount.com", prefix, project.ProjectNumber, agentName)
-	}
-
 	// Create the bindings we need to add to the policy.
 	var newBindings []*cloudresourcemanager.Binding
-	for _, role := range roles {
+	for _, member := range members {
 		newBindings = append(newBindings, &cloudresourcemanager.Binding{
-			Role:    role,
-			Members: members,
+			Role:    member.role,
+			Members: []string{strings.Replace(member.member, "{project_number}", project.ProjectNumber)},
 		})
 	}
 
@@ -68,10 +65,32 @@ func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []strin
 		for _, binding := range addedBindings {
 			msg += fmt.Sprintf("Members: %q, Role: %q\n", binding.Members, binding.Role)
 		}
-		msg += "Retry the test in a few minutes."
-		t.Error(msg)
-		return true
+		msg += "Waiting for IAM to propagate."
+		t.Log(msg)
+		time.Sleep(3 * time.Minute)
 	}
+}
+
+// BootstrapAllPSARoles ensures that the given project's IAM
+// policy grants the given service agents the given roles.
+// prefix is usually "service-" and indicates the service agent should have the
+// given prefix before the project number.
+// This is important to bootstrap because using iam policy resources means that
+// deleting them removes permissions for concurrent tests.
+// Return whether the bindings changed.
+func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []string) bool {
+	var members []IamMember
+	for i, agentName := range agentNames {
+		member := fmt.Sprintf("serviceAccount:%s{project_number}@%s.iam.gserviceaccount.com", prefix, agentName)
+		for _, role := range roles {
+			members = append(members, IamMember{
+				member: member,
+				role: role,
+			})
+		}
+	}
+	BootstrapIamMembers(t, members, roles)
+	// Always return false because we now wait for IAM propagation.
 	return false
 }
 

--- a/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
@@ -85,7 +85,7 @@ func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []strin
 		for _, role := range roles {
 			members = append(members, IamMember{
 				member: member,
-				role: role,
+				role:   role,
 			})
 		}
 	}

--- a/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/bootstrap_iam_test_utils.go
@@ -89,7 +89,7 @@ func BootstrapAllPSARoles(t *testing.T, prefix string, agentNames, roles []strin
 			})
 		}
 	}
-	BootstrapIamMembers(t, members, roles)
+	BootstrapIamMembers(t, members)
 	// Always return false because we now wait for IAM propagation.
 	return false
 }

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -22,14 +22,29 @@ const testComposerNetworkPrefix = "tf-test-composer-net"
 const testComposerBucketPrefix = "tf-test-composer-bucket"
 const testComposerNetworkAttachmentPrefix = "tf-test-composer-nta"
 
-func allComposerServiceAgents() []string {
-	return []string{
-		"cloudcomposer-accounts",
-		"compute-system",
-		"container-engine-robot",
-		"gcp-sa-artifactregistry",
-		"gcp-sa-pubsub",
-	}
+func bootstrapComposerServiceAgents() {
+	acctest.BootstrapIamMembers([]acctest.IamMember{
+		{
+			member: "serviceAccount:service-{project_number}@cloudcomposer-accounts.iam.gserviceaccount.com",
+			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
+			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			member: "serviceAccount:service-{project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			member: "serviceAccount:service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com",
+			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 }
 
 // Checks environment creation with minimum required information.
@@ -245,7 +260,7 @@ func TestAccComposerEnvironment_withEncryptionConfigComposer1(t *testing.T) {
 
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-composer1-key1")
 	pid := envvar.GetTestProjectFromEnv()
-	grantServiceAgentsRole(t, "service-", allComposerServiceAgents(), "roles/cloudkms.cryptoKeyEncrypterDecrypter")
+	bootstrapComposerServiceAgents()
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
 	subnetwork := network + "-1"
@@ -282,7 +297,7 @@ func TestAccComposerEnvironment_withEncryptionConfigComposer2(t *testing.T) {
 
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-composer2-key1")
 	pid := envvar.GetTestProjectFromEnv()
-	grantServiceAgentsRole(t, "service-", allComposerServiceAgents(), "roles/cloudkms.cryptoKeyEncrypterDecrypter")
+	bootstrapComposerServiceAgents()
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
 	subnetwork := network + "-1"
@@ -968,14 +983,6 @@ func TestAccComposerEnvironment_fixPyPiPackages(t *testing.T) {
 			},
 		},
 	})
-}
-
-// This bootstraps the IAM roles needed for the service agents.
-func grantServiceAgentsRole(t *testing.T, prefix string, agentNames []string, role string) {
-	if acctest.BootstrapAllPSARole(t, prefix, agentNames, role) {
-		// Fail this test run because the policy needs time to reconcile.
-		t.Fatal("Stopping test because permissions were added.")
-	}
 }
 
 func testAccComposerEnvironmentDestroyProducer(t *testing.T) func(s *terraform.State) error {

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -22,27 +22,27 @@ const testComposerNetworkPrefix = "tf-test-composer-net"
 const testComposerBucketPrefix = "tf-test-composer-bucket"
 const testComposerNetworkAttachmentPrefix = "tf-test-composer-nta"
 
-func bootstrapComposerServiceAgents() {
-	acctest.BootstrapIamMembers([]acctest.IamMember{
+func bootstrapComposerServiceAgents(t *testing.T) {
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
 		{
-			member: "serviceAccount:service-{project_number}@cloudcomposer-accounts.iam.gserviceaccount.com",
-			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+			Member: "serviceAccount:service-{project_number}@cloudcomposer-accounts.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 		},
 		{
-			member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
-			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+			Member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 		},
 		{
-			member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
-			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 		},
 		{
-			member: "serviceAccount:service-{project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
-			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+			Member: "serviceAccount:service-{project_number}@gcp-sa-artifactregistry.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 		},
 		{
-			member: "serviceAccount:service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com",
-			role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+			Member: "serviceAccount:service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
 		},
 	})
 }
@@ -260,7 +260,7 @@ func TestAccComposerEnvironment_withEncryptionConfigComposer1(t *testing.T) {
 
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-composer1-key1")
 	pid := envvar.GetTestProjectFromEnv()
-	bootstrapComposerServiceAgents()
+	bootstrapComposerServiceAgents(t)
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
 	subnetwork := network + "-1"
@@ -297,7 +297,7 @@ func TestAccComposerEnvironment_withEncryptionConfigComposer2(t *testing.T) {
 
 	kms := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-composer2-key1")
 	pid := envvar.GetTestProjectFromEnv()
-	bootstrapComposerServiceAgents()
+	bootstrapComposerServiceAgents(t)
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
 	subnetwork := network + "-1"


### PR DESCRIPTION
This should make it easier when looking at tests to see what is being bootstrapped.

I also switched the logic from failing on the first bootstrapping to waiting for the bootstrapping to finish.

I'll follow up with separate PRs to allow easier generation of this from yaml and convert at least some of the existing usage.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
