### PR TITLE
fix backup vault tests

### DIFF
--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_test.go.tmpl
@@ -18,9 +18,9 @@ func TestAccDataSourceGoogleCloudBackupDRBackup_basic(t *testing.T) {
 	project := envvar.GetTestProjectFromEnv()
 	location := "us-central1"
 	backupVaultId := "bv-test"
-	{{- if ne $.TargetVersionName "ga" -}}
+	{{ if ne $.TargetVersionName "ga" -}}
 	dataSourceId := "ds-test"
-	{{- else -}}
+	{{ else -}}
 	dataSourceId := "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
 	{{- end }}
 	

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_test.go.tmpl
@@ -9,13 +9,20 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
+//	this test cannot be ran locally without seeding your environment with a backup vault and scheduling the backup of a compute instance 
+//	to generate a unique datasourceId, that this test would need to be modified to use. the values in this test correspond to those used
+//	in our testing processes.
 func TestAccDataSourceGoogleCloudBackupDRBackup_basic(t *testing.T) {
     t.Parallel()
 
 	project := envvar.GetTestProjectFromEnv()
 	location := "us-central1"
 	backupVaultId := "bv-test"
+	{{- if ne $.TargetVersionName "ga" -}}
 	dataSourceId := "ds-test"
+	{{- else -}}
+	dataSourceId := "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
+	{{- end }}
 	
 	name :=	fmt.Sprintf("projects/%s/locations/%s/backupVaults/%s/dataSources/%s/backups", project, location, backupVaultId, dataSourceId)
 

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
@@ -48,7 +48,11 @@ data "google_backup_dr_data_source" "foo" {
   project = data.google_project.project.project_id
   location      = "us-central1"
   backup_vault_id = "bv-test"
+	{{- if ne $.TargetVersionName "ga" -}}
   data_source_id = "ds-test"
+	{{- else -}}
+	data_source_id = "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
+	{{- end }}
 }
 
 `, context)

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
+//	this test cannot be ran locally without seeding your environment with a backup vault and scheduling the backup of a compute instance 
+//	to generate a unique datasourceId, that this test would need to be modified to use. the values in this test correspond to those used
+//	in our testing processes.
 func TestAccDataSourceGoogleCloudBackupDRDataSource_basic(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
@@ -51,11 +51,11 @@ data "google_backup_dr_data_source" "foo" {
   project = data.google_project.project.project_id
   location      = "us-central1"
   backup_vault_id = "bv-test"
-	{{- if ne $.TargetVersionName "ga" -}}
+  {{- if ne $.TargetVersionName "ga" -}}
   data_source_id = "ds-test"
-	{{- else -}}
-	data_source_id = "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
-	{{- end }}
+  {{- else -}}
+  data_source_id = "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
+  {{- end }}
 }
 
 `, context)

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_test.go.tmpl
@@ -51,9 +51,9 @@ data "google_backup_dr_data_source" "foo" {
   project = data.google_project.project.project_id
   location      = "us-central1"
   backup_vault_id = "bv-test"
-  {{- if ne $.TargetVersionName "ga" -}}
+  {{ if ne $.TargetVersionName "ga" -}}
   data_source_id = "ds-test"
-  {{- else -}}
+  {{ else -}}
   data_source_id = "56b93b14529b77d764b21b2251e1ea8f0006e8dd"
   {{- end }}
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21159
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21179

These tests were failing due to not being seeded with the data needed -- the backup vault data source would not generate until a scheduled job is ran (which can not be handled in terraform), and in the time since our CI and beta environments were seeded with the original data, the behavior changed to always use generated random unique identifiers for these data sources rather than aligning with the display name.

This fix has amended the tests to use the unique identifier of the backup vault now present in our GA environment, and include a comment mentioning these tests will not be runnable locally without proper preparation. It might be ugly to be showing this unique identifier, this file is not used for a documentation sample, and functionally it has the same result (i.e. users know the location of a resource in our project). 

Potentially this approach could cause issues down the line if we begin testing GA VCRs in pull request CI, I don't believe we have any plans to do so at this time.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
