### PR TITLE
Reconcile Dataproc Metastore Autoscaling Configs w/ API status

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -135,22 +135,18 @@ examples:
       metastore_service_name: 'backup'
   - name: 'dataproc_metastore_service_autoscaling_max_scaling_factor'
     primary_resource_id: 'test_resource'
-    min_version: 'beta'
     vars:
       metastore_service_name: 'test-service'
   - name: 'dataproc_metastore_service_autoscaling_min_and_max_scaling_factor'
     primary_resource_id: 'test_resource'
-    min_version: 'beta'
     vars:
       metastore_service_name: 'test-service'
   - name: 'dataproc_metastore_service_autoscaling_min_scaling_factor'
     primary_resource_id: 'test_resource'
-    min_version: 'beta'
     vars:
       metastore_service_name: 'test-service'
   - name: 'dataproc_metastore_service_autoscaling_no_limit_config'
     primary_resource_id: 'test_resource'
-    min_version: 'beta'
     vars:
       metastore_service_name: 'test-service'
 parameters:
@@ -265,13 +261,17 @@ properties:
         type: NestedObject
         description: |
           Represents the autoscaling configuration of a metastore service.
-        min_version: 'beta'
         required: false
         properties:
           - name: 'autoscalingEnabled'
             type: Boolean
             description: |
               Defines whether autoscaling is enabled. The default value is false.
+          - name: 'autoscalingFactor'
+            type: Double
+            description: |
+              Output only. The scaling factor of a service with autoscaling enabled.
+            output: true
           - name: 'limitConfig'
             type: NestedObject
             description: |

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_max_scaling_factor.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   service_id = "{{index $.Vars "metastore_service_name"}}"
   location   = "us-central1"
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_and_max_scaling_factor.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   service_id = "{{index $.Vars "metastore_service_name"}}"
   location   = "us-central1"
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_min_scaling_factor.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   service_id = "{{index $.Vars "metastore_service_name"}}"
   location   = "us-central1"
 

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_autoscaling_no_limit_config.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta  
   service_id = "{{index $.Vars "metastore_service_name"}}"
   location   = "us-central1"
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21812

```release-note:enhancement
metastore: promoted `scaling_config` field to GA
```
