### PR TITLE
add region_ssl_policy data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -101,6 +101,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_compute_region_instance_template":          compute.DataSourceGoogleComputeRegionInstanceTemplate(),
 	"google_compute_region_network_endpoint_group":     compute.DataSourceGoogleComputeRegionNetworkEndpointGroup(),
 	"google_compute_region_ssl_certificate":            compute.DataSourceGoogleRegionComputeSslCertificate(),
+	"google_compute_region_ssl_policy":                 compute.DataSourceGoogleRegionComputeSslPolicy(),
 	"google_compute_reservation":                       compute.DataSourceGoogleComputeReservation(),
 	"google_compute_resource_policy":                   compute.DataSourceGoogleComputeResourcePolicy(),
 	"google_compute_router":                            compute.DataSourceGoogleComputeRouter(),

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy.go
@@ -1,0 +1,48 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleRegionComputeSslPolicy() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeRegionSslPolicy().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "region")
+
+	return &schema.Resource{
+		Read:   dataSourceComputeRegionSslPolicyRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceComputeRegionSslPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	project, region, name, err := tpgresource.GetRegionalResourcePropertiesFromSelfLinkOrSchema(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("projects/%s/regions/%s/sslPolicies/%s", project, region, name)
+	d.SetId(id)
+
+	err = resourceComputeRegionSslPolicyRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy_test.go
@@ -1,0 +1,45 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceComputeRegionSslPolicy(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComputeRegionSslPolicyConfig(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState(
+						"data.google_compute_region_ssl_policy.policy",
+						"google_compute_region_ssl_policy.foobar",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeRegionSslPolicyConfig(policyName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_ssl_policy" "foobar" {
+  name            = "policy-test-%s"
+  region          = "us-central1"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
+data "google_compute_region_ssl_policy" "policy" {
+  name   = google_compute_region_ssl_policy.foobar.name
+  region = google_compute_region_ssl_policy.foobar.region
+}
+`, policyName)
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_ssl_policy_test.go
@@ -31,7 +31,7 @@ func TestAccDataSourceComputeRegionSslPolicy(t *testing.T) {
 func testAccDataSourceComputeRegionSslPolicyConfig(policyName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_ssl_policy" "foobar" {
-  name            = "policy-test-%s"
+  name            = "tf-test-policyds-%s"
   region          = "us-central1"
   profile         = "MODERN"
   min_tls_version = "TLS_1_2"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds a google_compute_region_ssl_policy data source

### Related Issues

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/17141

### Release Note

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_compute_region_ssl_policy`	
```