### PR TITLE
Use the location of the folder when configuring folder logging bucket

### DIFF
--- a/mmv1/third_party/terraform/services/logging/data_source_google_logging_organization_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/data_source_google_logging_organization_settings_test.go
@@ -9,10 +9,13 @@ import (
 )
 
 func TestAccLoggingOrganizationSettings_datasource(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
-		"org_id": envvar.GetTestOrgFromEnv(t),
+		"org_id":       envvar.GetTestOrgFromEnv(t),
+		"original_key": acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
 	}
 	resourceName := "data.google_logging_organization_settings.settings"
 
@@ -20,6 +23,9 @@ func TestAccLoggingOrganizationSettings_datasource(t *testing.T) {
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSettings_full(context),
+			},
 			{
 				Config: testAccLoggingOrganizationSettings_datasource(context),
 				Check: resource.ComposeTestCheckFunc(

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -189,8 +189,8 @@ func resourceLoggingBucketConfigAcquireOrCreate(parentType string, iDFunc loggin
 			return err
 		}
 
-		if parentType == "project" || parentType == "folder" {
-			//logging bucket can be created only at the project level, in future api may allow for org and other parent resources
+		if parentType == "project" {
+			//logging bucket can be created only at the project level, in future api may allow for folder, org and other parent resources
 
 			log.Printf("[DEBUG] Fetching logging bucket config: %#v", id)
 			url, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", id))
@@ -205,7 +205,7 @@ func resourceLoggingBucketConfigAcquireOrCreate(parentType string, iDFunc loggin
 				UserAgent: userAgent,
 			})
 			if res == nil {
-				log.Printf("[DEGUG] Logging Bucket %q does not exist", id)
+				log.Printf("[DEGUG] Loggin Bucket not exist %s", id)
 				// we need to pass the id in here because we don't want to set it in state
 				// until we know there won't be any errors on create
 				return resourceLoggingBucketConfigCreate(d, meta, id)

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config.go
@@ -189,8 +189,8 @@ func resourceLoggingBucketConfigAcquireOrCreate(parentType string, iDFunc loggin
 			return err
 		}
 
-		if parentType == "project" {
-			//logging bucket can be created only at the project level, in future api may allow for folder, org and other parent resources
+		if parentType == "project" || parentType == "folder" {
+			//logging bucket can be created only at the project level, in future api may allow for org and other parent resources
 
 			log.Printf("[DEBUG] Fetching logging bucket config: %#v", id)
 			url, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("{{LoggingBasePath}}%s", id))
@@ -205,7 +205,7 @@ func resourceLoggingBucketConfigAcquireOrCreate(parentType string, iDFunc loggin
 				UserAgent: userAgent,
 			})
 			if res == nil {
-				log.Printf("[DEGUG] Loggin Bucket not exist %s", id)
+				log.Printf("[DEGUG] Logging Bucket %q does not exist", id)
 				// we need to pass the id in here because we don't want to set it in state
 				// until we know there won't be any errors on create
 				return resourceLoggingBucketConfigCreate(d, meta, id)

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -51,7 +51,9 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 }
 
 func TestAccLoggingBucketConfigProject_basic(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"random_suffix":   acctest.RandString(t, 10),
@@ -97,7 +99,9 @@ func TestAccLoggingBucketConfigProject_basic(t *testing.T) {
 }
 
 func TestAccLoggingBucketConfigProject_analyticsEnabled(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"random_suffix":   acctest.RandString(t, 10),

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -282,6 +282,11 @@ resource "google_logging_folder_bucket_config" "basic" {
 
 func testAccLoggingBucketConfigProject_basic(context map[string]interface{}, retention int) string {
 	return fmt.Sprintf(acctest.Nprintf(`
+// Reset the default bucket and location settings, which may have been changed by other tests.
+resource "google_logging_organization_settings" "default" {
+  organization = "%{org_id}"
+}
+
 resource "google_project" "default" {
 	project_id = "%{project_name}"
 	name       = "%{project_name}"

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -150,7 +150,9 @@ func TestAccLoggingBucketConfigProject_analyticsEnabled(t *testing.T) {
 }
 
 func TestAccLoggingBucketConfigProject_cmekSettings(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"project_name":    "tf-test-" + acctest.RandString(t, 10),
@@ -190,7 +192,9 @@ func TestAccLoggingBucketConfigProject_cmekSettings(t *testing.T) {
 }
 
 func TestAccLoggingBucketConfigBillingAccount_basic(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"random_suffix":        acctest.RandString(t, 10),
@@ -226,7 +230,9 @@ func TestAccLoggingBucketConfigBillingAccount_basic(t *testing.T) {
 }
 
 func TestAccLoggingBucketConfigOrganization_basic(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -271,9 +271,13 @@ resource "time_sleep" "wait_1_minute" {
 	]
 }
 
+data "google_logging_folder_settings" "settings" {
+	folder = google_folder.default.name
+}
+
 resource "google_logging_folder_bucket_config" "basic" {
 	folder    = google_folder.default.name
-	location  = "global"
+	location  = data.google_logging_folder_settings.settings.storage_location
 	retention_days = %d
 	description = "retention test %d days"
 	bucket_id = "_Default"

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -15,8 +15,8 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"folder_name":   "tf-test-" + acctest.RandString(t, 10),
-		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
-		"bucket_id":     "_Default",
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"bucket_id":     "tf-test-bucket-" + acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -256,11 +256,6 @@ func TestAccLoggingBucketConfigOrganization_basic(t *testing.T) {
 
 func testAccLoggingBucketConfigFolder_basic(context map[string]interface{}, retention int) string {
 	return fmt.Sprintf(acctest.Nprintf(`
-// Reset organization settings which may have been reconfigured by another test
-resource "google_logging_organization_settings" "example" {
-	organization = "%{org_id}"
-}
-
 resource "google_folder" "default" {
 	display_name = "%{folder_name}"
 	parent       = "organizations/%{org_id}"
@@ -282,7 +277,7 @@ resource "google_logging_folder_bucket_config" "basic" {
 	location  = "global"
 	retention_days = %d
 	description = "retention test %d days"
-	bucket_id = "_Default"
+	bucket_id = "%{bucket_id}"
 
 	depends_on = [time_sleep.wait_1_minute]
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
-	t.Parallel()
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -18,6 +18,7 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 		"random_suffix": acctest.RandString(t, 10),
 		"folder_name":   "tf-test-" + acctest.RandString(t, 10),
 		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"original_key":  acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -41,6 +42,9 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"folder"},
+			},
+			{
+				Config: testAccLoggingOrganizationSettings_full(context),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -260,7 +260,6 @@ resource "google_folder" "default" {
 	display_name = "%{folder_name}"
 	parent       = "organizations/%{org_id}"
 	deletion_protection = false
-	depends_on   = [google_logging_organization_settings.example]
 }
 
 // Give the _Default bucket a chance to be created

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -15,7 +15,7 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"folder_name":   "tf-test-" + acctest.RandString(t, 10),
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
 		"bucket_id":     "_Default",
 	}
 
@@ -256,10 +256,16 @@ func TestAccLoggingBucketConfigOrganization_basic(t *testing.T) {
 
 func testAccLoggingBucketConfigFolder_basic(context map[string]interface{}, retention int) string {
 	return fmt.Sprintf(acctest.Nprintf(`
+// Reset organization settings which may have been reconfigured by another test
+resource "google_logging_organization_settings" "example" {
+	organization = "%{org_id}"
+}
+
 resource "google_folder" "default" {
 	display_name = "%{folder_name}"
 	parent       = "organizations/%{org_id}"
 	deletion_protection = false
+	depends_on   = [google_logging_organization_settings.example]
 }
 
 // Give the _Default bucket a chance to be created

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -271,13 +271,9 @@ resource "time_sleep" "wait_1_minute" {
 	]
 }
 
-data "google_logging_folder_settings" "settings" {
-	folder = google_folder.default.folder_id
-}
-
 resource "google_logging_folder_bucket_config" "basic" {
 	folder    = google_folder.default.name
-	location  = data.google_logging_folder_settings.settings.storage_location
+	location  = "global"
 	retention_days = %d
 	description = "retention test %d days"
 	bucket_id = "_Default"

--- a/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_bucket_config_test.go
@@ -272,7 +272,7 @@ resource "time_sleep" "wait_1_minute" {
 }
 
 data "google_logging_folder_settings" "settings" {
-	folder = google_folder.default.name
+	folder = google_folder.default.folder_id
 }
 
 resource "google_logging_folder_bucket_config" "basic" {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
@@ -13,7 +13,7 @@ func TestAccLoggingFolderSettings_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 		"original_key":  acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
 		"updated_key":   acctest.BootstrapKMSKeyInLocation(t, "us-east1").CryptoKey.Name,
@@ -70,14 +70,14 @@ resource "google_folder" "my_folder" {
   deletion_protection = false
 }
 
-data "google_logging_folder_settings" "settings" {
-  folder = google_folder.my_folder.folder_id
+data "google_logging_organization_settings" "settings" {
+  organization = "%{org_id}"
 }
 
 resource "google_kms_crypto_key_iam_member" "iam" {
   crypto_key_id = "%{original_key}"
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${data.google_logging_folder_settings.settings.kms_service_account_id}"
+  member        = "serviceAccount:${data.google_logging_organization_settings.settings.kms_service_account_id}"
 }
 
 resource "google_logging_folder_settings" "example" {

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
@@ -47,17 +47,41 @@ func TestAccLoggingFolderSettings_update(t *testing.T) {
 
 func testAccLoggingFolderSettings_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_folder" "my_folder" {
+  display_name = "tf-test-folder-%{random_suffix}"
+  parent       = "organizations/%{org_id}"
+  deletion_protection = false
+}
+
+data "google_logging_folder_settings" "settings" {
+  folder = google_folder.my_folder.folder_id
+}
+
+resource "google_kms_crypto_key_iam_member" "iam_folder" {
+  crypto_key_id = "%{original_key}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${data.google_logging_folder_settings.settings.kms_service_account_id}"
+}
+
+data "google_logging_organization_settings" "settings" {
+  organization = "%{org_id}"
+}
+
+resource "google_kms_crypto_key_iam_member" "iam_org" {
+  crypto_key_id = "%{original_key}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${data.google_logging_organization_settings.settings.kms_service_account_id}"
+}
+
 resource "google_logging_folder_settings" "example" {
   disable_default_sink = true
   folder               = google_folder.my_folder.folder_id
   kms_key_name         = "%{original_key}"
   storage_location     = "us-central1"
-}
-
-resource "google_folder" "my_folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "organizations/%{org_id}"
-  deletion_protection = false
+  depends_on   = [
+    google_kms_crypto_key_iam_member.iam_folder,
+	google_kms_crypto_key_iam_member.iam_org
+  ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
@@ -52,9 +52,18 @@ resource "google_logging_folder_settings" "example" {
   folder               = google_folder.my_folder.folder_id
   kms_key_name         = "%{original_key}"
   storage_location     = "us-central1"
-  depends_on           = [ google_kms_crypto_key_iam_member.iam ]
 }
 
+resource "google_folder" "my_folder" {
+  display_name = "tf-test-folder-%{random_suffix}"
+  parent       = "organizations/%{org_id}"
+  deletion_protection = false
+}
+`, context)
+}
+
+func testAccLoggingFolderSettings_onlyRequired(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 resource "google_folder" "my_folder" {
   display_name = "tf-test-folder-%{random_suffix}"
   parent       = "organizations/%{org_id}"
@@ -70,19 +79,10 @@ resource "google_kms_crypto_key_iam_member" "iam" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = "serviceAccount:${data.google_logging_folder_settings.settings.kms_service_account_id}"
 }
-`, context)
-}
 
-func testAccLoggingFolderSettings_onlyRequired(context map[string]interface{}) string {
-	return acctest.Nprintf(`
 resource "google_logging_folder_settings" "example" {
-  folder = google_folder.my_folder.folder_id
-}
-
-resource "google_folder" "my_folder" {
-  display_name = "tf-test-folder-%{random_suffix}"
-  parent       = "organizations/%{org_id}"
-  deletion_protection = false
+  folder       = google_folder.my_folder.folder_id
+  depends_on   = [ google_kms_crypto_key_iam_member.iam ]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_settings_test.go
@@ -13,7 +13,7 @@ func TestAccLoggingFolderSettings_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 		"original_key":  acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name,
 		"updated_key":   acctest.BootstrapKMSKeyInLocation(t, "us-east1").CryptoKey.Name,

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_settings_test.go
@@ -1,6 +1,7 @@
 package logging_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -9,7 +10,13 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
+var orgSettingsMu sync.Mutex
+
 func TestAccLoggingOrganizationSettings_update(t *testing.T) {
+	// google_logging_organization_settings is a singleton, and multiple tests mutate it.
+	orgSettingsMu.Lock()
+	t.Cleanup(orgSettingsMu.Unlock)
+
 	context := map[string]interface{}{
 		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),


### PR DESCRIPTION
This should resolve https://github.com/hashicorp/terraform-provider-google/issues/17108 for real this time. The previous "fix" got it passing in the GitHub action integration tests, but it continued failing in the nightly test runs. The problem is that `google_logging_organization_settings` is a singleton, and some tests need it configured one way and others a different way. The changes here prevent the tests that depend on it from running concurrently, and each test configures it as needed rather than relying on a previously run test to do so.

```release-note: none

```
