### PR TITLE
cloudfunctions: bootstraped IAM roles for service agent

### DIFF
--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function_test.go.tmpl
@@ -25,6 +25,15 @@ const testFirestoreTriggerPath = "./test-fixtures/firestore_trigger.js"
 const testSecretEnvVarFunctionPath = "./test-fixtures/secret_environment_variables.js"
 const testSecretVolumesMountFunctionPath = "./test-fixtures/secret_volumes_mount.js"
 
+func bootstrapGcfAdminAgents(t *testing.T) {
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcf-admin-robot.iam.gserviceaccount.com",
+			Role:   "roles/vpcaccess.admin",
+		},
+	})
+}
+
 func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 	t.Parallel()
 
@@ -419,16 +428,16 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 	networkName := fmt.Sprintf("tf-test-net-%d", acctest.RandInt(t))
 	vpcConnectorName := fmt.Sprintf("tf-test-conn-%s", acctest.RandString(t, 5))
 	zipFilePath := acctest.CreateZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
-	projectNumber := os.Getenv("GOOGLE_PROJECT_NUMBER")
 	defer os.Remove(zipFilePath) // clean up
 
+	bootstrapGcfAdminAgents(t)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckCloudFunctionsFunctionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.10.0.0/28", vpcConnectorName),
+				Config: testAccCloudFunctionsFunction_vpcConnector(networkName, functionName, bucketName, zipFilePath, "10.10.0.0/28", vpcConnectorName),
 			},
 			{
 				ResourceName:            funcResourceName,
@@ -437,7 +446,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
-				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update"),
+				Config: testAccCloudFunctionsFunction_vpcConnector(networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update"),
 			},
 			{
 				ResourceName:            funcResourceName,
@@ -458,16 +467,16 @@ func TestAccCloudFunctionsFunction_vpcConnectorEgressSettings(t *testing.T) {
 	networkName := fmt.Sprintf("tf-test-net-%d", acctest.RandInt(t))
 	vpcConnectorName := fmt.Sprintf("tf-test-conn-%s", acctest.RandString(t, 5))
 	zipFilePath := acctest.CreateZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
-	projectNumber := os.Getenv("GOOGLE_PROJECT_NUMBER")
 	defer os.Remove(zipFilePath) // clean up
 
+	bootstrapGcfAdminAgents(t)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckCloudFunctionsFunctionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFunctionsFunction_vpcConnectorEgressSettings(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.10.0.0/28", vpcConnectorName, "PRIVATE_RANGES_ONLY"),
+				Config: testAccCloudFunctionsFunction_vpcConnectorEgressSettings(networkName, functionName, bucketName, zipFilePath, "10.10.0.0/28", vpcConnectorName, "PRIVATE_RANGES_ONLY"),
 			},
 			{
 				ResourceName:            funcResourceName,
@@ -476,7 +485,7 @@ func TestAccCloudFunctionsFunction_vpcConnectorEgressSettings(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"build_environment_variables", "labels", "terraform_labels"},
 			},
 			{
-				Config: testAccCloudFunctionsFunction_vpcConnectorEgressSettings(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update",  "ALL_TRAFFIC"),
+				Config: testAccCloudFunctionsFunction_vpcConnectorEgressSettings(networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update",  "ALL_TRAFFIC"),
 			},
 			{
 				ResourceName:            funcResourceName,
@@ -1053,15 +1062,9 @@ resource "google_cloudfunctions_function" "function" {
 `, bucketName, zipFilePath, functionName)
 }
 
-func testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcIp, vpcConnectorName string) string {
+func testAccCloudFunctionsFunction_vpcConnector(networkName, functionName, bucketName, zipFilePath, vpcIp, vpcConnectorName string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
-
-resource "google_project_iam_member" "gcfadmin" {
-  project = data.google_project.project.project_id
-  role     = "roles/editor"
-  member   = "serviceAccount:service-%s@gcf-admin-robot.iam.gserviceaccount.com"
-}
 
 resource "google_compute_network" "vpc" {
 	name = "%s"
@@ -1110,22 +1113,14 @@ resource "google_cloudfunctions_function" "function" {
   min_instances = 3
   vpc_connector = google_vpc_access_connector.%s.self_link
   vpc_connector_egress_settings = "PRIVATE_RANGES_ONLY"
-
-  depends_on = [google_project_iam_member.gcfadmin]
 }
-`, projectNumber, networkName, vpcConnectorName, vpcConnectorName, vpcIp, bucketName, zipFilePath, functionName, vpcConnectorName)
+`, networkName, vpcConnectorName, vpcConnectorName, vpcIp, bucketName, zipFilePath, functionName, vpcConnectorName)
 }
 
 
-func testAccCloudFunctionsFunction_vpcConnectorEgressSettings(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcIp, vpcConnectorName, vpcConnectorEgressSettings string) string {
+func testAccCloudFunctionsFunction_vpcConnectorEgressSettings(networkName, functionName, bucketName, zipFilePath, vpcIp, vpcConnectorName, vpcConnectorEgressSettings string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {}
-
-resource "google_project_iam_member" "gcfadmin" {
-  project = data.google_project.project.project_id
-  role     = "roles/editor"
-  member   = "serviceAccount:service-%s@gcf-admin-robot.iam.gserviceaccount.com"
-}
 
 resource "google_compute_network" "vpc" {
 	name = "%s"
@@ -1174,10 +1169,8 @@ resource "google_cloudfunctions_function" "function" {
   min_instances = 3
   vpc_connector = google_vpc_access_connector.%s.self_link
   vpc_connector_egress_settings = "%s"
-
-  depends_on = [google_project_iam_member.gcfadmin]
 }
-`, projectNumber, networkName, vpcConnectorName, vpcConnectorName, vpcIp, bucketName, zipFilePath, functionName, vpcConnectorName, vpcConnectorEgressSettings)
+`, networkName, vpcConnectorName, vpcConnectorName, vpcIp, bucketName, zipFilePath, functionName, vpcConnectorName, vpcConnectorEgressSettings)
 }
 
 {{ if ne $.TargetVersionName `ga` -}}


### PR DESCRIPTION
Bootstrap IAM role for `service-[project_number]@gcf-admin-robot.iam.gserviceaccount.com` to avoid having bindings get deleted when tests run in parallel.

Also adjust role(s) assigned to service agent.

Fixes hashicorp/terraform-provider-google#20570

Uses new bootstrapping utility from #12796

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
