### PR TITLE
Fixes flaky TestAccSqlDatabaseInstance_activationPolicy test, makes run sequential

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2228,8 +2228,6 @@ func TestAccSqlDatabaseInstance_SqlServerTimezoneUpdate(t *testing.T) {
 }
 
 func TestAccSqlDatabaseInstance_activationPolicy(t *testing.T) {
-	t.Parallel()
-
 	instanceName := "tf-test-" + acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
SQL test method `TestAccSqlDatabaseInstance_activationPolicy` is flaky, as the test steps are curated (and expected) to run one after the other. But currently parallel execution is enabled for the test steps ([reference](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go#L2231)) using [`Parallel()`](https://pkg.go.dev/testing#T.Parallel), which enables unordered execution making the test flaky.

[Debug logs](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-13090/artifacts/31e81699-bed1-4c04-8dcb-aa869596b6f7/recording) showing how, ([steps](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go#L2239)), after the `MySQL 8_0_18` step, the `MySQL 8_4` step got executed before the `MySQL 8_0_37` step (which is intended to run before the `MySQL 8_4` step, as described in the [steps](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go#L2239) sequence), creating this error: `"Invalid request: To upgrade to MySQL 8.4 source version should be 8.0.37 or higher."`. This issue surfaced in this PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/13090.

```release-note:bug
sql: Fixes flakiness of TestAccSqlDatabaseInstance_activationPolicy in `resource_sql_database_instance` by making test runs sequential
```