### PR TITLE
Promote network security mirroring resources to GA.

### DIFF
--- a/mmv1/products/networksecurity/MirroringDeployment.yaml
+++ b/mmv1/products/networksecurity/MirroringDeployment.yaml
@@ -18,11 +18,10 @@ description: |-
   GENEVE-encapsulated replica traffic, e.g. a zonal instance group fronted by
   an internal passthrough load balancer. Deployments are always part of a
   global deployment group which represents a global mirroring service.
-min_version: 'beta'
 references:
   guides:
     'Mirroring deployment overview': 'https://cloud.google.com/network-security-integration/docs/out-of-band/deployments-overview'
-  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1beta1/projects.locations.mirroringDeployments'
+  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1/projects.locations.mirroringDeployments'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/mirroringDeployments/{{mirroring_deployment_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/mirroringDeployments'
@@ -61,7 +60,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the deployment, e.g. `us-central1-a` or `asia-south1-b`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -70,7 +68,6 @@ parameters:
     description: |-
       The ID to use for the new deployment, which will become the final
       component of the deployment's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -81,7 +78,6 @@ properties:
       The resource name of this deployment, for example:
       `projects/123456789/locations/us-central1-a/mirroringDeployments/my-dep`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     immutable: true
     output: true
   - name: 'createTime'
@@ -89,27 +85,23 @@ properties:
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'forwardingRule'
     type: String
     description: |-
       The regional forwarding rule that fronts the mirroring collectors, for
       example: `projects/123456789/regions/us-central1/forwardingRules/my-rule`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'mirroringDeploymentGroup'
@@ -118,7 +110,6 @@ properties:
       The deployment group that this deployment is a part of, for example:
       `projects/123456789/locations/global/mirroringDeploymentGroups/my-dg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'state'
@@ -133,7 +124,6 @@ properties:
       DELETING
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -142,11 +132,9 @@ properties:
       and the system is working to reconcile them. This part of the normal
       operation (e.g. linking a new association to the parent group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: description
     type: String
     description: |-
       User-provided description of the deployment.
       Used as additional context for the deployment.
-    min_version: 'beta'

--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -17,11 +17,10 @@ description: |-
   A deployment group aggregates many zonal mirroring backends (deployments)
   into a single global mirroring service. Consumers can connect this service
   using an endpoint group.
-min_version: 'beta'
 references:
   guides:
     'Mirroring deployment group overview': 'https://cloud.google.com/network-security-integration/docs/out-of-band/deployment-groups-overview'
-  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1beta1/projects.locations.mirroringDeploymentGroups'
+  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1/projects.locations.mirroringDeploymentGroups'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups/{{mirroring_deployment_group_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/mirroringDeploymentGroups'
@@ -56,7 +55,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the deployment group, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -65,7 +63,6 @@ parameters:
     description: |-
       The ID to use for the new deployment group, which will become the final
       component of the deployment group's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -76,7 +73,6 @@ properties:
       The resource name of this deployment group, for example:
       `projects/123456789/locations/global/mirroringDeploymentGroups/my-dg`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     immutable: true
     output: true
   - name: 'createTime'
@@ -84,34 +80,29 @@ properties:
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'network'
     type: String
     description: |-
       The network that will be used for all child deployments, for example:
       `projects/{project}/global/networks/{network}`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'connectedEndpointGroups'
     type: Array
     description: |-
       The list of endpoint groups that are connected to this resource.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -122,7 +113,6 @@ properties:
             The connected endpoint group's resource name, for example:
             `projects/123456789/locations/global/mirroringEndpointGroups/my-eg`.
             See https://google.aip.dev/124.
-          min_version: 'beta'
           output: true
   - name: 'state'
     type: String
@@ -134,7 +124,6 @@ properties:
       ACTIVE
       CREATING
       DELETING
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -143,11 +132,9 @@ properties:
       and the system is working to reconcile them. This is part of the normal
       operation (e.g. adding a new deployment to the group)
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: description
     type: String
     description: |-
       User-provided description of the deployment group.
       Used as additional context for the deployment group.
-    min_version: 'beta'

--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -19,11 +19,10 @@ description: |-
   - An association between their network and the endpoint group.
   - A security profile that points to the endpoint group.
   - A mirroring rule that references the security profile (group).
-min_version: 'beta'
 references:
   guides:
     'Mirroring endpoint group overview': 'https://cloud.google.com/network-security-integration/docs/out-of-band/endpoint-groups-overview'
-  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1beta1/projects.locations.mirroringEndpointGroups'
+  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1/projects.locations.mirroringEndpointGroups'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups/{{mirroring_endpoint_group_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroups'
@@ -58,7 +57,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the endpoint group, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -67,7 +65,6 @@ parameters:
     description: |-
       The ID to use for the endpoint group, which will become the final component
       of the endpoint group's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -78,7 +75,6 @@ properties:
       The resource name of this endpoint group, for example:
       `projects/123456789/locations/global/mirroringEndpointGroups/my-eg`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     immutable: true
     output: true
   - name: 'createTime'
@@ -86,27 +82,23 @@ properties:
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'mirroringDeploymentGroup'
     type: String
     description: |-
       The deployment group that this DIRECT endpoint group is connected to, for example:
       `projects/123456789/locations/global/mirroringDeploymentGroups/my-dg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'state'
@@ -122,7 +114,6 @@ properties:
       DELETING
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -131,11 +122,9 @@ properties:
       and the system is working to reconcile them. This is part of the normal
       operation (e.g. adding a new association to the group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: description
     type: String
     description: |-
       User-provided description of the endpoint group.
       Used as additional context for the endpoint group.
-    min_version: 'beta'

--- a/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
@@ -21,11 +21,10 @@ description: |-
   network to the endpoint group, but does not enable mirroring by itself.
   To enable mirroring, the user must also create a network firewall policy
   containing mirroring rules and associate it with the network.
-min_version: 'beta'
 references:
   guides:
     'Mirroring endpoint group association overview': 'https://cloud.google.com/network-security-integration/docs/out-of-band/endpoint-groups-overview#mirroring-endpoint-group-association'
-  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1beta1/projects.locations.mirroringEndpointGroupAssociations'
+  api: 'https://cloud.google.com/network-security-integration/docs/reference/rest/v1/projects.locations.mirroringEndpointGroupAssociations'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations/{{mirroring_endpoint_group_association_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/mirroringEndpointGroupAssociations'
@@ -62,7 +61,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the association, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -72,7 +70,6 @@ parameters:
       The ID to use for the new association, which will become the final
       component of the endpoint group's resource name. If not provided, the
       server will generate a unique ID.
-    min_version: 'beta'
     url_param_only: true
     immutable: true
 properties:
@@ -82,7 +79,6 @@ properties:
       The resource name of this endpoint group association, for example:
       `projects/123456789/locations/global/mirroringEndpointGroupAssociations/my-eg-association`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     immutable: true
     output: true
   - name: 'createTime'
@@ -90,27 +86,23 @@ properties:
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'mirroringEndpointGroup'
     type: String
     description: |-
       The endpoint group that this association is connected to, for example:
       `projects/123456789/locations/global/mirroringEndpointGroups/my-eg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'network'
@@ -119,7 +111,6 @@ properties:
       The VPC network that is associated. for example:
       `projects/123456789/global/networks/my-network`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'locationsDetails'
@@ -128,7 +119,6 @@ properties:
       The list of locations where the association is present. This information
       is retrieved from the linked endpoint group, and not configured as part
       of the association itself.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -137,7 +127,6 @@ properties:
           type: String
           description: |-
             The cloud location, e.g. `us-central1-a` or `asia-south1`.
-          min_version: 'beta'
           output: true
         - name: 'state'
           type: String
@@ -147,7 +136,6 @@ properties:
             STATE_UNSPECIFIED
             ACTIVE
             OUT_OF_SYNC
-          min_version: 'beta'
           output: true
   - name: 'state'
     type: String
@@ -161,7 +149,6 @@ properties:
       CLOSED
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -170,5 +157,4 @@ properties:
       and the system is working to reconcile them. This part of the normal
       operation (e.g. adding a new location to the target deployment group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_basic.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -13,7 +11,6 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
   region   = "us-central1"
   http_health_check {
@@ -22,7 +19,6 @@ resource "google_compute_region_health_check" "health_check" {
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -31,7 +27,6 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
   name                   = "{{index $.Vars "forwarding_rule_name"}}"
   region                 = "us-central1"
   network                = google_compute_network.network.name
@@ -44,14 +39,12 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_deployment" "{{$.PrimaryResourceId}}" {
-  provider                   = google-beta
   mirroring_deployment_id    = "{{index $.Vars "deployment_id"}}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id

--- a/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_deployment_group_basic.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "{{$.PrimaryResourceId}}" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_association_basic.tf.tmpl
@@ -1,31 +1,26 @@
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "producer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "consumer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_mirroring_endpoint_group_association" "{{$.PrimaryResourceId}}" {
-  provider                                = google-beta
   mirroring_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_basic.tf.tmpl
@@ -1,18 +1,15 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResourceId}}" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_group_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityMirroringDeploymentGroup_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityMirroringDeploymentGroup_basic(context),
@@ -51,13 +50,11 @@ func TestAccNetworkSecurityMirroringDeploymentGroup_update(t *testing.T) {
 func testAccNetworkSecurityMirroringDeploymentGroup_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
@@ -72,13 +69,11 @@ resource "google_network_security_mirroring_deployment_group" "default" {
 func testAccNetworkSecurityMirroringDeploymentGroup_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
@@ -89,5 +84,3 @@ resource "google_network_security_mirroring_deployment_group" "default" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_deployment_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityMirroringDeployment_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityMirroringDeployment_basic(context),
@@ -51,13 +50,11 @@ func TestAccNetworkSecurityMirroringDeployment_update(t *testing.T) {
 func testAccNetworkSecurityMirroringDeployment_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "tf-test-example-subnet%{random_suffix}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -65,7 +62,6 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
   name     = "tf-test-example-hc%{random_suffix}"
   region   = "us-central1"
   http_health_check {
@@ -74,7 +70,6 @@ resource "google_compute_region_health_check" "health_check" {
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "tf-test-example-bs%{random_suffix}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -83,7 +78,6 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
   name                   = "tf-test-example-fwr%{random_suffix}"
   region                 = "us-central1"
   network                = google_compute_network.network.name
@@ -96,14 +90,12 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_deployment" "default" {
-  provider                   = google-beta
   mirroring_deployment_id    = "tf-test-example-deployment%{random_suffix}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
@@ -119,13 +111,11 @@ resource "google_network_security_mirroring_deployment" "default" {
 func testAccNetworkSecurityMirroringDeployment_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "tf-test-example-subnet%{random_suffix}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -133,7 +123,6 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
   name     = "tf-test-example-hc%{random_suffix}"
   region   = "us-central1"
   http_health_check {
@@ -142,7 +131,6 @@ resource "google_compute_region_health_check" "health_check" {
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "tf-test-example-bs%{random_suffix}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -151,7 +139,6 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
   name                   = "tf-test-example-fwr%{random_suffix}"
   region                 = "us-central1"
   network                = google_compute_network.network.name
@@ -164,14 +151,12 @@ resource "google_compute_forwarding_rule" "forwarding_rule" {
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_deployment" "default" {
-  provider                   = google-beta
   mirroring_deployment_id    = "tf-test-example-deployment%{random_suffix}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
@@ -183,5 +168,3 @@ resource "google_network_security_mirroring_deployment" "default" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_association_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityMirroringEndpointGroupAssociation_update(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityMirroringEndpointGroupAssociation_basic(context),
@@ -51,33 +50,28 @@ func TestAccNetworkSecurityMirroringEndpointGroupAssociation_update(t *testing.T
 func testAccNetworkSecurityMirroringEndpointGroupAssociation_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-prod-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-cons-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_mirroring_endpoint_group_association" "default" {
-  provider                                = google-beta
   mirroring_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
@@ -92,33 +86,28 @@ resource "google_network_security_mirroring_endpoint_group_association" "default
 func testAccNetworkSecurityMirroringEndpointGroupAssociation_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-prod-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-cons-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_mirroring_endpoint_group_association" "default" {
-  provider                                = google-beta
   mirroring_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
@@ -129,5 +118,3 @@ resource "google_network_security_mirroring_endpoint_group_association" "default
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_mirroring_endpoint_group_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityMirroringEndpointGroup_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityMirroringEndpointGroup_basic(context),
@@ -51,20 +50,17 @@ func TestAccNetworkSecurityMirroringEndpointGroup_update(t *testing.T) {
 func testAccNetworkSecurityMirroringEndpointGroup_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "default" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
@@ -79,20 +75,17 @@ resource "google_network_security_mirroring_endpoint_group" "default" {
 func testAccNetworkSecurityMirroringEndpointGroup_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "deployment_group" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "default" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.deployment_group.id
@@ -103,5 +96,3 @@ resource "google_network_security_mirroring_endpoint_group" "default" {
 }
 `, context)
 }
-
-{{ end }}


### PR DESCRIPTION
Promoting the Network Security Mirroring resources to GA:
* `google_network_security_mirroring_deployment`
* `google_network_security_mirroring_deployment_group`
* `google_network_security_mirroring_endpoint_group`
* `google_network_security_mirroring_endpoint_group_association`

APIs have already been promoted to v1.

```release-note:note
networksecurity: promoted `google_network_security_mirroring_deployment`, `google_network_security_mirroring_deployment_group`, `google_network_security_mirroring_endpoint_group_association`, `google_network_security_mirroring_endpoint_group` resources from Beta to GA
```
