### PR TITLE
Made nested query resources replace the whole resource instead of merging new over old

### DIFF
--- a/mmv1/templates/terraform/nested_query.go.tmpl
+++ b/mmv1/templates/terraform/nested_query.go.tmpl
@@ -140,15 +140,19 @@ func resource{{ $.ResourceName }}PatchUpdateEncoder(d *schema.ResourceData, meta
     return nil, fmt.Errorf("Unable to update {{ $.Name }} %q - not found in list", d.Id())
   }
 
-  // Override old object with new
-  items[idx] = obj
-  // Name is always required and won't be present in obj. Grab it from the item.
-  obj["name"] = item["name"]
+  // Copy over values for immutable fields
+{{- range $prop := $.SettableProperties }}
+{{- if $prop.IsForceNew }}
+  obj["{{$prop.ApiName}}"] = item["{{$prop.ApiName}}"]
+{{- end }}
+{{- end }}
   // Merge any fields in item that aren't managed by this resource into obj
   // This is necessary because item might be managed by multiple resources.
   settableFields := map[string]struct{}{
 {{- range $prop := $.SettableProperties }}
+{{- if not $prop.IsForceNew }}
     "{{$prop.ApiName}}": struct{}{},
+{{- end }}
 {{- end }}
   }
   for k, v := range item {
@@ -156,6 +160,10 @@ func resource{{ $.ResourceName }}PatchUpdateEncoder(d *schema.ResourceData, meta
       obj[k] = v
     }
   }
+
+  // Override old object with new
+  items[idx] = obj
+
   // Return list with new item added
   res := map[string]interface{}{
     "{{ $.LastNestedQueryKey }}": items,

--- a/mmv1/templates/terraform/nested_query.go.tmpl
+++ b/mmv1/templates/terraform/nested_query.go.tmpl
@@ -144,7 +144,18 @@ func resource{{ $.ResourceName }}PatchUpdateEncoder(d *schema.ResourceData, meta
   items[idx] = obj
   // Name is always required and won't be present in obj. Grab it from the item.
   obj["name"] = item["name"]
-
+  // Merge any fields in item that aren't managed by this resource into obj
+  // This is necessary because item might be managed by multiple resources.
+  settableFields := map[string]struct{}{
+{{- range $prop := $.SettableProperties }}
+    "{{$prop.ApiName}}": struct{}{},
+{{- end }}
+  }
+  for k, v := range item {
+    if _, ok := settableFields[k]; !ok {
+      obj[k] = v
+    }
+  }
   // Return list with new item added
   res := map[string]interface{}{
     "{{ $.LastNestedQueryKey }}": items,

--- a/mmv1/templates/terraform/nested_query.go.tmpl
+++ b/mmv1/templates/terraform/nested_query.go.tmpl
@@ -142,8 +142,8 @@ func resource{{ $.ResourceName }}PatchUpdateEncoder(d *schema.ResourceData, meta
 
   // Override old object with new
   items[idx] = obj
-  // Name is always required and won't be present in obj.
-  obj["name"] = d.Get("name")
+  // Name is always required and won't be present in obj. Grab it from the item.
+  obj["name"] = item["name"]
 
   // Return list with new item added
   res := map[string]interface{}{

--- a/mmv1/templates/terraform/nested_query.go.tmpl
+++ b/mmv1/templates/terraform/nested_query.go.tmpl
@@ -140,11 +140,10 @@ func resource{{ $.ResourceName }}PatchUpdateEncoder(d *schema.ResourceData, meta
     return nil, fmt.Errorf("Unable to update {{ $.Name }} %q - not found in list", d.Id())
   }
 
-  // Merge new object into old.
-  for k, v := range obj {
-    item[k] = v
-  }
-  items[idx] = item
+  // Override old object with new
+  items[idx] = obj
+  // Name is always required and won't be present in obj.
+  obj["name"] = d.Get("name")
 
   // Return list with new item added
   res := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
@@ -1229,40 +1229,6 @@ resource "google_compute_router_nat" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName)
 }
 
-func testAccComputeRouterNatUnsetOptionalFields(routerName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_address" "foobar" {
-  name   = "%s-addr"
-  region = google_compute_subnetwork.foobar.region
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                               = "%s"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
-  nat_ips                            = []
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-}
-`, routerName, routerName, routerName, routerName, routerName)
-}
-
 func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -84,6 +85,11 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 			},
 			{
 				Config: testAccComputeRouterNatUpdated(routerName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_router_nat.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -92,6 +98,11 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 			},
 			{
 				Config: testAccComputeRouterNatUpdateToNatIPsId(routerName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_router_nat.foobar", plancheck.ResourceActionNoop),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -100,6 +111,11 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 			},
 			{
 				Config: testAccComputeRouterNatUpdateToNatIPsName(routerName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_router_nat.foobar", plancheck.ResourceActionNoop),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -108,37 +124,11 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 			},
 			{
 				Config: testAccComputeRouterNatBasicBeforeUpdate(routerName),
-			},
-			{
-				ResourceName:      "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouterNat_removeLogConfig(t *testing.T) {
-	t.Parallel()
-
-	testId := acctest.RandString(t, 10)
-	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeRouterNatDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeRouterNatLogConfig(routerName),
-			},
-			{
-				ResourceName:      "google_compute_router_nat.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeRouterNatLogConfigRemoved(routerName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_router_nat.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -1016,6 +1006,7 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_network" "foobar" {
   name = "%s-net"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
@@ -1037,11 +1028,6 @@ resource "google_compute_router_nat" "foobar" {
   nat_ip_allocate_option             = "AUTO_ONLY"
   nat_ips                            = []
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-
-  log_config {
-    enable = true
-    filter = "ERRORS_ONLY"
-  }
 }
 `, routerName, routerName, routerName, routerName, routerName)
 }
@@ -1056,6 +1042,7 @@ resource "google_compute_router" "foobar" {
 
 resource "google_compute_network" "foobar" {
   name = "%s-net"
+  auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
@@ -1090,6 +1077,7 @@ resource "google_compute_router_nat" "foobar" {
   tcp_established_idle_timeout_sec = 1600
   tcp_transitory_idle_timeout_sec  = 60
   tcp_time_wait_timeout_sec        = 60
+  max_ports_per_vm                 = 128
 
   log_config {
     enable = true
@@ -1142,7 +1130,8 @@ network = google_compute_network.foobar.self_link
 }
 
 resource "google_compute_network" "foobar" {
-name = "%s-net"
+  name = "%s-net"
+  auto_create_subnetworks = false
 }
 resource "google_compute_subnetwork" "foobar" {
 name          = "%s-subnet"
@@ -1176,6 +1165,7 @@ resource "google_compute_router_nat" "foobar" {
   tcp_established_idle_timeout_sec = 1600
   tcp_transitory_idle_timeout_sec  = 60
   tcp_time_wait_timeout_sec        = 60
+  max_ports_per_vm                 = 128
 
   log_config {
     enable = true
@@ -1194,7 +1184,8 @@ network = google_compute_network.foobar.self_link
 }
 
 resource "google_compute_network" "foobar" {
-name = "%s-net"
+  name = "%s-net"
+  auto_create_subnetworks = false
 }
 resource "google_compute_subnetwork" "foobar" {
 name          = "%s-subnet"
@@ -1228,11 +1219,46 @@ resource "google_compute_router_nat" "foobar" {
   tcp_established_idle_timeout_sec = 1600
   tcp_transitory_idle_timeout_sec  = 60
   tcp_time_wait_timeout_sec        = 60
+  max_ports_per_vm                 = 128
 
   log_config {
     enable = true
     filter = "TRANSLATIONS_ONLY"
   }
+}
+`, routerName, routerName, routerName, routerName, routerName)
+}
+
+func testAccComputeRouterNatUnsetOptionalFields(routerName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_subnetwork.foobar.region
+  network = google_compute_network.foobar.self_link
+}
+
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s-addr"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_router_nat" "foobar" {
+  name                               = "%s"
+  router                             = google_compute_router.foobar.name
+  region                             = google_compute_router.foobar.region
+  nat_ips                            = []
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 `, routerName, routerName, routerName, routerName, routerName)
 }
@@ -1831,68 +1857,6 @@ resource "google_compute_router" "foobar" {
   network = google_compute_network.foobar.self_link
 }
 `, routerName, routerName, routerName)
-}
-
-func testAccComputeRouterNatLogConfig(routerName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                               = "%s"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  log_config {
-    enable = false
-    filter = "ALL"
-  }
-}
-`, routerName, routerName, routerName, routerName)
-}
-
-func testAccComputeRouterNatLogConfigRemoved(routerName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "foobar" {
-  name = "%s-net"
-}
-
-resource "google_compute_subnetwork" "foobar" {
-  name          = "%s-subnet"
-  network       = google_compute_network.foobar.self_link
-  ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
-}
-
-resource "google_compute_router" "foobar" {
-  name    = "%s"
-  region  = google_compute_subnetwork.foobar.region
-  network = google_compute_network.foobar.self_link
-}
-
-resource "google_compute_router_nat" "foobar" {
-  name                               = "%s"
-  router                             = google_compute_router.foobar.name
-  region                             = google_compute_router.foobar.region
-  nat_ip_allocate_option             = "AUTO_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-}
-`, routerName, routerName, routerName, routerName)
 }
 
 func testAccComputeRouterNatBaseResourcesWithPrivateNatSubnetworks(routerName, hubName string) string {


### PR DESCRIPTION
This allows fields to be unset using the same logic that any other field on any other resource would use.

Related to https://github.com/hashicorp/terraform-provider-google/issues/14848

b/394945456#comment14

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed bug in `google_compute_router_nat` where `max_ports_per_vm` couldn't be unset once set.
```

Note: Technically this also allows `nat_ip_allocate_option` to be unset, but that field must be set for type = PUBLIC and _can't_ be set for type = PRIVATE, and modifying `type` forces recreation, so there doesn't seem to be a case where it can actually be unset on update.

This doesn't impact `google_compute_router_nat` because the only optional field has send_empty_value set.