### PR TITLE
fix: Router advertised-route-priority undefined behavior 

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
@@ -3,7 +3,7 @@ package compute_test
 import (
 	"fmt"
 	"testing"
-  "regexp"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -25,9 +25,10 @@ func TestAccComputeRouterPeer_basic(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerKeepRouter(routerName),
@@ -86,9 +87,10 @@ func TestAccComputeRouterPeer_enable(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerEnable(routerName, false),
@@ -96,9 +98,10 @@ func TestAccComputeRouterPeer_enable(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerEnable(routerName, true),
@@ -106,9 +109,10 @@ func TestAccComputeRouterPeer_enable(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})
@@ -129,9 +133,10 @@ func TestAccComputeRouterPeer_bfd(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerBfd(routerName, "DISABLED"),
@@ -139,9 +144,10 @@ func TestAccComputeRouterPeer_bfd(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerBasic(routerName),
@@ -149,9 +155,10 @@ func TestAccComputeRouterPeer_bfd(t *testing.T) {
 					t, "google_compute_router_peer.foobar"),
 			},
 			{
-				ResourceName:      "google_compute_router_peer.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_router_peer.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})
@@ -199,9 +206,10 @@ func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})
@@ -226,9 +234,10 @@ func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerUpdateIpv4Address(routerName),
@@ -241,9 +250,10 @@ func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})
@@ -295,9 +305,10 @@ func TestAccComputeRouterPeer_UpdateIpv6Address(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerUpdateIpv6Address(routerName, true),
@@ -308,9 +319,10 @@ func TestAccComputeRouterPeer_UpdateIpv6Address(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})
@@ -335,9 +347,10 @@ func TestAccComputeRouterPeer_EnableDisableIpv6(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerIpv6(routerName, true),
@@ -348,9 +361,10 @@ func TestAccComputeRouterPeer_EnableDisableIpv6(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 			{
 				Config: testAccComputeRouterPeerIpv6(routerName, false),
@@ -361,9 +375,10 @@ func TestAccComputeRouterPeer_EnableDisableIpv6(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"is_advertised_route_priority_set"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_bgp_peer_test.go.tmpl
@@ -3,6 +3,7 @@ package compute_test
 import (
 	"fmt"
 	"testing"
+  "regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -207,9 +208,9 @@ func TestAccComputeRouterPeer_Ipv6Basic(t *testing.T) {
 }
 
 func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_router_peer.foobar"
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -235,14 +236,41 @@ func TestAccComputeRouterPeer_Ipv4BasicCreateUpdate(t *testing.T) {
 					testAccCheckComputeRouterPeerExists(
 						t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "enable_ipv4", "true"),
-          resource.TestCheckResourceAttr(resourceName, "ipv4_nexthop_address", "169.254.1.2"),
-          resource.TestCheckResourceAttr(resourceName, "peer_ipv4_nexthop_address", "169.254.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv4_nexthop_address", "169.254.1.2"),
+					resource.TestCheckResourceAttr(resourceName, "peer_ipv4_nexthop_address", "169.254.1.1"),
 				),
 			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouterPeer_UpdateRouterAdvertisedRoutePriority(t *testing.T) {
+	t.Parallel()
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	resourceName := "google_compute_router_peer.peer"
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerAdvertisedRoutePriority(routerName, 100, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "advertised_route_priority", "100"), // Check for one element in the list
+				),
+			}, {
+				Config:      testAccComputeRouterPeerAdvertisedRoutePriority(routerName, 0, false),
+				ExpectError: regexp.MustCompile(`Error: Invalid advertised_route_priority value: When zero_advertised_route_priority is set to 'false', the advertised_route_priority field cannot be 0. Please provide a non-zero value.`), // Expect the specific error message
+			}, {
+				Config: testAccComputeRouterPeerAdvertisedRoutePriority(routerName, 0, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "advertised_route_priority", "0"),
+				),
 			},
 		},
 	})
@@ -999,6 +1027,42 @@ func testAccComputeRouterPeerWithMd5AuthKeyUpdate(routerName string) string {
   }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName,
 		routerName, routerName)
+}
+
+func testAccComputeRouterPeerAdvertisedRoutePriority(routerName string, advertisedRoutePriority int, zeroAdvertisedRoutePriority bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "network" {
+  name                    = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "%s-sub"
+  network       = google_compute_network.network.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_router" "router" {
+  name    = "%s-router"
+  region  = google_compute_subnetwork.subnetwork.region
+  network = google_compute_network.network.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_peer" "peer" {
+  name                      = "%s-router-peer"
+  router                    = google_compute_router.router.name
+  region                    = google_compute_router.router.region
+  interface                 = "interface-1"
+  peer_asn                  = 65513
+  advertised_route_priority = %d
+  zero_advertised_route_priority = %t
+}
+  `, routerName, routerName, routerName, routerName, advertisedRoutePriority, zeroAdvertisedRoutePriority)
+
 }
 
 func testAccComputeRouterPeerKeepRouter(routerName string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -142,6 +142,16 @@ CIDR-formatted string.`,
 Where there is more than one matching route of maximum
 length, the routes with the lowest priority value win.`,
 			},
+			"zero_advertised_route_priority": {
+				Type:        schema.TypeBool,
+				Optional: true,
+				Description: `Force the advertised_route_priority to be 0.`,
+			},
+			"is_advertised_route_priority_set": {
+				Type:        schema.TypeBool,
+				Computed:    true, // This field is computed by the provider
+				Description: "An internal boolean field for provider use for zero_advertised_route_priority.",
+			},
 			"custom_learned_ip_ranges": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -419,9 +429,21 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	advertisedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerAdvertisedRoutePriority(d.Get("advertised_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOk("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
-		obj["advertisedRoutePriority"] = advertisedRoutePriorityProp
-	}
+	} else if v, ok := d.GetOkExists("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
+		if !d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp == 0 {
+			// Add the condition to check the present value
+			if !d.Get("is_advertised_route_priority_set").(bool) {
+				log.Printf("[WARN] advertised_route_priority can't be 0 unless zero_advertised_route_priority set to true")
+			} else {
+				return fmt.Errorf("Invalid advertised_route_priority value: When zero_advertised_route_priority is set to 'false', the advertised_route_priority field cannot be 0. Please provide a non-zero value.")
+			}
+		} else if d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp != 0 {
+			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_custom_learned_route_priority is false")
+		} else {
+			obj["advertisedRoutePriority"] =advertisedRoutePriorityProp
+			d.Set("is_advertised_route_priority_set", true)
+		}
+			}
 	advertiseModeProp, err := expandNestedComputeRouterBgpPeerAdvertiseMode(d.Get("advertise_mode"), d, config)
 	if err != nil {
 		return err
@@ -772,8 +794,20 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 	advertisedRoutePriorityProp, err := expandNestedComputeRouterBgpPeerAdvertisedRoutePriority(d.Get("advertised_route_priority"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOk("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
-		obj["advertisedRoutePriority"] = advertisedRoutePriorityProp
+	} else if v, ok := d.GetOkExists("advertised_route_priority"); ok || !reflect.DeepEqual(v, advertisedRoutePriorityProp) {
+		if !d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp == 0 {
+			// Add the condition to check the present value
+			if !d.Get("is_advertised_route_priority_set").(bool) {
+				log.Printf("[WARN] advertised_route_priority can't be 0 unless zero_advertised_route_priority set to true")
+			} else {
+				return fmt.Errorf("Invalid advertised_route_priority value: When zero_advertised_route_priority is set to 'false', the advertised_route_priority field cannot be 0. Please provide a non-zero value.")
+			}
+		} else if d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp != 0 {
+			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_custom_learned_route_priority is false")
+		} else {
+			obj["advertisedRoutePriority"] =advertisedRoutePriorityProp
+			d.Set("is_advertised_route_priority_set", true)
+		}
 	}
 	advertiseModeProp, err := expandNestedComputeRouterBgpPeerAdvertiseMode(d.Get("advertise_mode"), d, config)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -448,7 +448,7 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 				return fmt.Errorf("Invalid advertised_route_priority value: When zero_advertised_route_priority is set to 'false', the advertised_route_priority field cannot be 0. Please provide a non-zero value.")
 			}
 		} else if d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp != 0 {
-			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_custom_learned_route_priority is false")
+			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_advertised_route_priority is false")
 		} else {
 			obj["advertisedRoutePriority"] =advertisedRoutePriorityProp
 			d.Set("is_advertised_route_priority_set", true)
@@ -825,7 +825,7 @@ func resourceComputeRouterBgpPeerUpdate(d *schema.ResourceData, meta interface{}
 				return fmt.Errorf("Invalid advertised_route_priority value: When zero_advertised_route_priority is set to 'false', the advertised_route_priority field cannot be 0. Please provide a non-zero value.")
 			}
 		} else if d.Get("zero_advertised_route_priority").(bool) && advertisedRoutePriorityProp != 0 {
-			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_custom_learned_route_priority is false")
+			return fmt.Errorf("[ERROR] advertised_route_priority cannot be set to value other than zero unless zero_advertised_route_priority is false")
 		} else {
 			obj["advertisedRoutePriority"] =advertisedRoutePriorityProp
 			d.Set("is_advertised_route_priority_set", true)

--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -68,6 +68,21 @@ resource "google_compute_router_peer" "peer" {
   }
 }
 ```
+
+## Example Usage - Router Zero Advertised Route Priority
+
+
+```hcl
+resource "google_compute_router_peer" "peer" {
+  name                      = "my-router-peer"
+  router                    = "my-router"
+  region                    = "us-central1"
+  interface                 = "interface-1"
+  peer_asn                  = 65513
+  advertised_route_priority = 0
+  zero_advertised_route_priority = true
+}
+```
 <div class = "oics-button" style="float: right; margin: 0 0 -15px">
   <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Fterraform-google-modules%2Fdocs-examples.git&cloudshell_working_dir=router_peer_router_appliance&cloudshell_image=gcr.io%2Fcloudshell-images%2Fcloudshell%3Alatest&open_in_editor=main.tf&cloudshell_print=.%2Fmotd&cloudshell_tutorial=.%2Ftutorial.md" target="_blank">
     <img alt="Open in Cloud Shell" src="//gstatic.com/cloudssh/images/open-btn.svg" style="max-height: 44px; margin: 32px auto; max-width: 100%;">
@@ -383,6 +398,11 @@ The following arguments are supported:
   The priority of routes advertised to this BGP peer.
   Where there is more than one matching route of maximum
   length, the routes with the lowest priority value win.
+
+* `zero_advertised_route_priority` -
+  (Optional)
+  The user-defined zero-advertised-route-priority for a advertised-route-priority in BGP session.
+  This value has to be set true to force the advertised_route_priority to be 0.
 
 * `advertise_mode` -
   (Optional)


### PR DESCRIPTION
b/386726875
Issue: advertised-route-priority is an optional field and by current terraform configs user can't set the value of advertised-route-priority to 0.

**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
compute: made `google_compute_router_peer.advertised_route_priority` use server-side default if unset. To set the value to `0` you must also set `zero_advertised_route_priority = true`.
```

```release-note:enhancement
compute: added `zero_advertised_route_priority` field to 'google_compute_router_peer'
```