### PR TITLE
Add Optional Log Fields to google_cloud_region_backend_service

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -757,9 +757,7 @@ properties:
     output: true
   - name: 'iap'
     type: NestedObject
-    description: |
-      Settings for enabling Cloud Identity Aware Proxy.
-      If OAuth client is not set, Google-managed OAuth client is used.
+    description: Settings for enabling Cloud Identity Aware Proxy
     default_from_api: true
     send_empty_value: true
     properties:

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -757,7 +757,9 @@ properties:
     output: true
   - name: 'iap'
     type: NestedObject
-    description: Settings for enabling Cloud Identity Aware Proxy
+    description: |
+      Settings for enabling Cloud Identity Aware Proxy.
+      If OAuth client is not set, Google-managed OAuth client is used.
     default_from_api: true
     send_empty_value: true
     properties:
@@ -1324,12 +1326,14 @@ properties:
           - 'log_config.0.enable'
           - 'log_config.0.sample_rate'
           - 'log_config.0.optional_mode'
+        default_from_api: true
       - name: 'optionalFields'
         type: Array
         description: |
           Specifies the fields to include in logging. This field can only be specified if logging is enabled for this backend service.
         item_type:
           type: String
+        default_from_api: true
   - name: 'network'
     type: ResourceRef
     description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1297,6 +1297,7 @@ properties:
         at_least_one_of:
           - 'log_config.0.enable'
           - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
       - name: 'sampleRate'
         type: Double
         description: |
@@ -1307,8 +1308,28 @@ properties:
         at_least_one_of:
           - 'log_config.0.enable'
           - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
         diff_suppress_func: 'suppressWhenDisabled'
         default_value: 1.0
+      - name: 'optionalMode'
+        type: Enum
+        description: |
+          Specifies the optional logging mode for the load balancer traffic.
+          Supported values: INCLUDE_ALL_OPTIONAL, EXCLUDE_ALL_OPTIONAL, CUSTOM.
+        enum_values:
+          - 'INCLUDE_ALL_OPTIONAL'
+          - 'EXCLUDE_ALL_OPTIONAL'
+          - 'CUSTOM'
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+      - name: 'optionalFields'
+        type: Array
+        description: |
+          Specifies the fields to include in logging. This field can only be specified if logging is enabled for this backend service.
+        item_type:
+          type: String
   - name: 'network'
     type: ResourceRef
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -402,8 +402,7 @@ func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				// Test: Initial setup with minimal config
-				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 1.0, "INCLUDE_ALL_OPTIONAL"),
+				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName),
 			},
 			{
 				ResourceName:      "google_compute_region_backend_service.foobar",
@@ -411,43 +410,6 @@ func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				// Test: Update to EXCLUDE_ALL_OPTIONAL mode
-				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 0.5, "EXCLUDE_ALL_OPTIONAL"),
-			},
-			{
-				ResourceName:      "google_compute_region_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Test: Update to CUSTOM mode with fields
-				Config: testAccComputeRegionBackendService_withLogConfigOptionalFields(serviceName, checkName),
-			},
-			{
-				ResourceName:      "google_compute_region_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Test: CUSTOM mode with empty fields
-				Config: testAccComputeRegionBackendService_withLogConfigCustomEmpty(serviceName, checkName),
-			},
-			{
-				ResourceName:      "google_compute_region_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Test: Minimum sample rate
-				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 0.0, "INCLUDE_ALL_OPTIONAL"),
-			},
-			{
-				ResourceName:      "google_compute_region_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Test: Disable logging
 				Config: testAccComputeRegionBackendService_withLogConfigDisabled(serviceName, checkName),
 			},
 			{
@@ -1294,85 +1256,29 @@ resource "google_compute_region_security_policy" "policy" {
 }
 {{- end }}
 
-func testAccComputeRegionBackendService_withLogConfig(serviceName, checkName string, sampleRate float64, optionalMode string) string {
+func testAccComputeRegionBackendService_withLogConfig(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
-  health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.self_link]
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"
   
   log_config {
     enable      = true
-    sample_rate = %v
-    optional_mode = "%s"
+    sample_rate = 1.0
+    optional_mode = "INCLUDE_ALL_OPTIONAL"
   }
 }
 
-resource "google_compute_health_check" "health_check" {
-  name     = "%s"
-  http_health_check {
-    port = 80
-  }
-}
-`, serviceName, sampleRate, optionalMode, checkName)
-}
+resource "google_compute_region_health_check" "health_check" {
+  name               = "%s"
+  region             = "us-central1"
+  check_interval_sec = 1
+  timeout_sec        = 1
 
-func testAccComputeRegionBackendService_withLogConfigOptionalFields(serviceName, checkName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_region_backend_service" "foobar" {
-  name                  = "%s"
-  health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
-  protocol              = "HTTP"
-  load_balancing_scheme = "INTERNAL_MANAGED"
-  locality_lb_policy    = "ROUND_ROBIN"
-  
-  log_config {
-    enable      = true
-    sample_rate = 0.5
-    optional_mode = "CUSTOM"
-    optional_fields = [
-      "PROTOCOL",
-      "RESPONSE_CODE",
-      "REQUEST_METHOD",
-      "URL_MAP",
-      "BACKEND_TARGET"
-    ]
-  }
-}
-
-resource "google_compute_health_check" "health_check" {
-  name     = "%s"
-  http_health_check {
-    port = 80
-  }
-}
-`, serviceName, checkName)
-}
-
-func testAccComputeRegionBackendService_withLogConfigCustomEmpty(serviceName, checkName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_region_backend_service" "foobar" {
-  name                  = "%s"
-  health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
-  protocol              = "HTTP"
-  load_balancing_scheme = "INTERNAL_MANAGED"
-  locality_lb_policy    = "ROUND_ROBIN"
-  
-  log_config {
-    enable      = true
-    sample_rate = 0.5
-    optional_mode = "CUSTOM"
-    optional_fields = []
-  }
-}
-
-resource "google_compute_health_check" "health_check" {
-  name     = "%s"
   http_health_check {
     port = 80
   }
@@ -1384,8 +1290,8 @@ func testAccComputeRegionBackendService_withLogConfigDisabled(serviceName, check
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
-  health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.self_link]
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"
@@ -1395,8 +1301,12 @@ resource "google_compute_region_backend_service" "foobar" {
   }
 }
 
-resource "google_compute_health_check" "health_check" {
-  name     = "%s"
+resource "google_compute_region_health_check" "health_check" {
+  name               = "%s"
+  region             = "us-central1"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
   http_health_check {
     port = 80
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -390,6 +390,75 @@ func TestAccComputeRegionBackendService_subsettingUpdate(t *testing.T) {
 }
 {{- end }}
 
+func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Test: Initial setup with minimal config
+				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 1.0, "INCLUDE_ALL_OPTIONAL"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test: Update to EXCLUDE_ALL_OPTIONAL mode
+				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 0.5, "EXCLUDE_ALL_OPTIONAL"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test: Update to CUSTOM mode with fields
+				Config: testAccComputeRegionBackendService_withLogConfigOptionalFields(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test: CUSTOM mode with empty fields
+				Config: testAccComputeRegionBackendService_withLogConfigCustomEmpty(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test: Minimum sample rate
+				Config: testAccComputeRegionBackendService_withLogConfig(serviceName, checkName, 0.0, "INCLUDE_ALL_OPTIONAL"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Test: Disable logging
+				Config: testAccComputeRegionBackendService_withLogConfigDisabled(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeRegionBackendService_ilbBasic_withUnspecifiedProtocol(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -1224,3 +1293,113 @@ resource "google_compute_region_security_policy" "policy" {
 `, serviceName, polLink, polName)
 }
 {{- end }}
+
+func testAccComputeRegionBackendService_withLogConfig(serviceName, checkName string, sampleRate float64, optionalMode string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+  
+  log_config {
+    enable      = true
+    sample_rate = %v
+    optional_mode = "%s"
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name     = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, sampleRate, optionalMode, checkName)
+}
+
+func testAccComputeRegionBackendService_withLogConfigOptionalFields(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+  
+  log_config {
+    enable      = true
+    sample_rate = 0.5
+    optional_mode = "CUSTOM"
+    optional_fields = [
+      "PROTOCOL",
+      "RESPONSE_CODE",
+      "REQUEST_METHOD",
+      "URL_MAP",
+      "BACKEND_TARGET"
+    ]
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name     = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeRegionBackendService_withLogConfigCustomEmpty(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+  
+  log_config {
+    enable      = true
+    sample_rate = 0.5
+    optional_mode = "CUSTOM"
+    optional_fields = []
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name     = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeRegionBackendService_withLogConfigDisabled(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+  
+  log_config {
+    enable = false
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name     = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, checkName)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds optional log fields to to google_cloud_region_backend_service

### Related Issues

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/19187

### Release Note

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `log_config.optional_mode` and `log_config.optional_fields` fields to `google_compute_region_backend_service` resource  
```