### PR TITLE
GKE Add support to disable ip endpoints

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1783,6 +1783,27 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"ip_endpoint_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Computed:    true,
+							Description: `IP endpoints configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										ConflictsWith: []string{
+											"private_cluster_config.0.enable_private_endpoint",
+											"private_cluster_config.0.private_endpoint_subnetwork",
+											"private_cluster_config.0.master_global_access_config",
+										},
+										Description: `Controls whether to allow direct IP access. When this is false, all other ip_endpoint_config values are ignored. Implicitly true if private_cluster_config settings are still used.`,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -5581,9 +5602,10 @@ func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.Contro
 	}
 
 	ip := &container.IPEndpointsConfig{
-		// There isn't yet a config field to disable IP endpoints, so this is hardcoded to be enabled for the time being.
-		Enabled:         true,
 		ForceSendFields: []string{"Enabled"},
+	}
+	if v := d.Get("control_plane_endpoints_config.0.ip_endpoint_config.0.enabled"); v != nil {
+		ip.Enabled = v.(bool)
 	}
 	if v := d.Get("private_cluster_config.0.enable_private_endpoint"); v != nil {
 		ip.EnablePublicEndpoint = !v.(bool)
@@ -6298,6 +6320,7 @@ func flattenControlPlaneEndpointsConfig(c *container.ControlPlaneEndpointsConfig
 	return []map[string]interface{}{
 		{
 			"dns_endpoint_config": flattenDnsEndpointConfig(c.DnsEndpointConfig),
+			"ip_endpoint_config": flattenIpEndpointsConfig(c.IpEndpointsConfig),
 		},
 	}
 }
@@ -6314,6 +6337,18 @@ func flattenDnsEndpointConfig(dns *container.DNSEndpointConfig) []map[string]int
 	}
 }
 
+func flattenIpEndpointsConfig(ip *container.IPEndpointsConfig) []map[string]interface{} {
+	if ip == nil {
+		return nil
+	}
+	v := []map[string]interface{}{
+		{
+			"enabled": ip.Enabled,
+		},
+	}
+	return v
+}
+
 // Most of PrivateClusterConfig has moved to ControlPlaneEndpointsConfig.
 func flattenPrivateClusterConfig(cpec *container.ControlPlaneEndpointsConfig, pcc *container.PrivateClusterConfig, nc *container.NetworkConfig) []map[string]interface{} {
 	if cpec == nil && pcc == nil && nc == nil {
@@ -6321,7 +6356,7 @@ func flattenPrivateClusterConfig(cpec *container.ControlPlaneEndpointsConfig, pc
 	}
 
 	r := map[string]interface{}{}
-	if cpec != nil {
+	if cpec != nil && cpec.IpEndpointsConfig.Enabled {
 		// Note the change in semantics from private to public endpoint.
 		r["enable_private_endpoint"] =     !cpec.IpEndpointsConfig.EnablePublicEndpoint
 		r["private_endpoint"] =            cpec.IpEndpointsConfig.PrivateEndpoint

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -13229,3 +13229,60 @@ resource "google_container_cluster" "with_enterprise_config" {
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
+
+func TestAccContainerCluster_withIpEndpointConfigFalse(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withIpEndpointConfigFalse(clusterName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoint_config.0.enabled"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoint_config.0.enabled", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_withIpEndpointConfigFalse(clusterName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoint_config.0.enabled"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.ip_endpoint_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withIpEndpointConfigFalse(name string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  deletion_protection = false
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+    ip_endpoint_config {
+      enabled = %t
+    }
+  }
+}`, name, enabled)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Took parts from https://github.com/GoogleCloudPlatform/magic-modules/pull/12025 to be able to create a cluster with only the DNS endpoint enabled and the IP disabled. Will most likely need some assist if possible.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `ip_endpoint_config` field to `cluster` resource.
```
