### PR TITLE
alloydb: marked `google_alloydb_user.password` as sensitive

### DIFF
--- a/mmv1/products/alloydb/User.yaml
+++ b/mmv1/products/alloydb/User.yaml
@@ -119,6 +119,7 @@ properties:
     type: String
     description: |
       Password for this database user.
+    sensitive: true
     ignore_read: true
   - name: 'databaseRoles'
     type: Array


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#20996

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
alloydb: marked `google_alloydb_user.password` as sensitive
```
