### PR TITLE
Remove note about beta permissions from google_compute_shared_vpc_service_project docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -15,8 +15,6 @@ For more information, see,
 [the Project API documentation](https://cloud.google.com/compute/docs/reference/latest/projects),
 where the Shared VPC feature is referred to by its former name "XPN".
 
-~> **Note:** If Shared VPC Admin role is set at the folder level, use the google-beta provider. The google provider only supports this permission at project or organizational level currently. [[0]](https://cloud.google.com/vpc/docs/provisioning-shared-vpc#enable-shared-vpc-host)
-
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Warnings are gone from https://cloud.google.com/vpc/docs/provisioning-shared-vpc and b/218727896 has some context internally. 

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: removed the warning that `google_compute_shared_vpc_service_project` requires project or org-level permissions. Folder-level permissions should work when using the GA API, and should have been working for some time.
```
