### PR TITLE
[AlloyDB] PSC Outbound Connectivity Support

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -341,14 +341,15 @@ properties:
       - name: 'pscInterfaceConfigs'
         type: Array
         description: |
-          Configurations for setting up PSC interfaces attached to the instance which are used for outbound connectivity.
+          Configurations for setting up PSC interfaces attached to the instance
+          which are used for outbound connectivity. Currently, AlloyDB supports only 0 or 1 PSC interface.
         item_type:
           type: NestedObject
           properties:
             - name: 'networkAttachmentResource'
               type: String
               description: | 
-                The network attachment resource created in the consumer network to which the PSC interface will be linked.
+                The network attachment resource created in the consumer project to which the PSC interface will be linked.
                 This is of the format: "projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}".
                 The network attachment must be in the same region as the instance.
   - name: 'networkConfig'

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -338,6 +338,19 @@ properties:
           The DNS name of the instance for PSC connectivity.
           Name convention: <uid>.<uid>.<region>.alloydb-psc.goog
         output: true
+      - name: 'pscInterfaceConfigs'
+        type: Array
+        description: |
+          Configurations for setting up PSC interfaces attached to the instance which are used for outbound connectivity.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'networkAttachmentResource'
+              type: String
+              description: | 
+                The network attachment resource created in the consumer network to which the PSC interface will be linked.
+                This is of the format: "projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}".
+                The network attachment must be in the same region as the instance.
   - name: 'networkConfig'
     type: NestedObject
     description: |

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -350,7 +350,7 @@ properties:
               type: String
               description: | 
                 The network attachment resource created in the consumer project to which the PSC interface will be linked.
-                This is of the format: "projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}".
+                This is of the format: `projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}`.
                 The network attachment must be in the same region as the instance.
   - name: 'networkConfig'
     type: NestedObject

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -348,7 +348,7 @@ properties:
           properties:
             - name: 'networkAttachmentResource'
               type: String
-              description: | 
+              description: |
                 The network attachment resource created in the consumer project to which the PSC interface will be linked.
                 This is of the format: `projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}`.
                 The network attachment must be in the same region as the instance.

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -827,3 +827,84 @@ resource "google_alloydb_cluster" "default" {
 data "google_project" "project" {}
 `, context)
 }
+
+func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) {
+	t.Parallel()
+
+	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
+	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix":         random_suffix,
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_pscInterfaceConfigs(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbInstance_pscInterfaceConfigs(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+  machine_config {
+    cpu_count = 2
+  }
+  psc_instance_config {
+	allowed_consumer_projects = ["${data.google_project.project.number}"]
+	psc_interface_configs {
+		network_attachment_resource = "projects/1080570509669/regions/us-central1/networkAttachments/%{networkAttachmentName}"
+	}
+  }
+}
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  psc_config {
+	psc_enabled = true
+  }
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+data "google_project" "project" {}
+`, context)
+}
+
+func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) {
+	t.Parallel()
+
+	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
+	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix":         random_suffix,
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_pscInstanceConfig(context),
+			},
+			{
+				Config: testAccAlloydbInstance_pscInterfaceConfigs(context),
+			},
+		},
+	})
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -864,7 +864,7 @@ resource "google_alloydb_instance" "default" {
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]
 	psc_interface_configs {
-		network_attachment_resource = "projects/1080570509669/regions/us-central1/networkAttachments/%{networkAttachmentName}"
+		network_attachment_resource = "projects/${data.google_project.project.number}/regions/${google_alloydb_cluster.default.location}/networkAttachments/%{networkAttachmentName}"
 	}
   }
 }
@@ -908,3 +908,4 @@ func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) 
 		},
 	})
 }
+

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -831,10 +831,10 @@ data "google_project" "project" {}
 func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
 
+	random_suffix := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
 
-	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
@@ -884,11 +884,11 @@ data "google_project" "project" {}
 
 func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
-
+	
+	random_suffix := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
-
-	random_suffix := acctest.RandString(t, 10)
+	
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),


### PR DESCRIPTION
Description:
Changes for supporting Private Service Connect (PSC) Outbound Connectivity in Terraform.

Issue - https://b.corp.google.com/issues/388587671

```release-note:enhancement
alloydb: added `psc_instance_config.psc_interface_configs` field to ``google_alloydb_instance` resource
```
