### PR TITLE
Adding API Docs for resource_compute_interconnect_attachment for registry

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -17,6 +17,10 @@ kind: 'compute#interconnectAttachment'
 description: |
   Represents an InterconnectAttachment (VLAN attachment) resource. For more
   information, see Creating VLAN Attachments.
+references:
+  guides: 
+    'Create a Interconnect attachment': 'https://cloud.google.com/network-connectivity/docs/interconnect/how-to/dedicated/creating-vlan-attachments'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/interconnectAttachments'
 has_self_link: true

--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -18,7 +18,7 @@ description: |
   Represents an InterconnectAttachment (VLAN attachment) resource. For more
   information, see Creating VLAN Attachments.
 references:
-  guides: 
+  guides:
     'Create a Interconnect attachment': 'https://cloud.google.com/network-connectivity/docs/interconnect/how-to/dedicated/creating-vlan-attachments'
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments'
 docs:


### PR DESCRIPTION
Adding API Docs for  resource_compute_interconnect_attachment for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: adding API Docs for  resource_compute_interconnect_attachment
```