### PR TITLE
Suppressing diff for database_version for MySQL 8.0

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"log"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -737,9 +738,10 @@ is set to true. Defaults to ZONAL.`,
 				Description: `Available Maintenance versions.`,
 			},
 			"database_version": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: `The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
+				Type:             schema.TypeString,
+				Required:         true,
+				Description:      `The MySQL, PostgreSQL or SQL Server (beta) version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17, SQLSERVER_2017_STANDARD, SQLSERVER_2017_ENTERPRISE, SQLSERVER_2017_EXPRESS, SQLSERVER_2017_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
+				DiffSuppressFunc: databaseVersionDiffSuppress,
 			},
 
 			"encryption_key_name": {
@@ -2153,6 +2155,18 @@ func maintenanceVersionDiffSuppress(_, old, new string, _ *schema.ResourceData) 
 	} else {
 		return false
 	}
+}
+
+func databaseVersionDiffSuppress(_, oldVersion, newVersion string, _ *schema.ResourceData) bool {
+	// Suppress diff when newVersion is MYSQL_8_0 and oldVersion is >= MYSQL_8_0_35 for MySQL version auto-upgrade cases.
+	if newVersion == "MYSQL_8_0" && strings.HasPrefix(oldVersion, "MYSQL_8_0_") {
+		if oldMinorVersion, err := strconv.Atoi(oldVersion[len("MYSQL_8_0_"):]); err == nil && oldMinorVersion >= 35 {
+			log.Printf("[DEBUG] Database version is updated by auto version upgrade for MySQL 8.0, version updated from [%s] to [%s]. Suppressing diff.", oldVersion, newVersion)
+			return true
+		}
+	}
+
+	return false
 }
 
 func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{}) error {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_internal_test.go
@@ -36,3 +36,90 @@ func TestMaintenanceVersionDiffSuppress(t *testing.T) {
 		})
 	}
 }
+
+func TestDatabaseVersionDiffSuppress(t *testing.T) {
+	testCases := map[string]struct {
+		oldVersion, newVersion string
+		shouldSuppressDiff     bool
+	}{
+		"MySQL 5.6 (non-supported for auto-upgrade) to MySQL 5.7 (non-supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_5_6",
+			newVersion:         "MYSQL_5_7",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 5.7 (non-supported for auto-upgrade) to MySQL 8.0.31 (non-supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_5_7",
+			newVersion:         "MYSQL_8_0_31",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 5.7 (non-supported for auto-upgrade) to MySQL 8.0.40 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_5_7",
+			newVersion:         "MYSQL_8_0_40",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 5.7 (non-supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_5_7",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 8.0.31 (non-supported for auto-upgrade) to MySQL 8.0.35 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_8_0_31",
+			newVersion:         "MYSQL_8_0_35",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 8.0.31 (non-supported for auto-upgrade) to MySQL 8.0.40 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_8_0_31",
+			newVersion:         "MYSQL_8_0_40",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 8.0.31 (non-supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_8_0_31",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 8.0.35 (supported for auto-upgrade) to MySQL 8.0.40 (supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_8_0_35",
+			newVersion:         "MYSQL_8_0_40",
+			shouldSuppressDiff: false,
+		},
+		"MySQL 8.0.35 (supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should suppress diff": {
+			oldVersion:         "MYSQL_8_0_35",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: true,
+		},
+		"MySQL 8.0.37 (supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should suppress diff": {
+			oldVersion:         "MYSQL_8_0_37",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: true,
+		},
+		"MySQL 8.0.40 (supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should suppress diff": {
+			oldVersion:         "MYSQL_8_0_40",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: true,
+		},
+		"MySQL 8.0.41 (supported for auto-upgrade) to MySQL 8.0 (supported for auto-upgrade) change should suppress diff": {
+			oldVersion:         "MYSQL_8_0_41",
+			newVersion:         "MYSQL_8_0",
+			shouldSuppressDiff: true,
+		},
+		"MySQL 8.0.37 (supported for auto-upgrade) to MySQL 8.4 (non-supported for auto-upgrade) change should not suppress diff": {
+			oldVersion:         "MYSQL_8_0_37",
+			newVersion:         "MYSQL_8_4",
+			shouldSuppressDiff: false,
+		},
+		"Postgres (or any non-MySQL) versions should not suppress diff": {
+			oldVersion:         "POSTGRES_14",
+			newVersion:         "POSTGRES_15",
+			shouldSuppressDiff: false,
+		},
+	}
+
+	for testNumber, testCase := range testCases {
+		t.Run(testNumber, func(t *testing.T) {
+			t.Parallel()
+			if databaseVersionDiffSuppress("version", testCase.oldVersion, testCase.newVersion, nil) != testCase.shouldSuppressDiff {
+				t.Fatalf("%q => %q expect DiffSuppress to return %t", testCase.oldVersion, testCase.newVersion, testCase.shouldSuppressDiff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Suppressing diff for database_version for MySQL 8.0. With introduction of auto version upgrade for MySQL 8.0.35 and beyond, customers will be auto upgraded to a newer version which will lead to change in database version.

Hence, to avoid breakage of terraform scripts suppressing this diff while maintaining the sanity that the major version does not change, suppression is done only if there is a diff in minor version.

```release-note:enhancement
sql: added `databaseVersionDiffSuppress` to `google_sql_database_instance`. This change will suppress diff for database_version for MySQL 8.0 when the version is updated by auto version upgrade.
```