### PR TITLE
fix: compute instance internal ipv6 prefix length is not set in creation and read in syncing

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -508,6 +508,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 			"ipv6_address":        iface.Ipv6Address,
 			"queue_count":         iface.QueueCount,
+			"internal_ipv6_prefix_length": iface.InternalIpv6PrefixLength,
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -643,6 +644,7 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 			QueueCount:        int64(data["queue_count"].(int)),
 			Ipv6AccessConfigs: expandIpv6AccessConfigs(data["ipv6_access_config"].([]interface{})),
 			Ipv6Address:       data["ipv6_address"].(string),
+			InternalIpv6PrefixLength: int64(data["internal_ipv6_prefix_length"].(int)),
 		}
 	}
 	return ifaces, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -587,6 +587,30 @@ func TestAccComputeInstance_internalIPv6(t *testing.T) {
   })
 }
 
+func TestAccComputeInstance_internalIPv6PrefixLength(t *testing.T) {
+  t.Parallel()
+
+  var instance compute.Instance
+  var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeInstance_internalIpv6PrefixLength("96", instanceName),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeInstanceExists(
+            t, "google_compute_instance.foobar", &instance),
+          testAccCheckComputeInstanceIpv6AccessConfigHasInternalIPv6(&instance),
+        ),
+      },
+      computeInstanceImportStep("us-west2-a", instanceName, []string{"allow_stopping_for_update"}),
+    },
+  })
+}
+
 func TestAccComputeInstance_PTRRecord(t *testing.T) {
 	t.Parallel()
 
@@ -6220,6 +6244,46 @@ func testAccComputeInstance_internalIpv6(ip, instance string) string {
   `, instance, instance, ip, instance)
 }
 
+func testAccComputeInstance_internalIpv6PrefixLength(length, instance string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "vpc" {
+  name                     = "%s-network"
+  auto_create_subnetworks  = "false"
+  enable_ula_internal_ipv6 = true
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name             = "%s-subnetwork"
+  ip_cidr_range    = "10.0.0.0/22"
+  region           = "us-west2"
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "INTERNAL"
+  network          = google_compute_network.vpc.id
+}
+
+resource "google_compute_instance" "foobar" {
+  name                      = "%s"
+  machine_type              = "e2-micro"
+  allow_stopping_for_update = true
+  zone                      = "us-west2-a"
+  boot_disk {
+    auto_delete = false
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    network    = google_compute_network.vpc.self_link
+    subnetwork = google_compute_subnetwork.subnetwork.self_link
+    stack_type = "IPV4_IPV6"
+    access_config {
+      network_tier = "STANDARD"
+    }
+    internal_ipv6_prefix_length = %s
+  }
+}
+`, instance, instance, instance, length)
+}
 func testAccComputeInstance_ipv6ExternalReservation(instance string) string {
 	return fmt.Sprintf(`
 resource "google_compute_address" "ipv6-address" {


### PR DESCRIPTION
Fixes [hashicorp/terraform-provider-google#21520](https://github.com/hashicorp/terraform-provider-google/issues/21520).

This ensures that Terraform correctly reads the `compute_instance.network_interface.internal_ipv6_prefix_length` from GCP and stores it in `terraform.state`. Previously, the absence of this value in `terraform.state` caused `compute_instance` to be considered modified, even when no changes were made to the configuration.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fix `compute_instance.network_interface.internal_ipv6_prefix_length` not being set or read in Terraform state  
```
