### PR TITLE
Add Network Firewall Policy Policy Packet Mirroring Rule resource

### DIFF
--- a/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
@@ -1,0 +1,204 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'NetworkFirewallPolicyPacketMirroringRule'
+api_resource_type_kind: FirewallPolicy
+kind: 'compute#packetMirroringRule'
+min_version: 'beta'
+description: |
+  Represents a packet mirroring rule that describes one or more match conditions along with the action to be taken when traffic matches this condition (mirror or do_not_mirror).
+references:
+  guides:
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/networkFirewallPolicies/addPacketMirroringRule'
+docs:
+id_format: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/packetMirroringRules/{{priority}}'
+base_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}'
+self_link: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/getPacketMirroringRule?priority={{priority}}'
+create_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/addPacketMirroringRule'
+update_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/patchPacketMirroringRule?priority={{priority}}'
+update_verb: 'POST'
+delete_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/removePacketMirroringRule?priority={{priority}}'
+delete_verb: 'POST'
+legacy_long_form_project: true
+import_format:
+  - 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/packetMirroringRules/{{priority}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    kind: 'compute#operation'
+    path: 'name'
+    wait_ms: 1000
+  result:
+    path: 'targetLink'
+    resource_inside_response: false
+  error:
+    path: 'error/errors'
+    message: 'message'
+examples:
+  - name: 'compute_network_firewall_policy_packet_mirroring_rule'
+    primary_resource_id: 'primary'
+    vars:
+      fw_policy: 'fw-policy'
+      network_name: 'network'
+      tag_key: 'tag-key'
+      tag_value: 'tag-value'
+      deployment_group_id: 'deployment-group'
+      endpoint_group_id: 'endpoint-group'
+      security_profile_name: 'sec-profile'
+      security_profile_group_name: 'sec-profile-group'
+    test_env_vars:
+      project_name: 'PROJECT_NAME'
+      org_id: 'ORG_ID'
+parameters:
+  - name: 'firewallPolicy'
+    type: ResourceRef
+    description: |
+      The firewall policy of the resource.
+    url_param_only: true
+    required: true
+    immutable: true
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    resource: 'NetworkFirewallPolicy'
+    imports: 'name'
+properties:
+  - name: 'creationTimestamp'
+    type: String
+    description: |
+      Creation timestamp in RFC3339 text format.
+    output: true
+  - name: 'kind'
+    type: String
+    description: |
+      Type of the resource. Always `compute#packetMirroringRule` for firewall policy packet mirroring rules
+    output: true
+  - name: 'ruleName'
+    type: String
+    description: |
+      An optional name for the rule. This field is not a unique identifier and can be updated.
+  - name: 'description'
+    type: String
+    description: 'An optional description for this resource.'
+  - name: 'priority'
+    type: Integer
+    immutable: true
+    description: |
+      An integer indicating the priority of a rule in the list.
+      The priority must be a positive value between 0 and 2147483647.
+      Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest priority.
+    required: true
+  - name: 'match'
+    type: NestedObject
+    description: |
+      A match condition that incoming traffic is evaluated against. If it evaluates to true, the corresponding 'action' is enforced.
+    required: true
+    properties:
+      - name: 'srcIpRanges'
+        type: Array
+        send_empty_value: true
+        description: |
+          CIDR IP address range. Maximum number of source CIDR IP ranges allowed is 5000.
+        item_type:
+          type: String
+      - name: 'destIpRanges'
+        type: Array
+        send_empty_value: true
+        description: |
+          CIDR IP address range. Maximum number of destination CIDR IP ranges allowed is 5000.
+        item_type:
+          type: String
+      - name: 'layer4Configs'
+        type: Array
+        send_empty_value: true
+        description: |
+          Pairs of IP protocols and ports that the rule should match.
+        required: true
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'ipProtocol'
+              type: String
+              description: |
+                The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule.
+                This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp), or the IP protocol number.
+              required: true
+            - name: 'ports'
+              type: Array
+              description: |
+                An optional list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
+                Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
+              item_type:
+                type: String
+  - name: 'action'
+    type: String
+    description: 'The Action to perform when the client connection triggers the rule. Valid actions are "mirror", "do_not_mirror", "goto_next".'
+    required: true
+  - name: 'securityProfileGroup'
+    type: String
+    description: |
+      A fully-qualified URL of a SecurityProfile resource instance.
+      Example: https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
+      Must be specified if action = 'mirror' and cannot be specified for other actions.
+  - name: 'targetSecureTags'
+    type: Array
+    send_empty_value: true
+    description: |
+      A list of secure tags that controls which instances the firewall rule applies to.
+      If targetSecureTag are specified, then the firewall rule applies only to instances in the VPC network that have one of those EFFECTIVE secure tags, if all the targetSecureTag are in INEFFECTIVE state, then this rule will be ignored.
+      targetSecureTag may not be set at the same time as targetServiceAccounts. If neither targetServiceAccounts nor targetSecureTag are specified, the firewall rule applies to all instances on the specified network. Maximum number of target label tags allowed is 256.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            Name of the secure tag, created with TagManager's TagValue API.
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+        - name: 'state'
+          type: Enum
+          description: |
+            State of the secure tag, either EFFECTIVE or INEFFECTIVE. A secure tag is INEFFECTIVE when it is deleted or its network is deleted.
+          output: true
+          enum_values:
+            - 'EFFECTIVE'
+            - 'INEFFECTIVE'
+  - name: 'tlsInspect'
+    type: Boolean
+    description: |
+      Boolean flag indicating if the traffic should be TLS decrypted.
+      Can be set only if action = 'mirror' and cannot be set for other actions.
+  - name: 'direction'
+    type: Enum
+    description: |
+      The direction in which this rule applies.
+    required: true
+    enum_values:
+      - 'INGRESS'
+      - 'EGRESS'
+  - name: 'ruleTupleCount'
+    type: Integer
+    description: |
+      Calculation of the complexity of a single firewall policy rule.
+    output: true
+  - name: 'disabled'
+    type: Boolean
+    description: |
+      Denotes whether the firewall policy rule is disabled.
+      When set to true, the firewall policy rule is not enforced and traffic behaves as if it did not exist.
+      If this is unspecified, the firewall policy rule will be enabled.

--- a/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
@@ -42,21 +42,14 @@ async:
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'
-    kind: 'compute#operation'
-    path: 'name'
-    wait_ms: 1000
   result:
-    path: 'targetLink'
     resource_inside_response: false
-  error:
-    path: 'error/errors'
-    message: 'message'
 examples:
   - name: 'compute_network_firewall_policy_packet_mirroring_rule'
     primary_resource_id: 'primary'
     vars:
       fw_policy: 'fw-policy'
-      network_name: 'network'
+      network_name: 'fw-network'
       tag_key: 'tag-key'
       tag_value: 'tag-value'
       deployment_group_id: 'deployment-group'

--- a/mmv1/templates/terraform/examples/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
@@ -34,8 +34,8 @@ resource "google_compute_network_firewall_policy_packet_mirroring_rule" "{{$.Pri
   security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_1.id}"
 
   target_secure_tags {
-        name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
-      }
+    name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+  }
 }
 
 resource "google_network_security_mirroring_deployment_group" "default" {

--- a/mmv1/templates/terraform/examples/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
@@ -1,0 +1,91 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_firewall_policy" "basic_network_firewall_policy" {
+  provider    = google-beta
+  name        = "{{index $.Vars "fw_policy"}}"
+  description = "Sample global network firewall policy"
+  project     = "{{index $.TestEnvVars "project_name"}}"
+}
+
+resource "google_compute_network_firewall_policy_packet_mirroring_rule" "{{$.PrimaryResourceId}}" {
+  provider                = google-beta
+  action                  = "mirror"
+  description             = "This is a simple packet mirroring rule description"
+  direction               = "INGRESS"
+  disabled                = false
+  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  priority                = 1000
+  rule_name               = "test-rule"
+
+  match {
+    src_ip_ranges = ["10.100.0.1/32"]
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_1.id}"
+
+  target_secure_tags {
+        name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+      }
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "default" {
+  provider    = google-beta
+  name        = "{{index $.Vars "security_profile_name"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "my description"
+  type        = "CUSTOM_MIRRORING"
+
+  custom_mirroring_profile {
+    mirroring_endpoint_group = google_network_security_mirroring_endpoint_group.default.id
+  }
+}
+
+resource "google_network_security_security_profile_group" "security_profile_group_1" {
+  provider                 = google-beta
+  name                     = "{{index $.Vars "security_profile_group_name"}}"
+  parent                   = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description              = "my description"
+  custom_mirroring_profile = google_network_security_security_profile.default.id
+}
+
+resource "google_tags_tag_key" "secure_tag_key_1" {
+  provider    = google-beta
+  description = "Test tag key description"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{index $.Vars "tag_key"}}"
+  purpose_data = {
+    network = "{{index $.TestEnvVars "project_name"}}/${google_compute_network.default.name}"
+  }
+}
+
+resource "google_tags_tag_value" "secure_tag_value_1" {
+  provider    = google-beta
+  description = "Test tag value description."
+  parent      = google_tags_tag_key.secure_tag_key_1.id
+  short_name  = "{{index $.Vars "tag_value"}}"
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_packet_mirroring_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_packet_mirroring_rule_test.go.tmpl
@@ -73,12 +73,9 @@ resource "google_compute_network_firewall_policy" "basic_network_firewall_policy
 resource "google_compute_network_firewall_policy_packet_mirroring_rule" "primary" {
   provider                = google-beta
   action                  = "do_not_mirror"
-  description             = "This is a simple packet mirroring rule description"
   direction               = "INGRESS"
-  disabled                = false
   firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
   priority                = 1000
-  rule_name               = "test-rule"
 
   match {
     src_ip_ranges = ["10.100.0.1/32"]
@@ -130,7 +127,7 @@ resource "google_compute_network_firewall_policy_packet_mirroring_rule" "primary
   security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_1.id}"
 
   target_secure_tags {
-   name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+    name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
   }
 
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_packet_mirroring_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_packet_mirroring_rule_test.go.tmpl
@@ -1,0 +1,191 @@
+package compute_test
+{{- if ne $.TargetVersionName "ga" }}
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeNetworkFirewallPolicyPacketMirroringRule_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeNetworkFirewallPolicyPacketMirroringRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetworkFirewallPolicyPacketMirroringRule_basic(context),
+			},
+			{
+				ResourceName:            "google_compute_network_firewall_policy_packet_mirroring_rule.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
+			},
+			{
+				Config: testAccComputeNetworkFirewallPolicyPacketMirroringRule_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_network_firewall_policy_packet_mirroring_rule.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_compute_network_firewall_policy_packet_mirroring_rule.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
+			},
+		},
+	})
+}
+
+func testAccComputeNetworkFirewallPolicyPacketMirroringRule_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_firewall_policy" "basic_network_firewall_policy" {
+  provider    = google-beta
+  name        = "tf-test-fw-policy%{random_suffix}"
+  description = "Sample global network firewall policy"
+  project     = "%{project_name}"
+}
+
+resource "google_compute_network_firewall_policy_packet_mirroring_rule" "primary" {
+  provider                = google-beta
+  action                  = "do_not_mirror"
+  description             = "This is a simple packet mirroring rule description"
+  direction               = "INGRESS"
+  disabled                = false
+  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  priority                = 1000
+  rule_name               = "test-rule"
+
+  match {
+    src_ip_ranges = ["10.100.0.1/32"]
+    layer4_configs {
+      ip_protocol = "all"
+    }
+  }
+}
+
+`, context)
+}
+
+func testAccComputeNetworkFirewallPolicyPacketMirroringRule_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_firewall_policy" "basic_network_firewall_policy" {
+  provider    = google-beta
+  name        = "tf-test-fw-policy%{random_suffix}"
+  description = "Sample global network firewall policy"
+  project     = "%{project_name}"
+}
+
+resource "google_compute_network_firewall_policy_packet_mirroring_rule" "primary" {
+  provider                = google-beta
+  action                  = "mirror"
+  description             = "This is a simple packet mirroring rule description"
+  direction               = "INGRESS"
+  disabled                = true
+  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  priority                = 1000
+  rule_name               = "test-rule"
+
+  match {
+    src_ip_ranges = ["192.168.0.1/32"]
+    layer4_configs {
+      ip_protocol = "tcp"
+    }
+  }
+
+  security_profile_group = "//networksecurity.googleapis.com/${google_network_security_security_profile_group.security_profile_group_1.id}"
+
+  target_secure_tags {
+   name = "tagValues/${google_tags_tag_value.secure_tag_value_1.name}"
+  }
+
+}
+
+resource "google_network_security_mirroring_deployment_group" "default" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "tf-test-deployment-group%{random_suffix}"
+  location                      = "global"
+  network                       = google_compute_network.default.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "default" {
+  provider                      = google-beta
+  mirroring_endpoint_group_id   = "tf-test-endpoint-group%{random_suffix}"
+  location                      = "global"
+  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
+}
+
+resource "google_network_security_security_profile" "default" {
+  provider    = google-beta
+  name        = "tf-test-sec-profile%{random_suffix}"
+  parent      = "organizations/%{org_id}"
+  description = "my description"
+  type        = "CUSTOM_MIRRORING"
+
+  custom_mirroring_profile {
+    mirroring_endpoint_group = google_network_security_mirroring_endpoint_group.default.id
+  }
+}
+
+resource "google_network_security_security_profile_group" "security_profile_group_1" {
+  provider                 = google-beta
+  name                     = "tf-test-sec-profile-group%{random_suffix}"
+  parent                   = "organizations/%{org_id}"
+  description              = "my description"
+  custom_mirroring_profile = google_network_security_security_profile.default.id
+}
+
+resource "google_tags_tag_key" "secure_tag_key_1" {
+  provider    = google-beta
+  description = "Test tag key description"
+  parent      = "organizations/%{org_id}"
+  purpose     = "GCE_FIREWALL"
+  short_name  = "tf-test-tag-key%{random_suffix}"
+  purpose_data = {
+    network = "%{project_name}/${google_compute_network.default.name}"
+  }
+}
+
+resource "google_tags_tag_value" "secure_tag_value_1" {
+  provider    = google-beta
+  description = "Test tag value description."
+  parent      = google_tags_tag_key.secure_tag_key_1.id
+  short_name  = "tf-test-tag-value%{random_suffix}"
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
As part of the work to launch Network Security Integrations (NSI) (b/352252592) we introduce a new resource to allow users to configure [Network Firewall Policy Packet Mirroring rules](https://cloud.google.com/compute/docs/reference/rest/beta/networkFirewallPolicies/addPacketMirroringRule).

In this PR we  add Terraform support for the new resource type.

```release-note:new-resource
`google_compute_network_firewall_policy_packet_mirroring_rule` (beta)
```
