### PR TITLE
Change bootstrapped CodeRepositoryIndex debug label

### DIFF
--- a/mmv1/products/gemini/RepositoryGroup.yaml
+++ b/mmv1/products/gemini/RepositoryGroup.yaml
@@ -28,7 +28,7 @@ mutex: 'projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code
 examples:
   - name: "gemini_repository_group_basic"
     primary_resource_id: "example"
-    primary_resource_name: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{}), fmt.Sprintf("tf-test-gen-repository-group-%s", context["random_suffix"])'
+    primary_resource_name: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e"}), fmt.Sprintf("tf-test-gen-repository-group-%s", context["random_suffix"])'
     vars:
       repository_group_id: "example-repository-group"
       git_repository_link_id: 'example-git-repository-link-id'
@@ -37,7 +37,7 @@ examples:
       connection_id: "example-connection-id"
     test_vars_overrides:
       git_repository_link_id: 'acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
-      cri_id: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{})'
+      cri_id: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e"})'
       repository_resource: '"projects/"+envvar.GetTestProjectFromEnv()+"/locations/us-central1/connections/"+acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)+"/gitRepositoryLinks/"+acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
       connection_id: 'acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)'
     exclude_test: true

--- a/mmv1/products/gemini/RepositoryGroup.yaml
+++ b/mmv1/products/gemini/RepositoryGroup.yaml
@@ -28,7 +28,7 @@ mutex: 'projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code
 examples:
   - name: "gemini_repository_group_basic"
     primary_resource_id: "example"
-    primary_resource_name: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e"}), fmt.Sprintf("tf-test-gen-repository-group-%s", context["random_suffix"])'
+    primary_resource_name: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e_do_not_delete"}), fmt.Sprintf("tf-test-gen-repository-group-%s", context["random_suffix"])'
     vars:
       repository_group_id: "example-repository-group"
       git_repository_link_id: 'example-git-repository-link-id'
@@ -37,7 +37,7 @@ examples:
       connection_id: "example-connection-id"
     test_vars_overrides:
       git_repository_link_id: 'acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
-      cri_id: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e"})'
+      cri_id: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e_do_not_delete"})'
       repository_resource: '"projects/"+envvar.GetTestProjectFromEnv()+"/locations/us-central1/connections/"+acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)+"/gitRepositoryLinks/"+acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
       connection_id: 'acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)'
     exclude_test: true

--- a/mmv1/third_party/terraform/services/gemini/iam_gemini_repository_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/iam_gemini_repository_group_test.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func TestAccGeminiRepositoryGroupIamBinding(t *testing.T) {
 	location := "us-central1"
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
 	developerConnectionId := acctest.BootstrapDeveloperConnection(t, "basic", location, "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)
 	gitRepositoryLinkId := acctest.BootstrapGitRepository(t, "basic", location, "https://github.com/CC-R-github-robot/tf-test.git", developerConnectionId)
 	repositoryGroupId := "tf-test-iam-repository-group-id-" + acctest.RandString(t, 10)
@@ -59,7 +59,7 @@ func TestAccGeminiRepositoryGroupIamBinding(t *testing.T) {
 
 func TestAccGeminiRepositoryGroupIamMember(t *testing.T) {
 	location := "us-central1"
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_should_be_deleted"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
 	developerConnectionId := acctest.BootstrapDeveloperConnection(t, "basic", location, "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)
 	gitRepositoryLinkId := acctest.BootstrapGitRepository(t, "basic", location, "https://github.com/CC-R-github-robot/tf-test.git", developerConnectionId)
 	repositoryGroupId := "tf-test-iam-repository-group-id-" + acctest.RandString(t, 10)
@@ -94,7 +94,7 @@ func TestAccGeminiRepositoryGroupIamMember(t *testing.T) {
 
 func TestAccGeminiRepositoryGroupIamPolicy(t *testing.T) {
 	location := "us-central1"
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_should_be_deleted"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
 	developerConnectionId := acctest.BootstrapDeveloperConnection(t, "basic", location, "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)
 	gitRepositoryLinkId := acctest.BootstrapGitRepository(t, "basic", location, "https://github.com/CC-R-github-robot/tf-test.git", developerConnectionId)
 	repositoryGroupId := "tf-test-iam-repository-group-id-" + acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/services/gemini/iam_gemini_repository_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/iam_gemini_repository_group_test.go.tmpl
@@ -15,7 +15,7 @@ import (
 
 func TestAccGeminiRepositoryGroupIamBinding(t *testing.T) {
 	location := "us-central1"
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e_should_be_deleted"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", location, "", map[string]string{"ccfe_debug_note": "terraform_e2e"})
 	developerConnectionId := acctest.BootstrapDeveloperConnection(t, "basic", location, "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)
 	gitRepositoryLinkId := acctest.BootstrapGitRepository(t, "basic", location, "https://github.com/CC-R-github-robot/tf-test.git", developerConnectionId)
 	repositoryGroupId := "tf-test-iam-repository-group-id-" + acctest.RandString(t, 10)

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
@@ -13,7 +13,7 @@ import (
 // More details: https://cloud.google.com/developer-connect/docs/connect-github-repo#before_you_begin
 
 func TestAccGeminiRepositoryGroup_update(t *testing.T) {
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-test", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-test", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
 	context := map[string]interface{}{
 		"random_suffix":         acctest.RandString(t, 10),
 		"project_id":            os.Getenv("GOOGLE_PROJECT"),

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
@@ -13,7 +13,7 @@ import (
 // More details: https://cloud.google.com/developer-connect/docs/connect-github-repo#before_you_begin
 
 func TestAccGeminiRepositoryGroup_update(t *testing.T) {
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-test", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e_should_be_deleted"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-test", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e"})
 	context := map[string]interface{}{
 		"random_suffix":         acctest.RandString(t, 10),
 		"project_id":            os.Getenv("GOOGLE_PROJECT"),


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Despite being a part of e2e testing, bootstrapped resources should not have a label that recommends deleting them, as these resources role is to avoid recreating resources for tests.

```release-note:note
`gemini`: change bootstrapped `google_gemini_code_repository_index` debug label
```
