### PR TITLE
Promote Gemini Data Sharing With Google Setting Binding from google-beta to google

### DIFF
--- a/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
@@ -17,7 +17,6 @@ description: The resource for managing DataSharingWithGoogle setting bindings fo
 references:
   guides:
     'Gemini Cloud Assist overview': 'https://cloud.google.com/gemini/docs/cloud-assist/overview'
-min_version: 'beta'
 base_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings
 self_link: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings/{{setting_binding_id}}
 create_url: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}/settingBindings?settingBindingId={{setting_binding_id}}
@@ -29,7 +28,6 @@ import_format:
 mutex: projects/{{project}}/locations/{{location}}/dataSharingWithGoogleSettings/{{data_sharing_with_google_setting_id}}
 examples:
   - name: gemini_data_sharing_with_google_setting_binding_basic
-    min_version: 'beta'
     primary_resource_id: example
     exclude_test: true
     vars:

--- a/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_data_sharing_with_google_setting_binding_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_gemini_data_sharing_with_google_setting" "basic" {
-    provider = google-beta
     data_sharing_with_google_setting_id = "{{index $.Vars "data_sharing_with_google_setting_id"}}"
     location = "global"
     labels = {"my_key": "my_value"}
@@ -7,7 +6,6 @@ resource "google_gemini_data_sharing_with_google_setting" "basic" {
 }
 
 resource "google_gemini_data_sharing_with_google_setting_binding" "{{$.PrimaryResourceId}}" {
-    provider = google-beta
     data_sharing_with_google_setting_id = google_gemini_data_sharing_with_google_setting.basic.data_sharing_with_google_setting_id
     setting_binding_id = "{{index $.Vars "setting_binding_id"}}"
     location = "global"

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_data_sharing_with_google_setting_binding_test.go.tmpl
@@ -1,5 +1,4 @@
 package gemini_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
     "fmt"
@@ -21,7 +20,7 @@ func TestAccGeminiDataSharingWithGoogleSettingBinding_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGeminiDataSharingWithGoogleSettingBinding_basic(context),
@@ -53,11 +52,9 @@ func TestAccGeminiDataSharingWithGoogleSettingBinding_update(t *testing.T) {
 func testAccGeminiDataSharingWithGoogleSettingBinding_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-    provider = google-beta
 }
 
 resource "google_gemini_data_sharing_with_google_setting" "basic" {
-    provider = google-beta
     data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
     location = "global"
     labels = {"my_key" = "my_value"}
@@ -65,7 +62,6 @@ resource "google_gemini_data_sharing_with_google_setting" "basic" {
 }
 
 resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding" {
-    provider = google-beta
     data_sharing_with_google_setting_id = google_gemini_data_sharing_with_google_setting.basic.data_sharing_with_google_setting_id
     setting_binding_id = "%{setting_binding_id}"
     location = "global"
@@ -77,11 +73,9 @@ resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding
 func testAccGeminiDataSharingWithGoogleSettingBinding_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-    provider = google-beta
 }
 
 resource "google_gemini_data_sharing_with_google_setting" "basic" {
-    provider = google-beta
     data_sharing_with_google_setting_id = "%{data_sharing_with_google_setting_id}"
     location = "global"
     labels = {"my_key" = "my_value"}
@@ -89,7 +83,6 @@ resource "google_gemini_data_sharing_with_google_setting" "basic" {
 }
 
 resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding" {
-    provider = google-beta
     data_sharing_with_google_setting_id = google_gemini_data_sharing_with_google_setting.basic.data_sharing_with_google_setting_id
     setting_binding_id = "%{setting_binding_id}"
     location = "global"
@@ -99,4 +92,3 @@ resource "google_gemini_data_sharing_with_google_setting_binding" "basic_binding
 }
 `, context)
 }
-{{ end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Promote resources for Gemini Admin Control
```release-note:enhancement
gemini: promoted `google_gemini_data_sharing_with_google_setting_binding` resource to ga.
```