### PR TITLE
Add policyMode field

### DIFF
--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -54,6 +54,11 @@ examples:
     primary_resource_id: 'primary'
     vars:
       resource_name: 'star'
+  - name: 'network_connectivity_hub_policy_mode'
+    primary_resource_id: 'primary'
+    vars:
+      resource_name: 'policy'
+
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -108,6 +108,14 @@ properties:
       - 'MESH'
       - 'STAR'
     default_from_api: true
+  - name: 'policyMode'
+    type: Enum
+    description: Optional. The policy mode of this hub. This field can be either PRESET or CUSTOM. If unspecified, the policyMode defaults to PRESET.
+    immutable: true
+    enum_values:
+      - 'CUSTOM'
+      - 'PRESET'
+    default_from_api: true
   - name: 'exportPsc'
     type: Boolean
     description: Whether Private Service Connect transitivity is enabled for the hub. If true, Private Service Connect endpoints in VPC spokes attached to the hub are made accessible to other VPC spokes attached to the hub. The default value is false.

--- a/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
@@ -1,20 +1,3 @@
-resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
- name        = "{{index $.Vars "resource_name"}}"
- description = "A sample hub with policy_mode set to CUSTOM"
- policy_mode = "CUSTOM"
- labels = {
-    label-one = "value-one"
-  }
-}
-
-resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
- name        = "{{index $.Vars "resource_name"}}"
- description = "A sample hub with PRESET policy_mode (default topology should be MESH)"
- policy_mode = "PRESET"
- labels = {
-    label-one = "value-one"
-  }
-}
 
 resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
  name            = "{{index $.Vars "resource_name"}}"

--- a/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
@@ -1,9 +1,27 @@
 resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
-  name        = "{{index $.Vars "resource_name"}}"
-  description = "A sample hub with preset policy mode"
-  labels = {
+ name        = "{{index $.Vars "resource_name"}}"
+ description = "A sample hub with policy_mode set to CUSTOM"
+ policy_mode = "CUSTOM"
+ labels = {
     label-one = "value-one"
   }
-  policy_mode     = "PRESET"
-  preset_topology = "MESH"
+}
+
+resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
+ name        = "{{index $.Vars "resource_name"}}"
+ description = "A sample hub with PRESET policy_mode (default topology should be MESH)"
+ policy_mode = "PRESET"
+ labels = {
+    label-one = "value-one"
+  }
+}
+
+resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
+ name            = "{{index $.Vars "resource_name"}}"
+ description     = "A sample hub with PRESET policy_mode and STAR topology"
+ policy_mode     = "PRESET"
+ preset_topology = "STAR"
+ labels = {
+    label-one = "value-one"
+  }
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_hub_policy_mode.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_network_connectivity_hub" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "resource_name"}}"
+  description = "A sample hub with preset policy mode"
+  labels = {
+    label-one = "value-one"
+  }
+  policy_mode     = "PRESET"
+  preset_topology = "MESH"
+}


### PR DESCRIPTION
Addresses https://github.com/hashicorp/terraform-provider-google/issues/18837

This pr adds the policyMode field to the google_network_connectivity_hub resource.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkconnectivity: added `policy_mode` field to `google_network_connectivity_hub` resource
```
