### PR TITLE
Updated docs on running single tests

### DIFF
--- a/docs/content/code-review/create-pr.md
+++ b/docs/content/code-review/create-pr.md
@@ -52,7 +52,7 @@ VCR test failures that do not immediately seem related to your PR are most likel
    git checkout modular-magician/auto-pr-PR_NUMBER
    make test
    make lint
-   make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+   make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$'
    ```
    Replace PR_NUMBER with your PR's ID.
    {{< /tab >}}
@@ -65,7 +65,7 @@ VCR test failures that do not immediately seem related to your PR are most likel
    git checkout modular-magician/auto-pr-PR_NUMBER
    make test
    make lint
-   make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+   make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$'
    ```
    Replace PR_NUMBER with your PR's ID.
    {{< /tab >}}

--- a/docs/content/test/run-tests.md
+++ b/docs/content/test/run-tests.md
@@ -63,7 +63,13 @@ aliases:
     make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$'
     ```
 
-> **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
+    To run all tests matching, e.g., `TestAccContainerNodePool*`, omit the trailing `$$`:
+
+    ```bash
+    make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+    ```
+
+    > **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
 
 1. Optional: Save verbose test output (including API requests and responses) to a file for analysis.
 
@@ -95,7 +101,14 @@ aliases:
     ```bash
     make testacc TEST=./google-beta/services/container TESTARGS='-run=TestAccContainerNodePool'
     ```
-> **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
+
+    To run all tests matching, e.g., `TestAccContainerNodePool*`, omit the trailing `$$`:
+
+    ```bash
+    make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+    ```
+
+    > **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
 
 1. Optional: Save verbose test output to a file for analysis.
 
@@ -289,6 +302,26 @@ Configure Terraform to use locally-built binaries for `google` and `google-beta`
     ```bash
     TF_LOG=DEBUG TF_LOG_PATH=output.log TF_CLI_CONFIG_FILE="$HOME/tf-dev-override.tfrc" terraform apply
     ```
+
+### Run Tests with VCR Locally
+
+Running tests in "replaying" mode locally can sometimes be useful. In particular, it can allow you to test more quickly, cheaply, and without spinning up real infrastructure, once you've got an initial recording.
+
+It can also be helpful for debugging tests that seem to work locally, but fail in CI in replaying mode.
+   
+Make sure `$VCR_PATH` is set, and points to a local directory which exists, and set `VCR_MODE` appropriately.
+
+If you don't already have an existing cassette that's up to date, first do a run in "recording" mode:
+   
+```bash
+VCR_PATH=$HOME/.vcr/ VCR_MODE=RECORDING  make testacc TEST=./google/services/alloydb TESTARGS='-run=TestAccContainerNodePool_basic$$'
+```
+
+Now run the same test again in "replaying" mode:
+
+```bash
+VCR_PATH=$HOME/.vcr/ VCR_MODE=REPLAYING make testacc TEST=./google/services/alloydb TESTARGS='-run=TestAccContainerNodePool_basic$$'
+```
 
 ### Cleanup
 

--- a/docs/content/test/run-tests.md
+++ b/docs/content/test/run-tests.md
@@ -307,7 +307,7 @@ Configure Terraform to use locally-built binaries for `google` and `google-beta`
 
 VCR tests record HTTP request/response interactions in cassettes and replay them in future runs without calling the real API.
 
-Running tests in "REPLAYING" mode locally can sometimes be useful. In particular, it can allow you to test more quickly, cheaply, and without spinning up real infrastructure, once you've got an initial recording.
+Running tests in `REPLAYING` mode locally can sometimes be useful. In particular, it can allow you to test more quickly, cheaply, and without spinning up real infrastructure, once you've got an initial recording.
 
 It can also be helpful for debugging tests that seem to work locally, but fail in CI in replaying mode.
    

--- a/docs/content/test/run-tests.md
+++ b/docs/content/test/run-tests.md
@@ -105,7 +105,7 @@ aliases:
     To run all tests matching, e.g., `TestAccContainerNodePool*`, omit the trailing `$$`:
 
     ```bash
-    make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+    make testacc TEST=./google-beta/services/container TESTARGS='-run=TestAccContainerNodePool'
     ```
 
     > **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
@@ -305,19 +305,25 @@ Configure Terraform to use locally-built binaries for `google` and `google-beta`
 
 ### Run Tests with VCR Locally
 
-Running tests in "replaying" mode locally can sometimes be useful. In particular, it can allow you to test more quickly, cheaply, and without spinning up real infrastructure, once you've got an initial recording.
+VCR tests record HTTP request/response interactions in cassettes and replay them in future runs without calling the real API.
+
+Running tests in "REPLAYING" mode locally can sometimes be useful. In particular, it can allow you to test more quickly, cheaply, and without spinning up real infrastructure, once you've got an initial recording.
 
 It can also be helpful for debugging tests that seem to work locally, but fail in CI in replaying mode.
    
-Make sure `$VCR_PATH` is set, and points to a local directory which exists, and set `VCR_MODE` appropriately.
+VCR is controlled via two variables:
+- `VCR_MODE`: `REPLAYING` or `RECORDING` mode 
+- `VCR_PATH`: Path where recorded cassettes are stored. 
 
-If you don't already have an existing cassette that's up to date, first do a run in "recording" mode:
+Ensure both variables are configured to properly trigger VCR tests locally.
+
+If you don't already have an existing cassette that's up to date, first do a run in `RECORDING` mode:
    
 ```bash
 VCR_PATH=$HOME/.vcr/ VCR_MODE=RECORDING  make testacc TEST=./google/services/alloydb TESTARGS='-run=TestAccContainerNodePool_basic$$'
 ```
 
-Now run the same test again in "replaying" mode:
+Now run the same test again in `REPLAYING` mode:
 
 ```bash
 VCR_PATH=$HOME/.vcr/ VCR_MODE=REPLAYING make testacc TEST=./google/services/alloydb TESTARGS='-run=TestAccContainerNodePool_basic$$'

--- a/docs/content/test/run-tests.md
+++ b/docs/content/test/run-tests.md
@@ -60,7 +60,7 @@ aliases:
 1. Run acceptance tests for only modified resources. (Full test runs can take over 9 hours.) See [Go's documentation](https://pkg.go.dev/cmd/go#hdr-Testing_flags) for more information about `-run` and other flags.
 
     ```bash
-    make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool'
+    make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$'
     ```
 
 > **Note:** Acceptance tests create actual infrastructure which can incur costs. Acceptance tests may not clean up after themselves if interrupted, so you may want to check for stray resources and / or billing charges.
@@ -68,7 +68,7 @@ aliases:
 1. Optional: Save verbose test output (including API requests and responses) to a file for analysis.
 
     ```bash
-    TF_LOG=DEBUG make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic' > output.log
+    TF_LOG=DEBUG make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$' > output.log
     ```
 
 1. Optional: Debug tests with [Delve](https://github.com/go-delve/delve). See [`dlv test` documentation](https://github.com/go-delve/delve/blob/master/Documentation/usage/dlv_test.md) for information about available flags.
@@ -100,7 +100,7 @@ aliases:
 1. Optional: Save verbose test output to a file for analysis.
 
     ```bash
-    TF_LOG=DEBUG make testacc TEST=./google-beta/services/container TESTARGS='-run=TestAccContainerNodePool_basic' > output.log
+    TF_LOG=DEBUG make testacc TEST=./google-beta/services/container TESTARGS='-run=TestAccContainerNodePool_basic$$' > output.log
     ```
 
 1. Optional: Debug tests with [Delve](https://github.com/go-delve/delve). See [`dlv test` documentation](https://github.com/go-delve/delve/blob/master/Documentation/usage/dlv_test.md) for information about available flags.


### PR DESCRIPTION
The examples refer to running a single test, but the `-run` command in the example could potentially run lots of tests unexpectedly.

Use a `-run=` example with the correct syntax for passing a literal dollar sign to the regex -- while the docs link to the golang docs, because of shell quoting and because of it getting passed via make, it seems to be necessary to use double dollar signs.

I don't 100% know this is the right solution, but I haven't gotten a direct answer or an example of a better way to do it.

Open to suggestions both as to a better fix

I debated anchoring on the front side as well (`-run=^TestFoo_bar$$`), but seems less necessary. But it is very easy to accidentally kick off a whole bunch of expensive and slow tests if you match too broadly, including if you use a bad regex, forget the dash before `run`, or do any number of other things.

Fixes hashicorp/terraform-provider-google#19934

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
