### PR TITLE
Add CMEK support for Redis cluster

### DIFF
--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -200,6 +200,7 @@ examples:
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
+      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
       'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Id'

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -202,6 +202,7 @@ examples:
       'deletion_protection_enabled': 'false'
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
+      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -202,7 +202,7 @@ examples:
       'deletion_protection_enabled': 'false'
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
-      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Id'
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -203,7 +203,6 @@ examples:
       'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
-      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Id'
 parameters:
   - name: 'name'
     type: String

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -190,6 +190,9 @@ examples:
       'deletion_protection_enabled': 'false'
   - name: "redis_cluster_cmek"
     primary_resource_id: "cluster-cmek"
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@cloud-redis.iam.gserviceaccount.com"
+        role: role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     vars:
       cluster_name: "cmek-cluster"
       policy_name: "my-policy"

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -126,9 +126,9 @@ examples:
     primary_resource_id: 'cluster-ha'
     vars:
       cluster_name: 'ha-cluster'
-      policy_name: 'mypolicy'
-      subnet_name: 'mysubnet'
-      network_name: 'mynetwork'
+      policy_name: 'my-policy'
+      subnet_name: 'my-subnet'
+      network_name: 'my-network'
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
@@ -138,9 +138,9 @@ examples:
     primary_resource_id: 'cluster-ha-single-zone'
     vars:
       cluster_name: 'ha-cluster-single-zone'
-      policy_name: 'mypolicy'
-      subnet_name: 'mysubnet'
-      network_name: 'mynetwork'
+      policy_name: 'my-policy'
+      subnet_name: 'my-subnet'
+      network_name: 'my-network'
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
@@ -168,9 +168,9 @@ examples:
     primary_resource_id: "cluster-rdb"
     vars:
       cluster_name: "rdb-cluster"
-      policy_name: "mypolicy"
-      subnet_name: "mysubnet"
-      network_name: "mynetwork"
+      policy_name: "my-policy"
+      subnet_name: "my-subnet"
+      network_name: "my-network"
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
@@ -180,9 +180,9 @@ examples:
     primary_resource_id: "cluster-aof"
     vars:
       cluster_name: "aof-cluster"
-      policy_name: "mypolicy"
-      subnet_name: "mysubnet"
-      network_name: "mynetwork"
+      policy_name: "my-policy"
+      subnet_name: "my-subnet"
+      network_name: "my-network"
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
@@ -192,11 +192,11 @@ examples:
     primary_resource_id: "cluster-cmek"
     vars:
       cluster_name: "cmek-cluster"
-      policy_name: "mypolicy"
-      subnet_name: "mysubnet"
-      network_name: "mynetwork"
-      kms_key_name: "mykey"
-      kms_ring_name: "mykeyring"
+      policy_name: "my-policy"
+      subnet_name: "my-subnet"
+      network_name: "my-network"
+      kms_key_name: "my-key"
+      kms_ring_name: "my-key-ring"
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -188,6 +188,19 @@ examples:
       'deletion_protection_enabled': 'false'
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
+  - name: "redis_cluster_cmek"
+    primary_resource_id: "cluster-cmek"
+    vars:
+      cluster_name: "cmek-cluster"
+      policy_name: "mypolicy"
+      subnet_name: "mysubnet"
+      network_name: "mynetwork"
+      kms_key_name: "mykey"
+      kms_ring_name: "mykeyring"
+    test_vars_overrides:
+      'deletion_protection_enabled': 'false'
+    oics_vars_overrides:
+      'deletion_protection_enabled': 'false'
 parameters:
   - name: 'name'
     type: String
@@ -718,3 +731,6 @@ properties:
             - 'CONNECTION_TYPE_PRIMARY'
             - 'CONNECTION_TYPE_DISCOVERY'
           description: Type of a PSC connection targeting this service attachment.
+  - name: 'kmsKey'
+    type: String
+    description: The KMS key used to encrypt the at-rest data of the cluster.

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -203,7 +203,7 @@ examples:
       deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
-      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name
+      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     oics_vars_overrides:
       'deletion_protection_enabled': 'false'
 parameters:

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -197,6 +197,7 @@ examples:
       network_name: "mynetwork"
       kms_key_name: "mykey"
       kms_ring_name: "mykeyring"
+      deletion_protection_enabled: 'true'
     test_vars_overrides:
       'deletion_protection_enabled': 'false'
     oics_vars_overrides:

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -192,7 +192,7 @@ examples:
     primary_resource_id: "cluster-cmek"
     bootstrap_iam:
       - member: "serviceAccount:service-{project_number}@cloud-redis.iam.gserviceaccount.com"
-        role: role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+        role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     vars:
       cluster_name: "cmek-cluster"
       policy_name: "my-policy"

--- a/mmv1/products/redis/ClusterUserCreatedConnections.yaml
+++ b/mmv1/products/redis/ClusterUserCreatedConnections.yaml
@@ -18,8 +18,8 @@ description: |
   Manages user created connections for Redis cluster
 docs:
   note: |
-    Please ensure your connections meet the requirements outlined at 
-    https://cloud.devsite.corp.google.com/memorystore/docs/cluster/about-multiple-vpc-networking#application_connection_requirements. 
+    Please ensure your connections meet the requirements outlined at
+    https://cloud.devsite.corp.google.com/memorystore/docs/cluster/about-multiple-vpc-networking#application_connection_requirements.
     If you remove a connections item from the resource, the corresponding forwarding rule will no longer be functioning.
     If the corresponding forwarding rule is represented in your terraform configuration it is recommended to delete that
     `google_compute_forwarding_rule` resource at the same time.

--- a/mmv1/products/redis/ClusterUserCreatedConnections.yaml
+++ b/mmv1/products/redis/ClusterUserCreatedConnections.yaml
@@ -18,6 +18,8 @@ description: |
   Manages user created connections for Redis cluster
 docs:
   note: |
+    Please ensure your connections meet the requirements outlined at 
+    https://cloud.devsite.corp.google.com/memorystore/docs/cluster/about-multiple-vpc-networking#application_connection_requirements. 
     If you remove a connections item from the resource, the corresponding forwarding rule will no longer be functioning.
     If the corresponding forwarding rule is represented in your terraform configuration it is recommended to delete that
     `google_compute_forwarding_rule` resource at the same time.

--- a/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.Vars "cluster_name"}}"
   shard_count    = 3
   psc_configs {
-    network = google_compute_network.producer_net.id
+    network = google_compute_network.consumer_net.id
   }
   region = "us-central1"
   replica_count = 0
@@ -44,20 +44,20 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   location = "us-central1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
-  network = google_compute_network.producer_net.id
+  network = google_compute_network.consumer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.producer_subnet.id]
+    subnetworks = [google_compute_subnetwork.consumer_subnet.id]
   }
 }
 
-resource "google_compute_subnetwork" "producer_subnet" {
+resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.Vars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
   region        = "us-central1"
-  network       = google_compute_network.producer_net.id
+  network       = google_compute_network.consumer_net.id
 }
 
-resource "google_compute_network" "producer_net" {
+resource "google_compute_network" "consumer_net" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -6,6 +6,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   }
   kms_key = google_kms_crypto_key.kmskey.id
   region = "us-central1"
+  deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
   depends_on = [
     google_network_connectivity_service_connection_policy.default,
     google_kms_crypto_key_iam_binding.kms_key_iam_decrypter

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -23,7 +23,7 @@ resource "google_kms_crypto_key" "kmskey" {
 }
 
 resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
-  crypto_key_id = google_kms_crypto_key.kmsKey.id
+  crypto_key_id = google_kms_crypto_key.kmskey.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = "service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -25,7 +25,9 @@ resource "google_kms_crypto_key" "kmskey" {
 resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
   crypto_key_id = google_kms_crypto_key.kmskey.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members       = "service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com"
+  members       = [
+    "service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com",
+  ]
 }
 
 data "google_project" "project" {

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -27,7 +27,7 @@ resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
   crypto_key_id = google_kms_crypto_key.kmskey.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = [
-    "serviceAccount:service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com",
+    "serviceAccount:service-${data.google_project.project.number}@cloud-redis.iam.gserviceaccount.com",
   ]
 }
 

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -7,13 +7,14 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   kms_key = google_kms_crypto_key.kmskey.id
   region = "us-central1"
   depends_on = [
-    google_network_connectivity_service_connection_policy.default
+    google_network_connectivity_service_connection_policy.default,
+    google_kms_crypto_key_iam_binding.kms_key_iam_decrypter
   ]
 }
 
 resource "google_kms_key_ring" "keyring" {
   name     = "{{index $.Vars "kms_ring_name"}}"
-  location = "global"
+  location = "us-central1"
 }
 
 resource "google_kms_crypto_key" "kmskey" {
@@ -26,7 +27,7 @@ resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
   crypto_key_id = google_kms_crypto_key.kmskey.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = [
-    "service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com",
+    "serviceAccount:service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com",
   ]
 }
 

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -4,27 +4,31 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
+  kms
   region = "us-central1"
-  zone_distribution_config {
-    mode = "SINGLE_ZONE"
-    zone = "us-central1-f"
-  }
-  maintenance_policy {
-    weekly_maintenance_window {
-      day = "MONDAY"
-      start_time {
-        hours = 1
-        minutes = 0
-        seconds = 0
-        nanos = 0
-      }
-    }
-  }
-  deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
   depends_on = [
     google_network_connectivity_service_connection_policy.default
   ]
+}
 
+resource "google_kms_key_ring" "keyring" {
+  name     = "{{index $.Vars "kms_ring_name"}}"
+  location = "global"
+}
+
+resource "google_kms_crypto_key" "kmskey" {
+  name            = "{{index $.Vars "kms_key_name"}}"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "7776000s"
+}
+
+resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
+  crypto_key_id = google_kms_crypto_key.kmsKey.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  members       = "service-${data.google_project.project.number}@cloud-redis.iam.serviceaccount.com"
+}
+
+data "google_project" "project" {
 }
 
 resource "google_network_connectivity_service_connection_policy" "default" {
@@ -49,3 +53,4 @@ resource "google_compute_network" "consumer_net" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
+

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -13,13 +13,6 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   ]
 }
 
-resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
-  crypto_key_id = "{{index $.Vars "kms_key_name"}}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  members       = [
-    "serviceAccount:service-${data.google_project.project.number}@cloud-redis.iam.gserviceaccount.com",
-  ]
-}
 
 data "google_project" "project" {
 }

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  kms_key = google_kms_crypto_key.kmskey.id
+  kms_key = "{{index $.Vars "kms_key_name"}}"
   region = "us-central1"
   deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
   depends_on = [
@@ -13,19 +13,8 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   ]
 }
 
-resource "google_kms_key_ring" "keyring" {
-  name     = "{{index $.Vars "kms_ring_name"}}"
-  location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "kmskey" {
-  name            = "{{index $.Vars "kms_key_name"}}"
-  key_ring        = google_kms_key_ring.keyring.id
-  rotation_period = "7776000s"
-}
-
 resource "google_kms_crypto_key_iam_binding" "kms_key_iam_decrypter" {
-  crypto_key_id = google_kms_crypto_key.kmskey.id
+  crypto_key_id = "{{index $.Vars "kms_key_name"}}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   members       = [
     "serviceAccount:service-${data.google_project.project.number}@cloud-redis.iam.gserviceaccount.com",

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -4,7 +4,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   psc_configs {
     network = google_compute_network.consumer_net.id
   }
-  kms
+  kms_key = google_kms_crypto_key.kmskey.id
   region = "us-central1"
   depends_on = [
     google_network_connectivity_service_connection_policy.default

--- a/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_cmek.tf.tmpl
@@ -8,8 +8,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   region = "us-central1"
   deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
   depends_on = [
-    google_network_connectivity_service_connection_policy.default,
-    google_kms_crypto_key_iam_binding.kms_key_iam_decrypter
+    google_network_connectivity_service_connection_policy.default
   ]
 }
 

--- a/mmv1/templates/terraform/examples/redis_cluster_ha.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_ha.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.Vars "cluster_name"}}"
   shard_count    = 3
   psc_configs {
-    network = google_compute_network.producer_net.id
+    network = google_compute_network.consumer_net.id
   }
   region = "us-central1"
   replica_count = 1
@@ -38,20 +38,20 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   location = "us-central1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
-  network = google_compute_network.producer_net.id
+  network = google_compute_network.consumer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.producer_subnet.id]
+    subnetworks = [google_compute_subnetwork.consumer_subnet.id]
   }
 }
 
-resource "google_compute_subnetwork" "producer_subnet" {
+resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.Vars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
   region        = "us-central1"
-  network       = google_compute_network.producer_net.id
+  network       = google_compute_network.consumer_net.id
 }
 
-resource "google_compute_network" "producer_net" {
+resource "google_compute_network" "consumer_net" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/redis_cluster_rdb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_rdb.tf.tmpl
@@ -2,7 +2,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name           = "{{index $.Vars "cluster_name"}}"
   shard_count    = 3
   psc_configs {
-    network = google_compute_network.producer_net.id
+    network = google_compute_network.consumer_net.id
   }
   region = "us-central1"
   replica_count = 0
@@ -45,20 +45,20 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   location = "us-central1"
   service_class = "gcp-memorystore-redis"
   description   = "my basic service connection policy"
-  network = google_compute_network.producer_net.id
+  network = google_compute_network.consumer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.producer_subnet.id]
+    subnetworks = [google_compute_subnetwork.consumer_subnet.id]
   }
 }
 
-resource "google_compute_subnetwork" "producer_subnet" {
+resource "google_compute_subnetwork" "consumer_subnet" {
   name          = "{{index $.Vars "subnet_name"}}"
   ip_cidr_range = "10.0.0.248/29"
   region        = "us-central1"
-  network       = google_compute_network.producer_net.id
+  network       = google_compute_network.consumer_net.id
 }
 
-resource "google_compute_network" "producer_net" {
+resource "google_compute_network" "consumer_net" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/redis_cluster_secondary.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_secondary.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_redis_cluster" "primary_cluster" {
   name          = "{{index $.Vars "primary_cluster_name"}}"
   region        = "us-east1"
   psc_configs {
-    network = google_compute_network.producer_net.id
+    network = google_compute_network.consumer_net.id
   }
 
   // Settings that should match on primary and secondary clusters. 
@@ -54,7 +54,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.Vars "secondary_cluster_name"}}"
   region        = "europe-west1"
   psc_configs {
-    network = google_compute_network.producer_net.id
+    network = google_compute_network.consumer_net.id
   }
 
   // Settings that should match on primary and secondary clusters. 
@@ -113,17 +113,17 @@ resource "google_network_connectivity_service_connection_policy" "primary_cluste
   location = "us-east1"
   service_class = "gcp-memorystore-redis"
   description   = "Primary cluster service connection policy"
-  network = google_compute_network.producer_net.id
+  network = google_compute_network.consumer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.primary_cluster_producer_subnet.id]
+    subnetworks = [google_compute_subnetwork.primary_cluster_consumer_subnet.id]
   }
 }
 
-resource "google_compute_subnetwork" "primary_cluster_producer_subnet" {
+resource "google_compute_subnetwork" "primary_cluster_consumer_subnet" {
   name          = "{{index $.Vars "primary_cluster_subnet_name"}}"
   ip_cidr_range = "10.0.1.0/29"
   region        = "us-east1"
-  network       = google_compute_network.producer_net.id
+  network       = google_compute_network.consumer_net.id
 }
 
 
@@ -132,20 +132,20 @@ resource "google_network_connectivity_service_connection_policy" "secondary_clus
   location = "europe-west1"
   service_class = "gcp-memorystore-redis"
   description   = "Secondary cluster service connection policy"
-  network = google_compute_network.producer_net.id
+  network = google_compute_network.consumer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.secondary_cluster_producer_subnet.id]
+    subnetworks = [google_compute_subnetwork.secondary_cluster_consumer_subnet.id]
   }
 }
 
-resource "google_compute_subnetwork" "secondary_cluster_producer_subnet" {
+resource "google_compute_subnetwork" "secondary_cluster_consumer_subnet" {
   name          = "{{index $.Vars "secondary_cluster_subnet_name"}}"
   ip_cidr_range = "10.0.2.0/29"
   region        = "europe-west1"
-  network       = google_compute_network.producer_net.id
+  network       = google_compute_network.consumer_net.id
 }
 
-resource "google_compute_network" "producer_net" {
+resource "google_compute_network" "consumer_net" {
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }


### PR DESCRIPTION
Adds CMEK support to Redis cluster resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
redis: added `kms_key` field to `google_redis_cluster` resource
```
