### PR TITLE
Fix google_storage_bucket HNS example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -111,7 +111,7 @@ resource "google_storage_bucket" "auto-expire" {
   location      = "US"
   force_destroy = true
 
-  hierarchical_namespace = {
+  hierarchical_namespace {
     enabled = true
   }
 }


### PR DESCRIPTION
`hierarchical_namespace` is a block, not an attribute.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
