### PR TITLE
Add SchedulingConfig.spot to TPU v2 VM

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -265,6 +265,12 @@ properties:
         min_version: 'beta'
         immutable: true
         send_empty_value: true
+      - name: 'spot'
+        type: Boolean
+        description: |
+          Optional. Defines whether the node is Spot VM.
+        min_version: 'beta'
+        immutable: true
   - name: 'dataDisks'
     type: Array
     description: |

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_full.tf.tmpl
@@ -32,6 +32,7 @@ resource "google_tpu_v2_vm" "{{$.PrimaryResourceId}}" {
   
   scheduling_config {
     preemptible = true
+    spot = true
   }
 
   shielded_instance_config {


### PR DESCRIPTION
Support spot boolean field for TPU VMs in Terraform. This should closely mirror the gcloud --spot flag and can reuse the same external field description and wording.

```release-note:enhancement
tpuv2: added `spot` field to `google_tpu_v2_vm` resource
```