### PR TITLE
feat: add execution history level in cloud workflows

### DIFF
--- a/mmv1/products/workflows/Workflow.yaml
+++ b/mmv1/products/workflows/Workflow.yaml
@@ -152,10 +152,20 @@ properties:
       - 'LOG_ALL_CALLS'
       - 'LOG_ERRORS_ONLY'
       - 'LOG_NONE'
+  - name: 'executionHistoryLevel'
+    type: Enum
+    description: |
+      Describes the level of execution history to be stored for this workflow. This configuration
+      determines how much information about workflow executions is preserved. If not specified,
+      defaults to EXECUTION_HISTORY_LEVEL_UNSPECIFIED.
+    enum_values:
+      - 'EXECUTION_HISTORY_LEVEL_UNSPECIFIED'
+      - 'EXECUTION_HISTORY_BASIC'
+      - 'EXECUTION_HISTORY_DETAILED'
   - name: 'userEnvVars'
     type: KeyValuePairs
     description: |
-      User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 4KiB. Keys cannot be empty strings and cannot start with “GOOGLE” or “WORKFLOWS".
+      User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 4KiB. Keys cannot be empty strings and cannot start with "GOOGLE" or "WORKFLOWS".
   - name: 'tags'
     type: KeyValuePairs
     description: |

--- a/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workflows/resource_workflows_workflow_test.go.tmpl
@@ -39,6 +39,7 @@ resource "google_workflows_workflow" "example" {
   region         = "us-central1"
   description    = "Magic"
   call_log_level = "LOG_ERRORS_ONLY"
+  execution_history_level = "EXECUTION_HISTORY_BASIC"
   user_env_vars = {
     url = "https://timeapi.io/api/Time/current/zone?timeZone=Europe/Amsterdam"
   }
@@ -84,6 +85,7 @@ resource "google_workflows_workflow" "example" {
   region         = "us-central1"
   description    = "Magic-updated"
   call_log_level = "LOG_ALL_CALLS"
+  execution_history_level = "EXECUTION_HISTORY_DETAILED"
   user_env_vars = {
     url = "https://timeapi.io/api/Time/current/zone?timeZone=Europe/London"
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Support the new `execution_history_level` in Cloud Workflows
resource : `google_workflows_workflow`

The field execution_history_level is used to specify whether a workflow or execution should record Basic or Detailed history information, with Detailed providing additional data such as in-scope variable values and expected iteration counts for loops and parallel branches.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21491