### PR TITLE
`mmv1`: add `hashicorp/gocty/cty` in resource.go.tmpl

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -55,6 +55,7 @@ import (
     "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
     "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
     "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+    "github.com/hashicorp/go-cty/cty"
 
     "{{ $.ImportPath }}/tpgresource"
     transport_tpg "{{ $.ImportPath }}/transport"


### PR DESCRIPTION
Was running into issues with the provider generation when a resource required the use of `cty`. Instead of using `hashicorp/go-cty/cty` which is the intended dependency to use in `terraform-sdk-v2` it was using the `zclconf/go-cty/cty` which caused build errors upon generation. This exact build error was ran into when working on the following [PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/12800#issuecomment-2635871281). When using the appropriate dependency it builds and runs just fine.

No diffs on generation for all other resources.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
