### PR TITLE
tgc-revival: google_project tfplan2cai converter

### DIFF
--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converters.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converters.go.tmpl
@@ -29,7 +29,9 @@ package converters
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/cai"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/services/resourcemanager"
 )
 
 var ConverterMap = map[string]cai.ResourceConverter{
+	"google_project":          resourcemanager.ResourceConverterProject(),
 }

--- a/mmv1/third_party/tgc_next/caiasset/asset.go
+++ b/mmv1/third_party/tgc_next/caiasset/asset.go
@@ -1,0 +1,133 @@
+package caiasset
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Asset is the CAI representation of a resource.
+type Asset struct {
+	// The name, in a peculiar format: `\\<api>.googleapis.com/<self_link>`
+	Name string `json:"name"`
+	// The type name in `google.<api>.<resourcename>` format.
+	Type          string           `json:"assetType"`
+	Resource      *AssetResource   `json:"resource,omitempty"`
+	IAMPolicy     *IAMPolicy       `json:"iamPolicy,omitempty"`
+	OrgPolicy     []*OrgPolicy     `json:"orgPolicy,omitempty"`
+	V2OrgPolicies []*V2OrgPolicies `json:"v2_org_policies,omitempty"`
+	Ancestors     []string         `json:"ancestors"`
+	TfplanAddress []string         `json:"tfplanAddress,omitempty"`
+}
+
+// IAMPolicy is the representation of a Cloud IAM policy set on a cloud resource.
+type IAMPolicy struct {
+	Bindings []IAMBinding `json:"bindings"`
+}
+
+// IAMBinding binds a role to a set of members.
+type IAMBinding struct {
+	Role    string   `json:"role"`
+	Members []string `json:"members"`
+}
+
+// AssetResource is nested within the Asset type.
+type AssetResource struct {
+	Version              string                 `json:"version"`
+	DiscoveryDocumentURI string                 `json:"discoveryDocumentUri"`
+	DiscoveryName        string                 `json:"discoveryName"`
+	Parent               string                 `json:"parent"`
+	Data                 map[string]interface{} `json:"data"`
+	Location             string                 `json:"location,omitempty"`
+}
+
+// OrgPolicy is for managing organization policies.
+type OrgPolicy struct {
+	Constraint     string          `json:"constraint,omitempty"`
+	ListPolicy     *ListPolicy     `json:"list_policy,omitempty"`
+	BooleanPolicy  *BooleanPolicy  `json:"boolean_policy,omitempty"`
+	RestoreDefault *RestoreDefault `json:"restore_default,omitempty"`
+	UpdateTime     *Timestamp      `json:"update_time,omitempty"`
+}
+
+// V2OrgPolicies is the represtation of V2OrgPolicies
+type V2OrgPolicies struct {
+	Name       string      `json:"name"`
+	PolicySpec *PolicySpec `json:"spec,omitempty"`
+}
+
+// Spec is the representation of Spec for Custom Org Policy
+type PolicySpec struct {
+	Etag              string        `json:"etag,omitempty"`
+	UpdateTime        *Timestamp    `json:"update_time,omitempty"`
+	PolicyRules       []*PolicyRule `json:"rules,omitempty"`
+	InheritFromParent bool          `json:"inherit_from_parent,omitempty"`
+	Reset             bool          `json:"reset,omitempty"`
+}
+
+type PolicyRule struct {
+	Values    *StringValues `json:"values,omitempty"`
+	AllowAll  bool          `json:"allow_all,omitempty"`
+	DenyAll   bool          `json:"deny_all,omitempty"`
+	Enforce   bool          `json:"enforce,omitempty"`
+	Condition *Expr         `json:"condition,omitempty"`
+}
+
+type StringValues struct {
+	AllowedValues []string `json:"allowed_values,omitempty"`
+	DeniedValues  []string `json:"denied_values,omitempty"`
+}
+
+type Expr struct {
+	Expression  string `json:"expression,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Location    string `json:"location,omitempty"`
+}
+
+type Timestamp struct {
+	Seconds int64 `json:"seconds,omitempty"`
+	Nanos   int64 `json:"nanos,omitempty"`
+}
+
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Unix(0, t.Nanos).UTC().Format(time.RFC3339Nano) + `"`), nil
+}
+
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	p, err := time.Parse(time.RFC3339Nano, strings.Trim(string(b), `"`))
+	if err != nil {
+		return fmt.Errorf("bad Timestamp: %v", err)
+	}
+	t.Seconds = p.Unix()
+	t.Nanos = p.UnixNano()
+	return nil
+}
+
+// ListPolicyAllValues is used to set `Policies` that apply to all possible
+// configuration values rather than specific values in `allowed_values` or
+// `denied_values`.
+type ListPolicyAllValues int32
+
+// ListPolicy can define specific values and subtrees of Cloud Resource
+// Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that
+// are allowed or denied by setting the `allowed_values` and `denied_values`
+// fields.
+type ListPolicy struct {
+	AllowedValues     []string            `json:"allowed_values,omitempty"`
+	DeniedValues      []string            `json:"denied_values,omitempty"`
+	AllValues         ListPolicyAllValues `json:"all_values,omitempty"`
+	SuggestedValue    string              `json:"suggested_value,omitempty"`
+	InheritFromParent bool                `json:"inherit_from_parent,omitempty"`
+}
+
+// BooleanPolicy If `true`, then the `Policy` is enforced. If `false`,
+// then any configuration is acceptable.
+type BooleanPolicy struct {
+	Enforced bool `json:"enforced,omitempty"`
+}
+
+// RestoreDefault determines if the default values of the `Constraints` are active for the
+// resources.
+type RestoreDefault struct {
+}

--- a/mmv1/third_party/tgc_next/tfplan2cai/converters/services/resourcemanager/project.go
+++ b/mmv1/third_party/tgc_next/tfplan2cai/converters/services/resourcemanager/project.go
@@ -1,0 +1,149 @@
+package resourcemanager
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/cai"
+
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google-beta/google-beta/transport"
+
+	"google.golang.org/api/cloudbilling/v1"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func ResourceConverterProject() cai.ResourceConverter {
+	return cai.ResourceConverter{
+		Convert: GetProjectAndBillingInfoCaiObjects,
+	}
+}
+
+func GetProjectAndBillingInfoCaiObjects(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]caiasset.Asset, error) {
+	if projectAsset, err := GetProjectCaiObject(d, config); err == nil {
+		assets := []caiasset.Asset{projectAsset}
+		if billingAsset, err := GetProjectBillingInfoCaiObject(d, config); err == nil {
+			assets = append(assets, billingAsset)
+			return assets, nil
+		} else {
+			return []caiasset.Asset{}, err
+		}
+	} else {
+		return []caiasset.Asset{}, err
+	}
+}
+
+func GetProjectCaiObject(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (caiasset.Asset, error) {
+	linkTmpl := "//cloudresourcemanager.googleapis.com/projects/{{number}}"
+	name, err := cai.AssetName(d, config, linkTmpl)
+	if err != nil {
+		return caiasset.Asset{}, err
+	}
+	if data, err := GetProjectData(d, config); err == nil {
+		return caiasset.Asset{
+			Name: name,
+			Type: "cloudresourcemanager.googleapis.com/Project",
+			Resource: &caiasset.AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v1",
+				DiscoveryName:        "Project",
+				Data:                 data,
+			},
+		}, nil
+	} else {
+		return caiasset.Asset{}, err
+	}
+}
+
+func GetProjectData(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+	pid := d.Get("project_id").(string)
+
+	project := &cloudresourcemanager.Project{
+		ProjectId: pid,
+		Name:      d.Get("name").(string),
+	}
+
+	if res, ok := d.GetOk("number"); ok {
+		num, err := strconv.ParseInt(res.(string), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		project.ProjectNumber = num
+	}
+
+	if err := getParentResourceId(d, project); err != nil {
+		return nil, err
+	}
+
+	if _, ok := d.GetOk("effective_labels"); ok {
+		project.Labels = tpgresource.ExpandEffectiveLabels(d)
+	}
+
+	return cai.JsonMap(project)
+}
+
+func getParentResourceId(d tpgresource.TerraformResourceData, p *cloudresourcemanager.Project) error {
+	orgId := d.Get("org_id").(string)
+	folderId := d.Get("folder_id").(string)
+
+	if orgId != "" && folderId != "" {
+		return fmt.Errorf("'org_id' and 'folder_id' cannot be both set.")
+	}
+
+	if orgId != "" {
+		p.Parent = &cloudresourcemanager.ResourceId{
+			Id:   orgId,
+			Type: "organization",
+		}
+	}
+
+	if folderId != "" {
+		p.Parent = &cloudresourcemanager.ResourceId{
+			Id:   strings.TrimPrefix(folderId, "folders/"),
+			Type: "folder",
+		}
+	}
+
+	return nil
+}
+
+func GetProjectBillingInfoCaiObject(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (caiasset.Asset, error) {
+	linkTmpl := "//cloudbilling.googleapis.com/projects/{{project_id_or_project}}/billingInfo"
+	name, err := cai.AssetName(d, config, linkTmpl)
+	if err != nil {
+		return caiasset.Asset{}, err
+	}
+	project := strings.Split(name, "/")[4]
+	if data, err := GetProjectBillingInfoData(d, project); err == nil {
+		return caiasset.Asset{
+			Name: name,
+			Type: "cloudbilling.googleapis.com/ProjectBillingInfo",
+			Resource: &caiasset.AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://cloudbilling.googleapis.com/$discovery/rest",
+				DiscoveryName:        "ProjectBillingInfo",
+				Data:                 data,
+				Location:             "global",
+			},
+		}, nil
+	} else {
+		return caiasset.Asset{}, err
+	}
+}
+
+func GetProjectBillingInfoData(d tpgresource.TerraformResourceData, project string) (map[string]interface{}, error) {
+	if _, ok := d.GetOk("billing_account"); !ok {
+		return nil, cai.ErrNoConversion
+	}
+
+	ba := &cloudbilling.ProjectBillingInfo{
+		BillingAccountName: fmt.Sprintf("billingAccounts/%s", d.Get("billing_account")),
+		Name:               fmt.Sprintf("projects/%s/billingInfo", project),
+		ProjectId:          d.Get("project_id").(string),
+	}
+
+	return cai.JsonMap(ba)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
1. Put caiasset/asset.go under the management of mmv1
2. Add google_project tfplan2cai converter

**How to test**

Magic modules
1. make tgc  OUTPUT_PATH="$GOPATH/src/github.com/GoogleCloudPlatform/terraform-google-conversion" 

[TF config](https://paste.googleplex.com/5344206137327616)
Generate google-project-030602.tfplan.json



```
terraform plan -out=google-project-030602.tfplan
terraform show -json google-project-030602.tfplan > google-project-030602.tfplan.json
```
TGC
1. make build 
3. ./bin/tgc tfplan2cai convert google-project-030602.tfplan.json   > [google_project_create_converted-2.json](https://paste.googleplex.com/4898551707205632)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
