### PR TITLE
Add `locations` field to intercept endpoint group association.

### DIFF
--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -184,19 +184,19 @@ properties:
     item_type:
       type: NestedObject
       properties:
-      - name: location
-        type: String
-        description: |-
-          The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
-        min_version: 'beta'
-        output: true
-      - name: state
-        type: String
-        description: |-
-          The current state of the association in this location.
-          Possible values:
-          STATE_UNSPECIFIED
-          ACTIVE
-          OUT_OF_SYNC
-        min_version: 'beta'
-        output: true
+        - name: location
+          type: String
+          description: |-
+            The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
+          min_version: 'beta'
+          output: true
+        - name: state
+          type: String
+          description: |-
+            The current state of the association in this location.
+            Possible values:
+            STATE_UNSPECIFIED
+            ACTIVE
+            OUT_OF_SYNC
+          min_version: 'beta'
+          output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -127,6 +127,8 @@ properties:
       The list of locations where the association is present. This information
       is retrieved from the linked endpoint group, and not configured as part
       of the association itself.
+    deprecation_message: |-
+      `locationsDetails` is deprecated and will be removed in a future major release. Use `locations` instead.
     min_version: 'beta'
     output: true
     item_type:
@@ -171,3 +173,30 @@ properties:
       See https://google.aip.dev/128.
     min_version: 'beta'
     output: true
+  - name: locations
+    type: Array
+    is_set: true
+    description: |-
+      The list of locations where the association is configured. This information
+      is retrieved from the linked endpoint group.
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+      - name: location
+        type: String
+        description: |-
+          The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
+        min_version: 'beta'
+        output: true
+      - name: state
+        type: String
+        description: |-
+          The current state of the association in this location.
+          Possible values:
+          STATE_UNSPECIFIED
+          ACTIVE
+          OUT_OF_SYNC
+        min_version: 'beta'
+        output: true


### PR DESCRIPTION
Add the new `locations` output field to Intercept Endpoint Group Association resource.
Used to expose the locations where the producer is currently deployed.

Also marking `locationsDetails` as deprecated, as the new `locations` replaces it.
Both are still populated for now, but `locationsDetails` will eventually be removed.

```release-note:enhancement
networksecurity: added `locations` field to `google_network_security_intercept_endpoint_group_association` resource
```
