### PR TITLE
Add MaxRunDuration

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -813,6 +813,12 @@ func schemaNodeConfig() *schema.Schema {
 					ValidateFunc:     validation.StringInSlice([]string{"STANDARD_ENCRYPTION", "EPHEMERAL_KEY_ENCRYPTION"}, false),
 					Description:      `LocalSsdEncryptionMode specified the method used for encrypting the local SSDs attached to the node.`,
 				},
+				"max_run_duration" : {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: `The runtime of each node in the node pool in seconds, terminated by 's'. Example: "3600s".`,
+				},
 			},
 		},
 	}
@@ -1193,6 +1199,10 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 
 	if v,ok := nodeConfig["local_ssd_encryption_mode"]; ok {
 		nc.LocalSsdEncryptionMode = v.(string)
+	}
+
+	if v,ok := nodeConfig["max_run_duration"]; ok {
+		nc.MaxRunDuration = v.(string)
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}
@@ -1581,6 +1591,7 @@ func flattenNodeConfig(c *container.NodeConfig, v interface{}) []map[string]inte
 		"linux_node_config":        flattenLinuxNodeConfig(c.LinuxNodeConfig),
 		"node_group":               c.NodeGroup,
 		"advanced_machine_features": flattenAdvancedMachineFeaturesConfig(c.AdvancedMachineFeatures),
+		"max_run_duration": 		 c.MaxRunDuration,
 		"sole_tenant_config":        flattenSoleTenantConfig(c.SoleTenantConfig),
 		"fast_socket":               flattenFastSocket(c.FastSocket),
 		"resource_manager_tags":     flattenResourceManagerTags(c.ResourceManagerTags),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -459,6 +459,50 @@ func TestAccContainerCluster_withLocalSsdEncryptionMode(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withMaxRunDuration(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	npName := fmt.Sprintf("tf-test-node-pool-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withMaxRunDuration(clusterName, npName, networkName, subnetworkName, "3600s"),
+			},
+			{
+				ResourceName:            "google_container_cluster.max_run_duration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withMaxRunDuration(clusterName, npName, networkName, subnetworkName, "1800s"),
+			},
+			{
+				ResourceName:            "google_container_cluster.max_run_duration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_disableMaxRunDuration(clusterName, npName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_cluster.max_run_duration",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withILBSubsetting(t *testing.T) {
 	t.Parallel()
 
@@ -6737,6 +6781,55 @@ resource "google_container_cluster" "local_ssd_encryption_mode" {
   subnetwork    = "%s"
 }
 `, clusterName, npName, mode, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_disableMaxRunDuration(clusterName, npName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "max_run_duration" {
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+    channel = "RAPID"
+  }
+
+  node_pool {
+    name = "%s"
+    initial_node_count = 1
+    node_config {
+      machine_type = "n1-standard-2"
+    }
+  }
+
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, clusterName, npName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withMaxRunDuration(clusterName, npName, networkName, subnetworkName, duration string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "max_run_duration" {
+  name               = "%s"
+  location           = "us-central1-a"
+  release_channel {
+    channel = "RAPID"
+  }
+
+  node_pool {
+    name = "%s"
+    initial_node_count = 1
+    node_config {
+      machine_type = "n1-standard-2"
+	  max_run_duration = "%s"
+    }
+  }
+
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+`, clusterName, npName, duration, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withILBSubSetting(clusterName, npName, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4221,6 +4221,101 @@ resource "google_container_node_pool" "np" {
 `, clusterName, mode, networkName, subnetworkName, np, mode)
 }
 
+func TestAccContainerNodePool_withMaxRunDuration(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-cluster-nodepool-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withMaxRunDuration(clusterName, np, networkName, subnetworkName, "3600s"),
+			},
+			{
+				ResourceName:            "google_container_node_pool.np",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerNodePool_withMaxRunDuration(clusterName, np, networkName, subnetworkName, "1800s"),
+			},
+			{
+				ResourceName:            "google_container_node_pool.np",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccContainerNodePool_disableMaxRunDuration(clusterName, np, networkName, subnetworkName),
+			},
+			{
+				ResourceName:            "google_container_node_pool.np",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_withMaxRunDuration(clusterName, np, networkName, subnetworkName, duration string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  node_config {
+	max_run_duration = "%s"
+    machine_type = "n1-standard-1"
+  }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+   	machine_type = "n1-standard-1"
+	max_run_duration = "%s"
+  }
+}
+`, clusterName, duration, networkName, subnetworkName, np, duration)
+}
+
+func testAccContainerNodePool_disableMaxRunDuration(clusterName, np, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  node_config {
+    machine_type = "n1-standard-1"
+  }
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+   	machine_type = "n1-standard-1"
+  }
+}
+`, clusterName, networkName, subnetworkName, np)
+}
+
 func TestAccContainerNodePool_tpuTopology(t *testing.T) {
 	t.Parallel()
 	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/15254#issuecomment-1646277473")

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -918,6 +918,8 @@ gvnic {
 * `resource_labels` - (Optional) The GCP labels (key/value pairs) to be applied to each node. Refer [here](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-managing-labels)
     for how these labels are applied to clusters, node pools and nodes.
 
+* `max_run_duration` - (Optional) The runtime of each node in the node pool in seconds, terminated by 's'. Example: "3600s".
+
 * `local_ssd_count` - (Optional) The amount of local SSD disks that will be
     attached to each cluster node. Defaults to 0.
 


### PR DESCRIPTION
Add support for the MaxRunDuration field.

```
TF_LOG=TRACE make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerNodePool_withMaxRunDuration'
--- PASS: TestAccContainerNodePool_withMaxRunDuration (2534.71s)

TF_LOG=TRACE make testacc TEST=./google/services/container TESTARGS='-run=TestAccContainerCluster_withMaxRunDuration'
--- PASS: TestAccContainerCluster_withMaxRunDuration (1793.19s)
```

**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
container: added `max_run_duration` to `node_config` in `google_container_cluster` and `google_container_node_pool`
```
