### PR TITLE
Adding API Docs for secret manager based resources

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -17,6 +17,7 @@ description: |
   A Secret is a logical secret whose value and versions can be accessed.
 references:
   guides:
+    'Create and deploy a Secret': 'https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets'
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets'
 docs:
 base_url: 'projects/{{project}}/secrets'

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -15,6 +15,10 @@
 name: 'SecretVersion'
 description: |
   A secret version resource.
+references:
+  guides:
+    'Create and deploy a Secret Version': 'https://cloud.google.com/secret-manager/docs/add-secret-version'
+  api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions'
 docs:
   optional_properties: |
     * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is.

--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -18,6 +18,7 @@ description: |
   A Regional Secret is a logical secret whose value and versions can be created and accessed within a region only.
 references:
   guides:
+    'Create and deploy a Regional Secret': 'https://cloud.google.com/secret-manager/regional-secrets/create-regional-secret'
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.locations.secrets'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/secrets'

--- a/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
@@ -16,6 +16,10 @@ name: 'RegionalSecretVersion'
 api_resource_type_kind: SecretVersion
 description: |
   A regional secret version resource.
+references:
+  guides:
+    'Create and deploy a Regional Secret Version': 'https://cloud.google.com/secret-manager/regional-secrets/add-secret-version-rs'
+  api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.locations.secrets.versions'
 docs:
   optional_properties: |
     * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is.


### PR DESCRIPTION
Adding API Docs for  Adding API Docs for google_secret_manager_regional_secret, google_secret_manager_regional_secret_version,  google_secret_manager_secret, google_secret_manager_secret_version   for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
secretmanagerregional: and secretmanager  Adding API Docs for google_secret_manager_regional_secret, google_secret_manager_regional_secret_version,  google_secret_manager_secret, google_secret_manager_secret_version
```