### PR TITLE
Add `locations` field to mirroring deployment group.

### DIFF
--- a/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringDeploymentGroup.yaml
@@ -138,3 +138,26 @@ properties:
     description: |-
       User-provided description of the deployment group.
       Used as additional context for the deployment group.
+  - name: locations
+    type: Array
+    is_set: true
+    description: |-
+      The list of locations where the deployment group is present.
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: location
+          type: String
+          description: |-
+            The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
+          output: true
+        - name: state
+          type: String
+          description: |-
+            The current state of the association in this location.
+            Possible values:
+            STATE_UNSPECIFIED
+            ACTIVE
+            OUT_OF_SYNC
+          output: true


### PR DESCRIPTION
Add the new `locations` output field to Mirroring Deployment Group resource.
Used to expose the locations where the deployment group is currently deployed.

```release-note:enhancement
networksecurity: added `locations` field to `google_network_security_mirroring_deployment_group` resource
```
