### PR TITLE
Updated AlertPolicy resource to include sql condition types.

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -994,29 +994,29 @@ properties:
                     The time of day (in UTC) at which the query should run. If left
                     unspecified, the server picks an arbitrary time of day and runs
                     the query at the same time each day.
-                  properties: 
+                  properties:
                     - name: 'hours'
                       type: Integer
                       description: |
-                        Hours of a day in 24 hour format. Must be greater than or equal 
+                        Hours of a day in 24 hour format. Must be greater than or equal
                         to 0 and typically must be less than or equal to 23. An API may
                         choose to allow the value "24:00:00" for scenarios like business
                         closing time.
                     - name: 'minutes'
                       type: Integer
                       description: |
-                        Minutes of an hour. Must be greater than or equal to 0 and 
+                        Minutes of an hour. Must be greater than or equal to 0 and
                         less than or equal to 59.
                     - name: 'seconds'
                       type: Integer
                       description: |
                         Seconds of a minute. Must be greater than or equal to 0 and
-                        typically must be less than or equal to 59. An API may allow the 
+                        typically must be less than or equal to 59. An API may allow the
                         value 60 if it allows leap-seconds.
                     - name: 'nanos'
                       type: Integer
                       description: |
-                        Fractions of seconds, in nanoseconds. Must be greater than or 
+                        Fractions of seconds, in nanoseconds. Must be greater than or
                         equal to 0 and less than or equal to 999,999,999.
               exactly_one_of:
                 - 'minutes'

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -925,6 +925,150 @@ properties:
 
                 Users with the `monitoring.alertPolicyViewer` role are able to see the
                 name of the non-existent metric in the alerting policy condition.
+        - name: 'conditionSql'
+          type: NestedObject
+          description: |
+            A condition that allows alerting policies to be defined using GoogleSQL.
+            SQL conditions examine a sliding window of logs using GoogleSQL.
+            Alert policies with SQL conditions may incur additional billing.
+          properties:
+            - name: 'query'
+              type: String
+              description: |
+                The Log Analytics SQL query to run, as a string.  The query must
+                conform to the required shape. Specifically, the query must not try to
+                filter the input by time.  A filter will automatically be applied
+                to filter the input so that the query receives all rows received
+                since the last time the query was run.
+              required: true
+            - name: 'minutes'
+              type: NestedObject
+              description: |
+                Used to schedule the query to run every so many minutes.
+              properties:
+                - name: 'periodicity'
+                  type: Integer
+                  description: |
+                    Number of minutes between runs. The interval must be greater than or
+                    equal to 5 minutes and less than or equal to 1440 minutes.
+                  required: true
+              exactly_one_of:
+                - 'minutes'
+                - 'hourly'
+                - 'daily'
+            - name: 'hourly'
+              type: NestedObject
+              description: |
+                Used to schedule the query to run every so many hours.
+              properties:
+                - name: 'periodicity'
+                  type: Integer
+                  description: |
+                    Number of hours between runs. The interval must be greater than or
+                    equal to 1 hour and less than or equal to 48 hours.
+                  required: true
+                - name: 'minuteOffset'
+                  type: Integer
+                  description: |
+                    The number of minutes after the hour (in UTC) to run the query.
+                    Must be greater than or equal to 0 minutes and less than or equal to
+                    59 minutes.  If left unspecified, then an arbitrary offset is used.
+              exactly_one_of:
+                - 'minutes'
+                - 'hourly'
+                - 'daily'
+            - name: 'daily'
+              type: NestedObject
+              description: |
+                Used to schedule the query to run every so many days.
+              properties:
+                - name: periodicity
+                  type: Integer
+                  description: |
+                    The number of days between runs. Must be greater than or equal
+                    to 1 day and less than or equal to 30 days.
+                  required: true
+                - name: 'executionTime'
+                  type: NestedObject
+                  description: |
+                    The time of day (in UTC) at which the query should run. If left
+                    unspecified, the server picks an arbitrary time of day and runs
+                    the query at the same time each day.
+                  properties: 
+                    - name: 'hours'
+                      type: Integer
+                      description: |
+                        Hours of a day in 24 hour format. Must be greater than or equal 
+                        to 0 and typically must be less than or equal to 23. An API may
+                        choose to allow the value "24:00:00" for scenarios like business
+                        closing time.
+                    - name: 'minutes'
+                      type: Integer
+                      description: |
+                        Minutes of an hour. Must be greater than or equal to 0 and 
+                        less than or equal to 59.
+                    - name: 'seconds'
+                      type: Integer
+                      description: |
+                        Seconds of a minute. Must be greater than or equal to 0 and
+                        typically must be less than or equal to 59. An API may allow the 
+                        value 60 if it allows leap-seconds.
+                    - name: 'nanos'
+                      type: Integer
+                      description: |
+                        Fractions of seconds, in nanoseconds. Must be greater than or 
+                        equal to 0 and less than or equal to 999,999,999.
+              exactly_one_of:
+                - 'minutes'
+                - 'hourly'
+                - 'daily'
+            - name: 'rowCountTest'
+              type: NestedObject
+              description: |
+                Test the row count against a threshold.
+              properties:
+                - name: 'comparison'
+                  type: Enum
+                  description: |
+                    The comparison to apply between the time
+                    series (indicated by filter and aggregation)
+                    and the threshold (indicated by
+                    threshold_value). The comparison is applied
+                    on each time series, with the time series on
+                    the left-hand side and the threshold on the
+                    right-hand side. Only COMPARISON_LT and
+                    COMPARISON_GT are supported currently.
+                  enum_values:
+                    - 'COMPARISON_GT'
+                    - 'COMPARISON_GE'
+                    - 'COMPARISON_LT'
+                    - 'COMPARISON_LE'
+                    - 'COMPARISON_EQ'
+                    - 'COMPARISON_NE'
+                  required: true
+                - name: 'threshold'
+                  type: Integer
+                  description: |
+                    Test the boolean value in the indicated column.
+                  required: true
+              exactly_one_of:
+                - 'rowCountTest'
+                - 'booleanTest'
+            - name: 'booleanTest'
+              type: NestedObject
+              description: |
+                The start date and time of the query. If left unspecified, then the
+                query will start immediately.
+              properties:
+                - name: 'column'
+                  type: String
+                  description: |
+                    The name of the column containing the boolean value. If the value
+                    in a row is NULL, that row is ignored.
+                  required: true
+              exactly_one_of:
+                - 'rowCountTest'
+                - 'booleanTest'
   - name: 'notificationChannels'
     type: Array
     # TODO chrisst - turn this into a resource ref

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -238,36 +238,18 @@ func testAccMonitoringAlertPolicy_promql(t *testing.T) {
 
 func testAccMonitoringAlertPolicy_sql(t *testing.T) {
 
-	alertName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	conditionName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckAlertPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMonitoringAlertPolicy_sqlMinutesRowCountCfg(alertName, conditionName),
+				Config: testAccMonitoringAlertPolicy_sqlCfg(),
 			},
 			{
-				Config: testAccMonitoringAlertPolicy_sqlMinutesBooleanCfg(alertName, conditionName),
-			},
-			{
-				Config: testAccMonitoringAlertPolicy_sqlHourlyRowCountCfg(alertName, conditionName),
-			},
-			{
-				Config: testAccMonitoringAlertPolicy_sqlHourlyBooleanCfg(alertName, conditionName),
-			},
-			{
-				Config: testAccMonitoringAlertPolicy_sqlDailyRowCountCfg(alertName, conditionName),
-			},
-			{
-				Config: testAccMonitoringAlertPolicy_sqlDailyBooleanCfg(alertName, conditionName),
-			},
-			{
-				ResourceName:      "google_monitoring_alert_policy.sql",
-				ImportState:       true,
-				ImportStateVerify: true,
+				// SQL alerts require additional GCP resources to be created and billed,
+				// so we only run the plan test for now.
+				PlanOnly: true,
 			},
 		},
 	})
@@ -518,15 +500,15 @@ resource "google_monitoring_alert_policy" "promql" {
 `, alertName, conditionName)
 }
 
-func testAccMonitoringAlertPolicy_sqlMinutesRowCountCfg(alertName, conditionName string) string {
+func testAccMonitoringAlertPolicy_sqlCfg() string {
 	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+resource "google_monitoring_alert_policy" "sql_minutes_row_count" {
+  display_name = "minutes_row_count"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "minutes_row_count"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -552,18 +534,13 @@ resource "google_monitoring_alert_policy" "sql" {
     }
   }
 }
-`, alertName, conditionName)
-}
-
-func testAccMonitoringAlertPolicy_sqlMinutesBooleanCfg(alertName, conditionName string) string {
-	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+resource "google_monitoring_alert_policy" "sql_minutes_boolean" {
+  display_name = "minutes_boolean"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "minutes_boolean"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -587,19 +564,14 @@ resource "google_monitoring_alert_policy" "sql" {
         url = "http://mydomain.com"
     }
   }
-}
-`, alertName, conditionName)
-}
-
-func testAccMonitoringAlertPolicy_sqlHourlyRowCountCfg(alertName, conditionName string) string {
-	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+}	
+resource "google_monitoring_alert_policy" "sql_hourly_row_count" {
+  display_name = "hourly_row_count"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "hourly_row_count"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -626,18 +598,13 @@ resource "google_monitoring_alert_policy" "sql" {
     }
   }
 }
-`, alertName, conditionName)
-}
-
-func testAccMonitoringAlertPolicy_sqlHourlyBooleanCfg(alertName, conditionName string) string {
-	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+resource "google_monitoring_alert_policy" "sql_hourly_boolean" {
+  display_name = "hourly_boolean"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "hourly_boolean"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -663,18 +630,13 @@ resource "google_monitoring_alert_policy" "sql" {
     }
   }
 }
-`, alertName, conditionName)
-}
-
-func testAccMonitoringAlertPolicy_sqlDailyRowCountCfg(alertName, conditionName string) string {
-	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+resource "google_monitoring_alert_policy" "sql_daily_row_count" {
+  display_name = "daily_row_count"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "daily_row_count"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -706,18 +668,13 @@ resource "google_monitoring_alert_policy" "sql" {
     }
   }
 }
-`, alertName, conditionName)
-}
-
-func testAccMonitoringAlertPolicy_sqlDailyBooleanCfg(alertName, conditionName string) string {
-	return fmt.Sprintf(`
-resource "google_monitoring_alert_policy" "sql" {
-  display_name = "%s"
+resource "google_monitoring_alert_policy" "sql_daily_boolean" {
+  display_name = "daily_boolean"
   combiner     = "OR"
   enabled      = true
 
   conditions {
-    display_name = "%s"
+    display_name = "daily_boolean"
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
@@ -748,5 +705,5 @@ resource "google_monitoring_alert_policy" "sql" {
     }
   }
 }
-`, alertName, conditionName)
+`)
 }

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -247,7 +247,8 @@ func testAccMonitoringAlertPolicy_sql(t *testing.T) {
 				Config: testAccMonitoringAlertPolicy_sqlCfg(),
 				// SQL alerts require additional GCP resources to be created and billed,
 				// so we only run the plan test for now.
-				PlanOnly: true,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -523,6 +523,7 @@ resource "google_monitoring_alert_policy" "sql" {
         comparison = "COMPARISON_GT"
         threshold  = "0"
       }
+    }
   }
 
   severity     = "WARNING"

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -245,8 +245,6 @@ func testAccMonitoringAlertPolicy_sql(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMonitoringAlertPolicy_sqlCfg(),
-			},
-			{
 				// SQL alerts require additional GCP resources to be created and billed,
 				// so we only run the plan test for now.
 				PlanOnly: true,

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_alert_policy_test.go
@@ -247,7 +247,22 @@ func testAccMonitoringAlertPolicy_sql(t *testing.T) {
 		CheckDestroy:             testAccCheckAlertPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMonitoringAlertPolicy_sqlCfg(alertName, conditionName),
+				Config: testAccMonitoringAlertPolicy_sqlMinutesRowCountCfg(alertName, conditionName),
+			},
+			{
+				Config: testAccMonitoringAlertPolicy_sqlMinutesBooleanCfg(alertName, conditionName),
+			},
+			{
+				Config: testAccMonitoringAlertPolicy_sqlHourlyRowCountCfg(alertName, conditionName),
+			},
+			{
+				Config: testAccMonitoringAlertPolicy_sqlHourlyBooleanCfg(alertName, conditionName),
+			},
+			{
+				Config: testAccMonitoringAlertPolicy_sqlDailyRowCountCfg(alertName, conditionName),
+			},
+			{
+				Config: testAccMonitoringAlertPolicy_sqlDailyBooleanCfg(alertName, conditionName),
 			},
 			{
 				ResourceName:      "google_monitoring_alert_policy.sql",
@@ -503,7 +518,7 @@ resource "google_monitoring_alert_policy" "promql" {
 `, alertName, conditionName)
 }
 
-func testAccMonitoringAlertPolicy_sqlCfg(alertName, conditionName string) string {
+func testAccMonitoringAlertPolicy_sqlMinutesRowCountCfg(alertName, conditionName string) string {
 	return fmt.Sprintf(`
 resource "google_monitoring_alert_policy" "sql" {
   display_name = "%s"
@@ -515,13 +530,208 @@ resource "google_monitoring_alert_policy" "sql" {
     
     condition_sql {
       query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
-      duration        = "60s"
       minutes {
-        periodicity = 600
+        periodicity = 30
       }
       row_count_test {
         comparison = "COMPARISON_GT"
         threshold  = "0"
+      }
+    }
+  }
+
+  severity     = "WARNING"
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+    subject = "test subject"
+    links {
+        display_name = "link display name"
+        url = "http://mydomain.com"
+    }
+  }
+}
+`, alertName, conditionName)
+}
+
+func testAccMonitoringAlertPolicy_sqlMinutesBooleanCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "sql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+    
+    condition_sql {
+      query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
+      minutes {
+        periodicity = 30
+      }
+      boolean_test {
+        column  = "resource"
+      }
+    }
+  }
+
+  severity     = "WARNING"
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+    subject = "test subject"
+    links {
+        display_name = "link display name"
+        url = "http://mydomain.com"
+    }
+  }
+}
+`, alertName, conditionName)
+}
+
+func testAccMonitoringAlertPolicy_sqlHourlyRowCountCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "sql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+    
+    condition_sql {
+      query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
+      hourly {
+        periodicity = 3
+				minute_offset = 10
+      }
+      row_count_test {
+        comparison = "COMPARISON_GT"
+        threshold  = "0"
+      }
+    }
+  }
+
+  severity     = "WARNING"
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+    subject = "test subject"
+    links {
+        display_name = "link display name"
+        url = "http://mydomain.com"
+    }
+  }
+}
+`, alertName, conditionName)
+}
+
+func testAccMonitoringAlertPolicy_sqlHourlyBooleanCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "sql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+    
+    condition_sql {
+      query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
+      hourly {
+        periodicity = 3
+				minute_offset = 10
+      }
+      boolean_test {
+        column  = "resource"
+      }
+    }
+  }
+
+  severity     = "WARNING"
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+    subject = "test subject"
+    links {
+        display_name = "link display name"
+        url = "http://mydomain.com"
+    }
+  }
+}
+`, alertName, conditionName)
+}
+
+func testAccMonitoringAlertPolicy_sqlDailyRowCountCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "sql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+    
+    condition_sql {
+      query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
+      daily {
+        periodicity = 3
+				execution_time {
+					hours = 10
+					minutes = 10
+					seconds = 10
+					nanos = 10
+				}
+      }
+      row_count_test {
+        comparison = "COMPARISON_GT"
+        threshold  = "0"
+      }
+    }
+  }
+
+  severity     = "WARNING"
+
+  documentation {
+    content   = "test content"
+    mime_type = "text/markdown"
+    subject = "test subject"
+    links {
+        display_name = "link display name"
+        url = "http://mydomain.com"
+    }
+  }
+}
+`, alertName, conditionName)
+}
+
+func testAccMonitoringAlertPolicy_sqlDailyBooleanCfg(alertName, conditionName string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_alert_policy" "sql" {
+  display_name = "%s"
+  combiner     = "OR"
+  enabled      = true
+
+  conditions {
+    display_name = "%s"
+    
+    condition_sql {
+      query           = "SELECT severity, resource FROM project.global._Default._AllLogs WHERE severity IS NOT NULL"
+      daily {
+        periodicity = 3
+				execution_time {
+					hours = 10
+					minutes = 10
+					seconds = 10
+					nanos = 10
+				}
+      }
+      boolean_test {
+        column  = "resource"
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21259.

Adds support for SQL condition types when creating an Alert Policy. SQL conditions are currently configurable through the UI or API directly: https://cloud.google.com/logging/docs/analyze/sql-in-alerting

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
monitoring: added `condition_sql` field to `monitoring_alert_policy` resource
```
