### PR TITLE
Add Gemini Data Sharing With Google Setting resource

### DIFF
--- a/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSetting.yaml
@@ -1,0 +1,70 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: DataSharingWithGoogleSetting
+description: The resource for managing DataSharingWithGoogle settings for Admin Control.
+base_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings?dataSharingWithGoogleSettingId={{data_sharing_with_google_setting_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+mutex: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
+examples:
+  - name: gemini_data_sharing_with_google_setting_basic
+    min_version: 'beta'
+    primary_resource_id: example
+    vars:
+      data_sharing_with_google_setting_id: ls1-tf
+autogen_async: false
+autogen_status: RGF0YVNoYXJpbmdXaXRoR29vZ2xlU2V0dGluZw==
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: dataSharingWithGoogleSettingId
+    type: String
+    description: |-
+      Required. Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      data_sharing_with_google_setting_id from the method_signature of Create RPC
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/dataSharingWithGoogleSettings/{dataSharingWithGoogleSetting}
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. [Output only] Create time stamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. [Output only] Update time stamp.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Optional. Labels as key value pairs.
+  - name: enablePreviewDataSharing
+    type: Boolean
+    description: Optional. Whether preview data sharing should be enabled.

--- a/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_basic.tf.tmpl
@@ -1,0 +1,6 @@
+resource "google_gemini_data_sharing_with_google_setting" "{{$.PrimaryResourceId}}" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "{{index $.Vars "data_sharing_with_google_setting_id"}}"
+    location = "global"
+    enable_preview_data_sharing = true
+}

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_test.go.tmpl
@@ -1,0 +1,67 @@
+package gemini_test
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{
+		"setting_id": "ls-tf1",
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_basic(context),
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+			{
+				Config: testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gemini_data_sharing_with_google_setting.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_gemini_data_sharing_with_google_setting.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "data_sharing_with_google_setting_id", "terraform_labels"},
+			},
+		},
+	})
+}
+func testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "example" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{setting_id}"
+    location = "global"
+    enable_preview_data_sharing = true
+}
+`, context)
+}
+func testAccGeminiDataSharingWithGoogleSetting_geminiDataSharingWithGoogleSettingBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_gemini_data_sharing_with_google_setting" "example" {
+    provider = google-beta
+    data_sharing_with_google_setting_id = "%{setting_id}"
+    location = "global"
+    enable_preview_data_sharing = false
+}
+`, context)
+}
+{{ end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Add new resources for Gemini Admin Control
```release-note:new-resource
`google_gemini_data_sharing_with_google_setting`
```
