### PR TITLE
Add tags field to Certificate Manager Trust Config for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -142,3 +142,12 @@ properties:
           description: |
             PEM certificate that is allowlisted. The certificate can be up to 5k bytes, and must be a parseable X.509 certificate.
           required: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
@@ -94,3 +94,64 @@ resource "google_certificate_manager_trust_config" "default" {
 }
 `, context)
 }
+
+func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerTrustConfig_tags(context),
+			},
+			{
+				ResourceName:            "google_certificate_manager_trust_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerTrustConfig_tags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_certificate_manager_trust_config" "default" {
+  name        = "tf-test-trust-config%{random_suffix}"
+  description = "sample description for the trust config"
+  location = "global"
+
+  trust_stores {
+    trust_anchors { 
+      pem_certificate = file("test-fixtures/cert.pem")
+    }
+    intermediate_cas { 
+      pem_certificate = file("test-fixtures/cert.pem")
+    }
+  }
+
+  allowlisted_certificates  {
+    pem_certificate = file("test-fixtures/cert.pem") 
+  }
+
+  labels = {
+    "foo" = "bar"
+  }
+}
+`, context)
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}


### PR DESCRIPTION
Add tags field to certificate resource to allow setting tags at creation time.

release-note:none
```
Certificate Manager: added `tags` field to `Certificate Manager Trust Config` to allow setting tags for trustConfig at creation time
```
```
The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository
```

