### PR TITLE
Fix cross-project listing subscriptions

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -27,6 +27,8 @@ import_format:
   - 'projects/{{project}}/locations/{{location}}/subscriptions/{{subscription_id}}'
 custom_code:
   post_create: templates/terraform/post_create/analytics_hub_subscription.go.tmpl
+  pre_read: 'templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl'
+  pre_delete: 'templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl'
   post_import: templates/terraform/post_import/analytics_hub_subscription.go.tmpl
 sweeper:
   url_substitutions:

--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -19,6 +19,10 @@ references:
   guides:
     'Official Documentation': 'https://cloud.google.com/bigquery/docs/analytics-hub-introduction'
   api: 'https://cloud.google.com/bigquery/docs/reference/analytics-hub/rest/v1/projects.locations.subscriptions'
+docs:
+  note: |-
+    When importing the resource with `terraform import`, provide the destination project and location
+    in the format projects/{{destination_project}}/locations/{{destination_location}}/subscriptions/{{subscription_id}}
 base_url: 'projects/{{project}}/locations/{{location}}/subscriptions'
 self_link: 'projects/{{project}}/locations/{{location}}/subscriptions/{{subscription_id}}'
 create_url: 'projects/{{project}}/locations/{{location}}/dataExchanges/{{data_exchange_id}}/listings/{{listing_id}}:subscribe'
@@ -63,7 +67,7 @@ parameters:
   - name: 'location'
     type: String
     description: |
-      The name of the location for this subscription.
+      The name of the location of the data exchange. Distinct from the location of the destination data set.
     url_param_only: true
     required: true
     custom_flatten: 'templates/terraform/custom_flatten/bigquery_dataset_location.go.tmpl'

--- a/mmv1/templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl
+++ b/mmv1/templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl
@@ -1,0 +1,26 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+	// The project used for Create and Read may be different.
+	// Here, we will use the destination project specifically for reading and deleting.
+	// This cannot be done editing the self_link since the destination project is not a top-level field.
+	destinationProject, ok := d.GetOk("destination_dataset.0.dataset_reference.0.project_id")
+	if ok {
+		billingProject = destinationProject.(string)
+
+		// err == nil indicates that the billing_project value was found
+		if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+		projectToReplace := regexp.MustCompile(`projects\/.*\/locations`)
+		url = projectToReplace.ReplaceAllString(url, fmt.Sprintf("projects/%s/locations", destinationProject))
+	}

--- a/mmv1/templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl
+++ b/mmv1/templates/terraform/pre_read/bigqueryanalyticshub_listing_subscription.tmpl
@@ -21,6 +21,7 @@
 		if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
 			billingProject = bp
 		}
-		projectToReplace := regexp.MustCompile(`projects\/.*\/locations`)
-		url = projectToReplace.ReplaceAllString(url, fmt.Sprintf("projects/%s/locations", destinationProject))
-	}
+		destinationLocation := d.Get("destination_dataset.0.location")
+		partToReplace := regexp.MustCompile(`projects\/.*\/locations\/.*\/subscriptions`)
+		url = partToReplace.ReplaceAllString(url, fmt.Sprintf("projects/%s/locations/%s/subscriptions", destinationProject, destinationLocation))
+	}	

--- a/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_subsscription_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_subsscription_test.go
@@ -1,0 +1,104 @@
+package bigqueryanalyticshub_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccBigqueryAnalyticsHubListingSubscription_differentProject(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryAnalyticsHubListingSubscriptionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryAnalyticsHubListingSubscription_differentProject(context),
+			},
+			{
+				ResourceName:            "google_bigquery_analytics_hub_listing_subscription.subscription",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_exchange_id", "destination_dataset", "listing_id", "location", "subscription_id"},
+			},
+		},
+	})
+}
+
+func testAccBigqueryAnalyticsHubListingSubscription_differentProject(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+
+# Dataset created in default project
+resource "google_bigquery_dataset" "subscription" {
+	dataset_id                  = "tf_test_my_listing%{random_suffix}"
+	friendly_name               = "tf_test_my_listing%{random_suffix}"
+	description                 = ""
+	location                    = "US"
+}
+
+resource "google_project" "project" {
+	project_id      = "tf-test-%{random_suffix}"
+	name            = "tf-test-%{random_suffix}"
+	org_id          = "%{org_id}"
+	deletion_policy = "DELETE"
+}
+
+
+resource "google_project_service" "analyticshub" {
+	project  = google_project.project.project_id
+	service  = "analyticshub.googleapis.com"
+	disable_on_destroy = false # Need it enabled in the project when the test disables services in post-test cleanup
+}
+
+resource "google_bigquery_analytics_hub_data_exchange" "subscription" {
+  project          = google_project.project.project_id
+  location         = "US"
+  data_exchange_id = "tf_test_my_data_exchange%{random_suffix}"
+  display_name     = "tf_test_my_data_exchange%{random_suffix}"
+  description      = ""
+  depends_on = [google_project_service.analyticshub]
+}
+
+resource "google_bigquery_analytics_hub_listing" "subscription" {
+  project          = google_project.project.project_id
+  location         = "US"
+  data_exchange_id = google_bigquery_analytics_hub_data_exchange.subscription.data_exchange_id
+  listing_id       = "tf_test_my_listing%{random_suffix}"
+  display_name     = "tf_test_my_listing%{random_suffix}"
+  description      = ""
+
+  bigquery_dataset {
+    dataset = google_bigquery_dataset.subscription.id
+  }
+}
+
+resource "google_bigquery_analytics_hub_listing_subscription" "subscription" {
+  project          = google_project.project.project_id
+  location = "US"
+  data_exchange_id = google_bigquery_analytics_hub_data_exchange.subscription.data_exchange_id
+  listing_id       = google_bigquery_analytics_hub_listing.subscription.listing_id
+  destination_dataset {
+    description = "A test subscription"
+    friendly_name = "👋"
+    labels = {
+      testing = "123"
+    }
+    location = "US"
+    dataset_reference {
+      dataset_id = "tf_test_destination_dataset%{random_suffix}"
+      project_id = google_bigquery_dataset.subscription.project
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/21402

google_bigquery_analytics_hub_listing_subscription is unfortunately unique in that the create_url and self_link differ completely. What was missed in the original implementation was a cross-project setup that would cause one project needed for the create_url, but a separate one for the self_link.

This fix rectifies the issue by inserting pre_read and pre_delete code to overwrite the template URL to use the correct destination dataset project instead of the `project` field.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigqueryanalyticshub: fixed a bug in `google_bigquery_analytics_hub_listing_subscription` where a subscription using a different project than the dataset would not work
```
