### PR TITLE
Fix AlloyDB availabilityType documentation

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -189,12 +189,12 @@ properties:
   - name: 'availabilityType'
     type: Enum
     description: |
-      'Availability type of an Instance. Defaults to REGIONAL for both primary and read instances.
-      Note that primary and read instances can have different availability types.
-      Only READ_POOL instance supports ZONAL type. Users can't specify the zone for READ_POOL instance.
-      Zone is automatically chosen from the list of zones in the region specified.
-      Read pool of size 1 can only have zonal availability. Read pools with node count of 2 or more
-      can have regional availability (nodes are present in 2 or more zones in a region).'
+      'Availability type of an Instance. Defaults to REGIONAL for both primary and read instances. 
+      Note that primary and read instances can have different availability types. 
+      Primary instances can be either ZONAL or REGIONAL. Read Pool instances can also be either ZONAL or REGIONAL. 
+      Read pools of size 1 can only have zonal availability. Read pools with a node count of 2 or more 
+      can have regional availability (nodes are present in 2 or more zones in a region). 
+      Possible values are: `AVAILABILITY_TYPE_UNSPECIFIED`, `ZONAL`, `REGIONAL`.'
     default_from_api: true
     enum_values:
       - 'AVAILABILITY_TYPE_UNSPECIFIED'

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -189,11 +189,11 @@ properties:
   - name: 'availabilityType'
     type: Enum
     description: |
-      'Availability type of an Instance. Defaults to REGIONAL for both primary and read instances. 
-      Note that primary and read instances can have different availability types. 
-      Primary instances can be either ZONAL or REGIONAL. Read Pool instances can also be either ZONAL or REGIONAL. 
-      Read pools of size 1 can only have zonal availability. Read pools with a node count of 2 or more 
-      can have regional availability (nodes are present in 2 or more zones in a region). 
+      'Availability type of an Instance. Defaults to REGIONAL for both primary and read instances.
+      Note that primary and read instances can have different availability types.
+      Primary instances can be either ZONAL or REGIONAL. Read Pool instances can also be either ZONAL or REGIONAL.
+      Read pools of size 1 can only have zonal availability. Read pools with a node count of 2 or more
+      can have regional availability (nodes are present in 2 or more zones in a region).
       Possible values are: `AVAILABILITY_TYPE_UNSPECIFIED`, `ZONAL`, `REGIONAL`.'
     default_from_api: true
     enum_values:


### PR DESCRIPTION
Addresses https://github.com/hashicorp/terraform-provider-google/issues/16483

This PR updates the `availabilityType` field description in the AlloyDB instance documentation.

### What Changed
- The previous documentation incorrectly stated that only `READ_POOL` instances support `ZONAL` availability.
- Updated the description to clarify that **both PRIMARY and READ_POOL instances can be either `ZONAL` or `REGIONAL`**.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
