### PR TITLE
Add DSF on resource_labels in node_config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -240,10 +239,11 @@ func schemaNodeConfig() *schema.Schema {
 				},
 
 				"resource_labels": {
-					Type:        schema.TypeMap,
-					Optional:    true,
-					Elem:        &schema.Schema{Type: schema.TypeString},
-					Description: `The GCE resource labels (a map of key/value pairs) to be applied to the node pool.`,
+					Type:             schema.TypeMap,
+					Optional:         true,
+					Elem:             &schema.Schema{Type: schema.TypeString},
+					DiffSuppressFunc: containerNodePoolResourceLabelsDiffSuppress,
+					Description:      `The GCE resource labels (a map of key/value pairs) to be applied to the node pool.`,
 				},
 
 				"local_ssd_count": {
@@ -1858,14 +1858,6 @@ func containerNodePoolLabelsSuppress(k, old, new string, d *schema.ResourceData)
 {{- end }}
 
 func containerNodePoolResourceLabelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// Node configs are embedded into multiple resources (container cluster and
-	// container node pool) so we determine the node config key dynamically.
-	idx := strings.Index(k, ".resource_labels.")
-	if idx < 0 {
-		return false
-	}
-
-	root := k[:idx]
 	// Suppress diffs for server-specified labels
 	for _, label := range containerNodePoolProvidedResourceLabels {
 		if strings.Contains(k, label) && new == "" {
@@ -1874,7 +1866,7 @@ func containerNodePoolResourceLabelsDiffSuppress(k, old, new string, d *schema.R
 	}
 
 	// Let diff be determined by resource_labels (above)
-	if strings.Contains(k, fmt.Sprintf("%s%%", root)) {
+	if strings.Contains(k, "resource_labels.%") {
 		return true
 	}
 

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1858,11 +1858,9 @@ func containerNodePoolLabelsSuppress(k, old, new string, d *schema.ResourceData)
 {{- end }}
 
 func containerNodePoolResourceLabelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// Suppress diffs for server-specified labels
-	for _, label := range containerNodePoolProvidedResourceLabels {
-		if strings.Contains(k, label) && new == "" {
-			return true
-		}
+	// Suppress diffs for server-specified labels prefixed with "goog-gke"
+	if strings.Contains(k, "resource_labels.goog-gke") && new == "" {
+		return true
 	}
 
 	// Let diff be determined by resource_labels (above)
@@ -1872,12 +1870,6 @@ func containerNodePoolResourceLabelsDiffSuppress(k, old, new string, d *schema.R
 
 	// For other keys, don't suppress diff.
 	return false
-}
-
-var containerNodePoolProvidedResourceLabels = []string{
-	"goog-gke-accelerator-type",
-	"goog-gke-tpu-node-pool-type",
-	"goog-gke-node-pool-provisioning-model",
 }
 
 func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"fmt"
 	"log"
 {{- if ne $.TargetVersionName "ga" }}
 	"strings"
@@ -1857,6 +1858,37 @@ func containerNodePoolLabelsSuppress(k, old, new string, d *schema.ResourceData)
 	return true
 }
 {{- end }}
+
+func containerNodePoolResourceLabelsDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Node configs are embedded into multiple resources (container cluster and
+	// container node pool) so we determine the node config key dynamically.
+	idx := strings.Index(k, ".resource_labels.")
+	if idx < 0 {
+		return false
+	}
+
+	root := k[:idx]
+	// Suppress diffs for server-specified labels
+	for _, label := range containerNodePoolProvidedResourceLabels {
+		if strings.Contains(k, label) && new == "" {
+			return true
+		}
+	}
+
+	// Let diff be determined by resource_labels (above)
+	if strings.Contains(k, fmt.Sprintf("%s%%", root)) {
+		return true
+	}
+
+	// For other keys, don't suppress diff.
+	return false
+}
+
+var containerNodePoolProvidedResourceLabels = []string{
+	"goog-gke-accelerator-type",
+	"goog-gke-tpu-node-pool-type",
+	"goog-gke-node-pool-provisioning-model",
+}
 
 func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface{} {
 	result := []map[string]interface{}{}

--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -3,9 +3,7 @@ package container
 import (
 	"fmt"
 	"log"
-{{- if ne $.TargetVersionName "ga" }}
 	"strings"
-{{- end }}
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/15848

Well, only adds a DSF on resource_labels, doesn't fix the inability to remove all resource_labels
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed a diff caused by server-side set values for `node_config.resource_labels`
```
