### PR TITLE
Add etag checks to ACM directional policy resources

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
@@ -207,4 +207,4 @@ properties:
     type: String
     output: true
     description: |
-      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.
+      The perimeter etag is internally used to prevent overwriting the list of policies on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of policies. The policy defined in this resource is added or removed from that list, and then this etag is sent with the PATCH call along with the updated policies.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunEgressPolicy.yaml
@@ -71,9 +71,10 @@ nested_query:
 custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   encoder: 'templates/terraform/encoders/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl'
-  pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl'
   pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
-  pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
@@ -202,3 +203,8 @@ properties:
       The name of the Access Policy this resource belongs to.
     ignore_read: true
     output: true
+  - name: 'etag'
+    type: String
+    output: true
+    description: |
+      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
@@ -215,4 +215,4 @@ properties:
     type: String
     output: true
     description: |
-      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.
+      The perimeter etag is internally used to prevent overwriting the list of policies on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of policies. The policy defined in this resource is added or removed from that list, and then this etag is sent with the PATCH call along with the updated policies.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterDryRunIngressPolicy.yaml
@@ -72,9 +72,10 @@ nested_query:
 custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   encoder: 'templates/terraform/encoders/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl'
-  pre_create: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl'
   pre_update: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
-  pre_delete: 'templates/terraform/pre_create/access_context_manager_dry_run_resource.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
@@ -210,3 +211,8 @@ properties:
       The name of the Access Policy this resource belongs to.
     ignore_read: true
     output: true
+  - name: 'etag'
+    type: String
+    output: true
+    description: |
+      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
@@ -206,4 +206,4 @@ properties:
     type: String
     output: true
     description: |
-      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.
+      The perimeter etag is internally used to prevent overwriting the list of policies on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of policies. The policy defined in this resource is added or removed from that list, and then this etag is sent with the PATCH call along with the updated policies.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterEgressPolicy.yaml
@@ -72,6 +72,9 @@ custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_egress_policy.go.tmpl'
   encoder: 'templates/terraform/encoders/access_context_manager_service_perimeter_egress_policy.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/access_context_manager_service_perimeter_egress_policy.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/access_context_manager_service_perimeter_egress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
 exclude_sweeper: true
@@ -199,3 +202,8 @@ properties:
       The name of the Access Policy this resource belongs to.
     ignore_read: true
     output: true
+  - name: 'etag'
+    type: String
+    output: true
+    description: |
+      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -217,4 +217,4 @@ properties:
     type: String
     output: true
     description: |
-      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.
+      The perimeter etag is internally used to prevent overwriting the list of policies on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of policies. The policy defined in this resource is added or removed from that list, and then this etag is sent with the PATCH call along with the updated policies.

--- a/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterIngressPolicy.yaml
@@ -73,6 +73,9 @@ custom_code:
   constants: 'templates/terraform/constants/access_context_manager.go.tmpl'
   custom_import: 'templates/terraform/custom_import/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
   encoder: 'templates/terraform/encoders/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
+  post_read: 'templates/terraform/post_read/access_context_manager_service_perimeter_resource.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/access_context_manager_service_perimeter_ingress_policy.go.tmpl'
 exclude_tgc: true
 # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
 exclude_sweeper: true
@@ -210,3 +213,8 @@ properties:
       The name of the Access Policy this resource belongs to.
     ignore_read: true
     output: true
+  - name: 'etag'
+    type: String
+    output: true
+    description: |
+      The perimeter etag is internally used to prevent overwriting the list of perimeter resources on PATCH calls. It is retrieved from the same GET perimeter API call that's used to get the current list of resources. The resource to add or remove is merged into that list and then this etag is sent with the PATCH call along with the updated resource list.

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl
@@ -1,0 +1,17 @@
+obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.egressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl
@@ -1,0 +1,17 @@
+obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.ingressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_egress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_egress_policy.go.tmpl
@@ -1,0 +1,15 @@
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"status.egressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_ingress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/access_context_manager_service_perimeter_ingress_policy.go.tmpl
@@ -1,0 +1,15 @@
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"status.ingressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_egress_policy.go.tmpl
@@ -1,0 +1,17 @@
+obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.egressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_dry_run_ingress_policy.go.tmpl
@@ -1,0 +1,17 @@
+obj["use_explicit_dry_run_spec"] = true
+
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"spec.ingressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_egress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_egress_policy.go.tmpl
@@ -1,0 +1,15 @@
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"status.egressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}

--- a/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_ingress_policy.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/access_context_manager_service_perimeter_ingress_policy.go.tmpl
@@ -1,0 +1,15 @@
+etag := d.Get("etag").(string)
+
+if etag == "" {
+	log.Printf("[ERROR] Unable to get etag: %s", err)
+	return nil
+}
+obj["etag"] = etag
+
+// updateMask is a URL parameter but not present in the schema, so ReplaceVars
+// won't set it
+updateMask := []string{"status.ingressPolicies", "etag"}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Continuation of multiple PRs over the last month like #12736. This PR adds etag checks to the enforced and dry run resources for ACM directional policies (ingress and egress rules).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
accesscontextmanager: added `etag` to access context manager directional policy resources to prevent overriding changes
```
