### PR TITLE
Fix the issue that user can't use regional disk in global_instance_template

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+  "regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -230,6 +231,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 // ensures that overriding one of these properties does not override the others.
 func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_tpg.Config, it *compute.InstanceTemplate, zone *compute.Zone, project string, isFromRegionalTemplate bool) ([]*compute.AttachedDisk, error) {
 	disks := []*compute.AttachedDisk{}
+  re := regexp.MustCompile(`projects/[^/]+/(regions|zones)/[^/]+/disks/[^/]+$`)
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
 		bootDisk, err := expandBootDisk(d, config, project)
 		if err != nil {
@@ -240,7 +242,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 		// boot disk was not overridden, so use the one from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
-				if disk.Source != "" && !isFromRegionalTemplate {
+				if disk.Source != "" && !isFromRegionalTemplate && !re.MatchString(disk.Source){
 					// Instances need a URL for the disk, but instance templates only have the name
 					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone.Name, disk.Source)
 				}
@@ -303,7 +305,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 		// attached disks were not overridden, so use the ones from the instance template
 		for _, disk := range it.Properties.Disks {
 			if !disk.Boot && disk.Type != "SCRATCH" {
-				if s := disk.Source; s != ""  && !isFromRegionalTemplate {
+				if s := disk.Source; s != ""  && !isFromRegionalTemplate && !re.MatchString(disk.Source){
 					// Instances need a URL for the disk source, but instance templates
 					// only have the name (since they're global).
 					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone.Name, s)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -1170,6 +1170,155 @@ resource "google_compute_instance_from_template" "foobar" {
 
 {{ end }}
 
+func testAccComputeInstanceFromTemplate_regionalDisk(instance, template string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_disk" "foobar" {
+  name          = "%s"
+  size          = 10
+  type          = "pd-ssd"
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1"  // can't be e2 because of local-ssd
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = true
+    disk_type    = "pd-ssd"
+    type         = "PERSISTENT"
+  }
+
+  disk {
+    source      = google_compute_region_disk.foobar.self_link
+    auto_delete = false
+    boot        = false
+  }
+
+  disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  scheduling {
+    automatic_restart = true
+  }
+
+  can_ip_forward = true
+}
+
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  source_instance_template = google_compute_region_instance_template.foobar.id
+
+  // Overrides
+  can_ip_forward = false
+  labels = {
+    my_key = "my_value"
+  }
+  scheduling {
+    automatic_restart = false
+  }
+}
+`, template, template, instance)
+}
+
+func testAccComputeInstanceFromTemplate_zonalDiskWithSelflink(instance, template string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name          = "%s"
+  size          = 10
+  type          = "pd-ssd"
+  region        = "us-central1"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  region = "us-central1"
+  machine_type = "n1-standard-1"  // can't be e2 because of local-ssd
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = true
+    disk_type    = "pd-ssd"
+    type         = "PERSISTENT"
+  }
+
+  disk {
+    source      = google_compute_disk.foobar.self_link
+    auto_delete = false
+    boot        = false
+  }
+
+  disk {
+    disk_type    = "local-ssd"
+    type         = "SCRATCH"
+    interface    = "NVME"
+    disk_size_gb = 375
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  scheduling {
+    automatic_restart = true
+  }
+
+  can_ip_forward = true
+}
+
+resource "google_compute_instance_from_template" "foobar" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  source_instance_template = google_compute_region_instance_template.foobar.id
+
+  // Overrides
+  can_ip_forward = false
+  labels = {
+    my_key = "my_value"
+  }
+  scheduling {
+    automatic_restart = false
+  }
+}
+`, template, template, instance)
+}
+
 func testAccComputeInstanceFromTemplate_self_link_unique(instance, template string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {


### PR DESCRIPTION
Allow users to specify url link to zonal or regional disk resources in instance template.
Fixes https://github.com/hashicorp/terraform-provider-google/issues/10186

```release-note:bug
compute: fixed the issue that user can't use regional disk in `global_instance_template`.
```
