### PR TITLE
container: fixed `TestAccContainerNodePool_defaultDriverInstallation`

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -5073,7 +5073,6 @@ resource "google_container_node_pool" "np" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
-  version            = "1.30.1-gke.1329003"
 
   node_config {
     service_account = "default"

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -5027,7 +5027,6 @@ resource "google_container_node_pool" "np" {
 }
 
 func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))


### PR DESCRIPTION
Remove explicit version on the nodepool; this is unnecessary, and the cluster itself is already using a version based on `google_container_engine_versions`

Fixes hashicorp/terraform-provider-google#20960

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
