### PR TITLE
Remove v1 version guards for GKE auto-monitoring

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -5919,7 +5919,6 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
-		{{- if ne $.TargetVersionName "ga" }}
 		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok {
 		    if autoMonitoringList, ok := autoMonitoring.([]interface{}); ok {
 		        if len(autoMonitoringList) > 0 {
@@ -5932,7 +5931,6 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		        }
 		    }
 		}
-		{{- end }}
 	}
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
@@ -6917,7 +6915,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
     result := make(map[string]interface{})
     result["enabled"] = c.Enabled
 
-    {{- if ne $.TargetVersionName "ga" }}
     autoMonitoringList := []map[string]interface{}{}
     if c.AutoMonitoringConfig != nil && c.AutoMonitoringConfig.Scope != "" {
         autoMonitoringMap := map[string]interface{}{
@@ -6927,7 +6924,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
     }
 
     result["auto_monitoring_config"] = autoMonitoringList
-    {{- end }}
 
     return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1282,7 +1282,6 @@ func ResourceContainerCluster() *schema.Resource {
 										Required:    true,
 										Description: `Whether or not the managed collection is enabled.`,
 									},
-									{{- if ne $.TargetVersionName "ga" }}
 									"auto_monitoring_config": {
 										Type:        schema.TypeList,
 										Optional:    true,
@@ -1300,7 +1299,6 @@ func ResourceContainerCluster() *schema.Resource {
 											},
 										},
 									},
-									{{- end }}
 								},
 							},
 						},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -4068,7 +4068,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{{- if ne $.TargetVersionName "ga" }}
 			{
 				Config: testAccContainerCluster_withMonitoringConfigScopeAll(clusterName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
@@ -4093,7 +4092,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{{- end }}
 			// Back to basic settings to test setting Prometheus on its own
 			{
 				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
@@ -11165,7 +11163,6 @@ resource "google_container_cluster" "primary" {
 `, name, networkName, subnetworkName)
 }
 
-{{- if ne $.TargetVersionName "ga" }}								
 func testAccContainerCluster_withMonitoringConfigScopeAll(name, networkName, subnetworkName string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -11207,7 +11204,6 @@ resource "google_container_cluster" "primary" {
 }
 `, name, networkName, subnetworkName)
 }
-{{- end }}
 
 func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigEnabled(name string) string {
        return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -663,7 +663,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
-* `auto_monitoring_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for GKE Auto-Monitoring.
+* `auto_monitoring_config` - (Optional) Configuration options for GKE Auto-Monitoring.
 
 <a name="auto_monitoring_config"></a>The `auto_monitoring_config` block supports:
 


### PR DESCRIPTION
Now that the Go API client is published by OnePlatform for the GKE auto-monitoring feature, remove the version guards for v1.

```release-note:enhancement
container: added `monitoring_config.managed_prometheus.auto_monitoring_config` field to `google_container_cluster` resource (ga)
```