### PR TITLE
Add `locations` field to mirroring endpoint group association.

### DIFF
--- a/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroupAssociation.yaml
@@ -119,6 +119,8 @@ properties:
       The list of locations where the association is present. This information
       is retrieved from the linked endpoint group, and not configured as part
       of the association itself.
+    deprecation_message: |-
+      `locationsDetails` is deprecated and will be removed in a future major release. Use `locations` instead.
     output: true
     item_type:
       type: NestedObject
@@ -158,3 +160,26 @@ properties:
       operation (e.g. adding a new location to the target deployment group).
       See https://google.aip.dev/128.
     output: true
+  - name: locations
+    type: Array
+    is_set: true
+    description: |-
+      The list of locations where the association is configured. This information
+      is retrieved from the linked endpoint group.
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+      - name: location
+        type: String
+        description: The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
+        output: true
+      - name: state
+        type: String
+        description: |-
+          The current state of the association in this location.
+          Possible values:
+          STATE_UNSPECIFIED
+          ACTIVE
+          OUT_OF_SYNC
+        output: true


### PR DESCRIPTION
Add the new `locations` output field to Mirroring Endpoint Group Association resource.
Used to expose the locations where the producer is currently deployed.

```release-note:enhancement
networksecurity: added `locations` field to `google_network_security_mirroring_endpoint_group_association` resource
```
