### PR TITLE
Don't allow zone and location to be required toplevel properties

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -451,7 +451,7 @@ func (r *Resource) Validate() {
 	for _, property := range r.AllProperties() {
 		property.Validate(r.Name)
 		if (property.Name == "zone" || property.Name == "location") && property.Required {
-			log.Fatalf("Property %s in resource %s cannot be marked as required", property.Name, r.Name)
+			log.Fatalf("Property %s in resource %s cannot be marked as required to preserve provider-level defaults", property.Name, r.Name)
 		}
 	}
 

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -450,6 +450,9 @@ func (r *Resource) Validate() {
 
 	for _, property := range r.AllProperties() {
 		property.Validate(r.Name)
+		if (property.Name == "zone" || property.Name == "location") && property.Required {
+			log.Fatalf("Property %s in resource %s cannot be marked as required", property.Name, r.Name)
+		}
 	}
 
 	if r.IamPolicy != nil {

--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -103,7 +103,6 @@ parameters:
     description: |
       The location where the alloydb backup should reside.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -130,7 +130,6 @@ parameters:
     description: |
       The location where the alloydb cluster should reside.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/apigee/EndpointAttachment.yaml
+++ b/mmv1/products/apigee/EndpointAttachment.yaml
@@ -70,7 +70,6 @@ properties:
     type: String
     description: |
       Location of the endpoint attachment.
-    required: true
   - name: 'host'
     type: String
     description: |

--- a/mmv1/products/apigee/Instance.yaml
+++ b/mmv1/products/apigee/Instance.yaml
@@ -139,7 +139,6 @@ properties:
     type: String
     description: |
       Required. Compute Engine location where the instance resides.
-    required: true
     immutable: true
   - name: 'peeringCidrRange'
     type: String

--- a/mmv1/products/apphub/Application.yaml
+++ b/mmv1/products/apphub/Application.yaml
@@ -77,7 +77,6 @@ parameters:
     type: String
     description: 'Part of `parent`. See documentation of `projectsId`.'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'applicationId'
     type: String

--- a/mmv1/products/apphub/Service.yaml
+++ b/mmv1/products/apphub/Service.yaml
@@ -79,7 +79,6 @@ parameters:
     type: String
     description: 'Part of `parent`.  Full resource name of a parent Application. Example: projects/{HOST_PROJECT_ID}/locations/{LOCATION}/applications/{APPLICATION_ID}'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'applicationId'
     type: String

--- a/mmv1/products/apphub/Workload.yaml
+++ b/mmv1/products/apphub/Workload.yaml
@@ -77,7 +77,6 @@ parameters:
     type: String
     description: 'Part of `parent`.  Full resource name of a parent Application. Example: projects/{HOST_PROJECT_ID}/locations/{LOCATION}/applications/{APPLICATION_ID}'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'applicationId'
     type: String

--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -40,7 +40,6 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    required: true
     url_param_only: true
     description: |
       The location for the backup plan

--- a/mmv1/products/backupdr/BackupPlanAssociation.yaml
+++ b/mmv1/products/backupdr/BackupPlanAssociation.yaml
@@ -44,7 +44,6 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    required: true
     url_param_only: true
     description: |
       The location for the backupplan association

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -51,7 +51,6 @@ parameters:
     type: String
     description: "The GCP location for the backup vault. "
     url_param_only: true
-    required: true
     immutable: true
   - name: 'backupVaultId'
     type: String

--- a/mmv1/products/backupdr/ManagementServer.yaml
+++ b/mmv1/products/backupdr/ManagementServer.yaml
@@ -55,7 +55,6 @@ parameters:
       The location for the management server (management console)
     min_version: 'beta'
     url_param_only: true
-    required: true
   - name: 'name'
     type: String
     description: |-

--- a/mmv1/products/biglake/Catalog.yaml
+++ b/mmv1/products/biglake/Catalog.yaml
@@ -40,7 +40,6 @@ parameters:
     description: |
       The geographic location where the Catalog should reside.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/bigqueryanalyticshub/DataExchange.yaml
+++ b/mmv1/products/bigqueryanalyticshub/DataExchange.yaml
@@ -76,7 +76,6 @@ properties:
     description: |
       The name of the location this data exchange.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'displayName'
     type: String

--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -93,7 +93,6 @@ properties:
     description: |
       The name of the location this data exchange listing.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'displayName'
     type: String

--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -59,7 +59,6 @@ parameters:
     description: |
       The name of the location for this subscription.
     url_param_only: true
-    required: true
     custom_flatten: 'templates/terraform/custom_flatten/bigquery_dataset_location.go.tmpl'
     diff_suppress_func: 'tpgresource.CaseDiffSuppress'
 properties:
@@ -75,7 +74,6 @@ properties:
         description: |
           The geographic location where the dataset should reside.
           See https://cloud.google.com/bigquery/docs/locations for supported locations.
-        required: true
         custom_flatten: 'templates/terraform/custom_flatten/bigquery_dataset_location.go.tmpl'
         diff_suppress_func: 'tpgresource.CaseDiffSuppress'
       - name: 'datasetReference'

--- a/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
+++ b/mmv1/products/bigquerydatapolicy/DataPolicy.yaml
@@ -74,7 +74,6 @@ properties:
     description: |
       The name of the location of the data policy.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'policyTag'
     type: String

--- a/mmv1/products/bigqueryreservation/BiReservation.yaml
+++ b/mmv1/products/bigqueryreservation/BiReservation.yaml
@@ -51,7 +51,6 @@ parameters:
     description: |
       LOCATION_DESCRIPTION
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/blockchainnodeengine/BlockchainNodes.yaml
+++ b/mmv1/products/blockchainnodeengine/BlockchainNodes.yaml
@@ -54,7 +54,6 @@ parameters:
     description: |
       Location of Blockchain Node being created.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'blockchainNodeId'
     type: String

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -62,7 +62,6 @@ parameters:
     description: |
       The trust config location.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'createTime'

--- a/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
+++ b/mmv1/products/cloudbuild/BitbucketServerConfig.yaml
@@ -74,7 +74,6 @@ parameters:
     description: |
       The location of this bitbucket server config.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/cloudbuildv2/Connection.yaml
+++ b/mmv1/products/cloudbuildv2/Connection.yaml
@@ -70,7 +70,6 @@ parameters:
     type: String
     description: The location for the resource
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'createTime'

--- a/mmv1/products/clouddeploy/Automation.yaml
+++ b/mmv1/products/clouddeploy/Automation.yaml
@@ -61,7 +61,6 @@ parameters:
     type: String
     description: "The location for the resource"
     url_param_only: true
-    required: true
     immutable: true
   - name: 'delivery_pipeline'
     type: String

--- a/mmv1/products/clouddeploy/CustomTargetType.yaml
+++ b/mmv1/products/clouddeploy/CustomTargetType.yaml
@@ -76,7 +76,6 @@ parameters:
     type: String
     description: "The location of the source."
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/clouddomains/Registration.yaml
+++ b/mmv1/products/clouddomains/Registration.yaml
@@ -69,7 +69,6 @@ parameters:
     type: String
     description: "The location for the resource"
     url_param_only: true
-    required: true
   - name: 'domainName'
     type: String
     description: "Required. The domain name. Unicode domain names must be expressed in Punycode format."

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -302,7 +302,6 @@ parameters:
     type: String
     description: The location of this cloud function.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/cloudids/Endpoint.yaml
+++ b/mmv1/products/cloudids/Endpoint.yaml
@@ -52,7 +52,6 @@ parameters:
     description: |
       The location for the endpoint.
     url_param_only: true
-    required: true
     immutable: true
     ignore_read: true
 properties:

--- a/mmv1/products/cloudrun/DomainMapping.yaml
+++ b/mmv1/products/cloudrun/DomainMapping.yaml
@@ -61,7 +61,6 @@ parameters:
     type: String
     description: The location of the cloud run instance. eg us-central1
     url_param_only: true
-    required: true
 properties:
   - name: 'name'
     type: String

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -156,7 +156,6 @@ parameters:
     type: String
     description: The location of the cloud run instance. eg us-central1
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -134,7 +134,6 @@ parameters:
     type: String
     description: The location of the cloud run job
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -189,7 +189,6 @@ parameters:
     type: String
     description: The location of the cloud run service
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -61,7 +61,6 @@ parameters:
     type: String
     description: The location of the queue
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/colab/NotebookExecution.yaml
+++ b/mmv1/products/colab/NotebookExecution.yaml
@@ -73,7 +73,6 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    required: true
     url_param_only: true
     description: 'The location for the resource: https://cloud.google.com/colab/docs/locations'
   - name: 'notebookExecutionJobId'

--- a/mmv1/products/colab/Runtime.yaml
+++ b/mmv1/products/colab/Runtime.yaml
@@ -69,7 +69,6 @@ virtual_fields:
 parameters:
   - name: 'location'
     type: String
-    required: true
     url_param_only: true
     description: 'The location for the resource: https://cloud.google.com/colab/docs/locations'
     immutable: true

--- a/mmv1/products/colab/RuntimeTemplate.yaml
+++ b/mmv1/products/colab/RuntimeTemplate.yaml
@@ -63,7 +63,6 @@ examples:
 parameters:
   - name: 'location'
     type: String
-    required: true
     url_param_only: true
     description: 'The location for the resource: https://cloud.google.com/colab/docs/locations'
 properties:

--- a/mmv1/products/compute/DiskType.yaml
+++ b/mmv1/products/compute/DiskType.yaml
@@ -40,7 +40,6 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the disk type resides.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -49,7 +49,6 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the machine resides.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/InstanceGroup.yaml
+++ b/mmv1/products/compute/InstanceGroup.yaml
@@ -41,7 +41,6 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the instance group resides.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/InstanceGroupManager.yaml
+++ b/mmv1/products/compute/InstanceGroupManager.yaml
@@ -45,7 +45,6 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: 'The zone the managed instance group resides.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/InstanceSettings.yaml
+++ b/mmv1/products/compute/InstanceSettings.yaml
@@ -50,7 +50,6 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the machine resides.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/MachineType.yaml
+++ b/mmv1/products/compute/MachineType.yaml
@@ -124,7 +124,6 @@ properties:
   - name: 'zone'
     type: ResourceRef
     description: 'The zone the machine type is defined.'
-    required: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'

--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -68,7 +68,6 @@ parameters:
     type: ResourceRef
     description: |
       The zone where the reservation is made.
-    required: true
     immutable: true
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'

--- a/mmv1/products/compute/ResizeRequest.yaml
+++ b/mmv1/products/compute/ResizeRequest.yaml
@@ -65,7 +65,6 @@ parameters:
     description: |
       The reference of the compute zone scoping this request.
     url_param_only: true
-    required: true
     resource: 'Zone'
     imports: 'name'
   - name: 'instanceGroupManager'

--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -77,7 +77,6 @@ properties:
     description: |
       The location for the resource
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/databasemigrationservice/PrivateConnection.yaml
+++ b/mmv1/products/databasemigrationservice/PrivateConnection.yaml
@@ -59,7 +59,6 @@ parameters:
     description: |
       The name of the location this private connection is located in.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -90,7 +90,6 @@ parameters:
     description: |
       The location where the data scan should reside.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'dataScanId'
     type: String

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -118,7 +118,6 @@ parameters:
     description: |
       The name of the location this connection profile is located in.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -74,7 +74,6 @@ parameters:
     description: |
       The name of the location this private connection is located in.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -227,7 +227,6 @@ parameters:
     description: |
       The name of the location this stream is located in.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'
@@ -1210,7 +1209,6 @@ properties:
                     description: |
                       The geographic location where the dataset should reside.
                       See https://cloud.google.com/bigquery/docs/locations for supported locations.
-                    required: true
                   - name: 'datasetIdPrefix'
                     type: String
                     description: |

--- a/mmv1/products/developerconnect/GitRepositoryLink.yaml
+++ b/mmv1/products/developerconnect/GitRepositoryLink.yaml
@@ -54,7 +54,6 @@ parameters:
       within its parent collection as described in https://google.aip.dev/122. See documentation
       for resource type `developerconnect.googleapis.com/GitRepositoryLink`. "
     url_param_only: true
-    required: true
     immutable: true
   - name: 'parent_connection'
     type: String

--- a/mmv1/products/dialogflowcx/Agent.yaml
+++ b/mmv1/products/dialogflowcx/Agent.yaml
@@ -59,7 +59,6 @@ properties:
        This is a one time step but at the moment you can only [configure location settings](https://cloud.google.com/dialogflow/cx/docs/concept/region#location-settings) via the Dialogflow CX console.
        Another options is to use global location so you don't need to manually configure location settings.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'displayName'
     type: String

--- a/mmv1/products/dialogflowcx/SecuritySettings.yaml
+++ b/mmv1/products/dialogflowcx/SecuritySettings.yaml
@@ -63,7 +63,6 @@ properties:
       The location these settings are located in. Settings can only be applied to an agent in the same location.
       See [Available Regions](https://cloud.google.com/dialogflow/cx/docs/concept/region#avail) for a list of supported locations.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'displayName'
     type: String

--- a/mmv1/products/discoveryengine/ChatEngine.yaml
+++ b/mmv1/products/discoveryengine/ChatEngine.yaml
@@ -76,7 +76,6 @@ parameters:
     description: |
       Location.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -78,7 +78,6 @@ parameters:
       The geographic location where the data store should reside. The value can
       only be one of "global", "us" and "eu".
     url_param_only: true
-    required: true
     immutable: true
   - name: 'dataStoreId'
     type: String

--- a/mmv1/products/discoveryengine/Schema.yaml
+++ b/mmv1/products/discoveryengine/Schema.yaml
@@ -57,7 +57,6 @@ parameters:
       The geographic location where the data store should reside. The value can
       only be one of "global", "us" and "eu".
     url_param_only: true
-    required: true
     immutable: true
   - name: 'dataStoreId'
     type: String

--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -69,7 +69,6 @@ parameters:
     description: |
       Location.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/discoveryengine/TargetSite.yaml
+++ b/mmv1/products/discoveryengine/TargetSite.yaml
@@ -66,7 +66,6 @@ parameters:
       The geographic location where the data store should reside. The value can
       only be one of "global", "us" and "eu".
     url_param_only: true
-    required: true
     immutable: true
   - name: 'dataStoreId'
     type: String

--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -98,7 +98,6 @@ parameters:
     description: |
       Location to create the discovery config in.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/documentai/Processor.yaml
+++ b/mmv1/products/documentai/Processor.yaml
@@ -43,7 +43,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/documentaiwarehouse/DocumentSchema.yaml
+++ b/mmv1/products/documentaiwarehouse/DocumentSchema.yaml
@@ -48,7 +48,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/documentaiwarehouse/Location.yaml
+++ b/mmv1/products/documentaiwarehouse/Location.yaml
@@ -57,7 +57,6 @@ parameters:
     description: |
       The location in which the instance is to be provisioned. It takes the form projects/{projectNumber}/locations/{location}.
     url_param_only: true
-    required: true
 properties:
   - name: 'databaseType'
     type: Enum

--- a/mmv1/products/edgecontainer/Cluster.yaml
+++ b/mmv1/products/edgecontainer/Cluster.yaml
@@ -71,7 +71,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/edgecontainer/NodePool.yaml
+++ b/mmv1/products/edgecontainer/NodePool.yaml
@@ -81,7 +81,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'cluster'
     type: String

--- a/mmv1/products/edgecontainer/VpnConnection.yaml
+++ b/mmv1/products/edgecontainer/VpnConnection.yaml
@@ -57,7 +57,6 @@ parameters:
     description: |
       Google Cloud Platform location.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'createTime'

--- a/mmv1/products/edgenetwork/InterconnectAttachment.yaml
+++ b/mmv1/products/edgenetwork/InterconnectAttachment.yaml
@@ -55,14 +55,12 @@ parameters:
     description: |
       The Google Cloud region to which the target Distributed Cloud Edge zone belongs.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'zone'
     type: String
     description: |
       The name of the target Distributed Cloud Edge zone.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'interconnect_attachment_id'
     type: String

--- a/mmv1/products/edgenetwork/Network.yaml
+++ b/mmv1/products/edgenetwork/Network.yaml
@@ -55,14 +55,12 @@ parameters:
     description: |
       The Google Cloud region to which the target Distributed Cloud Edge zone belongs.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'zone'
     type: String
     description: |
       The name of the target Distributed Cloud Edge zone.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'network_id'
     type: String

--- a/mmv1/products/edgenetwork/Subnet.yaml
+++ b/mmv1/products/edgenetwork/Subnet.yaml
@@ -65,14 +65,12 @@ parameters:
     description: |
       The Google Cloud region to which the target Distributed Cloud Edge zone belongs.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'zone'
     type: String
     description: |
       The name of the target Distributed Cloud Edge zone.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'subnet_id'
     type: String

--- a/mmv1/products/filestore/Backup.yaml
+++ b/mmv1/products/filestore/Backup.yaml
@@ -54,7 +54,6 @@ parameters:
     description: |
       The name of the location of the instance. This can be a region for ENTERPRISE tier instances.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/filestore/Snapshot.yaml
+++ b/mmv1/products/filestore/Snapshot.yaml
@@ -59,7 +59,6 @@ parameters:
     description: |
       The name of the location of the instance. This can be a region for ENTERPRISE tier instances.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'instance'
     type: String

--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -164,7 +164,6 @@ parameters:
     description: |
       The region of the Backup Plan.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -188,7 +188,6 @@ parameters:
     description: |
       The region of the Restore Plan.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -106,7 +106,6 @@ parameters:
     type: String
     description: The location for the resource
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/gkehub2/MembershipBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipBinding.yaml
@@ -76,7 +76,6 @@ parameters:
     description: |
       Location of the membership
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'membershipBindingId'

--- a/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
@@ -78,7 +78,6 @@ parameters:
       Location of the Membership
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'membershipRbacRoleBindingId'

--- a/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
@@ -62,7 +62,6 @@ parameters:
     type: String
     description: The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'description'

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -68,7 +68,6 @@ parameters:
     type: String
     description: The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'adminClusterMembership'

--- a/mmv1/products/gkeonprem/BareMetalNodePool.yaml
+++ b/mmv1/products/gkeonprem/BareMetalNodePool.yaml
@@ -72,7 +72,6 @@ parameters:
     type: String
     description: The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'displayName'

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -68,7 +68,6 @@ parameters:
     type: String
     description: The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'adminClusterMembership'

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -70,7 +70,6 @@ parameters:
     type: String
     description: The location of the resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'displayName'

--- a/mmv1/products/healthcare/Dataset.yaml
+++ b/mmv1/products/healthcare/Dataset.yaml
@@ -59,7 +59,6 @@ parameters:
     description: |
       The location for the Dataset.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/healthcare/PipelineJob.yaml
+++ b/mmv1/products/healthcare/PipelineJob.yaml
@@ -65,7 +65,6 @@ custom_code:
 parameters:
   - name: 'location'
     type: String
-    required: true
     immutable: true
     url_param_only: true
     description: |

--- a/mmv1/products/iam3/FoldersPolicyBinding.yaml
+++ b/mmv1/products/iam3/FoldersPolicyBinding.yaml
@@ -66,7 +66,6 @@ parameters:
     description: |
       The location of the PolicyBinding.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'policyBindingId'
     type: String

--- a/mmv1/products/iam3/OrganizationsPolicyBinding.yaml
+++ b/mmv1/products/iam3/OrganizationsPolicyBinding.yaml
@@ -64,7 +64,6 @@ parameters:
     description: |
       The location of the Policy Binding
     url_param_only: true
-    required: true
     immutable: true
   - name: 'policyBindingId'
     type: String

--- a/mmv1/products/iam3/PrincipalAccessBoundaryPolicy.yaml
+++ b/mmv1/products/iam3/PrincipalAccessBoundaryPolicy.yaml
@@ -60,7 +60,6 @@ parameters:
     description: |
       The location the principal access boundary policy is in.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'principalAccessBoundaryPolicyId'
     type: String

--- a/mmv1/products/iam3/ProjectsPolicyBinding.yaml
+++ b/mmv1/products/iam3/ProjectsPolicyBinding.yaml
@@ -56,7 +56,6 @@ parameters:
     description: |
       The location of the Policy Binding
     url_param_only: true
-    required: true
     immutable: true
   - name: 'policyBindingId'
     type: String

--- a/mmv1/products/iamworkforcepool/WorkforcePool.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePool.yaml
@@ -66,7 +66,6 @@ properties:
     type: String
     description: The location for the resource.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'workforcePoolId'
     type: String

--- a/mmv1/products/iamworkforcepool/WorkforcePoolProvider.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePoolProvider.yaml
@@ -116,7 +116,6 @@ properties:
     type: String
     description: The location for the resource.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'workforcePoolId'
     type: String

--- a/mmv1/products/integrationconnectors/Connection.yaml
+++ b/mmv1/products/integrationconnectors/Connection.yaml
@@ -113,7 +113,6 @@ parameters:
     description: |
       Location in which Connection needs to be created.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/integrationconnectors/EndpointAttachment.yaml
+++ b/mmv1/products/integrationconnectors/EndpointAttachment.yaml
@@ -53,7 +53,6 @@ parameters:
     description: |
       Location in which Endpoint Attachment needs to be created.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/integrations/AuthConfig.yaml
+++ b/mmv1/products/integrations/AuthConfig.yaml
@@ -98,7 +98,6 @@ parameters:
     description: |
       Location in which client needs to be provisioned.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -52,7 +52,6 @@ parameters:
     description: |
       Location in which client needs to be provisioned.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'cloudKmsConfig'

--- a/mmv1/products/kms/EkmConnection.yaml
+++ b/mmv1/products/kms/EkmConnection.yaml
@@ -58,7 +58,6 @@ parameters:
       The location for the EkmConnection.
       A full list of valid locations can be found by running `gcloud kms locations list`.
     url_param_only: true
-    required: true
     immutable: true
     ignore_read: true
 properties:

--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -69,7 +69,6 @@ parameters:
       A full list of valid locations can be found by running `gcloud kms locations list`.
     min_version: 'beta'
     url_param_only: true
-    required: true
 properties:
   - name: 'name'
     type: String

--- a/mmv1/products/kms/KeyRing.yaml
+++ b/mmv1/products/kms/KeyRing.yaml
@@ -56,7 +56,6 @@ parameters:
     description: |
       The location for the KeyRing.
       A full list of valid locations can be found by running `gcloud kms locations list`.
-    required: true
     ignore_read: true
 properties:
   - name: 'name'

--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -58,7 +58,6 @@ parameters:
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     url_param_only: true
-    required: true
     immutable: true
   - name: 'clusterId'
     type: String

--- a/mmv1/products/managedkafka/Topic.yaml
+++ b/mmv1/products/managedkafka/Topic.yaml
@@ -43,7 +43,6 @@ parameters:
       https://cloud.google.com/managed-kafka/docs/locations for a list of
       supported locations."
     url_param_only: true
-    required: true
     immutable: true
   - name: 'cluster'
     type: String

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -99,7 +99,6 @@ parameters:
       within its parent collection as described in https://google.aip.dev/122. See documentation
       for resource type `memorystore.googleapis.com/CertificateAuthority`. "
     url_param_only: true
-    required: true
     immutable: true
   - name: 'instanceId'
     type: String

--- a/mmv1/products/migrationcenter/Group.yaml
+++ b/mmv1/products/migrationcenter/Group.yaml
@@ -48,7 +48,6 @@ parameters:
     type: String
     description: 'The location of the group.'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'groupId'
     type: String

--- a/mmv1/products/migrationcenter/PreferenceSet.yaml
+++ b/mmv1/products/migrationcenter/PreferenceSet.yaml
@@ -54,7 +54,6 @@ parameters:
     type: String
     description: 'Part of `parent`. See documentation of `projectsId`.'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'preferenceSetId'
     type: String

--- a/mmv1/products/netapp/ActiveDirectory.yaml
+++ b/mmv1/products/netapp/ActiveDirectory.yaml
@@ -56,7 +56,6 @@ parameters:
     description: |
       Name of the region for the policy to apply to.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/netapp/Backup.yaml
+++ b/mmv1/products/netapp/Backup.yaml
@@ -74,7 +74,6 @@ parameters:
     description: |
       Location of the backup.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'vault_name'
     type: String

--- a/mmv1/products/netapp/BackupPolicy.yaml
+++ b/mmv1/products/netapp/BackupPolicy.yaml
@@ -58,7 +58,6 @@ parameters:
     description: |
       Name of the region for the policy to apply to.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/netapp/BackupVault.yaml
+++ b/mmv1/products/netapp/BackupVault.yaml
@@ -58,7 +58,6 @@ parameters:
     description: |
       Location (region) of the backup vault.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -81,7 +81,6 @@ parameters:
     description: |
       Name of the location. For zonal Flex pools specify a zone name, in all other cases a region name.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -74,7 +74,6 @@ parameters:
     description: |
       Name of the pool location. Usually a region name, expect for some STANDARD service level pools which require a zone name.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/netapp/VolumeReplication.yaml
+++ b/mmv1/products/netapp/VolumeReplication.yaml
@@ -118,7 +118,6 @@ parameters:
     description: |
       Name of region for this resource. The resource needs to be created in the region of the destination volume.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'volumeName'
     type: String

--- a/mmv1/products/netapp/VolumeSnapshot.yaml
+++ b/mmv1/products/netapp/VolumeSnapshot.yaml
@@ -63,7 +63,6 @@ parameters:
     description: |
       Name of the snapshot location. Snapshots are child resources of volumes and live in the same location.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'volume_name'
     type: String

--- a/mmv1/products/netapp/kmsconfig.yaml
+++ b/mmv1/products/netapp/kmsconfig.yaml
@@ -69,7 +69,6 @@ parameters:
     description: |
       Name of the policy location. CMEK policies apply to the whole region.
     url_param_only: true
-    required: true
     immutable: true
     # OK: This needs to be 'name' IMHO
   - name: 'name'

--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -65,7 +65,6 @@ parameters:
       The location of the RegionalEndpoint.
 
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'createTime'

--- a/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
+++ b/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
@@ -68,7 +68,6 @@ parameters:
     description: |
       The location of the ServiceConnectionPolicy.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'createTime'

--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -111,7 +111,6 @@ parameters:
     type: String
     description: The location for the resource
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/networkmanagement/VpcFlowLogsConfig.yaml
+++ b/mmv1/products/networkmanagement/VpcFlowLogsConfig.yaml
@@ -84,7 +84,6 @@ parameters:
       within its parent collection as described in https://google.aip.dev/122. See documentation
       for resource type `networkmanagement.googleapis.com/VpcFlowLogsConfig`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'vpcFlowLogsConfigId'
     type: String

--- a/mmv1/products/networksecurity/AddressGroup.yaml
+++ b/mmv1/products/networksecurity/AddressGroup.yaml
@@ -91,7 +91,6 @@ parameters:
       The location of the gateway security policy.
       The default value is `global`.
     url_param_only: true
-    required: true
 properties:
   - name: 'description'
     type: String

--- a/mmv1/products/networksecurity/AuthzPolicy.yaml
+++ b/mmv1/products/networksecurity/AuthzPolicy.yaml
@@ -78,7 +78,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
 properties:
   - name: 'createTime'
     type: Time

--- a/mmv1/products/networksecurity/FirewallEndpoint.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpoint.yaml
@@ -73,7 +73,6 @@ parameters:
     description: |
       The location (zone) of the firewall endpoint.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'parent'
     type: String

--- a/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
+++ b/mmv1/products/networksecurity/FirewallEndpointAssociation.yaml
@@ -74,7 +74,6 @@ parameters:
     description: |
       The location (zone) of the firewall endpoint association.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'parent'
     type: String

--- a/mmv1/products/networksecurity/GatewaySecurityPolicyRule.yaml
+++ b/mmv1/products/networksecurity/GatewaySecurityPolicyRule.yaml
@@ -69,7 +69,6 @@ parameters:
     description: |
       The location of the gateway security policy.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'gateway_security_policy'
     type: String

--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -57,7 +57,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/InterceptDeployment`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'interceptDeploymentId'
     type: String

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -53,7 +53,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/InterceptDeploymentGroup`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'interceptDeploymentGroupId'
     type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -51,7 +51,6 @@ parameters:
     description: 'The location of the Intercept Endpoint Group, currently restricted to `global`.'
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'interceptEndpointGroupId'
     type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -53,7 +53,6 @@ parameters:
     description: 'The location of the Intercept Endpoint Group Association, currently restricted to `global`.'
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'interceptEndpointGroupAssociationId'
     type: String

--- a/mmv1/products/networksecurity/MirroringDeployment.yaml
+++ b/mmv1/products/networksecurity/MirroringDeployment.yaml
@@ -57,7 +57,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/MirroringDeployment`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'mirroringDeploymentId'
     type: String

--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -53,7 +53,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/MirroringDeploymentGroup`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'mirroringDeploymentGroupId'
     type: String

--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -53,7 +53,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/MirroringEndpointGroup`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'mirroringEndpointGroupId'
     type: String

--- a/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
@@ -55,7 +55,6 @@ parameters:
     for resource type `networksecurity.googleapis.com/MirroringEndpointGroupAssociation`. '
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
   - name: 'mirroringEndpointGroupAssociationId'
     type: String

--- a/mmv1/products/networksecurity/ProjectAddressGroup.yaml
+++ b/mmv1/products/networksecurity/ProjectAddressGroup.yaml
@@ -65,4 +65,3 @@ properties:
     description: |
       The location of the gateway security policy.
     url_param_only: true
-    required: true

--- a/mmv1/products/networksecurity/UrlLists.yaml
+++ b/mmv1/products/networksecurity/UrlLists.yaml
@@ -67,7 +67,6 @@ parameters:
     description: |
       The location of the url lists.
     url_param_only: true
-    required: true
 properties:
   - name: 'createTime'
     type: Time

--- a/mmv1/products/networkservices/AuthzExtension.yaml
+++ b/mmv1/products/networkservices/AuthzExtension.yaml
@@ -65,7 +65,6 @@ parameters:
     description: |
       The location of the resource.
     url_param_only: true
-    required: true
 properties:
   - name: 'createTime'
     type: Time

--- a/mmv1/products/networkservices/LbRouteExtension.yaml
+++ b/mmv1/products/networkservices/LbRouteExtension.yaml
@@ -69,7 +69,6 @@ parameters:
     description: |
       The location of the route extension
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -66,7 +66,6 @@ parameters:
     description: |
       The location of the traffic extension
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/networkservices/ServiceLbPolicies.yaml
+++ b/mmv1/products/networkservices/ServiceLbPolicies.yaml
@@ -70,7 +70,6 @@ parameters:
       The location of the service lb policy.
     min_version: 'beta'
     url_param_only: true
-    required: true
 properties:
   - name: 'createTime'
     type: Time

--- a/mmv1/products/notebooks/Environment.yaml
+++ b/mmv1/products/notebooks/Environment.yaml
@@ -54,7 +54,6 @@ properties:
     type: ResourceRef
     description: 'A reference to the zone where the machine resides.'
     url_param_only: true
-    required: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
     custom_expand: 'templates/terraform/custom_expand/resource_from_self_link.go.tmpl'

--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -108,7 +108,6 @@ parameters:
     type: ResourceRef
     description: 'A reference to the zone where the machine resides.'
     url_param_only: true
-    required: true
     immutable: true
     resource: 'Location'
     imports: 'selfLink'

--- a/mmv1/products/notebooks/Runtime.yaml
+++ b/mmv1/products/notebooks/Runtime.yaml
@@ -93,7 +93,6 @@ parameters:
     type: ResourceRef
     description: 'A reference to the zone where the machine resides.'
     url_param_only: true
-    required: true
     immutable: true
     resource: 'Location'
     imports: 'selfLink'

--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -85,7 +85,6 @@ parameters:
     description: 'Resource ID segment making up resource `name`. See documentation
     for resource type `oracledatabase.googleapis.com/AutonomousDatabaseBackup`. '
     url_param_only: true
-    required: true
     immutable: true
   - name: 'autonomousDatabaseId'
     type: String

--- a/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructure.yaml
@@ -89,7 +89,6 @@ parameters:
     description: 'Resource ID segment making up resource `name`. See documentation
     for resource type `oracledatabase.googleapis.com/DbServer`. '
     url_param_only: true
-    required: true
     immutable: true
   - name: 'cloudExadataInfrastructureId'
     type: String

--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -95,7 +95,6 @@ parameters:
     description: 'Resource ID segment making up resource `name`. See documentation
     for resource type `oracledatabase.googleapis.com/DbNode`. '
     url_param_only: true
-    required: true
     immutable: true
   - name: 'cloudVmClusterId'
     type: String

--- a/mmv1/products/parallelstore/Instance.yaml
+++ b/mmv1/products/parallelstore/Instance.yaml
@@ -56,7 +56,6 @@ parameters:
     description: |
       Part of `parent`. See documentation of `projectsId`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'instanceId'
     type: String

--- a/mmv1/products/parametermanagerregional/RegionalParameter.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameter.yaml
@@ -54,7 +54,6 @@ parameters:
     description: |
       The location of the regional parameter. eg us-central1
     url_param_only: true
-    required: true
     immutable: true
   - name: 'parameterId'
     type: String

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -68,7 +68,6 @@ parameters:
       Location of the CaPool. A full list of valid locations can be found by
       running `gcloud privateca locations list`.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -82,7 +82,6 @@ parameters:
       Location of the Certificate. A full list of valid locations can be found by
       running `gcloud privateca locations list`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'certificate_authority'
     type: String

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -169,7 +169,6 @@ properties:
       Location of the CertificateAuthority. A full list of valid locations can be found by
       running `gcloud privateca locations list`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'certificateAuthorityId'
     type: String

--- a/mmv1/products/privateca/CertificateTemplate.yaml
+++ b/mmv1/products/privateca/CertificateTemplate.yaml
@@ -64,7 +64,6 @@ properties:
     type: String
     description: The location for the resource
     url_param_only: true
-    required: true
     immutable: true
   - name: 'predefinedValues'
     type: NestedObject

--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -58,7 +58,6 @@ parameters:
     description: |
       The region of the Entitlement resource.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'entitlementId'
     type: String

--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -85,7 +85,6 @@ parameters:
     description: |
       The location of the regional secret. eg us-central1
     url_param_only: true
-    required: true
     immutable: true
   - name: 'secretId'
     type: String

--- a/mmv1/products/securesourcemanager/BranchRule.yaml
+++ b/mmv1/products/securesourcemanager/BranchRule.yaml
@@ -75,7 +75,6 @@ parameters:
     description: |
       The location for the Repository.
     url_param_only: true
-    required: true
   - name: 'repository_id'
     type: String
     description: |

--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -143,7 +143,6 @@ parameters:
     description: |
       The location for the Instance.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'instance_id'
     type: String

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -75,7 +75,6 @@ parameters:
     description: |
       The location for the Repository.
     url_param_only: true
-    required: true
   - name: 'repository_id'
     type: String
     description: |

--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -68,7 +68,6 @@ parameters:
     type: String
     description: "Location of the resource, eg: global."
     url_param_only: true
-    required: true
     immutable: true
   - name: 'postureId'
     type: String

--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -57,7 +57,6 @@ parameters:
     description: |
       The location of the resource, eg. global`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'postureDeploymentId'
     type: String

--- a/mmv1/products/servicedirectory/Namespace.yaml
+++ b/mmv1/products/servicedirectory/Namespace.yaml
@@ -57,7 +57,6 @@ parameters:
       `gcloud beta service-directory locations list`.
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
     ignore_read: true
   - name: 'namespaceId'

--- a/mmv1/products/storageinsights/ReportConfig.yaml
+++ b/mmv1/products/storageinsights/ReportConfig.yaml
@@ -42,7 +42,6 @@ parameters:
       The location of the ReportConfig. The source and destination buckets specified in the ReportConfig
       must be in the same location.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/transcoder/Job.yaml
+++ b/mmv1/products/transcoder/Job.yaml
@@ -83,7 +83,6 @@ parameters:
     description: |
       The location of the transcoding job resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/transcoder/JobTemplate.yaml
+++ b/mmv1/products/transcoder/JobTemplate.yaml
@@ -62,7 +62,6 @@ parameters:
     description: |
       The location of the transcoding job template resource.
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -71,7 +71,6 @@ parameters:
     type: String
     description: The location for the resource
     url_param_only: true
-    required: true
     immutable: true
   - name: 'region'
     type: String

--- a/mmv1/products/vmwareengine/Network.yaml
+++ b/mmv1/products/vmwareengine/Network.yaml
@@ -64,7 +64,6 @@ parameters:
     description: |
       The location where the VMwareEngineNetwork should reside.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/vmwareengine/NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/NetworkPolicy.yaml
@@ -67,7 +67,6 @@ parameters:
       Resource names are schemeless URIs that follow the conventions in https://cloud.google.com/apis/design/resource_names.
       For example: projects/my-project/locations/us-central1
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -89,7 +89,6 @@ parameters:
     description: |
       The location where the PrivateCloud should reside.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'name'
     type: String

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -112,7 +112,6 @@ parameters:
     type: String
     description: Part of `parent`. See documentation of `projectsId`.
     url_param_only: true
-    required: true
     immutable: true
   - name: 'instanceId'
     type: String

--- a/mmv1/products/workstations/Workstation.yaml
+++ b/mmv1/products/workstations/Workstation.yaml
@@ -93,7 +93,6 @@ parameters:
       The location where the workstation parent resources reside.
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'

--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -142,7 +142,6 @@ parameters:
       The location where the workstation cluster config should reside.
     min_version: 'beta'
     url_param_only: true
-    required: true
     immutable: true
 properties:
   - name: 'name'


### PR DESCRIPTION
Not sure if we want to do this, but would help solve for cases such as go/yaqs/6564158085101780992
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
