### PR TITLE
Adding pdpScope field to PAP resource

### DIFF
--- a/mmv1/products/compute/PublicAdvertisedPrefix.yaml
+++ b/mmv1/products/compute/PublicAdvertisedPrefix.yaml
@@ -45,6 +45,15 @@ examples:
     # PAPs have very low quota limits and a shared testing range so serialized tests exist in:
     # resource_compute_public_advertised_prefix_test.go
     exclude_test: true
+  - name: 'public_advertised_prefixes_pdp_scope'
+    primary_resource_id: 'prefixes'
+    vars:
+      prefixes_name: 'my-pap'
+    test_env_vars:
+      desc: 'PAP_DESCRIPTION'
+    # PAPs have very low quota limits and a shared testing range so serialized tests exist in:
+    # resource_compute_public_advertised_prefix_test.go
+    exclude_test: true
 parameters:
 properties:
   - name: 'description'
@@ -70,6 +79,14 @@ properties:
       The IPv4 address range, in CIDR format, represented by this public
       advertised prefix.
     required: true
+  - name: 'pdpScope'
+    type: Enum
+    description: |
+      Specifies how child public delegated prefix will be scoped. pdpScope
+      must be one of: GLOBAL, REGIONAL
+    enum_values:
+      - 'GLOBAL'
+      - 'REGIONAL'
   - name: 'sharedSecret'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/public_advertised_prefixes_pdp_scope.tf.tmpl
+++ b/mmv1/templates/terraform/examples/public_advertised_prefixes_pdp_scope.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_compute_public_advertised_prefix" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "prefixes_name"}}"
+  description = "{{index $.TestEnvVars "desc"}}"
+  dns_verification_ip = "127.127.0.0"
+  ip_cidr_range = "127.127.0.0/16"
+  pdp_scope = "REGIONAL"
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
@@ -18,6 +18,7 @@ func TestAccComputePublicPrefixes(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"delegated_prefix":  testAccComputePublicDelegatedPrefix_publicDelegatedPrefixesBasicTest,
 		"advertised_prefix": testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesBasicTest,
+		"advertised_prefix_pdp_scope": testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeTest,
 	}
 
 	for name, tc := range testCases {
@@ -30,6 +31,42 @@ func TestAccComputePublicPrefixes(t *testing.T) {
 			tc(t)
 		})
 	}
+}
+
+func testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeTest(t *testing.T) {
+
+	context := map[string]interface{}{
+		"description":   envvar.GetTestPublicAdvertisedPrefixDescriptionFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputePublicAdvertisedPrefixDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeExample(context),
+			},
+			{
+				ResourceName:      "google_compute_public_advertised_prefix.prefix",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeExample(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_public_advertised_prefix" "prefix" {
+  name = "tf-test-my-prefix%{random_suffix}"
+  description = "%{description}"
+  dns_verification_ip = "127.127.0.0"
+  ip_cidr_range = "127.127.0.0/16"
+  pdp_scope = "REGIONAL"
+}
+`, context)
 }
 
 func testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesBasicTest(t *testing.T) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
@@ -16,8 +16,8 @@ import (
 // Since we only have access to one test prefix range we cannot run tests in parallel
 func TestAccComputePublicPrefixes(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"delegated_prefix":  testAccComputePublicDelegatedPrefix_publicDelegatedPrefixesBasicTest,
-		"advertised_prefix": testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesBasicTest,
+		"delegated_prefix":            testAccComputePublicDelegatedPrefix_publicDelegatedPrefixesBasicTest,
+		"advertised_prefix":           testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesBasicTest,
 		"advertised_prefix_pdp_scope": testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeTest,
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_public_advertised_prefix_test.go
@@ -34,7 +34,6 @@ func TestAccComputePublicPrefixes(t *testing.T) {
 }
 
 func testAccComputePublicAdvertisedPrefix_publicAdvertisedPrefixesPdpScopeTest(t *testing.T) {
-
 	context := map[string]interface{}{
 		"description":   envvar.GetTestPublicAdvertisedPrefixDescriptionFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),


### PR DESCRIPTION
Fixes [b/390839623](https://b.corp.google.com/issues/390839623)
Adds `pdpScope` to PAP resource for providing Terraform support for BYOIP V2 API.

**Release Note Template for Downstream PRs**

```release-note:enhancement
compute: added `pdp_scope` field to `google_compute_public_advertised_prefix` resource
```
