### PR TITLE
Update document for Dataproc cluster ProvisioningModelMix field

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -628,6 +628,10 @@ cluster_config {
         machine_types = ["n2d-standard-2"]
         rank          = 3
       }
+      provisioning_model_mix {
+        standard_capacity_base = 1
+        standard_capacity_percent_above_base = 50
+      }
     }
   }
 }
@@ -666,6 +670,10 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
 
       * `rank` - (Optional) Preference of this instance selection. A lower number means higher preference. Dataproc will first try to create a VM based on the machine-type with priority rank and fallback to next rank based on availability. Machine types and instance selections with the same priority have the same preference.
 
+    * `provisioning_model_mix` - (Optional) Defines how the Group selects the provisioning model to ensure required reliability.
+      * `standard_capacity_base` - (Optional) The base capacity that will always use Standard VMs to avoid risk of more preemption than the minimum capacity you need. Dataproc will create only standard VMs until it reaches standardCapacityBase, then it will start using standardCapacityPercentAboveBase to mix Spot with Standard VMs. eg. If 15 instances are requested and standardCapacityBase is 5, Dataproc will create 5 standard VMs and then start mixing spot and standard VMs for remaining 10 instances.
+
+      * `standard_capacity_percent_above_base` - (Optional) The percentage of target capacity that should use Standard VM. The remaining percentage will use Spot VMs. The percentage applies only to the capacity above standardCapacityBase. eg. If 15 instances are requested and standardCapacityBase is 5 and standardCapacityPercentAboveBase is 30, Dataproc will create 5 standard VMs and then start mixing spot and standard VMs for remaining 10 instances. The mix will be 30% standard and 70% spot.
 - - -
 
 <a name="nested_software_config"></a>The `cluster_config.software_config` block supports:


### PR DESCRIPTION
Update missing document for Dataproc cluster ProvisioningModelMix field #12327 .

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
dataproc: update document for `cluster_config.preemptible_worker_config.instance_flexibility_policy.provisioning_model_mix` field
```
