### PR TITLE
spanner: Properly set fieldMask when removing autoscaling

### DIFF
--- a/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
@@ -30,6 +30,9 @@ if d.HasChange("autoscaling_config") {
 	newSlice := new.([]interface{})
 	if len(oldSlice) == 0 || len(newSlice) == 0 {
 		updateMask = append(updateMask, "autoscalingConfig")
+		if len(newSlice) == 0 {
+			updateMask = append(updateMask, "processingUnits")
+		}
 	} else {
 		if d.HasChange("autoscaling_config.0.autoscaling_limits.0.max_processing_units") {
 			updateMask = append(updateMask, "autoscalingConfig.autoscalingLimits.maxProcessingUnits")

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -313,6 +313,80 @@ func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdate(t *testing
 	})
 }
 
+func TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdateDisableAutoscaling(t *testing.T) {
+	t.Parallel()
+
+	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingNodesAsConfigsUpdate(displayName, 1, 2, 65, 95),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basicWithNodes(displayName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSpannerInstance_basicWithAutoscalingUsingPrecessingUnitsConfigUpdateDisableAutoscaling(t *testing.T) {
+	t.Parallel()
+
+	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basicWithAutoscalerConfigUsingProcessingUnitsAsConfigs(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basicWithProcessingUnits(displayName, 1000),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccSpannerInstance_basicWithAsymmetricAutoscalingConfigsUpdate(t *testing.T) {
 	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
@@ -398,6 +472,34 @@ resource "google_spanner_instance" "basic" {
   default_backup_schedule_type = "NONE"
 }
 `, name, name)
+}
+
+func testAccSpannerInstance_basicWithNodes(name string, nodes int) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-dname"
+
+  num_nodes                    = %d
+  edition                      = "ENTERPRISE"
+  default_backup_schedule_type = "NONE"
+}
+`, name, name, nodes)
+}
+
+func testAccSpannerInstance_basicWithProcessingUnits(name string, processingUnits int) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-dname"
+
+  processing_units             = %d
+  edition                      = "ENTERPRISE"
+  default_backup_schedule_type = "NONE"
+}
+`, name, name, processingUnits)
 }
 
 func testAccSpannerInstance_noNodeCountSpecified(name string) string {


### PR DESCRIPTION
Before this fix disabling autoscaling would fail with the following error:

```
googleapi: Error 400: The user should include both autoscaling_config and node_count/processing_units in the field masks, and explicitly clear the autoscaling_config field when disabling autoscaling.
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21652

Added two acceptance tests to surface this issue.

- TestAccSpannerInstance_basicWithAutoscalingUsingPrecessingUnitsConfigUpdateDisableAutoscaling
- TestAccSpannerInstance_basicWithAutoscalingUsingNodeConfigUpdateDisableAutoscaling

```release-note: bug
spanner: fixed issue with disabling autoscaling in `google_spanner_instance`
```
