### PR TITLE
Add tags field to GKE Clusters for TagsR2401

### DIFF
--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -370,3 +370,12 @@ properties:
         enum_values:
           - 'VULNERABILITY_DISABLED'
           - 'VULNERABILITY_ENTERPRISE'
+  - - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -12726,3 +12726,45 @@ resource "google_container_cluster" "primary" {
   }
 }`, name, enabled)
 }
+
+func TestAccContainerCluster_tags(t *testing.T) {
+	t.Parallel()
+        name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+        org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "container-clusters-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "container-clusters-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerClustersTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_container_cluster.cluster",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccContainerClustersTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}


### PR DESCRIPTION
Add tags field to GKE Clusters to allow setting tags on cluster resources at creation time.

release-note:none
````
GKE: added `tags` field to `GKE Cluster` to allow setting tags for clusters at creation time
````
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```