### PR TITLE
Set PageSize to 1000 when fetch images from GAR

### DIFF
--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_docker_image.go
@@ -132,7 +132,8 @@ func DataSourceArtifactRegistryDockerImageRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error setting api endpoint")
 		}
 
-		urlRequest, err = transport_tpg.AddQueryParams(urlRequest, map[string]string{"orderBy": "update_time desc"})
+		// to reduce the number of pages we need to fetch, we set the pageSize to 1000(max)
+		urlRequest, err = transport_tpg.AddQueryParams(urlRequest, map[string]string{"orderBy": "update_time desc", "pageSize": "1000"})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
artifactregistry: set pageSize to 1000 to speedup data.google_artifact_registry_docker_image queries
```

fix: https://github.com/hashicorp/terraform-provider-google/issues/21291
