### PR TITLE
Deprecate google_data_catalog_entry_group

### DIFF
--- a/mmv1/products/datacatalog/Entry.yaml
+++ b/mmv1/products/datacatalog/Entry.yaml
@@ -20,11 +20,6 @@ description: |
 
   An Entry resource contains resource details, such as its schema. An Entry can also be used to attach
   flexible metadata, such as a Tag.
-deprecation_message: >-
-  `google_data_catalog_entry` is deprecated and will be removed in a future major release.
-  Data Catalog is deprecated and will be discontinued on January 30, 2026. For steps to transition
-  your Data Catalog users, workloads, and content to Dataplex Catalog, see
-  https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/data-catalog/docs'

--- a/mmv1/products/datacatalog/EntryGroup.yaml
+++ b/mmv1/products/datacatalog/EntryGroup.yaml
@@ -15,6 +15,11 @@
 name: 'EntryGroup'
 description: |
   An EntryGroup resource represents a logical grouping of zero or more Data Catalog Entry resources.
+deprecation_message: >-
+  `google_data_catalog_entry_group` is deprecated and will be removed in a future major release.
+  Use `google_dataplex_entry_group` instead. For steps to transition
+  your Data Catalog users, workloads, and content to Dataplex Catalog, see
+  https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/data-catalog/docs'


### PR DESCRIPTION
Deprecates google_data_catalog_entry_group as Data Catalog is being deprecated: https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
deprecated `google_data_catalog_entry_group` resource. `google_data_catalog_entry_group` is deprecated and will be removed in a future major release. Use `google_dataplex_entry_group` instead. For steps to transition your Data Catalog users, workloads, and content to Dataplex Catalog, see https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
```
