### PR TITLE
Promote `singleInstanceAssignment` and `filter` to GA

### DIFF
--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -302,7 +302,6 @@ properties:
                 latency, since this value can't include a chunk assignable to a
                 single instance, it could be better used with utilization_target
                 instead.
-              min_version: 'beta'
             - name: 'target'
               type: Double
               description: |
@@ -361,7 +360,6 @@ properties:
                 (if you are using gce_instance resource type). If multiple
                 TimeSeries are returned upon the query execution, the autoscaler
                 will sum their respective values to obtain its scaling value.
-              min_version: 'beta'
               default_value: "resource.type = gce_instance"
       - name: 'loadBalancingUtilization'
         type: NestedObject


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch promotes `singleInstanceAssignment` and `filter` to GA - [reference to V1 API](https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: promote fields `singleInstanceAssignment` and `filter` to GA for `google_compute_autoscaler` resource
```
