### PR TITLE
manage ticket - remove review label

### DIFF
--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -1,24 +1,24 @@
 ---
 steps:
-    # - name: 'gcr.io/graphite-docker-images/go-plus'
-    #   id: collect-nightly-test-status
-    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-    #   secretEnv: ["TEAMCITY_TOKEN"]
-    #   args:
-    #     - 'collect-nightly-test-status'
-    #     - $_CUSTOM_DATE
-    # - name: 'gcr.io/graphite-docker-images/go-plus'
-    #   id: create-test-failure-ticket
-    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-    #   secretEnv: ["GITHUB_TOKEN"]
-    #   waitFor: ["collect-nightly-test-status"]
-    #   args:
-    #     - 'create-test-failure-ticket'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
+      id: collect-nightly-test-status
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      secretEnv: ["TEAMCITY_TOKEN"]
+      args:
+        - 'collect-nightly-test-status'
+        - $_CUSTOM_DATE
+    - name: 'gcr.io/graphite-docker-images/go-plus'
+      id: create-test-failure-ticket
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["collect-nightly-test-status"]
+      args:
+        - 'create-test-failure-ticket'
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: manage-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN"]
-      # waitFor: ["create-test-failure-ticket"]
+      waitFor: ["create-test-failure-ticket"]
       args:
         - 'manage-test-failure-ticket'
 
@@ -29,7 +29,7 @@ options:
 logsBucket: 'gs://cloudbuild-test-failure-ticket-logs'
 availableSecrets:
   secretManager:
-    # - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
-    #   env: TEAMCITY_TOKEN
+    - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
+      env: TEAMCITY_TOKEN
     - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -1,19 +1,26 @@
 ---
 steps:
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      id: collect-nightly-test-status
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["TEAMCITY_TOKEN"]
-      args:
-        - 'collect-nightly-test-status'
-        - $_CUSTOM_DATE
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      id: create-test-failure-ticket
+    # - name: 'gcr.io/graphite-docker-images/go-plus'
+    #   id: collect-nightly-test-status
+    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    #   secretEnv: ["TEAMCITY_TOKEN"]
+    #   args:
+    #     - 'collect-nightly-test-status'
+    #     - $_CUSTOM_DATE
+    # - name: 'gcr.io/graphite-docker-images/go-plus'
+    #   id: create-test-failure-ticket
+    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    #   secretEnv: ["GITHUB_TOKEN"]
+    #   waitFor: ["collect-nightly-test-status"]
+    #   args:
+    #     - 'create-test-failure-ticket'
+    # - name: 'gcr.io/graphite-docker-images/go-plus'
+      id: manage-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["collect-nightly-test-status"]
+      # waitFor: ["create-test-failure-ticket"]
       args:
-        - 'create-test-failure-ticket'
+        - 'manage-test-failure-ticket'
 
 timeout: 3600s
 options:
@@ -22,7 +29,7 @@ options:
 logsBucket: 'gs://cloudbuild-test-failure-ticket-logs'
 availableSecrets:
   secretManager:
-    - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
-      env: TEAMCITY_TOKEN
+    # - versionName: projects/673497134629/secrets/teamcity-token/versions/latest
+    #   env: TEAMCITY_TOKEN
     - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -14,7 +14,7 @@ steps:
     #   waitFor: ["collect-nightly-test-status"]
     #   args:
     #     - 'create-test-failure-ticket'
-    # - name: 'gcr.io/graphite-docker-images/go-plus'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
       id: manage-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
       secretEnv: ["GITHUB_TOKEN"]

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -14,6 +14,8 @@ steps:
       waitFor: ["collect-nightly-test-status"]
       args:
         - 'create-test-failure-ticket'
+    - name: 'ubuntu'
+      args: ['sleep', '120']
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: manage-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -1,0 +1,101 @@
+/*
+* Copyright 2025 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/go-github/v68/github"
+	"github.com/spf13/cobra"
+
+	_ "embed"
+)
+
+var mtftRequiredEnvironmentVariables = [...]string{
+	"GITHUB_TOKEN",
+}
+
+// manageTestFailureTicketCmd represents the manageTestFailureTicket command
+var manageTestFailureTicketCmd = &cobra.Command{
+	Use:   "manage-test-failure-ticket",
+	Short: "Manages GitHub test failure tickets",
+	Long: `This command manages the GitHub test failure tickets. 
+ 
+	 It performs the following operations:
+	 1. Lists out GitHub issues with test-failure and forward/review labels.
+	 2. Removes forward/review labels from these issues.
+ 
+	 The following environment variables are required:
+ ` + listMTFTRequiredEnvironmentVariables(),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		env := make(map[string]string)
+		for _, ev := range mtftRequiredEnvironmentVariables {
+			val, ok := os.LookupEnv(ev)
+			if !ok {
+				return fmt.Errorf("did not provide %s environment variable", ev)
+			}
+			env[ev] = val
+		}
+
+		gh := github.NewClient(nil).WithAuthToken(env["GITHUB_TOKEN"])
+
+		now := time.Now()
+
+		loc, err := time.LoadLocation("America/Los_Angeles")
+		if err != nil {
+			return fmt.Errorf("Error loading location: %s", err)
+		}
+		date := now.In(loc)
+
+		return execManageTestFailureTicket(date, gh)
+	},
+}
+
+func listMTFTRequiredEnvironmentVariables() string {
+	var result string
+	for i, ev := range mtftRequiredEnvironmentVariables {
+		result += fmt.Sprintf("\t%2d. %s\n", i+1, ev)
+	}
+	return result
+}
+
+func execManageTestFailureTicket(now time.Time, gh *github.Client) error {
+	ctx := context.Background()
+	opts := &github.IssueListByRepoOptions{
+		State:       "open",
+		Labels:      []string{"test-failure", "forward/review"},
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	issues, err := ListIssuesWithOpts(ctx, gh, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, issue := range issues {
+		_, err := gh.Issues.RemoveLabelForIssue(ctx, GithubOwner, GithubRepo, issue.GetNumber(), "forward/review")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(manageTestFailureTicketCmd)
+}


### PR DESCRIPTION
This is a temporary workaround to remove `forward/review` label for test failure ticket, as https://github.com/GoogleCloudPlatform/magic-modules/pull/13086 is not working as expected. I'll refactor some of the labeler code for a proper fix later.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
