### PR TITLE
Adding API Docs for google_secure_source_manager_repository and google_secure_source_manager_branch_rule for registry

### DIFF
--- a/mmv1/products/securesourcemanager/BranchRule.yaml
+++ b/mmv1/products/securesourcemanager/BranchRule.yaml
@@ -17,6 +17,7 @@ description: 'BranchRule is the protection rule to enforce pre-defined rules on 
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/secure-source-manager/docs/overview'
+  api: 'https://cloud.google.com/secure-source-manager/docs/reference/rest/v1/projects.locations.repositories.branchRules'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/branchRules/{{branch_rule_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/branchRules?branch_rule_id={{branch_rule_id}}'

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -17,6 +17,7 @@ description: 'Repositories store source code. It supports all Git SCM client com
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/secure-source-manager/docs/overview'
+  api: 'https://cloud.google.com/secure-source-manager/docs/reference/rest/v1/projects.locations.repositories'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/repositories?repository_id={{repository_id}}'
 self_link: 'projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}'


### PR DESCRIPTION
Adding API Docs for  google_secure_source_manager_branch_rule  and google_secure_source_manager_repository for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securesourcemanager: Adding API Docs for google_secure_source_manager_branch_rule and google_secure_source_manager_repository
```