### PR TITLE
Fixes issue #18911 for Eventarc test flakiness due to IAM races

### DIFF
--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -56,6 +56,9 @@ examples:
     exclude_docs: true
   - name: eventarc_trigger_with_channel_cmek
     primary_resource_id: primary
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
+        role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     vars:
       trigger_name: some-trigger
       service_name: some-service
@@ -63,7 +66,6 @@ examples:
       key_name: some-key
     test_env_vars:
       project_id: 'PROJECT_NAME'
-      project_number: 'PROJECT_NUMBER'
       service_account: 'SERVICE_ACCT'
     test_vars_overrides:
       'key_name': 'acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-trigger-key").CryptoKey.Name'

--- a/mmv1/templates/terraform/examples/eventarc_trigger_with_channel_cmek.tf.tmpl
+++ b/mmv1/templates/terraform/examples/eventarc_trigger_with_channel_cmek.tf.tmpl
@@ -1,15 +1,8 @@
-resource "google_kms_crypto_key_iam_member" "key_member" {
-  crypto_key_id = "{{index $.Vars "key_name"}}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-{{index $.TestEnvVars "project_number"}}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_channel" "test_channel" {
   location             = "us-central1"
   name                 = "{{index $.Vars "channel_name"}}"
   crypto_key_name      = "{{index $.Vars "key_name"}}"
   third_party_provider = "projects/{{index $.TestEnvVars "project_id"}}/locations/us-central1/providers/datadog"
-  depends_on           = [google_kms_crypto_key_iam_member.key_member]
 }
 
 resource "google_cloud_run_service" "default" {

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_google_channel_config_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_google_channel_config_test.go
@@ -38,9 +38,13 @@ func testAccEventarcGoogleChannelConfig_basic(t *testing.T) {
 		"project_number": envvar.GetTestProjectNumberFromEnv(),
 		"region":         region,
 		"random_suffix":  acctest.RandString(t, 10),
-		"key1":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key1").CryptoKey.Name,
-		"key2":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key2").CryptoKey.Name,
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -60,22 +64,9 @@ func testAccEventarcGoogleChannelConfig_basic(t *testing.T) {
 
 func testAccEventarcGoogleChannelConfig_basicCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_google_channel_config" "primary" {
-  location   = "%{region}"
-  name       = "googleChannelConfig"
-  depends_on = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
+  location = "%{region}"
+  name     = "googleChannelConfig"
 }
 `, context)
 }
@@ -87,9 +78,13 @@ func testAccEventarcGoogleChannelConfig_longForm(t *testing.T) {
 		"project_number": envvar.GetTestProjectNumberFromEnv(),
 		"region":         region,
 		"random_suffix":  acctest.RandString(t, 10),
-		"key1":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key1").CryptoKey.Name,
-		"key2":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key2").CryptoKey.Name,
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -110,23 +105,10 @@ func testAccEventarcGoogleChannelConfig_longForm(t *testing.T) {
 
 func testAccEventarcGoogleChannelConfig_longFormCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_google_channel_config" "primary" {
-  project    = "projects/%{project_name}"
-  location   = "long/form/%{region}"
-  name       = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
-  depends_on = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
+  project  = "projects/%{project_name}"
+  location = "long/form/%{region}"
+  name     = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
 }
 `, context)
 }
@@ -141,6 +123,12 @@ func testAccEventarcGoogleChannelConfig_cryptoKeyUpdate(t *testing.T) {
 		"key1":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key1").CryptoKey.Name,
 		"key2":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-google-channel-config-key2").CryptoKey.Name,
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -186,69 +174,30 @@ func testAccEventarcGoogleChannelConfig_cryptoKeyUpdate(t *testing.T) {
 
 func testAccEventarcGoogleChannelConfig_setCryptoKeyCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_google_channel_config" "primary" {
   location        = "%{region}"
   name            = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
   crypto_key_name = "%{key1}"
-  depends_on      = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
 }
 `, context)
 }
 
 func testAccEventarcGoogleChannelConfig_cryptoKeyUpdateCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_google_channel_config" "primary" {
   location        = "%{region}"
   name            = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
   crypto_key_name = "%{key2}"
-  depends_on      = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
 }
 `, context)
 }
 
 func testAccEventarcGoogleChannelConfig_deleteCryptoKeyCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_google_channel_config" "primary" {
   location        = "%{region}"
   name            = "projects/%{project_name}/locations/%{region}/googleChannelConfig"
   crypto_key_name = ""
-  depends_on      = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
@@ -39,6 +39,12 @@ func testAccEventarcMessageBus_basic(t *testing.T) {
 		"region":        envvar.GetTestRegionFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -76,13 +82,18 @@ resource "google_eventarc_message_bus" "primary" {
 
 func testAccEventarcMessageBus_cryptoKey(t *testing.T) {
 	region := envvar.GetTestRegionFromEnv()
-
 	context := map[string]interface{}{
 		"project_number": envvar.GetTestProjectNumberFromEnv(),
 		"region":         region,
 		"key":            acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-messagebus-key").CryptoKey.Name,
 		"random_suffix":  acctest.RandString(t, 10),
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -104,12 +115,6 @@ func testAccEventarcMessageBus_cryptoKey(t *testing.T) {
 
 func testAccEventarcMessageBus_cryptoKeyCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key_member" {
-  crypto_key_id = "%{key}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_message_bus" "primary" {
   location        = "%{region}"
   message_bus_id  = "tf-test-messagebus%{random_suffix}"
@@ -117,14 +122,12 @@ resource "google_eventarc_message_bus" "primary" {
   logging_config {
     log_severity = "ALERT"
   }
-  depends_on = [google_kms_crypto_key_iam_member.key_member]
 }
 `, context)
 }
 
 func testAccEventarcMessageBus_update(t *testing.T) {
 	region := envvar.GetTestRegionFromEnv()
-
 	context := map[string]interface{}{
 		"project_number": envvar.GetTestProjectNumberFromEnv(),
 		"region":         region,
@@ -132,6 +135,12 @@ func testAccEventarcMessageBus_update(t *testing.T) {
 		"key2":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-messagebus-key2").CryptoKey.Name,
 		"random_suffix":  acctest.RandString(t, 10),
 	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -181,12 +190,6 @@ func testAccEventarcMessageBus_update(t *testing.T) {
 
 func testAccEventarcMessageBus_setCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_message_bus" "primary" {
   location        = "%{region}"
   message_bus_id  = "tf-test-messagebus%{random_suffix}"
@@ -195,25 +198,12 @@ resource "google_eventarc_message_bus" "primary" {
   logging_config {
     log_severity = "ALERT"
   }
-  depends_on = [google_kms_crypto_key_iam_member.key1_member]
 }
 `, context)
 }
 
 func testAccEventarcMessageBus_updateCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_message_bus" "primary" {
   location        = "%{region}"
   message_bus_id  = "tf-test-messagebus%{random_suffix}"
@@ -222,25 +212,12 @@ resource "google_eventarc_message_bus" "primary" {
   logging_config {
     log_severity = "DEBUG"
   }
-  depends_on = [google_kms_crypto_key_iam_member.key1_member, google_kms_crypto_key_iam_member.key2_member]
 }
 `, context)
 }
 
 func testAccEventarcMessageBus_deleteCfg(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_kms_crypto_key_iam_member" "key1_member" {
-  crypto_key_id = "%{key1}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
-resource "google_kms_crypto_key_iam_member" "key2_member" {
-  crypto_key_id = "%{key2}"
-  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:service-%{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com"
-}
-
 resource "google_eventarc_message_bus" "primary" {
   location        = "%{region}"
   message_bus_id  = "tf-test-messagebus%{random_suffix}"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/18911

Bootstraps IAM Permissions for CMEK across the entire project, rather than depending on dynamic IAM membership grants.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
