### PR TITLE
Add disk related fields to google_compute_instance

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1026,6 +1026,34 @@ func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config 
 	}, nil
 }
 
+func flattenComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
+	if v == nil {
+		return nil
+	}
+	features, ok := v.([]*compute.GuestOsFeature)
+	if !ok {
+		return nil
+	}
+	var result []interface{}
+	for _, feature := range features {
+		if feature != nil && feature.Type != "" {
+			result = append(result, feature.Type)
+		}
+	}
+	return result
+}
+
+func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeature {
+	if v == nil {
+		return nil
+	}
+	var result []*compute.GuestOsFeature
+	for _, feature := range v.([]interface{}) {
+		result = append(result, &compute.GuestOsFeature{Type: feature.(string)})
+	}
+	return result
+}
+
 func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[string]interface{} {
 	if c == nil {
 		return nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -64,6 +64,7 @@ var (
 	}
 
 	bootDiskKeys = []string{
+		"boot_disk.0.guest_os_features",
 		"boot_disk.0.auto_delete",
 		"boot_disk.0.device_name",
 		"boot_disk.0.disk_encryption_key_raw",
@@ -84,6 +85,7 @@ var (
 		"boot_disk.0.initialize_params.0.enable_confidential_compute",
 		"boot_disk.0.initialize_params.0.storage_pool",
 		"boot_disk.0.initialize_params.0.resource_policies",
+		"boot_disk.0.initialize_params.0.architecture",
 	}
 
 	schedulingKeys = []string{
@@ -266,6 +268,18 @@ func ResourceComputeInstance() *schema.Resource {
 							Description:      `The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk. Only one of kms_key_self_link and disk_encryption_key_raw may be set.`,
 						},
 
+						"guest_os_features": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							AtLeastOneOf: bootDiskKeys,
+							ForceNew:     true,
+							Computed:     true,
+							Description:  `A list of features to enable on the guest operating system. Applicable only for bootable images.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+
 						"initialize_params": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -367,6 +381,16 @@ func ResourceComputeInstance() *schema.Resource {
 										ForceNew:         true,
 										DiffSuppressFunc: tpgresource.CompareResourceNames,
 										Description:      `The URL of the storage pool in which the new disk is created`,
+									},
+
+									"architecture": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Computed:     true,
+										ForceNew:     true,
+										AtLeastOneOf: initializeParamsKeys,
+										ValidateFunc: validation.StringInSlice([]string{"X86_64", "ARM64"}, false),
+										Description:  `The architecture of the disk. One of "X86_64" or "ARM64".`,
 									},
 								},
 							},
@@ -3199,6 +3223,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		disk.Interface = v.(string)
 	}
 
+	if v, ok := d.GetOk("boot_disk.0.guest_os_features"); ok {
+		disk.GuestOsFeatures = expandComputeInstanceGuestOsFeatures(v)
+	}
+
 	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_raw"); ok {
 		if v != "" {
 			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{
@@ -3288,6 +3316,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 			}
 			disk.InitializeParams.StoragePool = storagePoolUrl.(string)
 		}
+
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.architecture"); ok {
+			disk.InitializeParams.Architecture = v.(string)
+		}
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.mode"); ok {
@@ -3303,6 +3335,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 		"device_name": disk.DeviceName,
 		"mode":        disk.Mode,
 		"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
+		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(disk.GuestOsFeatures),
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
 		// originally specified to avoid diffs.
 		"disk_encryption_key_raw": d.Get("boot_disk.0.disk_encryption_key_raw"),
@@ -3334,6 +3367,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			// If the config specifies a family name that doesn't match the image name, then
 			// the diff won't be properly suppressed. See DiffSuppressFunc for this field.
 			"image":  diskDetails.SourceImage,
+			"architecture": diskDetails.Architecture,
 			"size":   diskDetails.SizeGb,
 			"labels": diskDetails.Labels,
 			"resource_manager_tags": d.Get("boot_disk.0.initialize_params.0.resource_manager_tags"),
@@ -3343,6 +3377,11 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
 			"storage_pool": tpgresource.GetResourceNameFromSelfLink(diskDetails.StoragePool),
 		{{"}}"}}
+	}
+
+	//nil until set by the user not to cause any diffs and force a new VM
+	if d.Get("boot_disk.0.guest_os_features") == "" || d.Get("boot_disk.0.guest_os_features") == nil {
+		diskDetails.GuestOsFeatures = nil
 	}
 
 	if disk.DiskEncryptionKey != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3379,11 +3379,6 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 		{{"}}"}}
 	}
 
-	//nil until set by the user not to cause any diffs and force a new VM
-	if d.Get("boot_disk.0.guest_os_features") == "" || d.Get("boot_disk.0.guest_os_features") == nil {
-		diskDetails.GuestOsFeatures = nil
-	}
-
 	if disk.DiskEncryptionKey != nil {
 		if disk.DiskEncryptionKey.Sha256 != "" {
 			result["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4554,6 +4554,33 @@ func TestAccComputeInstance_NicStackType_IPV6(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context_1 := map[string]interface{}{
+		"instance_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_guestOsFeatures(context_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.2", "GVNIC"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "boot_disk.0.guest_os_features.3", "IDPF"),
+				),
+			},
+		},
+	})
+}
+
 
 func testAccCheckComputeInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -11681,6 +11708,32 @@ resource "google_compute_instance" "foobar" {
 	key_revocation_action_type = %{key_revocation_action_type}
 }
 `, context)
+}
+
+func testAccComputeInstance_guestOsFeatures(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		guest_os_features = %{guest_os_features}
+		initialize_params {
+			architecture = "X86_64"
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+}`, context)
 }
 
 func testAccComputeInstance_nicStackTypeUpdate_ipv6(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -265,6 +265,8 @@ is desired, you will need to modify your state file manually using
 * `mode` - (Optional) The mode in which to attach this disk, either `READ_WRITE`
   or `READ_ONLY`. If not specified, the default is to attach the disk in `READ_WRITE` mode.
 
+* `guest_os_features` - (optional) A list of features to enable on the guest operating system. Applicable only for bootable images. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
+
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
@@ -302,6 +304,8 @@ is desired, you will need to modify your state file manually using
 
 * `labels` - (Optional) A set of key/value label pairs assigned to the disk. This
     field is only applicable for persistent disks.
+
+* `architecture` - (Optional) The architecture of the attached disk. Valid values are `ARM64` or `x86_64`.
 
 * `resource_manager_tags` - (Optional) A tag is a key-value pair that can be attached to a Google Cloud resource. You can use tags to conditionally allow or deny policies based on whether a resource has a specific tag. This value is not returned by the API. In Terraform, this value cannot be updated and changing it will recreate the resource.
 


### PR DESCRIPTION
@roaks3 
related to https://github.com/GoogleCloudPlatform/magic-modules/pull/13147

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `architecture` and `guest_os_features` to `google_compute_instance`
```
