### PR TITLE
Update the description of CryptoKeyVersion.state

### DIFF
--- a/mmv1/products/kms/CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/CryptoKeyVersion.yaml
@@ -63,7 +63,8 @@ properties:
   - name: 'state'
     type: Enum
     description: |
-      The current state of the CryptoKeyVersion.
+      The current state of the CryptoKeyVersion. Note: you can only specify this field to manually `ENABLE` or `DISABLE` the CryptoKeyVersion,
+      otherwise the value of this field is always retrieved automatically.
     default_from_api: true
     enum_values:
       - 'PENDING_GENERATION'


### PR DESCRIPTION
Note that only ENABLE/DISABLE are valid manual inputs for this field. For example, users cannot specify DESTROY_SCHEDULED to trigger key destruction, they should do so via terraform destroy or by removing the resource from the TF config.

Additional context: https://github.com/hashicorp/terraform-provider-google/issues/20298

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
kms: clarified description of the `state` argument of `google_kms_crypto_key_version`
```
