### PR TITLE
Add missing disk related fields to instance_template resources

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -150,6 +150,14 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Description: `Name of the disk. When not provided, this defaults to the name of the instance.`,
 						},
 
+						"architecture": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The architecture of the image. Allowed values are ARM64 or X86_64.`,
+						},
+
 						"disk_size_gb": {
 							Type:        schema.TypeInt,
 							Optional:    true,
@@ -199,6 +207,16 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Elem:         &schema.Schema{Type: schema.TypeString},
 							Set:          schema.HashString,
 							Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
+						},
+
+						"guest_os_features": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `A list of features to enable on the guest operating system. Applicable only for bootable images.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 
 						"source_image": {
@@ -1475,6 +1493,14 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 			disk.Type = v.(string)
 		}
 
+		if v, ok := d.GetOk(prefix + ".guest_os_features"); ok {
+			disk.GuestOsFeatures = expandComputeInstanceGuestOsFeatures(v.([]interface{}))
+		}
+
+		if v, ok := d.GetOk(prefix + ".architecture"); ok {
+			disk.Architecture = v.(string)
+		}
+
 		disks = append(disks, &disk)
 	}
 
@@ -1752,6 +1778,8 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 	diskMap["source"] = tpgresource.ConvertSelfLinkToV1(disk.Source)
 	diskMap["mode"] = disk.Mode
 	diskMap["type"] = disk.Type
+	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(disk.GuestOsFeatures)
+	diskMap["architecture"] = configDisk["architecture"]
 
 	return diskMap, nil
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -1775,6 +1775,36 @@ func TestAccComputeInstanceTemplate_migration(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_GuestOsFeatures(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	context := map[string]interface{}{
+		"template_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_GuestOsFeatures(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "disk.0.guest_os_features.#", "4"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "disk.0.guest_os_features.2", "GVNIC"),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "disk.0.guest_os_features.3", "IDPF"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_withLabels(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()
@@ -5234,6 +5264,33 @@ resource "google_compute_instance_template" "foobar" {
   }
 
   key_revocation_action_type = %{key_revocation_action_type}
+}
+`, context)
+}
+
+func testAccComputeInstanceTemplate_GuestOsFeatures(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%{template_name}"
+  machine_type = "e2-medium"
+
+  disk {
+	source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+	disk_size_gb = 10
+	architecture = "X86_64"
+	boot         = true
+	guest_os_features = %{guest_os_features}
+  }
+
+  network_interface {
+	network = "default"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -124,6 +124,14 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Description: `Name of the disk. When not provided, this defaults to the name of the instance.`,
 						},
 
+						"architecture": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							ForceNew:    true,
+							Computed:    true,
+							Description: `The architecture of the image. Allowed values are ARM64 or X86_64.`,
+						},
+
 						"disk_size_gb": {
 							Type:        schema.TypeInt,
 							Optional:    true,
@@ -173,6 +181,16 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Elem:         &schema.Schema{Type: schema.TypeString},
 							Set:          schema.HashString,
 							Description:  `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
+						},
+
+						"guest_os_features": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `A list of features to enable on the guest operating system. Applicable only for bootable images.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 
 						"source_image": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -1659,6 +1659,36 @@ func TestAccComputeRegionInstanceTemplate_gracefulShutdown(t *testing.T) {
 }
 {{- end }}
 
+func TestAccComputeRegionInstanceTemplate_GuestOsFeatures(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	context := map[string]interface{}{
+		"template_name":     fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"guest_os_features": `["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "GVNIC", "IDPF"]`,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_GuestOsFeatures(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "disk.0.guest_os_features.#", "4"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "disk.0.guest_os_features.0", "UEFI_COMPATIBLE"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "disk.0.guest_os_features.1", "VIRTIO_SCSI_MULTIQUEUE"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "disk.0.guest_os_features.2", "GVNIC"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "disk.0.guest_os_features.3", "IDPF"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRegionInstanceTemplateDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -4604,6 +4634,34 @@ resource "google_compute_region_instance_template" "foobar" {
 }
 
 data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeRegionInstanceTemplate_GuestOsFeatures(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%{template_name}"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+	source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+	disk_size_gb = 10
+	boot         = true
+	architecture = "X86_64"
+	guest_os_features = %{guest_os_features}
+  }
+
+  network_interface {
+	network = "default"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -451,6 +451,8 @@ The following arguments are supported:
 
 * `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to this disk. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
 
+* `guest_os_features` - (optional) A list of features to enable on the guest operating system. Applicable only for bootable images. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
+
 * `source_image` - (Optional) The image from which to
     initialize this disk. This can be one of: the image's `self_link`,
     `projects/{project}/global/images/{image}`,
@@ -483,6 +485,8 @@ The following arguments are supported:
 * `mode` - (Optional) The mode in which to attach this disk, either READ_WRITE
     or READ_ONLY. If you are attaching or creating a boot disk, this must
     read-write mode.
+
+* `architecture` - (Optional) The architecture of the attached disk. Valid values are `ARM64` or `x86_64`.
 
 * `source` - (Optional) The name (**not self_link**)
     of the disk (such as those managed by `google_compute_disk`) to attach.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -416,6 +416,8 @@ The following arguments are supported:
 
 * `resource_manager_tags` - (Optional) A set of key/value resource manager tag pairs to bind to this disk. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
 
+* `guest_os_features` - (optional) A list of features to enable on the guest operating system. Applicable only for bootable images. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
+
 * `source_image` - (Optional) The image from which to
     initialize this disk. This can be one of: the image's `self_link`,
     `projects/{project}/global/images/{image}`,
@@ -448,6 +450,8 @@ The following arguments are supported:
 * `mode` - (Optional) The mode in which to attach this disk, either READ_WRITE
     or READ_ONLY. If you are attaching or creating a boot disk, this must
     read-write mode.
+
+* `architecture` - (Optional) The architecture of the attached disk. Valid values are `ARM64` or `x86_64`.
 
 * `source` - (Optional) The name (**not self_link**)
     of the disk (such as those managed by `google_compute_disk`) to attach.


### PR DESCRIPTION
@roaks3
related to https://github.com/GoogleCloudPlatform/magic-modules/pull/13147

Tests will fail on this one until this PR gets merged (expand and flatten for `guest_os_features`)
https://github.com/GoogleCloudPlatform/magic-modules/pull/13193

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: add guest_os_features and architecture to `google_compute_instance_template` and `google_compute_region_instance_template`
```
