### PR TITLE
Add tests for force deletion

### DIFF
--- a/mmv1/products/firebasedataconnect/Service.yaml
+++ b/mmv1/products/firebasedataconnect/Service.yaml
@@ -35,6 +35,14 @@ examples:
       service_id: example-service
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: firebasedataconnect_service_with_force_deletion
+    primary_resource_id: default
+    vars:
+      service_id: example-service
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'deletion_policy'
 autogen_async: true
 async:
   operation:

--- a/mmv1/templates/terraform/examples/firebasedataconnect_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebasedataconnect_service_basic.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_project_service" "fdc" {
   disable_on_destroy = false
 }
 
-# Create an FDC service
+# Create a Firebase Data Connect service
 resource "google_firebase_data_connect_service" "default" {
   project = "{{index $.TestEnvVars "project_id"}}"
   location = "us-central1"

--- a/mmv1/templates/terraform/examples/firebasedataconnect_service_with_force_deletion.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebasedataconnect_service_with_force_deletion.tf.tmpl
@@ -5,7 +5,7 @@ resource "google_project_service" "fdc" {
   disable_on_destroy = false
 }
 
-# Create an FDC service
+# Create a Firebase Data Connect service
 resource "google_firebase_data_connect_service" "default" {
   project = "{{index $.TestEnvVars "project_id"}}"
   location = "us-central1"

--- a/mmv1/templates/terraform/examples/firebasedataconnect_service_with_force_deletion.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebasedataconnect_service_with_force_deletion.tf.tmpl
@@ -1,0 +1,16 @@
+# Enable Firebase Data Connect API
+resource "google_project_service" "fdc" {
+  project = "{{index $.TestEnvVars "project_id"}}"
+  service = "firebasedataconnect.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Create an FDC service
+resource "google_firebase_data_connect_service" "default" {
+  project = "{{index $.TestEnvVars "project_id"}}"
+  location = "us-central1"
+  service_id = "{{index $.Vars "service_id"}}"
+  deletion_policy = "FORCE"
+
+  depends_on = [google_project_service.fdc]
+}

--- a/mmv1/third_party/terraform/services/firebasedataconnect/resource_firebase_data_connect_service_test.go
+++ b/mmv1/third_party/terraform/services/firebasedataconnect/resource_firebase_data_connect_service_test.go
@@ -27,16 +27,16 @@ func TestAccFirebaseDataConnectService_Update(t *testing.T) {
 		CheckDestroy:             testAccCheckFirebaseDataConnectServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseDataConnectService_update(context, "Original display name"),
+				Config: testAccFirebaseDataConnectService_update(context, "Original display name", "DEFAULT"),
 			},
 			{
 				ResourceName:            "google_firebase_data_connect_service.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "service_id", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "service_id", "terraform_labels", "deletion_policy"},
 			},
 			{
-				Config: testAccFirebaseDataConnectService_update(context, "Updated display name"),
+				Config: testAccFirebaseDataConnectService_update(context, "Updated display name", "FORCE"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_firebase_data_connect_service.default", plancheck.ResourceActionUpdate),
@@ -47,15 +47,15 @@ func TestAccFirebaseDataConnectService_Update(t *testing.T) {
 				ResourceName:            "google_firebase_data_connect_service.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "service_id", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "service_id", "terraform_labels", "deletion_policy"},
 			},
 		},
 	})
 }
 
-// TODO(b/394642094): Cover force deletion once it's supported
-func testAccFirebaseDataConnectService_update(context map[string]interface{}, display_name string) string {
+func testAccFirebaseDataConnectService_update(context map[string]interface{}, display_name string, deletion_policy string) string {
 	context["display_name"] = display_name
+	context["deletion_policy"] = deletion_policy
 	return acctest.Nprintf(`
 # Enable Firebase Data Connect API
 resource "google_project_service" "fdc" {
@@ -70,6 +70,7 @@ resource "google_firebase_data_connect_service" "default" {
   location = "us-central1"
   service_id = "tf-fdc-%{random_suffix}"
   display_name = "%{display_name}"
+	deletion_policy = "%{deletion_policy}"
 
   depends_on = [google_project_service.fdc]
 }

--- a/mmv1/third_party/terraform/services/firebasedataconnect/resource_firebase_data_connect_service_test.go
+++ b/mmv1/third_party/terraform/services/firebasedataconnect/resource_firebase_data_connect_service_test.go
@@ -70,7 +70,7 @@ resource "google_firebase_data_connect_service" "default" {
   location = "us-central1"
   service_id = "tf-fdc-%{random_suffix}"
   display_name = "%{display_name}"
-	deletion_policy = "%{deletion_policy}"
+  deletion_policy = "%{deletion_policy}"
 
   depends_on = [google_project_service.fdc]
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

https://github.com/hashicorp/terraform-provider-google/issues/21028

Add tests for force deletion. This was recently supported across all regions in prod.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
firebasedataconnect: added `deletion_policy` support to `google_firebase_data_connect_service` resource
```
