### PR TITLE
Fix IAM Policy Datasource header

### DIFF
--- a/mmv1/templates/terraform/datasource_iam.html.markdown.tmpl
+++ b/mmv1/templates/terraform/datasource_iam.html.markdown.tmpl
@@ -54,7 +54,8 @@ description: |-
 ---
 
 
-# `{{ $.IamTerraformName }}_policy`
+# {{ $.IamTerraformName }}_policy
+
 Retrieves the current IAM policy data for {{ lower $.Name }}
 {{- if or (eq $.MinVersionObj.Name "beta") (eq $.IamPolicy.MinVersion "beta") }}
 ~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
@@ -62,7 +63,8 @@ See [Provider Versions](https://terraform.io/docs/providers/google/guides/provid
 {{- end }}
 
 
-## example
+## Example Usage
+
 
 ```hcl
 data "{{ $.IamTerraformName }}_policy" "policy" {


### PR DESCRIPTION
Currently displays as `code text` instead of header text. See https://registry.terraform.io/providers/hashicorp/google/6.19.0/docs/data-sources/compute_instance and https://registry.terraform.io/providers/hashicorp/google/6.19.0/docs/data-sources/compute_instance_iam_policy for an example of a typical vs IAM policy DS.

Also fix the example header- use `Example Usage` similar to old single-example handwritten resources instead of `example`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
