### PR TITLE
impl(google_bigquery_table): exposing TableMetadataView query param

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -645,3 +645,10 @@ properties:
           from BigQuery Engine. The connection_id can have the form `<project_id>.<location_id>.<connection_id>`
           or `projects/<project_id>/locations/<location_id>/connections/<connection_id>`.
         min_version: beta
+virtual_fields:
+  - name: 'table_metadata_view'
+    type: String
+    description: |
+      View sets the optional parameter "view": Specifies the view that determines which table information is
+      returned. By default, basic table information and storage statistics (STORAGE_STATS) are returned.
+      Possible values: TABLE_METADATA_VIEW_UNSPECIFIED, BASIC, STORAGE_STATS, FULL

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -3401,6 +3401,8 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
 	}
 
+	// Explicitly set virtual fields with default values to their default values on import
+
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/datasets/{{"{{"}}dataset_id{{"}}"}}/tables/{{"{{"}}table_id{{"}}"}}")
 	if err != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -1839,11 +1839,9 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
 
-	tableMetadataView := d.Get("table_metadata_view").(string)
-
 	client := config.NewBigQueryClient(userAgent).Tables.Get(project, datasetID, tableID)
-	if len(tableMetadataView) > 0 {
-	  client = client.View(tableMetadataView)
+	if tableMetadataViewRaw, ok := d.GetOk("table_metadata_view"); ok {
+		client = client.View(tableMetadataViewRaw.(string))
 	}
 	res, err := client.Do()
 
@@ -2072,7 +2070,7 @@ type TableReference struct {
 
 func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error {
 	// If only client-side fields were modified, short-circuit the Update function to avoid sending an update API request.
-	clientSideFields := map[string]bool{"deletion_protection": true}
+	clientSideFields := map[string]bool{"deletion_protection": true, "table_metadata_view": true}
 	clientSideOnly := true
 	for field := range ResourceBigQueryTable().Schema {
 		if d.HasChange(field) && !clientSideFields[field] {
@@ -2109,6 +2107,10 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
+	var tableMetadataView string
+	if tableMetadataViewRaw, ok := d.GetOk("table_metadata_view"); ok {
+		tableMetadataView = tableMetadataViewRaw.(string)
+	}
 
 	tableReference := &TableReference{
 		project:   project,
@@ -2116,7 +2118,7 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 		tableID:   tableID,
 	}
 
-	if err = resourceBigQueryTableColumnDrop(config, userAgent, table, tableReference); err != nil {
+	if err = resourceBigQueryTableColumnDrop(config, userAgent, table, tableReference, tableMetadataView); err != nil {
 		return err
 	}
 
@@ -2127,8 +2129,13 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 	return resourceBigQueryTableRead(d, meta)
 }
 
-func resourceBigQueryTableColumnDrop(config *transport_tpg.Config, userAgent string, table *bigquery.Table, tableReference *TableReference) error {
-	oldTable, err := config.NewBigQueryClient(userAgent).Tables.Get(tableReference.project, tableReference.datasetID, tableReference.tableID).Do()
+func resourceBigQueryTableColumnDrop(config *transport_tpg.Config, userAgent string, table *bigquery.Table, tableReference *TableReference, tableMetadataView string) error {
+	client := config.NewBigQueryClient(userAgent).Tables.Get(tableReference.project, tableReference.datasetID, tableReference.tableID)
+	if len(tableMetadataView) > 0 {
+		client = client.View(tableMetadataView)
+	}
+	oldTable, err := client.Do()
+
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -1447,6 +1447,11 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
+			"table_metadata_view": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `View sets the optional parameter "view": Specifies the view that determines which table information is returned. By default, basic table information and storage statistics (STORAGE_STATS) are returned. Possible values: TABLE_METADATA_VIEW_UNSPECIFIED, BASIC, STORAGE_STATS, FULL`,
+			},
 			// TableReplicationInfo: [Optional] Replication info of a table created using `AS REPLICA` DDL like: `CREATE MATERIALIZED VIEW mv1 AS REPLICA OF src_mv`.
 			"table_replication_info": {
 				Type:        schema.TypeList,
@@ -1834,7 +1839,14 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
 
-	res, err := config.NewBigQueryClient(userAgent).Tables.Get(project, datasetID, tableID).Do()
+	tableMetadataView := d.Get("table_metadata_view").(string)
+
+	client := config.NewBigQueryClient(userAgent).Tables.Get(project, datasetID, tableID)
+	if len(tableMetadataView) > 0 {
+	  client = client.View(tableMetadataView)
+	}
+	res, err := client.Do()
+
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go.tmpl
@@ -45,6 +45,39 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryTable_TableMetadataView(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableBasicWithTableMetadataView(datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "last_modified_time", "table_metadata_view"},
+			},
+			{
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "last_modified_time", "table_metadata_view"},
+			},
+		},
+	})
+}
+
 func TestAccBigQueryTable_OnlyDeletionProtectionUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -1946,6 +1979,22 @@ resource "google_bigquery_table" "test" {
 ]
 EOH
 
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTableBasicWithTableMetadataView(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+  deletion_protection = false
+  table_id   = "%s"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+
+  table_metadata_view = "BASIC"
 }
 `, datasetID, tableID)
 }


### PR DESCRIPTION
We are using [TablesGetCall.View](https://pkg.go.dev/google.golang.org/api/bigquery/v2#TablesGetCall.View) to set [TableMetadataView](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/get) through a virtual field `table_metadata_view`.

b/398215519

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added `table_metadata_view` query param to `google_bigquery_table`
```
