### PR TITLE
Mark `content` in storage object content data source as computed

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content.go
@@ -18,7 +18,9 @@ func DataSourceGoogleStorageBucketObjectContent() *schema.Resource {
 
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "bucket")
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
-	tpgresource.AddOptionalFieldsToSchema(dsSchema, "content")
+
+	// The field must be optional for backward compatibility.
+	dsSchema["content"].Optional = true
 
 	return &schema.Resource{
 		Read:   dataSourceGoogleStorageBucketObjectContentRead,

--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -47,3 +47,59 @@ resource "google_storage_bucket" "contenttest" {
 	force_destroy = true
 }`, content, bucket)
 }
+
+func TestAccDataSourceStorageBucketObjectContent_Issue15717(t *testing.T) {
+
+	bucket := "tf-bucket-object-content-" + acctest.RandString(t, 10)
+	content := "qwertyuioasdfghjk1234567!!@#$*"
+
+	config := fmt.Sprintf(`
+%s
+
+output "output" {
+	value = replace(data.google_storage_bucket_object_content.default.content, "q", "Q")
+}`, testAccDataSourceStorageBucketObjectContent_Basic(content, bucket))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_storage_bucket_object_content.default", "content"),
+					resource.TestCheckResourceAttr("data.google_storage_bucket_object_content.default", "content", content),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceStorageBucketObjectContent_Issue15717BackwardCompatibility(t *testing.T) {
+
+	bucket := "tf-bucket-object-content-" + acctest.RandString(t, 10)
+	content := "qwertyuioasdfghjk1234567!!@#$*"
+
+	config := fmt.Sprintf(`
+%s
+
+data "google_storage_bucket_object_content" "new" {
+	bucket  = google_storage_bucket.contenttest.name
+	content = "%s"
+	name    = google_storage_bucket_object.object.name
+}`, testAccDataSourceStorageBucketObjectContent_Basic(content, bucket), content)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_storage_bucket_object_content.new", "content"),
+					resource.TestCheckResourceAttr("data.google_storage_bucket_object_content.new", "content", content),
+				),
+			},
+		},
+	})
+}

--- a/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/storage_bucket_object_content.html.markdown
@@ -41,4 +41,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `content` - (Computed) [Content-Language](https://tools.ietf.org/html/rfc7231#section-3.1.3.2) of the object content.
+* `content` - (Computed) The content of the object.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/15717 in a backward-compatible manner.

The bug was once fixed in #10778, but it is reverted due to backward incompatibility.
This pull request retries to fix the bug without affecting to existing configuration.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
storage: fixed an issue where plans with a dependency on the `content` field in the `google_storage_bucket_object_content` data source could erroneously fail
```