### PR TITLE
upgrade download artifact to v4

### DIFF
--- a/.github/workflows/unit-test-tgc.yml
+++ b/.github/workflows/unit-test-tgc.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: artifact-terraform-google-conversion
           path: artifacts-tgc
 
       - name: Download built artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: artifact-terraform-provider-google-beta
           path: artifacts-tpgb

--- a/.github/workflows/unit-test-tpg.yml
+++ b/.github/workflows/unit-test-tpg.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: artifact-${{ inputs.repo }}
           path: artifacts


### PR DESCRIPTION
oops, also need to upgrade this package as well ^-^

follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/12843

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/12935732155/job/36079900272

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
