### PR TITLE
Make scope optional for google_compute_(region_)resize_request  so that the default can be taken from the provider configuration

### DIFF
--- a/mmv1/products/compute/RegionResizeRequest.yaml
+++ b/mmv1/products/compute/RegionResizeRequest.yaml
@@ -59,7 +59,7 @@ parameters:
     description: |
       The reference of the compute region scoping this request.
     url_param_only: true
-    required: true
+    required: false
     resource: 'Region'
     imports: 'name'
   - name: 'instanceGroupManager'

--- a/mmv1/products/compute/RegionResizeRequest.yaml
+++ b/mmv1/products/compute/RegionResizeRequest.yaml
@@ -57,8 +57,10 @@ parameters:
   - name: 'region'
     type: ResourceRef
     description: |
-      The reference of the compute region scoping this request.
-    url_param_only: true
+      The reference of the compute region scoping this request. If it is not provided, the provider region is used.
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    default_from_api: true
     required: false
     resource: 'Region'
     imports: 'name'

--- a/mmv1/products/compute/ResizeRequest.yaml
+++ b/mmv1/products/compute/ResizeRequest.yaml
@@ -65,7 +65,7 @@ parameters:
     description: |
       The reference of the compute zone scoping this request.
     url_param_only: true
-    required: true
+    required: false
     resource: 'Zone'
     imports: 'name'
   - name: 'instanceGroupManager'

--- a/mmv1/products/compute/ResizeRequest.yaml
+++ b/mmv1/products/compute/ResizeRequest.yaml
@@ -63,8 +63,10 @@ parameters:
   - name: 'zone'
     type: ResourceRef
     description: |
-      The reference of the compute zone scoping this request.
-    url_param_only: true
+      The reference of the compute zone scoping this request. If it is not provided, the provider zone is used.
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    default_from_api: true
     required: false
     resource: 'Zone'
     imports: 'name'


### PR DESCRIPTION
Makes it consistent with the other compute resources, especially in the instance_group_manager family.

```release-note:bug
compute: fixed google_compute_(region_)resize_request requiring region/zone to be specified in all cases. They can now be pulled from the provider.
```
