### PR TITLE
Adding API Docs for google_securityposture_posture for registry

### DIFF
--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -21,6 +21,7 @@ description: |
 references:
   guides:
     'Create and deploy a posture': 'https://cloud.google.com/security-command-center/docs/how-to-use-security-posture'
+  api: 'https://cloud.google.com/security-command-center/docs/reference/securityposture/rest/v1/Posture'
 docs:
 base_url: '{{parent}}/locations/{{location}}/postures'
 self_link: '{{parent}}/locations/{{location}}/postures/{{posture_id}}'


### PR DESCRIPTION
Adding API Docs for  google_securityposture_posture for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securityposture: Adding API Docs for google_securityposture_posture
```