### PR TITLE
Add `description` field to intercept resources.

### DIFF
--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -143,3 +143,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: 'description'
+    type: String
+    description: |-
+      User-provided description of the deployment.
+      Used as additional context for the deployment.
+    min_version: 'beta'

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -144,3 +144,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: 'description'
+    type: String
+    description: |-
+      User-provided description of the deployment group.
+      Used as additional context for the deployment group.
+    min_version: 'beta'

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -132,3 +132,9 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: description
+    type: String
+    description: |-
+      User-provided description of the endpoint group.
+      Used as additional context for the endpoint group.
+    min_version: 'beta'

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -55,6 +55,7 @@ resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  description                = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -9,6 +9,7 @@ resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResour
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -16,6 +16,7 @@ resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResource
   intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  description                   = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_generated_test.go.tmpl
@@ -107,6 +107,7 @@ resource "google_network_security_intercept_deployment" "default" {
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  description                = "initial description"
   labels = {
     foo = "bar"
   }
@@ -173,6 +174,7 @@ resource "google_network_security_intercept_deployment" "default" {
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
   intercept_deployment_group = google_network_security_intercept_deployment_group.deployment_group.id
+  description                = "updated description"
   labels = {
     foo = "goo"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_generated_test.go.tmpl
@@ -61,6 +61,7 @@ resource "google_network_security_intercept_deployment_group" "default" {
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "initial description"
   labels = {
     foo = "bar"
   }
@@ -81,6 +82,7 @@ resource "google_network_security_intercept_deployment_group" "default" {
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
+  description                   = "updated description"
   labels = {
     foo = "goo"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_generated_test.go.tmpl
@@ -68,6 +68,7 @@ resource "google_network_security_intercept_endpoint_group" "default" {
   intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  description                   = "initial description"
   labels = {
     foo = "bar"
   }
@@ -95,6 +96,7 @@ resource "google_network_security_intercept_endpoint_group" "default" {
   intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  description                   = "updated description"
   labels = {
     foo = "goo"
   }


### PR DESCRIPTION
Support the new `description` field in intercept resources:
* `google_network_security_intercept_deployment`
* `google_network_security_intercept_deployment_group`
* `google_network_security_intercept_endpoint_group`

The field is used to allow customers to describe the resources they're creating.

```release-note:enhancement
networksecurity: added `description` field to `google_network_security_intercept_deployment`, `google_network_security_intercept_deployment_group`, `google_network_security_intercept_endpoint_group` resources
```
