### PR TITLE
Add information about failing member into the error message

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_binding_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_binding_test.go.tmpl
@@ -267,7 +267,7 @@ func TestAccProjectIamBinding_invalidMembers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProjectAssociateBindingBasic(pid, org, role, "admin@hashicorptest.com"),
-				ExpectError: regexp.MustCompile("invalid value for members\\.0 \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
+				ExpectError: regexp.MustCompile("invalid value \"admin@hashicorptest.com\" for members\\.0 \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
 			},
 			{
 				Config: testAccProjectAssociateBindingBasic(pid, org, role, "user:admin@hashicorptest.com"),

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_member_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_member_test.go.tmpl
@@ -183,7 +183,7 @@ func TestAccProjectIamMember_invalidMembers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProjectAssociateMemberBasic(pid, org, role, "admin@hashicorptest.com"),
-				ExpectError: regexp.MustCompile("invalid value for member \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
+				ExpectError: regexp.MustCompile("invalid value \"admin@hashicorptest.com\" for member \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
 			},
 			{
 				Config: testAccProjectAssociateMemberBasic(pid, org, role, "user:admin@hashicorptest.com"),

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_policy_test.go.tmpl
@@ -177,7 +177,7 @@ func TestAccProjectIamPolicy_invalidMembers(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProjectAssociatePolicyBasic(pid, org, "admin@hashicorptest.com"),
-				ExpectError: regexp.MustCompile("invalid value for bindings\\.1\\.members\\.0 \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
+				ExpectError: regexp.MustCompile("invalid value \"admin@hashicorptest.com\" for bindings\\.1\\.members\\.0 \\(IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding\\)"),
 			},
 			{
 				Config: testAccProjectAssociatePolicyBasic(pid, org, "user:admin@hashicorptest.com"),

--- a/mmv1/third_party/terraform/tpgiamresource/resource_iam_member.go
+++ b/mmv1/third_party/terraform/tpgiamresource/resource_iam_member.go
@@ -38,7 +38,7 @@ func validateIAMMember(i interface{}, k string) ([]string, []error) {
 	if matched, err := regexp.MatchString("(.+:.+|projectOwners|projectReaders|projectWriters|allUsers|allAuthenticatedUsers)", v); err != nil {
 		return nil, []error{fmt.Errorf("error validating %s: %v", k, err)}
 	} else if !matched {
-		return nil, []error{fmt.Errorf("invalid value for %s (IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding)", k)}
+		return nil, []error{fmt.Errorf("invalid value \"%s\" for %s (IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding)", v, k)}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
When working with dynamically generated list of IAM resources, the error message is not that useful:
```
Error: invalid value for member (IAM members must have one of the values outlined here: https://cloud.google.com/billing/docs/reference/rest/v1/Policy#Binding)

  with module.projects-iam["service1"].google_project_iam_member.shared_vpc_host_iam["rw"],
  on ../project/shared-vpc.tf line 131, in resource "google_project_iam_member" "shared_vpc_host_iam":
 131:   member     = each.value
```
It makes hard to actually identify offending value. Returning failing member value helps to narrow down, which value was passed incorrectly.


See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
iam: added member value to the error message when member validation fails for google_project_iam_*
```
