### PR TITLE
Add notes that label starting with "__" are reserved for internal use case only in metrics labels

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -886,10 +886,9 @@ properties:
 
                 Label values can be templatized by using variables. The only available
                 variable names are the names of the labels in the PromQL result,
-                including "\_\_name\_\_" and "value", although "\_\_name\_\_" are
-                reserved for internal use only and the user cannot overwrite them.
-                "labels" may be empty.This field is intended to be used for organizing
-                and identifying the AlertPolicy.
+                although label names beginning with \_\_ (two "\_") are reserved for
+                internal use. "labels" may be empty. This field is intended to be used
+                for organizing and identifying the AlertPolicy.
             - name: 'ruleGroup'
               type: String
               description: |

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -885,9 +885,11 @@ properties:
                 must be valid.
 
                 Label values can be templatized by using variables. The only available
-                variable names are the names of the labels in the PromQL result, including
-                "__name__" and "value". "labels" may be empty. This field is intended to be
-                used for organizing and identifying the AlertPolicy
+                variable names are the names of the labels in the PromQL result,
+                including "\_\_name\_\_" and "value", although "\_\_name\_\_" are
+                reserved for internal use only and the user cannot overwrite them.
+                "labels" may be empty.This field is intended to be used for organizing
+                and identifying the AlertPolicy.
             - name: 'ruleGroup'
               type: String
               description: |


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20938

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added more description to make it clear that label starting with "__" are reserved for internal use case only in metrics labels, and cannot be overwritten. 
```
