### PR TITLE
make authz extension wire_format O+C

### DIFF
--- a/mmv1/products/networkservices/AuthzExtension.yaml
+++ b/mmv1/products/networkservices/AuthzExtension.yaml
@@ -142,9 +142,8 @@ properties:
   - name: 'wireFormat'
     type: Enum
     description: |
-      The format of communication supported by the callout extension.
-    default_value: "EXT_PROC_GRPC"
-    custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.tmpl'
+      The format of communication supported by the callout extension. Will be set to EXT_PROC_GRPC by the backend if no value is set.
+    default_from_api: true
     enum_values:
       - 'WIRE_FORMAT_UNSPECIFIED'
       - 'EXT_PROC_GRPC'

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
@@ -47,13 +47,13 @@ func TestAccNetworkServicesAuthzExtension_update(t *testing.T) {
 func testAccNetworkServicesAuthzExtension_start(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
-  name                    = "lb-network"
+  name                    = "lb-network%{random_suffix}"
   project                 = "%{project}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "backend-subnet"
+  name          = "backend-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.1.2.0/24"
@@ -61,7 +61,7 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxy_only" {
-  name          = "proxy-only-subnet"
+  name          = "proxy-only-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.129.0.0/23"
@@ -71,7 +71,7 @@ resource "google_compute_subnetwork" "proxy_only" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "l7-ilb-ip-address"
+  name         = "l7-ilb-ip-address%{random_suffix}"
   project      = "%{project}"
   region       = "us-west1"
   subnetwork   = google_compute_subnetwork.default.id
@@ -81,7 +81,7 @@ resource "google_compute_address" "default" {
 
 
 resource "google_compute_region_health_check" "default" {
-  name    = "l7-ilb-basic-check"
+  name    = "l7-ilb-basic-check%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
 
@@ -91,7 +91,7 @@ resource "google_compute_region_health_check" "default" {
 }
 
 resource "google_compute_region_backend_service" "url_map" {
-  name                  = "l7-ilb-backend-service"
+  name                  = "l7-ilb-backend-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -100,7 +100,7 @@ resource "google_compute_region_backend_service" "url_map" {
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  name                  = "l7-ilb-forwarding-rule"
+  name                  = "l7-ilb-forwarding-rule%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -115,21 +115,21 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  name            = "l7-ilb-map"
+  name            = "l7-ilb-map%{random_suffix}"
   project         = "%{project}"
   region          = "us-west1"
   default_service = google_compute_region_backend_service.url_map.id
 }
 
 resource "google_compute_region_target_http_proxy" "default" {
-  name    = "l7-ilb-proxy"
+  name    = "l7-ilb-proxy%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
   url_map = google_compute_region_url_map.default.id
 }
 
 resource "google_compute_region_backend_service" "default" {
-  name                  = "authz-service"
+  name                  = "authz-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
 
@@ -139,7 +139,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_backend_service" "updated" {
-  name                  = "authz-service-updated"
+  name                  = "authz-service-updated%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   
@@ -167,13 +167,13 @@ resource "google_network_services_authz_extension" "default" {
 func testAccNetworkServicesAuthzExtension_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
-  name                    = "lb-network"
+  name                    = "lb-network%{random_suffix}"
   project                 = "%{project}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "backend-subnet"
+  name          = "backend-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.1.2.0/24"
@@ -181,7 +181,7 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxy_only" {
-  name          = "proxy-only-subnet"
+  name          = "proxy-only-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.129.0.0/23"
@@ -191,7 +191,7 @@ resource "google_compute_subnetwork" "proxy_only" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "l7-ilb-ip-address"
+  name         = "l7-ilb-ip-address%{random_suffix}"
   project      = "%{project}"
   region       = "us-west1"
   subnetwork   = google_compute_subnetwork.default.id
@@ -200,7 +200,7 @@ resource "google_compute_address" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  name    = "l7-ilb-basic-check"
+  name    = "l7-ilb-basic-check%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
 
@@ -210,7 +210,7 @@ resource "google_compute_region_health_check" "default" {
 }
 
 resource "google_compute_region_backend_service" "url_map" {
-  name                  = "l7-ilb-backend-service"
+  name                  = "l7-ilb-backend-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -219,7 +219,7 @@ resource "google_compute_region_backend_service" "url_map" {
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  name                  = "l7-ilb-forwarding-rule"
+  name                  = "l7-ilb-forwarding-rule%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -234,21 +234,21 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  name            = "l7-ilb-map"
+  name            = "l7-ilb-map%{random_suffix}"
   project         = "%{project}"
   region          = "us-west1"
   default_service = google_compute_region_backend_service.url_map.id
 }
 
 resource "google_compute_region_target_http_proxy" "default" {
-  name    = "l7-ilb-proxy"
+  name    = "l7-ilb-proxy%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
   url_map = google_compute_region_url_map.default.id
 }
 
 resource "google_compute_region_backend_service" "default" {
-  name                  = "authz-service"
+  name                  = "authz-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
 
@@ -258,7 +258,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_backend_service" "updated" {
-  name                  = "authz-service-updated"
+  name                  = "authz-service-updated%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
@@ -279,7 +279,6 @@ resource "google_network_services_authz_extension" "default" {
   timeout               = "0.1s"
   fail_open             = false
   forward_headers       = ["Authorization"]
-  wire_format           = "EXT_PROC_GRPC"
 
   metadata = {
     forwarding_rule_id = google_compute_forwarding_rule.default.id

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
@@ -47,13 +47,13 @@ func TestAccNetworkServicesAuthzExtension_update(t *testing.T) {
 func testAccNetworkServicesAuthzExtension_start(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
-  name                    = "lb-network%{random_suffix}"
+  name                    = "tf-test-lb-network%{random_suffix}"
   project                 = "%{project}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "backend-subnet%{random_suffix}"
+  name          = "tf-test-backend-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.1.2.0/24"
@@ -61,7 +61,7 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxy_only" {
-  name          = "proxy-only-subnet%{random_suffix}"
+  name          = "tf-test-proxy-only-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.129.0.0/23"
@@ -71,7 +71,7 @@ resource "google_compute_subnetwork" "proxy_only" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "l7-ilb-ip-address%{random_suffix}"
+  name         = "tf-test-l7-ilb-ip-address%{random_suffix}"
   project      = "%{project}"
   region       = "us-west1"
   subnetwork   = google_compute_subnetwork.default.id
@@ -81,7 +81,7 @@ resource "google_compute_address" "default" {
 
 
 resource "google_compute_region_health_check" "default" {
-  name    = "l7-ilb-basic-check%{random_suffix}"
+  name    = "tf-test-l7-ilb-basic-check%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
 
@@ -91,7 +91,7 @@ resource "google_compute_region_health_check" "default" {
 }
 
 resource "google_compute_region_backend_service" "url_map" {
-  name                  = "l7-ilb-backend-service%{random_suffix}"
+  name                  = "tf-test-l7-ilb-backend-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -100,7 +100,7 @@ resource "google_compute_region_backend_service" "url_map" {
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  name                  = "l7-ilb-forwarding-rule%{random_suffix}"
+  name                  = "tf-test-l7-ilb-forwarding-rule%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -115,21 +115,21 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  name            = "l7-ilb-map%{random_suffix}"
+  name            = "tf-test-l7-ilb-map%{random_suffix}"
   project         = "%{project}"
   region          = "us-west1"
   default_service = google_compute_region_backend_service.url_map.id
 }
 
 resource "google_compute_region_target_http_proxy" "default" {
-  name    = "l7-ilb-proxy%{random_suffix}"
+  name    = "tf-test-l7-ilb-proxy%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
   url_map = google_compute_region_url_map.default.id
 }
 
 resource "google_compute_region_backend_service" "default" {
-  name                  = "authz-service%{random_suffix}"
+  name                  = "tf-test-authz-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
 
@@ -139,7 +139,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_backend_service" "updated" {
-  name                  = "authz-service-updated%{random_suffix}"
+  name                  = "tf-test-authz-service-updated%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   
@@ -167,13 +167,13 @@ resource "google_network_services_authz_extension" "default" {
 func testAccNetworkServicesAuthzExtension_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "default" {
-  name                    = "lb-network%{random_suffix}"
+  name                    = "tf-test-lb-network%{random_suffix}"
   project                 = "%{project}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "backend-subnet%{random_suffix}"
+  name          = "tf-test-backend-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.1.2.0/24"
@@ -181,7 +181,7 @@ resource "google_compute_subnetwork" "default" {
 }
 
 resource "google_compute_subnetwork" "proxy_only" {
-  name          = "proxy-only-subnet%{random_suffix}"
+  name          = "tf-test-proxy-only-subnet%{random_suffix}"
   project       = "%{project}"
   region        = "us-west1"
   ip_cidr_range = "10.129.0.0/23"
@@ -191,7 +191,7 @@ resource "google_compute_subnetwork" "proxy_only" {
 }
 
 resource "google_compute_address" "default" {
-  name         = "l7-ilb-ip-address%{random_suffix}"
+  name         = "tf-test-l7-ilb-ip-address%{random_suffix}"
   project      = "%{project}"
   region       = "us-west1"
   subnetwork   = google_compute_subnetwork.default.id
@@ -200,7 +200,7 @@ resource "google_compute_address" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  name    = "l7-ilb-basic-check%{random_suffix}"
+  name    = "tf-test-l7-ilb-basic-check%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
 
@@ -210,7 +210,7 @@ resource "google_compute_region_health_check" "default" {
 }
 
 resource "google_compute_region_backend_service" "url_map" {
-  name                  = "l7-ilb-backend-service%{random_suffix}"
+  name                  = "tf-test-l7-ilb-backend-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -219,7 +219,7 @@ resource "google_compute_region_backend_service" "url_map" {
 }
 
 resource "google_compute_forwarding_rule" "default" {
-  name                  = "l7-ilb-forwarding-rule%{random_suffix}"
+  name                  = "tf-test-l7-ilb-forwarding-rule%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -234,21 +234,21 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  name            = "l7-ilb-map%{random_suffix}"
+  name            = "tf-test-l7-ilb-map%{random_suffix}"
   project         = "%{project}"
   region          = "us-west1"
   default_service = google_compute_region_backend_service.url_map.id
 }
 
 resource "google_compute_region_target_http_proxy" "default" {
-  name    = "l7-ilb-proxy%{random_suffix}"
+  name    = "tf-test-l7-ilb-proxy%{random_suffix}"
   project = "%{project}"
   region  = "us-west1"
   url_map = google_compute_region_url_map.default.id
 }
 
 resource "google_compute_region_backend_service" "default" {
-  name                  = "authz-service%{random_suffix}"
+  name                  = "tf-test-authz-service%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
 
@@ -258,7 +258,7 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_backend_service" "updated" {
-  name                  = "authz-service-updated%{random_suffix}"
+  name                  = "tf-test-authz-service-updated%{random_suffix}"
   project               = "%{project}"
   region                = "us-west1"
   


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/21129
fixes https://github.com/hashicorp/terraform-provider-google/issues/21120
fixes https://github.com/hashicorp/terraform-provider-google/issues/21180
fixes https://github.com/hashicorp/terraform-provider-google/issues/21171

not sure if the API changed behavior since resource implementation, but the API no longer accepts the provider supplying the default value. Changing the field to be O+C to allow the API to set the default itself.

Should _not_ be a breaking change due to making it O+C while also moving away from a default that is just straight up invalid.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkservices: fixed a bug with `google_network_services_authz_extension.wire_format` sending an invalid default value by removing the Terraform default and letting the API set the default.
```
