### PR TITLE
Fix Firestore field deletion for wildcard fields

### DIFF
--- a/mmv1/products/firestore/Field.yaml
+++ b/mmv1/products/firestore/Field.yaml
@@ -86,6 +86,15 @@ examples:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
       'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
+  - name: 'firestore_field_wildcard'
+    primary_resource_id: 'wildcard'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
 parameters:
 properties:
   - name: 'database'

--- a/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.tmpl
@@ -15,8 +15,16 @@ if err != nil {
 	return err
 }
 
-updateMask := []string{"indexConfig", "ttlConfig"}
-
+// For wildcard fields, do not add ttlConfig to the update mask (unsupported)
+updateMask := []string{"indexConfig"}
+re := regexp.MustCompile("^projects/([^/]+)/databases/([^/]+)/collectionGroups/([^/]+)/fields/(.+)$")
+match := re.FindStringSubmatch(d.Get("name").(string))
+if len(match) < 5 {
+	return fmt.Errorf("Error parsing field name for App")
+}
+if fieldName := match[4]; fieldName != "*" {
+	updateMask = append(updateMask, "ttlConfig")
+}
 url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
 if err != nil {
 	return err

--- a/mmv1/templates/terraform/examples/firestore_field_wildcard.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_field_wildcard.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_firestore_database" "database" {
+	project     = "{{index $.TestEnvVars "project_id"}}"
+	name        = "{{index $.Vars "database_id"}}"
+	location_id = "nam5"
+	type        = "FIRESTORE_NATIVE"
+
+	delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
+	deletion_policy         = "DELETE"
+  }
+
+  resource "google_firestore_field" "{{$.PrimaryResourceId}}" {
+	project    = "{{index $.TestEnvVars "project_id"}}"
+	database   = google_firestore_database.database.name
+	collection = "chatrooms_%{random_suffix}"
+	field      = "*"
+
+	index_config {
+	  indexes {
+		  order       = "ASCENDING"
+		  query_scope = "COLLECTION_GROUP"
+	  }
+	  indexes {
+		  array_config = "CONTAINS"
+	  }
+	}
+  }


### PR DESCRIPTION
You can update index configs for wildcard fields, but you can't update TTL configs. When we "delete" SFIs, we actually issue a PATCH with empty index and TTL configs. We put both indexConfig and ttlConfig in the update mask for this PATCH accordingly.

For wildcard fields, simply exclude ttlConfig from the update mask when issuing this PATCH to avoid the "unsupported" error.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20397

```release-note:bug
firestore: fixed deletion of wildcard fields in `google_firestore_field`
```
