### PR TITLE
Fix big table markdown parser

### DIFF
--- a/tools/diff-processor/documentparser/document_parser.go
+++ b/tools/diff-processor/documentparser/document_parser.go
@@ -11,7 +11,7 @@ var (
 	fieldNameRegex      = regexp.MustCompile("[\\*|-]\\s+`([a-z0-9_\\./]+)`") // * `xxx`
 	nestedObjectRegex   = regexp.MustCompile(`<a\s+name="([a-z0-9_]+)">`)     // <a name="xxx">
 	nestedHashTagRegex  = regexp.MustCompile(`\(#(nested_[a-z0-9_]+)\)`)      // #(nested_xxx)
-	horizontalLineRegex = regexp.MustCompile("- - -|-{4,}")                   // - - - or ----
+	horizontalLineRegex = regexp.MustCompile("- - -|-{3,}")                   // - - - or ---
 
 	sectionSeparator = "## "
 )

--- a/tools/diff-processor/documentparser/document_parser.go
+++ b/tools/diff-processor/documentparser/document_parser.go
@@ -11,7 +11,7 @@ var (
 	fieldNameRegex      = regexp.MustCompile("[\\*|-]\\s+`([a-z0-9_\\./]+)`") // * `xxx`
 	nestedObjectRegex   = regexp.MustCompile(`<a\s+name="([a-z0-9_]+)">`)     // <a name="xxx">
 	nestedHashTagRegex  = regexp.MustCompile(`\(#(nested_[a-z0-9_]+)\)`)      // #(nested_xxx)
-	horizontalLineRegex = regexp.MustCompile("- - -|-{10,}")                  // - - - or ------------
+	horizontalLineRegex = regexp.MustCompile("- - -|-{4,}")                   // - - - or ----
 
 	sectionSeparator = "## "
 )


### PR DESCRIPTION
Just found the parser got stuck at a different horizontal line, so fixing the separator. 

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
