### PR TITLE
Fix bad preamble on RMIG DS docs

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_region_instance_group_manager.html.markdown
@@ -1,6 +1,5 @@
 ---
 subcategory: "Compute Engine"
-page_title: "Google: google_compute_region_instance_group_manager"
 description: |-
 Get a Compute Region Instance Group within GCE.
 ---


### PR DESCRIPTION
See https://registry.terraform.io/providers/hashicorp/google/6.24.0/docs/data-sources/compute_region_instance_group_manager where this is uncategorised. The `:` in `page_title` causes issues, I think we ignore the value anyways.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
