### PR TITLE
Fix version used in metadata for folder

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_meta.yaml
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_meta.yaml
@@ -1,7 +1,7 @@
 resource: 'google_folder'
 generation_type: 'handwritten'
 api_service_name: 'cloudresourcemanager.googleapis.com'
-api_version: 'v1'
+api_version: 'v3'
 api_resource_type_kind: 'Folder'
 fields:
   - field: 'create_time'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This was most likely just a mistake; most of the other resourcemanager resources use v1.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
