### PR TITLE
Removed trailing reference in docs to rake tests

### DIFF
--- a/docs/content/code-review/review-pr.md
+++ b/docs/content/code-review/review-pr.md
@@ -46,7 +46,6 @@ The following types of PRs may require additional scrutiny and/or multiple revie
       * for example - a bugfix should test the bug (or explain why it's not feasible to do so in the description, including manual results when possible) and an enhancement should test the new behaviour(s).
    1. all related PR presubmit tests have been completed successfully, including:
       * terraform-provider-breaking-change-test
-      * presubmit-rake-tests
       * terraform-provider-google-build-and-unit-tests
       * terraform-provider-google-beta-build-and-unit-tests
       * VCR-test


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
