### PR TITLE
Add `description` field to mirroring resources.

### DIFF
--- a/mmv1/products/networksecurity/MirroringDeployment.yaml
+++ b/mmv1/products/networksecurity/MirroringDeployment.yaml
@@ -144,3 +144,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: description
+    type: String
+    description: |-
+      User-provided description of the deployment.
+      Used as additional context for the deployment.
+    min_version: 'beta'

--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -145,3 +145,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: description
+    type: String
+    description: |-
+      User-provided description of the deployment group.
+      Used as additional context for the deployment group.
+    min_version: 'beta'

--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -133,3 +133,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: description
+    type: String
+    description: |-
+      User-provided description of the endpoint group.
+      Used as additional context for the endpoint group.
+    min_version: 'beta'

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -56,6 +56,7 @@ resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
@@ -9,6 +9,7 @@ resource "google_network_security_mirroring_deployment_group" "{{$.PrimaryResour
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
@@ -16,6 +16,7 @@ resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResource
   mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                   = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_generated_test.go.tmpl
@@ -108,6 +108,7 @@ resource "google_network_security_mirroring_deployment" "default" {
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                = "initial description"
   labels = {
     foo = "bar"
   }
@@ -175,6 +176,7 @@ resource "google_network_security_mirroring_deployment" "default" {
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   mirroring_deployment_group = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                = "updated description"
   labels = {
     foo = "goo"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_generated_test.go.tmpl
@@ -61,6 +61,7 @@ resource "google_network_security_mirroring_deployment_group" "default" {
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "initial description"
   labels = {
     foo = "bar"
   }
@@ -81,6 +82,7 @@ resource "google_network_security_mirroring_deployment_group" "default" {
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "updated description"
   labels = {
     foo = "goo"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_generated_test.go.tmpl
@@ -68,6 +68,7 @@ resource "google_network_security_mirroring_endpoint_group" "default" {
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                   = "initial description"
   labels = {
     foo = "bar"
   }
@@ -95,6 +96,7 @@ resource "google_network_security_mirroring_endpoint_group" "default" {
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
+  description                   = "updated description"
   labels = {
     foo = "goo"
   }


### PR DESCRIPTION
Support the new `description` field in mirroring resources:
* `google_network_security_mirroring_deployment`
* `google_network_security_mirroring_deployment_group`
* `google_network_security_mirroring_endpoint_group`

The field is used to allow customers to describe the resources they're creating.

```release-note:enhancement
networksecurity: added `description` field to `google_network_security_mirroring_deployment`, `google_network_security_mirroring_deployment_group`, `google_network_security_mirroring_endpoint_group` resources
```
