### PR TITLE
networksecurity: add not_operations array to AuthzPolicy resource

### DIFF
--- a/mmv1/products/networksecurity/AuthzPolicy.yaml
+++ b/mmv1/products/networksecurity/AuthzPolicy.yaml
@@ -469,6 +469,141 @@ properties:
                       A list of HTTP methods to match against. Each entry must be a valid HTTP method name (GET, PUT, POST, HEAD, PATCH, DELETE, OPTIONS). It only allows exact match and is always case sensitive.
                     item_type:
                       type: String
+            - name: 'notOperations'
+              type: Array
+              description: |
+                Describes the negated properties of the targets of a request. Matches requests for operations that do not match the criteria specified in this field. At least one of operations or notOperations must be specified.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'headerSet'
+                    type: NestedObject
+                    description: |
+                      A list of headers to match against in http header.
+                    properties:
+                      - name: 'headers'
+                        type: Array
+                        description: |
+                          A list of headers to match against in http header. The match can be one of exact, prefix, suffix, or contains (substring match). The match follows AND semantics which means all the headers must match. Matches are always case sensitive unless the ignoreCase is set. Limited to 5 matches.
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: 'name'
+                              type: String
+                              description: |
+                                Specifies the name of the header in the request.
+                            - name: 'value'
+                              type: NestedObject
+                              description: |
+                                Specifies how the header match will be performed.
+                              properties:
+                                - name: 'ignoreCase'
+                                  type: Boolean
+                                  description: |
+                                    If true, indicates the exact/prefix/suffix/contains matching should be case insensitive. For example, the matcher data will match both input string Data and data if set to true.
+                                - name: 'exact'
+                                  type: String
+                                  description: |
+                                    The input string must match exactly the string specified here.
+                                    Examples:
+                                    * abc only matches the value abc.
+                                - name: 'prefix'
+                                  type: String
+                                  description: |
+                                    The input string must have the prefix specified here. Note: empty prefix is not allowed, please use regex instead.
+                                    Examples:
+                                    * abc matches the value abc.xyz
+                                - name: 'suffix'
+                                  type: String
+                                  description: |
+                                    The input string must have the suffix specified here. Note: empty prefix is not allowed, please use regex instead.
+                                    Examples:
+                                    * abc matches the value xyz.abc
+                                - name: 'contains'
+                                  type: String
+                                  description: |
+                                    The input string must have the substring specified here. Note: empty contains match is not allowed, please use regex instead.
+                                    Examples:
+                                    * abc matches the value xyz.abc.def
+                  - name: 'hosts'
+                    type: Array
+                    description: |
+                      A list of HTTP Hosts to match against. The match can be one of exact, prefix, suffix, or contains (substring match). Matches are always case sensitive unless the ignoreCase is set.
+                      Limited to 5 matches.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'ignoreCase'
+                          type: Boolean
+                          description: |
+                            If true, indicates the exact/prefix/suffix/contains matching should be case insensitive. For example, the matcher data will match both input string Data and data if set to true.
+                        - name: 'exact'
+                          type: String
+                          description: |
+                            The input string must match exactly the string specified here.
+                            Examples:
+                            * abc only matches the value abc.
+                        - name: 'prefix'
+                          type: String
+                          description: |
+                            The input string must have the prefix specified here. Note: empty prefix is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value abc.xyz
+                        - name: 'suffix'
+                          type: String
+                          description: |
+                            The input string must have the suffix specified here. Note: empty prefix is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value xyz.abc
+                        - name: 'contains'
+                          type: String
+                          description: |
+                            The input string must have the substring specified here. Note: empty contains match is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value xyz.abc.def
+                  - name: 'paths'
+                    type: Array
+                    description: |
+                      A list of paths to match against. The match can be one of exact, prefix, suffix, or contains (substring match). Matches are always case sensitive unless the ignoreCase is set.
+                      Limited to 5 matches.
+                      Note that this path match includes the query parameters. For gRPC services, this should be a fully-qualified name of the form /package.service/method.
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'ignoreCase'
+                          type: Boolean
+                          description: |
+                            If true, indicates the exact/prefix/suffix/contains matching should be case insensitive. For example, the matcher data will match both input string Data and data if set to true.
+                        - name: 'exact'
+                          type: String
+                          description: |
+                            The input string must match exactly the string specified here.
+                            Examples:
+                            * abc only matches the value abc.
+                        - name: 'prefix'
+                          type: String
+                          description: |
+                            The input string must have the prefix specified here. Note: empty prefix is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value abc.xyz
+                        - name: 'suffix'
+                          type: String
+                          description: |
+                            The input string must have the suffix specified here. Note: empty prefix is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value xyz.abc
+                        - name: 'contains'
+                          type: String
+                          description: |
+                            The input string must have the substring specified here. Note: empty contains match is not allowed, please use regex instead.
+                            Examples:
+                            * abc matches the value xyz.abc.def
+                  - name: 'methods'
+                    type: Array
+                    description: |
+                      A list of HTTP methods to match against. Each entry must be a valid HTTP method name (GET, PUT, POST, HEAD, PATCH, DELETE, OPTIONS). It only allows exact match and is always case sensitive.
+                    item_type:
+                      type: String
         - name: 'when'
           type: String
           description: |

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_services_authz_policy_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_services_authz_policy_test.go
@@ -353,6 +353,79 @@ resource "google_network_security_authz_policy" "default" {
           ignore_case = true
         }
       }
+      not_operations {
+        methods = ["GET", "PUT", "POST", "HEAD", "PATCH", "DELETE", "OPTIONS"]
+		header_set {
+          # Prefix
+		  headers {
+            name = "PrefixHeader"
+            value {
+			  ignore_case = false
+			  prefix      = "prefix"
+            }
+          }
+		  # Suffix / Ignore case
+		  headers {
+			name = "SuffixHeader"
+			value {
+			  ignore_case = true
+			  suffix      = "suffix"
+			}
+		  }
+		  # Exact
+		  headers {
+            name = "ExactHeader"
+            value {
+              exact       = "exact"
+          	  ignore_case = false
+            }
+          }
+		  # Contains / Ignore case
+		  headers {
+            name = "ContainsHeader"
+            value {
+              contains    = "contains"
+          	  ignore_case = true
+            }
+          }
+        }
+        # Prefix
+		hosts {
+			ignore_case = false
+			prefix      = "prefix"
+        }
+		paths {
+          ignore_case = false
+          prefix      = "prefix"
+        }
+		# Suffix / Ignore case
+		hosts {
+          ignore_case = true
+          suffix      = "suffix"
+        }
+        paths {
+          ignore_case = true
+          suffix      = "suffix"
+        }
+		# Exact
+		hosts {
+          exact       = "exact"
+          ignore_case = false
+        }
+		paths {
+		  exact       = "exact"
+		  ignore_case = false
+        }
+		# Contains / Ignore case
+		hosts {
+          contains    = "contains"
+          ignore_case = true
+        }
+		paths {
+          contains    = "contains"
+          ignore_case = true
+        }
+      }
     }
 	when = "request.host.endsWith('.example.com')"
   }


### PR DESCRIPTION
This change adds the `not_operations` field that is missing from the `AuthzPolicy` resource. It functions the same as the `operations` field but represents the negation[^1].

[^1]: Relevant docs [here](https://cloud.google.com/load-balancing/docs/reference/network-security/rest/v1beta1/projects.locations.authzPolicies#to)

```release-note:enhancement
networksecurity: added `not_operations` field to `google_network_security_authz_policy` resource
```
