### PR TITLE
artifactregistry: fix cleanup policies updates

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -423,11 +423,13 @@ properties:
               description: |-
                 Match versions older than a duration.
               custom_expand: 'templates/terraform/custom_expand/duration_to_seconds.go.tmpl'
+              diff_suppress_func: 'durationDiffSuppress'
             - name: 'newerThan'
               type: String
               description: |-
                 Match versions newer than a duration.
               custom_expand: 'templates/terraform/custom_expand/duration_to_seconds.go.tmpl'
+              diff_suppress_func: 'durationDiffSuppress'
         - name: 'mostRecentVersions'
           type: NestedObject
           description: |-

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -423,13 +423,11 @@ properties:
               description: |-
                 Match versions older than a duration.
               custom_expand: 'templates/terraform/custom_expand/duration_to_seconds.go.tmpl'
-              diff_suppress_func: 'durationDiffSuppress'
             - name: 'newerThan'
               type: String
               description: |-
                 Match versions newer than a duration.
               custom_expand: 'templates/terraform/custom_expand/duration_to_seconds.go.tmpl'
-              diff_suppress_func: 'durationDiffSuppress'
         - name: 'mostRecentVersions'
           type: NestedObject
           description: |-

--- a/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
+++ b/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
@@ -66,6 +66,31 @@ func parseDurationAsSeconds(v string) (int, bool) {
 	}
 }
 
+// Like tpgresource.DurationDiffSuppress, but supports 'd'
+func durationDiffSuppress(k, oldr, newr string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(k)
+	old, ok := o.(string)
+	if !ok {
+		return false
+	}
+	new, ok := n.(string)
+	if !ok {
+		return false
+	}
+	if old == new {
+		return true
+	}
+	oldSeconds, ok := parseDurationAsSeconds(old)
+	if !ok {
+		return false
+	}
+	newSeconds, ok := parseDurationAsSeconds(new)
+	if !ok {
+		return false
+	}
+	return oldSeconds == newSeconds
+}
+
 func mapHashID(v any) int {
 	replaceNestedValue(v, []string{"condition", "older_than"}, expandDuration)
 	replaceNestedValue(v, []string{"condition", "newer_than"}, expandDuration)

--- a/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
+++ b/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
@@ -66,34 +66,60 @@ func parseDurationAsSeconds(v string) (int, bool) {
 	}
 }
 
-// Like tpgresource.DurationDiffSuppress, but supports 'd'
-func durationDiffSuppress(k, oldr, newr string, d *schema.ResourceData) bool {
-	o, n := d.GetChange(k)
-	old, ok := o.(string)
-	if !ok {
-		return false
-	}
-	new, ok := n.(string)
-	if !ok {
-		return false
-	}
-	if old == new {
-		return true
-	}
-	oldSeconds, ok := parseDurationAsSeconds(old)
-	if !ok {
-		return false
-	}
-	newSeconds, ok := parseDurationAsSeconds(new)
-	if !ok {
-		return false
-	}
-	return oldSeconds == newSeconds
+func mapHashID(v any) int {
+	replaceNestedValue(v, []string{"condition", "older_than"}, expandDuration)
+	replaceNestedValue(v, []string{"condition", "newer_than"}, expandDuration)
+	return schema.HashString(fmt.Sprintf("%v", v))
 }
 
-func mapHashID(v any) int {
-	obj := v.(map[string]any)
-	return schema.HashString(obj["id"])
+func expandDuration(v any) (any, bool) {
+	if val, ok := v.(string); ok {
+		if secs, ok := parseDurationAsSeconds(val); ok {
+			return fmt.Sprintf("%ds", secs), true
+		}
+	}
+	return nil, false
+
+}
+
+// Replace a value in a schema object, if it exists.
+// Nested maps follow the pattern map[string]any -> [1]any -> map[string]any
+func replaceNestedValue(obj any, keys []string, replaceFunc func(any) (any, bool)) {
+	if len(keys) == 0 {
+		return
+	}
+	next := &obj
+	for _, key := range keys[:len(keys)-1] {
+		nextMap, ok := (*next).(map[string]any)
+		if !ok {
+			return
+		}
+		arrObj, ok := nextMap[key]
+		if !ok {
+			return
+		}
+		arr, ok := arrObj.([]any)
+		if !ok {
+			return
+		}
+		if len(arr) != 1 {
+			return
+		}
+		next = &arr[0]
+	}
+	lastMap, ok := (*next).(map[string]any)
+	if !ok {
+		return
+	}
+	lastKey := keys[len(keys)-1]
+	last, ok := lastMap[lastKey]
+	if !ok {
+		return
+	}
+	result, ok := replaceFunc(last)
+	if ok {
+		lastMap[lastKey] = result
+	}
 }
 
 func isDefaultEnum(val any) bool {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes hashicorp/terraform-provider-google#21348

[The original fix](https://github.com/GoogleCloudPlatform/magic-modules/pull/12667) panicked on type assertion failures and incorrectly hashed objects. Turns out, for objects in Maps (stored as sets) the diff suppress func doesn't matter as the values hash differently. This change moves the diff suppress functionality to the hashing step.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
artifactregistry: fixed failing update when changing cleanup policies in `google_artifact_registry_repository`
```
