### PR TITLE
Adding in datasource for google_alloydb_instance

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -24,6 +24,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_active_folder":                             resourcemanager.DataSourceGoogleActiveFolder(),
 	"google_alloydb_locations":                         alloydb.DataSourceAlloydbLocations(),
 	"google_alloydb_supported_database_flags":          alloydb.DataSourceAlloydbSupportedDatabaseFlags(),
+	"google_alloydb_instance":          				alloydb.DataSourceAlloydbDatabaseInstance(),
 	"google_artifact_registry_docker_image":            artifactregistry.DataSourceArtifactRegistryDockerImage(),
         "google_artifact_registry_locations":               artifactregistry.DataSourceGoogleArtifactRegistryLocations(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -24,7 +24,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_active_folder":                             resourcemanager.DataSourceGoogleActiveFolder(),
 	"google_alloydb_locations":                         alloydb.DataSourceAlloydbLocations(),
 	"google_alloydb_supported_database_flags":          alloydb.DataSourceAlloydbSupportedDatabaseFlags(),
-	"google_alloydb_instance":          				alloydb.DataSourceAlloydbDatabaseInstance(),
+	"google_alloydb_instance":                          alloydb.DataSourceAlloydbDatabaseInstance(),
 	"google_artifact_registry_docker_image":            artifactregistry.DataSourceArtifactRegistryDockerImage(),
         "google_artifact_registry_locations":               artifactregistry.DataSourceGoogleArtifactRegistryLocations(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
@@ -34,7 +34,6 @@ func DataSourceAlloydbDatabaseInstance() *schema.Resource {
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "instance_id")
 
 	// Set 'Required' schema elements
-
 	dsSchema_m := tpgresource.MergeSchemas(dsScema_cluster_id, dsSchema)
 
 	return &schema.Resource{
@@ -46,7 +45,7 @@ func DataSourceAlloydbDatabaseInstance() *schema.Resource {
 func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 
-	// Get feilds for ID for setting cluster filed in resource
+	// Get feilds for setting cluster field in resource
 	cluster_id := d.Get("cluster_id").(string)
 
 	location, err := tpgresource.GetLocation(d, config)
@@ -64,7 +63,7 @@ func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interfac
 	}
 	d.SetId(id)
 
-	// Setting cluster field
+	// Setting cluster field as this is set as a required field in instance resource
 	d.Set("cluster", fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, cluster_id))
 
 	err = resourceAlloydbInstanceRead(d, meta)

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
@@ -1,7 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package alloydb
 
 import (
 	"fmt"
+
+	// "log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -9,32 +13,38 @@ import (
 )
 
 func DataSourceAlloydbDatabaseInstance() *schema.Resource {
-	// Generate datasource schema from resource
-	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceAlloydbInstance().Schema)
-
-	// Set 'Required' schema elements
-	tpgresource.AddRequiredFieldsToSchema(dsSchema, "cluster", "instance_id")
-
 	return &schema.Resource{
-		Read:   dataSourceAlloydbDatabaseInstanceRead,
-		Schema: dsSchema,
+		Read: dataSourceAlloydbDatabaseInstanceRead,
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the alloydb cluster that the instance belongs to.'alloydb_cluster_id'`,
+			},
+			"instance_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The ID of the alloydb instance.'alloydb_instance_id'`,
+			},
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `Project ID of the project.`,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The canonical ID for the location. For example: "us-east1".`,
+			},
+		},
 	}
 }
 
 func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 
-	// location, err := tpgresource.GetLocation(d, config)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// project, err := tpgresource.GetProject(d, config)
-	// if err != nil {
-	// 	return err
-	// }
-
-	id, err := tpgresource.ReplaceVars(d, config, "{{cluster}}/instances/{{instance_id}}")
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}/instances/{{instance_id}}")
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
@@ -5,50 +5,67 @@ package alloydb
 import (
 	"fmt"
 
-	// "log"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func DataSourceAlloydbDatabaseInstance() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceAlloydbDatabaseInstanceRead,
-		Schema: map[string]*schema.Schema{
-			"cluster_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The ID of the alloydb cluster that the instance belongs to.'alloydb_cluster_id'`,
-			},
-			"instance_id": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The ID of the alloydb instance.'alloydb_instance_id'`,
-			},
-			"project": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `Project ID of the project.`,
-			},
-			"location": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The canonical ID for the location. For example: "us-east1".`,
-			},
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceAlloydbInstance().Schema)
+	// Set custom fields
+	dsScema_cluster_id := map[string]*schema.Schema{
+		"cluster_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: `The ID of the alloydb cluster that the instance belongs to.'alloydb_cluster_id'`,
 		},
+		"project": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `Project ID of the project.`,
+		},
+		"location": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The canonical ID for the location. For example: "us-east1".`,
+		},
+	}
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "instance_id")
+
+	// Set 'Required' schema elements
+
+	dsSchema_m := tpgresource.MergeSchemas(dsScema_cluster_id, dsSchema)
+
+	return &schema.Resource{
+		Read:   dataSourceAlloydbDatabaseInstanceRead,
+		Schema: dsSchema_m,
 	}
 }
 
 func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 
+	// Get feilds for ID for setting cluster filed in resource
+	cluster_id := d.Get("cluster_id").(string)
+
+	location, err := tpgresource.GetLocation(d, config)
+	if err != nil {
+		return err
+	}
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
 	// Store the ID now
 	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}/instances/{{instance_id}}")
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
+
+	// Setting cluster field
+	d.Set("cluster", fmt.Sprintf("projects/%s/locations/%s/clusters/%s", project, location, cluster_id))
 
 	err = resourceAlloydbInstanceRead(d, meta)
 	if err != nil {

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
@@ -1,0 +1,59 @@
+package alloydb
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceAlloydbDatabaseInstance() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceAlloydbInstance().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+
+	return &schema.Resource{
+		Read:   dataSourceAlloydbDatabaseInstanceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	location, err := tpgresource.GetLocation(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, location, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+	d.SetId(id)
+
+	err = resourceAlloydbInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance.go
@@ -13,10 +13,7 @@ func DataSourceAlloydbDatabaseInstance() *schema.Resource {
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceAlloydbInstance().Schema)
 
 	// Set 'Required' schema elements
-	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
-
-	// Set 'Optional' schema elements
-	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "cluster", "instance_id")
 
 	return &schema.Resource{
 		Read:   dataSourceAlloydbDatabaseInstanceRead,
@@ -27,19 +24,19 @@ func DataSourceAlloydbDatabaseInstance() *schema.Resource {
 func dataSourceAlloydbDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 
-	location, err := tpgresource.GetLocation(d, config)
-	if err != nil {
-		return err
-	}
+	// location, err := tpgresource.GetLocation(d, config)
+	// if err != nil {
+	// 	return err
+	// }
 
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return err
-	}
+	// project, err := tpgresource.GetProject(d, config)
+	// if err != nil {
+	// 	return err
+	// }
 
-	id := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, location, d.Get("name").(string))
+	id, err := tpgresource.ReplaceVars(d, config, "{{cluster}}/instances/{{instance_id}}")
 	if err != nil {
-		return err
+		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
 

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
@@ -55,8 +55,8 @@ data "google_compute_network" "default" {
 }
 
 data "google_alloydb_instance" "default" {
-  cluster = google_alloydb_cluster.default.name
-  instance_id = google_alloydb_instance.default.id
+  cluster_id = google_alloydb_cluster.default.cluster_id
+  instance_id = google_alloydb_instance.default.instance_id
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
@@ -55,8 +55,8 @@ data "google_compute_network" "default" {
 }
 
 data "google_alloydb_instance" "default" {
-  name = google_alloydb_instance.default.name
-  location = "us-central1"
+  cluster = google_alloydb_cluster.default.name
+  instance_id = google_alloydb_instance.default.id
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
@@ -1,0 +1,62 @@
+package alloydb_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccAlloydbDatabaseInstanceDatasourceConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "alloydb-instance-mandatory-1"),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbDatabaseInstanceDatasourceConfig(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbDatabaseInstanceDatasourceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network_config {
+    network = data.google_compute_network.default.id
+  }
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+data "google_alloydb_instance" "default" {
+  name = google_alloydb_instance.default.name
+  location = "us-central1"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_database_instance_test.go
@@ -57,6 +57,7 @@ data "google_compute_network" "default" {
 data "google_alloydb_instance" "default" {
   cluster_id = google_alloydb_cluster.default.cluster_id
   instance_id = google_alloydb_instance.default.instance_id
+  location = "us-central1"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
@@ -20,14 +20,23 @@ data "google_alloydb_instance" "qa" {
 
 The following arguments are supported:
 
-* `cluster` -
+* `cluster_id` -
   (Required)
-  Identifies the alloydb cluster. Must be in the format
-  'projects/{project}/locations/{location}/clusters/{cluster_id}'
+  The ID of the alloydb cluster that the instance belongs to.
+  'alloydb_cluster_id'
 
 * `instance_id` -
   (Required)
   The ID of the alloydb instance.
+  'alloydb_instance_id'
+
+* `project` - 
+  (optional) 
+  The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+* `location` -
+  (optional)
+  The canonical id of the location.If it is not provided, the provider project is used. For example: us-east1.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
@@ -1,0 +1,34 @@
+---
+subcategory: "AlloyDB"
+description: |-
+  Fetches the details of available locations.
+---
+
+# google_alloydb_instance
+
+Use this data source to get information about the available instance. For more details refer the [API docs](https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.clusters.instances).
+
+## Example Usage
+
+
+```hcl
+data "google_alloydb_instance" "qa" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cluster` -
+  (Required)
+  Identifies the alloydb cluster. Must be in the format
+  'projects/{project}/locations/{location}/clusters/{cluster_id}'
+
+* `instance_id` -
+  (Required)
+  The ID of the alloydb instance.
+
+## Attributes Reference
+
+See [google_alloydb_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/alloydb_instance) resource for details of all the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/alloydb_instance.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "AlloyDB"
 description: |-
-  Fetches the details of available locations.
+  Fetches the details of available instance.
 ---
 
 # google_alloydb_instance


### PR DESCRIPTION
Adding in a data source for google_alloydb_instance


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.



```release-note:new-datasource
`google_alloydb_instance`
```
