### PR TITLE
Add missing KMS fields to google_compute_instance

### DIFF
--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -173,7 +173,6 @@ properties:
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
-        api_name: rawKey
         ignore_read: true
         sensitive: true
       - name: 'rsaEncryptedKey'
@@ -181,7 +180,6 @@ properties:
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
-        api_name: rsaEncryptedKey
         ignore_read: true
         sensitive: true
   - name: 'labels'

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -168,6 +168,22 @@ properties:
           The service account being used for the encryption request for the
           given KMS key. If absent, the Compute Engine default service
           account is used.
+      - name: 'rawKey'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        api_name: rawKey
+        ignore_read: true
+        sensitive: true
+      - name: 'rsaEncryptedKey'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        api_name: rsaEncryptedKey
+        ignore_read: true
+        sensitive: true
   - name: 'labels'
     type: KeyValueLabels
     description: Labels to apply to this Image.

--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -123,6 +123,13 @@ parameters:
         ignore_read: true
         sensitive: true
         custom_flatten: 'templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.tmpl'
+      - name: 'rsaEncryptedKey'
+        type: String
+        description: |
+          Specifies an encryption key stored in Google Cloud KMS, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        ignore_read: true
+        sensitive: true
       - name: 'sha256'
         type: String
         description: |

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1089,3 +1089,61 @@ func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[
 		},
 	}
 }
+
+func expandComputeInstanceEncryptionKey(d tpgresource.TerraformResourceData) *compute.CustomerEncryptionKey {
+	iek, ok := d.GetOk("instance_encryption_key")
+	if !ok {
+		return nil
+	}
+
+	iekRes := iek.([]interface{})[0].(map[string]interface{})
+	return &compute.CustomerEncryptionKey{
+		KmsKeyName:      	  iekRes["kms_key_self_link"].(string),
+		Sha256:          	  iekRes["sha256"].(string),
+		KmsKeyServiceAccount: iekRes["kms_key_service_account"].(string),
+	}
+}
+
+func flattenComputeInstanceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"kms_key_self_link": 	   v.KmsKeyName,
+			"sha256":            	   v.Sha256,
+			"kms_key_service_account": v.KmsKeyServiceAccount,
+		},
+	}
+}
+
+func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceData, field string) *compute.CustomerEncryptionKey {
+	cek, ok := d.GetOk(field)
+	if !ok {
+		return nil
+	}
+
+	cekRes := cek.([]interface{})[0].(map[string]interface{})
+	return &compute.CustomerEncryptionKey{
+		RsaEncryptedKey:      cekRes["rsa_encrypted_key"].(string),
+		RawKey:               cekRes["raw_key"].(string),
+		KmsKeyName:           cekRes["kms_key_self_link"].(string),
+		Sha256:               cekRes["sha256"].(string),
+		KmsKeyServiceAccount: cekRes["kms_key_service_account"].(string),
+	}
+}
+
+func flattenComputeInstanceSourceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"rsa_encrypted_key":       v.RsaEncryptedKey,
+			"raw_key":                 v.RawKey,
+			"kms_key_self_link":       v.KmsKeyName,
+			"sha256":                  v.Sha256,
+			"kms_key_service_account": v.KmsKeyServiceAccount,
+		},
+	}
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -53,6 +53,13 @@ func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+func KmsKeyNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if tpgresource.CompareCryptoKeyVersions(k, old, new, d) || tpgresource.CompareSelfLinkRelativePaths(k, old, new, d) {
+		return true
+	}
+	return false
+}
+
 var (
 	advancedMachineFeaturesKeys = []string{
 		"advanced_machine_features.0.enable_nested_virtualization",
@@ -69,6 +76,8 @@ var (
 		"boot_disk.0.device_name",
 		"boot_disk.0.disk_encryption_key_raw",
 		"boot_disk.0.kms_key_self_link",
+		"boot_disk.0.disk_encryption_key_rsa",
+		"boot_disk.0.disk_encryption_service_account",
 		"boot_disk.0.initialize_params",
 		"boot_disk.0.mode",
 		"boot_disk.0.source",
@@ -83,6 +92,9 @@ var (
 		"boot_disk.0.initialize_params.0.provisioned_iops",
 		"boot_disk.0.initialize_params.0.provisioned_throughput",
 		"boot_disk.0.initialize_params.0.enable_confidential_compute",
+		"boot_disk.0.initialize_params.0.source_image_encryption_key",
+		"boot_disk.0.initialize_params.0.snapshot",
+		"boot_disk.0.initialize_params.0.source_snapshot_encryption_key",
 		"boot_disk.0.initialize_params.0.storage_pool",
 		"boot_disk.0.initialize_params.0.resource_policies",
 		"boot_disk.0.initialize_params.0.architecture",
@@ -240,15 +252,33 @@ func ResourceComputeInstance() *schema.Resource {
 							Optional:      true,
 							AtLeastOneOf:  bootDiskKeys,
 							ForceNew:      true,
-							ConflictsWith: []string{"boot_disk.0.kms_key_self_link"},
+							ConflictsWith: []string{"boot_disk.0.kms_key_self_link", "boot_disk.0.disk_encryption_key_rsa"},
 							Sensitive:     true,
-							Description:   `A 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to encrypt this disk. Only one of kms_key_self_link and disk_encryption_key_raw may be set.`,
+							Description:   `A 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to encrypt this disk. Only one of kms_key_self_link, disk_encryption_key_raw and disk_encryption_key_rsa may be set.`,
+						},
+
+						"disk_encryption_key_rsa": {
+							Type:          schema.TypeString,
+							Optional:      true,
+							AtLeastOneOf:  bootDiskKeys,
+							ForceNew:      true,
+							ConflictsWith: []string{"boot_disk.0.kms_key_self_link", "boot_disk.0.disk_encryption_key_raw"},
+							Sensitive:     true,
+							Description:   `Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit customer-supplied encryption key to either encrypt or decrypt this resource. Only one of kms_key_self_link, disk_encryption_key_raw and disk_encryption_key_rsa may be set.`,
 						},
 
 						"disk_encryption_key_sha256": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: `The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied encryption key that protects this resource.`,
+						},
+
+						"disk_encryption_service_account": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							AtLeastOneOf: bootDiskKeys,
+							ForceNew:     true,
+							Description:  `The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used`,
 						},
 
 						"interface": {
@@ -263,10 +293,22 @@ func ResourceComputeInstance() *schema.Resource {
 							Optional:         true,
 							AtLeastOneOf:     bootDiskKeys,
 							ForceNew:         true,
-							ConflictsWith:    []string{"boot_disk.0.disk_encryption_key_raw"},
+							ConflictsWith:    []string{"boot_disk.0.disk_encryption_key_raw", "boot_disk.0.disk_encryption_key_rsa"},
 							DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
 							Computed:         true,
-							Description:      `The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk. Only one of kms_key_self_link and disk_encryption_key_raw may be set.`,
+							Description:      `The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk. Only one of kms_key_self_link, disk_encryption_key_raw and disk_encryption_key_rsa may be set.`,
+						},
+
+						"guest_os_features": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							AtLeastOneOf: bootDiskKeys,
+							ForceNew:     true,
+							Computed:     true,
+							Description:  `A list of features to enable on the guest operating system. Applicable only for bootable images.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 
 						"guest_os_features": {
@@ -318,6 +360,114 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:         true,
 										DiffSuppressFunc: DiskImageDiffSuppress,
 										Description:      `The image from which this disk was initialised.`,
+									},
+
+									"source_image_encryption_key": {
+										Type: schema.TypeList,
+										Optional: true,
+										AtLeastOneOf: initializeParamsKeys,
+										MaxItems: 1,
+										Description: `The encryption key used to decrypt the source image.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"raw_key": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Sensitive:        true,
+													Description:      `Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to either encrypt or decrypt this resource. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"rsa_encrypted_key": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Sensitive:        true,
+													Description:      `Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit customer-supplied encryption key to either encrypt or decrypt this resource. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"kms_key_self_link": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Computed:         true,
+													DiffSuppressFunc: KmsKeyNameDiffSuppress,
+													Description:      `The self link of the encryption key that is stored in Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"kms_key_service_account": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Description:      `The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.`,
+												},
+
+												"sha256": {
+													Type:             schema.TypeString,
+													Computed:         true,
+													Description:      `The SHA256 hash of the encryption key used to encrypt this disk.`,
+												},
+											},
+										},
+									},
+
+									"snapshot": {
+										Type:             schema.TypeString,
+										Optional:         true,
+										AtLeastOneOf:     initializeParamsKeys,
+										Computed:         true,
+										ForceNew:         true,
+										DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+										Description:      `The snapshot from which this disk was initialised.`,
+									},
+
+									"source_snapshot_encryption_key": {
+										Type: schema.TypeList,
+										Optional: true,
+										AtLeastOneOf: initializeParamsKeys,
+										MaxItems: 1,
+										Description: `The encryption key used to decrypt the source snapshot.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"raw_key": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Sensitive:        true,
+													Description:      `Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to either encrypt or decrypt this resource. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"rsa_encrypted_key": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Sensitive:        true,
+													Description:      `Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit customer-supplied encryption key to either encrypt or decrypt this resource. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"kms_key_self_link": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Computed:         true,
+													DiffSuppressFunc: KmsKeyNameDiffSuppress,
+													Description:      `The self link of the encryption key that is stored in Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
+												},
+
+												"kms_key_service_account": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ForceNew:         true,
+													Description:      `The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.`,
+												},
+
+												"sha256": {
+													Type:             schema.TypeString,
+													Computed:         true,
+													Description:      `The SHA256 hash of the encryption key used to encrypt this disk.`,
+												},
+											},
+										},
 									},
 
 									"labels": {
@@ -702,7 +852,14 @@ func ResourceComputeInstance() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Sensitive:   true,
-							Description: `A 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to encrypt this disk. Only one of kms_key_self_link and disk_encryption_key_raw may be set.`,
+							Description: `A 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to encrypt this disk. Only one of kms_key_self_link, disk_encryption_key_rsa and disk_encryption_key_raw may be set.`,
+						},
+
+						"disk_encryption_key_rsa": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Sensitive:   true,
+							Description: `Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit customer-supplied encryption key to either encrypt or decrypt this resource. Only one of kms_key_self_link, disk_encryption_key_rsa and disk_encryption_key_raw may be set.`,
 						},
 
 						"kms_key_self_link": {
@@ -710,7 +867,13 @@ func ResourceComputeInstance() *schema.Resource {
 							Optional:         true,
 							DiffSuppressFunc: tpgresource.CompareSelfLinkRelativePaths,
 							Computed:         true,
-							Description:      `The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk. Only one of kms_key_self_link and disk_encryption_key_raw may be set.`,
+							Description:      `The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk. Only one of kms_key_self_link, disk_encryption_key_rsa and disk_encryption_key_raw may be set.`,
+						},
+
+						"disk_encryption_service_account": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used`,
 						},
 
 						"disk_encryption_key_sha256": {
@@ -1389,6 +1552,39 @@ be from 0 to 999,999,999 inclusive.`,
 				ValidateFunc: validation.StringInSlice([]string{"STOP", "NONE", ""}, false),
 				Description:  `Action to be taken when a customer's encryption key is revoked. Supports "STOP" and "NONE", with "NONE" being the default.`,
 			},
+
+			"instance_encryption_key": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Encryption key used to provide data encryption on the given instance.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"kms_key_self_link": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							DiffSuppressFunc: KmsKeyNameDiffSuppress,
+							Computed:    true,
+							Description: `The self link of the encryption key that is stored in Google Cloud KMS.`,
+						},
+
+						"kms_key_service_account": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.`,
+						},
+
+						"sha256": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The SHA256 hash of the customer's encryption key.`,
+						},
+					},
+				},
+			},
 		},
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
@@ -1567,6 +1763,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		ResourcePolicies:           tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{})),
 		ReservationAffinity:        reservationAffinity,
 		KeyRevocationActionType:    d.Get("key_revocation_action_type").(string),
+		InstanceEncryptionKey:      expandComputeInstanceEncryptionKey(d),
 	}, nil
 }
 
@@ -1890,9 +2087,16 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			}
 			if key := disk.DiskEncryptionKey; key != nil {
 				if inConfig {
+					rsaKey := d.Get(fmt.Sprintf("attached_disk.%d.disk_encryption_key_rsa", adIndex))
+					if rsaKey != "" {
+						di["disk_encryption_key_rsa"] = rsaKey
+					}
 					rawKey := d.Get(fmt.Sprintf("attached_disk.%d.disk_encryption_key_raw", adIndex))
 					if rawKey != "" {
 						di["disk_encryption_key_raw"] = rawKey
+					}
+					if serviceAccount := d.Get(fmt.Sprintf("attached_disk.%d.disk_encryption_service_account", adIndex)); serviceAccount != "" {
+						di["disk_encryption_service_account"] = serviceAccount
 					}
 				}
 				if key.KmsKeyName != "" {
@@ -2022,6 +2226,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
+	}
+	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(instance.InstanceEncryptionKey)); err != nil {
+		return fmt.Errorf("Error setting instance_encryption_key: %s", err)
 	}
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))
@@ -3010,6 +3217,15 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 		}
 	}
 
+	keyValue, keyOk = diskConfig["disk_encryption_key_rsa"]
+	if keyOk {
+		if keyValue != "" {
+			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
+				RsaEncryptedKey: keyValue.(string),
+			}
+		}
+	}
+
 	kmsValue, kmsOk := diskConfig["kms_key_self_link"]
 	if kmsOk {
 		if keyOk && keyValue != "" && kmsValue != "" {
@@ -3019,6 +3235,18 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
 				KmsKeyName: kmsValue.(string),
 			}
+		}
+	}
+
+	kmsServiceAccount, kmsServiceAccountOk := diskConfig["disk_encryption_service_account"]
+	if kmsServiceAccountOk {
+		if kmsServiceAccount != "" {
+			if disk.DiskEncryptionKey == nil {
+				disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
+					KmsKeyServiceAccount: kmsServiceAccount.(string),
+				}
+			}
+			disk.DiskEncryptionKey.KmsKeyServiceAccount = kmsServiceAccount.(string)
 		}
 	}
 	return disk, nil
@@ -3245,6 +3473,14 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 	}
 
+	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_rsa"); ok {
+		if v != "" {
+			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
+				RsaEncryptedKey: v.(string),
+			}
+		}
+	}
+
 	if v, ok := d.GetOk("boot_disk.0.kms_key_self_link"); ok {
 		if v != "" {
 			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
@@ -3252,6 +3488,13 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			}
 		}
 	}
+
+	if v, ok := d.GetOk("boot_disk.0.disk_encryption_service_account"); ok {
+		if v != "" {
+			disk.DiskEncryptionKey.KmsKeyServiceAccount = v.(string)
+		}
+	}
+
 
 	if v, ok := d.GetOk("boot_disk.0.source"); ok {
 		var err error
@@ -3307,6 +3550,23 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			disk.InitializeParams.SourceImage = imageUrl
 		}
 
+		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_image_encryption_key"); ok {
+			disk.InitializeParams.SourceImageEncryptionKey = expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_image_encryption_key")
+		}
+
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.snapshot"); ok {
+			snapshotName := v.(string)
+			snapshotUrl, err := tpgresource.ParseSnapshotFieldValue(snapshotName, d, config)
+			if err != nil {
+				return nil, fmt.Errorf("Error resolving snapshot name '%s': %s", snapshotName, err)
+			}
+			disk.InitializeParams.SourceSnapshot = snapshotUrl.RelativeLink()
+		}
+
+		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"); ok {
+			disk.InitializeParams.SourceSnapshotEncryptionKey = expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_snapshot_encryption_key")
+		}
+
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.labels"); ok {
 			disk.InitializeParams.Labels = tpgresource.ExpandStringMap(d, "boot_disk.0.initialize_params.0.labels")
 		}
@@ -3349,6 +3609,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
 		// originally specified to avoid diffs.
 		"disk_encryption_key_raw": d.Get("boot_disk.0.disk_encryption_key_raw"),
+		"disk_encryption_key_rsa": d.Get("boot_disk.0.disk_encryption_key_rsa"),
 	}
         if _,ok := d.GetOk("boot_disk.0.interface"); ok {
                result["interface"] = disk.Interface
@@ -3377,6 +3638,9 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			// If the config specifies a family name that doesn't match the image name, then
 			// the diff won't be properly suppressed. See DiffSuppressFunc for this field.
 			"image":  diskDetails.SourceImage,
+			"source_image_encryption_key":    d.Get("boot_disk.0.initialize_params.0.source_image_encryption_key"),
+			"snapshot":                       diskDetails.SourceSnapshot,
+			"source_snapshot_encryption_key": d.Get("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"),
 			"architecture": diskDetails.Architecture,
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
@@ -3397,6 +3661,9 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			// The response for crypto keys often includes the version of the key which needs to be removed
 			// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
 			result["kms_key_self_link"] = strings.Split(disk.DiskEncryptionKey.KmsKeyName, "/cryptoKeyVersions")[0]
+		}
+		if v, ok := d.GetOk("boot_disk.0.disk_encryption_service_account"); ok {
+			result["disk_encryption_service_account"] = v.(string)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -304,18 +304,6 @@ func ResourceComputeInstance() *schema.Resource {
 							},
 						},
 
-						"guest_os_features": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							AtLeastOneOf: bootDiskKeys,
-							ForceNew:     true,
-							Computed:     true,
-							Description:  `A list of features to enable on the guest operating system. Applicable only for bootable images.`,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-
 						"initialize_params": {
 							Type:         schema.TypeList,
 							Optional:     true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -53,13 +53,6 @@ func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-func KmsKeyNameDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if tpgresource.CompareCryptoKeyVersions(k, old, new, d) || tpgresource.CompareSelfLinkRelativePaths(k, old, new, d) {
-		return true
-	}
-	return false
-}
-
 var (
 	advancedMachineFeaturesKeys = []string{
 		"advanced_machine_features.0.enable_nested_virtualization",
@@ -391,7 +384,7 @@ func ResourceComputeInstance() *schema.Resource {
 													Optional:         true,
 													ForceNew:         true,
 													Computed:         true,
-													DiffSuppressFunc: KmsKeyNameDiffSuppress,
+													DiffSuppressFunc: tpgresource.CompareCryptoKeyVersions,
 													Description:      `The self link of the encryption key that is stored in Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
 												},
 
@@ -450,7 +443,7 @@ func ResourceComputeInstance() *schema.Resource {
 													Optional:         true,
 													ForceNew:         true,
 													Computed:         true,
-													DiffSuppressFunc: KmsKeyNameDiffSuppress,
+													DiffSuppressFunc: tpgresource.CompareCryptoKeyVersions,
 													Description:      `The self link of the encryption key that is stored in Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key may be set.`,
 												},
 
@@ -1565,7 +1558,7 @@ be from 0 to 999,999,999 inclusive.`,
 							Type:        schema.TypeString,
 							Optional:    true,
 							ForceNew:    true,
-							DiffSuppressFunc: KmsKeyNameDiffSuppress,
+							DiffSuppressFunc: tpgresource.CompareCryptoKeyVersions,
 							Computed:    true,
 							Description: `The self link of the encryption key that is stored in Google Cloud KMS.`,
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3639,7 +3639,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			// the diff won't be properly suppressed. See DiffSuppressFunc for this field.
 			"image":  diskDetails.SourceImage,
 			"source_image_encryption_key":    d.Get("boot_disk.0.initialize_params.0.source_image_encryption_key"),
-			"snapshot":                       diskDetails.SourceSnapshot,
+			"snapshot":                       d.Get("boot_disk.0.initialize_params.0.snapshot"),
 			"source_snapshot_encryption_key": d.Get("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"),
 			"architecture": diskDetails.Architecture,
 			"size":   diskDetails.SizeGb,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -690,6 +690,10 @@ func TestAccComputeInstance_diskEncryption(t *testing.T) {
 			RawKey: "dGhpcmQ2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
 			Sha256: "b3pvaS7BjDbCKeLPPTx7yXBuQtxyMobCHN1QJR43xeM=",
 		},
+		fmt.Sprintf("tf-testd-%s", acctest.RandString(t, 10)): {
+			RsaEncryptedKey: "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg==",
+			Sha256:          "rRMQGdop82ArhrmlouYFR0+TJJL96KPCxe2qjorh1KA=",
+		},
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -788,6 +792,218 @@ func TestAccComputeInstance_kmsDiskEncryption(t *testing.T) {
 				),
 			},
 			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
+func TestAccComputeInstance_rsaBootDiskEncryption(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context := map[string]interface{}{
+		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"rsa_encrypted_key": "ieCx/NcW06PcT7Ep1X6LUTc/hLvUDYyzSZPPVCVPTVEohpeHASqC8uw5TzyO9U+Fka9JFHz0mBibXUInrC/jEk014kCK/NPjYgEMOyssZ4ZINPKxlUh2zn1bV+MCaTICrdmuSBTWlUUiFoDD6PYznLwh8ZNdaheCeZ8ewEXgFQ8V+sDroLaN3Xs3MDTXQEMMoNUXMCZEIpg9Vtp9x2oeQ5lAbtt7bYAAHf5l+gJWw3sUfs0/Glw5fpdjT8Uggrr+RMZezGrltJEF293rvTIjWOEB3z5OHyHwQkvdrPDFcTqsLfh+8Hr8g+mf+7zVPEC8nEbqpdl3GPv3A7AwpFp7MA==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_rsaBootDiskEncryption(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_instanceEncryption(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	kms := acctest.BootstrapKMSKey(t)
+
+	context_1 := map[string]interface{}{
+		"instance_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"encryption_key": kms.CryptoKey.Name,
+		"desired_status": "RUNNING",
+	}
+
+	context_2 := map[string]interface{}{
+		"instance_name":  context_1["instance_name"],
+		"encryption_key": context_1["encryption_key"],
+		"desired_status": "TERMINATED",
+	}
+
+	context_3 := map[string]interface{}{
+		"instance_name":  context_1["instance_name"],
+		"encryption_key": context_1["encryption_key"],
+		"desired_status": "RUNNING",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context_3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context_1 := map[string]interface{}{
+		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_guestOsFeatures(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.2", "GVNIC"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.3", "IDPF"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_snapshot(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+
+	context := map[string]interface{}{
+		"instance_name1": fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"instance_name2": fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"snapshot_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_snapshot_init(context), //set up snapshot
+			},
+			{
+				Config: testAccComputeInstance_snapshot(context), //create from snapshot
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_snapshotEncryption(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	kms := acctest.BootstrapKMSKey(t)
+	context := map[string]interface{}{
+		"instance_name1":    fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"instance_name2":    fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"snapshot_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"kms_key":           kms.CryptoKey.Name,
+		"raw_key":           "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
+		"rsa_encrypted_key": "ieCx/NcW06PcT7Ep1X6LUTc/hLvUDYyzSZPPVCVPTVEohpeHASqC8uw5TzyO9U+Fka9JFHz0mBibXUInrC/jEk014kCK/NPjYgEMOyssZ4ZINPKxlUh2zn1bV+MCaTICrdmuSBTWlUUiFoDD6PYznLwh8ZNdaheCeZ8ewEXgFQ8V+sDroLaN3Xs3MDTXQEMMoNUXMCZEIpg9Vtp9x2oeQ5lAbtt7bYAAHf5l+gJWw3sUfs0/Glw5fpdjT8Uggrr+RMZezGrltJEF293rvTIjWOEB3z5OHyHwQkvdrPDFcTqsLfh+8Hr8g+mf+7zVPEC8nEbqpdl3GPv3A7AwpFp7MA==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_snapshotEncryption_KMS(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_snapshotEncryption_RawKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_snapshotEncryption_RsaKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_imageEncryption(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	kms := acctest.BootstrapKMSKey(t)
+	context := map[string]interface{}{
+		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"image_name":        fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"disk_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"kms_key":           kms.CryptoKey.Name,
+		"raw_key":           "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
+		"rsa_encrypted_key": "ieCx/NcW06PcT7Ep1X6LUTc/hLvUDYyzSZPPVCVPTVEohpeHASqC8uw5TzyO9U+Fka9JFHz0mBibXUInrC/jEk014kCK/NPjYgEMOyssZ4ZINPKxlUh2zn1bV+MCaTICrdmuSBTWlUUiFoDD6PYznLwh8ZNdaheCeZ8ewEXgFQ8V+sDroLaN3Xs3MDTXQEMMoNUXMCZEIpg9Vtp9x2oeQ5lAbtt7bYAAHf5l+gJWw3sUfs0/Glw5fpdjT8Uggrr+RMZezGrltJEF293rvTIjWOEB3z5OHyHwQkvdrPDFcTqsLfh+8Hr8g+mf+7zVPEC8nEbqpdl3GPv3A7AwpFp7MA==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_imageEncryption_KMS(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_imageEncryption_RawKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_imageEncryption_RsaKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
 		},
 	})
 }
@@ -6541,6 +6757,17 @@ resource "google_compute_disk" "foobar4" {
   zone = "us-central1-a"
 }
 
+resource "google_compute_disk" "foobar5" {
+  name = "%s"
+  size = 10
+  type = "pd-ssd"
+  zone = "us-central1-a"
+
+  disk_encryption_key {
+	rsa_encrypted_key = "%s"
+  }
+}
+
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
@@ -6568,6 +6795,12 @@ resource "google_compute_instance" "foobar" {
   }
 
   attached_disk {
+	source                  = google_compute_disk.foobar5.self_link
+	disk_encryption_key_rsa = "%s"
+	disk_encryption_service_account = data.google_compute_default_service_account.default.email
+  }
+
+  attached_disk {
     source                  = google_compute_disk.foobar3.self_link
     disk_encryption_key_raw = "%s"
   }
@@ -6582,12 +6815,16 @@ resource "google_compute_instance" "foobar" {
 
   allow_stopping_for_update = true
 }
+
+data "google_compute_default_service_account" "default" {
+}
 `, diskNames[0], diskNameToEncryptionKey[diskNames[0]].RawKey,
 		diskNames[1], diskNameToEncryptionKey[diskNames[1]].RawKey,
 		diskNames[2], diskNameToEncryptionKey[diskNames[2]].RawKey,
+		diskNames[3], diskNameToEncryptionKey[diskNames[3]].RsaEncryptedKey,
 		"tf-testd-"+suffix,
 		instance, bootEncryptionKey,
-		diskNameToEncryptionKey[diskNames[0]].RawKey, diskNameToEncryptionKey[diskNames[1]].RawKey, diskNameToEncryptionKey[diskNames[2]].RawKey)
+		diskNameToEncryptionKey[diskNames[0]].RawKey, diskNameToEncryptionKey[diskNames[1]].RawKey, diskNameToEncryptionKey[diskNames[2]].RawKey, diskNameToEncryptionKey[diskNames[3]].RsaEncryptedKey)
 }
 
 func testAccComputeInstance_disks_encryption_restart(bootEncryptionKey string, diskNameToEncryptionKey map[string]*compute.CustomerEncryptionKey, instance string) string {
@@ -11897,6 +12134,476 @@ resource "google_compute_instance" "foobar" {
 			network_tier = "PREMIUM"
 	  	}
 	}
+}
+`, context)
+}
+
+func testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+	instance_encryption_key {
+		kms_key_self_link       = "%{encryption_key}"
+		kms_key_service_account = data.google_compute_default_service_account.default.email
+	}
+	desired_status = "%{desired_status}"
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeInstance_guestOsFeatures(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		guest_os_features = %{guest_os_features}
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}`, context)
+}
+
+func testAccComputeInstance_snapshot_init(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name1}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+resource "google_compute_snapshot" "foobar" {
+	name = "%{snapshot_name}"
+	source_disk = google_compute_instance.foobar.name
+	zone = google_compute_instance.foobar.zone
+}
+`, context)
+}
+
+func testAccComputeInstance_snapshot(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name1}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+resource "google_compute_snapshot" "foobar" {
+	name = "%{snapshot_name}"
+	source_disk = google_compute_instance.foobar.name
+	zone = google_compute_instance.foobar.zone
+}
+
+resource "google_compute_instance" "foobar2" {
+	name         = "%{instance_name2}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			snapshot = google_compute_snapshot.foobar.name
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, context)
+}
+
+func testAccComputeInstance_snapshotEncryption_KMS(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name1}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+resource "google_compute_snapshot" "foobar" {
+	name = "%{snapshot_name}"
+	source_disk = google_compute_instance.foobar.name
+	snapshot_encryption_key {
+		kms_key_self_link = "%{kms_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar2" {
+	name         = "%{instance_name2}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			snapshot = google_compute_snapshot.foobar.name
+			source_snapshot_encryption_key {
+				kms_key_self_link = "%{kms_key}"
+				kms_key_service_account = data.google_compute_default_service_account.default.email
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeInstance_snapshotEncryption_RawKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name1}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		disk_encryption_key_raw = "%{raw_key}"
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+resource "google_compute_snapshot" "foobar" {
+	name = "%{snapshot_name}"
+	source_disk = google_compute_instance.foobar.name
+	source_disk_encryption_key {
+		raw_key = "%{raw_key}"
+	}
+	snapshot_encryption_key {
+		raw_key = "%{raw_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar2" {
+	name         = "%{instance_name2}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			snapshot = google_compute_snapshot.foobar.name
+			source_snapshot_encryption_key {
+				raw_key = "%{raw_key}"
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, context)
+}
+
+func testAccComputeInstance_snapshotEncryption_RsaKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name1}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		disk_encryption_key_raw = "%{raw_key}"
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+resource "google_compute_snapshot" "foobar" {
+	name = "%{snapshot_name}"
+	source_disk = google_compute_instance.foobar.name
+	source_disk_encryption_key {
+		raw_key = "%{raw_key}"
+	}
+	snapshot_encryption_key {
+		rsa_encrypted_key = "%{rsa_encrypted_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar2" {
+	name         = "%{instance_name2}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			snapshot = google_compute_snapshot.foobar.name
+			source_snapshot_encryption_key {
+				rsa_encrypted_key = "%{rsa_encrypted_key}"
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+`, context)
+}
+
+func testAccComputeInstance_imageEncryption_KMS(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "%{disk_name}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+}
+
+resource "google_compute_image" "foobar" {
+	name        = "%{image_name}"
+	source_disk = google_compute_disk.foobar.self_link
+	image_encryption_key {
+		kms_key_self_link = "%{kms_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = google_compute_image.foobar.self_link
+			source_image_encryption_key {
+				kms_key_self_link = "%{kms_key}"
+				kms_key_service_account = data.google_compute_default_service_account.default.email
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeInstance_imageEncryption_RawKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "%{disk_name}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+}
+
+resource "google_compute_image" "foobar" {
+	name        = "%{image_name}"
+	source_disk = google_compute_disk.foobar.self_link
+	image_encryption_key {
+		raw_key = "%{raw_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = google_compute_image.foobar.self_link
+			source_image_encryption_key {
+				raw_key = "%{raw_key}"
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, context)
+}
+
+func testAccComputeInstance_imageEncryption_RsaKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "%{disk_name}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+}
+
+resource "google_compute_image" "foobar" {
+	name        = "%{image_name}"
+	source_disk = google_compute_disk.foobar.self_link
+	image_encryption_key {
+		rsa_encrypted_key = "%{rsa_encrypted_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = google_compute_image.foobar.self_link
+			source_image_encryption_key {
+				rsa_encrypted_key = "%{rsa_encrypted_key}"
+			}
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, context)
+}
+
+func testAccComputeInstance_rsaBootDiskEncryption(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone = "us-central1-a"
+
+	boot_disk {
+		device_name = "my-boot-disk"
+		disk_encryption_key_rsa = "%{rsa_encrypted_key}"
+		disk_encryption_service_account = data.google_compute_default_service_account.default.email
+		initialize_params {
+			architecture = "X86_64"
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+data "google_compute_default_service_account" "default" {
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -977,6 +977,31 @@ func TestAccComputeInstance_imageEncryption(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_attachedDisk_RSAencryption(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context := map[string]interface{}{
+		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"disk_name":         fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"rsa_encrypted_key": "ieCx/NcW06PcT7Ep1X6LUTc/hLvUDYyzSZPPVCVPTVEohpeHASqC8uw5TzyO9U+Fka9JFHz0mBibXUInrC/jEk014kCK/NPjYgEMOyssZ4ZINPKxlUh2zn1bV+MCaTICrdmuSBTWlUUiFoDD6PYznLwh8ZNdaheCeZ8ewEXgFQ8V+sDroLaN3Xs3MDTXQEMMoNUXMCZEIpg9Vtp9x2oeQ5lAbtt7bYAAHf5l+gJWw3sUfs0/Glw5fpdjT8Uggrr+RMZezGrltJEF293rvTIjWOEB3z5OHyHwQkvdrPDFcTqsLfh+8Hr8g+mf+7zVPEC8nEbqpdl3GPv3A7AwpFp7MA==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_attachedDisk_RSAencryption(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_resourcePolicyUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -12518,6 +12543,51 @@ resource "google_compute_instance" "foobar" {
 		initialize_params {
 			image = data.google_compute_image.my_image.self_link
 		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeInstance_attachedDisk_RSAencryption(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+	name = "%{disk_name}"
+	size = 10
+	type = "pd-ssd"
+	zone = "us-central1-a"
+
+	disk_encryption_key {
+		rsa_encrypted_key = "%{rsa_encrypted_key}"
+	}
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	attached_disk {
+		source = google_compute_disk.foobar.self_link
+		disk_encryption_key_rsa = "%{rsa_encrypted_key}"
+		disk_encryption_service_account = data.google_compute_default_service_account.default.email
 	}
 
 	network_interface {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -690,10 +690,6 @@ func TestAccComputeInstance_diskEncryption(t *testing.T) {
 			RawKey: "dGhpcmQ2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
 			Sha256: "b3pvaS7BjDbCKeLPPTx7yXBuQtxyMobCHN1QJR43xeM=",
 		},
-		fmt.Sprintf("tf-testd-%s", acctest.RandString(t, 10)): {
-			RsaEncryptedKey: "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg==",
-			Sha256:          "rRMQGdop82ArhrmlouYFR0+TJJL96KPCxe2qjorh1KA=",
-		},
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -865,33 +861,6 @@ func TestAccComputeInstance_instanceEncryption(t *testing.T) {
 				Config: testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context_3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
-				),
-			},
-		},
-	})
-}
-
-func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
-	t.Parallel()
-
-	var instance compute.Instance
-	context_1 := map[string]interface{}{
-		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
-		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeInstance_guestOsFeatures(context_1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.2", "GVNIC"),
-					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.3", "IDPF"),
 				),
 			},
 		},
@@ -6757,17 +6726,6 @@ resource "google_compute_disk" "foobar4" {
   zone = "us-central1-a"
 }
 
-resource "google_compute_disk" "foobar5" {
-  name = "%s"
-  size = 10
-  type = "pd-ssd"
-  zone = "us-central1-a"
-
-  disk_encryption_key {
-	rsa_encrypted_key = "%s"
-  }
-}
-
 resource "google_compute_instance" "foobar" {
   name         = "%s"
   machine_type = "e2-medium"
@@ -6795,12 +6753,6 @@ resource "google_compute_instance" "foobar" {
   }
 
   attached_disk {
-	source                  = google_compute_disk.foobar5.self_link
-	disk_encryption_key_rsa = "%s"
-	disk_encryption_service_account = data.google_compute_default_service_account.default.email
-  }
-
-  attached_disk {
     source                  = google_compute_disk.foobar3.self_link
     disk_encryption_key_raw = "%s"
   }
@@ -6821,10 +6773,9 @@ data "google_compute_default_service_account" "default" {
 `, diskNames[0], diskNameToEncryptionKey[diskNames[0]].RawKey,
 		diskNames[1], diskNameToEncryptionKey[diskNames[1]].RawKey,
 		diskNames[2], diskNameToEncryptionKey[diskNames[2]].RawKey,
-		diskNames[3], diskNameToEncryptionKey[diskNames[3]].RsaEncryptedKey,
 		"tf-testd-"+suffix,
 		instance, bootEncryptionKey,
-		diskNameToEncryptionKey[diskNames[0]].RawKey, diskNameToEncryptionKey[diskNames[1]].RawKey, diskNameToEncryptionKey[diskNames[2]].RawKey, diskNameToEncryptionKey[diskNames[3]].RsaEncryptedKey)
+		diskNameToEncryptionKey[diskNames[0]].RawKey, diskNameToEncryptionKey[diskNames[1]].RawKey, diskNameToEncryptionKey[diskNames[2]].RawKey)
 }
 
 func testAccComputeInstance_disks_encryption_restart(bootEncryptionKey string, diskNameToEncryptionKey map[string]*compute.CustomerEncryptionKey, instance string) string {
@@ -12171,31 +12122,6 @@ data "google_compute_default_service_account" "default" {
 `, context)
 }
 
-func testAccComputeInstance_guestOsFeatures(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-data "google_compute_image" "my_image" {
-	family  = "debian-11"
-	project = "debian-cloud"
-}
-
-resource "google_compute_instance" "foobar" {
-	name         = "%{instance_name}"
-	machine_type = "e2-medium"
-	zone         = "us-central1-a"
-
-	boot_disk {
-		guest_os_features = %{guest_os_features}
-		initialize_params {
-			image = data.google_compute_image.my_image.self_link
-		}
-	}
-
-	network_interface {
-		network = "default"
-	}
-}`, context)
-}
-
 func testAccComputeInstance_snapshot_init(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_compute_image" "my_image" {
@@ -12593,7 +12519,6 @@ resource "google_compute_instance" "foobar" {
 		disk_encryption_key_rsa = "%{rsa_encrypted_key}"
 		disk_encryption_service_account = data.google_compute_default_service_account.default.email
 		initialize_params {
-			architecture = "X86_64"
 			image = data.google_compute_image.my_image.self_link
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -12113,6 +12113,22 @@ resource "google_compute_instance" "foobar" {
 
 func testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_compute_default_service_account" "default" {}
+
+data "google_project" "default" {}
+
+resource "google_project_iam_member" "default-service-agent" {
+	project = data.google_project.default.project_id
+	role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+	member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
+}
+
+resource "google_project_iam_member" "default-service-account" {
+	project = data.google_project.default.project_id
+	role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+	member  = "serviceAccount:${data.google_project.default.number}-compute@developer.gserviceaccount.com"
+}
+
 data "google_compute_image" "my_image" {
 	family  = "debian-11"
 	project = "debian-cloud"
@@ -12137,9 +12153,8 @@ resource "google_compute_instance" "foobar" {
 		kms_key_service_account = data.google_compute_default_service_account.default.email
 	}
 	desired_status = "%{desired_status}"
-}
 
-data "google_compute_default_service_account" "default" {
+	depends_on = [google_project_iam_member.default-service-agent, google_project_iam_member.default-service-account]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -6767,9 +6767,6 @@ resource "google_compute_instance" "foobar" {
 
   allow_stopping_for_update = true
 }
-
-data "google_compute_default_service_account" "default" {
-}
 `, diskNames[0], diskNameToEncryptionKey[diskNames[0]].RawKey,
 		diskNames[1], diskNameToEncryptionKey[diskNames[1]].RawKey,
 		diskNames[2], diskNameToEncryptionKey[diskNames[2]].RawKey,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -840,6 +840,17 @@ func TestAccComputeInstance_instanceEncryption(t *testing.T) {
 		"desired_status": "RUNNING",
 	}
 
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:{project_number}-compute@developer.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -12115,20 +12126,6 @@ func testAccComputeInstance_instanceEncryption_SelfLinkServiceAccount(context ma
 	return acctest.Nprintf(`
 data "google_compute_default_service_account" "default" {}
 
-data "google_project" "default" {}
-
-resource "google_project_iam_member" "default-service-agent" {
-	project = data.google_project.default.project_id
-	role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	member  = "serviceAccount:${data.google_compute_default_service_account.default.email}"
-}
-
-resource "google_project_iam_member" "default-service-account" {
-	project = data.google_project.default.project_id
-	role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	member  = "serviceAccount:${data.google_project.default.number}-compute@developer.gserviceaccount.com"
-}
-
 data "google_compute_image" "my_image" {
 	family  = "debian-11"
 	project = "debian-cloud"
@@ -12153,8 +12150,6 @@ resource "google_compute_instance" "foobar" {
 		kms_key_service_account = data.google_compute_default_service_account.default.email
 	}
 	desired_status = "%{desired_status}"
-
-	depends_on = [google_project_iam_member.default-service-agent, google_project_iam_member.default-service-account]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/tpgresource/field_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/field_helpers.go
@@ -102,6 +102,10 @@ func ParseNetworkEndpointGroupRegionalFieldValue(networkEndpointGroup string, d 
 	return ParseRegionalFieldValue("networkEndpointGroups", networkEndpointGroup, "project", "region", "zone", d, config, false)
 }
 
+func ParseSnapshotFieldValue(snapshot string, d TerraformResourceData, config *transport_tpg.Config) (*GlobalFieldValue, error) {
+	return ParseGlobalFieldValue("snapshots", snapshot, "project", d, config, false)
+}
+
 // ------------------------------------------------------------
 // Base helpers used to create helpers for specific fields.
 // ------------------------------------------------------------

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -252,6 +252,8 @@ is desired, you will need to modify your state file manually using
 
 * `key_revocation_action_type` - (optional) Action to be taken when a customer's encryption key is revoked. Supports `STOP` and `NONE`, with `NONE` being the default.
 
+* `instance_encryption_key` - (optional) Configuration for data encryption on the instance with encryption keys. Structure is [documented below](#nested_instance_encryption_key`).
+
 ---
 
 <a name="nested_boot_disk"></a>The `boot_disk` block supports:
@@ -270,12 +272,18 @@ is desired, you will need to modify your state file manually using
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
-    to encrypt this disk. Only one of `kms_key_self_link` and `disk_encryption_key_raw`
+    to encrypt this disk. Only one of `kms_key_self_link`, `disk_encryption_key_rsa` and `disk_encryption_key_raw`
     may be set.
 
+* `disk_encryption_key_rsa` - (Optional) Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) to encrypt this disk. Only one of `kms_key_self_link`, `disk_encryption_key_rsa` and `disk_encryption_key_raw`
+
 * `kms_key_self_link` - (Optional) The self_link of the encryption key that is
-    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`
-    and `disk_encryption_key_raw` may be set.
+    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`,
+    `disk_encryption_key_rsa` and `disk_encryption_key_raw`
+    may be set.
+
+* `disk_encryption_service_account` - (Optional) The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
 
 * `initialize_params` - (Optional) Parameters for a new disk that will be created
     alongside the new instance. Either `initialize_params` or `source` must be set.
@@ -304,6 +312,12 @@ is desired, you will need to modify your state file manually using
 
 * `labels` - (Optional) A set of key/value label pairs assigned to the disk. This
     field is only applicable for persistent disks.
+
+* `source_image_encryption_key` - (Optional) Encryption key used to decrypt the given image. Structure is [documented below](#nested_source_image_encryption_key).
+
+* `snapshot` - (Optional) The snapshot from which to initialize this disk. To create a disk with a snapshot that you created, specify the snapshot name in the following format: `global/snapshots/my-backup`
+
+* `source_snapshot_encryption_key` - (Optional) Encryption key used to decrypt the given snapshot. Structure is [documented below](#nested_source_snapshot_ecryption_key).
 
 * `architecture` - (Optional) The architecture of the attached disk. Valid values are `ARM64` or `x86_64`.
 
@@ -356,11 +370,54 @@ is desired, you will need to modify your state file manually using
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
-    to encrypt this disk. Only one of `kms_key_self_link` and `disk_encryption_key_raw` may be set.
+    to encrypt this disk. Only one of `kms_key_self_link`, `disk_encryption_key_rsa` and `disk_encryption_key_raw`
+    may be set.
+
+* `disk_encryption_key_rsa` - (Optional) Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) to encrypt this disk. Only one of `kms_key_self_link`, `disk_encryption_key_rsa` and `disk_encryption_key_raw`
+    may be set.
 
 * `kms_key_self_link` - (Optional) The self_link of the encryption key that is
-    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`
-    and `disk_encryption_key_raw` may be set.
+    stored in Google Cloud KMS to encrypt this disk. Only one of `kms_key_self_link`, `disk_encryption_key_rsa` and `disk_encryption_key_raw`
+    may be set.
+
+* `disk_encryption_service_account` - (Optional) The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
+
+<a name="nested_source_image_encryption_key"></a>The `source_snapshot_encryption_key` block supports:
+
+* `raw_key` - (Optional)  A 256-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
+    encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    to decrypt the given image. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `rsa_encrypted_key` - (Optional) Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) to decrypt the given image. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `kms_key_self_link` - (Optional) The self_link of the encryption key that is
+    stored in Google Cloud KMS to decrypt the given image. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `kms_key_service_account` - (Optional) The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
+
+<a name="nested_source_snapshot_encryption_key"></a>The `source_snapshot_encryption_key` block supports:
+
+* `raw_key` - (Optional) A 256-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
+    encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    to decrypt the given snapshot. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `rsa_encrypted_key` - (Optional) Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) to decrypt the given snapshot. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `kms_key_self_link` - (Optional) The self_link of the encryption key that is
+    stored in Google Cloud KMS to decrypt the given image. Only one of `kms_key_self_link`, `rsa_encrypted_key` and `raw_key`
+    may be set.
+
+* `kms_key_service_account` - (Optional) The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
 
 <a name="nested_network_performance_config"></a>The `network_performance_config` block supports:
 
@@ -467,6 +524,13 @@ specified, then this instance will have no external IPv6 Internet access. Struct
     short names are supported. To allow full access to all Cloud APIs, use the
     `cloud-platform` scope. See a complete list of scopes [here](https://cloud.google.com/sdk/gcloud/reference/alpha/compute/instances/set-scopes#--scopes).
     **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true or your instance must have a `desired_status` of `TERMINATED` in order to update this field.
+
+<a name="nested_instance_encryption_key"></a>The `instance_encryption_key` block supports:
+
+* `kms_key_self_link` - (Optional) The self_link of the encryption key that is
+    stored in Google Cloud KMS to encrypt the data on this instance.
+
+* `kms_key_service_account` - (Optional) The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
 
 <a name="nested_scheduling"></a>The `scheduling` block supports:
 
@@ -654,6 +718,14 @@ This field is always inherited from its subnetwork.
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
 
 * `boot_disk.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    encoded SHA-256 hash of the [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
+
+* `boot_disk.initialize_params.source_image_encryption_key.sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    encoded SHA-256 hash of the [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
+
+* `boot_disk.initialize_params.source_snapshot_encryption_key.sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     encoded SHA-256 hash of the [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.
 

--- a/mmv1/third_party/tgc/tfdata/fake_resource_data_test.go
+++ b/mmv1/third_party/tgc/tfdata/fake_resource_data_test.go
@@ -319,12 +319,14 @@ func TestFakeResourceData_getOknsetTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "",
-		"mode":                       "",
-		"source":                     "",
+		"device_name":                     "",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "",
+		"mode":                            "",
+		"source":                          "",
 	}, res)
 	assert.False(t, ok)
 }

--- a/mmv1/third_party/tgc/tfdata/fake_resource_data_test.go
+++ b/mmv1/third_party/tgc/tfdata/fake_resource_data_test.go
@@ -170,11 +170,13 @@ func TestFakeResourceData_getOkTypeObject(t *testing.T) {
 		"allow_stopping_for_update": nil,
 		"attached_disk": []interface{}{
 			map[string]interface{}{
-				"device_name":             "test-device_name",
-				"disk_encryption_key_raw": nil,
-				"kms_key_self_link":       "test-kms_key_self_link",
-				"mode":                    "READ_ONLY",
-				"source":                  "test-source",
+				"device_name":                     "test-device_name",
+				"disk_encryption_key_raw":         nil,
+				"disk_encryption_key_rsa":         nil,
+				"kms_key_self_link":               "test-kms_key_self_link",
+				"disk_encryption_service_account": nil,
+				"mode":                            "READ_ONLY",
+				"source":                          "test-source",
 			},
 			map[string]interface{}{
 				"disk_encryption_key_raw": nil,
@@ -240,12 +242,14 @@ func TestFakeResourceData_getOkTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "test-device_name",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "test-kms_key_self_link",
-		"mode":                       "READ_ONLY",
-		"source":                     "test-source",
+		"device_name":                     "test-device_name",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "test-kms_key_self_link",
+		"mode":                            "READ_ONLY",
+		"source":                          "test-source",
 	}, res)
 	assert.True(t, ok)
 }

--- a/mmv1/third_party/tgc_next/tfplan2cai/models/fake_resource_data_with_meta_test.go
+++ b/mmv1/third_party/tgc_next/tfplan2cai/models/fake_resource_data_with_meta_test.go
@@ -337,12 +337,14 @@ func TestFakeResourceDataWithMeta_getOknsetTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "",
-		"mode":                       "",
-		"source":                     "",
+		"device_name":                     "",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "",
+		"mode":                            "",
+		"source":                          "",
 	}, res)
 	assert.False(t, ok)
 }

--- a/mmv1/third_party/tgc_next/tfplan2cai/models/fake_resource_data_with_meta_test.go
+++ b/mmv1/third_party/tgc_next/tfplan2cai/models/fake_resource_data_with_meta_test.go
@@ -184,11 +184,13 @@ func TestFakeResourceDataWithMeta_getOkTypeObject(t *testing.T) {
 		"allow_stopping_for_update": nil,
 		"attached_disk": []interface{}{
 			map[string]interface{}{
-				"device_name":             "test-device_name",
-				"disk_encryption_key_raw": nil,
-				"kms_key_self_link":       "test-kms_key_self_link",
-				"mode":                    "READ_ONLY",
-				"source":                  "test-source",
+				"device_name":                     "test-device_name",
+				"disk_encryption_key_raw":         nil,
+				"disk_encryption_key_rsa":         nil,
+				"kms_key_self_link":               "test-kms_key_self_link",
+				"disk_encryption_service_account": nil,
+				"mode":                            "READ_ONLY",
+				"source":                          "test-source",
 			},
 			map[string]interface{}{
 				"disk_encryption_key_raw": nil,
@@ -256,12 +258,14 @@ func TestFakeResourceDataWithMeta_getOkTypeObject(t *testing.T) {
 	)
 	res, ok := d.GetOk("attached_disk.0")
 	assert.Equal(t, map[string]interface{}{
-		"device_name":                "test-device_name",
-		"disk_encryption_key_raw":    "",
-		"disk_encryption_key_sha256": "",
-		"kms_key_self_link":          "test-kms_key_self_link",
-		"mode":                       "READ_ONLY",
-		"source":                     "test-source",
+		"device_name":                     "test-device_name",
+		"disk_encryption_key_raw":         "",
+		"disk_encryption_key_sha256":      "",
+		"disk_encryption_key_rsa":         "",
+		"disk_encryption_service_account": "",
+		"kms_key_self_link":               "test-kms_key_self_link",
+		"mode":                            "READ_ONLY",
+		"source":                          "test-source",
 	}, res)
 	assert.True(t, ok)
 }


### PR DESCRIPTION
@roaks3 

This one is the most important. It blocks me from pushing the Snapshot and Image feature gap

related to https://github.com/GoogleCloudPlatform/magic-modules/pull/13147

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added several `boot_disk`, `attached_disk`, and `instance_encryption_key` fields for improved encryption key support in `google_compute_instance` and template resources
```

```release-note:enhancement
compute: added support for `image_encryption_key.raw_key` and ` image_encryption_key.rsa_encrypted_key` to `google_compute_image` resource
```

```release-note:enhancement
compute: added support for `snapshot_encryption_key.rsa_encrypted_key` to `google_compute_snapshot` resource
```
