### PR TITLE
FEAT: Adds readiness_probe support for google_cloud_run_service [google-beta]

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -660,6 +660,93 @@ properties:
                                 The name of the service to place in the gRPC HealthCheckRequest
                                 (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
                                 If this is not specified, the default behavior is defined by gRPC.
+                    - name: 'readinessProbe'
+                      type: NestedObject
+                      description: |-
+                        Readiness probe to be used for health checks. Currently, only HTTP and GRPC probes are supported.
+                      default_from_api: true
+                      min_version: 'beta'
+                      properties:
+                        - name: 'timeoutSeconds'
+                          type: Integer
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1. Maximum value is 300.
+                            Must be smaller than periodSeconds.
+                          default_value: 0
+                        - name: 'periodSeconds'
+                          type: Integer
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1. Maximum value is 300.
+                          default_value: 10
+                        - name: 'failureThreshold'
+                          type: Integer
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after
+                            having succeeded. Defaults to 3. Minimum value is 1.
+                          default_value: 3
+                        - name: 'httpGet'
+                          type: NestedObject
+                          description: |-
+                            HttpGet specifies the http request to perform.
+                          send_empty_value: true
+                          allow_empty_object: true
+                          exactly_one_of:
+                            - 'template.0.spec.0.containers.0.startup_probe.0.http_get'
+                            - 'template.0.spec.0.containers.0.startup_probe.0.grpc'
+                          properties:
+                            - name: 'path'
+                              type: String
+                              description: |-
+                                Path to access on the HTTP server. If set, it should not be empty string.
+                              default_value: "/"
+                            - name: 'port'
+                              type: Integer
+                              description: |-
+                                Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
+                              default_from_api: true
+                            - name: 'httpHeaders'
+                              type: Array
+                              description: |-
+                                Custom headers to set in the request. HTTP allows repeated headers.
+                              item_type:
+                                type: NestedObject
+                                properties:
+                                  - name: 'name'
+                                    type: String
+                                    description: |-
+                                      The header field name.
+                                    required: true
+                                  - name: 'value'
+                                    type: String
+                                    description: |-
+                                      The header field value.
+                                    send_empty_value: true
+                                    default_value: ""
+                        - name: 'grpc'
+                          type: NestedObject
+                          description: |-
+                            GRPC specifies an action involving a GRPC port.
+                          send_empty_value: true
+                          allow_empty_object: true
+                          exactly_one_of:
+                            - 'template.0.spec.0.containers.0.startup_probe.0.http_get'
+                            - 'template.0.spec.0.containers.0.startup_probe.0.grpc'
+                          properties:
+                            - name: 'port'
+                              type: Integer
+                              description: |-
+                                Port number to access on the container. Number must be in the range 1 to 65535.
+                                If not specified, defaults to the same value as container.ports[0].containerPort.
+                              default_from_api: true
+                            - name: 'service'
+                              type: String
+                              description: |-
+                                The name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                If this is not specified, the default behavior is defined by gRPC.
                     - name: 'livenessProbe'
                       type: NestedObject
                       description: |-

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -840,6 +840,15 @@ func TestAccCloudRunService_probes(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
 			},
+      {
+        Config: testAccCloudRunService_cloudRunServiceWithReadinessProbe(name, project, "2", "1", "5", "2"),
+      },
+      {
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
+			},
 		},
 	})
 }
@@ -883,7 +892,56 @@ resource "google_cloud_run_service" "default" {
 `, name, project)
 }
 
-func testAccCloudRunService_cloudRunServiceUpdateWithTCPStartupProbeAndHTTPLivenessProbe(name, project, delay, timeout, peroid, failure_threshold string) string {
+func testAccCloudRunService_cloudRunServiceWithReadinessProbe(name, project, timeout, period, failure_threshold string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_run_service" "default" {
+  name     = "%s"
+  location = "us-central1"
+
+  metadata {
+    namespace = "%s"
+    annotations = {
+      generated-by = "magic-modules"
+    }
+  }
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+        ports {
+          container_port = 8080
+        }
+        readiness_probe {
+          period_seconds = %s
+          timeout_seconds = %s
+          failure_threshold = %s
+          http_get {
+            path: "/"
+            port: 8080
+            http_headers {
+              name = "User-Agent"
+              value = "magic-modules"
+            }
+            http_headers {
+              name = "Some-Name"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
+  }
+}
+`, name, project, period, timeout, failure_threshold, delay, peroid, timeout, failure_threshold)
+}
+
+func testAccCloudRunService_cloudRunServiceUpdateWithTCPStartupProbeAndHTTPLivenessProbe(name, project, delay, timeout, period, failure_threshold string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
   name     = "%s"
@@ -939,7 +997,7 @@ resource "google_cloud_run_service" "default" {
     ]
   }
 }
-`, name, project, delay, peroid, timeout, failure_threshold, delay, peroid, timeout, failure_threshold)
+`, name, project, delay, period, timeout, failure_threshold, delay, peroid, timeout, failure_threshold)
 }
 
 func testAccCloudRunService_cloudRunServiceUpdateWithEmptyHTTPStartupProbe(name, project string) string {

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -841,7 +841,7 @@ func TestAccCloudRunService_probes(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "metadata.0.annotations", "metadata.0.labels", "metadata.0.terraform_labels", "status.0.conditions"},
 			},
       {
-        Config: testAccCloudRunService_cloudRunServiceWithReadinessProbe(name, project, "2", "1", "5", "2"),
+        Config: testAccCloudRunService_cloudRunServiceWithReadinessProbe(name, project, "10", "10", "1"),
       },
       {
 				ResourceName:            "google_cloud_run_service.default",


### PR DESCRIPTION
```release-note:enhancement
cloudrun: added `readiness_probe` fields to `google_cloud_run_service` resource
```

readiness_probe already exists in v1 API for knative compatibility, but Cloud Run ignores it [link](https://cloud.google.com/run/docs/reference/rest/v1/Container#:~:text=the%20probe%20fails.-,readinessProbe,to%20be%20used%20for%20health%20checks.%20Not%20supported%20by%20Cloud%20Run.,-startupProbe). We're preparing to launch support for it

https://github.com/hashicorp/terraform-provider-google/issues/21703
