### PR TITLE
Add diff suppression for the renewal_plan field in google_bigquery_capacity_commitment

### DIFF
--- a/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
+++ b/mmv1/products/bigqueryreservation/CapacityCommitment.yaml
@@ -109,6 +109,7 @@ properties:
     type: String
     description: |
       The plan this capacity commitment is converted to after commitmentEndTime passes. Once the plan is changed, committed period is extended according to commitment plan. Only applicable for some commitment plans.
+    diff_suppress_func: 'bigqueryReservationCapacityCommitmentPlanDiffSuppressFunc'
   - name: 'edition'
     type: String
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes b/392883972. `plan` and `renewal_plan` are both `CommitmentPlan` and should share the same diff suppression logic: https://cloud.google.com/bigquery/docs/reference/reservations/rpc/google.cloud.bigquery.reservation.v1#capacitycommitment.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigquery: added diff suppression for legacy values in `renewal_plan` field in `google_bigquery_capacity_commitment` resource
```
