### PR TITLE
Made resources set fields used in the ID format on post-create

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1203,6 +1203,12 @@ func (r Resource) GetIdFormat() string {
 	return idFormat
 }
 
+// Returns true if the Type is in the ID format and false otherwise.
+func (r Resource) InIdFormat(prop Type) bool {
+	fields := r.ExtractIdentifiers(r.GetIdFormat())
+	return slices.Contains(fields, prop.Name)
+}
+
 // ====================
 // Template Methods
 // ====================

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1206,7 +1206,7 @@ func (r Resource) GetIdFormat() string {
 // Returns true if the Type is in the ID format and false otherwise.
 func (r Resource) InIdFormat(prop Type) bool {
 	fields := r.ExtractIdentifiers(r.GetIdFormat())
-	return slices.Contains(fields, prop.Name)
+	return slices.Contains(fields, google.Underscore(prop.Name))
 }
 
 // ====================

--- a/mmv1/products/firebasehosting/Release.yaml
+++ b/mmv1/products/firebasehosting/Release.yaml
@@ -37,7 +37,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  decoder: 'templates/terraform/decoders/firebasehosting_release.go.tmpl'
   post_create: 'templates/terraform/post_create/firebasehosting_release.tmpl'
 exclude_sweeper: true
 examples:
@@ -106,7 +105,7 @@ properties:
     type: String
     description: The unique identifier for the Release.
     min_version: 'beta'
-    ignore_read: true
+    custom_flatten: 'templates/terraform/custom_flatten/id_from_name.tmpl'
     output: true
   - name: 'type'
     type: Enum

--- a/mmv1/products/firebasehosting/Version.yaml
+++ b/mmv1/products/firebasehosting/Version.yaml
@@ -35,7 +35,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  decoder: 'templates/terraform/decoders/firebasehosting_version.go.tmpl'
   post_create: 'templates/terraform/post_create/firebasehosting_version_immediate_finalize.tmpl'
 exclude_sweeper: true
 examples:
@@ -114,7 +113,7 @@ properties:
     type: String
     description: The ID for the version as in sites/SITE_ID/versions/VERSION_ID
     min_version: 'beta'
-    ignore_read: true
+    custom_flatten: 'templates/terraform/custom_flatten/id_from_name.tmpl'
     output: true
   - name: 'config'
     type: NestedObject

--- a/mmv1/templates/terraform/decoders/firebasehosting_release.go.tmpl
+++ b/mmv1/templates/terraform/decoders/firebasehosting_release.go.tmpl
@@ -1,5 +1,0 @@
-if err := d.Set("release_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string))); err != nil {
-    return nil, err
-}
-
-return res, nil

--- a/mmv1/templates/terraform/decoders/firebasehosting_version.go.tmpl
+++ b/mmv1/templates/terraform/decoders/firebasehosting_version.go.tmpl
@@ -1,5 +1,0 @@
-if err := d.Set("version_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string))); err != nil {
-    return nil, err
-}
-
-return res, nil

--- a/mmv1/templates/terraform/post_create/firebasehosting_version_immediate_finalize.tmpl
+++ b/mmv1/templates/terraform/post_create/firebasehosting_version_immediate_finalize.tmpl
@@ -1,14 +1,7 @@
-	// Store the name as ID
-	d.SetId(res["name"].(string))
-
-	if err = d.Set("version_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string))); err != nil {
-		return fmt.Errorf("Error setting version_id: %s", err)
-	}
-
 	obj = make(map[string]interface{})
 	obj["status"] = "FINALIZED"
 
-	url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}FirebaseHostingBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
+	url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}FirebaseHostingBasePath{{"}}"}}sites/{{"{{"}}site_id{{"}}"}}/versions/{{"{{"}}version_id{{"}}"}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -293,6 +293,12 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- if or (not $.GetAsync) (not (and ($.GetAsync.IsA "OpAsync") ($.GetAsync.Allow "Create"))) }}
 {{- range $prop := $.GettableProperties }}
 {{-  if $.InIdFormat $prop }}
+{{-  if eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl" }}
+    // Setting `name` field so that `id_from_name` flattener will work properly.
+    if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(res["name"], d, config)); err != nil {
+        return fmt.Errorf(`Error setting computed identity field "name": %s`, err)
+    }
+{{-  end }}
 {{-    if and $prop.Output (not $prop.IgnoreRead) }}
     if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
         return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -293,11 +293,11 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- if or (not $.GetAsync) (not (and ($.GetAsync.IsA "OpAsync") ($.GetAsync.Allow "Create"))) }}
 {{- range $prop := $.GettableProperties }}
 {{-  if $.InIdFormat $prop }}
-{{-    if $prop.Output }}
+{{-    if and $prop.Output (not $prop.IgnoreRead) }}
     if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
         return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
     }
-{{-    else if $prop.DefaultFromApi }}
+{{-    else if and $prop.DefaultFromApi (not $prop.IgnoreRead) }}
     // {{ underscore $prop.Name }} is set by API when unset
     if tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("{{ underscore $prop.Name }}"))) {
         if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -288,13 +288,23 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- end}}
         return fmt.Errorf("Error creating {{ $.Name -}}: %s", err)
     }
-{{- /* # Set resource properties from create API response (unless it returns an Operation) */}}
-{{- if not (and $.GetAsync ($.GetAsync.IsA "OpAsync")) }}
+{{- /* Set output-only resource properties from create API response (as long as Create doesn't use an async operation) */}}
+{{- /* This is necessary so that the ID is built correctly. */}}
+{{- if or (not $.GetAsync) (not (and ($.GetAsync.IsA "OpAsync") ($.GetAsync.Allow "Create"))) }}
 {{- range $prop := $.GettableProperties }}
-{{-  if and ($.IsInIdentity $prop) $prop.Output }}
+{{-  if $.InIdFormat $prop }}
+{{-    if $prop.Output }}
     if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
         return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
     }
+{{-    else if $prop.DefaultFromApi }}
+    // {{ underscore $prop.Name }} is set by API when unset
+    if tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("{{ underscore $prop.Name }}"))) {
+        if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
+            return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
+        }
+    }
+{{-    end }}
 {{- end}}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
Previously this used 'identity' fields, but that's a rarely-used feature that doesn't reflect the actual reason these are needed: filling out the resource ID. There are a number of post_create custom codes that specifically work around this issue.

I didn't remove the existing custom code since there are a bunch of them and some of them are doing more complex things, so we'd need to verify one-by-one that they are safe to back out - but this should at least remove the need to introduce more custom code like this.

One consideration is that we also need to make sure we're setting anything required by Read, which generally uses SelfLink rather than IdFormat - though they are often the same, it might be necessary to check both.

In particular, if self-link is ever set to `{{name}}`, but IdFormat is something else, the previous default behavior for identity fields was to set a value for `{{name}}` - any resources like this will start to fail.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
