### PR TITLE
Update cluster versions in TestAccContainerNodePool_concurrent

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -3985,7 +3985,7 @@ resource "google_container_cluster" "cluster" {
   deletion_protection = false
   network             = "%s"
   subnetwork          = "%s"
-  version             = "1.32.0-gke.1448000"
+  min_master_version  = "1.32.0-gke.1448000"
 }
 
 resource "google_container_node_pool" "np1" {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -3960,6 +3960,8 @@ resource "google_container_node_pool" "np1" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
+  // 2025-02-03: current default cluster version is 1.31.5-gke.1023000. This will change over time.
+  // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
 }
 
 resource "google_container_node_pool" "np2" {
@@ -3967,6 +3969,8 @@ resource "google_container_node_pool" "np2" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
+  // 2025-02-03: current default cluster version is 1.31.5-gke.1023000. This will change over time.
+  // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
 }
 `, cluster, networkName, subnetworkName, np1, np2)
 }
@@ -3987,7 +3991,11 @@ resource "google_container_node_pool" "np1" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
-  version            = "1.29.4-gke.1043002"
+  version            = "1.32.0-gke.1448000"
+  // This must remain within one minor version of the default cluster version
+  // Cross-ref: https://github.com/hashicorp/terraform-provider-google/issues/21116
+  // Cross-ref: https://github.com/GoogleCloudPlatform/magic-modules/pull/11115
+  // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
 }
 
 resource "google_container_node_pool" "np2" {
@@ -3995,7 +4003,11 @@ resource "google_container_node_pool" "np2" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
-  version            = "1.29.4-gke.1043002"
+  version            = "1.32.0-gke.1448000"
+  // This must remain within one minor version of the default cluster version
+  // Cross-ref: https://github.com/hashicorp/terraform-provider-google/issues/21116
+  // Cross-ref: https://github.com/GoogleCloudPlatform/magic-modules/pull/11115
+  // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
 }
 `, cluster, networkName, subnetworkName, np1, np2)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -3953,7 +3953,7 @@ resource "google_container_cluster" "cluster" {
   deletion_protection = false
   network             = "%s"
   subnetwork          = "%s"
-  version             = "1.32.0-gke.1448000"
+  min_master_version  = "1.32.0-gke.1448000"
 }
 
 resource "google_container_node_pool" "np1" {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -3953,6 +3953,7 @@ resource "google_container_cluster" "cluster" {
   deletion_protection = false
   network             = "%s"
   subnetwork          = "%s"
+  version             = "1.32.0-gke.1448000"
 }
 
 resource "google_container_node_pool" "np1" {
@@ -3978,12 +3979,13 @@ resource "google_container_node_pool" "np2" {
 func testAccContainerNodePool_concurrentUpdate(cluster, np1, np2, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 3
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 3
   deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
+  network             = "%s"
+  subnetwork          = "%s"
+  version             = "1.32.0-gke.1448000"
 }
 
 resource "google_container_node_pool" "np1" {
@@ -3992,7 +3994,7 @@ resource "google_container_node_pool" "np1" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
   version            = "1.32.0-gke.1448000"
-  // This must remain within one minor version of the default cluster version
+  // The node version must remain within one minor version of the cluster ("master") version, and it must not exceed the cluster ("master") version
   // Cross-ref: https://github.com/hashicorp/terraform-provider-google/issues/21116
   // Cross-ref: https://github.com/GoogleCloudPlatform/magic-modules/pull/11115
   // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions
@@ -4004,7 +4006,7 @@ resource "google_container_node_pool" "np2" {
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 2
   version            = "1.32.0-gke.1448000"
-  // This must remain within one minor version of the default cluster version
+  // The node version must remain within one minor version of the cluster ("master") version, and it must not exceed the cluster ("master") version
   // Cross-ref: https://github.com/hashicorp/terraform-provider-google/issues/21116
   // Cross-ref: https://github.com/GoogleCloudPlatform/magic-modules/pull/11115
   // Reference:  https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions


### PR DESCRIPTION
At time of this writing, the cluster default version is 1.31.5. The acceptance test fails because the API will not update such a cluster to 1.29.4.

This change updates the static versions and leaves hyper-breadcrumbs for the next traveler on this path.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21116

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
