### PR TITLE
feat(bigquery): Add cross-region replication support for BigQuery Dataset

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -118,7 +118,7 @@ examples:
     description: |
       Configuration for cross-region replication of the dataset. When enabled, BigQuery will automatically
       replicate the data in this dataset to the specified regions. This provides higher availability and
-      disaster recovery capabilities. For more information, see [Cross-region replication](https://cloud.google.com/bigquery/docs/cross-region-replication).
+      disaster recovery capabilities. For more information, see [Cross-region dataset replication](https://cloud.google.com/bigquery/docs/data-replication).
     properties:
       - name: 'enabled'
         type: Boolean

--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -106,6 +106,35 @@ examples:
       tag_key2: 'tag_key2'
       tag_value2: 'tag_value2'
     exclude_docs: true
+  - name: 'bigquery_dataset_cross_region_replication'
+    primary_resource_id: 'dataset'
+    vars:
+      dataset_id: 'example_dataset'
+      location: 'US'
+      replica_region1: 'asia-northeast1'
+      replica_region2: 'europe-west1'
+  - name: 'crossRegionReplication'
+    type: NestedObject
+    description: |
+      Configuration for cross-region replication of the dataset. When enabled, BigQuery will automatically
+      replicate the data in this dataset to the specified regions. This provides higher availability and
+      disaster recovery capabilities. For more information, see [Cross-region replication](https://cloud.google.com/bigquery/docs/cross-region-replication).
+    properties:
+      - name: 'enabled'
+        type: Boolean
+        description: |
+          Whether cross-region replication is enabled for this dataset. When enabled, BigQuery will
+          automatically replicate the data in this dataset to the specified regions.
+        required: true
+      - name: 'replicaRegions'
+        type: Array
+        description: |
+          The list of regions where the dataset should be replicated. Each region must be different
+          from the dataset's primary location. For example, if the dataset is in 'US', you might
+          specify ['asia-northeast1', 'europe-west1'] as replica regions.
+        required: true
+        item_type:
+          type: String
 virtual_fields:
   - name: 'delete_contents_on_destroy'
     description: |

--- a/mmv1/templates/terraform/examples/bigquery_dataset_cross_region_replication.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_cross_region_replication.tf.tmpl
@@ -1,0 +1,28 @@
+resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
+  dataset_id                  = "{{$.Vars.dataset_id}}"
+  friendly_name              = "Cross Region Replication Example"
+  description               = "This is a test dataset with cross-region replication enabled"
+  location                  = "{{$.Vars.location}}"
+  delete_contents_on_destroy = true
+
+  cross_region_replication {
+    enabled = true
+    replica_regions = [
+      "{{$.Vars.replica_region1}}",
+      "{{$.Vars.replica_region2}}"
+    ]
+  }
+
+  labels = {
+    env = "test"
+  }
+
+  access {
+    role          = "OWNER"
+    user_by_email = google_service_account.bqowner.email
+  }
+}
+
+resource "google_service_account" "bqowner" {
+  account_id = "bqowner"
+}


### PR DESCRIPTION
This PR adds support for cross-region replication configuration in BigQuery datasets.

## Description
This change introduces the ability to configure cross-region replication for BigQuery datasets through Terraform. The feature allows users to automatically replicate their datasets to specified regions for improved availability and disaster recovery.

Key changes:
- Added new `cross_region_replication` configuration block
- Added example configuration for cross-region replication
- Added documentation for the new feature

## Example Configuration
``` hcl
resource "google_bigquery_dataset" "dataset" {
  dataset_id = "example_dataset"
  location = "US"
  cross_region_replication {
    enabled = true
    replica_regions = [
      "asia-northeast1",
      "europe-west1"
    ]
  }
}
```

## Documentation
Added comprehensive documentation explaining:
- How to enable cross-region replication
- How to specify replica regions
- Limitations and considerations

## Release Note

```release-note:enhancement
bigquery: added `cross_region_replication` field to `google_bigquery_dataset` resource
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18185