### PR TITLE
Add tags field to CCM Cerificate Map for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -117,3 +117,12 @@ properties:
             Proxy name must be in the format projects/*/locations/*/targetSslProxies/*.
             This field is part of a union field `target_proxy`: Only one of `targetHttpsProxy` or
             `targetSslProxy` may be set.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
@@ -1,0 +1,59 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateMap_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificates-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificates-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificatemap.certificatemap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateMapTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificatemap" "certificatemap" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}
+Footer
+© 2025 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
@@ -51,9 +51,4 @@ tags = {`, name)
 	l += fmt.Sprintf("}\n}")
 	return r + l
 }
-Footer
-© 2025 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
 


### PR DESCRIPTION
Add tags field to CCM Certificate map to allow setting tags on certificate Map resources at creation time.

release-note:none
````
Certificate Manager: added `tags` field to `CCM Caertificate map` to allow setting tags for certificate maps at creation time
````
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```
