### PR TITLE
Resource list fallback to items index

### DIFF
--- a/mmv1/templates/terraform/sweeper_file.go.tmpl
+++ b/mmv1/templates/terraform/sweeper_file.go.tmpl
@@ -126,10 +126,18 @@ func testSweep{{ $.ResourceName }}(_ string) error {
 			return err
 		}
 
+		// First try the expected resource key
 		resourceList, ok := res["{{ $.ResourceListKey }}"]
-		if !ok {
-			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
-			continue
+		if ok {
+				log.Printf("[INFO][SWEEPER_LOG] Found resources under expected key '{{ $.ResourceListKey }}'")
+		} else {
+			// Next, try the common "items" pattern
+			resourceList, ok = res["items"]
+			if ok {
+					log.Printf("[INFO][SWEEPER_LOG] Found resources under standard 'items' key")
+			} else {
+				continue
+			}
 		}
 
 		{{- if contains $.ListUrlTemplate "/aggregated/" }}

--- a/mmv1/templates/terraform/sweeper_file.go.tmpl
+++ b/mmv1/templates/terraform/sweeper_file.go.tmpl
@@ -129,12 +129,12 @@ func testSweep{{ $.ResourceName }}(_ string) error {
 		// First try the expected resource key
 		resourceList, ok := res["{{ $.ResourceListKey }}"]
 		if ok {
-				log.Printf("[INFO][SWEEPER_LOG] Found resources under expected key '{{ $.ResourceListKey }}'")
+			log.Printf("[INFO][SWEEPER_LOG] Found resources under expected key '{{ $.ResourceListKey }}'")
 		} else {
 			// Next, try the common "items" pattern
 			resourceList, ok = res["items"]
 			if ok {
-					log.Printf("[INFO][SWEEPER_LOG] Found resources under standard 'items' key")
+				log.Printf("[INFO][SWEEPER_LOG] Found resources under standard 'items' key")
 			} else {
 				continue
 			}


### PR DESCRIPTION
Sometimes this value isn't defined on the resource yaml and the resource is improperly reporting that their is no items in the array. This value is currently manually read from the [collection_url_key](https://github.com/ScottSuarez/magic-modules/blob/ea17257d22bba227c9d39135a358d72c004e5e9c/mmv1/products/appengine/FirewallRule.yaml#L42).

I thought about dynamically trying to find an array value, but unsure. I think it may work as long as there are no other toplevel arrrays. Which is a normally good assumption.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
