### PR TITLE
Adding API Docs for google_securityposture_posture_deployment for registry 

### DIFF
--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -22,7 +22,7 @@ description: |
 references:
   guides:
     'Create and deploy a posture': 'https://cloud.google.com/security-command-center/docs/how-to-use-security-posture'
-  api: 'https://cloud.google.com/security-command-center/docs/reference/securityposture/rest/v1/PostureDeployment'
+  api: 'https://cloud.google.com/security-command-center/docs/reference/securityposture/rest/v1/organizations.locations.postureDeployments'
 docs:
 base_url: '{{parent}}/locations/{{location}}/postureDeployments'
 self_link: '{{parent}}/locations/{{location}}/postureDeployments/{{posture_deployment_id}}'

--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -22,6 +22,7 @@ description: |
 references:
   guides:
     'Create and deploy a posture': 'https://cloud.google.com/security-command-center/docs/how-to-use-security-posture'
+  api: 'https://cloud.google.com/security-command-center/docs/reference/securityposture/rest/v1/PostureDeployment'
 docs:
 base_url: '{{parent}}/locations/{{location}}/postureDeployments'
 self_link: '{{parent}}/locations/{{location}}/postureDeployments/{{posture_deployment_id}}'


### PR DESCRIPTION
Adding API Docs for  google_securityposture_posture_deployment for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
securityposture: Adding API Docs for google_securityposture_posture_deployment
```