### PR TITLE
Allow storage_operation to gracefully cancel the LRO if an interrupt is received to prevent the orphaned LRO

### DIFF
--- a/mmv1/third_party/terraform/services/storage/storage_operation.go
+++ b/mmv1/third_party/terraform/services/storage/storage_operation.go
@@ -23,6 +23,27 @@ func (w *StorageOperationWaiter) QueryOp() (interface{}, error) {
 	if w == nil {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
+
+	if w.Config.Context != nil {
+		select {
+		case <-w.Config.Context.Done():
+			opCancelUrl := fmt.Sprintf("%s/cancel", w.SelfLink)
+			_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    w.Config,
+				Method:    "POST",
+				RawURL:    opCancelUrl,
+				UserAgent: w.UserAgent,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Error cancelling the LRO: %s", err)
+			}
+			return nil, fmt.Errorf("Interrupt recieved, operation cancelled")
+
+		default:
+			// Default case is intentionally left empty, as per original logic.
+		}
+	}
+
 	// Returns the proper get.
 	url := fmt.Sprintf(w.SelfLink)
 


### PR DESCRIPTION
```release-note:none
Made storage_operation to gracefully cancel the LRO if an interrupt is received to prevent the orphaned LRO
```
