### PR TITLE
Deprecate google_data_catalog_entry

### DIFF
--- a/mmv1/products/datacatalog/Entry.yaml
+++ b/mmv1/products/datacatalog/Entry.yaml
@@ -23,7 +23,7 @@ description: |
 deprecation_message: >-
   `google_data_catalog_entry` is deprecated and will be removed in a future major release.
   Data Catalog is deprecated and will be discontinued on January 30, 2026. For steps to transition
-  your Data Catalog users, workloads, and content to Dataplex Catalog, see 
+  your Data Catalog users, workloads, and content to Dataplex Catalog, see
   https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:

--- a/mmv1/products/datacatalog/Entry.yaml
+++ b/mmv1/products/datacatalog/Entry.yaml
@@ -20,6 +20,11 @@ description: |
 
   An Entry resource contains resource details, such as its schema. An Entry can also be used to attach
   flexible metadata, such as a Tag.
+deprecation_message: >-
+  `google_data_catalog_entry` is deprecated and will be removed in a future major release.
+  Data Catalog is deprecated and will be discontinued on January 30, 2026. For steps to transition
+  your Data Catalog users, workloads, and content to Dataplex Catalog, see 
+  https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/data-catalog/docs'


### PR DESCRIPTION
Deprecates google_data_catalog_entry as Data Catalog is being deprecated: https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
datacatalog: deprecated `google_data_catalog_entry` resource. For steps to transition your Data Catalog users, workloads, and content to Dataplex Catalog, see https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
```
