### PR TITLE
Adding API Docs for google_privileged_access_manager_entitlement for registry 

### DIFF
--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -15,6 +15,11 @@
 name: 'Entitlement'
 description: |
   An Entitlement defines the eligibility of a set of users to obtain a predefined access for some time possibly after going through an approval workflow.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/iam/docs/pam-overview'
+    'How to create an Entitlement': 'https://cloud.google.com/iam/docs/pam-create-entitlements'
+  api: 'https://cloud.google.com/iam/docs/reference/pam/rest'
 docs:
 id_format: '{{parent}}/locations/{{location}}/entitlements/{{entitlement_id}}'
 base_url: '{{parent}}/locations/{{location}}/entitlements'


### PR DESCRIPTION
Adding API Docs for  google_privileged_access_manager_entitlement for registry 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```