### PR TITLE
add `raw_resource_config_validation` for `validation.PreferWriteOnlyAttribute` support

### DIFF
--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -133,4 +133,6 @@ type CustomCode struct {
 	// resource was successfully deleted. Use this if the API responds
 	// with a success HTTP code for deleted resources
 	TestCheckDestroy string `yaml:"test_check_destroy"`
+
+	ValidateRawResourceConfigFuncs string `yaml:"raw_resource_config_validation"`
 }

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -134,7 +134,11 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 {{- end }}
         ),
 {{- end}}
-
+{{- if $.CustomCode.ValidateRawResourceConfigFuncs }}
+		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
+			{{$.CustomTemplate $.CustomCode.ValidateRawResourceConfigFuncs false}},
+		},
+{{- end }}
 {{ if $.DeprecationMessage }}
         DeprecationMessage: "{{ $.DeprecationMessage -}}",
 {{- end}}


### PR DESCRIPTION
In order include validation for WriteOnly attributes it's necessary to include the following `raw_resource_config_validation` as part of the generation. 

This allows us to include the validation method for `PreferWriteOnlyAttribute` which lets the user know about the new write-only attribute and to transition to the new field instead of using sensitive.

![image](https://github.com/user-attachments/assets/bc17fe19-f672-4edd-8e77-227d902dae2b)

it's treated like any other custom_code where we provided the file path which would include the following:
![image](https://github.com/user-attachments/assets/ed2a54c7-35fa-4c97-a6b3-79de654a8886)

This is the yaml config:
![image](https://github.com/user-attachments/assets/4df5dfea-3344-455f-b124-3bb90f74b0f3)

```release-note:none

```