### PR TITLE
Update Gemini Logging Setting Binding Resource - Change product possible values

### DIFF
--- a/mmv1/products/gemini/LoggingSettingBinding.yaml
+++ b/mmv1/products/gemini/LoggingSettingBinding.yaml
@@ -88,7 +88,6 @@ properties:
     description: |-
       Product type of the setting binding.
     enum_values:
-      - 'GEMINI_CLOUD_ASSIST'
       - 'GEMINI_CODE_ASSIST'
   - name: name
     type: String


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
gemini: removed unsupported value `GEMINI_CLOUD_ASSIST` for field `product` in `google_gemini_logging_setting_binding` resource
```
