### PR TITLE
Fixed not being able to update preview status in SecurityPolicyRule and RegionSecurityPolicyRule

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -484,6 +484,7 @@ properties:
     description: |
       If set to true, the specified action is not enforced.
     min_version: 'beta'
+    send_empty_value: true
   - name: 'networkMatch'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -484,3 +484,4 @@ properties:
     type: Boolean
     description: |
       If set to true, the specified action is not enforced.
+    send_empty_value: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_rule_test.go.tmpl
@@ -24,19 +24,27 @@ func TestAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRuleBasicUpdate(
 			{
 				Config: testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePreUpdate(context),
 			},
-      {
-        ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
-      {
-        Config: testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePostUpdate(context),
-      },
-      {
-        ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
-        ImportState:       true,
-        ImportStateVerify: true,
-      },
+			{
+				ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePostUpdate(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionSecurityPolicyRule_regionSecurityPolicyRulePreUpdate(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go.tmpl
@@ -27,10 +27,18 @@ func TestAccComputeSecurityPolicyRule_basicUpdate(t *testing.T) {
 			{
 				ResourceName:      "google_compute_security_policy_rule.policy_rule",
 				ImportState:       true,
-      	ImportStateVerify: true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccComputeSecurityPolicyRule_postBasicUpdate(context),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSecurityPolicyRule_preBasicUpdate(context),
 			},
 			{
 				ResourceName:      "google_compute_security_policy_rule.policy_rule",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes not being able to update the field `preview` from true to false in `google_compute_security_policy_rule` and `google_compute_region_security_policy_rule`, causing a permadiff.

Fixes: [#19443](https://github.com/hashicorp/terraform-provider-google/issues/19443),[ #20949](https://github.com/hashicorp/terraform-provider-google/issues/20949)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed unable to update the `preview` field for `google_compute_security_policy_rule` resource
```
```release-note:bug
compute: fixed unable to update the `preview` field for `google_compute_region_security_policy_rule` resource (beta)
```