### PR TITLE
Add `optional_mode` and `optional_fields` to BackendService log_config.

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -120,6 +120,12 @@ examples:
     primary_resource_id: 'default'
     vars:
       backend_service_name: 'backend-service'
+  - name: 'backend_service_log_config'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-backend-service%s", context["random_suffix"])'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
   - name: 'backend_service_custom_metrics'
     primary_resource_id: 'default'
     vars:
@@ -133,12 +139,6 @@ examples:
       backend_service_name: 'backend-service'
       health_check_name: 'health-check'
       authentication_name: 'authentication'
-  - name: 'backend_service_log_config'
-    primary_resource_id: 'default'
-    primary_resource_name: 'fmt.Sprintf("tf-test-backend-service%s", context["random_suffix"])'
-    vars:
-      backend_service_name: 'backend-service'
-      http_health_check_name: 'health-check'
 parameters:
 properties:
   - name: 'affinityCookieTtlSec'

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1455,6 +1455,7 @@ properties:
         at_least_one_of:
           - 'log_config.0.enable'
           - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
       - name: 'sampleRate'
         type: Double
         description: |
@@ -1465,8 +1466,30 @@ properties:
         at_least_one_of:
           - 'log_config.0.enable'
           - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
         diff_suppress_func: 'suppressWhenDisabled'
         default_value: 1.0
+      - name: 'optionalMode'
+        type: Enum
+        description: |
+          Specifies the optional logging mode for the load balancer traffic.
+          Supported values: INCLUDE_ALL_OPTIONAL, EXCLUDE_ALL_OPTIONAL, CUSTOM.
+        enum_values:
+          - 'INCLUDE_ALL_OPTIONAL'
+          - 'EXCLUDE_ALL_OPTIONAL'
+          - 'CUSTOM'
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+        default_from_api: true
+      - name: 'optionalFields'
+        type: Array
+        description: |
+          Specifies the fields to include in logging. This field can only be specified if logging is enabled for this backend service.
+        item_type:
+          type: String
+        default_from_api: true
   - name: 'serviceLbPolicy'
     type: String
     description: |

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -133,6 +133,12 @@ examples:
       backend_service_name: 'backend-service'
       health_check_name: 'health-check'
       authentication_name: 'authentication'
+  - name: 'backend_service_log_config'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-backend-service%s", context["random_suffix"])'
+    vars:
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'health-check'
 parameters:
 properties:
   - name: 'affinityCookieTtlSec'

--- a/mmv1/templates/terraform/examples/backend_service_log_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_log_config.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.Vars "backend_service_name"}}"
+  health_checks = [google_compute_http_health_check.default.id]
+  log_config {
+     enable      = true
+     sample_rate = 1.0
+     optional_mode = "CUSTOM"
+     optional_fields = [ "orca.cpu_utilization", "orca.named_metrics.foo" ]
+   }  
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.Vars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/mmv1/templates/terraform/examples/backend_service_log_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_log_config.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.Vars "backend_service_name"}}"
   health_checks = [google_compute_http_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
   log_config {
      enable      = true
      sample_rate = 1.0


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: Add `optional_mode` and `optional_fields` to `log_config` of `google_compute_backend_service`
```

Corresponding PR for regional backend services: #13094 
