### PR TITLE
EphemeralWriteOnly: add `secret_data_wo` in `google_secret_version`

### DIFF
--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -152,7 +152,7 @@ properties:
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
         conflicts:
-          - 'payload.0.secretDataWo'
+          - 'secretDataWo'
         immutable: true
         sensitive: true
       - name: 'secretDataWo'
@@ -166,5 +166,7 @@ properties:
         write_only: true
       - name: 'SecretDataWoVersion'
         type: Integer
+        default_value: 0
+        ignore_read: true
         description: Triggers update of secret data write-only
         immutable: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -162,3 +162,6 @@ properties:
         conflicts:
           - 'payload.0.secretData'
         write_only: true
+      - name: 'newSecretDataWo'
+        type: Boolean
+        description: Triggers update of secret data.

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -159,9 +159,12 @@ properties:
         type: String
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
+        required_with:
+          - 'SecretDataWoVersion'
         conflicts:
           - 'payload.0.secretData'
         write_only: true
-      - name: 'newSecretDataWo'
-        type: Boolean
-        description: Triggers update of secret data.
+      - name: 'SecretDataWoVersion'
+        type: Integer
+        description: Triggers update of secret data write-only
+        immutable: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -41,6 +41,7 @@ custom_code:
   custom_update: 'templates/terraform/custom_update/secret_version.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/secret_version_deletion_policy.go.tmpl'
   custom_import: 'templates/terraform/custom_import/secret_version.go.tmpl'
+  validation: 'templates/terraform/validation/secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 examples:

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -49,6 +49,11 @@ examples:
     vars:
       secret_id: 'secret-version'
       data: 'secret-data'
+  - name: 'secret_version_basic_write_only'
+    primary_resource_id: 'secret-version-basic-write-only'
+    vars:
+      secret_id: 'secret-version-write-only'
+      data: 'secret-data-write-only'
   - name: 'secret_version_deletion_policy_abandon'
     primary_resource_id: 'secret-version-deletion-policy'
     vars:

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -132,11 +132,20 @@ properties:
     custom_flatten: 'templates/terraform/custom_flatten/secret_version_access.go.tmpl'
     flatten_object: true
     properties:
-      - name: 'secret_data'
+      - name: 'secretData'
         type: String
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
-        required: true
+        at_least_one_of:
+          - 'payload.0.secretDataWo'
         immutable: true
         sensitive: true
+        custom_expand: 'templates/terraform/custom_expand/secret_version_secret_data.go.tmpl'
+      - name: 'secretDataWo'
+        type: String
+        description: The secret data. Must be no larger than 64KiB.
+        api_name: data
+        at_least_one_of:
+          - 'payload.0.secretData'
+        write_only: true
         custom_expand: 'templates/terraform/custom_expand/secret_version_secret_data.go.tmpl'

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -77,6 +77,15 @@ examples:
       'data': '"./test-fixtures/binary-file.pfx"'
     ignore_read_extra:
       - 'is_secret_data_base64'
+  - name: 'secret_version_with_base64_string_secret_data_write_only'
+    primary_resource_id: 'secret-version-base64-write-only'
+    vars:
+      secret_id: 'secret-version-base64-write-only'
+      data: 'secret-data-base64-write-only.pfx'
+    test_vars_overrides:
+      'data': '"./test-fixtures/binary-file.pfx"'
+    ignore_read_extra:
+      - 'is_secret_data_base64'
 virtual_fields:
   - name: 'deletion_policy'
     description: |

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -41,7 +41,7 @@ custom_code:
   custom_update: 'templates/terraform/custom_update/secret_version.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/secret_version_deletion_policy.go.tmpl'
   custom_import: 'templates/terraform/custom_import/secret_version.go.tmpl'
-  validation: 'templates/terraform/validation/secret_version.go.tmpl'
+  raw_resource_config_validation: 'templates/terraform/validation/secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 examples:

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -130,22 +130,21 @@ properties:
     description: The secret payload of the SecretVersion.
     required: true
     custom_flatten: 'templates/terraform/custom_flatten/secret_version_access.go.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/secret_version_access.go.tmpl'
     flatten_object: true
     properties:
       - name: 'secretData'
         type: String
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
-        at_least_one_of:
+        conflicts:
           - 'payload.0.secretDataWo'
         immutable: true
         sensitive: true
-        custom_expand: 'templates/terraform/custom_expand/secret_version_secret_data.go.tmpl'
       - name: 'secretDataWo'
         type: String
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
-        at_least_one_of:
+        conflicts:
           - 'payload.0.secretData'
         write_only: true
-        custom_expand: 'templates/terraform/custom_expand/secret_version_secret_data.go.tmpl'

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -1,6 +1,6 @@
 {{/*
 	The license inside this block applies to this file
-	Copyright 2024 Google Inc.
+	Copyright 2025 Google Inc.
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -44,7 +44,7 @@ func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresou
 func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
 	path := cty.GetAttrPath("secret_data_wo")
 	woVal, _ := d.GetRawConfigAt(path)
-	if !woVal.Type().Equals(cty.String) {
+	if !woVal.Type().Equals(cty.String) || woVal.IsNull() {
 		return nil, nil
 	}
 	if d.Get("is_secret_data_base64").(bool) {

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -44,7 +44,7 @@ func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresou
 func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
 	path := cty.GetAttrPath("secret_data_wo")
 	woVal, _ := d.GetRawConfigAt(path)
-	if !woVal.Type().Equals(cty.Bool) {
+	if !woVal.Type().Equals(cty.String) {
 		return nil, nil
 	}
 	if d.Get("is_secret_data_base64").(bool) {

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -19,13 +19,14 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		transformed["data"] = transformedSecretData
 	}
 
+{{- if ne $.ResourceMetadata.Compiler "terraformgoogleconversion-codegen" }}
 	transformedSecretDataWo, err := expandSecretManagerSecretVersionPayloadSecretDataWo(d.Get("secret_data_wo"), d.(*schema.ResourceData), config)
 	if err != nil {
 		return nil, err
 	} else if val := reflect.ValueOf(transformedSecretDataWo); val.IsValid() && !tpgresource.IsEmptyValue(val) {
 		transformed["data"] = transformedSecretDataWo
 	}
-
+{{- end }}
 	return transformed, nil
 }
 
@@ -39,7 +40,7 @@ func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresou
 	}
 	return base64.StdEncoding.EncodeToString([]byte(v.(string))), nil
 }
-
+{{- if ne $.ResourceMetadata.Compiler "terraformgoogleconversion-codegen" }}
 func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
 	path := cty.GetAttrPath("secret_data_wo")
 	woVal, _ := d.GetRawConfigAt(path)
@@ -48,3 +49,4 @@ func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schem
 	}
 	return base64.StdEncoding.EncodeToString([]byte(woVal.AsString())), nil
 }
+{{- end }}

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -44,6 +44,9 @@ func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresou
 func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
 	path := cty.GetAttrPath("secret_data_wo")
 	woVal, _ := d.GetRawConfigAt(path)
+	if !woVal.Type().Equals(cty.Bool) {
+		return nil, nil
+	}
 	if d.Get("is_secret_data_base64").(bool) {
 		return woVal.AsString(), nil
 	}

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -1,0 +1,47 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	transformed := make(map[string]interface{})
+	transformedSecretData, err := expandSecretManagerSecretVersionPayloadSecretData(d.Get("secret_data"), d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedSecretData); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["data"] = transformedSecretData
+	}
+
+	transformedSecretDataWo, err := expandSecretManagerSecretVersionPayloadSecretDataWo(d.Get("secret_data_wo"), d.(*schema.ResourceData), config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedSecretDataWo); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["data"] = transformedSecretDataWo
+	}
+
+	return transformed, nil
+}
+
+func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	if d.Get("is_secret_data_base64").(bool) {
+		return v, nil
+	}
+	return base64.StdEncoding.EncodeToString([]byte(v.(string))), nil
+}
+
+func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
+	path := cty.GetAttrPath("secret_data_wo")
+	woVal, _ := d.GetRawConfigAt(path)
+	return base64.StdEncoding.EncodeToString([]byte(woVal.AsString())), nil
+}

--- a/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_access.go.tmpl
@@ -43,5 +43,8 @@ func expandSecretManagerSecretVersionPayloadSecretData(v interface{}, d tpgresou
 func expandSecretManagerSecretVersionPayloadSecretDataWo(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}, error) {
 	path := cty.GetAttrPath("secret_data_wo")
 	woVal, _ := d.GetRawConfigAt(path)
+	if d.Get("is_secret_data_base64").(bool) {
+		return woVal.AsString(), nil
+	}
 	return base64.StdEncoding.EncodeToString([]byte(woVal.AsString())), nil
 }

--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -11,11 +11,11 @@
 	limitations under the License.
 */ -}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	if rawConfig, _ := d.GetRawConfigAt(cty.GetAttrPath("secret_data_wo")); !rawConfig.IsNull() {
-		return nil
-	}
-
 	transformed := make(map[string]interface{})
+	if d.Get("secret_data").(string) == "" {
+		transformed["new_secret_data_wo"] = false
+		return []interface{}{transformed}
+	}
 
 	// if this secret version is disabled, the api will return an error, as the value cannot be accessed, return what we have
 	if d.Get("enabled").(bool) == false {

--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -13,7 +13,6 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	transformed := make(map[string]interface{})
 	if d.Get("secret_data").(string) == "" {
-		transformed["secret_data_wo_version"] = d.Get("secret_data_wo_version")
 		return []interface{}{transformed}
 	}
 

--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -13,7 +13,7 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	transformed := make(map[string]interface{})
 	if d.Get("secret_data").(string) == "" {
-		transformed["new_secret_data_wo"] = false
+		transformed["secret_data_wo_version"] = d.Get("secret_data_wo_version")
 		return []interface{}{transformed}
 	}
 

--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -11,6 +11,10 @@
 	limitations under the License.
 */ -}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if rawConfig, _ := d.GetRawConfigAt(cty.GetAttrPath("secret_data_wo")); !rawConfig.IsNull() {
+		return nil
+	}
+
 	transformed := make(map[string]interface{})
 
 	// if this secret version is disabled, the api will return an error, as the value cannot be accessed, return what we have

--- a/mmv1/templates/terraform/examples/secret_version_basic_write_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secret_version_basic_write_only.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_secret_manager_secret" "secret-basic-write-only" {
+  secret_id = "{{index $.Vars "secret_id"}}"
+  
+  labels = {
+    label = "my-label"
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+
+resource "google_secret_manager_secret_version" "{{$.PrimaryResourceId}}" {
+  secret = google_secret_manager_secret.secret-basic-write-only.id
+
+  secret_data_wo = "{{index $.Vars "data"}}"
+}

--- a/mmv1/templates/terraform/examples/secret_version_basic_write_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secret_version_basic_write_only.tf.tmpl
@@ -13,6 +13,6 @@ resource "google_secret_manager_secret" "secret-basic-write-only" {
 
 resource "google_secret_manager_secret_version" "{{$.PrimaryResourceId}}" {
   secret = google_secret_manager_secret.secret-basic-write-only.id
-
+  secret_data_wo_version = 1
   secret_data_wo = "{{index $.Vars "data"}}"
 }

--- a/mmv1/templates/terraform/examples/secret_version_with_base64_string_secret_data_write_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secret_version_with_base64_string_secret_data_write_only.tf.tmpl
@@ -14,5 +14,6 @@ resource "google_secret_manager_secret_version" "{{$.PrimaryResourceId}}" {
   secret = google_secret_manager_secret.secret-basic.id
 
   is_secret_data_base64 = true
+  secret_data_wo_version = 1
   secret_data_wo = filebase64("{{index $.Vars "data"}}")
 }

--- a/mmv1/templates/terraform/examples/secret_version_with_base64_string_secret_data_write_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secret_version_with_base64_string_secret_data_write_only.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "{{index $.Vars "secret_id"}}"
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "{{$.PrimaryResourceId}}" {
+  secret = google_secret_manager_secret.secret-basic.id
+
+  is_secret_data_base64 = true
+  secret_data_wo = filebase64("{{index $.Vars "data"}}")
+}

--- a/mmv1/templates/terraform/validation/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/validation/secret_version.go.tmpl
@@ -1,0 +1,1 @@
+validation.PreferWriteOnlyAttribute(cty.GetAttrPath("secret_data"),cty.GetAttrPath("secret_data_wo"))

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_version_test.go.tmpl
@@ -26,6 +26,7 @@ func TestAccSecretManagerSecretVersion_update(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret_version.secret-version-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"secret_data", "secret_data_wo_version"},
 			},
 			{
 				Config: testAccSecretManagerSecretVersion_disable(context),
@@ -36,7 +37,7 @@ func TestAccSecretManagerSecretVersion_update(t *testing.T) {
 				ImportStateVerify:       true,
 				// at this point the secret data is disabled and so reading the data on import will
 				// give an empty string
-				ImportStateVerifyIgnore: []string{"secret_data"},
+				ImportStateVerifyIgnore: []string{"secret_data", "secret_data_wo_version"},
 			},
 			{
 				Config: testAccSecretManagerSecretVersion_basic(context),
@@ -45,6 +46,7 @@ func TestAccSecretManagerSecretVersion_update(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret_version.secret-version-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"secret_data", "secret_data_wo_version"},
 			},
 		},
 	})


### PR DESCRIPTION
Here's a demo of the payload showcasing the new write-only attribute with logs:
```hcl
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: ---[ REQUEST ]---------------------------------------
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: POST /v1/projects/hc-terraform-testing/secrets/secret-version:addVersion?alt=json HTTP/1.1
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: Host: secretmanager.googleapis.com
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: User-Agent: Terraform/1.11.0-beta1 (+https://www.terraform.io) Terraform-Plugin-SDK/2.36.0 terraform-provider-google/dev6
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: Content-Length: 40
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: Content-Type: application/json
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: Accept-Encoding: gzip
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: {
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64:  "payload": {
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64:   "data": "c2VjcmV0LWRhdGE="
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64:  }
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: }
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64
2025-02-05T16:38:16.137-0800 [DEBUG] provider.terraform-provider-google_9.9.9_darwin_arm64: -----------------------------------------------------
```
TFCONFIG used:
```hcl
   1   │ resource "google_secret_manager_secret" "secret-basic" {
   2   │   secret_id = "secret-version"
   3   │
   4   │   labels = {
   5   │     label = "my-label"
   6   │   }
   7   │
   8   │   replication {
   9   │     auto {}
  10   │   }
  11   │ }
  12   │
  13   │
  14   │ resource "google_secret_manager_secret_version" "secret-version-basic" {
  15   │   secret = google_secret_manager_secret.secret-basic.id
  16   │
  17   │   secret_data_wo = "secret-data"
  18   │ }
```


`TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample`:
```hcl
󰀵 mau  …/terraform-provider-google   ephemeral-writeonly-env $   v1.23.4   12:38   devbuild

󰀵 mau  …/terraform-provider-google   ephemeral-writeonly-env $!   v1.23.4   12:51   envchain GCLOUD make testacc TEST=./google/services/secretmanager TESTARGS='-run=TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/secretmanager -v -run=TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample
=== PAUSE TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample
=== CONT  TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample
--- PASS: TestAccSecretManagerSecretVersion_secretVersionBasicWriteOnlyExample (15.24s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/secretmanager    16.721s
```
`TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample`:
```hcl
󰀵 mau  …/terraform-provider-google   ephemeral-writeonly-env $   v1.23.4   15:58   devbuild

󰀵 mau  …/terraform-provider-google   ephemeral-writeonly-env $!   v1.23.4   16:20   envchain GCLOUD make testacc TEST=./google/services/secretmanager TESTARGS='-run=TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/secretmanager -v -run=TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample
=== PAUSE TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample
=== CONT  TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample
--- PASS: TestAccSecretManagerSecretVersion_secretVersionWithBase64StringSecretDataWriteOnlyExample (16.43s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/secretmanager    17.932s
```
```release-note:none
`secretmanager`: added `secret_version_wo` write-only field to `google_secret_version` resource
```
