### PR TITLE
Add default value to env.value to fix the plan diffs in cloud run services

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -451,6 +451,7 @@ properties:
                             description: Name of the environment variable.
                           - name: 'value'
                             type: String
+                            default_value: ""
                             description: |-
                               Defaults to "".
                           - name: 'valueFrom'

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -451,6 +451,9 @@ properties:
                             description: Name of the environment variable.
                           - name: 'value'
                             type: String
+                            # env is a set.
+                            # The env.value has value "" in Terraform state, but it has value nil in Terraform plan,
+                            # which causes the diffs for unchanged env. default_value: "" is to suppress the diffs.
                             default_value: ""
                             description: |-
                               Defaults to "".

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -481,6 +481,9 @@ properties:
                     required: true
                   - name: 'value'
                     type: String
+                    # env is a set.
+                    # The env.value has value "" in Terraform state, but it has value nil in Terraform plan,
+                    # which causes the diffs for unchanged env. default_value: "" is to suppress the diffs.
                     default_value: ""
                     description: |-
                       Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -481,6 +481,7 @@ properties:
                     required: true
                   - name: 'value'
                     type: String
+                    default_value: ""
                     description: |-
                       Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.
                     # exactly_one_of:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/7467
fixes https://github.com/hashicorp/terraform-provider-google/issues/10634

This change will fix the diffs for unchanged `env`. `env` is a set. The `env.value` has value "" in Terraform state, but it has value nil in Terraform plan, which causes the diffs for unchanged `env`.  

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudrun: fixed the perma-diffs for unchanged `template.spec.containers.env` in `google_cloud_run_service` resource
```

```release-note:bug
cloudrunv2: fixed the perma-diffs for unchanged `template.containers.env` in `google_cloud_run_v2_service` resource
```
