### PR TITLE
Remove alpha only field 'datatables' from google_chronicle_rule resource

### DIFF
--- a/mmv1/products/chronicle/Rule.yaml
+++ b/mmv1/products/chronicle/Rule.yaml
@@ -265,9 +265,3 @@ properties:
           type: String
           description: Output only. Link to documentation that describes a diagnostic in more detail.
           output: true
-  - name: dataTables
-    type: Array
-    description: Output only. Resource names of the data tables used in this rule.
-    output: true
-    item_type:
-      type: String


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: note
Remove alpha only field 'datatables' from google_chronicle_rule resource
```
