### PR TITLE
implement hacky workaround so downstreams runs in the merge queue.

### DIFF
--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -8,7 +8,7 @@ on:
       - 'FEATURE-BRANCH-*'
   merge_group:
     types: [checks_requested]
-
+  pull_request:    
 
 concurrency:
   group: ${{ github.event_name == 'merge_group' && format('merge-group-{0}', github.event.merge_group.head_sha) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('commit-{0}', github.sha) }}
@@ -17,23 +17,28 @@ concurrency:
 jobs:
 
   terraform-provider-google:
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-provider-google'
   terraform-provider-google-beta:
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-provider-google-beta'
   terraform-google-conversion:
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-google-conversion'
   docs-examples:
+    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'docs-examples'
 
   unit-test-terraform-provider-google:
+    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-provider-google
     needs: terraform-provider-google
     uses: ./.github/workflows/unit-test-tpg.yml
@@ -41,6 +46,7 @@ jobs:
       repo: 'terraform-provider-google'
 
   unit-test-terraform-provider-googele-beta:
+    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-provider-google-beta
     needs: terraform-provider-google-beta
     uses: ./.github/workflows/unit-test-tpg.yml
@@ -48,6 +54,7 @@ jobs:
       repo: 'terraform-provider-google-beta'
 
   unit-test-terraform-google-conversion:
+    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-google-conversion
     needs: [terraform-google-conversion, terraform-provider-google-beta]
     uses: ./.github/workflows/unit-test-tgc.yml

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -17,28 +17,23 @@ concurrency:
 jobs:
 
   terraform-provider-google:
-    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-provider-google'
   terraform-provider-google-beta:
-    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-provider-google-beta'
   terraform-google-conversion:
-    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'terraform-google-conversion'
   docs-examples:
-    if: ${{ github.event_name != 'pull_request' }}
     uses: ./.github/workflows/build-downstream.yml
     with:
       repo: 'docs-examples'
 
   unit-test-terraform-provider-google:
-    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-provider-google
     needs: terraform-provider-google
     uses: ./.github/workflows/unit-test-tpg.yml
@@ -46,7 +41,6 @@ jobs:
       repo: 'terraform-provider-google'
 
   unit-test-terraform-provider-googele-beta:
-    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-provider-google-beta
     needs: terraform-provider-google-beta
     uses: ./.github/workflows/unit-test-tpg.yml
@@ -54,7 +48,6 @@ jobs:
       repo: 'terraform-provider-google-beta'
 
   unit-test-terraform-google-conversion:
-    if: ${{ github.event_name != 'pull_request' }}
     name: terraform-google-conversion
     needs: [terraform-google-conversion, terraform-provider-google-beta]
     uses: ./.github/workflows/unit-test-tgc.yml

--- a/.github/workflows/downstreams.yml
+++ b/.github/workflows/downstreams.yml
@@ -8,7 +8,7 @@ on:
       - 'FEATURE-BRANCH-*'
   merge_group:
     types: [checks_requested]
-  pull_request:    
+  pull_request:
 
 concurrency:
   group: ${{ github.event_name == 'merge_group' && format('merge-group-{0}', github.event.merge_group.head_sha) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('commit-{0}', github.sha) }}


### PR DESCRIPTION
see https://stackoverflow.com/questions/76655935/when-does-a-github-workflow-trigger-for-merge-group-and-is-it-restricted-by-bran

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
