### PR TITLE
Add Dataproc Metastore Database Resource for IAM support

### DIFF
--- a/mmv1/products/metastore/Database.yaml
+++ b/mmv1/products/metastore/Database.yaml
@@ -1,0 +1,48 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: 'Database'
+description: |
+  Only used to generate IAM resources
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+docs:
+base_url: 'projects/{{project}}/locations/{{location}}/services/{{serviceId}}/databases/{{name}}'
+self_link: 'projects/{{project}}/locations/{{location}}/services/{{serviceId}}/databases/{{name}}'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/services/{{serviceId}}/databases/{{name}}'
+  - '{{name}}'
+exclude_resource: true
+timeouts:
+  insert_minutes: 2
+  update_minutes: 2
+  delete_minutes: 2
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_attribute: 'database'
+  parent_resource_type: "google_dataproc_metastore_service"
+  example_config_body: "templates/terraform/iam/example_config_body/dataproc_metastore_database_template.tf.tmpl"
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/services/{{serviceId}}/databases/{{name}}'
+    - '{{name}}'
+custom_code:
+examples:
+  - name: 'dataproc_metastore_service_database_iam'
+    primary_resource_id: 'dpms_service'
+    primary_resource_name: 'fmt.Sprintf("tf-test-metastore-srv-%s", context["random_suffix"]), "testdb"'
+parameters:
+properties:
+  - name: 'name'
+    type: String
+    description: Dummy property.
+    required: true

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_database_iam.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_database_iam.tf.tmpl
@@ -1,0 +1,59 @@
+resource "google_dataproc_metastore_service" "dpms_service" {
+  service_id = "tf-test-metastore-srv-%{random_suffix}"
+  location   = "us-central1"
+
+  tier       = "DEVELOPER"
+
+  hive_metastore_config {
+    version = "3.1.2"
+  }
+}
+
+resource "google_dataproc_cluster" "dp_cluster" {
+  name   = "tf-dpms-tbl-creator-%{random_suffix}"
+  region = google_dataproc_metastore_service.dpms_service.location
+
+  cluster_config {
+    # Keep the costs down with smallest config we can get away with
+    software_config {
+      override_properties = {
+        "dataproc:dataproc.allow.zero.workers" = "true"
+      }
+    }
+
+    endpoint_config {
+      enable_http_port_access = true
+    }
+
+    master_config {
+      num_instances = 1
+      machine_type  = "e2-standard-2"
+      disk_config {
+        boot_disk_size_gb = 35
+      }
+    }
+
+    metastore_config {
+      dataproc_metastore_service = google_dataproc_metastore_service.dpms_service.name
+    }
+  }
+}
+
+resource "google_dataproc_job" "hive" {
+  region = google_dataproc_cluster.dp_cluster.region
+
+  force_delete = true
+  placement {
+    cluster_name = google_dataproc_cluster.dp_cluster.name
+  }
+
+  hive_config {
+    properties = {
+      "database" = "testdb"
+    }
+    query_list = [
+      "DROP DATABASE IF EXISTS testdb CASCADE",
+      "CREATE DATABASE testdb",
+    ]
+  }
+}

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_database_iam.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_database_iam.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_dataproc_metastore_service" "dpms_service" {
 }
 
 resource "google_dataproc_cluster" "dp_cluster" {
-  name   = "tf-dpms-tbl-creator-%{random_suffix}"
+  name   = "tf-test-dpms-tbl-creator-%{random_suffix}"
   region = google_dataproc_metastore_service.dpms_service.location
 
   cluster_config {

--- a/mmv1/templates/terraform/iam/example_config_body/dataproc_metastore_database_template.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/dataproc_metastore_database_template.tf.tmpl
@@ -1,0 +1,5 @@
+
+  project = google_dataproc_metastore_service.dpms_service.project
+  location = google_dataproc_metastore_service.dpms_service.location
+  service_id = google_dataproc_metastore_service.dpms_service.service_id
+  database = google_dataproc_job.hive.hive_config[0].properties["database"]


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21822

This resource is only meant for IAM usage, as it doesn't really "exist" in GCP. The "database" resource cannot be created via terraform, so the example configuration required a custom yaml.tmpl for testing.

Tested via running `acctest` with personal credentials.

```release-note:enhancement
metastore: Add `google_dataproc_metastore_database_iam_*` resources 
```
