### PR TITLE
Stop setting the description field of google_gke_hub_membership

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -375,9 +375,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -435,9 +432,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -495,9 +489,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -780,9 +771,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -833,9 +821,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -885,9 +870,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_feature" "feature" {
@@ -1168,9 +1150,6 @@ resource "google_gke_hub_membership" "membership" {
       resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_membership" "membership_second" {
@@ -1181,9 +1160,6 @@ resource "google_gke_hub_membership" "membership_second" {
       resource_link = "//container.googleapis.com/${google_container_cluster.secondary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_membership" "membership_third" {
@@ -1194,9 +1170,6 @@ resource "google_gke_hub_membership" "membership_third" {
       resource_link = "//container.googleapis.com/${google_container_cluster.tertiary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 
 resource "google_gke_hub_membership" "membership_fourth" {
@@ -1207,9 +1180,6 @@ resource "google_gke_hub_membership" "membership_fourth" {
       resource_link = "//container.googleapis.com/${google_container_cluster.quarternary.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 `, context)
 }
@@ -1242,9 +1212,6 @@ resource "google_gke_hub_membership" "membership_acmoci" {
       resource_link = "//container.googleapis.com/${google_container_cluster.container_acmoci.id}"
     }
   }
-{{- if ne $.TargetVersionName "ga" }}
-  description = "test resource."
-{{- end }}
 }
 `, context)
 }


### PR DESCRIPTION
We plan to update the gkehub beta api endpoint from v1beta1 to v1beta. Unfortunately, the description field is output-only in v1beta and cannot be set by users.

part of https://github.com/hashicorp/terraform-provider-google/issues/21641

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
