### PR TITLE
[AlloyDB] PSC Outbound Connectivity Support

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -338,6 +338,20 @@ properties:
           The DNS name of the instance for PSC connectivity.
           Name convention: <uid>.<uid>.<region>.alloydb-psc.goog
         output: true
+      - name: 'pscInterfaceConfigs'
+        type: Array
+        description: |
+          Configurations for setting up PSC interfaces attached to the instance
+          which are used for outbound connectivity. Currently, AlloyDB supports only 0 or 1 PSC interface.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'networkAttachmentResource'
+              type: String
+              description: |
+                The network attachment resource created in the consumer project to which the PSC interface will be linked.
+                This is of the format: "projects/${CONSUMER_PROJECT}/regions/${REGION}/networkAttachments/${NETWORK_ATTACHMENT_NAME}".
+                The network attachment must be in the same region as the instance.
   - name: 'networkConfig'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -831,10 +831,10 @@ data "google_project" "project" {}
 func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
 
-	random_suffix := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
-	
+
+	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
@@ -884,11 +884,11 @@ data "google_project" "project" {}
 
 func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
-	
-	random_suffix := acctest.RandString(t, 10)
+
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
 
+	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -827,3 +827,84 @@ resource "google_alloydb_cluster" "default" {
 data "google_project" "project" {}
 `, context)
 }
+
+func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) {
+	t.Parallel()
+
+	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
+	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix":         random_suffix,
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_pscInterfaceConfigs(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbInstance_pscInterfaceConfigs(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+  machine_config {
+    cpu_count = 2
+  }
+  psc_instance_config {
+	allowed_consumer_projects = ["${data.google_project.project.number}"]
+	psc_interface_configs {
+		network_attachment_resource = "projects/${data.google_project.project.number}/regions/${google_alloydb_cluster.default.location}/networkAttachments/%{networkAttachmentName}"
+	}
+  }
+}
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  psc_config {
+	psc_enabled = true
+  }
+  initial_user {
+    password = "tf-test-alloydb-cluster%{random_suffix}"
+  }
+}
+data "google_project" "project" {}
+`, context)
+}
+
+func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) {
+	t.Parallel()
+
+	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
+	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
+
+	random_suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix":         random_suffix,
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_pscInstanceConfig(context),
+			},
+			{
+				Config: testAccAlloydbInstance_pscInterfaceConfigs(context),
+			},
+		},
+	})
+}

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -831,10 +831,10 @@ data "google_project" "project" {}
 func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
 
+	random_suffix := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
-
-	random_suffix := acctest.RandString(t, 10)
+	
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
@@ -884,11 +884,11 @@ data "google_project" "project" {}
 
 func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) {
 	t.Parallel()
-
+	
+	random_suffix := acctest.RandString(t, 10)
 	networkName := acctest.BootstrapSharedTestNetwork(t, "tf-test-alloydb-network")
 	subnetworkName := acctest.BootstrapSubnet(t, "tf-test-alloydb-subnetwork", networkName)
 
-	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
 		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -837,7 +837,7 @@ func TestAccAlloydbInstance_createInstanceWithPscInterfaceConfigs(t *testing.T) 
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
-		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-create-na", subnetworkName),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -891,7 +891,7 @@ func TestAccAlloydbInstance_updateInstanceWithPscInterfaceConfigs(t *testing.T) 
 	random_suffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix":         random_suffix,
-		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-na", subnetworkName),
+		"networkAttachmentName": acctest.BootstrapNetworkAttachment(t, "tf-test-alloydb-update-na", subnetworkName),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
Description:
Supporting Private Service Connect (PSC) Outbound Connectivity in Terraform.

Issue - https://b.corp.google.com/issues/388587671

```release-note:enhancement
alloydb: added `psc_instance_config.psc_interface_configs` field to ``google_alloydb_instance` resource
```
