### PR TITLE
Fix google_dns_managed_zone update

### DIFF
--- a/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
+++ b/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
@@ -8,5 +8,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   if err != nil {
     return "", err
   }
-  return url, nil
+
+  // v1 is the only version in use, replace the first occurrence of v1beta with v1 in the URL
+  return strings.Replace(url, "/v1beta/", "/v1/", 1), nil
 }

--- a/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
+++ b/mmv1/templates/terraform/custom_expand/sd_full_url.tmpl
@@ -10,5 +10,5 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   }
 
   // v1 is the only version in use, replace the first occurrence of v1beta with v1 in the URL
-  return strings.Replace(url, "/v1beta/", "/v1/", 1), nil
+  return strings.Replace(url, "/v1beta1/", "/v1/", 1), nil
 }

--- a/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
@@ -661,3 +661,113 @@ resource "google_dns_managed_zone" "foobar" {
 }
 `, suffix, suffix, description, project)
 }
+
+{{ if not (or (eq $.TargetVersionName ``) (eq $.TargetVersionName `ga`)) }}
+func TestAccDNSManagedZone_dnsManagedZoneUpdateWithServiceDirectory(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSManagedZone_dnsManagedZoneWithServiceDirectory(context),
+			},
+			{
+				ResourceName:            "google_dns_managed_zone.sd-zone",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccDNSManagedZone_dnsManagedZoneWithServiceDirectoryUpdate(context),
+			},
+			{
+				ResourceName:            "google_dns_managed_zone.sd-zone",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDNSManagedZone_dnsManagedZoneWithServiceDirectory(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dns_managed_zone" "sd-zone" {
+  provider = google-beta
+
+  name        = "tf-test-peering-zone%{random_suffix}"
+  dns_name    = "services.example.com."
+  description = "Example private DNS Service Directory zone"
+
+  visibility = "private"
+
+  service_directory_config {
+    namespace {
+      namespace_url = google_service_directory_namespace.example.id
+    }
+  }
+}
+
+resource "google_service_directory_namespace" "example" {
+  provider = google-beta
+
+  namespace_id = "tf-test-example%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_compute_network" "network" {
+  provider = google-beta
+
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
+}
+
+func testAccDNSManagedZone_dnsManagedZoneWithServiceDirectoryUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dns_managed_zone" "sd-zone" {
+  provider = google-beta
+
+  name        = "tf-test-peering-zone%{random_suffix}"
+  dns_name    = "services.example.com."
+  description = "Example private DNS Service Directory zone"
+
+  visibility = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = google_compute_network.network.id
+    }
+  }
+
+  service_directory_config {
+    namespace {
+      namespace_url = google_service_directory_namespace.example.id
+    }
+  }
+}
+
+resource "google_service_directory_namespace" "example" {
+  provider = google-beta
+
+  namespace_id = "tf-test-example%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_compute_network" "network" {
+  provider = google-beta
+
+  name                    = "tf-test-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
The API standardizes the namespace url to `v1`, and therefore making this corresponding change in the expander to address the mismatch issue.

This is a revised version of https://github.com/GoogleCloudPlatform/magic-modules/pull/12934 to ensure the URL is safely converted to use for [universe domain](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#universe_domain-1) and [custom endpoint](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#{{service}}_custom_endpoint-1)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
dns: fixed a bug where `google_dns_managed_zone` is unable to update with `service_directory_config` specified (beta)
```
