### PR TITLE
Feature gap: add `gracefulShutdown` field for beta

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -181,6 +181,15 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 	if v, ok := original["maintenance_interval"]; ok {
 		scheduling.MaintenanceInterval = v.(string)
 	}
+
+	if v, ok := original["graceful_shutdown"]; ok {
+		transformedGracefulShutdown, err := expandGracefulShutdown(v)
+		if err != nil {
+			return nil, err
+		}
+		scheduling.GracefulShutdown = transformedGracefulShutdown
+		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "GracefulShutdown")
+	}
 {{- end }}
 	if v, ok := original["local_ssd_recovery_timeout"]; ok {
 		transformedLocalSsdRecoveryTimeout, err := expandComputeLocalSsdRecoveryTimeout(v)
@@ -278,6 +287,55 @@ func expandComputeLocalSsdRecoveryTimeoutSeconds(v interface{}) (interface{}, er
 	return v, nil
 }
 
+{{- if ne $.TargetVersionName "ga" }}
+func expandGracefulShutdown(v interface{}) (*compute.SchedulingGracefulShutdown, error) {
+	l := v.([]interface{})
+	gracefulShutdown := compute.SchedulingGracefulShutdown{}
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	originalMaxDuration := original["max_duration"].([]interface{})
+	maxDuration, err := expandGracefulShutdownMaxDuration(originalMaxDuration)
+	if err != nil {
+		return nil, err
+	}
+	if maxDuration != nil {
+		gracefulShutdown.MaxDuration = maxDuration
+	}
+
+	gracefulShutdown.Enabled = original["enabled"].(bool)
+	gracefulShutdown.ForceSendFields = append(gracefulShutdown.ForceSendFields, "Enabled")
+	return &gracefulShutdown, nil
+}
+
+func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error) {
+	l := v.([]interface{})
+	duration := compute.Duration{}
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+
+	maxDurationMap := raw.(map[string]interface{})
+	transformedNanos := maxDurationMap["nanos"]
+	transformedSeconds := maxDurationMap["seconds"]
+
+	if val := reflect.ValueOf(transformedNanos); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		duration.Nanos = int64(transformedNanos.(int))
+	}
+	if val := reflect.ValueOf(transformedSeconds); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		duration.Seconds = int64(transformedSeconds.(int))
+	}
+
+	duration.ForceSendFields = append(duration.ForceSendFields, "Seconds")
+
+	return &duration, nil
+}
+{{ end }}
+
 func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 	schedulingMap := map[string]interface{}{
 		"on_host_maintenance": resp.OnHostMaintenance,
@@ -307,6 +365,10 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 
 	if resp.MaintenanceInterval != "" {
 		schedulingMap["maintenance_interval"] = resp.MaintenanceInterval
+	}
+
+	if resp.GracefulShutdown != nil {
+		schedulingMap["graceful_shutdown"] = flattenGracefulShutdown(resp.GracefulShutdown)
 	}
 {{- end }}
 
@@ -355,6 +417,28 @@ func flattenComputeLocalSsdRecoveryTimeout(v *compute.Duration) []interface{} {
 	transformed["seconds"] = v.Seconds
 	return []interface{}{transformed}
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func flattenGracefulShutdown(v *compute.SchedulingGracefulShutdown) []interface{} {
+	if v == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["enabled"] = v.Enabled
+	transformed["max_duration"] = flattenGracefulShutdownMaxDuration(v.MaxDuration)
+	return []interface{}{transformed}
+}
+
+func flattenGracefulShutdownMaxDuration(v *compute.Duration) []interface{} {
+	if v == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["nanos"] = v.Nanos
+	transformed["seconds"] = v.Seconds
+	return []interface{}{transformed}
+}
+{{- end }}
 
 func flattenAccessConfigs(accessConfigs []*compute.AccessConfig) ([]map[string]interface{}, string) {
 	flattened := make([]map[string]interface{}, len(accessConfigs))
@@ -423,7 +507,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"stack_type":          iface.StackType,
 			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 			"ipv6_address":        iface.Ipv6Address,
-			"queue_count":         iface.QueueCount,			
+			"queue_count":         iface.QueueCount,
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -723,7 +807,13 @@ func schedulingHasChangeRequiringReboot(d *schema.ResourceData) bool {
 	oScheduling := o.([]interface{})[0].(map[string]interface{})
 	newScheduling := n.([]interface{})[0].(map[string]interface{})
 
+{{ if ne $.TargetVersionName `ga` -}}
+	return hasNodeAffinitiesChanged(oScheduling, newScheduling) ||
+		hasMaxRunDurationChanged(oScheduling, newScheduling) ||
+		hasGracefulShutdownChangedWithReboot(d, oScheduling, newScheduling)
+{{- else }}
 	return hasNodeAffinitiesChanged(oScheduling, newScheduling) || hasMaxRunDurationChanged(oScheduling, newScheduling)
+{{- end }}
 }
 
 // Terraform doesn't correctly calculate changes on schema.Set, so we do it manually
@@ -768,15 +858,72 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 	if oScheduling["host_error_timeout_seconds"] != newScheduling["host_error_timeout_seconds"] {
 		return true
 	}
+
+	if hasGracefulShutdownChanged(oScheduling, newScheduling) {
+		return true
+	}
 {{- end }}
 
 	return false
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func hasGracefulShutdownChangedWithReboot(d *schema.ResourceData, oScheduling, nScheduling map[string]interface{}) bool {
+	allow_stopping_for_update := d.Get("allow_stopping_for_update").(bool)
+	if !allow_stopping_for_update {
+		return false
+	}
+	return hasGracefulShutdownChanged(oScheduling, nScheduling)
+}
+
+func hasGracefulShutdownChanged(oScheduling, nScheduling map[string]interface{}) bool {
+	oGrShut := oScheduling["graceful_shutdown"].([]interface{})
+	nGrShut := nScheduling["graceful_shutdown"].([]interface{})
+
+	if (len(oGrShut) == 0 || oGrShut[0] == nil) && (len(nGrShut) == 0 || nGrShut[0] == nil) {
+		return false
+	}
+	if (len(oGrShut) == 0 || oGrShut[0] == nil) || (len(nGrShut) == 0 || nGrShut[0] == nil) {
+		return true
+	}
+
+	oldGrShut := oGrShut[0].(map[string]interface{})
+	newGrShut := nGrShut[0].(map[string]interface{})
+	oldMaxDuration := oldGrShut["max_duration"].([]interface{})
+	newMaxDuration := newGrShut["max_duration"].([]interface{})
+	var oldMaxDurationMap map[string]interface{}
+	var newMaxDurationMap map[string]interface{}
+
+	if len(oldMaxDuration) > 0 && oldMaxDuration[0] != nil {
+		oldMaxDurationMap = oldMaxDuration[0].(map[string]interface{})
+	} else {
+		oldMaxDurationMap = nil
+	}
+
+	if len(newMaxDuration) > 0 && newMaxDuration[0] != nil {
+		newMaxDurationMap = newMaxDuration[0].(map[string]interface{})
+	} else {
+		newMaxDurationMap = nil
+	}
+
+	if oldGrShut["enabled"] != newGrShut["enabled"] {
+		return true
+	}
+	if oldMaxDurationMap["seconds"] != newMaxDurationMap["seconds"] {
+		return true
+	}
+	if oldMaxDurationMap["nanos"] != newMaxDurationMap["nanos"] {
+		return true
+	}
+
+	return false
+}
+{{- end }}
+
 func hasMaxRunDurationChanged(oScheduling, nScheduling map[string]interface{}) bool {
 	oMrd := oScheduling["max_run_duration"].([]interface{})
 	nMrd := nScheduling["max_run_duration"].([]interface{})
-	
+
 	if (len(oMrd) == 0 || oMrd[0] == nil) &&  (len(nMrd) == 0 || nMrd[0] == nil) {
 		return false
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -100,6 +100,7 @@ var (
 {{- if ne $.TargetVersionName "ga" }}
 		"scheduling.0.maintenance_interval",
 		"scheduling.0.host_error_timeout_seconds",
+		"scheduling.0.graceful_shutdown",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
 	}
@@ -992,6 +993,49 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
+						{{ if ne $.TargetVersionName `ga` -}}
+						"graceful_shutdown": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `Settings for the instance to perform a graceful shutdown.`,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Opts-in for graceful shutdown.`,
+									},
+									"max_duration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Description: `The time allotted for the instance to gracefully shut down.
+										If the graceful shutdown isn't complete after this time, then the instance
+										transitions to the STOPPING state.`,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"seconds": {
+													Type:     schema.TypeInt,
+													Required: true,
+													Description: `Span of time at a resolution of a second.
+													The value must be between 1 and 3600, which is 3,600 seconds (one hour).`,
+												},
+												"nanos": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													Description: `Span of time that's a fraction of a second at nanosecond
+													resolution. Durations less than one second are represented
+													with a 0 seconds field and a positive nanos field. Must
+													be from 0 to 999,999,999 inclusive.`,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{{- end }}
 					},
 				},
 			},
@@ -1863,9 +1907,28 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("scratch_disk", scratchDisks); err != nil {
 		return fmt.Errorf("Error setting scratch_disk: %s", err)
 	}
+
+{{ if eq $.TargetVersionName `ga` -}}
 	if err := d.Set("scheduling", flattenScheduling(instance.Scheduling)); err != nil {
 		return fmt.Errorf("Error setting scheduling: %s", err)
 	}
+{{ else -}}
+	// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
+	// To avoid diff, we need to set the value from the state not from API response.
+	scheduling := flattenScheduling(instance.Scheduling)
+	if nanos, ok := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos"); ok {
+		graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
+		max_duration := graceful_shutdown["max_duration"].([]interface{})[0].(map[string]interface{})
+		max_duration["nanos"] = int64(nanos.(int))
+
+		graceful_shutdown["max_duration"] = []interface{}{max_duration}
+		scheduling[0]["graceful_shutdown"] = []interface{}{graceful_shutdown}
+	}
+	if err := d.Set("scheduling", scheduling); err != nil {
+		return fmt.Errorf("Error setting scheduling: %s", err)
+	}
+{{- end }}
+
 	if err := d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators)); err != nil {
 		return fmt.Errorf("Error setting guest_accelerator: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -40,6 +40,7 @@ var (
 {{- if ne $.TargetVersionName "ga" }}
 		"scheduling.0.maintenance_interval",
 		"scheduling.0.host_error_timeout_seconds",
+		"scheduling.0.graceful_shutdown",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -821,6 +821,53 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
+{{ if ne $.TargetVersionName `ga` }}
+						"graceful_shutdown": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Settings for the instance to perform a graceful shutdown.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Opts-in for graceful shutdown.`,
+									},
+									"max_duration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Description: `The time allotted for the instance to gracefully shut down.
+										If the graceful shutdown isn't complete after this time, then the instance
+										transitions to the STOPPING state.`,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"seconds": {
+													Type:     schema.TypeInt,
+													Required: true,
+													ForceNew: true,
+													Description: `Span of time at a resolution of a second.
+													The value must be between 1 and 3600, which is 3,600 seconds (one hour).`,
+												},
+												"nanos": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													ForceNew: true,
+													Description: `Span of time that's a fraction of a second at nanosecond
+													resolution. Durations less than one second are represented
+													with a 0 seconds field and a positive nanos field. Must
+													be from 0 to 999,999,999 inclusive.`,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+{{- end }}
 					},
 				},
 			},
@@ -1920,6 +1967,18 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 	if instanceTemplate.Properties.Scheduling != nil {
 		scheduling := flattenScheduling(instanceTemplate.Properties.Scheduling)
+{{ if ne $.TargetVersionName `ga` }}
+		// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
+		// To avoid diff, we need to set the value from the state not from API response.
+		if nanos, ok := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos"); ok {
+			graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
+			max_duration := graceful_shutdown["max_duration"].([]interface{})[0].(map[string]interface{})
+			max_duration["nanos"] = int64(nanos.(int))
+
+			graceful_shutdown["max_duration"] = []interface{}{max_duration}
+			scheduling[0]["graceful_shutdown"] = []interface{}{graceful_shutdown}
+		}
+{{- end }}
 		if err = d.Set("scheduling", scheduling); err != nil {
 			return fmt.Errorf("Error setting scheduling: %s", err)
 		}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -1822,6 +1822,82 @@ func TestAccComputeInstanceTemplate_keyRevocationActionType(t *testing.T) {
 	})
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeInstanceTemplate_gracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+
+	acceptableByApi_1 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       fmt.Sprintf("enabled = %t", true),
+		"seconds":       fmt.Sprintf("seconds = %d", 1),
+		"nanos":         fmt.Sprintf("nanos = %d", 1000000),
+	}
+	invalid_1 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   "",
+		"nanos":                     "",
+	}
+	invalid_2 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       "",
+		"seconds":       "",
+		"nanos":         "",
+	}
+	invalid_3 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 3601),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000000),
+	}
+	invalid_4 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 0),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000000000),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeInstanceTemplate_gracefulShutdown(invalid_1),
+				ExpectError: regexp.MustCompile("The argument \"seconds\" is required, but no definition was found."),
+			},
+			{
+				Config:      testAccComputeInstanceTemplate_gracefulShutdown(invalid_2),
+				ExpectError: regexp.MustCompile("The argument \"enabled\" is required, but no definition was found."),
+			},
+			{
+				Config:      testAccComputeInstanceTemplate_gracefulShutdown(invalid_3),
+				ExpectError: regexp.MustCompile("must be more than 1 second in the future and less than 1 hour., invalid"),
+			},
+			{
+				Config:      testAccComputeInstanceTemplate_gracefulShutdown(invalid_4),
+				ExpectError: regexp.MustCompile("Must be less than or equal to 999999999, invalid"),
+			},
+			{
+				Config: testAccComputeInstanceTemplate_gracefulShutdown(acceptableByApi_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.graceful_shutdown.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "1"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.nanos", "1000000"),
+				),
+			},
+		},
+	})
+}
+{{- end }}
+
 func TestUnitComputeInstanceTemplate_IpCidrRangeDiffSuppress(t *testing.T) {
 	cases := map[string]struct {
 		Old, New           string
@@ -4743,6 +4819,55 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, context)
 }
+
+func testAccComputeInstanceTemplate_gracefulShutdown(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+	graceful_shutdown {
+	  %{enabled}
+	  max_duration {
+		%{seconds}
+		%{nanos}
+	  }
+	}
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, context)
+}
+
 {{- end }}
 
 func testAccComputeInstanceTemplate_keyRevocationActionType(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -3851,6 +3851,193 @@ func TestAccComputeInstanceNetworkIntefaceWithSecurityPolicy(t *testing.T) {
 	}
 }
 
+func TestAccComputeInstance_GracefulShutdownWithResetUpdate(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acceptableByApi_1 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": fmt.Sprintf("allow_stopping_for_update = %t", true),
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 1),
+		"nanos":                     "",
+	}
+	acceptableByApi_2 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": fmt.Sprintf("allow_stopping_for_update = %t", true),
+		"enabled":                   fmt.Sprintf("enabled = %t", false),
+		"seconds":                   fmt.Sprintf("seconds = %d", 1),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000),
+	}
+	acceptableByApi_3 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": fmt.Sprintf("allow_stopping_for_update = %t", true),
+		"enabled":                   fmt.Sprintf("enabled = %t", false),
+		"seconds":                   fmt.Sprintf("seconds = %d", 100),
+		"nanos":                     "",
+	}
+	ivalid_1 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": fmt.Sprintf("allow_stopping_for_update = %t", true),
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 3601),
+		"nanos":                     "",
+	}
+	ivalid_2 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": fmt.Sprintf("allow_stopping_for_update = %t", true),
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 0),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000000000),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "allow_stopping_for_update", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "1"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "allow_stopping_for_update", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.enabled", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.nanos", "1000"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "allow_stopping_for_update", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "100"),
+				),
+			},
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_1),
+				ExpectError: regexp.MustCompile("must be more than 1 second in the future and less than 1 hour., invalid"),
+			},
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_2),
+				ExpectError: regexp.MustCompile("Must be less than or equal to 999999999, invalid"),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_GracefulShutdownWithoutResetUpdate(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acceptableByApi_1 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 1),
+		"nanos":                     "",
+	}
+	acceptableByApi_2 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", false),
+		"seconds":                   fmt.Sprintf("seconds = %d", 1),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000),
+	}
+	acceptableByApi_3 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", false),
+		"seconds":                   fmt.Sprintf("seconds = %d", 100),
+		"nanos":                     "",
+	}
+	ivalid_1 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   "",
+		"nanos":                     "",
+	}
+	ivalid_2 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   "",
+		"seconds":                   "",
+		"nanos":                     "",
+	}
+	ivalid_3 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 3601),
+		"nanos":                     "",
+	}
+	ivalid_4 := map[string]interface{}{
+		"instance_name":             instanceName,
+		"allow_stopping_for_update": "",
+		"enabled":                   fmt.Sprintf("enabled = %t", true),
+		"seconds":                   fmt.Sprintf("seconds = %d", 0),
+		"nanos":                     fmt.Sprintf("nanos = %d", 1000000000),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_1),
+				ExpectError: regexp.MustCompile("The argument \"seconds\" is required, but no definition was found."),
+			},
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_2),
+				ExpectError: regexp.MustCompile("The argument \"enabled\" is required, but no definition was found."),
+			},
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "1"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.enabled", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.nanos", "1000"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_GracefulShutdownUpdate(acceptableByApi_3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "100"),
+				),
+			},
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_3),
+				ExpectError: regexp.MustCompile("must be more than 1 second in the future and less than 1 hour., invalid"),
+			},
+			{
+				Config:      testAccComputeInstance_GracefulShutdownUpdate(ivalid_4),
+				ExpectError: regexp.MustCompile("Must be less than or equal to 999999999, invalid"),
+			},
+		},
+	})
+}
+
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigs(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
@@ -4147,6 +4334,42 @@ func testAccComputeInstance_nic_securityPolicyCreateWithoutAccessConfig(t *testi
 			},
 		},
 	})
+}
+
+func testAccComputeInstance_GracefulShutdownUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+	%{allow_stopping_for_update}
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+		access_config {}
+	}
+
+	scheduling {
+		graceful_shutdown {
+			%{enabled}
+			max_duration {
+				%{seconds}
+				%{nanos}
+			}
+		}
+	}
+}
+`, context)
 }
 
 {{ end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -780,6 +780,53 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
+{{ if ne $.TargetVersionName `ga` }}
+						"graceful_shutdown": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Settings for the instance to perform a graceful shutdown.`,
+							MaxItems:    1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Opts-in for graceful shutdown.`,
+									},
+									"max_duration": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Description: `The time allotted for the instance to gracefully shut down.
+										If the graceful shutdown isn't complete after this time, then the instance
+										transitions to the STOPPING state.`,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"seconds": {
+													Type:     schema.TypeInt,
+													Required: true,
+													ForceNew: true,
+													Description: `Span of time at a resolution of a second.
+													The value must be between 1 and 3600, which is 3,600 seconds (one hour).`,
+												},
+												"nanos": {
+													Type:     schema.TypeInt,
+													Optional: true,
+													ForceNew: true,
+													Description: `Span of time that's a fraction of a second at nanosecond
+													resolution. Durations less than one second are represented
+													with a 0 seconds field and a positive nanos field. Must
+													be from 0 to 999,999,999 inclusive.`,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+{{- end }}
 					},
 				},
 			},
@@ -1407,6 +1454,18 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	}
 	if instanceProperties.Scheduling != nil {
 		scheduling := flattenScheduling(instanceProperties.Scheduling)
+{{ if ne $.TargetVersionName `ga` }}
+		// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
+		// To avoid diff, we need to set the value from the state not from API response.
+		if nanos, ok := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos"); ok {
+			graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
+			max_duration := graceful_shutdown["max_duration"].([]interface{})[0].(map[string]interface{})
+			max_duration["nanos"] = int64(nanos.(int))
+
+			graceful_shutdown["max_duration"] = []interface{}{max_duration}
+			scheduling[0]["graceful_shutdown"] = []interface{}{graceful_shutdown}
+		}
+{{- end }}
 		if err = d.Set("scheduling", scheduling); err != nil {
 			return fmt.Errorf("Error setting scheduling: %s", err)
 		}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -1471,6 +1471,79 @@ func TestAccComputeRegionInstanceTemplate_keyRevocationActionType(t *testing.T) 
 	})
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeRegionInstanceTemplate_gracefulShutdown(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+
+	acceptableByApi_1 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       fmt.Sprintf("enabled = %t", true),
+		"seconds":       fmt.Sprintf("seconds = %d", 1),
+		"nanos":         fmt.Sprintf("nanos = %d", 1000000),
+	}
+	invalid_1 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       fmt.Sprintf("enabled = %t", true),
+		"seconds":       "",
+		"nanos":         "",
+	}
+	invalid_2 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       "",
+		"seconds":       "",
+		"nanos":         "",
+	}
+	invalid_3 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       fmt.Sprintf("enabled = %t", true),
+		"seconds":       fmt.Sprintf("seconds = %d", 3601),
+		"nanos":         fmt.Sprintf("nanos = %d", 1000000),
+	}
+	invalid_4 := map[string]interface{}{
+		"instance_name": instanceName,
+		"enabled":       fmt.Sprintf("enabled = %t", true),
+		"seconds":       fmt.Sprintf("seconds = %d", 0),
+		"nanos":         fmt.Sprintf("nanos = %d", 1000000000),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeRegionInstanceTemplate_gracefulShutdown(invalid_1),
+				ExpectError: regexp.MustCompile("The argument \"seconds\" is required, but no definition was found."),
+			},
+			{
+				Config:      testAccComputeRegionInstanceTemplate_gracefulShutdown(invalid_2),
+				ExpectError: regexp.MustCompile("The argument \"enabled\" is required, but no definition was found."),
+			},
+			{
+				Config:      testAccComputeRegionInstanceTemplate_gracefulShutdown(invalid_3),
+				ExpectError: regexp.MustCompile("must be more than 1 second in the future and less than 1 hour., invalid"),
+			},
+			{
+				Config:      testAccComputeRegionInstanceTemplate_gracefulShutdown(invalid_4),
+				ExpectError: regexp.MustCompile("Must be less than or equal to 999999999, invalid"),
+			},
+			{
+				Config: testAccComputeRegionInstanceTemplate_gracefulShutdown(acceptableByApi_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.graceful_shutdown.0.enabled", "true"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.seconds", "1"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.graceful_shutdown.0.max_duration.0.nanos", "1000000"),
+				),
+			},
+		},
+	})
+}
+{{- end }}
+
 func testAccCheckComputeRegionInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -4141,3 +4214,44 @@ resource "google_compute_region_instance_template" "foobar" {
 }
 `, context)
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func testAccComputeRegionInstanceTemplate_gracefulShutdown(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+	source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+	boot         = true
+  }
+
+  network_interface {
+	network = "default"
+  }
+
+  scheduling {
+	automatic_restart = true
+	preemptible = false
+
+	graceful_shutdown {
+	  %{enabled}
+
+	  max_duration {
+		%{seconds}
+		%{nanos}
+	  }
+	}
+  }
+}
+`, context)
+}
+{{- end }}

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -505,6 +505,25 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 * `maintenance_interval` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 
 * `local_ssd_recovery_timeout` -  (Optional) (https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the maximum amount of time a Local Ssd Vm should wait while recovery of the Local Ssd state is attempted. Its value should be in between 0 and 168 hours with hour granularity and the default value being 1 hour. Structure is [documented below](#nested_local_ssd_recovery_timeout).
+
+* `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
+
+<a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
+
+* `enabled` - (Required) Opts-in for graceful shutdown.
+
+* `max_duration` (Optional) The time allotted for the instance to gracefully shut down.
+    If the graceful shutdown isn't complete after this time, then the instance
+    transitions to the STOPPING state. Structure is documented below:
+
+    * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond
+        resolution. Durations less than one second are represented with a 0
+        `seconds` field and a positive `nanos` field. Must be from 0 to
+        999,999,999 inclusive.
+
+    * `seconds` - (Required) Span of time at a resolution of a second.
+        The value must be between 1 and 3600, which is 3,600 seconds (one hour).`
+
 <a name="nested_local_ssd_recovery_timeout"></a>The `local_ssd_recovery_timeout` block supports:
 
 * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -650,6 +650,25 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 * `maintenance_interval` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the frequency of planned maintenance events. The accepted values are: `PERIODIC`.
 
 * `local_ssd_recovery_timeout` -  (Optional) (https://terraform.io/docs/providers/google/guides/provider_versions.html) Specifies the maximum amount of time a Local Ssd Vm should wait while recovery of the Local Ssd state is attempted. Its value should be in between 0 and 168 hours with hour granularity and the default value being 1 hour. Structure is [documented below](#nested_local_ssd_recovery_timeout).
+
+* `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
+
+<a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
+
+* `enabled` - (Required) Opts-in for graceful shutdown.
+
+* `max_duration` (Optional) The time allotted for the instance to gracefully shut down.
+    If the graceful shutdown isn't complete after this time, then the instance
+    transitions to the STOPPING state. Structure is documented below:
+
+    * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond
+        resolution. Durations less than one second are represented with a 0
+        `seconds` field and a positive `nanos` field. Must be from 0 to
+        999,999,999 inclusive.
+
+    * `seconds` - (Required) Span of time at a resolution of a second.
+        The value must be between 1 and 3600, which is 3,600 seconds (one hour).`
+
 <a name="nested_local_ssd_recovery_timeout"></a>The `local_ssd_recovery_timeout` block supports:
 
 * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -636,6 +636,24 @@ specified, then this instance will have no external IPv6 Internet access. Struct
    315,576,000,000 inclusive. Note: these bounds are computed from: 60
    sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years.
 
+* `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
+
+<a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
+
+* `enabled` - (Required) Opts-in for graceful shutdown.
+
+* `max_duration` (Optional) The time allotted for the instance to gracefully shut down.
+    If the graceful shutdown isn't complete after this time, then the instance
+    transitions to the STOPPING state. Structure is documented below:
+
+    * `nanos` - (Optional) Span of time that's a fraction of a second at nanosecond
+        resolution. Durations less than one second are represented with a 0
+        `seconds` field and a positive `nanos` field. Must be from 0 to
+        999,999,999 inclusive.
+
+    * `seconds` - (Required) Span of time at a resolution of a second.
+        The value must be between 1 and 3600, which is 3,600 seconds (one hour).`
+
 <a name="nested_guest_accelerator"></a>The `guest_accelerator` block supports:
 
 * `type` (Required) - The accelerator type resource to expose to this instance. E.g. `nvidia-tesla-k80`.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch adds `graceful_shutdown` field to `resource_compute_instance`, `resource_compute_instance_template` and `resource_compute_region_instance_template`. This fields is a configuration setting for a compute instance that allows it to perform a graceful shutdown. The graceful_shutdown field is responsible for:

* Enabling or disabling the graceful shutdown feature for the compute instance.
* Defining the maximum duration allowed for the shutdown process, ensuring that the instance has enough time to close resources and complete operations before transitioning to the STOPPING state.
* Providing a detailed configuration for the shutdown duration, including both seconds and nanoseconds for precise control.
* This configuration helps ensure that the instance can shut down in a controlled manner, minimizing the risk of data loss or corruption.

[Gracefull shutdown](https://cloud.google.com/compute/docs/instances/graceful-shutdown-overview?hl=en) overview.

Related issue [here](https://github.com/hashicorp/terraform-provider-google/issues/21057).

This PR provides a workaround for `max_duration.0.nanos` due to an issue with the API. Please find the details below:

* When the `seconds` field is set (1–3600 s) and the `nanos` field is also set, the value is passed in the request body but is not updated in the cloud, as observed in the `GET` response.
* It is not possible to set seconds to zero (the API returns an error).
* Because of this, a workaround is needed — the value of `nanos` is read from the resource state to avoid not updated tfstate (constant diff between setup and state).

POST REQUEST:
```http
POST /compute/beta/projects/iac-poc-krakow4/zones/us-central1-a/instances/test/setScheduling?alt=json&prettyPrint=false HTTP/1.1  

Host: compute.googleapis.com  

User-Agent: google-api-go-client/0.5 Terraform/1.10.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.33.0 terraform-provider-google-beta/dev6  

Content-Length: 272  

Content-Type: application/json  

X-Goog-Api-Client: gl-go/1.23.0 gdcl/0.214.0  

Accept-Encoding: gzip  
```

Request body:
```json
{  

"automaticRestart": true,  

"gracefulShutdown": {  

  "enabled": true,  

  "maxDuration": {  

   "nanos": 1000,  

   "seconds": "1"  

  }  

},  

"hostErrorTimeoutSeconds": null,  

"instanceTerminationAction": "",  

"nodeAffinities": [  

  null  

],  

"onHostMaintenance": "MIGRATE",  

"preemptible": false,  

"provisioningModel": "STANDARD"  

}  
```
 
GET REQUEST RESPONSE 
```json
(…) 

"scheduling": { 

"onHostMaintenance": "MIGRATE", 

"automaticRestart": true, 

"preemptible": false, 

"provisioningModel": "STANDARD", 

"gracefulShutdown": { 

  "enabled": true, 

  "maxDuration": { 

   "seconds": "1" 

  } 
} 
}, 
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `graceful_shutdown` field to `google_compute_instance`, `google_compute_instance_template` and `google_compute_region_instance_template` resource (beta)
```
