### PR TITLE
Update Composer configuration description to inform configuration is not supported in Composer 3

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -725,7 +725,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 													Type:         schema.TypeString,
 													Optional:     true,
 													ValidateFunc: validation.StringInSlice([]string{"CLOUD_LOGGING_ONLY", "CLOUD_LOGGING_AND_CLOUD_STORAGE"}, false),
-													Description:  `Whether logs in cloud logging only is enabled or not. This field is supported for Cloud Composer environments in versions composer-2.0.32-airflow-2.1.4 and newer.`,
+													Description:  `Whether logs in cloud logging only is enabled or not. This field is supported for Cloud Composer environments in versions composer-2.0.32-airflow-2.1.4 and newer but not in composer-3*`,
 												},
 											},
 										},

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -732,7 +732,7 @@ func ResourceComposerEnvironment() *schema.Resource {
 									},
 									"airflow_metadata_retention_config": {
 										Type:         schema.TypeList,
-										Description: `Optional. The configuration setting for database retention.`,
+										Description: `Optional. The policy for airflow metadata database retention.`,
 										Optional:     true,
 										Computed:     true,
 										Elem: &schema.Resource{

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1367,17 +1367,20 @@ The following arguments are supported:
   [documented below](#nested_data_retention_config_c3).
 
 <a name="nested_data_retention_config_c3"></a>The `data_retention_config` block supports:
-* `task_logs_retention_config` - 
+* `airflow_metadata_retention_config` - 
   (Optional)
-  The configuration setting for Airflow task logs. Structure is
+  The retention policy for airflow metadata database. Structure is
   [documented below](#nested_task_logs_retention_config_c3).
 
-<a name="nested_task_logs_retention_config_c3"></a>The `task_logs_retention_config` block supports:
-* `storage_mode` - 
+<a name="nested_task_logs_retention_config_c3"></a>The `airflow_metadata_retention_config` block supports:
+* `retention_mode` - 
   (Optional)
-  The mode of storage for Airflow task logs. Values for storage mode are 
-  `CLOUD_LOGGING_ONLY` to only store logs in cloud logging and 
-  `CLOUD_LOGGING_AND_CLOUD_STORAGE` to store logs in cloud logging and cloud storage.
+  Retention can be either enabled or disabled. Values for retention_mode are 
+  `RETENTION_MODE_ENABLED` to enable retention and `RETENTION_MODE_DISABLED` 
+  to disable retention.
+* `retention_days` - 
+  (Optional)
+  How many days data should be retained for.
 
 
 <a name="nested_storage_config_c3"></a>The `storage_config` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1370,9 +1370,9 @@ The following arguments are supported:
 * `airflow_metadata_retention_config` - 
   (Optional)
   The retention policy for airflow metadata database. Structure is
-  [documented below](#nested_task_logs_retention_config_c3).
+  [documented below](#nested_airflow_metadata_retention_config_c3).
 
-<a name="nested_task_logs_retention_config_c3"></a>The `airflow_metadata_retention_config` block supports:
+<a name="nested_airflow_metadata_retention_config_c3"></a>The `airflow_metadata_retention_config` block supports:
 * `retention_mode` - 
   (Optional)
   Retention can be either enabled or disabled. Values for retention_mode are 


### PR DESCRIPTION
Update description to make it clear that configuration is [not supported in Composer 3](https://cloud.google.com/composer/docs/composer-3/enable-saving-logs-to-environment-bucket)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
composer: inform users that the `task_logs_retention_config` is not relevant to Composer 3 and add `airflow_metadata_retention_config`
```
