### PR TITLE
Adding missing fields to google_compute_snapshot

### DIFF
--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -165,13 +165,6 @@ parameters:
         ignore_read: true
         sensitive: true
         custom_flatten: 'templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.tmpl'
-      - name: 'rsaEncryptedKey'
-        type: String
-        description: |
-          Specifies an encryption key stored in Google Cloud KMS, encoded in
-          RFC 4648 base64 to either encrypt or decrypt this resource.
-        ignore_read: true
-        sensitive: true
       - name: 'sha256'
         type: String
         description: |

--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -81,13 +81,55 @@ parameters:
   - name: 'sourceDisk'
     type: ResourceRef
     description: 'A reference to the disk used to create this snapshot.'
-    required: true
     immutable: true
     # ignore_read in providers - this is only used in Create
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Disk'
     imports: 'name'
+  - name: 'sourceInstantSnapshot'
+    type: ResourceRef
+    description: |
+      The source instant snapshot used to create this snapshot
+    immutable: true
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    #custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'InstantSnapshot'
+    imports: 'name'
+  - name: 'sourceInstantSnapshotEncryptionKey'
+    type: NestedObject
+    properties:
+      - name: 'rawKey'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to decrypt the source instant snapshot.
+        ignore_read: true
+        sensitive: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.tmpl'
+      - name: 'rsaEncryptedKey'
+        type: String
+        description: |
+          Specifies an encryption key stored in Google Cloud KMS, encoded in
+          RFC 4648 base64 to decrypt the source instant snapshot.
+        ignore_read: true
+        sensitive: true
+      - name: 'sha256'
+        type: String
+        description: |
+          The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+          encryption key that protects the source instant snapshot.
+        output: true
+      - name: 'kmsKeySelfLink'
+        type: String
+        description: |
+          The name of the encryption key that is stored in Google Cloud KMS.
+        api_name: kmsKeyName
+      - name: 'kmsKeyServiceAccount'
+        type: String
+        description: |
+          The service account used for the encryption request for the given KMS key.
+          If absent, the Compute Engine Service Agent service account is used.
   - name: 'zone'
     type: ResourceRef
     description: 'A reference to the zone where the disk is hosted.'
@@ -123,6 +165,13 @@ parameters:
         ignore_read: true
         sensitive: true
         custom_flatten: 'templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.tmpl'
+      - name: 'rsaEncryptedKey'
+        type: String
+        description: |
+          Specifies an encryption key stored in Google Cloud KMS, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        ignore_read: true
+        sensitive: true
       - name: 'sha256'
         type: String
         description: |
@@ -161,6 +210,46 @@ parameters:
         description: |
           The service account used for the encryption request for the given KMS key.
           If absent, the Compute Engine Service Agent service account is used.
+  - name: 'guestOsFeatures'
+    type: Array
+    description: |
+      A list of features to enable on the guest operating system.
+      Applicable only for bootable disks.
+    is_set: true
+    default_from_api: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'type'
+          type: String
+          description: |
+            The type of supported feature. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
+          required: true
+  - name: 'architecture'
+    ignore_read: true
+    type: String
+    description: |
+      The architecture of the disk.
+    enum_values:
+      - 'X86_64'
+      - 'ARM64'
+  - name: 'snapshotType'
+    type: String
+    ignore_read: true
+    description: |
+      Indicates the type of the snapshot.
+    enum_values:
+      - 'STANDARD'
+      - 'ARCHIVE'
+  - name: 'sourceDiskForRecoveryCheckpoint'
+    type: ResourceRef
+    description: |
+      The source disk whose recovery checkpoint will be used to create this snapshot.
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    immutable: true
+    resource: 'Disk'
+    imports: 'name'
 properties:
   - name: 'creationTimestamp'
     type: Time

--- a/mmv1/third_party/terraform/services/compute/resource_compute_snapshot_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_snapshot_test.go
@@ -59,6 +59,137 @@ func TestAccComputeSnapshot_encryptionCMEK(t *testing.T) {
 	})
 }
 
+func TestAccComputeSnapshot_encryptionRSA(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]any{
+		"resource_id":       acctest.RandString(t, 10),
+		"rsa_encrypted_key": "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSnapshotDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSnapshot_encryptionRSA(context),
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+		},
+	})
+}
+
+func TestAccComputeSnapshot_instantSnapshot(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]any{
+		"resource_id":       acctest.RandString(t, 10),
+		"kms_key_self_link": acctest.BootstrapKMSKey(t).CryptoKey.Name,
+		"raw_key":           "",
+		"rsa_encrypted_key": "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg==",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSnapshotDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSnapshot_instantSnapshot(context),
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot-raw",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot-rsa",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot-kms",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+		},
+	})
+}
+
+func TestAccComputeSnapshot_guestOSFeatures(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]any{
+		"resource_id":       acctest.RandString(t, 10),
+		"guest_os_features": "",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSnapshotDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSnapshot_guestOsFeatures(context),
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+		},
+	})
+}
+
+func TestAccComputeSnapshot_snapshotType(t *testing.T) {
+	t.Parallel()
+
+	context_1 := map[string]any{
+		"resource_id":   acctest.RandString(t, 10),
+		"snapshot_type": "",
+	}
+	context_2 := map[string]any{
+		"resource_id":   context_1["resource_id"],
+		"snapshot_type": "",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSnapshotDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSnapshot_snapshotType(context_1),
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+			{
+				Config: testAccComputeSnapshot_snapshotType(context_2),
+			},
+			{
+				ResourceName:            "google_compute_snapshot.snapshot",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"architecture", "labels", "snapshot_encryption_key.0.raw_key", "snapshot_encryption_key.0.rsa_encrypted_key", "snapshot_type", "source_disk", "source_disk_encryption_key", "source_disk_for_recovery_checkpoint", "source_instant_snapshot", "source_instant_snapshot_encryption_key.0.raw_key", "source_instant_snapshot_encryption_key.0.rsa_encrypted_key", "terraform_labels", "zone"},
+			},
+		},
+	})
+}
+
 func testAccComputeSnapshot_encryption(snapshotName string, diskName string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -133,4 +264,171 @@ resource "google_compute_snapshot" "foobar" {
   }
 }
 `, diskName, kmsKeyName, diskName, kmsKeyName, snapshotName, kmsKeyName)
+}
+
+func testAccComputeSnapshot_encryptionRSA(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "tf-test-disk-%{resource_id}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  disk_encryption_key {
+    rsa_encrypted_key = "%{rsa_encrypted_key}"
+  }
+}
+
+resource "google_compute_snapshot" "foobar" {
+  name        = "%s"
+  source_disk = google_compute_disk.foobar.name
+  zone        = "us-central1-a"
+  snapshot_encryption_key {
+    rsa_encrypted_key = "%{rsa_encrypted_key}"
+  }
+
+  source_disk_encryption_key {
+    rsa_encrypted_key = "%{rsa_encrypted_key}"
+  }
+}
+`, context)
+}
+
+func testAccComputeSnapshot_instantSnapshot(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "tf-test-disk-%{resource_id}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  disk_encryption_key {
+    raw_key = "%{raw_key}"
+  }
+}
+
+resource "google_compute_instant_snapshot" "foobar-raw" {
+	name = "tf-test-isnapshot1-%{resource_id}"
+  	source_disk = "google_compute_disk.foobar.id"
+
+	instant_snapshot_encryption_key {
+		raw_key = %{raw_key}
+	}
+}
+
+resource "google_compute_instant_snapshot" "foobar-rsa" {
+	name = "tf-test-isnapshot2-%{resource_id}"
+	source_disk = "google_compute_disk.foobar.id"
+
+	instant_snapshot_encryption_key {
+		rsa_encrypted_key = %{rsa_encrypted_key}
+	}
+}
+
+resource "google_compute_instant_snapshot" "foobar-kms" {
+	name = "tf-test-isnapshot3-%{resource_id}"
+	source_disk = "google_compute_disk.foobar.id"
+
+	instant_snapshot_encryption_key {
+		kms_key_self_link = %{kms_key_self_link}
+	}
+}
+
+resource "google_compute_snapshot" "foobar-raw" {
+	name = "tf-test-snapshot1-%{resource_id}"
+	source_instant_snapshot = google_compute_instant_snapshot.foobar-raw.id
+
+	source_instant_snapshot_encryption_key {
+		raw_key = %{raw_key}
+	}
+
+	snapshot_encryption_key {
+		raw_key = %{raw_key}
+	}
+}
+
+resource "google_compute_snapshot" "foobar-rsa" {
+	name = "tf-test-snapshot2-%{resource_id}"
+	source_instant_snapshot = google_compute_instant_snapshot.foobar-rsa.id
+
+	source_instant_snapshot_encryption_key {
+		rsa_encrypted_key = %{rsa_encrypted_key}
+	}
+
+	snapshot_encryption_key {
+		rsa_encrypted_key = %{rsa_encrypted_key}
+	}
+}
+
+resource "google_compute_snapshot" "foobar-kms" {
+	name = "tf-test-snapshot3-%{resource_id}"
+	source_instant_snapshot = google_compute_instant_snapshot.foobar-kms.id
+
+	source_instant_snapshot_encryption_key {
+		kms_key_self_link = %{kms_key_self_link}
+	}
+
+	snapshot_encryption_key {
+		kms_key_self_link = %{kms_key_self_link}
+	}
+}
+`, context)
+}
+
+func testAccComputeSnapshot_snapshotType(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "tf-test-disk-%{resource_id}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "foobar" {
+  name        = "tf-test-snapshot-%{resource_id}"
+  source_disk = google_compute_disk.foobar.name
+  snapshot_type = "%{snapshot_type}"
+}
+`, context)
+}
+
+func testAccComputeSnapshot_guestOsFeatures(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "tf-test-disk-%{resource_id}"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "foobar" {
+  name        = "tf-test-snapshot-%{resource_id}"
+  source_disk = google_compute_disk.foobar.name
+
+  guest_os_features {
+	type = "%{guest_os_features}"
+  }
+`, context)
 }


### PR DESCRIPTION
Some tests will fail until `rsaEncryptedKey` from this [PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/13192) gets merged

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added fields `guest_os_features`, `snapshot_type`, `architecture`, `source_disk_for_recovery_checkpoint` and fields related to `source_instant_snapshot` into `google_compute_snapshot`
```
