### PR TITLE
Feature gap: Add `failoverAction` and `onFailedHealth` to IGM and RIGM

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
@@ -364,6 +364,18 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, true),
 							Description:  `Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: YES, NO. If YES and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If NO (default), then updates are applied in accordance with the group's update policy type.`,
 						},
+{{ if ne $.TargetVersionName `ga` -}}
+						"on_failed_health": {
+							Type:         schema.TypeString,
+							Default:      "DEFAULT_ACTION",
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"DEFAULT_ACTION", "REPAIR", "DO_NOTHING"}, true),
+							Description: `The action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are:
+							- DEFAULT_ACTION (default): MIG uses the same action configured for instanceLifecyclePolicy.defaultActionOnFailure field.
+							- REPAIR: MIG automatically repairs an unhealthy VM by recreating it.
+							- DO_NOTHING: MIG doesn't repair an unhealthy VM.`,
+						},
+{{- end }}
 					},
 				},
 			},
@@ -1303,6 +1315,9 @@ func expandInstanceLifecyclePolicy(configured []interface{}) *compute.InstanceGr
 		data := raw.(map[string]interface{})
 		instanceLifecyclePolicy.ForceUpdateOnRepair = data["force_update_on_repair"].(string)
 		instanceLifecyclePolicy.DefaultActionOnFailure = data["default_action_on_failure"].(string)
+{{- if ne $.TargetVersionName "ga" }}
+		instanceLifecyclePolicy.OnFailedHealthCheck = data["on_failed_health"].(string)
+{{- end }}
 	}
 	return instanceLifecyclePolicy
 }
@@ -1501,6 +1516,9 @@ func flattenInstanceLifecyclePolicy(instanceLifecyclePolicy *compute.InstanceGro
 		ilp := map[string]interface{}{}
 		ilp["force_update_on_repair"] = instanceLifecyclePolicy.ForceUpdateOnRepair
 		ilp["default_action_on_failure"] = instanceLifecyclePolicy.DefaultActionOnFailure
+{{- if ne $.TargetVersionName "ga" }}
+		ilp["on_failed_health"] = instanceLifecyclePolicy.OnFailedHealthCheck
+{{- end }}
 		results = append(results, ilp)
 	}
 	return results

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -155,6 +155,19 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status"},
 			},
+			{
+				Config: testAccInstanceGroupManager_update4(template1, target1, target2, template2, description2, igm),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
+					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health", "DO_NOTHING"),
+				),
+			},
+			{
+				ResourceName:            "google_compute_instance_group_manager.igm-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
 		},
 	})
 }
@@ -940,6 +953,98 @@ resource "google_compute_instance_group_manager" "igm-update" {
   named_port {
     name = "customhttps"
     port = 8443
+  }
+}
+`, template1, target1, target2, template2, description2, igm)
+}
+
+func testAccInstanceGroupManager_update4(template1, target1, target2, template2, description2, igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-update" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_target_pool" "igm-update" {
+  description      = "Resource created for Terraform acceptance testing"
+  name             = "%s"
+  session_affinity = "CLIENT_IP_PROTO"
+}
+
+resource "google_compute_target_pool" "igm-update2" {
+  description      = "Resource created for Terraform acceptance testing"
+  name             = "%s"
+  session_affinity = "CLIENT_IP_PROTO"
+}
+
+resource "google_compute_instance_template" "igm-update2" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_instance_group_manager" "igm-update" {
+  description = "%s"
+  name        = "%s"
+
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.igm-update2.self_link
+  }
+
+  base_instance_name             = "tf-test-igm-update"
+  zone                           = "us-central1-c"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+  named_port {
+    name = "customhttps"
+    port = 8443
+  }
+
+  instance_lifecycle_policy {
+    force_update_on_repair = "NO"
+    default_action_on_failure = "REPAIR"
+    on_failed_health = "DO_NOTHING"
   }
 }
 `, template1, target1, target2, template2, description2, igm)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -300,6 +300,16 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Description: `The shape to which the group converges either proactively or on resize events (depending on the value set in updatePolicy.instanceRedistributionType).`,
 			},
 
+{{ if ne $.TargetVersionName `ga` -}}
+			"failover_action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"NO_FAILOVER"}, true),
+				Description:  `The action to perform in case of zone failure. Only one value is supported, NO_FAILOVER. The default is NO_FAILOVER.`,
+			},
+{{- end }}
+
 			"instance_lifecycle_policy": {
 				Computed:    true,
 				Type:        schema.TypeList,
@@ -322,6 +332,18 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, false),
 							Description:  `Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: YES, NO. If YES and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If NO (default), then updates are applied in accordance with the group's update policy type.`,
 						},
+{{ if ne $.TargetVersionName `ga` -}}
+						"on_failed_health": {
+							Type:         schema.TypeString,
+							Default:      "DEFAULT_ACTION",
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"DEFAULT_ACTION", "REPAIR", "DO_NOTHING"}, true),
+							Description: `The action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are:
+							- DEFAULT_ACTION (default): MIG uses the same action configured for instanceLifecyclePolicy.defaultActionOnFailure field.
+							- REPAIR: MIG automatically repairs an unhealthy VM by recreating it.
+							- DO_NOTHING: MIG doesn't repair an unhealthy VM.`,
+						},
+{{- end }}
 					},
 				},
 			},
@@ -679,6 +701,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		DistributionPolicy:          expandDistributionPolicyForCreate(d),
 		StatefulPolicy:              expandStatefulPolicy(d),
 		{{- if ne $.TargetVersionName "ga" }}
+		FailoverAction:              d.Get("failover_action").(string),
 		Params:                      expandInstanceGroupManagerParams(d),
 		{{- end }}
 		// Force send TargetSize to allow size of 0.
@@ -891,6 +914,11 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 			return fmt.Errorf("Error setting all_instances_config in state: %s", err.Error())
 		}
 	}
+{{- if ne $.TargetVersionName "ga" }}
+	if err = d.Set("failover_action", manager.FailoverAction); err != nil {
+		return fmt.Errorf("Error setting failover_action in state: %s", err.Error())
+	}
+{{- end }}
 	if err = d.Set("stateful_disk", flattenStatefulPolicy(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_disk in state: %s", err.Error())
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -122,6 +122,21 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status"},
 			},
+{{- if ne $.TargetVersionName "ga" }}
+			{
+				Config: testAccRegionInstanceGroupManager_update4(template1, target1, target2, template2, igm),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health", "DO_NOTHING"),
+				),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_group_manager.igm-update",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status"},
+			},
+{{- end }}
 		},
 	})
 }
@@ -513,6 +528,42 @@ func TestAccRegionInstanceGroupManager_resourceManagerTags(t *testing.T) {
 			},
 			{
 				ResourceName:            "google_compute_region_instance_group_manager.rigm-tags",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status", "params"},
+			},
+		},
+	})
+}
+
+func TestAccRegionInstanceGroupManager_failoverAction(t *testing.T) {
+	t.Parallel()
+
+	template_name := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
+	igm_name := fmt.Sprintf("tf-test-igm-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckInstanceGroupManagerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRegionInstanceGroupManager_failoverAction(template_name, igm_name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-failover-action", "failover_action", "NO_FAILOVER"),
+				),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_group_manager.igm-failover-action",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"status", "params"},
+			},
+			{
+				Config: testAccRegionInstanceGroupManager_failoverAction2(template_name, igm_name),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_group_manager.igm-failover-action",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"status", "params"},
@@ -959,6 +1010,98 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 }
 `, tag, igm)
 }
+
+
+{{- if ne $.TargetVersionName "ga" }}
+func testAccRegionInstanceGroupManager_update4(template1, target1, target2, template2, igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-update" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_target_pool" "igm-update" {
+  description      = "Resource created for Terraform acceptance testing"
+  name             = "%s"
+  session_affinity = "CLIENT_IP_PROTO"
+}
+
+resource "google_compute_target_pool" "igm-update2" {
+  description      = "Resource created for Terraform acceptance testing"
+  name             = "%s"
+  session_affinity = "CLIENT_IP_PROTO"
+}
+
+resource "google_compute_instance_template" "igm-update2" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-update" {
+  description = "Terraform test instance group manager"
+  name        = "%s"
+
+  version {
+    instance_template = google_compute_instance_template.igm-update2.self_link
+    name              = "primary"
+  }
+
+  base_instance_name             = "tf-test-igm-update"
+  region                         = "us-central1"
+  target_size                    = 3
+  list_managed_instances_results = "PAGINATED"
+  named_port {
+    name = "customhttp"
+    port = 8080
+  }
+  named_port {
+    name = "customhttps"
+    port = 8443
+  }
+  instance_lifecycle_policy {
+    on_failed_health = "DO_NOTHING"
+  }
+}
+`, template1, target1, target2, template2, igm)
+}
+{{- end }}
 
 func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	return fmt.Sprintf(`
@@ -2189,5 +2332,100 @@ resource "google_compute_region_instance_group_manager" "rigm-tags" {
   }
 }
 `, template_name, project_id, tag_name, tag_name, igm_name)
+}
+
+func testAccRegionInstanceGroupManager_failoverAction(template, igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  provider = google-beta
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-basic" {
+  provider = google-beta
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-failover-action" {
+  provider = google-beta
+  description = "Terraform test instance group manager"
+  name        = "%s"
+  failover_action = "NO_FAILOVER"
+
+  version {
+    name              = "primary"
+    instance_template = google_compute_instance_template.igm-basic.self_link
+  }
+
+  base_instance_name             = "tf-test-igm-no-tp"
+  region                         = "us-central1"
+  target_size                    = 2
+}
+`, template, igm)
+}
+
+func testAccRegionInstanceGroupManager_failoverAction2(template, igm string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  provider = google-beta
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "igm-basic" {
+  provider = google-beta
+  name           = "%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "igm-failover-action" {
+  provider = google-beta
+  description = "Terraform test instance group manager"
+  name        = "%s"
+
+  version {
+    name              = "primary"
+    instance_template = google_compute_instance_template.igm-basic.self_link
+  }
+
+  base_instance_name             = "tf-test-igm-no-tp"
+  region                         = "us-central1"
+  target_size                    = 2
+}
+`, template, igm)
 }
 {{- end }}

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -188,6 +188,8 @@ group. You can specify only one value. Structure is [documented below](#nested_a
 
 * `target_stopped_size` - (Optional) The target number of stopped instances for this managed instance group.
 
+* `failover_action` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The action to perform in case of zone failure. Only one value is supported, NO_FAILOVER. The default is NO_FAILOVER.
+
 * `stateful_disk` - (Optional) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is [documented below](#nested_stateful_disk). For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs).
 
 * `stateful_internal_ip` - (Optional) Internal network IPs assigned to the instances that will be preserved on instance delete, update, etc. This map is keyed with the network interface name. Structure is [documented below](#nested_stateful_internal_ip).
@@ -245,11 +247,16 @@ update_policy {
 instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
+  on_failed_health          = "DO_NOTHING"
 }
 ```
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Default behavior for all instance or health check failures. Valid options are: `REPAIR`, `DO_NOTHING`. If `DO_NOTHING` then instances will not be repaired. If `REPAIR` (default), then failed instances will be repaired.
+* `on_failed_health` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)), The action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are:
+    - DEFAULT_ACTION (default): MIG uses the same action configured for instanceLifecyclePolicy.defaultActionOnFailure field.
+    - REPAIR: MIG automatically repairs an unhealthy VM by recreating it.
+    - DO_NOTHING: MIG doesn't repair an unhealthy VM.
 - - -
 
 <a name="nested_all_instances_config"></a>The `all_instances_config` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -255,11 +255,16 @@ update_policy {
 instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
+  on_failed_health          = "DO_NOTHING"
 }
 ```
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Default behavior for all instance or health check failures. Valid options are: `REPAIR`, `DO_NOTHING`. If `DO_NOTHING` then instances will not be repaired. If `REPAIR` (default), then failed instances will be repaired.
+* `on_failed_health` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)), The action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are:
+    - DEFAULT_ACTION (default): MIG uses the same action configured for instanceLifecyclePolicy.defaultActionOnFailure field.
+    - REPAIR: MIG automatically repairs an unhealthy VM by recreating it.
+    - DO_NOTHING: MIG doesn't repair an unhealthy VM.
 
 - - -
 <a name="nested_instance_flexibility_policy"></a>The `instance_flexibility_policy` block supports:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch adds new fields for `RegionInstanceGroupManager` and `InstanceGroupManager`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `failover_action` and `instance_lifecycle_policy.0.on_failed_health` to `google_compute_region_instance_group_manager` resource (beta)
```

```release-note:enhancement
compute: added `instance_lifecycle_policy.0.on_failed_health` to `google_compute_instance_group_manager` resource (beta)
```
