### PR TITLE
Feature/support-bigquery-connection-alloydb

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -141,6 +141,23 @@ examples:
     ignore_read_extra:
       # password removed
       - 'cloud_sql.0.credential'
+  - name: 'bigquery_connection_alloydb'
+    primary_resource_id: 'connection'
+    vars:
+      connection_id: 'my-connection'
+      instance_id: 'alloydb-instance'
+      username: 'user'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      'deletion_protection': 'false'
+    oics_vars_overrides:
+      'deletion_protection': 'false'
+    ignore_read_extra:
+      # password removed
+      - 'alloydb.0.credential'
+    external_providers: ["random", "time"]
+    # Random provider
+    skip_vcr: true
 parameters:
 properties:
   - name: 'name'
@@ -260,7 +277,7 @@ properties:
           - name: 'iamRoleId'
             type: String
             description:
-              The user’s AWS IAM Role that trusts the Google-owned AWS IAM user
+              The user's AWS IAM Role that trusts the Google-owned AWS IAM user
               Connection.
             required: true
           - name: 'identity'
@@ -424,3 +441,53 @@ properties:
           - name: 'dataprocCluster'
             type: String
             description: Resource name of an existing Dataproc Cluster to act as a Spark History Server for the connection if the form of projects/[projectId]/regions/[region]/clusters/[cluster_name].
+  - name: 'alloydb'
+    type: NestedObject
+    description: Connection properties specific to AlloyDB.
+    exactly_one_of:
+      - 'cloud_sql'
+      - 'aws'
+      - 'azure'
+      - 'cloud_spanner'
+      - 'cloud_resource'
+      - 'spark'
+      - 'alloydb'
+    properties:
+      - name: 'instanceId'
+        type: String
+        description: |
+          AlloyDB instance ID in the form project:location:instance.
+        required: true
+      - name: 'database'
+        type: String
+        description: Database name.
+        required: true
+      - name: 'credential'
+        type: NestedObject
+        description: AlloyDB properties.
+        required: true
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.go.tmpl'
+        properties:
+          - name: 'username'
+            type: String
+            description: Username for database.
+            required: true
+          - name: 'password'
+            type: String
+            description: Password for database.
+            required: true
+            sensitive: true
+      - name: 'type'
+        type: Enum
+        description: Type of the AlloyDB database.
+        required: true
+        enum_values:
+          - 'DATABASE_TYPE_UNSPECIFIED'
+          - 'POSTGRES'
+      - name: 'serviceAccountId'
+        type: String
+        description: |
+          When the connection is used in the context of an operation in
+          BigQuery, this service account will serve as the identity being used
+          for connecting to the AlloyDB instance specified in this connection.
+        output: true

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -145,8 +145,6 @@ examples:
     primary_resource_id: 'connection'
     vars:
       connection_id: 'my-connection'
-      instance_id: 'alloydb-instance'
-      username: 'user'
       deletion_protection: 'true'
     test_vars_overrides:
       'deletion_protection': 'false'

--- a/mmv1/templates/terraform/examples/bigquery_connection_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_alloydb.tf.tmpl
@@ -1,0 +1,46 @@
+resource "google_bigquery_connection" "connection" {
+  connection_id = "{{index $.Vars "connection_id"}}"
+  location = "US"
+  friendly_name = "👋"
+  description = "a riveting description"
+
+  alloydb {
+    instance_id = google_alloydb_instance.default.id
+    database = "db"
+    type = "POSTGRES"
+    credential {
+      username = "user"
+      password = "password"
+    }
+  }
+
+  deletion_protection = false
+}
+
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "alloydb-instance"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "alloydb-cluster"
+  location   = "us-central1"
+  network_config {
+    network = google_compute_network.default.id
+  }
+
+  initial_user {
+    password = "alloydb-cluster"
+  }
+}
+
+data "google_project" "project" {}
+
+resource "google_compute_network" "default" {
+  name = "alloydb-network"
+}

--- a/mmv1/templates/terraform/examples/bigquery_connection_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_alloydb.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_bigquery_connection" "connection" {
     }
   }
 
-  deletion_protection = false
+  deletion_protection = {{index $.Vars "deletion_protection"}}
 }
 
 resource "google_alloydb_instance" "default" {


### PR DESCRIPTION
# Description

This PR adds AlloyDB connection type support to BigQuery Connection resource. This allows users to create BigQuery connections to AlloyDB instances.

The changes include:
- Added `alloydb` block to the `google_bigquery_connection` resource
- Added example and test for AlloyDB connection type
- Added documentation for the new connection type

## Release Note

```release-note:enhancement
bigqueryconnection: added `alloydb` fields to `google_bigquery_connection` resource
```

FIXES: https://github.com/hashicorp/terraform-provider-google/issues/18663