### PR TITLE
Fixed documentation for `google_parameter_manager_parameter_version_render` and `google_parameter_manager_regional_parameter_version_render`

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version_render.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version_render.html.markdown
@@ -38,7 +38,7 @@ The following attributes are exported:
 
 * `parameter_data` - The Parameter data.
 
-* `render_parameter_data` - The Rendered Parameter Data specifies that if you use `__REF__()` to reference a secret and the format is JSON or YAML, the placeholder `__REF__()` will be replaced with the actual secret value. However, if the format is UNFORMATTED, it will stay the same as the original `parameter_data`.
+* `rendered_parameter_data` - The Rendered Parameter Data specifies that if you use `__REF__()` to reference a secret and the format is JSON or YAML, the placeholder `__REF__()` will be replaced with the actual secret value. However, if the format is UNFORMATTED, it will stay the same as the original `parameter_data`.
 
 * `name` - The resource name of the ParameterVersion. Format:
   `projects/{{project}}/locations/global/parameters/{{parameter_id}}/versions/{{parameter_version_id}}`

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version_render.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version_render.html.markdown
@@ -44,7 +44,7 @@ The following attributes are exported:
 
 * `parameter_data` - The Parameter data.
 
-* `render_parameter_data` - The Rendered Parameter Data specifies that if you use `__REF__()` to reference a secret and the format is JSON or YAML, the placeholder `__REF__()` will be replaced with the actual secret value. However, if the format is UNFORMATTED, it will stay the same as the original `parameter_data`.
+* `rendered_parameter_data` - The Rendered Parameter Data specifies that if you use `__REF__()` to reference a secret and the format is JSON or YAML, the placeholder `__REF__()` will be replaced with the actual secret value. However, if the format is UNFORMATTED, it will stay the same as the original `parameter_data`.
 
 * `name` - The resource name of the RegionalParameterVersion. Format:
   `projects/{{project}}/locations/{{location}}/parameters/{{parameter_id}}/versions/{{parameter_version_id}}`


### PR DESCRIPTION
Fixed documentation for `google_parameter_manager_parameter_version_render` and `google_parameter_manager_regional_parameter_version_render` datasources for the field `rendered_parameter_data`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: none
```
