### PR TITLE
Remove immutable annotation from node type to support vertical scaling for Valkey.

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -211,9 +211,8 @@ properties:
   - name: 'nodeType'
     type: String
     description:
-      "Optional. Immutable. Machine type for individual nodes of the instance.
+      "Optional. Machine type for individual nodes of the instance.
       \n Possible values:\n SHARED_CORE_NANO\nHIGHMEM_MEDIUM\nHIGHMEM_XLARGE\nSTANDARD_SMALL"
-    immutable: true
     default_from_api: true
   - name: 'persistenceConfig'
     type: NestedObject

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -186,6 +186,49 @@ func TestAccMemorystoreInstance_updateDeletionProtection(t *testing.T) {
 	})
 }
 
+// Validate that node type is updated for the cluster
+func TestAccMemorystoreInstance_updateNodeType(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// create cluster with node type highmem medium
+				Config: createOrUpdateMemorystoreInstance(&InstanceParams{
+					name:                 name,
+					shardCount:           3,
+					zoneDistributionMode: "MULTI_ZONE",
+					nodeType:             "HIGHMEM_MEDIUM",
+				}),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// update cluster with node type standard small
+				Config: createOrUpdateMemorystoreInstance(&InstanceParams{
+					name:                 name,
+					shardCount:           3,
+					zoneDistributionMode: "MULTI_ZONE",
+					nodeType:             "STANDARD_SMALL",
+				}),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Validate that engine version is updated for the cluster
 func TestAccMemorystoreInstance_updateEngineVersion(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
memorystore: enabled update support for `node_type` field in `google_memorystore_instance` resource
```
