### PR TITLE
Adding API Docs for Developer Connect

### DIFF
--- a/mmv1/products/developerconnect/Connection.yaml
+++ b/mmv1/products/developerconnect/Connection.yaml
@@ -14,6 +14,10 @@
 ---
 name: Connection
 description: A connection for GitHub, GitHub Enterprise, GitLab, and GitLab Enterprise.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/developer-connect/docs/overview'
+  api: 'https://cloud.google.com/developer-connect/docs/api/reference/rest/v1/projects.locations.connections'
 base_url: projects/{{project}}/locations/{{location}}/connections
 update_mask: true
 self_link: projects/{{project}}/locations/{{location}}/connections/{{connection_id}}

--- a/mmv1/products/developerconnect/GitRepositoryLink.yaml
+++ b/mmv1/products/developerconnect/GitRepositoryLink.yaml
@@ -14,7 +14,10 @@
 ---
 name: 'GitRepositoryLink'
 description: "A git repository link to a parent connection."
-docs:
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/developer-connect/docs/overview'
+  api: 'https://cloud.google.com/developer-connect/docs/api/reference/rest/v1/projects.locations.connections.gitRepositoryLinks'
 id_format: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks/{{git_repository_link_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks'
 self_link: 'projects/{{project}}/locations/{{location}}/connections/{{parent_connection}}/gitRepositoryLinks/{{git_repository_link_id}}'


### PR DESCRIPTION
 Adding API Docs for   google_developer_connect_connection and google_developer_connect_git_repository_link

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
developerconnect:  Adding API Docs for google_developer_connect_connection and google_developer_connect_git_repository_link
```