### PR TITLE
fix type check panic on `GetRawConfigAt`

### DIFF
--- a/mmv1/templates/terraform/constants/bigquery_data_transfer.go.tmpl
+++ b/mmv1/templates/terraform/constants/bigquery_data_transfer.go.tmpl
@@ -14,10 +14,10 @@ func sensitiveParamCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v
 	for _, sp := range sensitiveWoParams {
 		mapLabel := diff.Get("params." + sp[:len(sp)-3]).(string)
 		authLabel, _ := diff.GetRawConfigAt(cty.GetAttrPath("sensitive_params").IndexInt(0).GetAttr(sp))
-		if mapLabel != "" && authLabel.AsString() != "" {
+		if mapLabel != "" && (!authLabel.IsNull() && authLabel.Type() == cty.String) {
 			return fmt.Errorf("Sensitive param [%s] cannot be set in both `params` and the `sensitive_params` block.", sp)
 		}
-		if authLabel.AsString() != "" {
+		if !authLabel.IsNull() && authLabel.Type() == cty.String {
 			if _, versionExists := diff.GetOkExists("sensitive_params.0.secret_access_key_wo_version"); !versionExists {
 				return fmt.Errorf("Sensitive param [%s] must be set with %s_version", sp, sp)
 			}


### PR DESCRIPTION
There was a type check error when running TeamCity tests: https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_BIGQUERYDATATRANSFER/329553

This PR resolves it.

https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_EPHEMERALWRITEONLYGA__MM_GOOGLE_PACKAGE_BIGQUERYDATATRANSFER?branch=refs%2Fheads%2Fauto-pr-13204&buildTypeTab=overview#all-projects

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
