### PR TITLE
Skip changelog generation when changelog type is none

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -1,3 +1,18 @@
+/*
+* Copyright 2025 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
 package cmd
 
 import (
@@ -15,7 +30,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var changelogExp = regexp.MustCompile("(?s)```release-note.*?```")
+var changelogExp = regexp.MustCompile("(?s)```release-note:(?P<noteType>[a-zA-Z]+).*```")
 
 var gdEnvironmentVariables = [...]string{
 	"BASE_BRANCH",
@@ -354,8 +369,11 @@ func addChangelogEntry(downstreamRepo *source.Repo, pullRequest *github.PullRequ
 		return err
 	}
 	rnr.Mkdir(".changelog")
-	if err := rnr.WriteFile(filepath.Join(".changelog", fmt.Sprintf("%d.txt", pullRequest.Number)), strings.Join(changelogExp.FindAllString(pullRequest.Body, -1), "\n")); err != nil {
-		return err
+	matches := changelogExp.FindStringSubmatch(pullRequest.Body)
+	if matches != nil && matches[1] != "none" {
+		if err := rnr.WriteFile(filepath.Join(".changelog", fmt.Sprintf("%d.txt", pullRequest.Number)), strings.Join(changelogExp.FindAllString(pullRequest.Body, -1), "\n")); err != nil {
+			return err
+		}
 	}
 	return rnr.PopDir()
 }


### PR DESCRIPTION
Could use some help in terms of doing some functional testing on this and / or suggesting a way I could add some test coverage. But basically, the idea here is to skip generating a changelog entry when the changelog type is `none`

Mostly, this should prevent adding an extra changelog entry (whether or not any other changes are generated), avoiding creating extra noise in the downstream repos to create a bunch of empty files.

Separately, I could make a PR to clean up the empty changelog files in the tpg / tpg-beta repos if there's interest.

Fixes hashicorp/terraform-provider-google#20134

**Release Note Template for Downstream PRs (will be copied)**
```release-note:none

```

I made a first pass at some unit tests locally (this file currently has 0 coverage), but a bit stuck on the best way to mock the runner and whether or not to use `mock_runner_test.go`.

Looking at downstream, I do see that there are a handful of cases where there's a note even though release notes is `none`, e.g., (in `9889.txt`):
````
```release-note:none
Fixes: b/304402329, b/304432955, b/304432958
```
````
It would probably be a little harder, but would be possible to retain those if we did want to send them downstream, though I think the changelog is only used for release notes anyway?