### PR TITLE
Add location field to google_network_services_mesh

### DIFF
--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -59,6 +59,11 @@ examples:
     min_version: 'beta'
     vars:
       resource_name: 'my-mesh-noport'
+  - name: 'network_services_mesh_location'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      resource_name: 'my-mesh'
 parameters:
   - name: 'name'
     type: String
@@ -112,4 +117,6 @@ properties:
     url_param_only: true
     immutable: true
     default_value: 'global'
+    validation:
+      regex: '^global$'
 

--- a/mmv1/products/networkservices/Mesh.yaml
+++ b/mmv1/products/networkservices/Mesh.yaml
@@ -22,13 +22,13 @@ references:
   guides:
   api: 'https://cloud.google.com/traffic-director/docs/reference/network-services/rest/v1beta1/projects.locations.meshes'
 docs:
-base_url: 'projects/{{project}}/locations/global/meshes'
-self_link: 'projects/{{project}}/locations/global/meshes/{{name}}'
-create_url: 'projects/{{project}}/locations/global/meshes?meshId={{name}}'
+base_url: 'projects/{{project}}/locations/{{location}}/meshes'
+self_link: 'projects/{{project}}/locations/{{location}}/meshes/{{name}}'
+create_url: 'projects/{{project}}/locations/{{location}}/meshes?meshId={{name}}'
 update_verb: 'PATCH'
 update_mask: true
 import_format:
-  - 'projects/{{project}}/locations/global/meshes/{{name}}'
+  - 'projects/{{project}}/locations/{{location}}/meshes/{{name}}'
 timeouts:
   insert_minutes: 30
   update_minutes: 30
@@ -46,6 +46,8 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+schema_version: 1
+state_upgraders: true
 examples:
   - name: 'network_services_mesh_basic'
     primary_resource_id: 'default'
@@ -102,3 +104,12 @@ properties:
       '15001' is used as the interception port. This will is applicable only for sidecar proxy
       deployments.
     min_version: 'beta'
+  - name: 'location'
+    type: String
+    description: |
+      Location (region) of the Mesh resource to be created. Only the value 'global' is currently allowed; defaults to 'global' if omitted.
+    min_version: 'beta'
+    url_param_only: true
+    immutable: true
+    default_value: 'global'
+

--- a/mmv1/templates/terraform/examples/network_services_mesh_location.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_mesh_location.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_network_services_mesh" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  name        = "{{index $.Vars "resource_name"}}"
+  location    = "global"
+}

--- a/mmv1/templates/terraform/state_migrations/network_services_mesh.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/network_services_mesh.go.tmpl
@@ -1,0 +1,98 @@
+func resourceNetworkServicesMeshResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkServicesMeshCreate,
+		Read:   resourceNetworkServicesMeshRead,
+		Update: resourceNetworkServicesMeshUpdate,
+		Delete: resourceNetworkServicesMeshDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: resourceNetworkServicesMeshImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
+		CustomizeDiff: customdiff.All(
+			tpgresource.SetLabelsDiff,
+			tpgresource.DefaultProviderProject,
+		),
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `Short name of the Mesh resource to be created.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `A free-text description of the resource. Max length 1024 characters.`,
+			},
+			"interception_port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Description: `Optional. If set to a valid TCP port (1-65535), instructs the SIDECAR proxy to listen on the
+specified port of localhost (127.0.0.1) address. The SIDECAR proxy will expect all traffic to
+be redirected to this port regardless of its actual ip:port destination. If unset, a port
+'15001' is used as the interception port. This will is applicable only for sidecar proxy
+deployments.`,
+			},
+			"labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Description: `Set of label tags associated with the Mesh resource.
+
+**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
+Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
+				Elem: &schema.Schema{Type: schema.TypeString},
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Time the Mesh was created in UTC.`,
+			},
+			"effective_labels": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"self_link": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Server-defined URL of this resource.`,
+			},
+			"terraform_labels": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Description: `The combination of labels configured directly on the resource
+ and default labels configured on the provider.`,
+				Elem: &schema.Schema{Type: schema.TypeString},
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Time the Mesh was updated in UTC.`,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func ResourceNetworkServicesMeshUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error){
+    log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+    if _, ok := rawState["location"]; !ok {
+        rawState["location"] = "global"
+    }
+    log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+    return rawState, nil
+}


### PR DESCRIPTION
Adds a new `location` field to `google_network_services_mesh`.

In the future, this will allow creating a regional Mesh resource, but currently regional Meshes are internal-only and not yet publicly available, so only the value `'global'` may be set. If omitted, the location defaults to `'global'`.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `location` field to `google_network_services_mesh` resource
```
