### PR TITLE
Promoted Instance NetworkAttachment field to V1;

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -436,7 +436,6 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			internalIP = iface.NetworkIP
 		}
 
-		{{ if ne $.TargetVersionName `ga` -}}
 		if iface.NetworkAttachment != "" {
 			networkAttachment, err := tpgresource.GetRelativePath(iface.NetworkAttachment)
 			if err != nil {
@@ -444,7 +443,6 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			}
 			flattened[i]["network_attachment"] = networkAttachment
 		}
-		{{- end }}
 
 		{{ if ne $.TargetVersionName `ga` -}}
 		// the security_policy for a network_interface is found in one of its accessConfigs.
@@ -511,8 +509,6 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 	for i, raw := range configs {
 		data := raw.(map[string]interface{})
 
-
-		{{ if ne $.TargetVersionName `ga` -}}
 		var networkAttachment = ""
 		network := data["network"].(string)
 		subnetwork := data["subnetwork"].(string)
@@ -523,16 +519,6 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 		if networkAttachment == "" && network == "" && subnetwork == "" {
 			return nil, fmt.Errorf("exactly one of network, subnetwork, or network_attachment must be provided")
 		}
-
-		{{- else }}
-
-		network := data["network"].(string)
-		subnetwork := data["subnetwork"].(string)
-		if network == "" && subnetwork == "" {
-			return nil, fmt.Errorf("exactly one of network or subnetwork must be provided")
-		}
-
-		{{ end }}
 
 		nf, err := tpgresource.ParseNetworkFieldValue(network, d, config)
 		if err != nil {
@@ -548,9 +534,7 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 		ifaces[i] = &compute.NetworkInterface{
 			NetworkIP:         data["network_ip"].(string),
 			Network:           nf.RelativeLink(),
-			{{- if ne $.TargetVersionName "ga" }}
 			NetworkAttachment: networkAttachment,
-			{{- end }}
 			Subnetwork:        sf.RelativeLink(),
 			AccessConfigs:     expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges:     expandAliasIpRanges(data["alias_ip_range"].([]interface{})),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_test.go.tmpl
@@ -136,7 +136,7 @@ data "google_compute_instance" "baz" {
 }
 `, instanceName)
 }
-{{- if ne $.TargetVersionName "ga" }}
+
 func TestAccDataSourceComputeInstance_networkAttachmentUsageExample(t *testing.T) {
 	t.Parallel()
 
@@ -144,7 +144,7 @@ func TestAccDataSourceComputeInstance_networkAttachmentUsageExample(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -158,7 +158,6 @@ func TestAccDataSourceComputeInstance_networkAttachmentUsageExample(t *testing.T
 func testAccDataSourceComputeInstance_networkAttachmentUsageConfig(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_instance" "foo" {
-  provider = google-beta
   name           = "%s"
   machine_type   = "n1-standard-1"   // can't be e2 because of local-ssd
   zone           = "us-central1-a"
@@ -198,23 +197,19 @@ resource "google_compute_instance" "foo" {
 }
 
 data "google_compute_instance" "bar" {
-  provider = google-beta
   name = google_compute_instance.foo.name
   zone = "us-central1-a"
 }
 
 data "google_compute_instance" "baz" {
-  provider = google-beta
   self_link = google_compute_instance.foo.self_link
 }
 resource "google_compute_network" "net_att_default" {   
-  provider = google-beta
   name = "%s"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnet_att_default" {    
-  provider = google-beta
   name   = "%s" 
   region = "us-central1"  
   network       = google_compute_network.net_att_default.id
@@ -222,7 +217,6 @@ resource "google_compute_subnetwork" "subnet_att_default" {
 }
 
 resource "google_compute_network_attachment" "net_attar_default" {   
-  provider = google-beta 
   name   = "%s"
   region = "us-central1"
   subnetworks = [google_compute_subnetwork.subnet_att_default.id]
@@ -230,4 +224,3 @@ resource "google_compute_network_attachment" "net_attar_default" {
 }
 `, instanceName, instanceName, instanceName, instanceName)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -433,7 +433,6 @@ func ResourceComputeInstance() *schema.Resource {
 							Description:      `The name or self_link of the subnetwork attached to this interface.`,
 						},
 
-						{{ if ne $.TargetVersionName `ga` -}}
 						"network_attachment": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -442,7 +441,6 @@ func ResourceComputeInstance() *schema.Resource {
 							DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
 							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
-						{{- end }}
 
 						"subnetwork_project": {
 							Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4190,20 +4190,27 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 	}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeInstance_NetworkAttachment(t *testing.T) {
 	t.Parallel()
 	suffix := fmt.Sprintf("%s", acctest.RandString(t, 10))
+  envRegion := envvar.GetTestRegionFromEnv()
 	var instance compute.Instance
+
+{{ if eq $.TargetVersionName `ga` }}
+	providerVersion := "v1"
+{{- else }}
+	providerVersion := "beta"
+{{- end }}
 
 	testNetworkAttachmentName := fmt.Sprintf("tf-test-network-attachment-%s", suffix)
 
 	// Need to have the full network attachment name in the format project/{project_id}/regions/{region_id}/networkAttachments/{testNetworkAttachmentName}
-	fullFormNetworkAttachmentName := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", envvar.GetTestProjectFromEnv(), envvar.GetTestRegionFromEnv(), testNetworkAttachmentName)
+	fullFormNetworkAttachmentName := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", envvar.GetTestProjectFromEnv(), envRegion, testNetworkAttachmentName)
 
 	context := map[string]interface{}{
 		"suffix":                  (acctest.RandString(t, 10)),
 		"network_attachment_name": testNetworkAttachmentName,
+    "region":                  envRegion,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -4216,7 +4223,7 @@ func TestAccComputeInstance_NetworkAttachment(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(
 						t, "google_compute_instance.foobar", &instance),
-					testAccCheckComputeInstanceHasNetworkAttachment(&instance, fmt.Sprintf("https://www.googleapis.com/compute/beta/%s", fullFormNetworkAttachmentName)),
+					testAccCheckComputeInstanceHasNetworkAttachment(&instance, fmt.Sprintf("https://www.googleapis.com/compute/%s/%s", providerVersion, fullFormNetworkAttachmentName)),
 				),
 			},
 		},
@@ -4252,7 +4259,6 @@ func TestAccComputeInstance_NetworkAttachmentUpdate(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
 	t.Parallel()
@@ -4980,7 +4986,6 @@ func testAccCheckComputeInstanceHasMinCpuPlatform(instance *compute.Instance, mi
 	}
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccCheckComputeInstanceHasNetworkAttachment(instance *compute.Instance, networkAttachmentName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, networkInterface := range instance.NetworkInterfaces {
@@ -4991,7 +4996,6 @@ func testAccCheckComputeInstanceHasNetworkAttachment(instance *compute.Instance,
 		return fmt.Errorf("Network Attachment %s, was not found in the instance template", networkAttachmentName)
 	}
 }
-{{- end }}
 
 func testAccCheckComputeInstanceHasMachineType(instance *compute.Instance, machineType string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -11005,7 +11009,6 @@ resource "google_compute_instance" "foobar" {
 
 {{ end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeInstance_networkAttachment(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
@@ -11039,6 +11042,7 @@ resource "google_compute_network_attachment" "test_network_attachment" {
 resource "google_compute_instance" "foobar" {
   name         = "tf-test-instance-%{suffix}"
   machine_type = "e2-medium"
+  zone         = "%{region}-a"
 
 	boot_disk {
 		initialize_params {
@@ -11050,7 +11054,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	network_interface{
+	network_interface {
 		network_attachment = google_compute_network_attachment.test_network_attachment.self_link
 	}
 
@@ -11130,7 +11134,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	network_interface{
+	network_interface {
 		network_attachment = %s
 	}
 
@@ -11140,7 +11144,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, suffix, suffix, suffix, region, suffix, region, suffix, region, suffix, region, suffix, region, networkAttachment)
 }
-{{- end }}
 
 func testAccComputeInstance_nicStackTypeUpdate(suffix, region, stack_type, instance string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance.html.markdown
@@ -165,7 +165,7 @@ The following arguments are supported:
 
 * `alias_ip_range` - An array of alias IP ranges for this network interface. Structure [documented below](#nested_alias_ip_range).
 
-* `network_attachment` - [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) The URL of the network attachment to this interface.	
+* `network_attachment` - The URL of the network attachment to this interface.
 
 <a name="nested_access_config"></a>The `access_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -399,7 +399,7 @@ is desired, you will need to modify your state file manually using
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET, IDPF, MRDMA, IRDMA.
 
-* `network_attachment` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) The URL of the network attachment that this interface should connect to in the following format: `projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}`.
+* `network_attachment` - (Optional) The URL of the network attachment that this interface should connect to in the following format: `projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}`.
 
 * `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6, IPV6_ONLY or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Promotes `network_interface.network_attachment` field from the `compute_instance` resource from Beta to GA.
Also promotes `network_attachment` test from the `compute_instance` dataset  from Beta to GA.

Beta PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/8829

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `network_interface.network_attachment` field to `google_compute_instance` resource (ga)
```

```release-note:enhancement
compute: added `network_interface.network_attachment` to `google_compute_instance` data source (ga)
```
