### PR TITLE
Update ChatEngine documentation

### DIFF
--- a/mmv1/products/discoveryengine/ChatEngine.yaml
+++ b/mmv1/products/discoveryengine/ChatEngine.yaml
@@ -103,7 +103,7 @@ properties:
   - name: 'dataStoreIds'
     type: Array
     description: |
-      The data stores associated with this engine. Multiple DataStores in the same Collection can be associated here. All listed DataStores must be `SOLUTION_TYPE_CHAT`. Adding or removing data stores will force recreation.
+      The data stores associated with this engine. Multiple DataStores in the same Collection can be associated here. All listed DataStores must be `SOLUTION_TYPE_CHAT`. 
     required: true
     item_type:
       type: String

--- a/mmv1/products/discoveryengine/ChatEngine.yaml
+++ b/mmv1/products/discoveryengine/ChatEngine.yaml
@@ -103,7 +103,7 @@ properties:
   - name: 'dataStoreIds'
     type: Array
     description: |
-      The data stores associated with this engine. Multiple DataStores in the same Collection can be associated here. All listed DataStores must be `SOLUTION_TYPE_CHAT`. 
+      The data stores associated with this engine. Multiple DataStores in the same Collection can be associated here. All listed DataStores must be `SOLUTION_TYPE_CHAT`.
     required: true
     item_type:
       type: String


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The documentation for the `google_discovery_engine_chat_engine` resource incorrectly states that updating the `data_store_ids` field will force recreation. As this field is not immutable, adding or deleting IDs will result in the resource to be patched, instead of re-created.

Initially, this field was was set to be immutable, but this has been changed in [this pr](https://github.com/GoogleCloudPlatform/magic-modules/pull/11889/files#diff-d19f7c8370bbdea9f665b6e233bde07f0fa14a4efe9d013a4cfe3ba0090f8483). However, it seems that the documentation was not updated correctly.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
discoveryengine: update description for  the `data_store_ids` field in `google_discovery_engine_chat_engine` resource.
```
