### PR TITLE
fix: handle responses without policies

### DIFF
--- a/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_access_policy.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_access_policy.go
@@ -75,7 +75,7 @@ func dataSourceAccessContextManagerAccessPolicyRead(d *schema.ResourceData, meta
 
 	policies, err := parse_policies_response(res)
 	if err != nil {
-		fmt.Errorf("Error parsing list policies response: %s", err)
+		return fmt.Errorf("Error parsing list policies response: %s", err)
 	}
 
 	// Find the matching policy in the list of policies response. Both the parent and scopes
@@ -102,6 +102,11 @@ func dataSourceAccessContextManagerAccessPolicyRead(d *schema.ResourceData, meta
 
 func parse_policies_response(res map[string]interface{}) ([]AccessPolicy, error) {
 	var policies []AccessPolicy
+	if _, ok := res["accessPolicies"].([]interface{}); !ok {
+		// response did not include any policies
+		return policies, nil
+	}
+
 	for _, res_policy := range res["accessPolicies"].([]interface{}) {
 		parsed_policy := &AccessPolicy{}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21740

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
accesscontextmanager: fix panic on empty accessPolicies in `google_access_context_manager_access_policy`
```
