### PR TITLE
Update max_staleness in google_bigquery_table to be a computed field

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -965,6 +965,7 @@ func ResourceBigQueryTable() *schema.Resource {
 			"max_staleness": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				Description: `The maximum staleness of data that could be returned when the table (or stale MV) is queried. Staleness encoded as a string encoding of [SQL IntervalValue type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#interval_type).`,
 			},
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21136.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21167.

Suspected to be a recent change in the server where `max_staleness` for a replica materialized view is now copied from its source materialized view even when it's unset at creation.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigquery: updated the `max_staleness` field in `google_bigquery_table` to be a computed field
```
