### PR TITLE
Add "References" section to the bottom of the test page

### DIFF
--- a/docs/content/test/test.md
+++ b/docs/content/test/test.md
@@ -330,5 +330,6 @@ These tests can still run in VCR replaying mode; however, REPLAYING mode can't b
 
 ## References
 
+* [Official Terraform documentation on Acceptance Tests](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests)
 * [MMv1 resource reference: `examples` ↗]({{<ref "/reference/resource#examples" >}})
 

--- a/docs/content/test/test.md
+++ b/docs/content/test/test.md
@@ -327,3 +327,8 @@ These tests can still run in VCR replaying mode; however, REPLAYING mode can't b
 ## What's next?
 
 [Run your tests]({{< ref "/test/run-tests" >}})
+
+## References
+
+* [MMv1 resource reference: `examples` ↗]({{<ref "/reference/resource#examples" >}})
+


### PR DESCRIPTION
When referring a contributor to the new IAM boostrapping schema I missed the link to the reference page at https://googlecloudplatform.github.io/magic-modules/test/test/#add-a-create-test when skimming the page, this should add a catch-all for other readers who are similarly prone to skimming.

Feel free to reject if not desirable- it could just be that I need to read better.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
