### PR TITLE
Fix a broken e2e test - TestAccGKEHubFeatureMembership_gkehubFeatureAcmAllFields

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -397,7 +397,7 @@ resource "google_gke_hub_feature_membership" "feature_member" {
   feature = google_gke_hub_feature.feature.name
   membership = google_gke_hub_membership.membership.membership_id
   configmanagement {
-    version = "1.18.2"
+    version = "1.20.1"
     config_sync {
       enabled = true
       git {


### PR DESCRIPTION
Use version 1.20.1 instead of 1.18.2 to test the configmanagement gogole_gke_hub_feature_membership resource whose
`config_sync.stop_syncing` field is set to `true`. The field is only supported in versions >= 1.20.0.

This is to fix https://github.com/hashicorp/terraform-provider-google/issues/21439

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
