### PR TITLE
Modify labeler to consider issues with more than 3 services impacted as cross-provider

### DIFF
--- a/tools/issue-labeler/cmd/compute_new_labels.go
+++ b/tools/issue-labeler/cmd/compute_new_labels.go
@@ -45,6 +45,21 @@ func execComputeNewLabels() error {
 	affectedResources := labeler.ExtractAffectedResources(issueBody)
 	labels := labeler.ComputeLabels(affectedResources, regexpLabels)
 
+	// If there are more than 3 service labels, treat this as a cross-provider issue
+	var serviceLabels []string
+	var nonServiceLabels []string
+	for _, l := range labels {
+		if strings.HasPrefix(l, "service/") {
+			serviceLabels = append(serviceLabels, l)
+		} else {
+			nonServiceLabels = append(serviceLabels, l)
+		}
+	}
+	if len(serviceLabels) > 3 {
+		serviceLabels = []string{"service/terraform"}
+	}
+	labels = append(nonServiceLabels, serviceLabels...)
+
 	if len(labels) > 0 {
 		labels = append(labels, "forward/review")
 		sort.Strings(labels)

--- a/tools/issue-labeler/cmd/compute_new_labels.go
+++ b/tools/issue-labeler/cmd/compute_new_labels.go
@@ -45,14 +45,16 @@ func execComputeNewLabels() error {
 	affectedResources := labeler.ExtractAffectedResources(issueBody)
 	labels := labeler.ComputeLabels(affectedResources, regexpLabels)
 
-	// If there are more than 3 service labels, treat this as a cross-provider issue
+	// If there are more than 3 service labels, treat this as a cross-provider issue.
+	// Note that labeler.ComputeLabels() currently only returns service labels, but
+	// the logic here remains defensive in case that changes.
 	var serviceLabels []string
 	var nonServiceLabels []string
 	for _, l := range labels {
 		if strings.HasPrefix(l, "service/") {
 			serviceLabels = append(serviceLabels, l)
 		} else {
-			nonServiceLabels = append(serviceLabels, l)
+			nonServiceLabels = append(nonServiceLabels, l)
 		}
 	}
 	if len(serviceLabels) > 3 {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20818

* I tested locally with some issue bodies and the results looked good
* I chose not to include the backfill job: basically, the backfill job ignores issues with `service/terraform`, so the condition mentioned here would only be triggered after a ticket is created with < 4 services, and then more are added later, which is both unusual, and something we can handle manually.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
