### PR TITLE
Feature gap: Add missed `enable_flow_logs` & `state` to subnetwork

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -337,12 +337,14 @@ properties:
       isn't supported if the subnet `purpose` field is set to subnetwork is
       `REGIONAL_MANAGED_PROXY` or `GLOBAL_MANAGED_PROXY`.
     send_empty_value: true
+    default_from_api: true
     update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
     update_verb: 'PATCH'
     update_id: 'logConfig'
     fingerprint_name: 'fingerprint'
     custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.tmpl'
     custom_expand: 'templates/terraform/custom_expand/subnetwork_log_config.go.tmpl'
+    diff_suppress_func: 'subnetworkLogConfigDiffSuppress'
     properties:
       - name: 'aggregationInterval'
         type: Enum
@@ -467,3 +469,23 @@ properties:
     update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
     update_verb: 'PATCH'
     fingerprint_name: 'fingerprint'
+  - name: 'enableFlowLogs'
+    type: Boolean
+    description: |
+      Whether to enable flow logging for this subnetwork. If this field is not explicitly set,
+      it will not appear in get listings. If not set the default behavior is determined by the
+      org policy, if there is no org policy specified, then it will default to disabled.
+      This field isn't supported if the subnet purpose field is set to REGIONAL_MANAGED_PROXY.
+    default_from_api: true
+    send_empty_value: true
+    update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
+    update_verb: 'PATCH'
+    fingerprint_name: 'fingerprint'
+  - name: 'state'
+    type: Enum
+    description: |
+     'The state of the subnetwork, which can be one of the following values:
+      READY: Subnetwork is created and ready to use DRAINING: only applicable to subnetworks that have the purpose
+      set to INTERNAL_HTTPS_LOAD_BALANCER and indicates that connections to the load balancer are being drained.
+      A subnetwork that is draining cannot be used or modified until it reaches a status of READY'
+    output: true

--- a/mmv1/templates/terraform/constants/subnetwork.tmpl
+++ b/mmv1/templates/terraform/constants/subnetwork.tmpl
@@ -48,3 +48,13 @@ func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDif
 
 	return nil
 }
+
+// DiffSuppressFunc for fields inside `log_config`.
+func subnetworkLogConfigDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// If the enable_flow_logs is not enabled, we don't need to check for differences.
+	if enable_flow_logs := d.Get("enable_flow_logs"); !enable_flow_logs.(bool) {
+		return true
+	}
+
+	return false
+}

--- a/mmv1/templates/terraform/custom_expand/subnetwork_log_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/subnetwork_log_config.go.tmpl
@@ -16,12 +16,14 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 	if len(l) == 0 || l[0] == nil {
 		purpose, ok := d.GetOkExists("purpose")
 
-		if ok &&(purpose.(string) == "REGIONAL_MANAGED_PROXY" || purpose.(string) == "GLOBAL_MANAGED_PROXY" || purpose.(string) == "INTERNAL_HTTPS_LOAD_BALANCER") {
+		if ok && (purpose.(string) == "REGIONAL_MANAGED_PROXY" || purpose.(string) == "GLOBAL_MANAGED_PROXY" || purpose.(string) == "INTERNAL_HTTPS_LOAD_BALANCER") {
 			// Subnetworks for regional L7 ILB/XLB or cross-regional L7 ILB do not accept any values for logConfig
 			return nil, nil
 		}
-		// send enable = false to ensure logging is disabled if there is no config
-		transformed["enable"] = false
+
+		// set enable field basing on the enable_flow_logs field. It's needed for case when enable_flow_logs
+		// is set to true to avoid conflict with the API. In that case API will return default values for log_config
+		transformed["enable"] = d.Get("enable_flow_logs")
 		return transformed, nil
 	}
 
@@ -34,7 +36,7 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 	transformed["flowSampling"] = original["flow_sampling"]
 	transformed["metadata"] = original["metadata"]
 	transformed["filterExpr"] = original["filter_expr"]
-	
+
 	// make it JSON marshallable
 	transformed["metadataFields"] = original["metadata_fields"].(*schema.Set).List()
 

--- a/mmv1/templates/terraform/custom_flatten/subnetwork_log_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/subnetwork_log_config.go.tmpl
@@ -39,6 +39,6 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 		transformed["metadata_fields"] = nil
 	}
 	transformed["filter_expr"] = original["filterExpr"]
-	
+
 	return []interface{}{transformed}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -456,6 +456,66 @@ func TestAccComputeSubnetwork_internal_ipv6(t *testing.T) {
 	})
 }
 
+func TestAccComputeSubnetwork_enableFlowLogs(t *testing.T) {
+	t.Parallel()
+	var subnetwork compute.Subnetwork
+
+	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	subnetworkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* precheck logic here */ },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSubnetwork_enableFlowLogs(cnName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.subnetwork", &subnetwork),
+					testAccCheckComputeSubnetworkIfLogConfigExists(&subnetwork, "google_compute_subnetwork.subnetwork"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.enable", "true"),
+					resource.TestCheckResourceAttr("google_compute_subnetwork.subnetwork", "enable_flow_logs", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.subnetwork",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSubnetwork_enableFlowLogs_with_logConfig(cnName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.subnetwork", &subnetwork),
+					resource.TestCheckResourceAttr("google_compute_subnetwork.subnetwork", "enable_flow_logs", "true"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.enable", "true"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.aggregation_interval", "INTERVAL_1_MIN"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.metadata", "INCLUDE_ALL_METADATA"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.subnetwork",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSubnetwork_enableFlowLogs(cnName, subnetworkName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(t, "google_compute_subnetwork.subnetwork", &subnetwork),
+					resource.TestCheckResourceAttr("google_compute_subnetwork.subnetwork", "enable_flow_logs", "false"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.enable", "false"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.aggregation_interval", "INTERVAL_1_MIN"),
+					testAccCheckComputeSubnetworkLogConfig(&subnetwork, "log_config.0.metadata", "INCLUDE_ALL_METADATA"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.subnetwork",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeSubnetworkExists(t *testing.T, n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -510,6 +570,111 @@ func testAccCheckComputeSubnetworkHasNotSecondaryIpRange(subnetwork *compute.Sub
 					return fmt.Errorf("Secondary range %s has the wrong ip_cidr_range. Expected %s, got %s", rangeName, ipCidrRange, secondaryRange.IpCidrRange)
 				}
 			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeSubnetworkIfLogConfigExists(subnetwork *compute.Subnetwork, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Retrieve the resource state using a fixed resource name
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource google_compute_subnetwork.subnetwork not found in state")
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource ID is not set")
+		}
+
+		// Ensure that the log_config exists in the API response.
+		if subnetwork.LogConfig == nil {
+			return fmt.Errorf("no log_config exists in subnetwork")
+		}
+
+		stateAttrs := rs.Primary.Attributes
+
+		// Check aggregation_interval.
+		aggInterval, ok := stateAttrs["log_config.0.aggregation_interval"]
+		if !ok {
+			return fmt.Errorf("aggregation_interval not found in state")
+		}
+		if subnetwork.LogConfig.AggregationInterval != aggInterval {
+			return fmt.Errorf("aggregation_interval mismatch: expected %s, got %s", aggInterval, subnetwork.LogConfig.AggregationInterval)
+		}
+
+		// Check flow_sampling.
+		fsState, ok := stateAttrs["log_config.0.flow_sampling"]
+		if !ok {
+			return fmt.Errorf("flow_sampling not found in state")
+		}
+		actualFS := fmt.Sprintf("%g", subnetwork.LogConfig.FlowSampling)
+		if actualFS != fsState {
+			return fmt.Errorf("flow_sampling mismatch: expected %s, got %s", fsState, actualFS)
+		}
+
+		// Check metadata.
+		metadata, ok := stateAttrs["log_config.0.metadata"]
+		if !ok {
+			return fmt.Errorf("metadata not found in state")
+		}
+		if subnetwork.LogConfig.Metadata != metadata {
+			return fmt.Errorf("metadata mismatch: expected %s, got %s", metadata, subnetwork.LogConfig.Metadata)
+		}
+
+		// Optionally, check filter_expr if it exists.
+		if subnetwork.LogConfig.FilterExpr != "" {
+			filterExpr, ok := stateAttrs["log_config.0.filter_expr"]
+			if !ok {
+				return fmt.Errorf("filter_expr is set in API but not found in state")
+			}
+			if subnetwork.LogConfig.FilterExpr != filterExpr {
+				return fmt.Errorf("filter_expr mismatch: expected %s, got %s", filterExpr, subnetwork.LogConfig.FilterExpr)
+			}
+		}
+
+		// Optionally, check metadata_fields if present.
+		if len(subnetwork.LogConfig.MetadataFields) > 0 {
+			if _, ok := stateAttrs["log_config.0.metadata_fields"]; !ok {
+				return fmt.Errorf("metadata_fields are set in API but not found in state")
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeSubnetworkLogConfig(subnetwork *compute.Subnetwork, key, value string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if subnetwork.LogConfig == nil {
+			return fmt.Errorf("no log_config found")
+		}
+
+		switch key {
+		case "log_config.0.enable":
+			if subnetwork.LogConfig.Enable != (value == "true") {
+				return fmt.Errorf("expected %s to be '%s', got '%t'", key, value, subnetwork.LogConfig.Enable)
+			}
+		case "log_config.0.aggregation_interval":
+			if subnetwork.LogConfig.AggregationInterval != value {
+				return fmt.Errorf("expected %s to be '%s', got '%s'", key, value, subnetwork.LogConfig.AggregationInterval)
+			}
+		case "log_config.0.metadata":
+			if subnetwork.LogConfig.Metadata != value {
+				return fmt.Errorf("expected %s to be '%s', got '%s'", key, value, subnetwork.LogConfig.Metadata)
+			}
+		case "log_config.0.flow_sampling":
+			flowSamplingStr := fmt.Sprintf("%g", subnetwork.LogConfig.FlowSampling)
+			if flowSamplingStr != value {
+				return fmt.Errorf("expected %s to be '%s', got '%s'", key, value, flowSamplingStr)
+			}
+		case "log_config.0.filterExpr":
+			if subnetwork.LogConfig.FilterExpr != value {
+				return fmt.Errorf("expected %s to be '%s', got '%s'", key, value, subnetwork.LogConfig.FilterExpr)
+			}
+		default:
+			return fmt.Errorf("unknown log_config key: %s", key)
 		}
 
 		return nil
@@ -955,4 +1120,43 @@ resource "google_compute_subnetwork" "subnetwork" {
   ipv6_access_type = "INTERNAL"
 }
 `, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_enableFlowLogs(cnName, subnetworkName string, enableFlowLogs bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.self_link
+  enable_flow_logs = %t
+}
+`, cnName, subnetworkName, enableFlowLogs)
+}
+
+func testAccComputeSubnetwork_enableFlowLogs_with_logConfig(cnName, subnetworkName string, enableFlowLogs bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.self_link
+  enable_flow_logs = %t
+
+  log_config {
+    aggregation_interval = "INTERVAL_1_MIN"
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+}
+`, cnName, subnetworkName, enableFlowLogs)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -463,8 +463,8 @@ func TestAccComputeSubnetwork_enableFlowLogs(t *testing.T) {
 	cnName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	subnetworkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { /* precheck logic here */ },
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
 		Steps: []resource.TestStep{

--- a/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.json
+++ b/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.json
@@ -26,7 +26,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "ipCidrRange": "10.0.0.0/24",
-        "enable_flow_logs": true,
+        "enableFlowLogs": true,
         "logConfig": {
           "aggregationInterval": "INTERVAL_10_MIN",
           "enable": true,

--- a/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.json
+++ b/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.json
@@ -26,6 +26,7 @@
       "parent": "//cloudresourcemanager.googleapis.com/projects/{{.Provider.project}}",
       "data": {
         "ipCidrRange": "10.0.0.0/24",
+        "enable_flow_logs": true,
         "logConfig": {
           "aggregationInterval": "INTERVAL_10_MIN",
           "enable": true,

--- a/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.tf
+++ b/mmv1/third_party/tgc/tests/data/example_compute_subnetwork.tf
@@ -38,6 +38,7 @@ resource "google_compute_subnetwork" "my-test-subnetwork" {
   region        = "us-central1"
   network       = google_compute_network.default.id
 
+  enable_flow_logs = true
   log_config {
     aggregation_interval = "INTERVAL_10_MIN"
     flow_sampling        = 0.5


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch introduces new fields to the Terraform provider for the `subnetwork` resource:  
- `enable_flow_logs` - a field that allows enabling flow logs. If the `log_config` field is not set in the configuration, the default `log_config` value returned by the API will be stored in `tfstate`.  
- `state` - a read-only field. During testing, it was observed that the API does not return this field in response to a GET request. Nevertheless, the field is stored in `tfstate` as an empty string.  

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `enable_flow_logs` and `state` fields to `google_compute_subnetwork` resource
```
