### PR TITLE
Support new Network Security Integration security profile types

### DIFF
--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -53,6 +53,16 @@ examples:
       resource_name: 'my-security-profile'
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'network_security_security_profile_mirroring'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-security-profile'
+      network_name: 'my-network'
+      deployment_group_id: 'my-dg'
+      endpoint_group_id: 'my-eg'
+    test_env_vars:
+      org_id: 'ORG_ID'
 parameters:
   - name: 'name'
     type: String
@@ -166,6 +176,22 @@ properties:
                 - 'UNKNOWN'
                 - 'VULNERABILITY'
                 - 'SPYWARE'
+    conflicts:
+      - 'customMirroringProfile'
+  - name: 'customMirroringProfile'
+    type: NestedObject
+    description: |
+      The configuration for defining the Mirroring Endpoint Group used to
+      mirror traffic to third-party collectors.
+    properties:
+    - name: mirroringEndpointGroup
+      type: String
+      description: |
+        The Mirroring Endpoint Group to which matching traffic should be mirrored.
+        Format: projects/{project_id}/locations/global/mirroringEndpointGroups/{endpoint_group_id}
+      required: true
+    conflicts:
+      - 'threatPreventionProfile'
   - name: 'type'
     type: Enum
     description: The type of security profile.
@@ -173,3 +199,4 @@ properties:
     immutable: true
     enum_values:
       - 'THREAT_PREVENTION'
+      - 'CUSTOM_MIRRORING'

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -63,6 +63,16 @@ examples:
       endpoint_group_id: 'my-eg'
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'network_security_security_profile_intercept'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      resource_name: 'my-security-profile'
+      network_name: 'my-network'
+      deployment_group_id: 'my-dg'
+      endpoint_group_id: 'my-eg'
+    test_env_vars:
+      org_id: 'ORG_ID'
 parameters:
   - name: 'name'
     type: String
@@ -178,6 +188,7 @@ properties:
                 - 'SPYWARE'
     conflicts:
       - 'customMirroringProfile'
+      - 'customInterceptProfile'
   - name: 'customMirroringProfile'
     type: NestedObject
     description: |
@@ -192,6 +203,22 @@ properties:
       required: true
     conflicts:
       - 'threatPreventionProfile'
+      - 'customInterceptProfile'
+  - name: 'customInterceptProfile'
+    type: NestedObject
+    description: |
+      The configuration for defining the Intercept Endpoint Group used to
+      intercept traffic to third-party firewall appliances.
+    properties:
+    - name: interceptEndpointGroup
+      type: String
+      description: |
+        The Intercept Endpoint Group to which matching traffic should be intercepted.
+        Format: projects/{project_id}/locations/global/interceptEndpointGroups/{endpoint_group_id}
+      required: true
+    conflicts:
+      - 'threatPreventionProfile'
+      - 'customMirroringProfile'
   - name: 'type'
     type: Enum
     description: The type of security profile.
@@ -200,3 +227,4 @@ properties:
     enum_values:
       - 'THREAT_PREVENTION'
       - 'CUSTOM_MIRRORING'
+      - 'CUSTOM_INTERCEPT'

--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -195,12 +195,12 @@ properties:
       The configuration for defining the Mirroring Endpoint Group used to
       mirror traffic to third-party collectors.
     properties:
-    - name: mirroringEndpointGroup
-      type: String
-      description: |
-        The Mirroring Endpoint Group to which matching traffic should be mirrored.
-        Format: projects/{project_id}/locations/global/mirroringEndpointGroups/{endpoint_group_id}
-      required: true
+      - name: mirroringEndpointGroup
+        type: String
+        description: |
+          The Mirroring Endpoint Group to which matching traffic should be mirrored.
+          Format: projects/{project_id}/locations/global/mirroringEndpointGroups/{endpoint_group_id}
+        required: true
     conflicts:
       - 'threatPreventionProfile'
       - 'customInterceptProfile'
@@ -210,12 +210,12 @@ properties:
       The configuration for defining the Intercept Endpoint Group used to
       intercept traffic to third-party firewall appliances.
     properties:
-    - name: interceptEndpointGroup
-      type: String
-      description: |
-        The Intercept Endpoint Group to which matching traffic should be intercepted.
-        Format: projects/{project_id}/locations/global/interceptEndpointGroups/{endpoint_group_id}
-      required: true
+      - name: interceptEndpointGroup
+        type: String
+        description: |
+          The Intercept Endpoint Group to which matching traffic should be intercepted.
+          Format: projects/{project_id}/locations/global/interceptEndpointGroups/{endpoint_group_id}
+        required: true
     conflicts:
       - 'threatPreventionProfile'
       - 'customMirroringProfile'

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -100,3 +100,7 @@ properties:
     type: String
     description: |
       Reference to a SecurityProfile with the threat prevention configuration for the SecurityProfileGroup.
+  - name: 'customMirroringProfile'
+    type: String
+    description: |
+      Reference to a SecurityProfile with the custom mirroring configuration for the SecurityProfileGroup.

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -49,6 +49,28 @@ examples:
       security_profile_name: 'sec-profile'
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'network_security_security_profile_group_mirroring'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'network'
+      deployment_group_id: 'deployment-group'
+      endpoint_group_id: 'endpoint-group'
+      security_profile_name: 'sec-profile'
+      security_profile_group_name: 'sec-profile-group'
+    test_env_vars:
+      org_id: 'ORG_ID'
+  - name: 'network_security_security_profile_group_intercept'
+    min_version: 'beta'
+    primary_resource_id: 'default'
+    vars:
+      network_name: 'network'
+      deployment_group_id: 'deployment-group'
+      endpoint_group_id: 'endpoint-group'
+      security_profile_name: 'sec-profile'
+      security_profile_group_name: 'sec-profile-group'
+    test_env_vars:
+      org_id: 'ORG_ID'
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -104,3 +104,7 @@ properties:
     type: String
     description: |
       Reference to a SecurityProfile with the custom mirroring configuration for the SecurityProfileGroup.
+  - name: 'customInterceptProfile'
+    type: String
+    description: |
+      Reference to a SecurityProfile with the CustomIntercept configuration.

--- a/mmv1/templates/terraform/examples/network_security_security_profile_group_intercept.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_group_intercept.tf.tmpl
@@ -1,0 +1,39 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "default" {
+  provider    = google-beta
+  name        = "{{index $.Vars "security_profile_name"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "my description"
+  type        = "CUSTOM_INTERCEPT"
+
+  custom_intercept_profile {
+    intercept_endpoint_group = google_network_security_intercept_endpoint_group.default.id
+  }
+}
+
+resource "google_network_security_security_profile_group" "{{$.PrimaryResourceId}}" {
+  provider                 = google-beta
+  name                     = "{{index $.Vars "security_profile_group_name"}}"
+  parent                   = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description              = "my description"
+  custom_intercept_profile = google_network_security_security_profile.default.id
+}

--- a/mmv1/templates/terraform/examples/network_security_security_profile_group_mirroring.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_group_mirroring.tf.tmpl
@@ -1,0 +1,39 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "default" {
+  provider    = google-beta
+  name        = "{{index $.Vars "security_profile_name"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "my description"
+  type        = "CUSTOM_MIRRORING"
+
+  custom_mirroring_profile {
+    mirroring_endpoint_group = google_network_security_mirroring_endpoint_group.default.id
+  }
+}
+
+resource "google_network_security_security_profile_group" "{{$.PrimaryResourceId}}" {
+  provider                 = google-beta
+  name                     = "{{index $.Vars "security_profile_group_name"}}"
+  parent                   = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description              = "my description"
+  custom_mirroring_profile = google_network_security_security_profile.default.id
+}

--- a/mmv1/templates/terraform/examples/network_security_security_profile_intercept.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_intercept.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_intercept_deployment_group" "default" {
+  provider                      = google-beta
+  intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_intercept_endpoint_group" "default" {
+  provider                      = google-beta
+  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  intercept_deployment_group    = google_network_security_intercept_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  name        = "{{index $.Vars "resource_name"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "my description"
+  type        = "CUSTOM_INTERCEPT"
+
+  custom_intercept_profile {
+    intercept_endpoint_group = google_network_security_intercept_endpoint_group.default.id
+  }
+}

--- a/mmv1/templates/terraform/examples/network_security_security_profile_mirroring.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_mirroring.tf.tmpl
@@ -1,0 +1,31 @@
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  name        = "{{index $.Vars "resource_name"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "my description"
+  type        = "CUSTOM_MIRRORING"
+
+  custom_mirroring_profile {
+    mirroring_endpoint_group = google_network_security_mirroring_endpoint_group.default.id
+  }
+}


### PR DESCRIPTION
As part of the work to launch NSI out-of-band and NSI in-band (b/352252592, b/353960081) the Security Profile and Security Profile Group APIs now support the Custom Mirroring and Custom Intercept profiles, which are used to configure mirroring or interception firewall rules.

In this PR we also add Terraform support for these new fields.

```release-note:enhancement
networksecurity: added `customMirroringProfile` and `customInterceptProfile` fields to `google_network_security_security_profile` and `google_network_security_security_profile_group`  resources
```
