### PR TITLE
Adding Datasource for Memorystore

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -252,6 +252,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_tpu_v2_accelerator_types":                  tpuv2.DataSourceTpuV2AcceleratorTypes(),
 	{{- end }}
 	"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
+	"google_memorystore_instance":						memorystore.DataSourceMemorystoreInstance(),
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
 	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance.go
@@ -1,0 +1,58 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package memorystore
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceMemorystoreInstance() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceMemorystoreInstance().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "instance_id")
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+
+	return &schema.Resource{
+		Read:   dataSourceMemorystoreInstanceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceMemorystoreInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	location, err := tpgresource.GetLocation(d, config)
+	if err != nil {
+		return err
+	}
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/instances/{{instance_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	// Setting location field, as this is set as a required field in instance resource to build the url
+	d.Set("location", location)
+
+	err = resourceMemorystoreInstanceRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
@@ -1,0 +1,78 @@
+package memorystore_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccMemorystoreInstanceDatasourceConfig(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "memorystore-instance-ds"),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemorystoreInstanceDatasourceConfig(context),
+			},
+		},
+	})
+}
+
+func testAccMemorystoreInstanceDatasourceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-basic" {
+  instance_id                 = "tf-test-memorystore-instance%{random_suffix}"
+  shard_count                 = 3
+  desired_psc_auto_connections {
+    network                   = google_compute_network.producer_net.id
+    project_id                = data.google_project.project.project_id
+  }
+  location                    = "us-central1"
+  deletion_protection_enabled = false
+  depends_on                  = [google_network_connectivity_service_connection_policy.default]
+
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                        = "%{network_name}-policy"
+  location                    = "us-central1"
+  service_class               = "gcp-memorystore"
+  description                 = "my basic service connection policy"
+  network                     = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks               = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+
+resource "google_compute_subnetwork" "producer_subnet" {
+	name                      = "%{network_name}-sn"
+	ip_cidr_range             = "10.0.0.248/29"
+	region                    = "us-central1"
+	network                   = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                        = "%{network_name}-vpc"
+  auto_create_subnetworks     = false
+}
+
+ data "google_project" "project" {
+ }
+
+data "google_memorystore_instance" "default" {
+  instance_id                 = google_memorystore_instance.instance-basic.instance_id
+  location                    = "us-central1"
+
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/memorystore_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/memorystore_instance.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "Memorystore"
+description: |-
+  Fetches the details of available instance.
+---
+
+# google_memorystore_instance
+
+Use this data source to get information about the available instance. For more details refer the [API docs](https://cloud.google.com/memorystore/docs/valkey/reference/rest/v1/projects.locations.instances).
+
+## Example Usage
+
+
+```hcl
+data "google_memorystore_instance" "qa" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `instance_id` -
+  (Required)
+  The ID of the memorystore instance.
+  'memorystore_instance_id'
+
+* `project` - 
+  (optional) 
+  The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+* `location` -
+  (optional)
+  The canonical id of the location.If it is not provided, the provider project is used. For example: us-east1.
+
+## Attributes Reference
+
+See [google_memorystore_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/memorystore_instance) resource for details of all the available attributes.


### PR DESCRIPTION
Adding in a data source for google_memorystore_instance


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.



```release-note:new-datasource
`google_memorystore_instance`
```
