### PR TITLE
Apply service label during test ticket creation

### DIFF
--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -402,6 +402,7 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		failureRatelabel,
 	}
 
+	// Apply service labels to forward test failure ticket automatically
 	regexpLabels, err := labeler.BuildRegexLabels(labeler.EnrolledTeamsYaml)
 	if err != nil {
 		return fmt.Errorf("error building regex labels: %w", err)

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -87,6 +87,7 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client) error {
 		return err
 	}
 
+	// Remove review labels to forward test failure tickets 
 	for _, issue := range issues {
 		_, err := gh.Issues.RemoveLabelForIssue(ctx, GithubOwner, GithubRepo, issue.GetNumber(), "forward/review")
 		if err != nil {

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -87,7 +87,7 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client) error {
 		return err
 	}
 
-	// Remove review labels to forward test failure tickets 
+	// Remove review labels to forward test failure tickets
 	for _, issue := range issues {
 		_, err := gh.Issues.RemoveLabelForIssue(ctx, GithubOwner, GithubRepo, issue.GetNumber(), "forward/review")
 		if err != nil {

--- a/tools/issue-labeler/cmd/compute_new_labels.go
+++ b/tools/issue-labeler/cmd/compute_new_labels.go
@@ -50,11 +50,7 @@ func execComputeNewLabels() error {
 	// the logic here remains defensive in case that changes.
 	var serviceLabels []string
 	var nonServiceLabels []string
-	testFailureIssue := false
 	for _, l := range labels {
-		if l == "test-failure" {
-			testFailureIssue = true
-		}
 		if strings.HasPrefix(l, "service/") {
 			serviceLabels = append(serviceLabels, l)
 		} else {
@@ -67,10 +63,7 @@ func execComputeNewLabels() error {
 	labels = append(nonServiceLabels, serviceLabels...)
 
 	if len(labels) > 0 {
-		// Forwarding test failure ticket directly
-		if !testFailureIssue {
-			labels = append(labels, "forward/review")
-		}
+		labels = append(labels, "forward/review")
 		sort.Strings(labels)
 		fmt.Println(`["` + strings.Join(labels, `", "`) + `"]`)
 	}


### PR DESCRIPTION
This PR updates the test failure tickets creator to add service labels and reverts the changes to compute_new_labels made in https://github.com/GoogleCloudPlatform/magic-modules/pull/13086 since it was working as expected, while keep the labeler backfill changes made in that PR unchanged as it should be working.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
