### PR TITLE
Add back agentPools a resource type kind

### DIFF
--- a/mmv1/products/storagetransfer/AgentPool.yaml
+++ b/mmv1/products/storagetransfer/AgentPool.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: 'AgentPool'
+api_resource_type_kind: agentPools
 description: 'Represents an On-Premises Agent pool.'
 references:
   guides:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Similar to https://github.com/GoogleCloudPlatform/magic-modules/pull/13180, this was changed in https://github.com/GoogleCloudPlatform/magic-modules/pull/13105 to match the "types" name, but then it breaks compliance by no longer matching the "resources" name.

This is the only other name change that I found in that PR that resulted in a compliance regression, but I will be handling this issue more comprehensively as a follow-up.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
