### PR TITLE
Promote workload identity federation data sources to ga

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -135,10 +135,8 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_iam_policy":                                resourcemanager.DataSourceGoogleIamPolicy(),
 	"google_iam_role":                                  resourcemanager.DataSourceGoogleIamRole(),
 	"google_iam_testable_permissions":                  resourcemanager.DataSourceGoogleIamTestablePermissions(),
-	{{- if ne $.TargetVersionName "ga" }}
 	"google_iam_workload_identity_pool":                iambeta.DataSourceIAMBetaWorkloadIdentityPool(),
 	"google_iam_workload_identity_pool_provider":       iambeta.DataSourceIAMBetaWorkloadIdentityPoolProvider(),
-	{{- end }}
 	"google_iap_client":                                iap.DataSourceGoogleIapClient(),
 	"google_kms_crypto_key":                            kms.DataSourceGoogleKmsCryptoKey(),
 	"google_kms_crypto_keys":                           kms.DataSourceGoogleKmsCryptoKeys(),

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 
@@ -41,4 +40,3 @@ func dataSourceIAMBetaWorkloadIdentityPoolRead(d *schema.ResourceData, meta inte
 
 	return nil
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_provider.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_provider.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 
@@ -42,4 +41,3 @@ func dataSourceIAMBetaWorkloadIdentityPoolProviderRead(d *schema.ResourceData, m
 
 	return nil
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_provider_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -58,4 +57,3 @@ data "google_iam_workload_identity_pool_provider" "foo" {
 }
 `, context)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/data_source_iam_workload_identity_pool_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -44,4 +43,3 @@ data "google_iam_workload_identity_pool" "foo" {
 }
 `, context)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_id_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"strings"
 	"testing"
@@ -33,4 +32,3 @@ func TestValidateIAMBetaWorkloadIdentityPoolId(t *testing.T) {
 		t.Errorf("Failed to validate WorkloadIdentityPool names: %v", es)
 	}
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_id_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_id_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"strings"
 	"testing"
@@ -33,4 +32,3 @@ func TestValidateIAMBetaWorkloadIdentityPoolProviderId(t *testing.T) {
 		t.Errorf("Failed to validate WorkloadIdentityPoolProvider names: %v", es)
 	}
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_provider_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"testing"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -330,5 +329,3 @@ resource "google_iam_workload_identity_pool_provider" "example" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go.tmpl
@@ -1,6 +1,5 @@
 package iambeta_test
 
-{{ if ne $.TargetVersionName `ga` -}}
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -98,4 +97,3 @@ resource "google_iam_workload_identity_pool" "my_pool" {
 }
 `, suffix)
 }
-{{- end }}


### PR DESCRIPTION
```release-note: enhancement
iambeta: Promoted data sources `google_iam_workload_identity_pool` and `google_iam_workload_identity_pool_provider` to GA
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/21079