### PR TITLE
Adding API Docs for google_resource_manager_lien for registry

### DIFF
--- a/mmv1/products/resourcemanager/Lien.yaml
+++ b/mmv1/products/resourcemanager/Lien.yaml
@@ -16,6 +16,10 @@ name: 'Lien'
 description:
   A Lien represents an encumbrance on the actions that can be performed on a
   resource.
+references:
+  guides:
+    'Create a Lien': 'https://cloud.google.com/resource-manager/docs/project-liens'
+  api: 'https://cloud.google.com/resource-manager/reference/rest'
 docs:
 id_format: '{{name}}'
 base_url: 'liens'


### PR DESCRIPTION
Adding API Docs for  google_resource_manager_lien for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
resourcemanager: added API Docs for google_resource_manager_lien 
```