### PR TITLE
Fixed error message when naming disks

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -294,6 +294,8 @@ properties:
       character, which cannot be a dash.
     required: true
     immutable: true
+    validation:
+      function: 'verify.ValidateGCEName'
   - name: 'size'
     type: Integer
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

### Related :

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/18165

Added validation for disk names in `google_compute_disk`
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: added validation for disk names in `google_compute_disk`
```