### PR TITLE
EphemeralWriteOnly: add `password_wo` field to `google_sql_user`

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -112,10 +112,10 @@ func ResourceSqlUser() *schema.Resource {
 			},
 
 			"password_wo_version": {
-				Type:        schema.TypeInt,
-				Optional:    true,
+				Type:         schema.TypeInt,
+				Optional:     true,
 				RequiredWith: []string{"password_wo"},
-				Description: `The version of the password_wo.`,
+				Description:  `The version of the password_wo.`,
 			},
 
 			"type": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -113,7 +113,6 @@ func ResourceSqlUser() *schema.Resource {
 
 			"password_wo_version": {
 				Type:        schema.TypeInt,
-				ForceNew:    true,
 				RequiredWith: []string{"password_wo"},
 				Description: `The version of the password_wo.`,
 			},
@@ -476,7 +475,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	if d.HasChange("password") || d.HasChange("password_policy") {
+	if d.HasChange("password") || d.HasChange("password_policy") || d.HasChange("password_wo_version") {
 		project, err := tpgresource.GetProject(d, config)
 		if err != nil {
 			return err

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -113,6 +113,7 @@ func ResourceSqlUser() *schema.Resource {
 
 			"password_wo_version": {
 				Type:        schema.TypeInt,
+				Optional:    true,
 				RequiredWith: []string{"password_wo"},
 				Description: `The version of the password_wo.`,
 			},

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -62,6 +62,10 @@ func ResourceSqlUser() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 		),
 
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("password"), cty.GetAttrPath("password_wo")),
+		},
+
 		SchemaVersion: 1,
 		MigrateState:  resourceSqlUserMigrateState,
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -111,11 +111,11 @@ func ResourceSqlUser() *schema.Resource {
 				either CLOUD_IAM_USER or CLOUD_IAM_SERVICE_ACCOUNT.`,
 			},
 
-			"new_wo_password": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				WriteOnly:   true,
-				Description: `If true, the password_wo will be updated.`,
+			"password_wo_version": {
+				Type:        schema.TypeInt,
+				ForceNew:    true,
+				RequiredWith: []string{"password_wo"},
+				Description: `The version of the password_wo.`,
 			},
 
 			"type": {
@@ -476,8 +476,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	isNewPasswordWO, _ := d.GetRawConfigAt(cty.GetAttrPath("new_wo_password"))
-	if d.HasChange("password") || d.HasChange("password_policy") || isNewPasswordWO.Equals(cty.BoolVal(true)).True() {
+	if d.HasChange("password") || d.HasChange("password_policy") {
 		project, err := tpgresource.GetProject(d, config)
 		if err != nil {
 			return err

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -70,7 +70,6 @@ func TestAccSqlUser_password_wo(t *testing.T) {
 				Config: testGoogleSqlUser_password_wo(instance, "password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
-					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
 				),
 			},
 			{
@@ -78,9 +77,14 @@ func TestAccSqlUser_password_wo(t *testing.T) {
 				Config: testGoogleSqlUser_new_password_wo(instance, "new_password"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user1"),
-					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user2"),
-					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user3"),
 				),
+			},
+			{
+				ResourceName:            "google_sql_user.user1",
+				ImportStateId:           fmt.Sprintf("%s/%s/gmail.com/admin", envvar.GetTestProjectFromEnv(), instance),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
 			},
 		},
 	})
@@ -429,7 +433,7 @@ resource "google_sql_database_instance" "instance" {
 resource "google_sql_user" "user1" {
   name     = "admin"
   instance = google_sql_database_instance.instance.name
-  host     = "google.com"
+  host     = "gmail.com"
   password_wo = "%s"
 }
 `, instance, password)
@@ -450,7 +454,7 @@ resource "google_sql_database_instance" "instance" {
 resource "google_sql_user" "user1" {
   name     = "admin"
   instance = google_sql_database_instance.instance.name
-  host     = "google.com"
+  host     = "gmail.com"
   password_wo = "%s"
   new_wo_password = true
 }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -456,7 +456,7 @@ resource "google_sql_user" "user1" {
   instance = google_sql_database_instance.instance.name
   host     = "gmail.com"
   password_wo = "%s"
-  new_wo_password = true
+  password_wo_version = 1
 }
 `, instance, password)
 }

--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -130,6 +130,8 @@ The following arguments are supported:
 
     Possible values are: `ABANDON`.
 
+* `password_wo_version` - (Optional) The version of the password_wo.
+
 - - -
 
 * `host` - (Optional) The host the user can connect from. This is only supported
@@ -154,6 +156,15 @@ The read only `password_policy.status` subblock supports:
 * `locked` - (read only) If true, user does not have login privileges.
 
 * `password_expiration_time` - (read only) Password expiration duration with one week grace period.
+
+## Ephemeral Attributes Reference
+
+The following write-only attributes are supported:
+
+* `password_wo` -
+  (Optional)
+  The password for the user.
+  **Note**: This property is write-only and will not be read from the API.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: added `password_wo` and `password_wo_version` fields to `google_sql_user` resource
```
