### PR TITLE
Support for service owned project number 

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -285,6 +285,10 @@ properties:
       - name: 'pscEnabled'
         type: Boolean
         description: 'Create an instance that allows connections from Private Service Connect endpoints to the instance.'
+      - name: 'serviceOwnedProjectNumber'
+        type: Integer
+        description: 'The project number that needs to be allowlisted on the network attachment to enable outbound connectivity.'
+        output: true
   - name: 'initialUser'
     type: NestedObject
     description: |

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -287,7 +287,9 @@ properties:
         description: 'Create an instance that allows connections from Private Service Connect endpoints to the instance.'
       - name: 'serviceOwnedProjectNumber'
         type: Integer
-        description: 'The project number that needs to be allowlisted on the network attachment to enable outbound connectivity.'
+        description: |
+          The project number that needs to be allowlisted on the network attachment to enable outbound connectivity, if the network attachment is configured to ACCEPT_MANUAL connections.
+          In case the network attachment is configured to ACCEPT_AUTOMATIC, this project number does not need to be allowlisted explicitly.
         output: true
   - name: 'initialUser'
     type: NestedObject

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_cluster_test.go
@@ -1472,6 +1472,7 @@ func TestAccAlloydbCluster_withPrivateServiceConnect(t *testing.T) {
 				Config: testAccAlloydbCluster_withPrivateServiceConnect(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_alloydb_cluster.default", "psc_config.0.psc_enabled", "true"),
+					resource.TestMatchResourceAttr("google_alloydb_cluster.default", "psc_config.0.service_owned_project_number", regexp.MustCompile("^[1-9]\\d*$")),
 				),
 			},
 		},


### PR DESCRIPTION
Description:
Supporting service owned project number for Private Service Connect (PSC) clusters in Terraform. This is a output only field.

```release-note:enhancement
alloydb: added `psc_config` field to ``google_alloydb_cluster` resource
```
