### PR TITLE
add ip_endpoints_config field to google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1765,7 +1765,7 @@ func ResourceContainerCluster() *schema.Resource {
 				MaxItems:    1,
 				Computed:    true,
 				Optional:    true,
-				Description: `Configuration for all of the cluster's control plane endpoints. Currently supports only DNS endpoint configuration, IP endpoint configuration is available in private_cluster_config.`,
+				Description: `Configuration for all of the cluster's control plane endpoints. Currently supports only DNS endpoint configuration and disable IP endpoint. Other IP endpoint configurations are available in private_cluster_config.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"dns_endpoint_config": {
@@ -1786,6 +1786,22 @@ func ResourceContainerCluster() *schema.Resource {
 										Type:        schema.TypeBool,
 										Optional:    true,
 										Description: `Controls whether user traffic is allowed over this endpoint. Note that GCP-managed services may still use the endpoint even if this is false.`,
+									},
+								},
+							},
+						},
+						"ip_endpoints_config": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Computed:    true,
+							Description: `IP endpoint configuration.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: `Controls whether to allow direct IP access.`,
 									},
 								},
 							},
@@ -5588,9 +5604,18 @@ func expandControlPlaneEndpointsConfig(d *schema.ResourceData) *container.Contro
 	}
 
 	ip := &container.IPEndpointsConfig{
-		// There isn't yet a config field to disable IP endpoints, so this is hardcoded to be enabled for the time being.
 		Enabled:         true,
 		ForceSendFields: []string{"Enabled"},
+	}
+	if v := d.Get("control_plane_endpoints_config.0.ip_endpoints_config.#"); v != 0 {
+		ip.Enabled = d.Get("control_plane_endpoints_config.0.ip_endpoints_config.0.enabled").(bool)
+
+		if !ip.Enabled {
+			return &container.ControlPlaneEndpointsConfig{
+				DnsEndpointConfig: dns,
+				IpEndpointsConfig: ip,
+			}
+		}
 	}
 	if v := d.Get("private_cluster_config.0.enable_private_endpoint"); v != nil {
 		ip.EnablePublicEndpoint = !v.(bool)
@@ -6305,6 +6330,7 @@ func flattenControlPlaneEndpointsConfig(c *container.ControlPlaneEndpointsConfig
 	return []map[string]interface{}{
 		{
 			"dns_endpoint_config": flattenDnsEndpointConfig(c.DnsEndpointConfig),
+			"ip_endpoints_config": flattenIpEndpointsConfig(c.IpEndpointsConfig),
 		},
 	}
 }
@@ -6317,6 +6343,17 @@ func flattenDnsEndpointConfig(dns *container.DNSEndpointConfig) []map[string]int
 		{
 			"endpoint":               dns.Endpoint,
 			"allow_external_traffic": dns.AllowExternalTraffic,
+		},
+	}
+}
+
+func flattenIpEndpointsConfig(ip *container.IPEndpointsConfig) []map[string]interface{} {
+	if ip == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"enabled": ip.Enabled,
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -13323,3 +13323,60 @@ resource "google_container_cluster" "with_enterprise_config" {
 }
 `, projectID, clusterName, networkName, subnetworkName)
 }
+
+func TestAccContainerCluster_disableControlPlaneIP(t *testing.T) {
+  t.Parallel()
+
+  clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+  subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:     func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
+      },
+      {
+        ResourceName:      "google_container_cluster.primary",
+        ImportState:       true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"deletion_protection"},
+      },
+      {
+        Config: testAccContainerCluster_ControlPlaneIPdisabled(clusterName, networkName, subnetworkName),
+      },
+      {
+        ResourceName:      "google_container_cluster.primary",
+        ImportState:       true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"deletion_protection"},
+      },
+    },
+  })
+}
+
+func testAccContainerCluster_ControlPlaneIPdisabled(clusterName, networkName, subnetworkName string) string {
+        return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network            = "%s"
+  subnetwork         = "%s"
+
+  deletion_protection = false
+
+  control_plane_endpoints_config {
+    ip_endpoints_config {
+      enabled = false
+    }
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+  }
+}
+`, clusterName, networkName, subnetworkName)
+}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1193,12 +1193,17 @@ notification_config {
 <a name="nested_control_plane_endpoints_config"></a>The `control_plane_endpoints_config` block supports:
 
 * `dns_endpoint_config` - (Optional) DNS endpoint configuration.
+* `ip_endpoints_config` - (Optional) IP endpoint configuration.
 
 The `control_plane_endpoints_config.dns_endpoint_config` block supports:
 
 * `endpoint` - (Output) The cluster's DNS endpoint.
 
 * `allow_external_traffic` - (Optional) Controls whether user traffic is allowed over this endpoint. Note that GCP-managed services may still use the endpoint even if this is false.
+
+The `control_plane_endpoints_config.ip_endpoints_config` block supports:
+
+* `enabled` - (Optional) Controls whether to allow direct IP access. Defaults to `true`.
 
 <a name="nested_private_cluster_config"></a>The `private_cluster_config` block supports:
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20369

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `ip_endpoints_config` field to `google_container_cluster` resource
```
