### PR TITLE
Make reassign reviewer only work for core contributors

### DIFF
--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -32,14 +32,15 @@ var reassignReviewerCmd = &cobra.Command{
 
 	The command expects the following PR details as arguments:
 	1. PR_NUMBER
-	2. REVIEWER (optional)
+	2. COMMENT_AUTHOR
+	3. REVIEWER (optional)
 
 
 	It then performs the following operations:
 	1. Updates the reviewer comment to reflect the new primary reviewer.
 	2. Requests a review from the new primary reviewer.
 	`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		prNumber := args[0]
 		fmt.Println("PR Number: ", prNumber)
@@ -49,9 +50,15 @@ var reassignReviewerCmd = &cobra.Command{
 			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(githubToken)
+
+		author := args[1]
+		if gh.GetUserType(author) != github.CoreContributorUserType {
+			return fmt.Errorf("comment author is not a core contributor")
+		}
+
 		var newPrimaryReviewer string
-		if len(args) > 1 {
-			newPrimaryReviewer = args[1]
+		if len(args) > 2 {
+			newPrimaryReviewer = args[2]
 		}
 		return execReassignReviewer(prNumber, newPrimaryReviewer, gh)
 	},

--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -42,4 +42,4 @@ jobs:
           go build .
       - name: Run command
         if: steps.read-comment.outputs.match != ''
-        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ steps.read-comment.outputs.group1 }}
+        run: .ci/magician/magician reassign-reviewer ${{ github.event.issue.number }} ${{ github.event.comment.user.login }} ${{ steps.read-comment.outputs.group1 }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
