### PR TITLE
Add data source for retrieving organization iam custom roles

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -187,6 +187,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_organization":                              resourcemanager.DataSourceGoogleOrganization(),
 	"google_organizations":                             resourcemanager.DataSourceGoogleOrganizations(),
 	"google_organization_iam_custom_role":              resourcemanager.DataSourceGoogleOrganizationIamCustomRole(),
+	"google_organization_iam_custom_roles":             resourcemanager.DataSourceGoogleOrganizationIamCustomRoles(),
 	{{- if ne $.TargetVersionName "ga" }}
 	"google_parameter_manager_parameter":               parametermanager.DataSourceParameterManagerParameter(),
 	"google_parameter_manager_parameters":              parametermanager.DataSourceParameterManagerParameters(),

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization_iam_custom_roles.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization_iam_custom_roles.go
@@ -1,0 +1,143 @@
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/iam/v1"
+)
+
+func DataSourceGoogleOrganizationIamCustomRoles() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOrganizationIamCustomRolesRead,
+		Schema: map[string]*schema.Schema{
+			"org_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"show_deleted": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"view": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "BASIC",
+				ValidateFunc: validateViewOrganizationIamCustomRoles,
+			},
+			"roles": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"deleted": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"permissions": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"role_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stage": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func validateViewOrganizationIamCustomRoles(val interface{}, key string) ([]string, []error) {
+	v := val.(string)
+	var errs []error
+
+	if v != "BASIC" && v != "FULL" {
+		errs = append(errs, fmt.Errorf("%q must be either 'BASIC' or 'FULL', got %q", key, v))
+	}
+
+	return nil, errs
+}
+
+func dataSourceOrganizationIamCustomRolesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	orgId := d.Get("org_id").(string)
+
+	roles := make([]map[string]interface{}, 0)
+
+	showDeleted := d.Get("show_deleted").(bool)
+	view := d.Get("view").(string)
+
+	request := config.NewIamClient(userAgent).Organizations.Roles.List("organizations/" + orgId).ShowDeleted(showDeleted).View(view)
+
+	err = request.Pages(context.Background(), func(roleList *iam.ListRolesResponse) error {
+		for _, role := range roleList.Roles {
+			var permissions []string
+
+			switch view {
+			case "BASIC":
+				permissions = []string{}
+			case "FULL":
+				permissions = role.IncludedPermissions
+			default:
+				return fmt.Errorf("Unsupported view type: %s", view)
+			}
+
+			roles = append(roles, map[string]interface{}{
+				"deleted":     role.Deleted,
+				"description": role.Description,
+				"id":          role.Name,
+				"name":        role.Name,
+				"permissions": permissions,
+				"role_id":     path.Base(role.Name),
+				"stage":       role.Stage,
+				"title":       role.Title,
+			})
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error retrieving organization custom roles: %s", err)
+	}
+
+	if err := d.Set("roles", roles); err != nil {
+		return fmt.Errorf("Error setting organization custom roles: %s", err)
+	}
+
+	d.SetId("organizations/" + orgId)
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization_iam_custom_roles_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_organization_iam_custom_roles_test.go
@@ -1,0 +1,55 @@
+package resourcemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDataSourceGoogleOrganizationIamCustomRoles_basic(t *testing.T) {
+	t.Parallel()
+
+	orgId := envvar.GetTestOrgFromEnv(t)
+	roleId := "tfIamCustomRole" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleOrganizationIamCustomRolesConfig(orgId, roleId),
+				Check: resource.ComposeTestCheckFunc(
+					// We can't guarantee no organization won't have our custom role as first element, so we'll check set-ness rather than correctness
+					resource.TestCheckResourceAttrSet("data.google_organization_iam_custom_roles.this", "roles.0.id"),
+					resource.TestCheckResourceAttrSet("data.google_organization_iam_custom_roles.this", "roles.0.name"),
+					resource.TestCheckResourceAttrSet("data.google_organization_iam_custom_roles.this", "roles.0.role_id"),
+					resource.TestCheckResourceAttrSet("data.google_organization_iam_custom_roles.this", "roles.0.stage"),
+					resource.TestCheckResourceAttrSet("data.google_organization_iam_custom_roles.this", "roles.0.title"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleOrganizationIamCustomRolesConfig(orgId string, roleId string) string {
+	return fmt.Sprintf(`
+resource "google_organization_iam_custom_role" "this" {
+  org_id  = "%s"
+  role_id = "%s"
+  title   = "Terraform Test"
+
+  permissions = [
+	"iam.roles.create",
+	"iam.roles.delete",
+	"iam.roles.list",
+  ]
+}
+
+data "google_organization_iam_custom_roles" "this" {
+  org_id = google_organization_iam_custom_role.this.org_id
+}
+`, orgId, roleId)
+}

--- a/mmv1/third_party/terraform/website/docs/d/organization_iam_custom_roles.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/organization_iam_custom_roles.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+Get information about a Google Cloud Organization IAM Custom Roles.
+---
+
+# google_organization_iam_custom_roles
+
+Get information about a Google Cloud Organization IAM Custom Roles.
+Note that you must have the `roles/iam.organizationRoleViewer`.
+See [the official documentation](https://cloud.google.com/iam/docs/creating-custom-roles)
+and [API](https://cloud.google.com/iam/docs/reference/rest/v1/organizations.roles/list).
+
+```hcl
+data "google_organization_iam_custom_roles" "example" {
+  org_id       = "1234567890"
+  show_deleted = true
+  view         = "FULL"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org_id` - (Required) The numeric ID of the organization.
+
+* `show_deleted` - (Optional) Include Roles that have been deleted. Defaults to `false`.
+
+* `view` - (Optional) When `"FULL"` is specified, the `permissions` field is returned, which includes a list of all permissions in the role. The default value is `"BASIC"`, which does not return the `permissions`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `roles` - A list of all retrieved custom roles roles. Structure is [defined below](#nested_roles).
+
+<a name="nested_roles"></a>The `roles` block supports:
+
+* `deleted` - The current deleted state of the role.
+
+* `description` - A human-readable description for the role.
+
+* `id` - an identifier for the resource with the format `organizations/{{org_id}}/roles/{{role_id}}`.
+
+* `name` - The name of the role in the format `organizations/{{org_id}}/roles/{{role_id}}`. Like `id`, this field can be used as a reference in other resources such as IAM role bindings.
+
+* `permissions` -  The names of the permissions this role grants when bound in an IAM policy.
+
+* `role_id` - The camel case role id used for this role.
+
+* `stage` - The current launch stage of the role. List of possible stages is [here](https://cloud.google.com/iam/reference/rest/v1/organizations.roles#Role.RoleLaunchStage).
+
+* `title` - A human-readable title for the role.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source "google_organization_iam_custom_roles", allowing to retrieve organization iam custom roles.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/21779

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_organization_iam_custom_roles`
```