### PR TITLE
Add tags field to Certificate Manager Certificate Map Entry for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/CertificateMapEntry.yaml
+++ b/mmv1/products/certificatemanager/CertificateMapEntry.yaml
@@ -131,3 +131,12 @@ properties:
     exactly_one_of:
       - 'hostname'
       - 'matcher'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemapentry_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemapentry_test.go
@@ -1,0 +1,53 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateMapEntry_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificatemapentry-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificatemapentry-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificatemapentry.certificatemapentry",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateMapEntryTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificatemapentry" "certificatemapentry" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}


### PR DESCRIPTION
Add tags field to certificate resource to allow setting tags at creation time.

release-note:none
```
Certificate Manager: added `tags` field to `Certificate Manager Certificate Map Entries` to allow setting tags for certificateMapEntries at creation time
```
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```