### PR TITLE
Deprecate google_data_catalog_tag

### DIFF
--- a/mmv1/products/datacatalog/Tag.yaml
+++ b/mmv1/products/datacatalog/Tag.yaml
@@ -17,6 +17,10 @@ description: |
   Tags are used to attach custom metadata to Data Catalog resources. Tags conform to the specifications within their tag template.
 
   See [Data Catalog IAM](https://cloud.google.com/data-catalog/docs/concepts/iam) for information on the permissions needed to create or view tags.
+deprecation_message: >-
+  `google_data_catalog_tag` is deprecated and will be removed in a future major release.
+  For steps to transition your Data Catalog users, workloads, and content to Dataplex Catalog, see
+  https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/data-catalog/docs'


### PR DESCRIPTION
Deprecates google_data_catalog_tag as Data Catalog is being deprecated: https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
Deprecated google_data_catalog_tag
```
