### PR TITLE
Add tags field to Certificate Manager for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -285,3 +285,12 @@ properties:
                 address the configuration issues.
                 Not guaranteed to be stable. For programmatic access use `failure_reason` field.
               output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -132,3 +132,12 @@ properties:
               "projects/{project}/locations/{location}/caPools/{caPool}".
             required: true
             diff_suppress_func: 'tpgresource.CompareResourceNames'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -117,3 +117,12 @@ properties:
             Proxy name must be in the format projects/*/locations/*/targetSslProxies/*.
             This field is part of a union field `target_proxy`: Only one of `targetHttpsProxy` or
             `targetSslProxy` may be set.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateMapEntry.yaml
+++ b/mmv1/products/certificatemanager/CertificateMapEntry.yaml
@@ -131,3 +131,12 @@ properties:
     exactly_one_of:
       - 'hostname'
       - 'matcher'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -131,3 +131,12 @@ properties:
         description: |
           Data of the DNS Resource Record.
         output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -142,3 +142,12 @@ properties:
           description: |
             PEM certificate that is allowlisted. The certificate can be up to 5k bytes, and must be a parseable X.509 certificate.
           required: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
@@ -1,0 +1,53 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificate_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificates-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificates-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificate.certificate",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificate" "certificate" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
@@ -1,0 +1,54 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateMap_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificates-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificates-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificatemap.certificatemap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateMapTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificatemap" "certificatemap" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}
+

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemapentry_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemapentry_test.go
@@ -1,0 +1,53 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateMapEntry_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificatemapentry-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificatemapentry-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificatemapentry.certificatemapentry",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateMapEntryTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificatemapentry" "certificatemapentry" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certissuanceconfig_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certissuanceconfig_test.go
@@ -1,0 +1,53 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateIssuanceConfig_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificateissuanceconfig-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificateissuanceconfig-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateIssuanceConfigTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificateissuanceconfig.certificateissuanceconfig",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateIssuanceConfigTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificateissuanceconfig" "certificateissuanceconfig" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
@@ -65,4 +66,50 @@ resource "google_certificate_manager_dns_authorization" "default" {
   domain      = "%{random_suffix}.hashicorptest.com"
 }
 `, context)
+}
+
+func TestAccCertificateManagerDnsAuthorization_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorizationTags(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerDnsAuthorizationTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "tf-test-dns-auth%{random_suffix}"
+  description = "The default dnss"
+	labels = {
+		a = "a"
+	}
+  domain      = "%{random_suffix}.hashicorptest.com"
+`, context)
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
@@ -94,3 +94,61 @@ resource "google_certificate_manager_trust_config" "default" {
 }
 `, context)
 }
+
+func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerTrustConfig_tags(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_trust_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerTrustConfig_tags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_certificate_manager_trust_config" "default" {
+  name        = "tf-test-trust-config%{random_suffix}"
+  description = "sample description for the trust config"
+  location = "global"
+  trust_stores {
+    trust_anchors { 
+      pem_certificate = file("test-fixtures/cert.pem")
+    }
+    intermediate_cas { 
+      pem_certificate = file("test-fixtures/cert.pem")
+    }
+  }
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem") 
+  }
+  labels = {
+    "foo" = "bar"
+  }
+`, context)
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}
+


### PR DESCRIPTION
Add tags field to certificate resource to allow setting tags at creation time.

release-note:none
```
Certificate Manager: added `tags` field to `Certificate Manager Certificates, Certificate Map, Certificate Map entry, DNS Authorization, Trust Config and certificate Issuance Config` to allow setting tags for certificates at creation time
```
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```