### PR TITLE
SWP: Match properties description

### DIFF
--- a/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
+++ b/mmv1/products/networksecurity/TlsInspectionPolicy.yaml
@@ -107,6 +107,7 @@ properties:
       - 'TLS_1_1'
       - 'TLS_1_2'
       - 'TLS_1_3'
+    default_from_api: true
   - name: 'tlsFeatureProfile'
     type: Enum
     description: |
@@ -117,6 +118,7 @@ properties:
       - 'PROFILE_MODERN'
       - 'PROFILE_RESTRICTED'
       - 'PROFILE_CUSTOM'
+    default_from_api: true
   - name: 'customTlsFeatures'
     type: Array
     description: |

--- a/mmv1/products/networkservices/Gateway.yaml
+++ b/mmv1/products/networkservices/Gateway.yaml
@@ -97,7 +97,7 @@ parameters:
   - name: 'name'
     type: String
     description: |
-      Short name of the Gateway resource to be created.
+      Name of the Gateway resource.
     url_param_only: true
     required: true
   - name: 'location'
@@ -106,7 +106,7 @@ parameters:
       The location of the gateway.
       The default value is `global`.
     url_param_only: true
-    default_value: "global"
+    default_value: 'global'
 properties:
   - name: 'selfLink'
     type: String
@@ -116,16 +116,17 @@ properties:
   - name: 'createTime'
     type: Time
     description: |
-      Time the AccessPolicy was created in UTC.
+      The timestamp when the resource was created.
     output: true
   - name: 'updateTime'
     type: Time
     description: |
-      Time the AccessPolicy was updated in UTC.
+      The timestamp when the resource was updated.
     output: true
   - name: 'labels'
     type: KeyValueLabels
-    description: Set of label tags associated with the Gateway resource.
+    description: |
+      Set of label tags associated with the Gateway resource.
   - name: 'description'
     type: String
     description: |
@@ -133,19 +134,30 @@ properties:
   - name: 'type'
     type: Enum
     description: |
-      Immutable. The type of the customer-managed gateway. Possible values are: * OPEN_MESH * SECURE_WEB_GATEWAY.
+      Immutable. The type of the customer managed gateway.
     required: true
     immutable: true
     enum_values:
-      - 'TYPE_UNSPECIFIED'
       - 'OPEN_MESH'
       - 'SECURE_WEB_GATEWAY'
+  - name: 'addresses'
+    type: Array
+    description: |
+      Zero or one IPv4 or IPv6 address on which the Gateway will receive the traffic.
+      When no address is provided, an IP from the subnetwork is allocated.
+
+      This field only applies to gateways of type 'SECURE_WEB_GATEWAY'.
+      Gateways of type 'OPEN_MESH' listen on 0.0.0.0 for IPv4 and :: for IPv6.
+    immutable: true
+    default_from_api: true
+    item_type:
+      type: String
   - name: 'ports'
     type: Array
     description: |
       One or more port numbers (1-65535), on which the Gateway will receive traffic.
-      The proxy binds to the specified ports. Gateways of type 'SECURE_WEB_GATEWAY' are
-      limited to 1 port. Gateways of type 'OPEN_MESH' listen on 0.0.0.0 and support multiple ports.
+      The proxy binds to the specified ports. Gateways of type 'SECURE_WEB_GATEWAY' are limited to 1 port.
+       Gateways of type 'OPEN_MESH' listen on 0.0.0.0 for IPv4 and :: for IPv6 and support multiple ports.
     required: true
     item_type:
       type: Integer
@@ -153,45 +165,14 @@ properties:
     type: String
     description: |
       Immutable. Scope determines how configuration across multiple Gateway instances are merged.
-      The configuration for multiple Gateway instances with the same scope will be merged as presented as
-      a single coniguration to the proxy/load balancer.
+      The configuration for multiple Gateway instances with the same scope will be merged as presented as a single coniguration to the proxy/load balancer.
+
       Max length 64 characters. Scope should start with a letter and can only have letters, numbers, hyphens.
     immutable: true
   - name: 'serverTlsPolicy'
     type: String
     description: |
-      A fully-qualified ServerTLSPolicy URL reference. Specifies how TLS traffic is terminated.
-      If empty, TLS termination is disabled.
-  - name: 'addresses'
-    type: Array
-    description: |
-      Zero or one IPv4-address on which the Gateway will receive the traffic. When no address is provided,
-      an IP from the subnetwork is allocated This field only applies to gateways of type 'SECURE_WEB_GATEWAY'.
-      Gateways of type 'OPEN_MESH' listen on 0.0.0.0.
-    immutable: true
-    default_from_api: true
-    item_type:
-      type: String
-  - name: 'subnetwork'
-    type: String
-    description: |
-      The relative resource name identifying the subnetwork in which this SWG is allocated.
-      For example: `projects/*/regions/us-central1/subnetworks/network-1`.
-      Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY.
-    immutable: true
-  - name: 'network'
-    type: String
-    description: |
-      The relative resource name identifying the VPC network that is using this configuration.
-      For example: `projects/*/global/networks/network-1`.
-      Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
-    immutable: true
-  - name: 'gatewaySecurityPolicy'
-    type: String
-    description: |
-      A fully-qualified GatewaySecurityPolicy URL reference. Defines how a server should apply security policy to inbound (VM to Proxy) initiated connections.
-      For example: `projects/*/locations/*/gatewaySecurityPolicies/swg-policy`.
-      This policy is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+      A fully-qualified ServerTLSPolicy URL reference. Specifies how TLS traffic is terminated. If empty, TLS termination is disabled.
   - name: 'certificateUrls'
     type: Array
     description: |
@@ -199,6 +180,46 @@ properties:
       This feature only applies to gateways of type 'SECURE_WEB_GATEWAY'.
     item_type:
       type: String
+  - name: 'gatewaySecurityPolicy'
+    type: String
+    description: |
+      A fully-qualified GatewaySecurityPolicy URL reference. Defines how a server should apply security policy to inbound (VM to Proxy) initiated connections.
+      For example: 'projects/*/locations/*/gatewaySecurityPolicies/swg-policy'.
+      This policy is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+  - name: 'network'
+    type: String
+    description: |
+      The relative resource name identifying the VPC network that is using this configuration.
+      For example: 'projects/*/global/networks/network-1'.
+
+      Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+    immutable: true
+  - name: 'subnetwork'
+    type: String
+    description: |
+      The relative resource name identifying the subnetwork in which this SWG is allocated.
+      For example: projects/*/regions/us-central1/subnetworks/network-1.
+
+      Currently, this field is specific to gateways of type 'SECURE_WEB_GATEWAY'.
+    immutable: true
+  - name: 'ipVersion'
+    type: Enum
+    description: |
+      The IP Version that will be used by this gateway.
+    enum_values:
+      - 'IPV4'
+      - 'IPV6'
+    default_value: 'IPV4'
+  - name: 'envoyHeaders'
+    type: Enum
+    description: |
+      Determines if envoy will insert internal debug headers into upstream requests.
+      Other Envoy headers may still be injected.
+      By default, envoy will not insert any debug headers.
+    enum_values:
+      - 'NONE'
+      - 'DEBUG_HEADERS'
+    default_value: 'NONE'
   - name: 'routingMode'
     type: Enum
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Hello folks.
This PR is to change the properties/fields descriptions on the Gateway `google_network_services_gateway` (_Secure Web Proxy_)

During the development one test failed because of **TlsInspectionPolicy** resource that has a _default value from API_. So this change was done as well to not break the tests.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `ipVersion` and `envoyHeaders` fields to `google_network_services_gateway` resource and updated descriptions.
```

```release-note:enhancement
networksecurity: added default_from_api on `minTlsVersion` and `tlsFeatureProfile` fields to `google_network_security_tls_inspection_policy` resource.
```
