### PR TITLE
Fix various product headings in the Registry

### DIFF
--- a/mmv1/products/apihub/product.yaml
+++ b/mmv1/products/apihub/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: Apihub
-display_name: API hub
+display_name: "API Hub"
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:

--- a/mmv1/products/bigqueryanalyticshub/product.yaml
+++ b/mmv1/products/bigqueryanalyticshub/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'BigqueryAnalyticsHub'
-display_name: 'Bigquery Analytics Hub'
+display_name: 'BigQuery Analytics Hub'
 versions:
   - name: 'beta'
     base_url: 'https://analyticshub.googleapis.com/v1/'

--- a/mmv1/products/blockchainnodeengine/product.yaml
+++ b/mmv1/products/blockchainnodeengine/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'BlockchainNodeEngine'
-display_name: 'Blockchain node engine'
+display_name: 'Blockchain Node Engine'
 versions:
   - name: 'ga'
     base_url: 'https://blockchainnodeengine.googleapis.com/v1/'

--- a/mmv1/products/certificatemanager/product.yaml
+++ b/mmv1/products/certificatemanager/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'CertificateManager'
-display_name: 'Certificate manager'
+display_name: 'Certificate Manager'
 versions:
   - name: 'beta'
     base_url: 'https://certificatemanager.googleapis.com/v1/'

--- a/mmv1/products/datacatalog/product.yaml
+++ b/mmv1/products/datacatalog/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'DataCatalog'
-display_name: 'Data catalog'
+display_name: 'Data Catalog'
 versions:
   - name: 'ga'
     base_url: 'https://datacatalog.googleapis.com/v1/'

--- a/mmv1/products/dlp/product.yaml
+++ b/mmv1/products/dlp/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'DataLossPrevention'
-display_name: 'Data loss prevention'
+display_name: 'Data Loss Prevention'
 versions:
   - name: 'ga'
     base_url: 'https://dlp.googleapis.com/v2/'

--- a/mmv1/products/metastore/product.yaml
+++ b/mmv1/products/metastore/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'DataprocMetastore'
-display_name: 'Dataproc metastore'
+display_name: 'Dataproc Metastore'
 versions:
   - name: 'beta'
     base_url: 'https://metastore.googleapis.com/v1beta/'

--- a/mmv1/products/networkmanagement/product.yaml
+++ b/mmv1/products/networkmanagement/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'NetworkManagement'
-display_name: 'NetworkManagement'
+display_name: 'Network Management'
 versions:
   - name: 'ga'
     base_url: 'https://networkmanagement.googleapis.com/v1/'

--- a/mmv1/products/networksecurity/product.yaml
+++ b/mmv1/products/networksecurity/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'NetworkSecurity'
-display_name: 'Network security'
+display_name: 'Network Security'
 versions:
   - name: 'beta'
     base_url: 'https://networksecurity.googleapis.com/v1beta1/'

--- a/mmv1/products/networkservices/product.yaml
+++ b/mmv1/products/networkservices/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'NetworkServices'
-display_name: 'Network services'
+display_name: 'Network Services'
 versions:
   - name: 'beta'
     base_url: 'https://networkservices.googleapis.com/v1/'

--- a/mmv1/products/publicca/product.yaml
+++ b/mmv1/products/publicca/product.yaml
@@ -13,7 +13,7 @@
 
 ---
 name: 'PublicCA'
-display_name: 'Public ca'
+display_name: 'Public CA'
 versions:
   - name: 'ga'
     base_url: 'https://publicca.googleapis.com/v1/'

--- a/mmv1/products/securitycenterv2/product.yaml
+++ b/mmv1/products/securitycenterv2/product.yaml
@@ -14,7 +14,7 @@
 ---
 name: 'SecurityCenterV2'
 legacy_name: 'scc_v2'
-display_name: 'Security Command Center (SCC)v2 API'
+display_name: 'Security Command Center (SCC) v2 API'
 versions:
   - name: 'ga'
     base_url: 'https://securitycenter.googleapis.com/v2/'

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_backup.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_backup.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Backup and DR Backup"
+subcategory: "Backup and DR Service"
 description: |-
   Get information about a Backupdr Backup.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_plan_association.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_plan_association.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Backup and DR BackupPlanAssociation"
+subcategory: "Backup and DR Service"
 description: |-
   Get information about a Backupdr BackupPlanAssociation.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_vault.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_vault.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Backup and DR BackupVault"
+subcategory: "Backup and DR Service"
 description: |-
   Get information about a Backupdr BackupVault.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Backup and DR Data Source"
+subcategory: "Backup and DR Service"
 description: |-
   Get information about a Backupdr Data Source.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_management_server.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_management_server.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "BackupDR Management Server"
+subcategory: "Backup and DR Service"
 description: |-
   Get information about a Backupdr Management server.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificate_map.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificate_map.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Certificate manager"
+subcategory: "Certificate Manager"
 description: |-
   Contains the data that describes a Certificate Map
 ---

--- a/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificates.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/certificate_manager_certificates.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Certificate manager"
+subcategory: "Certificate Manager"
 description: |-
   List all certificates within a project and region.
 ---

--- a/mmv1/third_party/terraform/website/docs/d/dataproc_metastore_service.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/dataproc_metastore_service.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Dataproc metastore"
+subcategory: "Dataproc Metastore"
 description: |-
   Get a Dataproc Metastore Service from Google Cloud
 ---


### PR DESCRIPTION
Saw a wall of BackupDR datasources (filed https://github.com/hashicorp/terraform-provider-google/issues/21261 to mitigate in the future) and did a pass of product names to fix caps / spacing / other minor issues.

We should probably validate "Cloud" prefixes and naming for remaining v2s after b/392147882. I almost removed DM's but then checked and it's inconsistently referred to as "Google Cloud Deployment Manager", "Cloud Deployment Manager", and "Deployment Manager" where I wouldn't have expected "Cloud Deployment Manager" to be in the mix.

To review, I'd recommend checking the handwritten resources and datasources for these products to make sure I didn't orphan any.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
