### PR TITLE
Fix mmv1 merge function by removing private field from struct

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -342,7 +342,6 @@ type Resource struct {
 
 	ImportPath     string `yaml:"-"`
 	SourceYamlFile string `yaml:"-"`
-	githubUrl      string
 }
 
 func (r *Resource) UnmarshalYAML(unmarshal func(any) error) error {
@@ -1836,12 +1835,7 @@ func (r Resource) ShouldGenerateSweepers() bool {
 }
 
 func (r Resource) GithubURL() string {
-	if r.githubUrl != "" {
-		return r.githubUrl
-	}
-
-	r.githubUrl = GITHUB_BASE_URL + r.SourceYamlFile
-	return r.githubUrl
+	return GITHUB_BASE_URL + r.SourceYamlFile
 }
 
 func (r Resource) CodeHeader(templatePath string) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes b/396575323

https://github.com/GoogleCloudPlatform/magic-modules/pull/13071 added a `githubUrl` field that causes an error for our private provider build (mmv1/api/product.go:280):

```
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method
```

Because it is not exportable, it breaks our merge function and generation panics.

It looks like we don't need the caching as best I can tell, so I went ahead and removed it.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
