### PR TITLE
Add `google_compute_images` data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -82,6 +82,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_compute_ha_vpn_gateway":                    compute.DataSourceGoogleComputeHaVpnGateway(),
 	"google_compute_health_check":                      compute.DataSourceGoogleComputeHealthCheck(),
 	"google_compute_image":                             compute.DataSourceGoogleComputeImage(),
+	"google_compute_images":							compute.DataSourceGoogleComputeImages(),
 	"google_compute_instance":                          compute.DataSourceGoogleComputeInstance(),
 	"google_compute_instance_group":                    compute.DataSourceGoogleComputeInstanceGroup(),
 	"google_compute_instance_group_manager":            compute.DataSourceGoogleComputeInstanceGroupManager(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
@@ -102,7 +102,7 @@ func dataSourceGoogleComputeImagesRead(d *schema.ResourceData, meta interface{})
 
 	imageList, err := config.NewComputeClient(userAgent).Images.List(project).Filter(filter).Do()
 	if err != nil {
-		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Images : %s", project))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Images : %s", project))
 	}
 
 	for _, image := range imageList.Items {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
@@ -102,7 +102,7 @@ func dataSourceGoogleComputeImagesRead(d *schema.ResourceData, meta interface{})
 
 	imageList, err := config.NewComputeClient(userAgent).Images.List(project).Filter(filter).Do()
 	if err != nil {
-		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Images : %s", project))
+		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Images : %s", project), fmt.Sprintf("Images : %s", project))
 	}
 
 	for _, image := range imageList.Items {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images.go.tmpl
@@ -1,0 +1,135 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeImages() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeImagesRead,
+
+		Schema: map[string]*schema.Schema{
+			"filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"images": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"family": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"self_link": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"archive_size_bytes": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"creation_timestamp": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"disk_size_gb": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"image_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"labels": {
+							Type: schema.TypeMap,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Computed: true,
+						},
+						"source_disk": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_disk_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source_image_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeImagesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for image: %s", err)
+	}
+
+	filter := d.Get("filter").(string)
+
+	images := make([]map[string]interface{}, 0)
+
+	imageList, err := config.NewComputeClient(userAgent).Images.List(project).Filter(filter).Do()
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Images : %s", project))
+	}
+
+	for _, image := range imageList.Items {
+		images = append(images, map[string]interface{}{
+			"name":               image.Name,
+			"family":             image.Family,
+			"self_link":          image.SelfLink,
+			"archive_size_bytes": image.ArchiveSizeBytes,
+			"creation_timestamp": image.CreationTimestamp,
+			"description":        image.Description,
+			"disk_size_gb":       image.DiskSizeGb,
+			"image_id":           image.Id,
+			"labels":             image.Labels,
+			"source_disk":        image.SourceDisk,
+			"source_disk_id":     image.SourceDiskId,
+			"source_image_id":    image.SourceImageId,
+		})
+	}
+
+	if err := d.Set("images", images); err != nil {
+		return fmt.Errorf("Error retrieving images: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf(
+		"projects/%s/global/images",
+		project,
+	))
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
@@ -26,6 +26,11 @@ func TestAccDataSourceComputeImages_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// Test schema
 					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.0.name"),
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.1.name"),
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.0.self_link"),
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.1.self_link"),
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.0.image_id"),
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.1.image_id"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_images_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceComputeImages_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"image":         "debian-cloud/debian-11",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleComputeImagesConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Test schema
+					resource.TestCheckResourceAttrSet("data.google_compute_images.all", "images.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleComputeImagesConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_disk" "test-disk" {
+  name  = "tf-test-disk-%{random_suffix}"
+  type  = "pd-standard"
+  image = "%{image}"
+  size  = 10
+}
+
+resource "google_compute_image" "foo" {
+  name = "tf-test-image1-%{random_suffix}"
+  source_disk = google_compute_disk.test-disk.self_link
+}
+
+resource "google_compute_image" "bar" {
+  name = "tf-test-image2-%{random_suffix}"
+  source_image = google_compute_image.foo.self_link
+}
+
+data "google_compute_images" "all" {
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/compute_images.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_images.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  Get information about Google Compute Images.
+---
+
+# google_compute_images
+
+Get information about Google Compute Images. Check that your service account has the `compute.imageUser` role if you want to share [custom images](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) from another project. If you want to use [public images][pubimg], do not forget to specify the dedicated project. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/images) and its [API](https://cloud.google.com/compute/docs/reference/latest/images).
+
+## Example Usage
+
+```hcl
+data "google_compute_images" "debian" {
+  filter = "name eq my-image.*"
+}
+
+resource "google_compute_instance" "default" {
+  name         = "test"
+  machine_type = "f1-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_images.debian.images[0].self_link
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.default.name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `filter` -Filter for the images to be returned by the data source. Syntax can be found [here](https://cloud.google.com/compute/docs/reference/rest/v1/images/list) in the filter section.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it is not
+  provided, the provider project is used. If you are using a
+  [public base image][pubimg], be sure to specify the correct Image Project.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `self_link` - The URI of the image.
+* `name` - The name of the image.
+* `family` - The family name of the image.
+* `disk_size_gb` - The size of the image when restored onto a persistent disk in gigabytes.
+* `archive_size_bytes` - The size of the image tar.gz archive stored in Google Cloud Storage in bytes.
+* `source_image_id` - The ID value of the image used to create this image.
+* `source_disk` - The URL of the source disk used to create this image.
+* `source_disk_id` - The ID value of the disk used to create this image.
+* `creation_timestamp` - The creation timestamp in RFC3339 text format.
+* `description` - An optional description of this image.
+* `labels` - All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
+
+[pubimg]: https://cloud.google.com/compute/docs/images#os-compute-support "Google Cloud Public Base Images"


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/11515

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_compute_images`
```
