### PR TITLE
Adds Datastream connection profile for Salesforce

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -143,6 +143,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       - name: 'hostname'
         type: String
@@ -185,6 +186,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       - name: 'bucket'
         type: String
@@ -206,6 +208,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       - name: 'hostname'
         type: String
@@ -289,6 +292,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       []
   - name: 'postgresqlProfile'
@@ -302,6 +306,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       - name: 'hostname'
         type: String
@@ -330,6 +335,73 @@ properties:
         description: |
           Database for the PostgreSQL connection.
         required: true
+  - name: 'salesforceProfile'
+    min_version: beta
+    type: NestedObject
+    description: |
+      Salesforce profile.
+    exactly_one_of:
+      - 'oracle_profile'
+      - 'gcs_profile'
+      - 'mysql_profile'
+      - 'bigquery_profile'
+      - 'postgresql_profile'
+      - 'sql_server_profile'
+      - 'salesforce_profile'
+    properties:
+      - name: 'domain'
+        type: String
+        description: |
+          Domain for the Salesforce Org.
+        required: true
+      - name: 'userCredentials'
+        type: NestedObject
+        description: |
+          User credentials to use for Salesforce authentication.
+        exactly_one_of:
+        - 'user_credentials'
+        - 'oauth2_client_credentials'
+        properties:
+          - name: 'username'
+            type: String
+            description: |
+              Username to use for authentication.
+          - name: 'password'
+            type: String
+            description: |
+              Password of the user.
+          - name: 'security_token'
+            type: String
+            description: |
+              Security token of the user.
+          - name: 'secret_manager_stored_password'
+            type: String
+            description: |
+              A reference to a Secret Manager resource name storing the user's password.
+          - name: 'secret_manager_stored_security_token'
+            type: String
+            description: |
+              A reference to a Secret Manager resource name storing the user's security token.
+      - name: 'oauth2ClientCredentials'
+        type: NestedObject
+        description: |
+          OAuth credentials to use for Salesforce authentication.
+        exactly_one_of:
+        - 'user_credentials'
+        - 'oauth2_client_credentials'
+        properties:
+        - name: 'client_id'
+          type: String
+          description: |
+            Client ID to use for authentication.
+        - name: 'client_secret'
+          type: String
+          description: |
+            Client secret to use for authentication.
+        - name: 'secret_manager_stored_client_secret'
+          type: String
+          description: |
+            A reference to a Secret Manager resource name storing the client secret.
   - name: 'sqlServerProfile'
     type: NestedObject
     description: |
@@ -341,6 +413,7 @@ properties:
       - 'bigquery_profile'
       - 'postgresql_profile'
       - 'sql_server_profile'
+      - 'salesforce_profile'
     properties:
       - name: 'hostname'
         type: String

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -97,6 +97,11 @@ examples:
     test_vars_overrides:
       'deletion_protection': 'false'
     exclude_test: true
+  - name: 'datastream_connection_profile_salesforce'
+    primary_resource_id: 'default'
+    vars:
+      source_connection_profile_id: 'source-profile'
+    exclude_test: true
 parameters:
   - name: 'connectionProfileId'
     type: String

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_salesforce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_salesforce.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_datastream_connection_profile" "default" {
+    display_name          = "Salesforce Source"
+    location              = "us-central1"
+    connection_profile_id = "{{index $.Vars "source_connection_profile_id"}}"
+    create_without_validation: true
+    provider = google-beta
+
+    salesforce_profile {
+        domain = "fake-domain.my.salesforce.com"
+        user_credentials {
+          username = "fake-username"
+          secret_manager_stored_password = "fake-password"
+          secret_manager_stored_security_token = "fake-token"
+        }
+    }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Adds Datastream connection profile for Salesforce.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datastream: Add support for creating connection profiles for Salesforce. (beta)

```
