### PR TITLE
Add analyticsConfig block to google_apigee_addons_config

### DIFF
--- a/mmv1/products/apigee/AddonsConfig.yaml
+++ b/mmv1/products/apigee/AddonsConfig.yaml
@@ -122,3 +122,28 @@ properties:
               Flag that specifies whether the Advanced API Ops add-on is
               enabled.
             output: true
+      - name: 'analyticsConfig'
+        type: NestedObject
+        description: Configuration for the Analytics add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Analytics add-on is
+              enabled.
+          - name: 'expireTimeMillis'
+            type: String
+            description:
+              Time at which the Analytics add-on expires in milliseconds 
+              since epoch. If unspecified, the add-on will never expire.
+            output: true
+          - name: 'updateTime'
+            type: String
+            description:
+              The latest update time.
+            output: true
+          - name: 'state'
+            type: String
+            description:
+              The actual state of the Analytics add-on.
+            output: true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds `analyticsConfig` block to `google_apigee_addons_config`  resource. Matches the pattern from other blocks in this resource, and includes all available (output-only) fields.

Available fields and descriptions taken from [the REST API documentation](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations#analyticsconfig).

```release-note:enhancement
apigee: added nested `analyticsConfig` block to `google_apigee_addons_config` resource
```