### PR TITLE
Deprecate google_data_catalog_tag_template

### DIFF
--- a/mmv1/products/datacatalog/TagTemplate.yaml
+++ b/mmv1/products/datacatalog/TagTemplate.yaml
@@ -16,6 +16,11 @@ name: 'TagTemplate'
 description: |
   A tag template defines a tag, which can have one or more typed fields.
   The template is used to create and attach the tag to GCP resources.
+deprecation_message: >-
+  `google_data_catalog_tag_template` is deprecated and will be removed in a future major release.
+  Use `google_dataplex_aspect_type` instead. For steps to transition
+  your Data Catalog users, workloads, and content to Dataplex Catalog, see
+  https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/data-catalog/docs'


### PR DESCRIPTION
Deprecates google_data_catalog_tag_template as Data Catalog is being deprecated: https://cloud.google.com/dataplex/docs/transition-to-dataplex-catalog

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
datacatalog: deprecated `google_data_catalog_tag_template` resource
```
