### PR TITLE
Update PrivateCloud documentation to include the expected stretch cluster location format

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -209,10 +209,12 @@ properties:
             type: String
             description: |
               Zone that will remain operational when connection between the two zones is lost.
+              Specify the zone in the following format: projects/{project}/locations/{location}.
           - name: 'secondaryLocation'
             type: String
             description: |
               Additional zone for a higher level of availability and load balancing.
+              Specify the zone in the following format: projects/{project}/locations/{location}.
       - name: 'autoscalingSettings'
         type: NestedObject
         description: |


### PR DESCRIPTION
Update PrivateCloud documentation to include the expected stretch cluster location format

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
