### PR TITLE
Add CreateTime & UpdateTime to google_dataproc_metastore_federation

### DIFF
--- a/mmv1/products/metastore/Federation.yaml
+++ b/mmv1/products/metastore/Federation.yaml
@@ -79,6 +79,16 @@ properties:
     description: |
       The relative resource name of the metastore federation.
     output: true
+  - name: 'createTime'
+    type: Time
+    description: |
+      Output only. The time when the metastore federation was created.
+    output: true
+  - name: 'updateTime'
+    type: Time
+    description: |
+      Output only. The time when the metastore federation was last updated.
+    output: true
   - name: 'labels'
     type: KeyValueLabels
     description: 'User-defined labels for the metastore federation.'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21810


```release-note:enhancement
metastore: added `CreateTime` and `UpdateTime` fields to `google_dataproc_metastore_federation` resource
```
