### PR TITLE
Fixed TestAccComposerEnvironment_fixPyPiPackages

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go.tmpl
@@ -971,7 +971,7 @@ func TestAccComposerEnvironment_fixPyPiPackages(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComposerEnvironment_fixPyPiPackages(envName, network, subnetwork, serviceAccount),
-				ExpectError: regexp.MustCompile("Failed to install pypi packages"),
+				ExpectError: regexp.MustCompile("Failed to install Python packages"),
 			},
 			{
 				Config: testAccComposerEnvironment_fixPyPiPackagesUpdate(envName, network, subnetwork, serviceAccount),


### PR DESCRIPTION
Updated expected failure message for pypi install issues. I used `(Python|pypi)` since this is failing 100% in Beta but less than that in GA - probably this is in the process of rolling out, so let's support both for now.

Fixed https://github.com/hashicorp/terraform-provider-google/issues/21242

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
