### PR TITLE
Feature/add quota adjuster

### DIFF
--- a/mmv1/products/quota/QuotaAdjusterSettings.yaml
+++ b/mmv1/products/quota/QuotaAdjusterSettings.yaml
@@ -28,12 +28,12 @@ update_mask: true
 immutable: false
 
 parameters:
-  - name: 'project'
+  - name: 'name'
     type: String
     required: true
     immutable: true
     description: |
-      The ID of the project in which the quota adjuster should be enabled.
+      Name of the configuration, in the following format: projects/PROJECT_NUMBER/locations/global/quotaAdjusterSettings. Replace PROJECT_NUMBER with the project number for your project.
 
 properties:
   - name: 'enablement'
@@ -57,4 +57,4 @@ properties:
     output: true
     optional: true
     description: |
-      The ETag of the QuotaAdjusterSettings. Used for concurrency control when updating.
+      The current ETag of the QuotaAdjusterSettings. If an ETag is provided on update and does not match the current server's ETag in the QuotaAdjusterSettings, the request is blocked and returns an ABORTED error

--- a/mmv1/products/quota/QuotaAdjusterSettings.yaml
+++ b/mmv1/products/quota/QuotaAdjusterSettings.yaml
@@ -1,0 +1,60 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'QuotaAdjusterSettings'
+description: |
+  Manages the Quota Adjuster settings for a Google Cloud project.
+references:
+  api: 'https://cloud.google.com/docs/quota/quota-adjuster'
+
+base_url: 'projects/{{project}}/locations/global/quotaAdjusterSettings'
+self_link: 'projects/{{project}}/locations/global/quotaAdjusterSettings'
+
+create_url: 'projects/{{project}}/locations/global/quotaAdjusterSettings'
+update_url: 'projects/{{project}}/locations/global/quotaAdjusterSettings'
+update_verb: 'PATCH'
+update_mask: true
+immutable: false
+
+parameters:
+  - name: 'project'
+    type: String
+    required: true
+    immutable: true
+    description: |
+      The ID of the project in which the quota adjuster should be enabled.
+
+properties:
+  - name: 'enablement'
+    type: Enum
+    required: true
+    description: |
+      The enablement status of the quota adjuster.
+    enum_values:
+      - 'ENABLED'
+      - 'DISABLED'
+
+  - name: 'update_time'
+    type: String
+    output: true
+    description: |
+      The timestamp when the QuotaAdjusterSettings resource was last updated.
+      This is an RFC3339 UTC "Zulu" format timestamp with nanosecond precision.
+
+  - name: 'etag'
+    type: String
+    output: true
+    optional: true
+    description: |
+      The ETag of the QuotaAdjusterSettings. Used for concurrency control when updating.


### PR DESCRIPTION
This PR introduces a new resource, google_project_quota_adjuster, to manage Quota Adjuster settings in Google Cloud via Terraform. The resource allows users to enable or disable the Quota Adjuster for a given project.

- Supports enablement (ENABLED, DISABLED)
- Reads API-managed metadata fields: update_time, etag (support for safe updates)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
