### PR TITLE
Adding API Docs for google_workbench_instance for registry

### DIFF
--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -16,7 +16,7 @@ name: 'Instance'
 description: A Workbench instance.
 references:
   guides:
-    'Official Documentation': 'hhttps://cloud.google.com/vertex-ai/docs/workbench/instances/introduction'
+    'Official Documentation': 'https://cloud.google.com/vertex-ai/docs/workbench/instances/introduction'
   api: 'https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v2/projects.locations.instances'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -16,7 +16,7 @@ name: 'Instance'
 description: A Workbench instance.
 references:
   guides:
-    'Official Documentation': 'https://cloud.google.com/ai-platform-notebooks'
+    'Official Documentation': 'hhttps://cloud.google.com/vertex-ai/docs/workbench/instances/introduction'
   api: 'https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v1/projects.locations.instances'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -14,6 +14,10 @@
 ---
 name: 'Instance'
 description: A Workbench instance.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/ai-platform-notebooks'
+  api: 'https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v1/projects.locations.instances'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
 base_url: 'projects/{{project}}/locations/{{location}}/instances'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -17,7 +17,7 @@ description: A Workbench instance.
 references:
   guides:
     'Official Documentation': 'hhttps://cloud.google.com/vertex-ai/docs/workbench/instances/introduction'
-  api: 'https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v1/projects.locations.instances'
+  api: 'https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v2/projects.locations.instances'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/instances/{{name}}'
 base_url: 'projects/{{project}}/locations/{{location}}/instances'


### PR DESCRIPTION
Adding API Docs for  google_workbench_instance for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
workbench: added API Docs for `google_workbench_instance`
```