### PR TITLE
Add support for continuous query to google_bigquery_job in beta

### DIFF
--- a/mmv1/products/bigquery/Job.yaml
+++ b/mmv1/products/bigquery/Job.yaml
@@ -57,6 +57,15 @@ examples:
     ignore_read_extra:
       - 'etag'
       - 'status.0.state'
+  - name: 'bigquery_job_query_continuous'
+    exclude_docs: true
+    primary_resource_id: 'job'
+    vars:
+      job_id: 'job_query_continuous'
+    ignore_read_extra:
+      - 'etag'
+      - 'status.0.state'
+    min_version: beta
   - name: 'bigquery_job_query_table_reference'
     primary_resource_id: 'job'
     vars:
@@ -392,6 +401,11 @@ properties:
                 enum_values:
                   - 'LAST'
                   - 'FIRST_SELECT'
+          - name: 'continuous'
+            type: Boolean
+            description: |
+              Whether to run the query as continuous or a regular query.
+            min_version: beta
       - name: 'load'
         type: NestedObject
         description: 'Configures a load job.'

--- a/mmv1/templates/terraform/examples/bigquery_job_query_continuous.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_job_query_continuous.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_bigquery_job" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  job_id     = "{{index $.Vars "job_id"}}"
+
+  query {
+    query = "SELECT state FROM [lookerdata:cdc.project_tycho_reports]"
+    continuous = true
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add support for continuous query to `google_bigquery_job` in beta

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added support for continuous query to `google_bigquery_job` (beta)
```
