### PR TITLE
bigtable: update automated backups documentation for bigtable table

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -100,7 +100,7 @@ to delete/recreate the entire `google_bigtable_table` resource.
 
 * `change_stream_retention` - (Optional) Duration to retain change stream data for the table. Set to 0 to disable. Must be between 1 and 7 days.
 
-* `automated_backup_policy` - (Optional) Defines an automated backup policy for a table, specified by Retention Period and Frequency. To disable, set both Retention Period and Frequency to 0.
+* `automated_backup_policy` - (Optional) Defines an automated backup policy for a table, specified by Retention Period and Frequency. To _create_ a table with automated backup disabled, omit this argument. To disable automated backup on an _existing_ table that has automated backup enabled, set both Retention Period and Frequency to 0.
 
 -----
 


### PR DESCRIPTION
Update bigtable automated backup documentation

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21602

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
docs: updated `automated_backup_policy` in `google_bigtable_table` documentation
```
