### PR TITLE
Adds StorageControl service folder for GCS JSON v2 resource support.

### DIFF
--- a/mmv1/products/storagecontrol/product.yaml
+++ b/mmv1/products/storagecontrol/product.yaml
@@ -1,0 +1,21 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'StorageControl'
+display_name: 'Cloud Storage Control'
+versions:
+  - name: 'ga'
+    base_url: 'https://storage.googleapis.com/v2/'
+scopes:
+  - 'https://www.googleapis.com/auth/devstorage.full_control'


### PR DESCRIPTION

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note: none

```
