### PR TITLE
Bigtable: fixes updating clusters with autoscaling

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -614,7 +614,6 @@ func expandBigtableClusters(clusters []interface{}, instanceID string, config *t
 			InstanceID:  instanceID,
 			Zone:        zone,
 			ClusterID:   cluster["cluster_id"].(string),
-			NumNodes:    int32(cluster["num_nodes"].(int)),
 			StorageType: storageType,
 			KMSKeyName:  cluster["kms_key_name"].(string),
 		}
@@ -627,6 +626,10 @@ func expandBigtableClusters(clusters []interface{}, instanceID string, config *t
 				CPUTargetPercent:          autoscaling_config["cpu_target"].(int),
 				StorageUtilizationPerNode: autoscaling_config["storage_target"].(int),
 			}
+		} else {
+			// We only set num_nodes if there is no auto-scaling config, since if
+			// auto-scaling is enabled the number of live nodes is dynamic
+			cluster_config.NumNodes = int32(cluster["num_nodes"].(int))
 		}
 		results = append(results, cluster_config)
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -1007,7 +1007,6 @@ resource "time_offset" "week-in-future" {
 `
 }
 
-
 type cluster struct {
 	clusterId         string
 	zone              string


### PR DESCRIPTION
Prevents adding `num_nodes` to update cluster requests for clusters that have `autoscaling` enabled, since that results in errors. Also included a test for that scenario.

The github issue has an example of how to trigger this bug.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21434

**Release Note Template for Downstream PRs (will be copied)**

```release-note: bug
bigtable: fixed a bug where sometimes updating an instance's cluster list could result in an error if there was an existing cluster with autoscaling enabled
```
