### PR TITLE
`VCR`: Update build-environment image to use Terraform `1.11.0`

### DIFF
--- a/.ci/containers/build-environment/Dockerfile
+++ b/.ci/containers/build-environment/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 1777 "$GOPATH"
 WORKDIR $GOPATH
 
 # terraform binary used by tfv/tgc
-COPY --from=hashicorp/terraform:1.10.0 /bin/terraform /bin/terraform
+COPY --from=hashicorp/terraform:1.11.0 /bin/terraform /bin/terraform
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/containers/go-plus/Dockerfile
+++ b/.ci/containers/go-plus/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget https://releases.hashicorp.com/terraform/1.10.0/terraform_1.10.0_linux_amd64.zip \
-    && unzip terraform_1.10.0_linux_amd64.zip \
-    && rm terraform_1.10.0_linux_amd64.zip \
+RUN wget https://releases.hashicorp.com/terraform/1.11.0/terraform_1.11.0_linux_amd64.zip \
+    && unzip terraform_1.11.0_linux_amd64.zip \
+    && rm terraform_1.11.0_linux_amd64.zip \
     && mv ./terraform /bin/terraform


### PR DESCRIPTION
Referencing this [issue](https://github.com/hashicorp/terraform-provider-google/issues/19685) since although we didn't face any issues with the bump in `1.10` we should still be aware of any VCR issues that could arise. We can potentially close the issue if we once again face no issues when bumping to `1.11`, jusst like we did in the previous TF version bump.

We'll merge once we have [TeamCity: update defaultTerraformCoreVersion to 1.11.0](https://github.com/GoogleCloudPlatform/magic-modules/pull/13333) merged first.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
