### PR TITLE
Metadata fixes 20250303

### DIFF
--- a/mmv1/products/artifactregistry/VPCSCConfig.yaml
+++ b/mmv1/products/artifactregistry/VPCSCConfig.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: 'VPCSCConfig'
+api_resource_type_kind: VpcscConfig
 description: |-
   The Artifact Registry VPC SC config that applies to a Project.
 min_version: 'beta'

--- a/mmv1/products/healthcare/Workspace.yaml
+++ b/mmv1/products/healthcare/Workspace.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: 'Workspace'
+api_resource_type_kind: DataMapperWorkspace
 description: |
   A Data Mapper workspace is used to configure Data Mapper access, permissions and data sources for mapping clinical patient data to the FHIR standard.
 references:

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_meta.yaml
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_meta.yaml
@@ -2,7 +2,7 @@ resource: 'google_apigee_api'
 generation_type: 'handwritten'
 api_service_name: 'apigee.googleapis.com'
 api_version: 'v1'
-api_resource_type_kind: 'ApiProxy'
+api_resource_type_kind: 'Proxy'
 fields:
   - field: 'config_bundle'
   - field: 'detect_md5hash'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This follows from https://github.com/GoogleCloudPlatform/magic-modules/pull/13105, where we tried matching on "types" name, but then realized it breaks compliance for some resources by no longer matching the "resources" name.

I had already addressed the only 2 resources where compliance regressed, and this change completes all remaining known mismatches where a resource descriptor can be used.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
