### PR TITLE
Add new dataproc label to test checks

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -953,8 +953,8 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
 					resource.TestCheckNoResourceAttr("google_dataproc_cluster.with_labels", "labels.%"),
-					// We don't provide any, but GCP adds three and goog-dataproc-autozone is added internally, so expect 4.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "4"),
+					// We don't provide any, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 5.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
 				),
 			},
 			{
@@ -964,8 +964,8 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 5.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 6.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "6"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.key1", "value1"),
 				),
 			},
@@ -985,8 +985,8 @@ func TestAccDataprocCluster_withLabels(t *testing.T) {
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
 					resource.TestCheckNoResourceAttr("google_dataproc_cluster.with_labels", "labels.%"),
-					// We don't provide any, but GCP adds three and goog-dataproc-autozone is added internally, so expect 4.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "4"),
+					// We don't provide any, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 5.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_upgrade_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_upgrade_test.go
@@ -44,8 +44,8 @@ func TestAccDataprocClusterLabelsMigration_withoutLabels_withoutChanges(t *testi
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
 					resource.TestCheckNoResourceAttr("google_dataproc_cluster.with_labels", "labels.%"),
-					// GCP adds three and goog-dataproc-autozone is added internally, so expect 4.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "4"),
+					// GCP adds 4 and goog-dataproc-autozone is added internally, so expect 5.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
 				),
 			},
 			{
@@ -56,8 +56,8 @@ func TestAccDataprocClusterLabelsMigration_withoutLabels_withoutChanges(t *testi
 
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 5.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 6.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "6"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.key1", "value1"),
 				),
 			},
@@ -98,8 +98,8 @@ func TestAccDataprocClusterLabelsMigration_withLabels_withoutChanges(t *testing.
 
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 5.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 6.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "6"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.key1", "value1"),
 				),
 			},
@@ -112,8 +112,8 @@ func TestAccDataprocClusterLabelsMigration_withLabels_withoutChanges(t *testing.
 					// We only provide one, so expect 1.
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key2", "value2"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 5.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 6.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "6"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.key2", "value2"),
 				),
 			},
@@ -154,8 +154,8 @@ func TestAccDataprocClusterLabelsMigration_withUpdate(t *testing.T) {
 
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.%", "1"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "labels.key1", "value1"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 5.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 6.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "6"),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.key1", "value1"),
 				),
 			},
@@ -166,8 +166,8 @@ func TestAccDataprocClusterLabelsMigration_withUpdate(t *testing.T) {
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_labels", &cluster),
 
 					resource.TestCheckNoResourceAttr("google_dataproc_cluster.with_labels", "labels.%"),
-					// We only provide one, but GCP adds three and goog-dataproc-autozone is added internally, so expect 4.
-					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "4"),
+					// We only provide one, but GCP adds 4 and goog-dataproc-autozone is added internally, so expect 5.
+					resource.TestCheckResourceAttr("google_dataproc_cluster.with_labels", "effective_labels.%", "5"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21443, fixes https://github.com/hashicorp/terraform-provider-google/issues/20256 (which was failing for a diff. reason when that was filed but the original issue has since been resolved)


Before:

```
  "labels": {
   "goog-dataproc-cluster-name": "tf-test-dproc-x0ra2rhtjw",
   "goog-dataproc-cluster-uuid": "542e929f-ee15-457b-8cdf-96ab4208e212",
   "goog-dataproc-location": "us-central1",
   "goog-dataproc-autozone": "enabled"
  }
```

After:

```
  "labels": {
   "goog-dataproc-cluster-name": "tf-test-dproc-qokjxq63ow",
   "goog-dataproc-cluster-uuid": "c1b7ad4b-570e-4a80-9263-621dc766e3dd",
   "goog-dataproc-location": "us-central1",
   "goog-drz-dataproc-uuid": "cluster-c1b7ad4b-570e-4a80-9263-621dc766e3dd",
   "goog-dataproc-autozone": "enabled"
  }
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
