### PR TITLE
Adding API Docs for Composer datasources and resources

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -8,6 +8,12 @@ description: |-
 
 Provides access to Cloud Composer environment configuration in a region for a given project.
 
+To get more information about Composer Environment, see:
+
+* [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
@@ -8,6 +8,12 @@ description: |-
 
 Provides access to available Cloud Composer versions in a region for a given project.
 
+To get more information about Composer Image Versions, see:
+
+* [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.imageVersions)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
@@ -8,6 +8,12 @@ description: |-
 
 Provides access to Kubernetes ConfigMap configuration for a given project, region and Composer Environment.
 
+To get more information about Composer User Workloads Config Map, see:
+
+* [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsConfigMaps)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
@@ -8,6 +8,12 @@ description: |-
 
 Provides access to Kubernetes Secret configuration for a given project, region and Composer Environment.
 
+To get more information about Composer User Workloads Secrets, see:
+
+* [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsSecrets)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/artifact-registry/docs/overview)
+    
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
 Adding API Docs for   google_composer_user_workloads_secret,  google_composer_user_workloads_config_map, google_composer_image_versions, google_composer_environment

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
composer:  Adding API Docs for google_composer_user_workloads_secret,google_composer_user_workloads_config_map,google_composer_image_versions, google_composer_environment
```