### PR TITLE
feat(bigqueryanalyticshub): add resource tags to the listing subscription resource

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -109,10 +109,10 @@ properties:
       - name: 'resourceTags'
         type: KeyValuePairs
         description: |
-          The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
-          in the namespaced format, for example "123456789012/environment" where 123456789012 is the
-          ID of the parent organization or project resource for this tag key. Tag value is expected
-          to be the short name, for example "Production". See [Tag definitions](https://cloud.google.com/iam/docs/tags-access-control#definitions)
+          Tag keys are globally unique. Tag key is expected to bein the namespaced format,
+          for example "123456789012/environment" where 123456789012 is the ID of the parent organization
+          or project resource for this tag key. Tag value is expected to be the short name,
+          for example "Production". See [Tag definitions](https://cloud.google.com/iam/docs/tags-access-control#definitions)
           for more details.
   - name: 'name'
     type: String

--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -106,6 +106,14 @@ properties:
         description: |
           The labels associated with this dataset. You can use these to
           organize and group your datasets.
+      - name: 'resourceTags'
+        type: KeyValuePairs
+        description: |
+          The tags attached to this table. Tag keys are globally unique. Tag key is expected to be
+          in the namespaced format, for example "123456789012/environment" where 123456789012 is the
+          ID of the parent organization or project resource for this tag key. Tag value is expected
+          to be the short name, for example "Production". See [Tag definitions](https://cloud.google.com/iam/docs/tags-access-control#definitions)
+          for more details.
   - name: 'name'
     type: String
     description: |-


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigqueryanalyticshub: added `resource_tags` field to `google_bigquery_analytics_hub_listing_subscription`

```
