### PR TITLE
Feature gap: Add `ipCollection` field to Subnetwork (beta)

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -146,6 +146,15 @@ examples:
     vars:
       subnetwork_name: 'subnet-ipv6-only'
       network_name: 'network-ipv6-only'
+  - name: 'subnetwork_ipcollection'
+    primary_resource_id: 'subnetwork-ip-collection'
+    min_version: 'beta'
+    vars:
+      subnetwork_name: 'subnet-ip-collection'
+      network_name: 'website-net'
+      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
+    test_vars_overrides:
+      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
 virtual_fields:
   - name: 'send_secondary_ip_range_if_empty'
     description: |
@@ -467,3 +476,17 @@ properties:
     update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
     update_verb: 'PATCH'
     fingerprint_name: 'fingerprint'
+  - name: ipCollection
+    type: String
+    min_version: 'beta'
+    diff_suppress_func: 'IpCollectionDiffSuppress'
+    description: |
+      Resource reference of a PublicDelegatedPrefix. The PDP must be a sub-PDP
+      in EXTERNAL_IPV6_FORWARDING_RULE_CREATION mode.
+      Use one of the following formats to specify a sub-PDP when creating an
+      IPv6 NetLB forwarding rule using BYOIP:
+      Full resource URL, as in:
+        * `https://www.googleapis.com/compute/v1/projects/{{projectId}}/regions/{{region}}/publicDelegatedPrefixes/{{sub-pdp-name}}`
+      Partial URL, as in:
+        * `projects/{{projectId}}/regions/region/publicDelegatedPrefixes/{{sub-pdp-name}}`
+        * `regions/{{region}}/publicDelegatedPrefixes/{{sub-pdp-name}}`

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -476,10 +476,13 @@ properties:
     update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
     update_verb: 'PATCH'
     fingerprint_name: 'fingerprint'
-  - name: ipCollection
+  - name: 'ipCollection'
     type: String
     min_version: 'beta'
     diff_suppress_func: 'IpCollectionDiffSuppress'
+    update_url: 'projects/{{project}}/regions/{{region}}/subnetworks/{{name}}'
+    update_verb: 'PATCH'
+    fingerprint_name: 'fingerprint'
     description: |
       Resource reference of a PublicDelegatedPrefix. The PDP must be a sub-PDP
       in EXTERNAL_IPV6_FORWARDING_RULE_CREATION mode.

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -152,9 +152,6 @@ examples:
     vars:
       subnetwork_name: 'subnet-ip-collection'
       network_name: 'website-net'
-      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
-    test_vars_overrides:
-      ip_collection_url: '"projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"'
 virtual_fields:
   - name: 'send_secondary_ip_range_if_empty'
     description: |

--- a/mmv1/templates/terraform/examples/subnetwork_ipcollection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/subnetwork_ipcollection.tf.tmpl
@@ -1,10 +1,12 @@
 resource "google_compute_subnetwork" "subnetwork-ip-collection" {
-  provider      = google-beta
-  name          = "{{index $.Vars "subnetwork_name"}}"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.custom-test.id
-  ip_collection = "{{index $.Vars "ip_collection_url"}}"
+  provider          = google-beta
+  name              = "{{index $.Vars "subnetwork_name"}}"
+  ip_cidr_range     = "10.2.0.0/16"
+  region            = "us-central1"
+  network           = google_compute_network.custom-test.id
+  ipv6_access_type  = "EXTERNAL"
+  stack_type        = "IPV4_IPV6"
+  ip_collection     = "projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"
 }
 
 resource "google_compute_network" "custom-test" {

--- a/mmv1/templates/terraform/examples/subnetwork_ipcollection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/subnetwork_ipcollection.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_compute_subnetwork" "subnetwork-ip-collection" {
+  provider      = google-beta
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.id
+  ip_collection = "{{index $.Vars "ip_collection_url"}}"
+}
+
+resource "google_compute_network" "custom-test" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -140,6 +140,14 @@ func TestAccComputeSubnetwork_update(t *testing.T) {
 				),
 			},
 			{
+				// Add a ip_collection and related fields
+				Config: testAccComputeSubnetwork_update4(cnName, "10.2.0.0/24", subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(
+						t, "google_compute_subnetwork.network-with-private-google-access", &subnetwork),
+				),
+			},
+			{
 				ResourceName:      "google_compute_subnetwork.network-with-private-google-access",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -456,6 +464,31 @@ func TestAccComputeSubnetwork_internal_ipv6(t *testing.T) {
 	})
 }
 
+func TestAccComputeSubnetwork_subnetworkIpcollectionExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSubnetwork_subnetworkIpcollectionExample(context),
+			},
+			{
+				ResourceName:            "google_compute_subnetwork.subnetwork-ip-collection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"network", "region", "reserved_internal_range"},
+			},
+		},
+	})
+}
+
 func testAccCheckComputeSubnetworkExists(t *testing.T, n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -597,6 +630,31 @@ resource "google_compute_subnetwork" "network-with-private-google-access" {
     range_name    = "tf-test-secondary-range-update"
     ip_cidr_range = "192.168.10.0/24"
   }
+}
+`, cnName, subnetworkName, cidrRange)
+}
+
+func testAccComputeSubnetwork_update4(cnName, cidrRange, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-private-google-access" {
+  name          = "%s"
+  ip_cidr_range = "%s"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.self_link
+
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update"
+    ip_cidr_range = "192.168.10.0/24"
+  }
+
+  ipv6_access_type = "EXTERNAL"
+  stack_type    = "IPV4_IPV6"
+  ip_collection = "projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"
 }
 `, cnName, subnetworkName, cidrRange)
 }
@@ -955,4 +1013,25 @@ resource "google_compute_subnetwork" "subnetwork" {
   ipv6_access_type = "INTERNAL"
 }
 `, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_subnetworkIpcollectionExample(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_subnetwork" "subnetwork-ip-collection" {
+  provider      = google-beta
+  name          = "tf-test-subnet-ip-collection%{random_suffix}"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.id
+  ipv6_access_type = "EXTERNAL"
+  stack_type    = "IPV4_IPV6"
+  ip_collection = "projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"
+}
+
+resource "google_compute_network" "custom-test" {
+  provider                = google-beta
+  name                    = "tf-test-website-net%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -464,31 +464,6 @@ func TestAccComputeSubnetwork_internal_ipv6(t *testing.T) {
 	})
 }
 
-func TestAccComputeSubnetwork_subnetworkIpcollectionExample(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeSubnetwork_subnetworkIpcollectionExample(context),
-			},
-			{
-				ResourceName:            "google_compute_subnetwork.subnetwork-ip-collection",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"network", "region", "reserved_internal_range"},
-			},
-		},
-	})
-}
-
 func testAccCheckComputeSubnetworkExists(t *testing.T, n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1013,25 +988,4 @@ resource "google_compute_subnetwork" "subnetwork" {
   ipv6_access_type = "INTERNAL"
 }
 `, cnName, subnetworkName)
-}
-
-func testAccComputeSubnetwork_subnetworkIpcollectionExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_compute_subnetwork" "subnetwork-ip-collection" {
-  provider      = google-beta
-  name          = "tf-test-subnet-ip-collection%{random_suffix}"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.custom-test.id
-  ipv6_access_type = "EXTERNAL"
-  stack_type    = "IPV4_IPV6"
-  ip_collection = "projects/tf-static-byoip/regions/us-central1/publicDelegatedPrefixes/tf-test-forwarding-rule-mode-pdp"
-}
-
-resource "google_compute_network" "custom-test" {
-  provider                = google-beta
-  name                    = "tf-test-website-net%{random_suffix}"
-  auto_create_subnetworks = false
-}
-`, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch adds `IpCollection` field to subnetwork resource. It's field available for beta API only.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `ip_collection` field to `google_compute_subnetwork` resource (beta)
```
