### PR TITLE
Add maxStreamDuration to global UrlMap

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -754,6 +754,28 @@ properties:
                           Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
                           inclusive.
                         required: true
+                  - name: 'maxStreamDuration'
+                    type: NestedObject
+                    description: |
+                      Specifies the maximum duration (timeout) for streams on the selected route.
+                      Unlike the `Timeout` field where the timeout duration starts from the time the request
+                      has been fully processed (known as end-of-stream), the duration in this field
+                      is computed from the beginning of the stream until the response has been processed,
+                      including all retries. A stream that does not complete in this duration is closed.
+                    default_from_api: true
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
                   - name: 'urlRewrite'
                     type: NestedObject
                     description: |
@@ -1487,6 +1509,28 @@ properties:
                           Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
                           inclusive.
                         required: true
+                  - name: 'maxStreamDuration'
+                    type: NestedObject
+                    description: |
+                      Specifies the maximum duration (timeout) for streams on the selected route.
+                      Unlike the `Timeout` field where the timeout duration starts from the time the request
+                      has been fully processed (known as end-of-stream), the duration in this field
+                      is computed from the beginning of the stream until the response has been processed,
+                      including all retries. A stream that does not complete in this duration is closed.
+                    default_from_api: true
+                    properties:
+                      - name: 'nanos'
+                        type: Integer
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations
+                          less than one second are represented with a 0 `seconds` field and a positive
+                          `nanos` field. Must be from 0 to 999,999,999 inclusive.
+                      - name: 'seconds'
+                        type: String
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000
+                          inclusive.
+                        required: true
                   - name: 'urlRewrite'
                     type: NestedObject
                     description: |
@@ -1916,6 +1960,27 @@ properties:
                   description: |
                     Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
                     with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+            - name: 'maxStreamDuration'
+              type: NestedObject
+              description: |
+                Specifies the maximum duration (timeout) for streams on the selected route.
+                Unlike the `Timeout` field where the timeout duration starts from the time the request
+                has been fully processed (known as end-of-stream), the duration in this field
+                is computed from the beginning of the stream until the response has been processed,
+                including all retries. A stream that does not complete in this duration is closed.
+              default_from_api: true
+              properties:
+                - name: 'nanos'
+                  type: Integer
+                  description: |
+                    Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                    with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                - name: 'seconds'
+                  type: String
+                  description: |
+                    Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                    Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                  required: true
             - name: 'retryPolicy'
               type: NestedObject
               description: |
@@ -2452,6 +2517,27 @@ properties:
             at_least_one_of:
               - 'default_route_action.0.timeout.0.seconds'
               - 'default_route_action.0.timeout.0.nanos'
+      - name: 'maxStreamDuration'
+        type: NestedObject
+        description: |
+          Specifies the maximum duration (timeout) for streams on the selected route.
+          Unlike the `Timeout` field where the timeout duration starts from the time the request
+          has been fully processed (known as end-of-stream), the duration in this field
+          is computed from the beginning of the stream until the response has been processed,
+          including all retries. A stream that does not complete in this duration is closed.
+        default_from_api: true
+        properties:
+          - name: 'nanos'
+            type: Integer
+            description: |
+              Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+              with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+          - name: 'seconds'
+            type: String
+            description: |
+              Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+              Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+            required: true
       - name: 'retryPolicy'
         type: NestedObject
         description: |

--- a/mmv1/templates/terraform/examples/url_map_traffic_director_path_partial.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_traffic_director_path_partial.tf.tmpl
@@ -43,6 +43,10 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
             }
           }
         }
+        max_stream_duration {
+          nanos   = 500000
+          seconds = 9
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add maxStreamDuration to google_compute_url_map.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19555

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `max_stream_duration` field to `google_compute_url_map` resource
```
