### PR TITLE
Fixes issue #21482 related to google_eventarc_trigger name with Firestore sources

### DIFF
--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -83,6 +83,16 @@ examples:
       service_account_id: trigger-sa
       service_name: some-service
     exclude_docs: true
+  - name: eventarc_trigger_with_firestore_source
+    primary_resource_id: primary
+    vars:
+      trigger_name: some-trigger
+      service_account_id: trigger-sa
+      service_name: some-service
+      database_id: some-database
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    exclude_docs: true
 parameters:
   - name: location
     type: String
@@ -97,6 +107,7 @@ properties:
     required: true
     immutable: true
     diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
+    custom_expand: templates/terraform/custom_expand/eventarc_trigger_name.go.tmpl
   - name: uid
     type: String
     description: Output only. Server assigned unique identifier for the trigger. The value is a UUID4 string and guaranteed to remain unchanged until the resource is deleted.

--- a/mmv1/templates/terraform/custom_expand/eventarc_trigger_name.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/eventarc_trigger_name.go.tmpl
@@ -1,0 +1,15 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return expandToRegionalLongForm("projects/%s/locations/%s/triggers/%s", v, d, config)
+}

--- a/mmv1/templates/terraform/examples/eventarc_trigger_with_firestore_source.tf.tmpl
+++ b/mmv1/templates/terraform/examples/eventarc_trigger_with_firestore_source.tf.tmpl
@@ -1,0 +1,64 @@
+resource "google_firestore_database" "database" {
+  project     = "{{index $.TestEnvVars "project_id"}}"
+  name        = "{{index $.Vars "database_id"}}"
+  location_id = "us-central1"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+}
+
+resource "google_eventarc_trigger" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.Vars "trigger_name"}}"
+  location = "us-central1"
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.firestore.document.v1.written"
+  }
+  matching_criteria {
+    attribute = "database"
+    value     = google_firestore_database.database.name
+  }
+  destination {
+    cloud_run_service {
+      service = google_cloud_run_service.default.name
+      region  = "us-central1"
+    }
+  }
+  event_data_content_type = "application/protobuf"
+  service_account         = google_service_account.trigger_service_account.email
+  depends_on              = [google_project_iam_member.event_receiver]
+}
+
+resource "google_service_account" "trigger_service_account" {
+  account_id = "{{index $.Vars "service_account_id"}}"
+}
+
+resource "google_project_iam_member" "event_receiver" {
+  project = google_service_account.trigger_service_account.project
+  role    = "roles/eventarc.eventReceiver"
+  member  = "serviceAccount:${google_service_account.trigger_service_account.email}"
+}
+
+resource "google_cloud_run_service" "default" {
+  name     = "{{index $.Vars "service_name"}}"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        ports {
+          container_port = 8080
+        }
+      }
+      container_concurrency = 50
+      timeout_seconds       = 100
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21482

Also adds acceptance tests for google_eventarc_trigger with Firestore source

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
eventarc: fixed an issue where `google_eventarc_trigger` creation failed due to the region could not be parsed from the trigger's name
```
