### PR TITLE
Fix the incorrect default GKE cpu_cfs_quota

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -609,8 +609,9 @@ func schemaNodeConfig() *schema.Schema {
 								Description:  `Control the CPU management policy on the node.`,
 							},
 							"cpu_cfs_quota": {
-								Type:     schema.TypeBool,
-								Optional: true,
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Default:     true,
 								Description: `Enable CPU CFS quota enforcement for containers that specify CPU limits.`,
 							},
 							"cpu_cfs_quota_period": {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/20283

Fix an incorrect default value in GKE cpu_cfs_quota

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
