### PR TITLE
Use the v2alpha1 Cloud TPU API version in the google-beta Terraform provider

### DIFF
--- a/mmv1/products/tpuv2/product.yaml
+++ b/mmv1/products/tpuv2/product.yaml
@@ -16,6 +16,8 @@ name: 'TpuV2'
 display_name: 'Cloud TPU v2'
 versions:
   - name: 'beta'
-    base_url: 'https://tpu.googleapis.com/v2/'
+    # The v2alpha1 version of the Cloud TPU API is best suited for the google-beta Terraform provider.
+    # This more closely matches current Cloud TPU API usage and is recommended by the Cloud TPU team.
+    base_url: 'https://tpu.googleapis.com/v2alpha1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'


### PR DESCRIPTION
Use the v2alpha1 Cloud TPU API version in the google-beta Terraform provider. Left a comment with brief justification, and extended justification can be found in [go/terraform-for-tpus](https://docs.google.com/document/d/1fCyhnWY-qkj_0iRaYctMW1vgzK0SfBPhs_yYxKmMh6k/edit?pli=1&tab=t.0#heading=h.xzptrog8pyxf).

```release-note:note
tpuv2: used the v2alpha1 Cloud TPU API version in the google-beta provider.
```
