### PR TITLE
Add Gemini Data Sharing With Google Setting Binding resource

### DIFF
--- a/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
@@ -1,0 +1,71 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: DataSharingWithGoogleSetting
+description: The resource for managing DataSharingWithGoogle settings for Admin Control. 
+base_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings?dataSharingWithGoogleSettingId={{data_sharing_with_google_setting_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+examples:
+  - name: gemini_data_sharing_with_google_setting_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      data_sharing_with_google_setting_id: ls1-tf
+      project_id: "aandrei-test"
+autogen_async: false
+autogen_status: RGF0YVNoYXJpbmdXaXRoR29vZ2xlU2V0dGluZw==
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: dataSharingWithGoogleSettingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      data_sharing_with_google_setting_id from the method_signature of Create RPC
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/dataSharingWithGoogleSettings/{dataSharingWithGoogleSetting}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: enablePreviewDataSharing
+    type: Boolean
+    description: Optional. Whether preview data sharing should be enabled.

--- a/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: DataSharingWithGoogleSetting
-description: The resource for managing DataSharingWithGoogle settings for Admin Control. 
+description: The resource for managing DataSharingWithGoogle settings for Admin Control.
 base_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings
 update_mask: true
 self_link: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}

--- a/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
@@ -1,0 +1,104 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: DataSharingWithGoogleSettingBinding
+description: The resource for managing DataSharingWithGoogle setting bindings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+update_verb: PATCH
+update_mask: true
+id_format: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings/{{setting_binding_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings/{{setting_binding_id}}
+mutex: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+examples:
+- name: gemini_data_sharing_with_google_setting_binding_basic
+  min_version: 'beta'
+  primary_resource_id: example
+  vars:
+    data_sharing_with_google_setting_id: ls-tf1
+    setting_binding_id: ls-tf1b1
+    project_id: aandrei-test
+    target: projects/980109375338
+autogen_async: true
+async:
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  type: OpAsync
+  result:
+    resource_inside_response: true
+  error: {}
+  include_project: false
+autogen_status: U2V0dGluZ0JpbmRpbmc=
+parameters:
+- name: location
+  type: String
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+  required: true
+- name: dataSharingWithGoogleSettingId
+  type: String
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+  required: true
+- name: settingBindingId
+  type: String
+  description: |-
+    Required. Id of the requesting object.
+    If auto-generating Id server-side, remove this field and
+    setting_id from the method_signature of Create RPC.
+  immutable: true
+  url_param_only: true
+  required: true
+properties:
+- name: product
+  type: String
+  description: |-
+    Required. Product type of the setting binding.
+    Possible values:
+    PRODUCT_UNSPECIFIED
+    GEMINI_CLOUD_ASSIST
+    GEMINI_CODE_ASSIST
+- name: name
+  type: String
+  description: |-
+    Identifier. Name of the resource.
+    Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
+  output: true
+- name: createTime
+  type: String
+  description: Output only. [Output only] Create time stamp.
+  output: true
+- name: updateTime
+  type: String
+  description: Output only. [Output only] Update time stamp.
+  output: true
+- name: labels
+  type: KeyValueLabels
+  description: Optional. Labels as key value pairs.
+- name: target
+  type: String
+  description: Required. Target of the binding.
+  required: true

--- a/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
@@ -24,14 +24,14 @@ import_format:
   - projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings/{{setting_binding_id}}
 mutex: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
 examples:
-- name: gemini_data_sharing_with_google_setting_binding_basic
-  min_version: 'beta'
-  primary_resource_id: example
-  vars:
-    data_sharing_with_google_setting_id: ls-tf1
-    setting_binding_id: ls-tf1b1
-    project_id: aandrei-test
-    target: projects/980109375338
+  - name: gemini_data_sharing_with_google_setting_binding_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      data_sharing_with_google_setting_id: ls-tf1
+      setting_binding_id: ls-tf1b1
+      project_id: aandrei-test
+      target: projects/980109375338
 autogen_async: true
 async:
   operation:
@@ -51,54 +51,54 @@ async:
   include_project: false
 autogen_status: U2V0dGluZ0JpbmRpbmc=
 parameters:
-- name: location
-  type: String
-  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
-  immutable: true
-  url_param_only: true
-  required: true
-- name: dataSharingWithGoogleSettingId
-  type: String
-  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
-  immutable: true
-  url_param_only: true
-  required: true
-- name: settingBindingId
-  type: String
-  description: |-
-    Required. Id of the requesting object.
-    If auto-generating Id server-side, remove this field and
-    setting_id from the method_signature of Create RPC.
-  immutable: true
-  url_param_only: true
-  required: true
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: dataSharingWithGoogleSettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+    required: true
 properties:
-- name: product
-  type: String
-  description: |-
-    Required. Product type of the setting binding.
-    Possible values:
-    PRODUCT_UNSPECIFIED
-    GEMINI_CLOUD_ASSIST
-    GEMINI_CODE_ASSIST
-- name: name
-  type: String
-  description: |-
-    Identifier. Name of the resource.
-    Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
-  output: true
-- name: createTime
-  type: String
-  description: Output only. [Output only] Create time stamp.
-  output: true
-- name: updateTime
-  type: String
-  description: Output only. [Output only] Update time stamp.
-  output: true
-- name: labels
-  type: KeyValueLabels
-  description: Optional. Labels as key value pairs.
-- name: target
-  type: String
-  description: Required. Target of the binding.
-  required: true
+  - name: product
+    type: String
+    description: |-
+      Required. Product type of the setting binding.
+      Possible values:
+      PRODUCT_UNSPECIFIED
+      GEMINI_CLOUD_ASSIST
+      GEMINI_CODE_ASSIST
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: target
+    type: String
+    description: Required. Target of the binding.
+    required: true

--- a/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
@@ -1,0 +1,71 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GeminiGcpEnablementSetting
+description: The resource for managing GeminiGcpEnablement settings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings?geminiGcpEnablementSettingId={{gemini_gcp_enablement_setting_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+examples:
+  - name: gemini_gemini_gcp_enablement_setting_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      gemini_gcp_enablement_setting_id: ls1-tf
+      project_id: "aandrei-test"
+autogen_async: false
+autogen_status: R2VtaW5pR2NwRW5hYmxlbWVudFNldHRpbmc=
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: geminiGcpEnablementSettingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      gemini_gcp_enablement_setting_id from the method_signature of Create RPC
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/geminiGcpEnablementSettings/{geminiGcpEnablementSetting}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: enableCustomerDataSharing
+    type: Boolean
+    description: Optional. Whether customer data sharing should be enabled.

--- a/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
@@ -1,0 +1,104 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GeminiGcpEnablementSettingBinding
+description: The resource for managing GeminiGcpEnablementSetting setting bindings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+id_format: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}/settingBindings/{{setting_binding_id}}
+update_verb: PATCH
+update_mask: true
+import_format:
+  - projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}/settingBindings/{{setting_binding_id}}
+mutex: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+examples:
+  - name: gemini_gemini_gcp_enablement_setting_binding_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      gemini_gcp_enablement_setting_id: ls-tf1
+      setting_binding_id: ls-tf1b1
+      project_id: aandrei-test
+      target: projects/980109375338
+autogen_async: true
+async:
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+  - create
+  - delete
+  - update
+  type: OpAsync
+  result:
+    resource_inside_response: true
+  error: {}
+  include_project: false
+autogen_status: U2V0dGluZ0JpbmRpbmdCeVByb2plY3RBbmRMb2NhdGlvbkFuZEdlbWluaWdjcGVuYWJsZW1lbnRzZXR0aW5n
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: geminiGcpEnablementSettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: target
+    type: String
+    description: Required. Target of the binding.
+    required: true
+  - name: product
+    type: String
+    description: |-
+      Required. Product type of the setting binding.
+      Possible values:
+      PRODUCT_UNSPECIFIED
+      GEMINI_CLOUD_ASSIST
+      GEMINI_CODE_ASSIST
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true

--- a/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
@@ -41,9 +41,9 @@ async:
       delete_minutes: 90
     base_url: '{{op_id}}'
   actions:
-  - create
-  - delete
-  - update
+    - create
+    - delete
+    - update
   type: OpAsync
   result:
     resource_inside_response: true

--- a/mmv1/products/gemini/LoggingSetting.yaml
+++ b/mmv1/products/gemini/LoggingSetting.yaml
@@ -21,14 +21,14 @@ create_url: projects/{{project}}/locations/{{location}}/loggingSettings?loggingS
 update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
 import_format:
-- projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+  - projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
 mutex: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
 examples:
-- name: gemini_logging_setting_basic
-  min_version: 'beta'
-  primary_resource_id: "example"
-  vars:
-    name: projects/aandrei-test/locations/global/loggingSettings/ls1-tf
+  - name: gemini_logging_setting_basic
+    min_version: 'beta'
+    primary_resource_id: "example"
+    vars:
+      name: projects/aandrei-test/locations/global/loggingSettings/ls1-tf
 autogen_async: false
 timeouts:
   insert_minutes: 90
@@ -36,42 +36,42 @@ timeouts:
   delete_minutes: 90
 autogen_status: TG9nZ2luZ1NldHRpbmc=
 parameters:
-- name: location
-  type: String
-  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
-  immutable: true
-  url_param_only: true
-  required: true
-- name: loggingSettingId
-  type: String
-  description: |-
-    Required. Id of the requesting object.
-    If auto-generating Id server-side, remove this field and
-    setting_id from the method_signature of Create RPC.
-  immutable: true
-  url_param_only: true
-  required: true
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: loggingSettingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+    required: true
 properties:
-- name: name
-  type: String
-  description: |-
-    Identifier. Name of the resource.
-    Format:projects/{project}/locations/{location}/loggingsettings/{loggingsetting}
-  output: true
-- name: createTime
-  type: String
-  description: Output only. [Output only] Create time stamp.
-  output: true
-- name: updateTime
-  type: String
-  description: Output only. [Output only] Update time stamp.
-  output: true
-- name: labels
-  type: KeyValueLabels
-  description: Optional. Labels as key value pairs.
-- name: logPromptsAndResponses
-  type: Boolean
-  description: Optional. Whether to log prompts and responses.
-- name: logMetadata
-  type: Boolean
-  description: Optional. Whether to log metadata.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/loggingsettings/{loggingsetting}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: logPromptsAndResponses
+    type: Boolean
+    description: Optional. Whether to log prompts and responses.
+  - name: slogMetadata
+    type: Boolean
+    description: Optional. Whether to log metadata.

--- a/mmv1/products/gemini/LoggingSetting.yaml
+++ b/mmv1/products/gemini/LoggingSetting.yaml
@@ -1,0 +1,77 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: LoggingSetting
+description: The resource for managing Logging settings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/loggingSettings
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/loggingSettings?loggingSettingId={{logging_setting_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+import_format:
+- projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+examples:
+- name: gemini_logging_setting_basic
+  min_version: 'beta'
+  primary_resource_id: "example"
+  vars:
+    name: projects/aandrei-test/locations/global/loggingSettings/ls1-tf
+autogen_async: false
+timeouts:
+  insert_minutes: 90
+  update_minutes: 90
+  delete_minutes: 90
+autogen_status: TG9nZ2luZ1NldHRpbmc=
+parameters:
+- name: location
+  type: String
+  description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+  immutable: true
+  url_param_only: true
+  required: true
+- name: loggingSettingId
+  type: String
+  description: |-
+    Required. Id of the requesting object.
+    If auto-generating Id server-side, remove this field and
+    setting_id from the method_signature of Create RPC.
+  immutable: true
+  url_param_only: true
+  required: true
+properties:
+- name: name
+  type: String
+  description: |-
+    Identifier. Name of the resource.
+    Format:projects/{project}/locations/{location}/loggingsettings/{loggingsetting}
+  output: true
+- name: createTime
+  type: String
+  description: Output only. [Output only] Create time stamp.
+  output: true
+- name: updateTime
+  type: String
+  description: Output only. [Output only] Update time stamp.
+  output: true
+- name: labels
+  type: KeyValueLabels
+  description: Optional. Labels as key value pairs.
+- name: logPromptsAndResponses
+  type: Boolean
+  description: Optional. Whether to log prompts and responses.
+- name: logMetadata
+  type: Boolean
+  description: Optional. Whether to log metadata.

--- a/mmv1/products/gemini/LoggingSetting.yaml
+++ b/mmv1/products/gemini/LoggingSetting.yaml
@@ -28,7 +28,8 @@ examples:
     min_version: 'beta'
     primary_resource_id: "example"
     vars:
-      name: projects/aandrei-test/locations/global/loggingSettings/ls1-tf
+      logging_setting_id: ls1-tf
+      project_id: "aandrei-test"
 autogen_async: false
 timeouts:
   insert_minutes: 90

--- a/mmv1/products/gemini/LoggingSettingBinding.yaml
+++ b/mmv1/products/gemini/LoggingSettingBinding.yaml
@@ -1,0 +1,108 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: LoggingSettingBinding
+description: The resource for managing Logging setting bindings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+id_format: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings/{{setting_binding_id}}
+update_verb: PATCH
+update_mask: true
+import_format:
+- projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings/{{setting_binding_id}}
+mutex: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
+examples:
+- name: gemini_logging_setting_binding_basic
+  min_version: 'beta'
+  primary_resource_id: example
+  vars:
+    logging_setting_id: ls-tf1
+    setting_binding_id: ls-tf1b1
+    project_id: aandrei-test
+    target: projects/980109375338
+autogen_async: true
+timeouts:
+  insert_minutes: 90
+  update_minutes: 90
+  delete_minutes: 90
+async:
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+  - create
+  - delete
+  - update
+  type: OpAsync
+  result:
+    resource_inside_response: true
+  error: {}
+  include_project: false
+autogen_status: U2V0dGluZ0JpbmRpbmdCeVByb2plY3RBbmRMb2NhdGlvbkFuZExvZ2dpbmdzZXR0aW5n
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: loggingSettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: target
+    type: String
+    description: Required. Target of the binding.
+    required: true
+  - name: product
+    type: String
+    description: |-
+      Required. Product type of the setting binding.
+      Possible values:
+      PRODUCT_UNSPECIFIED
+      GEMINI_CLOUD_ASSIST
+      GEMINI_CODE_ASSIST
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true

--- a/mmv1/products/gemini/LoggingSettingBinding.yaml
+++ b/mmv1/products/gemini/LoggingSettingBinding.yaml
@@ -21,17 +21,17 @@ id_format: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging
 update_verb: PATCH
 update_mask: true
 import_format:
-- projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings/{{setting_binding_id}}
+  - projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}/settingBindings/{{setting_binding_id}}
 mutex: projects/{{project}}/locations/{{location}}/loggingSettings/{{logging_setting_id}}
 examples:
-- name: gemini_logging_setting_binding_basic
-  min_version: 'beta'
-  primary_resource_id: example
-  vars:
-    logging_setting_id: ls-tf1
-    setting_binding_id: ls-tf1b1
-    project_id: aandrei-test
-    target: projects/980109375338
+  - name: gemini_logging_setting_binding_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      logging_setting_id: ls-tf1
+      setting_binding_id: ls-tf1b1
+      project_id: aandrei-test
+      target: projects/980109375338
 autogen_async: true
 timeouts:
   insert_minutes: 90
@@ -45,9 +45,9 @@ async:
       delete_minutes: 90
     base_url: '{{op_id}}'
   actions:
-  - create
-  - delete
-  - update
+    - create
+    - delete
+    - update
   type: OpAsync
   result:
     resource_inside_response: true

--- a/mmv1/products/gemini/ReleaseChannelSetting.yaml
+++ b/mmv1/products/gemini/ReleaseChannelSetting.yaml
@@ -1,0 +1,76 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ReleaseChannelSetting
+description: The resource for managing ReleaseChannel settings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/releaseChannelSettings
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/releaseChannelSettings?releaseChannelSettingId={{release_channel_setting_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+import_format:
+- projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+examples:
+  - name: gemini_release_channel_setting_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      release_channel_setting_id: ls1-tf
+      project_id: "aandrei-test"
+autogen_async: false
+autogen_status: UmVsZWFzZUNoYW5uZWxTZXR0aW5n
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: releaseChannelSettingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      release_channel_setting_id from the method_signature of Create RPC
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: releaseChannel
+    type: String
+    description: |-
+      Optional. Release channel to be used.
+      Possible values:
+      CHANNEL_TYPE_UNSPECIFIED
+      STABLE
+      EXPERIMENTAL
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/releaseChannelSettings/{releaseChannelSetting}
+    output: true

--- a/mmv1/products/gemini/ReleaseChannelSetting.yaml
+++ b/mmv1/products/gemini/ReleaseChannelSetting.yaml
@@ -21,7 +21,7 @@ create_url: projects/{{project}}/locations/{{location}}/releaseChannelSettings?r
 update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
 import_format:
-- projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+  - projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
 mutex: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
 examples:
   - name: gemini_release_channel_setting_basic

--- a/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
+++ b/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
@@ -1,0 +1,104 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ReleaseChannelSettingBinding
+description: The resource for managing ReleaseChannel setting bindings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}/settingBindings
+self_link: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}/settingBindings/{{setting_binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
+id_format: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}/settingBindings/{{setting_binding_id}}
+update_verb: PATCH
+update_mask: true
+import_format:
+  - projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}/settingBindings/{{setting_binding_id}}
+mutex: projects/{{project}}/locations/{{location}}/releaseChannelSettings/{{release_channel_setting_id}}
+examples:
+  - name: gemini_release_channel_setting_binding_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      release_channel_setting_id: ls-tf1
+      setting_binding_id: ls-tf1b1
+      project_id: aandrei-test
+      target: projects/980109375338
+autogen_async: true
+async:
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 90
+      delete_minutes: 90
+    base_url: '{{op_id}}'
+  actions:
+  - create
+  - delete
+  - update
+  type: OpAsync
+  result:
+    resource_inside_response: true
+  error: {}
+  include_project: false
+autogen_status: U2V0dGluZ0JpbmRpbmdCeVByb2plY3RBbmRMb2NhdGlvbkFuZFJlbGVhc2VjaGFubmVsc2V0dGluZw==
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: releaseChannelSettingId
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: settingBindingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/{settingType}/{setting}/settingBindings/{setting_binding}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: target
+    type: String
+    description: Required. Target of the binding.
+    required: true
+  - name: product
+    type: String
+    description: |-
+      Required. Product type of the setting binding.
+      Possible values:
+      PRODUCT_UNSPECIFIED
+      GEMINI_CLOUD_ASSIST
+      GEMINI_CODE_ASSIST

--- a/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
+++ b/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
@@ -41,9 +41,9 @@ async:
       delete_minutes: 90
     base_url: '{{op_id}}'
   actions:
-  - create
-  - delete
-  - update
+    - create
+    - delete
+    - update
   type: OpAsync
   result:
     resource_inside_response: true

--- a/mmv1/products/gemini/product.yaml
+++ b/mmv1/products/gemini/product.yaml
@@ -19,5 +19,5 @@ scopes:
 versions:
   - base_url: https://cloudaicompanion.googleapis.com/v1/
     name: 'ga'
-  - base_url: https://cloudaicompanion.googleapis.com/v1/
+  - base_url: https://staging-cloudaicompanion.sandbox.googleapis.com/v1/
     name: 'beta'

--- a/mmv1/products/gemini/product.yaml
+++ b/mmv1/products/gemini/product.yaml
@@ -19,5 +19,5 @@ scopes:
 versions:
   - base_url: https://cloudaicompanion.googleapis.com/v1/
     name: 'ga'
-  - base_url: https://staging-cloudaicompanion.sandbox.googleapis.com/v1/
+  - base_url: https://cloudaicompanion.googleapis.com/v1/
     name: 'beta'

--- a/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_gemini_data_sharing_with_google_setting" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "{{index $.Vars "data_sharing_with_google_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    enable_preview_data_sharing = true
+}

--- a/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_binding_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_gemini_data_sharing_with_google_setting" "basic" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "{{index $.Vars "data_sharing_with_google_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    enable_preview_data_sharing = true
+}
+
+resource "google_gemini_data_sharing_with_google_setting_binding" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "{{index $.Vars "data_sharing_with_google_setting_id"}}"
+    setting_binding_id = "{{index $.Vars "setting_binding_id"}}"
+    location = "global"
+    target = "{{index $.Vars "target"}}"
+    depends_on = [google_gemini_data_sharing_with_google_setting.basic]
+}

--- a/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_gemini_gemini_gcp_enablement_setting" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "{{index $.Vars "gemini_gcp_enablement_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    enable_customer_data_sharing = true
+}

--- a/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_binding_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "{{index $.Vars "gemini_gcp_enablement_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    enable_customer_data_sharing = true
+}
+
+resource "google_gemini_gemini_gcp_enablement_setting_binding" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "{{index $.Vars "gemini_gcp_enablement_setting_id"}}"
+    setting_binding_id = "{{index $.Vars "setting_binding_id"}}"
+    location = "global"
+    target = "{{index $.Vars "target"}}"
+    depends_on = [google_gemini_gemini_gcp_enablement_setting.basic]
+}

--- a/mmv1/templates/terraform/examples/gemini_logging_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_logging_setting_basic.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_gemini_logging_setting" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    logging_setting_id = "{{index $.Vars "name"}}"
+    location = "global"
+    log_prompts_and_responses = true
+}

--- a/mmv1/templates/terraform/examples/gemini_logging_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_logging_setting_basic.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_gemini_logging_setting" "{{$.PrimaryResourceId}}" {
     provider = google-beta
-    logging_setting_id = "{{index $.Vars "name"}}"
+    logging_setting_id = "{{index $.Vars "logging_setting_id"}}"
     location = "global"
+    project = "{{index $.Vars "project_id"}}"
     log_prompts_and_responses = true
 }

--- a/mmv1/templates/terraform/examples/gemini_logging_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_logging_setting_binding_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_gemini_logging_setting" "basic" {
+    provider = google-beta
+    logging_setting_id = "{{index $.Vars "logging_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    log_prompts_and_responses = true
+}
+
+resource "google_gemini_logging_setting_binding" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    logging_setting_id = "{{index $.Vars "logging_setting_id"}}"
+    setting_binding_id = "{{index $.Vars "setting_binding_id"}}"
+    location = "global"
+    target = "{{index $.Vars "target"}}"
+    depends_on = [google_gemini_logging_setting.basic]
+}

--- a/mmv1/templates/terraform/examples/gemini_release_channel_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_release_channel_setting_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_gemini_release_channel_setting" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    release_channel_setting_id = "{{index $.Vars "release_channel_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    release_channel = "EXPERIMENTAL"
+}

--- a/mmv1/templates/terraform/examples/gemini_release_channel_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_release_channel_setting_binding_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_gemini_release_channel_setting" "basic" {
+    provider = google-beta
+    release_channel_setting_id = "{{index $.Vars "release_channel_setting_id"}}"
+    location = "global"
+    project = "{{index $.Vars "project_id"}}"
+    release_channel = "EXPERIMENTAL"
+}
+
+resource "google_gemini_release_channel_setting_binding" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    release_channel_setting_id = "{{index $.Vars "release_channel_setting_id"}}"
+    setting_binding_id = "{{index $.Vars "setting_binding_id"}}"
+    location = "global"
+    target = "{{index $.Vars "target"}}"
+    depends_on = [google_gemini_release_channel_setting.basic]
+}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_binding_test.go.tmpl
@@ -1,0 +1,98 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiDataSharingWithGoogleSettingBinding_geminiDataSharingWithGoogleSettingBindingBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"data_sharing_with_google_setting_id": "ls-tf1",
+		"setting_binding_id": "ls-tf1b1",
+		"project_id":         "aandrei-test",
+		"target":             "projects/980109375338",
+		"new_target":         "projects/283661608541",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDataSharingWithGoogleSettingBinding_geminiDataSharingWithGoogleSettingBindingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiDataSharingWithGoogleSettingBinding_geminiDataSharingWithGoogleSettingBindingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_data_sharing_with_google_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiDataSharingWithGoogleSettingBinding_geminiDataSharingWithGoogleSettingBindingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "basic" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    enable_preview_data_sharing = true
+}
+
+resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{target}"
+	depends_on = [google_gemini_data_sharing_with_google_setting.basic]
+}
+`, context)
+}
+
+func testAccGeminiDataSharingWithGoogleSettingBinding_geminiDataSharingWithGoogleSettingBindingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "basic" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    enable_preview_data_sharing = true
+}
+
+resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{new_target}"
+	depends_on = [google_gemini_data_sharing_with_google_setting.basic]
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_test.go.tmpl
@@ -1,0 +1,70 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"setting_id": "ls-tf1",
+		"project_id": "aandrei-test",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_data_sharing_with_google_setting.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+func testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "example" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+    enable_preview_data_sharing = true
+}
+`, context)
+}
+func testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "example" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+    enable_preview_data_sharing = false
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_binding_test.go.tmpl
@@ -1,0 +1,98 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiGeminiGcpEnablementSettingBinding_geminiGeminiGcpEnablementSettingBindingBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"gemini_gcp_enablement_setting_id": "ls-tf1",
+		"setting_binding_id": "ls-tf1b1",
+		"project_id":         "aandrei-test",
+		"target":             "projects/980109375338",
+		"new_target":         "projects/283661608541",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiGeminiGcpEnablementSettingBinding_geminiGeminiGcpEnablementSettingBindingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_gemini_gcp_enablement_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gemini_gcp_enablement_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiGeminiGcpEnablementSettingBinding_geminiGeminiGcpEnablementSettingBindingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_gemini_gcp_enablement_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_gemini_gcp_enablement_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gemini_gcp_enablement_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiGeminiGcpEnablementSettingBinding_geminiGeminiGcpEnablementSettingBindingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{gemini_gcp_enablement_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+	enable_customer_data_sharing = true
+}
+
+resource "google_gemini_gemini_gcp_enablement_setting_binding" "basic_binding" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{gemini_gcp_enablement_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{target}"
+	depends_on = [google_gemini_gemini_gcp_enablement_setting.basic]
+}
+`, context)
+}
+
+func testAccGeminiGeminiGcpEnablementSettingBinding_geminiGeminiGcpEnablementSettingBindingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{gemini_gcp_enablement_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+	enable_customer_data_sharing = true
+}
+
+resource "google_gemini_gemini_gcp_enablement_setting_binding" "basic_binding" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{gemini_gcp_enablement_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{new_target}"
+	depends_on = [google_gemini_gemini_gcp_enablement_setting.basic]
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go.tmpl
@@ -1,0 +1,70 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_update(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"setting_id": "ls-tf1",
+		"project_id": "aandrei-test",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_gemini_gcp_enablement_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gemini_gcp_enablement_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_gemini_gcp_enablement_setting.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_gemini_gcp_enablement_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "gemini_gcp_enablement_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+func testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_gemini_gcp_enablement_setting" "example" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+	enable_customer_data_sharing = true
+}
+`, context)
+}
+func testAccGeminiGeminiGcpEnablementSetting_geminiGeminiGcpEnablementSettingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_gemini_gcp_enablement_setting" "example" {
+    provider = google-beta
+    gemini_gcp_enablement_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+	enable_customer_data_sharing = false
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_binding_test.go.tmpl
@@ -1,0 +1,98 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiLoggingSettingBinding_geminiLoggingSettingBindingBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"logging_setting_id": "ls-tf1",
+		"setting_binding_id": "ls-tf1b1",
+		"project_id":         "aandrei-test",
+		"target":             "projects/980109375338",
+		"new_target":         "projects/283661608541",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiLoggingSettingBinding_geminiLoggingSettingBindingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_logging_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "logging_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiLoggingSettingBinding_geminiLoggingSettingBindingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_logging_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_logging_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "logging_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiLoggingSettingBinding_geminiLoggingSettingBindingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_logging_setting" "basic" {
+    provider = google-beta
+    logging_setting_id = "%{logging_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    log_prompts_and_responses = true
+}
+
+resource "google_gemini_logging_setting_binding" "basic_binding" {
+    provider = google-beta
+    logging_setting_id = "%{logging_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{target}"
+	depends_on = [google_gemini_logging_setting.basic]
+}
+`, context)
+}
+
+func testAccGeminiLoggingSettingBinding_geminiLoggingSettingBindingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_logging_setting" "basic" {
+    provider = google-beta
+    logging_setting_id = "%{logging_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    log_prompts_and_responses = true
+}
+
+resource "google_gemini_logging_setting_binding" "basic_binding" {
+    provider = google-beta
+    logging_setting_id = "%{logging_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{new_target}"
+	depends_on = [google_gemini_logging_setting.basic]
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_test.go.tmpl
@@ -18,7 +18,6 @@ func TestAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_update(t *test
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		// CheckDestroy:             testAccCheckGeminiLoggingSettingDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_basic(context),

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_logging_setting_test.go.tmpl
@@ -1,0 +1,71 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_update(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"setting_id": "ls-tf1",
+		"project_id": "aandrei-test",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		// CheckDestroy:             testAccCheckGeminiLoggingSettingDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_logging_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "logging_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_logging_setting.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_logging_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "logging_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+func testAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_logging_setting" "example" {
+    provider = google-beta
+    logging_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+	log_prompts_and_responses = true
+}
+`, context)
+}
+func testAccGeminiLoggingSetting_geminiLoggingSettingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_logging_setting" "example" {
+    provider = google-beta
+    logging_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+	log_prompts_and_responses = false
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_release_channel_setting_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_release_channel_setting_binding_test.go.tmpl
@@ -1,0 +1,98 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiReleaseChannelSettingBinding_geminiReleaseChannelSettingBindingBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"release_channel_setting_id": "ls-tf1",
+		"setting_binding_id": "ls-tf1b1",
+		"project_id":         "aandrei-test",
+		"target":             "projects/980109375338",
+		"new_target":         "projects/283661608541",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiReleaseChannelSettingBinding_geminiReleaseChannelSettingBindingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_release_channel_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "release_channel_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiReleaseChannelSettingBinding_geminiReleaseChannelSettingBindingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_release_channel_setting_binding.basic_binding", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_release_channel_setting_binding.basic_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "release_channel_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccGeminiReleaseChannelSettingBinding_geminiReleaseChannelSettingBindingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_release_channel_setting" "basic" {
+    provider = google-beta
+    release_channel_setting_id = "%{release_channel_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    release_channel = "EXPERIMENTAL"
+}
+
+resource "google_gemini_release_channel_setting_binding" "basic_binding" {
+    provider = google-beta
+    release_channel_setting_id = "%{release_channel_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{target}"
+	depends_on = [google_gemini_release_channel_setting.basic]
+}
+`, context)
+}
+
+func testAccGeminiReleaseChannelSettingBinding_geminiReleaseChannelSettingBindingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_release_channel_setting" "basic" {
+    provider = google-beta
+    release_channel_setting_id = "%{release_channel_setting_id}"
+	location = "global"
+	project = "%{project_id}"
+    release_channel = "EXPERIMENTAL"
+}
+
+resource "google_gemini_release_channel_setting_binding" "basic_binding" {
+    provider = google-beta
+    release_channel_setting_id = "%{release_channel_setting_id}"
+    setting_binding_id = "%{setting_binding_id}"
+	location = "global"
+	project = "%{project_id}"
+	target = "%{new_target}"
+	depends_on = [google_gemini_release_channel_setting.basic]
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_release_channel_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_release_channel_setting_test.go.tmpl
@@ -1,0 +1,70 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiReleaseChannelSetting_geminiReleaseChannelSettingBasicExample_update(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"setting_id": "ls-tf1",
+		"project_id": "aandrei-test",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiReleaseChannelSetting_geminiReleaseChannelSettingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_release_channel_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "release_channel_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiReleaseChannelSetting_geminiReleaseChannelSettingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_release_channel_setting.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_release_channel_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "release_channel_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+func testAccGeminiReleaseChannelSetting_geminiReleaseChannelSettingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_release_channel_setting" "example" {
+    provider = google-beta
+    release_channel_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+    release_channel = "EXPERIMENTAL"
+}
+`, context)
+}
+func testAccGeminiReleaseChannelSetting_geminiReleaseChannelSettingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_release_channel_setting" "example" {
+    provider = google-beta
+    release_channel_setting_id = "%{setting_id}"
+    location = "global"
+	project = "%{project_id}"
+    release_channel = "STABLE"
+}
+`, context)
+}
+{{ end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Add new resources for Gemini Admin Control
```release-note:new-resource
`google_gemini_data_sharing_with_google_setting_binding`
```
