### PR TITLE
Add support for GPU redundancy to Cloud Run v2 service

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -76,7 +76,6 @@ examples:
   - name: 'cloud_run_service_gpu'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-cloudrun-srv%s", context["random_suffix"])'
-    min_version: 'beta'
     vars:
       cloud_run_service_name: 'cloudrun-srv'
     test_env_vars:
@@ -758,7 +757,6 @@ properties:
                   Node Selector describes the hardware requirements of the resources.
                   Use the following node selector keys to configure features on a Revision:
                     - `run.googleapis.com/accelerator` sets the [type of GPU](https://cloud.google.com/run/docs/configuring/services/gpu) required by the Revision to run.
-                min_version: 'beta'
               - name: 'containerConcurrency'
                 type: Integer
                 description: |-

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -321,10 +321,14 @@ properties:
                     for connections to the Revision.
                   - `run.googleapis.com/startup-cpu-boost` sets whether to allocate extra CPU to containers on startup.
                     See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--[no-]cpu-boost.
+                  - `run.googleapis.com/network-interfaces` sets [Direct VPC egress](https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#yaml)
+                    for the Revision. See
                   - `run.googleapis.com/vpc-access-connector` sets a [VPC connector](https://cloud.google.com/run/docs/configuring/connecting-vpc#terraform_1)
                     for the Revision.
                   - `run.googleapis.com/vpc-access-egress` sets the outbound traffic to send through the VPC connector for this resource.
                     See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--vpc-egress.
+                  - `run.googleapis.com/gpu-zonal-redundancy-disabled` sets
+                    [GPU zonal redundancy](https://cloud.google.com/run/docs/configuring/services/gpu-zonal-redundancy) for the Revision.
                 default_from_api: true
                 diff_suppress_func: 'cloudrunTemplateAnnotationDiffSuppress'
               - name: 'name'

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -322,7 +322,7 @@ properties:
                   - `run.googleapis.com/startup-cpu-boost` sets whether to allocate extra CPU to containers on startup.
                     See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--[no-]cpu-boost.
                   - `run.googleapis.com/network-interfaces` sets [Direct VPC egress](https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#yaml)
-                    for the Revision. See
+                    for the Revision.
                   - `run.googleapis.com/vpc-access-connector` sets a [VPC connector](https://cloud.google.com/run/docs/configuring/connecting-vpc#terraform_1)
                     for the Revision.
                   - `run.googleapis.com/vpc-access-egress` sets the outbound traffic to send through the VPC connector for this resource.

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -964,6 +964,7 @@ properties:
       - name: 'gpuZonalRedundancyDisabled'
         type: Boolean
         description: True if GPU zonal redundancy is disabled on this revision.
+        default_from_api: true
   - name: 'traffic'
     type: Array
     description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -964,7 +964,6 @@ properties:
       - name: 'gpuZonalRedundancyDisabled'
         type: Boolean
         description: True if GPU zonal redundancy is disabled on this revision.
-        default_from_api: true
   - name: 'traffic'
     type: Array
     description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -98,7 +98,6 @@ examples:
   - name: 'cloudrunv2_service_gpu'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-cloudrun-srv%s", context["random_suffix"])'
-    min_version: 'beta'
     vars:
       cloud_run_service_name: 'cloudrun-service'
     ignore_read_extra:
@@ -956,13 +955,15 @@ properties:
       - name: 'nodeSelector'
         type: NestedObject
         description: Node Selector describes the hardware requirements of the resources.
-        min_version: 'beta'
         properties:
           - name: 'accelerator'
             type: String
             description:
               The GPU to attach to an instance. See https://cloud.google.com/run/docs/configuring/services/gpu for configuring GPU.
             required: true
+      - name: 'gpuZonalRedundancyDisabled'
+        type: Boolean
+        description: True if GPU zonal redundancy is disabled on this revision.
   - name: 'traffic'
     type: Array
     description: |-

--- a/mmv1/templates/terraform/examples/cloud_run_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloud_run_service_gpu.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_cloud_run_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name     = "{{index $.Vars "cloud_run_service_name"}}"
   location = "us-central1"
 

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name     = "{{index $.Vars "cloud_run_service_name"}}"
   location = "us-central1"
   deletion_protection = false

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -1564,10 +1564,6 @@ resource "google_cloud_run_service" "default" {
 
   metadata {
     namespace = "%s"
-    annotations = {
-      "run.googleapis.com/launch-stage" = "BETA"
-      "run.googleapis.com/gpu-zonal-redundancy-disabled" = "true"
-    }
   }
 
   template {
@@ -1575,6 +1571,7 @@ resource "google_cloud_run_service" "default" {
       annotations = {
         "autoscaling.knative.dev/maxScale": "1"
         "run.googleapis.com/cpu-throttling": "false"
+        "run.googleapis.com/gpu-zonal-redundancy-disabled" = "true"
       }
     }
     spec {

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -1490,7 +1490,7 @@ func TestAccCloudRunService_resourcesRequirements(t *testing.T) {
 
        acctest.VcrTest(t, resource.TestCase{
                PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-               ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+               ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
                Steps: []resource.TestStep{
                        {
                                Config: testAccCloudRunV2Service_cloudrunServiceWithoutGpu(name, project),

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -1482,7 +1482,6 @@ resource "google_cloud_run_service" "default" {
 `, name, project)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccCloudRunService_resourcesRequirements(t *testing.T) {
        t.Parallel()
 
@@ -1527,7 +1526,6 @@ func TestAccCloudRunService_resourcesRequirements(t *testing.T) {
 func testAccCloudRunV2Service_cloudrunServiceWithoutGpu(name, project string) string {
        return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
-  provider = google-beta
   name     = "%s"
   location = "us-central1"
 
@@ -1561,7 +1559,6 @@ resource "google_cloud_run_service" "default" {
 func testAccCloudRunV2Service_cloudrunServiceWithGpu(name, project string) string {
        return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
-  provider = google-beta
   name     = "%s"
   location = "us-central1"
 
@@ -1569,6 +1566,7 @@ resource "google_cloud_run_service" "default" {
     namespace = "%s"
     annotations = {
       "run.googleapis.com/launch-stage" = "BETA"
+      "run.googleapis.com/gpu-zonal-redundancy-disabled" = "true"
     }
   }
 
@@ -1598,4 +1596,3 @@ resource "google_cloud_run_service" "default" {
 }
 `, name, project)
 }
-{{- end }}

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1269,7 +1269,6 @@ resource "google_network_services_mesh" "new_mesh" {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithResourcesRequirements(t *testing.T) {
   t.Parallel()
   context := map[string]interface{} {
@@ -1379,6 +1378,7 @@ resource "google_cloud_run_v2_service" "default" {
     node_selector {
       accelerator = "nvidia-l4"
     }
+    gpu_zonal_redundancy_disabled = true
     scaling {
       max_instance_count = 1
     }
@@ -1386,7 +1386,6 @@ resource "google_cloud_run_v2_service" "default" {
 }
 `, context)
 }
-{{- end }}
 
 func TestAccCloudRunV2Service_cloudrunv2ServiceFunctionExample_update(t *testing.T) {
         t.Parallel()

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1353,7 +1353,6 @@ resource "google_cloud_run_v2_service" "default" {
   description = "description creating"
   location = "us-central1"
   deletion_protection = false
-  launch_stage = "BETA"
   annotations = {
     generated-by = "magic-modules"
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds support for GPU redundancy to Cloud Run v2 service. Also promotes other GPU fields to GA version in both v1 and v2 Cloud Run service resources.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrun: promoted `node_selector` field in `google_cloud_run_service` resource to GA.
```
```release-note:enhancement
cloudrunv2: promoted `node_selector` field in  `google_cloud_run_v2_service` resource to GA.
```
```release-note:enhancement
cloudrunv2: added `gpu_zonal_redundancy_disabled` field to `google_cloud_run_v2_service` resource.
```
