### PR TITLE
Fix perma-diff in `google_container_cluster` when `cluster_dns_scope` is unspecified

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2206,8 +2206,7 @@ func ResourceContainerCluster() *schema.Resource {
 						},
 						"cluster_dns_scope": {
 							Type:         schema.TypeString,
-							Default:      "DNS_SCOPE_UNSPECIFIED",
-							ValidateFunc: validation.StringInSlice([]string{"DNS_SCOPE_UNSPECIFIED", "CLUSTER_SCOPE", "VPC_SCOPE"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"CLUSTER_SCOPE", "VPC_SCOPE"}, false),
 							Description:  `The scope of access to cluster DNS records.`,
 							Optional:     true,
 						},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6783,7 +6783,7 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 		{
 			"additive_vpc_scope_dns_domain": 	c.AdditiveVpcScopeDnsDomain,
 			"cluster_dns":        				c.ClusterDns,
-			"cluster_dns_scope":  				flattenClusterDnsScope(c.ClusterDnsScope),
+			"cluster_dns_scope":  				c.ClusterDnsScope,
 			"cluster_dns_domain": 				c.ClusterDnsDomain,
 		},
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6789,13 +6789,6 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 	}
 }
 
-func flattenClusterDnsScope(s string) string {
-	if s == "" {
-		return "DNS_SCOPE_UNSPECIFIED"
-	}
-	return s
-}
-
 func flattenGatewayApiConfig(c *container.GatewayAPIConfig) []map[string]interface{} {
 	if c == nil {
 		return nil

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6784,10 +6784,17 @@ func flattenDnsConfig(c *container.DNSConfig) []map[string]interface{} {
 		{
 			"additive_vpc_scope_dns_domain": 	c.AdditiveVpcScopeDnsDomain,
 			"cluster_dns":        				c.ClusterDns,
-			"cluster_dns_scope":  				c.ClusterDnsScope,
+			"cluster_dns_scope":  				flattenClusterDnsScope(c.ClusterDnsScope),
 			"cluster_dns_domain": 				c.ClusterDnsDomain,
 		},
 	}
+}
+
+func flattenClusterDnsScope(s string) string {
+	if s == "" {
+		return "DNS_SCOPE_UNSPECIFIED"
+	}
+	return s
 }
 
 func flattenGatewayApiConfig(c *container.GatewayAPIConfig) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6066,7 +6066,7 @@ func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
 			{
 				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, false, true, true, false, ""),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.cluster_dns_scope", "DNS_SCOPE_UNSPECIFIED"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.cluster_dns_scope", ""),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6065,9 +6065,6 @@ func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, false, true, true, false, ""),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.cluster_dns_scope", ""),
-				),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5953,7 +5953,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -5962,7 +5962,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, false, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -5971,7 +5971,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, true, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, true, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -5980,7 +5980,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, true, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, true, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6003,7 +6003,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6015,7 +6015,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6027,7 +6027,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, true, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, true, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6039,9 +6039,34 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, true, true, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, true, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, false, true, true, false, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.cluster_dns_scope", "DNS_SCOPE_UNSPECIFIED"),
 				),
 			},
 			{
@@ -6065,7 +6090,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
 				),
@@ -6077,7 +6102,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6090,7 +6115,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_autopilot_withDNSConfig(clusterName, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
 				),
@@ -11436,14 +11461,22 @@ resource "google_container_cluster" "primary" {
 }`, name)
 }
 
-func testAccContainerCluster_autopilot_withDNSConfig(name string, dnsConfigSectionPresent, clusterDnsPresent, clusterDnsScopePresent bool, additiveVpcDnsDomain string) string {
+func testAccContainerCluster_withAdvancedDNSConfig(name string, autopilot, dnsConfigSectionPresent, clusterDnsPresent, clusterDnsScopePresent bool, additiveVpcDnsDomain string) string {
 	config := fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
   location            = "us-central1"
-  enable_autopilot    = true
   deletion_protection = false
 `, name)
+	if autopilot {
+		config += `
+  enable_autopilot    = true
+`
+	} else {
+		config += `
+  initial_node_count = 2
+`
+	}
 	if dnsConfigSectionPresent {
 		config += `
   dns_config {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Terraform defaults this field to DNS_SCOPE_UNSPECIFIED, but the API
corrects this to an empty value.

Following https://googlecloudplatform.github.io/magic-modules/develop/diffs/#default_if_empty
to tackle this issue.

To make writing DNS tests faster, I refactored the helper function `testAccContainerCluster_autopilot_withDNSConfig` I added previously into `testAccContainerCluster_withAdvancedDNSConfig`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20285

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed perma-diff in `google_container_cluster` when `cluster_dns_scope` is unspecified
```
