### PR TITLE
Add fields to support configuring new Media CDN features via Terraform.

### DIFF
--- a/mmv1/products/networkservices/EdgeCacheService.yaml
+++ b/mmv1/products/networkservices/EdgeCacheService.yaml
@@ -329,6 +329,24 @@ properties:
                           # TODO: (scottsuarez) conflicts also won't work for array path matchers yet, uncomment here once supported.
                           # conflicts:
                           #   - Routing.PathMatcher.RouteRule.prefixMatch
+                  - name: 'routeMethods'
+                    type: NestedObject
+                    description: |
+                      Allow overriding the set of methods that are allowed for this route.
+                      When not set, Media CDN allows only "GET", "HEAD", and "OPTIONS".
+                    properties:
+                      - name: 'allowedMethods'
+                        type: Array
+                        description: |
+                          The non-empty set of HTTP methods that are allowed for this route.
+
+                          Any combination of "GET", "HEAD", "OPTIONS", "PUT", "POST", "DELETE", and "PATCH".
+                        item_type:
+                          type: String
+                        min_size: 1
+                        max_size: 7
+                        item_validation:
+                          regex: '^(?:GET|HEAD|OPTIONS|PUT|POST|DELETE|PATCH)$'
                   - name: 'headerAction'
                     type: NestedObject
                     description: |
@@ -818,6 +836,15 @@ properties:
                             type: Boolean
                             description: |
                               If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+                      - name: 'compressionMode'
+                        type: Enum
+                        description: |
+                          Setting the compression mode to automatic enables dynamic compression for every eligible response.
+
+                          When dynamic compression is enabled, it is recommended to also set a cache policy to maximize efficiency.
+                        enum_values:
+                          - 'DISABLED'
+                          - 'AUTOMATIC'
                   - name: 'origin'
                     type: String
                     description: |

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
@@ -77,6 +77,7 @@ resource "google_network_services_edge_cache_service" "served" {
             cache_mode  = "CACHE_ALL_STATIC"
             default_ttl = "3600s"
           }
+          compression_mode = "AUTOMATIC"
         }
         header_action {
           response_header_to_add {
@@ -130,6 +131,9 @@ resource "google_network_services_edge_cache_service" "served" {
             cache_mode  = "CACHE_ALL_STATIC"
             default_ttl = "3600s"
           }
+        }
+        route_methods {
+          allowed_methods = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "DELETE", "PATCH"]
         }
         header_action {
           response_header_to_add {


### PR DESCRIPTION
Add fields to support new Media CDN features via Terraform.
 
Feature: Dynamic Compression.
Documentation: http://cloud/media-cdn/docs/dynamic-compression
  - Added compression_mode Enum [DISABLED, AUTOMATIC]

Setting the mode to automatic enables dynamic compression for every eligible response. Further, it instructs Media CDN to automatically choose the best compression algorithm.

Feature: HTTP Method Filtering.
Documentation: https://cloud.google.com/media-cdn/docs/routing#method-filtering
  - Added allowed_methods Array[String]

By default, Media CDN proxies only GET, HEAD, and OPTIONS methods to your origin and filters out the methods that can modify your origin. You can override this default behavior for a specific route rule by specifying the methods that you would like proxied to your origin. Besides GET, HEAD, and OPTIONS, Media CDN supports PUT, POST, DELETE, and PATCH.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21064

```release-note:enhancement
networkservices: added `compression_mode` and `allowed_methods` fields to `edge_cache_service` resource
```