### PR TITLE
Added SUNDAY as a day of the week

### DIFF
--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -138,6 +138,7 @@ properties:
                   - THURSDAY
                   - FRIDAY
                   - SATURDAY
+                  - SUNDAY
             - name: 'daysOfMonth'
               type: 'Array'
               description: 'Specifies days of months like 1, 5, or 14 on which jobs will run.'


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/21424

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
backup_dr: added missing SUNDAY option for `google_backup_dr_backup_plan.days_of_week`
```
