### PR TITLE
spanner: fixed applying default_labels changes

### DIFF
--- a/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance_update.go.tmpl
@@ -18,7 +18,7 @@ if d.HasChange("num_nodes") {
 if d.HasChange("display_name") {
 	updateMask = append(updateMask, "displayName")
 }
-if d.HasChange("labels") {
+if d.HasChange("labels") || d.HasChange("terraform_labels") {
 	updateMask = append(updateMask, "labels")
 }
 if d.HasChange("processing_units") {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -36,6 +36,43 @@ func TestAccSpannerInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccSpannerInstance_basicUpdateWithProviderDefaultLabels(t *testing.T) {
+	t.Parallel()
+
+	idName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_basicWithProviderLabel(idName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_basicWithProviderLabel(idName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 	t.Parallel()
 
@@ -500,6 +537,34 @@ resource "google_spanner_instance" "basic" {
   default_backup_schedule_type = "NONE"
 }
 `, name, name, processingUnits)
+}
+
+func testAccSpannerInstance_basicWithProviderLabel(name string, addLabel bool) string {
+	extraLabel := ""
+	if addLabel {
+		extraLabel = "\"key2\" = \"value2\""
+	}
+	return fmt.Sprintf(`
+provider "google" {
+  alias          = "with-labels"
+  default_labels = {
+    %s
+  }
+}
+
+resource "google_spanner_instance" "basic" {
+  provider     = google.with-labels
+  config       = "regional-us-central1"
+  name         = "%s"
+  display_name = "%s"
+
+  processing_units = 100
+
+  labels = {
+    "key1" = "value1"
+  }
+}
+`, extraLabel, name, name)
 }
 
 func testAccSpannerInstance_noNodeCountSpecified(name string) string {


### PR DESCRIPTION
Before this fix just changing `default_labels` on the provider for a `google_spanner_instance` resulted in this error:

```
googleapi: Error 400: Invalid UpdateInstance request.
[...]
Must specify a non-empty field mask
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/18445

Added one acceptance tests to surface this issue.

- TestAccSpannerInstance_basicUpdateWithProviderDefaultLabels

```release-note: bug
spanner: fixed issue with applying changes in provider `default_labels` on `google_spanner_instance`
```