### PR TITLE
Add support for baseImageUri and buildInfo in Cloud Run V2 Service.template.containers

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -775,7 +775,7 @@ properties:
             - name: 'baseImageUri'
               type: String
               description: |-
-                Base image for this container. Only supported for services. If set, it indicates that the service is enrolled into automatic base image update.
+                Base image for this container. If set, it indicates that the service is enrolled into automatic base image update.
             - name: 'buildInfo'
               type: NestedObject
               description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -772,6 +772,26 @@ properties:
                 Containers which should be started before this container. If specified the container will wait to start until all containers with the listed names are healthy.
               item_type:
                 type: String
+            - name: 'baseImageUri'
+              type: String
+              description: |-
+                Base image for this container. Only supported for services. If set, it indicates that the service is enrolled into automatic base image update.
+            - name: 'buildInfo'
+              type: NestedObject
+              description: |-
+                The build info of the container image.
+              output: true
+              properties:
+                - name: 'functionTarget'
+                  type: String
+                  description: |-
+                    Entry point of the function when the image is a Cloud Run function.
+                  output: true
+                - name: 'source_location'
+                  type: String
+                  description: |-
+                    Source code location of the image.
+                  output: true
       - name: 'volumes'
         type: Array
         description: |-

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_function.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_function.tf.tmpl
@@ -7,6 +7,7 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
+      base_image_uri = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs22"
     }
   }
   build_config {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  "github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
   "github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/cloudrunv2"
@@ -1386,3 +1387,175 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 {{- end }}
+
+func TestAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_update(t *testing.T) {
+        t.Parallel()
+
+        context := map[string]interface{}{
+                "zip_path":      "./test-fixtures/function-source.zip",
+                "random_suffix": acctest.RandString(t, 10),
+        }
+
+        acctest.VcrTest(t, resource.TestCase{
+                PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+                ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+                CheckDestroy:             testAccCheckCloudRunV2ServiceDestroyProducer(t),
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_full(context),
+                        },
+                        {
+                                ResourceName:            "google_cloud_run_v2_service.default",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                                ImportStateVerifyIgnore: []string{"annotations", "deletion_protection", "labels", "location", "name", "terraform_labels"},
+                        },
+                        {
+                                Config: testAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_update(context),
+                                ConfigPlanChecks: resource.ConfigPlanChecks{
+                                        PreApply: []plancheck.PlanCheck{
+                                                plancheck.ExpectResourceAction("google_cloud_run_v2_service.default", plancheck.ResourceActionUpdate),
+                                        },
+                                },
+                        },
+                        {
+                                ResourceName:            "google_cloud_run_v2_service.default",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                                ImportStateVerifyIgnore: []string{"annotations", "deletion_protection", "labels", "location", "name", "terraform_labels"},
+                        },
+                },
+        })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_full(context map[string]interface{}) string {
+        return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      base_image_uri = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs22"
+    }
+  }
+  build_config {
+    source_location = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
+    function_target = "helloHttp"
+    image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
+    base_image = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs22"
+    enable_automatic_updates = true
+    worker_pool = "worker-pool"
+    environment_variables = {
+      FOO_KEY = "FOO_VALUE"
+      BAR_KEY = "BAR_VALUE"
+    }
+    service_account = google_service_account.cloudbuild_service_account.id
+  }
+  depends_on = [
+    google_project_iam_member.act_as,
+    google_project_iam_member.logs_writer
+  ]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${data.google_project.project.project_id}-tf-test-gcf-source%{random_suffix}"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%{zip_path}"  # Add path to the zipped function source code
+}
+
+resource "google_service_account" "cloudbuild_service_account" {
+  account_id = "tf-test-build-sa%{random_suffix}"
+}
+
+resource "google_project_iam_member" "act_as" {
+  project = data.google_project.project.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudbuild_service_account.email}"
+}
+
+resource "google_project_iam_member" "logs_writer" {
+  project = data.google_project.project.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudbuild_service_account.email}"
+}
+`, context)
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_update(context map[string]interface{}) string {
+        return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+      base_image_uri = "us-central1-docker.pkg.dev/serverless-runtimes/google-22/runtimes/nodejs22"
+    }
+  }
+  build_config {
+    source_location = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
+    function_target = "helloHttp"
+    image_uri = "gcr.io/cloudrun/hello:latest"
+    base_image = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs20"
+    enable_automatic_updates = false
+    worker_pool = "worker-pool-2"
+    environment_variables = {
+      FOO_KEY_FOO = "FOO_VALUE_FOO"
+      BAR_KEY_BAR = "BAR_VALUE_BAR"
+    }
+    service_account = google_service_account.cloudbuild_service_account.id
+  }
+  depends_on = [
+    google_project_iam_member.act_as,
+    google_project_iam_member.logs_writer
+  ]
+}
+
+data "google_project" "project" {
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "${data.google_project.project.project_id}-tf-test-gcf-source%{random_suffix}"  # Every bucket name must be globally unique
+  location = "US"
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "object" {
+  name   = "function-source-updated.zip"
+  bucket = google_storage_bucket.bucket.name
+  source = "%{zip_path}"  # Add path to the zipped function source code
+}
+
+resource "google_service_account" "cloudbuild_service_account" {
+  account_id = "tf-test-build-sa-2-%{random_suffix}"
+}
+
+resource "google_project_iam_member" "act_as" {
+  project = data.google_project.project.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.cloudbuild_service_account.email}"
+}
+
+resource "google_project_iam_member" "logs_writer" {
+  project = data.google_project.project.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloudbuild_service_account.email}"
+}
+`, context)
+}


### PR DESCRIPTION
This PR also fixes the update tests for Cloud Run functions by moving the test code from `mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go` to `mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `base_image_uri` and `build_info` to `google_cloud_run_v2_service`
```
