### PR TITLE
Allow parallelization of per instance config deletions by not locking on the IGM

### DIFF
--- a/mmv1/templates/terraform/custom_delete/per_instance_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/per_instance_config.go.tmpl
@@ -3,7 +3,7 @@
 		return err
 	}
 
-	lockName, err := tpgresource.ReplaceVars(d, config, "instanceGroupManager/{{"{{"}}project{{"}}"}}/{{"{{"}}zone{{"}}"}}/{{"{{"}}instance_group_manager{{"}}"}}")
+	lockName, err := tpgresource.ReplaceVars(d, config, "instanceGroupManager/{{"{{"}}project{{"}}"}}/{{"{{"}}zone{{"}}"}}/{{"{{"}}instance_group_manager{{"}}"}}/{{"{{"}}name{{"}}"}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/templates/terraform/custom_delete/region_per_instance_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/region_per_instance_config.go.tmpl
@@ -3,7 +3,7 @@
 		return err
 	}
 
-	lockName, err := tpgresource.ReplaceVars(d, config, "instanceGroupManager/{{"{{"}}project{{"}}"}}/{{"{{"}}region{{"}}"}}/{{"{{"}}region_instance_group_manager{{"}}"}}")
+	lockName, err := tpgresource.ReplaceVars(d, config, "instanceGroupManager/{{"{{"}}project{{"}}"}}/{{"{{"}}region{{"}}"}}/{{"{{"}}region_instance_group_manager{{"}}"}}/{{"{{"}}name{{"}}"}}")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allow parallelization of per instance config related operations by not locking on the IGM
Fixes b/270736647
follow up to https://github.com/GoogleCloudPlatform/magic-modules/pull/12829

```release-note:enhancement
compute: allow parallelization of `google_compute_per_instance_config` and `google_compute_region_per_instance_config` deletions by not locking on the parent resource, but including instance name.
```
