### PR TITLE
Fix error details type on google_database_migration_service_migration_job

### DIFF
--- a/mmv1/products/databasemigrationservice/MigrationJob.yaml
+++ b/mmv1/products/databasemigrationservice/MigrationJob.yaml
@@ -155,6 +155,7 @@ properties:
         description: |
           A list of messages that carry the error details.
         output: true
+        custom_flatten: 'templates/terraform/custom_flatten/dms_migration_job_error_details.tmpl'
         item_type:
           type: KeyValuePairs
   - name: 'type'

--- a/mmv1/templates/terraform/custom_flatten/dms_migration_job_error_details.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/dms_migration_job_error_details.tmpl
@@ -1,0 +1,36 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	detailsArray := v.([]interface{})
+	for i, raw := range detailsArray {
+		m := raw.(map[string]interface{})
+		if len(m) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		for k, val := range m {
+			if _, ok := val.(string); !ok {
+				b, err := json.Marshal(v)
+				if err != nil {
+					return err
+				}
+				m[k] = string(b)
+			}
+		}
+		detailsArray[i] = m
+	}
+	return detailsArray
+}


### PR DESCRIPTION
In the event that there is an error with a MigrationJob in GCP, the Terraform google provider can not properly create a plan because the schema for `google_database_migration_service_migration_job` is incorrect.

`... expected type 'string', got unconvertible type 'map[string]interface {}' ...`

I am not sure if this is the proper way to fix the issue, but based on the details of the error response from Terraform and comparing `magic-modules` source code with `gcloud` output, it seems like this code change will fix the issue. `magic-modules` has a MigrationJob error configured as a `KeyValuePairs` when it is in fact an Object with arbitrary properties.

Terraform execution error:
```
Error: Error reading MigrationJob: error.0.details.1.metadata: '' expected type 'string', got unconvertible type 'map[string]interface {}', value: 'map[errorMessage:The migration job is currently running. Restart is not available on a running Migration job. nativeErrorMessage:Cloud SQL replica is already setup and it's replicating from the source database server. severity:ERROR]'
  with google_database_migration_service_migration_job.dms_task,
  on main.tf line 167, in resource "google_database_migration_service_migration_job" "dms_task":
 167: resource "google_database_migration_service_migration_job" "dms_task" {
```

Data returned from `gcloud database-migration migration-jobs describe dms-task`:
```
...
error:
  code: 9
  details:
  - '@type': type.googleapis.com/google.cloud.clouddms.v1.MigrationJobVerificationError
    errorCode: CANT_RESTART_RUNNING_MIGRATION
    errorDetailMessage: Cloud SQL replica is already setup and it's replicating from
      the source database server.
    errorMessage: "The migration job is currently running. Restart is not available\
      \ on a running Migration job. Details: Cloud SQL replica is already setup and\
      \ it's replicating from the source database server."
  - '@type': type.googleapis.com/google.rpc.ErrorInfo
    domain: datamigration.googleapis.com
    metadata:
      errorMessage: The migration job is currently running. Restart is not available
        on a running Migration job.
      nativeErrorMessage: Cloud SQL replica is already setup and it's replicating
        from the source database server.
      severity: ERROR
    reason: CANT_RESTART_RUNNING_MIGRATION
  - '@type': type.googleapis.com/google.rpc.Help
    links:
    - description: 'Learn more:'
      url: https://cloud.google.com/database-migration/docs/diagnose-issues
  message: The migration job is currently running. Restart is not available on a running
    Migration job.
labels:
  goog-terraform-provisioned: 'true'
...
```

```release-note:bug
fix: error details type on google_database_migration_service_migration_job
```