### PR TITLE
Add `connectedDeploymentGroup` and `associations` fields to intercept endpoint group.

### DIFF
--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -183,6 +183,7 @@ properties:
     description: |-
       The endpoint group's view of a connected deployment group.
     min_version: 'beta'
+    output: true
     properties:
       - name: name
         type: String

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -138,3 +138,82 @@ properties:
       User-provided description of the endpoint group.
       Used as additional context for the endpoint group.
     min_version: 'beta'
+  - name: associations
+    type: Array
+    is_set: true
+    description: |-
+      List of associations to this endpoint group.
+    min_version: 'beta'
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: name
+          type: String
+          description: |-
+            The connected association's resource name, for example:
+            `projects/123456789/locations/global/interceptEndpointGroupAssociations/my-ega`.
+            See https://google.aip.dev/124.
+          min_version: 'beta'
+          output: true
+        - name: network
+          type: String
+          description: |-
+            The associated network, for example:
+            projects/123456789/global/networks/my-network.
+            See https://google.aip.dev/124.
+          min_version: 'beta'
+          output: true
+        - name: state
+          type: String
+          description: |-
+            Most recent known state of the association.
+            Possible values:
+            STATE_UNSPECIFIED
+            ACTIVE
+            CREATING
+            DELETING
+            CLOSED
+            OUT_OF_SYNC
+            DELETE_FAILED
+          min_version: 'beta'
+          output: true
+  - name: connectedDeploymentGroup
+    type: NestedObject
+    description: |-
+      The endpoint group's view of a connected deployment group.
+    min_version: 'beta'
+    properties:
+      - name: name
+        type: String
+        description: |-
+          The connected deployment group's resource name, for example:
+          `projects/123456789/locations/global/interceptDeploymentGroups/my-dg`.
+          See https://google.aip.dev/124.
+        min_version: 'beta'
+        output: true
+      - name: locations
+        type: Array
+        is_set: true
+        description: |-
+          The list of locations where the deployment group is present.
+        min_version: 'beta'
+        output: true
+        item_type:
+          type: NestedObject
+          properties:
+            - name: location
+              type: String
+              description: |-
+                The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
+              output: true
+            - name: state
+              type: String
+              description: |-
+                The current state of the association in this location.
+                Possible values:
+                STATE_UNSPECIFIED
+                ACTIVE
+                OUT_OF_SYNC
+              min_version: 'beta'
+              output: true


### PR DESCRIPTION
Add the new `connectedDeploymentGroup` and `associations` output fields to Intercept Endpoint Group resource.
These fields expose to the user more data on the connected deployment group and the associated networks.

```release-note:enhancement
networksecurity: added `connectedDeploymentGroup` and `associations` fields to `google_network_security_intercept_endpoint_group` resource
```
