### PR TITLE
Add tags field to Certificate Manager Certificate Issuance Config for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -132,3 +132,12 @@ properties:
               "projects/{project}/locations/{location}/caPools/{caPool}".
             required: true
             diff_suppress_func: 'tpgresource.CompareResourceNames'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certissuanceconfig_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certissuanceconfig_test.go
@@ -1,0 +1,53 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateIssuanceConfig_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificateissuanceconfig-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificateissuanceconfig-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		CheckDestroy: testAccCheckCertificateManagerCertificateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:            testAccCertificateManagerCertificateIssuanceConfigTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificateissuanceconfig.certificateissuanceconfig",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateIssuanceConfigTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificateissuanceconfig" "certificateissuanceconfig" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}


### PR DESCRIPTION
Add tags field to certificate resource to allow setting tags at creation time.

release-note:none
```
Certificate Manager: added `tags` field to `Certificate Manager Certificate Issuance Config` to allow setting tags for certificateIssuanceConfig at creation time
```
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```
