### PR TITLE
Add tags field to Certificate Manager DNS Authorization for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -131,3 +131,12 @@ properties:
         description: |
           Data of the DNS Resource Record.
         output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
@@ -65,4 +66,51 @@ resource "google_certificate_manager_dns_authorization" "default" {
   domain      = "%{random_suffix}.hashicorptest.com"
 }
 `, context)
+}
+
+func TestAccCertificateManagerDnsAuthorization_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorizationTags(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerDnsAuthorizationTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "tf-test-dns-auth%{random_suffix}"
+  description = "The default dnss"
+	labels = {
+		a = "a"
+	}
+  domain      = "%{random_suffix}.hashicorptest.com"
+}
+`, context)
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }


### PR DESCRIPTION
Add tags field to certificate resource to allow setting tags at creation time.

release-note:none
```
Certificate Manager: added `tags` field to `Certificate Manager DNS Authorization` to allow setting tags for dnsAuthorization at creation time
```
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```