### PR TITLE
Update StandardApVersion.yaml to reflect new default for automaticSca…

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -407,6 +407,9 @@ properties:
             type: Integer
             description: |
               Maximum number of instances to run for this version. Set to zero to disable maxInstances configuration.
+
+              **Note:** Starting from February 17, 2025, App Engine sets the maxInstances default for standard environment deployments to 20. This change doesn't impact existing apps. To override the default, specify a new value between 0 and 2147483647, and deploy a new version or redeploy over an existing version. To disable the maxInstances default configuration setting, specify the maximum permitted value 2147483647.
+            default_from_api: true
   - name: 'basicScaling'
     type: NestedObject
     description: |


### PR DESCRIPTION
…ling maxInstances that will apply to deployments to apps created after Feb 17th 2025. Similar notes will be pushed out to Google public docs.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21256

```release-note:enhancement
appengine: added a mitigation for an upcoming default change to `standard_scheduler_settings.max_instances` for new `google_app_engine_standard_app_version` resources. If the field is not specified in configuration, diffs will now be ignored.
```
