### PR TITLE
Update to use a regional template bucket

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_job_test.go.tmpl
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	testDataflowJobTemplateWordCountUrl = "gs://dataflow-templates/latest/Word_Count"
+	testDataflowJobTemplateWordCountUrl = "gs://dataflow-templates-us-central1/latest/Word_Count"
 	testDataflowJobSampleFileUrl        = "gs://dataflow-samples/shakespeare/various.txt"
-	testDataflowJobTemplateTextToPubsub = "gs://dataflow-templates/latest/Stream_GCS_Text_to_Cloud_PubSub"
+	testDataflowJobTemplateTextToPubsub = "gs://dataflow-templates-us-central1/latest/Stream_GCS_Text_to_Cloud_PubSub"
 	testDataflowJobRegion               = "us-central1"
 )
 


### PR DESCRIPTION
Temporary workaround to unblock Dataflow job testing: https://github.com/hashicorp/terraform-provider-google/issues/21567

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
