### PR TITLE
Fix failing TestAccDataflowJob tests.

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
@@ -1,15 +1,18 @@
 package dataflow_test
 
 import (
+    "context"
 	"fmt"
-  "strconv"
+	"path"
+    "strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-google/google/services/dataflow"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/services/dataflow"
+	dataflowapi "google.golang.org/api/dataflow/v1b3"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -25,6 +28,7 @@ const (
 	testDataflowJobTemplateWordCountUrl = "gs://dataflow-templates/latest/Word_Count"
 	testDataflowJobSampleFileUrl        = "gs://dataflow-samples/shakespeare/various.txt"
 	testDataflowJobTemplateTextToPubsub = "gs://dataflow-templates/latest/Stream_GCS_Text_to_Cloud_PubSub"
+	testDataflowJobRegion               = "us-central1"
 )
 
 func TestAccDataflowJob_basic(t *testing.T) {
@@ -36,7 +40,6 @@ func TestAccDataflowJob_basic(t *testing.T) {
 	randStr := acctest.RandString(t, 10)
 	bucket := "tf-test-dataflow-gcs-" + randStr
 	job := "tf-test-dataflow-job-" + randStr
-	zone := "us-east5-b"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -44,7 +47,7 @@ func TestAccDataflowJob_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJob_zone(bucket, job, zone),
+				Config: testAccDataflowJob(bucket, job, testDataflowJobRegion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
 				),
@@ -53,7 +56,7 @@ func TestAccDataflowJob_basic(t *testing.T) {
 				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "zone", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -68,7 +71,6 @@ func TestAccDataflowJobSkipWait_basic(t *testing.T) {
 	randStr := acctest.RandString(t, 10)
 	bucket := "tf-test-dataflow-gcs-" + randStr
 	job := "tf-test-dataflow-job-" + randStr
-	zone := "us-east5-b"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -76,40 +78,9 @@ func TestAccDataflowJobSkipWait_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJobSkipWait_zone(bucket, job, zone),
+				Config: testAccDataflowJobSkipWait(bucket, job, testDataflowJobRegion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
-				),
-			},
-			{
-				ResourceName:            "google_dataflow_job.big_data",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "zone", "state"},
-			},
-		},
-	})
-}
-
-func TestAccDataflowJob_withRegion(t *testing.T) {
-	// Dataflow responses include serialized java classes and bash commands
-	// This makes body comparison infeasible
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	randStr := acctest.RandString(t, 10)
-	bucket := "tf-test-dataflow-gcs-" + randStr
-	job := "tf-test-dataflow-job-" + randStr
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataflowJobRegionDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDataflowJob_region(bucket, job),
-				Check: resource.ComposeTestCheckFunc(
-					testAccRegionalDataflowJobExists(t, "google_dataflow_job.big_data", "us-central1"),
 				),
 			},
 			{
@@ -149,7 +120,7 @@ func TestAccDataflowJob_withServiceAccount(t *testing.T) {
 				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -182,7 +153,7 @@ func TestAccDataflowJob_withNetwork(t *testing.T) {
 				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -216,7 +187,7 @@ func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "subnetwork", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "subnetwork", "region", "state"},
 			},
 		},
 	})
@@ -265,7 +236,6 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 	randStr := acctest.RandString(t, 10)
 	bucket := "tf-test-dataflow-gcs-" + randStr
 	job := "tf-test-dataflow-job-" + randStr
-	zone := "us-east5-b"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -288,10 +258,10 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.big_data",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
+				ResourceName:            "google_dataflow_job.big_data",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "region", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccDataflowJob_resourceLabelsOverridesProviderDefaultLabels(bucket, job),
@@ -333,9 +303,9 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.big_data",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_dataflow_job.big_data",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
 			},
 			{
@@ -355,13 +325,13 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.big_data",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_dataflow_job.big_data",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state", "labels", "terraform_labels"},
 			},
 			{
-				Config: testAccDataflowJob_zone(bucket, job, zone),
+				Config: testAccDataflowJob(bucket, job, testDataflowJobRegion),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckNoResourceAttr("google_dataflow_job.big_data", "labels.%"),
 					// goog-terraform-provisioned: true is added
@@ -369,10 +339,10 @@ func TestAccDataflowJob_withProviderDefaultLabels(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_dataflow_job.big_data",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "zone", "state"},
+				ResourceName:            "google_dataflow_job.big_data",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -420,7 +390,6 @@ func TestAccDataflowJob_withKmsKey(t *testing.T) {
 	crypto_key := "tf-test-dataflow-kms-key-" + randStr
 	bucket := "tf-test-dataflow-gcs-" + randStr
 	job := "tf-test-dataflow-job-" + randStr
-	zone := "us-east5-b"
 
 	if acctest.BootstrapPSARole(t, "service-", "compute-system", "roles/cloudkms.cryptoKeyEncrypterDecrypter") {
 		t.Fatal("Stopping the test because a role was added to the policy.")
@@ -436,7 +405,7 @@ func TestAccDataflowJob_withKmsKey(t *testing.T) {
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJob_kms(key_ring, crypto_key, bucket, job, zone),
+				Config: testAccDataflowJob_kms(key_ring, crypto_key, bucket, job, testDataflowJobRegion),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
 				),
@@ -445,7 +414,7 @@ func TestAccDataflowJob_withKmsKey(t *testing.T) {
 				ResourceName:            "google_dataflow_job.big_data",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "zone", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -489,20 +458,47 @@ func TestAccDataflowJob_streamUpdate(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
+	randStr := acctest.RandString(t, 10)
+	job := "tf-test-dataflow-job-" + randStr
+	serviceAccount := "tf-test-dataflow-sa" + randStr
+
 	suffix := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJob_updateStream(suffix, "google_storage_bucket.bucket1.url"),
+				Config: testAccDataflowJob_stream(suffix, job, serviceAccount, "google_storage_bucket.bucket1.url", "cancel"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.pubsub_stream"),
+					func(s *terraform.State) error {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+						defer cancel()
+						tick := time.NewTicker(10 * time.Second)
+						defer tick.Stop()
+						for {
+							select {
+							case <-tick.C:
+								job, err := testAccDataflowGetJob(t, s, "google_dataflow_job.pubsub_stream")
+								if err != nil {
+									return err
+								}
+								if job.CurrentState == "JOB_STATE_RUNNING" {
+									return nil
+								}
+							case <-ctx.Done():
+								return fmt.Errorf("timeout waiting for Job to reach RUNNING state")
+							}
+						}
+					},
 				),
 			},
 			{
-				Config: testAccDataflowJob_updateStream(suffix, "google_storage_bucket.bucket2.url"),
+				Config: testAccDataflowJob_stream(suffix, job, serviceAccount, "google_storage_bucket.bucket2.url", "cancel"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobHasTempLocation(t, "google_dataflow_job.pubsub_stream", "gs://tf-test-bucket2-"+suffix),
 				),
@@ -523,6 +519,10 @@ func TestAccDataflowJob_virtualUpdate(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
+	randStr := acctest.RandString(t, 10)
+	job := "tf-test-dataflow-job-" + randStr
+	serviceAccount := "tf-test-dataflow-sa" + randStr
+
 	suffix := acctest.RandString(t, 10)
 
 	// If the update is virtual-only, the ID should remain the same after updating.
@@ -531,16 +531,39 @@ func TestAccDataflowJob_virtualUpdate(t *testing.T) {
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDataflowJobDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJob_virtualUpdate(suffix, "drain"),
+				Config: testAccDataflowJob_stream(suffix, job, serviceAccount, "google_storage_bucket.bucket1.url", "drain"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.pubsub_stream"),
 					testAccDataflowSetId(t, "google_dataflow_job.pubsub_stream", &id),
+					func(s *terraform.State) error {
+						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+						defer cancel()
+						tick := time.NewTicker(10 * time.Second)
+						defer tick.Stop()
+						for {
+							select {
+							case <-tick.C:
+								job, err := testAccDataflowGetJob(t, s, "google_dataflow_job.pubsub_stream")
+								if err != nil {
+									return err
+								}
+								if job.CurrentState == "JOB_STATE_RUNNING" {
+									return nil
+								}
+							case <-ctx.Done():
+								return fmt.Errorf("timeout waiting for Job to reach RUNNING state")
+							}
+						}
+					},
 				),
 			},
 			{
-				Config: testAccDataflowJob_virtualUpdate(suffix, "cancel"),
+				Config: testAccDataflowJob_stream(suffix, job, serviceAccount, "google_storage_bucket.bucket1.url", "cancel"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowCheckId(t, "google_dataflow_job.pubsub_stream", &id),
 					resource.TestCheckResourceAttr("google_dataflow_job.pubsub_stream", "on_delete", "cancel"),
@@ -550,7 +573,7 @@ func TestAccDataflowJob_virtualUpdate(t *testing.T) {
 				ResourceName:            "google_dataflow_job.pubsub_stream",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "skip_wait_on_job_termination", "state"},
+				ImportStateVerifyIgnore: []string{"on_delete", "parameters", "transform_name_mapping", "skip_wait_on_job_termination", "region", "state"},
 			},
 		},
 	})
@@ -566,18 +589,18 @@ func testAccCheckDataflowJobDestroyProducer(t *testing.T) func(s *terraform.Stat
 			config := acctest.GoogleProviderConfig(t)
 			job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
 			if job != nil {
-        var ok bool
-        skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
-        if err != nil {
-          return fmt.Errorf("could not parse attribute: %v", err)
-        }
+				var ok bool
+				skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
+				if err != nil {
+					return fmt.Errorf("could not parse attribute: %v", err)
+				}
 				_, ok = dataflow.DataflowTerminalStatesMap[job.CurrentState]
-        if !ok && skipWait {
-				  _, ok = dataflow.DataflowTerminatingStatesMap[job.CurrentState]
-        }
-        if !ok {
-          return fmt.Errorf("Job still present")
-        }
+				if !ok && skipWait {
+					_, ok = dataflow.DataflowTerminatingStatesMap[job.CurrentState]
+				}
+				if !ok {
+					return fmt.Errorf("Job still present")
+				}
 			} else if err != nil {
 				return err
 			}
@@ -596,18 +619,18 @@ func testAccCheckDataflowJobRegionDestroyProducer(t *testing.T) func(s *terrafor
 			config := acctest.GoogleProviderConfig(t)
 			job, err := config.NewDataflowClient(config.UserAgent).Projects.Locations.Jobs.Get(config.Project, "us-central1", rs.Primary.ID).Do()
 			if job != nil {
-        var ok bool
-        skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
-        if err != nil {
-          return fmt.Errorf("could not parse attribute: %v", err)
-        }
+				var ok bool
+				skipWait, err := strconv.ParseBool(rs.Primary.Attributes["skip_wait_on_job_termination"])
+				if err != nil {
+					return fmt.Errorf("could not parse attribute: %v", err)
+				}
 				_, ok = dataflow.DataflowTerminalStatesMap[job.CurrentState]
-        if !ok && skipWait {
-				  _, ok = dataflow.DataflowTerminatingStatesMap[job.CurrentState]
-        }
-        if !ok {
-          return fmt.Errorf("Job still present")
-        }
+				if !ok && skipWait {
+					_, ok = dataflow.DataflowTerminatingStatesMap[job.CurrentState]
+				}
+				if !ok {
+					return fmt.Errorf("Job still present")
+				}
 			} else if err != nil {
 				return err
 			}
@@ -619,22 +642,45 @@ func testAccCheckDataflowJobRegionDestroyProducer(t *testing.T) func(s *terrafor
 
 func testAccDataflowJobExists(t *testing.T, resource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[resource]
-		if !ok {
-			return fmt.Errorf("resource %q not in state", resource)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("no ID is set")
-		}
-
-		config := acctest.GoogleProviderConfig(t)
-		_, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
-		if err != nil {
-			return fmt.Errorf("could not confirm Dataflow Job %q exists: %v", rs.Primary.ID, err)
-		}
-
-		return nil
+		_, err := testAccDataflowGetJob(t, s, resource)
+		return err
 	}
+}
+
+func testAccDataflowGetJob(t *testing.T, s *terraform.State, resource string) (*dataflowapi.Job, error) {
+	rs, ok := s.RootModule().Resources[resource]
+	if !ok {
+		return nil, fmt.Errorf("resource %q not in state", resource)
+	}
+	if rs.Primary.ID == "" {
+		return nil, fmt.Errorf("no ID is set")
+	}
+
+	region, ok := rs.Primary.Attributes["region"]
+	if !ok {
+		region = testDataflowJobRegion
+	}
+	config := acctest.GoogleProviderConfig(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	job, err := config.NewDataflowClient(config.UserAgent).Projects.Locations.Jobs.Get(config.Project, region, rs.Primary.ID).Context(ctx).View("JOB_VIEW_ALL").Do()
+	if err != nil {
+		return nil, fmt.Errorf("could not get Dataflow Job 'projects/%s/regions/%s/jobs/%s': %w", config.Project, config.Region, rs.Primary.ID, err)
+	}
+	return job, nil
+}
+
+func testAccDataflowWorkerPool(job *dataflowapi.Job) (*dataflowapi.WorkerPool, error) {
+	if job == nil {
+		return nil, fmt.Errorf("job is nil")
+	}
+	if job.Environment == nil {
+		return nil, fmt.Errorf("job has no environment: %+v", job)
+	}
+	if len(job.Environment.WorkerPools) == 0 {
+		return nil, fmt.Errorf("job has no worker pools: %+v", job)
+	}
+	return job.Environment.WorkerPools[0], nil
 }
 
 func testAccDataflowSetId(t *testing.T, resource string, id *string) resource.TestCheckFunc {
@@ -665,16 +711,16 @@ func testAccDataflowCheckId(t *testing.T, resource string, id *string) resource.
 
 func testAccDataflowJobHasNetwork(t *testing.T, res, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		instanceTmpl, err := testAccDataflowJobGetGeneratedInstanceTemplate(t, s, res)
+		job, err := testAccDataflowGetJob(t, s, res)
 		if err != nil {
-			return fmt.Errorf("Error getting dataflow job instance template: %s", err)
+			return err
 		}
-		if len(instanceTmpl.Properties.NetworkInterfaces) == 0 {
-			return fmt.Errorf("no network interfaces in template properties: %+v", instanceTmpl.Properties)
+		wp, err := testAccDataflowWorkerPool(job)
+		if err != nil {
+			return err
 		}
-		actual := instanceTmpl.Properties.NetworkInterfaces[0].Network
-		if tpgresource.GetResourceNameFromSelfLink(actual) != tpgresource.GetResourceNameFromSelfLink(expected) {
-			return fmt.Errorf("network mismatch: %s != %s", actual, expected)
+		if wp.Network != expected {
+			return fmt.Errorf("network mismatch: %s != %s", wp.Network, expected)
 		}
 		return nil
 	}
@@ -682,16 +728,17 @@ func testAccDataflowJobHasNetwork(t *testing.T, res, expected string) resource.T
 
 func testAccDataflowJobHasSubnetwork(t *testing.T, res, expected string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		instanceTmpl, err := testAccDataflowJobGetGeneratedInstanceTemplate(t, s, res)
+		job, err := testAccDataflowGetJob(t, s, res)
 		if err != nil {
-			return fmt.Errorf("Error getting dataflow job instance template: %s", err)
+			return err
 		}
-		if len(instanceTmpl.Properties.NetworkInterfaces) == 0 {
-			return fmt.Errorf("no network interfaces in template properties: %+v", instanceTmpl.Properties)
+		wp, err := testAccDataflowWorkerPool(job)
+		if err != nil {
+			return err
 		}
-		actual := instanceTmpl.Properties.NetworkInterfaces[0].Subnetwork
-		if tpgresource.GetResourceNameFromSelfLink(actual) != tpgresource.GetResourceNameFromSelfLink(expected) {
-			return fmt.Errorf("subnetwork mismatch: %s != %s", actual, expected)
+		got := path.Base(wp.Subnetwork)
+		if got != expected {
+			return fmt.Errorf("network mismatch: %s != %s", got, expected)
 		}
 		return nil
 	}
@@ -739,7 +786,7 @@ func testAccDataflowJobGetGeneratedInstanceTemplate(t *testing.T, s *terraform.S
 			return resource.NonRetryableError(rerr)
 		}
 		if len(instanceTemplates.Items) == 0 {
-			return resource.RetryableError(fmt.Errorf("no instance template found for dataflow job %q", rs.Primary.ID))
+			return resource.RetryableError(fmt.Errorf("no instance template found for dataflow job 'projects/%s/regions/%s/jobs/%s'", config.Project, config.Region, rs.Primary.ID))
 		}
 		if len(instanceTemplates.Items) > 1 {
 			return resource.NonRetryableError(fmt.Errorf("Wrong number of matching instance templates for dataflow job: %s, %d", rs.Primary.ID, len(instanceTemplates.Items)))
@@ -778,19 +825,13 @@ func testAccRegionalDataflowJobExists(t *testing.T, res, region string) resource
 
 func testAccDataflowJobHasLabels(t *testing.T, res, key string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		job, err := testAccDataflowGetJob(t, s, res)
+		if err != nil {
+			return err
+		}
 		rs, ok := s.RootModule().Resources[res]
 		if !ok {
 			return fmt.Errorf("resource %q not found in state", res)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-		config := acctest.GoogleProviderConfig(t)
-
-		job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
-		if err != nil {
-			return fmt.Errorf("dataflow job does not exist")
 		}
 
 		if job.Labels[key] != rs.Primary.Attributes["labels."+key] {
@@ -803,21 +844,10 @@ func testAccDataflowJobHasLabels(t *testing.T, res, key string) resource.TestChe
 
 func testAccDataflowJobHasExperiments(t *testing.T, res string, experiments []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[res]
-		if !ok {
-			return fmt.Errorf("resource %q not found in state", res)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-		config := acctest.GoogleProviderConfig(t)
-
-		job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).View("JOB_VIEW_ALL").Do()
+		job, err := testAccDataflowGetJob(t, s, res)
 		if err != nil {
-			return fmt.Errorf("dataflow job does not exist")
+			return err
 		}
-
 		for _, expectedExperiment := range experiments {
 			var contains = false
 			for _, actualExperiment := range job.Environment.Experiments {
@@ -836,19 +866,15 @@ func testAccDataflowJobHasExperiments(t *testing.T, res string, experiments []st
 
 func testAccDataflowJobHasTempLocation(t *testing.T, res, targetLocation string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[res]
-		if !ok {
-			return fmt.Errorf("resource %q not found in state", res)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-		config := acctest.GoogleProviderConfig(t)
-
-		job, err := config.NewDataflowClient(config.UserAgent).Projects.Jobs.Get(config.Project, rs.Primary.ID).View("JOB_VIEW_ALL").Do()
+		job, err := testAccDataflowGetJob(t, s, res)
 		if err != nil {
-			return fmt.Errorf("dataflow job does not exist")
+			return err
+		}
+		if job.Environment == nil {
+			return fmt.Errorf("job has no environment: %+v", job)
+		}
+		if job.Environment.SdkPipelineOptions == nil {
+			return fmt.Errorf("SDK pipeline options are nil")
 		}
 		sdkPipelineOptions, err := tpgresource.ConvertToMap(job.Environment.SdkPipelineOptions)
 		if err != nil {
@@ -864,18 +890,19 @@ func testAccDataflowJobHasTempLocation(t *testing.T, res, targetLocation string)
 	}
 }
 
-func testAccDataflowJob_zone(bucket, job, zone string) string {
+func testAccDataflowJob(bucket, job, region string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
   name = "%s"
 
-  zone    = "%s"
+  region = "%s"
 
   machine_type      = "e2-standard-2"
   template_gcs_path = "%s"
@@ -886,21 +913,22 @@ resource "google_dataflow_job" "big_data" {
   }
   on_delete = "cancel"
 }
-`, bucket, job, zone, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, bucket, job, region, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
-func testAccDataflowJobSkipWait_zone(bucket, job, zone string) string {
+func testAccDataflowJobSkipWait(bucket, job, region string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
   name = "%s"
 
-  zone    = "%s"
+  region = "%s"
 
   machine_type      = "e2-standard-2"
   template_gcs_path = "%s"
@@ -912,31 +940,7 @@ resource "google_dataflow_job" "big_data" {
   on_delete                    = "cancel"
   skip_wait_on_job_termination = true
 }
-`, bucket, job, zone, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
-}
-
-func testAccDataflowJob_region(bucket, job string) string {
-	return fmt.Sprintf(`
-resource "google_storage_bucket" "temp" {
-  name          = "%s"
-  location      = "US"
-  force_destroy = true
-}
-
-resource "google_dataflow_job" "big_data" {
-  name = "%s"
-  region  = "us-central1"
-
-  template_gcs_path = "%s"
-  temp_gcs_location = google_storage_bucket.temp.url
-  parameters = {
-    inputFile = "%s"
-    output    = "${google_storage_bucket.temp.url}/output"
-  }
-
-  on_delete = "cancel"
-}
-`, bucket, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, bucket, job, region, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
 func testAccDataflowJob_network(bucket, job, network string) string {
@@ -945,6 +949,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_compute_network" "net" {
@@ -974,6 +979,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_compute_network" "net" {
@@ -984,13 +990,14 @@ resource "google_compute_network" "net" {
 resource "google_compute_subnetwork" "subnet" {
   name          = "%s"
   ip_cidr_range = "10.2.0.0/16"
-  network       = google_compute_network.net.self_link
+  network       = google_compute_network.net.name
+  region 		= "%s"
 }
 
 resource "google_dataflow_job" "big_data" {
   name = "%s"
-
-  subnetwork        = google_compute_subnetwork.subnet.self_link
+  region     = "%s"
+  subnetwork = google_compute_subnetwork.subnet.self_link
 
   template_gcs_path = "%s"
   temp_gcs_location = google_storage_bucket.temp.url
@@ -1000,7 +1007,7 @@ resource "google_dataflow_job" "big_data" {
   }
   on_delete = "cancel"
 }
-`, bucket, network, subnet, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, bucket, network, subnet, testDataflowJobRegion, job, testDataflowJobRegion, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
 func testAccDataflowJob_serviceAccount(bucket, job, accountId string) string {
@@ -1011,6 +1018,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_service_account" "dataflow-sa" {
@@ -1032,6 +1040,7 @@ resource "google_project_iam_member" "dataflow-worker" {
 
 resource "google_dataflow_job" "big_data" {
   name = "%s"
+  region = "%s"
   depends_on = [
     google_storage_bucket_iam_member.dataflow-gcs,
     google_project_iam_member.dataflow-worker
@@ -1046,7 +1055,7 @@ resource "google_dataflow_job" "big_data" {
 
   service_account_email = google_service_account.dataflow-sa.email
 }
-`, bucket, accountId, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, bucket, accountId, job, testDataflowJobRegion, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
 func testAccDataflowJob_ipConfig(bucket, job string) string {
@@ -1055,6 +1064,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
@@ -1079,6 +1089,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
@@ -1111,6 +1122,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
@@ -1144,6 +1156,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
@@ -1179,6 +1192,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
@@ -1200,7 +1214,7 @@ resource "google_dataflow_job" "big_data" {
 `, bucket, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
-func testAccDataflowJob_kms(key_ring, crypto_key, bucket, job, zone string) string {
+func testAccDataflowJob_kms(key_ring, crypto_key, bucket, job, region string) string {
 	return fmt.Sprintf(`
 resource "google_kms_key_ring" "keyring" {
   name     = "%s"
@@ -1217,12 +1231,13 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "big_data" {
   name = "%s"
 
-  zone    = "%s"
+  region = "%s"
 
   machine_type      = "e2-standard-2"
   template_gcs_path = "%s"
@@ -1234,7 +1249,7 @@ resource "google_dataflow_job" "big_data" {
   }
   on_delete = "cancel"
 }
-`, key_ring, crypto_key, bucket, job, zone, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, key_ring, crypto_key, bucket, job, region, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
 func testAccDataflowJob_additionalExperiments(bucket string, job string, experiments []string) string {
@@ -1243,6 +1258,7 @@ resource "google_storage_bucket" "temp" {
   name          = "%s"
   location      = "US"
   force_destroy = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_dataflow_job" "with_additional_experiments" {
@@ -1261,8 +1277,11 @@ resource "google_dataflow_job" "with_additional_experiments" {
 `, bucket, job, strings.Join(experiments, `", "`), testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
-func testAccDataflowJob_updateStream(suffix, tempLocation string) string {
+func testAccDataflowJob_stream(suffix, job, serviceAccount, tempLocation, ondelete string) string {
 	return fmt.Sprintf(`
+
+data "google_project" "project" {}
+
 resource "google_pubsub_topic" "topic" {
 	name     = "tf-test-dataflow-job-%s"
 }
@@ -1270,14 +1289,46 @@ resource "google_storage_bucket" "bucket1" {
 	name          = "tf-test-bucket1-%s"
 	location      = "US"
 	force_destroy = true
+    uniform_bucket_level_access = true
 }
 resource "google_storage_bucket" "bucket2" {
 	name          = "tf-test-bucket2-%s"
 	location      = "US"
 	force_destroy = true
+    uniform_bucket_level_access = true
 }
+
+resource "google_service_account" "dataflow-sa" {
+  account_id   = "%s"
+  display_name = "DataFlow Service Account"
+}
+
+resource "google_storage_bucket_iam_member" "bucket1" {
+  bucket = google_storage_bucket.bucket1.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.dataflow-sa.email}"
+}
+
+resource "google_storage_bucket_iam_member" "bucket2" {
+  bucket = google_storage_bucket.bucket2.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.dataflow-sa.email}"
+}
+
+resource "google_project_iam_member" "dataflow-worker" {
+  project = data.google_project.project.project_id
+  role   = "roles/dataflow.worker"
+  member = "serviceAccount:${google_service_account.dataflow-sa.email}"
+}
+
+resource "time_sleep" "wait_bind_iam_roles" {
+  depends_on = [google_project_iam_member.dataflow-worker, google_storage_bucket_iam_member.bucket1, google_storage_bucket_iam_member.bucket2]
+  create_duration = "300s"
+}
+
 resource "google_dataflow_job" "pubsub_stream" {
-	name = "tf-test-dataflow-job-%s"
+	depends_on = [time_sleep.wait_bind_iam_roles]
+	name = "%s"
 	template_gcs_path = "%s"
 	temp_gcs_location = %s
 	parameters = {
@@ -1288,9 +1339,10 @@ resource "google_dataflow_job" "pubsub_stream" {
 		name = "test_job"
 		env = "test"
 	}
-	on_delete = "cancel"
+    service_account_email = google_service_account.dataflow-sa.email
+	on_delete = "%s"
 }
-  `, suffix, suffix, suffix, suffix, testDataflowJobTemplateTextToPubsub, tempLocation)
+  `, suffix, suffix, suffix, serviceAccount, job, testDataflowJobTemplateTextToPubsub, tempLocation, ondelete)
 }
 
 func testAccDataflowJob_virtualUpdate(suffix, onDelete string) string {
@@ -1302,6 +1354,7 @@ resource "google_storage_bucket" "bucket" {
 	name          = "tf-test-bucket-%s"
 	location      = "US"
 	force_destroy = true
+  	uniform_bucket_level_access = true
 }
 resource "google_dataflow_job" "pubsub_stream" {
 	name = "tf-test-dataflow-job-%s"


### PR DESCRIPTION
This PR fixes https://github.com/hashicorp/terraform-provider-google/issues/18074 largely changing the use of the Projects.Jobs.Get to the recommended Projects.Locations.Jobs.Get which is based on the regional endpoints.

```release-note:none

```