### PR TITLE
Add support for the managed disaster recovery feature in google_bigquery_reservation

### DIFF
--- a/mmv1/products/bigqueryreservation/Reservation.yaml
+++ b/mmv1/products/bigqueryreservation/Reservation.yaml
@@ -35,6 +35,11 @@ examples:
     primary_resource_id: 'reservation'
     vars:
       name: 'my-reservation'
+  - name: 'bigquery_reservation_with_disaster_recovery'
+    primary_resource_id: 'reservation'
+    vars:
+      name: 'my-reservation'
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String
@@ -90,3 +95,64 @@ properties:
         type: Integer
         description: |
           Number of slots to be scaled when needed.
+  - name: 'primaryLocation'
+    type: String
+    description: |
+      The current location of the reservation's primary replica. This field is only set for
+      reservations using the managed disaster recovery feature.
+    output: true
+  - name: 'secondaryLocation'
+    type: String
+    description: |
+      The current location of the reservation's secondary replica. This field is only set for
+      reservations using the managed disaster recovery feature. Users can set this in create
+      reservation calls to create a failover reservation or in update reservation calls to convert
+      a non-failover reservation to a failover reservation(or vice versa).
+  - name: 'originalPrimaryLocation'
+    type: String
+    description: |
+      The location where the reservation was originally created. This is set only during the
+      failover reservation's creation. All billing charges for the failover reservation will be
+      applied to this location.
+    output: true
+  - name: 'replicationStatus'
+    type: NestedObject
+    description: |
+      The Disaster Recovery(DR) replication status of the reservation. This is only available for
+      the primary replicas of DR/failover reservations and provides information about the both the
+      staleness of the secondary and the last error encountered while trying to replicate changes
+      from the primary to the secondary. If this field is blank, it means that the reservation is
+      either not a DR reservation or the reservation is a DR secondary or that any replication
+      operations on the reservation have succeeded.
+    properties:
+      - name: 'error'
+        type: NestedObject
+        description: |
+          The last error encountered while trying to replicate changes from the primary to the
+          secondary. This field is only available if the replication has not succeeded since.
+        properties:
+          - name: 'code'
+            type: Integer
+            description: |
+              The status code, which should be an enum value of [google.rpc.Code](https://cloud.google.com/bigquery/docs/reference/reservations/rpc/google.rpc#google.rpc.Code).
+            output: true
+          - name: 'message'
+            type: String
+            description: |
+              A developer-facing error message, which should be in English.
+            output: true
+        output: true
+      - name: 'lastErrorTime'
+        type: Time
+        description: |
+          The time at which the last error was encountered while trying to replicate changes from
+          the primary to the secondary. This field is only available if the replication has not
+          succeeded since.
+        output: true
+      - name: 'lastReplicationTime'
+        type: Time
+        description: |
+          A timestamp corresponding to the last change on the primary that was successfully
+          replicated to the secondary.
+        output: true
+    output: true

--- a/mmv1/templates/terraform/examples/bigquery_reservation_with_disaster_recovery.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_reservation_with_disaster_recovery.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_bigquery_reservation" "{{$.PrimaryResourceId}}" {
+  name           = "{{index $.Vars "name"}}"
+  location       = "us-west2"
+  secondary_location = "us-west1"
+  // Set to 0 for testing purposes
+  // In reality this would be larger than zero
+  slot_capacity     = 0
+  edition = "ENTERPRISE_PLUS"
+  ignore_idle_slots = true
+  concurrency       = 0
+  autoscale {
+    max_slots = 100
+  }
+}

--- a/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_test.go
@@ -1,0 +1,80 @@
+package bigqueryreservation_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccBigqueryReservation_withDisasterRecovery_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryReservation_withDisasterRecovery_basic(context),
+			},
+			{
+				ResourceName:      "google_bigquery_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigqueryReservation_withDisasterRecovery_update(context),
+			},
+			{
+				ResourceName:      "google_bigquery_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBigqueryReservation_withDisasterRecovery_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+  name           = "tf-test-reservation-%{random_suffix}"
+  location       = "us-west2"
+  secondary_location = "us-west1"
+
+  // Set to 0 for testing purposes
+  // In reality this would be larger than zero
+  slot_capacity     = 0
+  edition = "ENTERPRISE_PLUS"
+  ignore_idle_slots = true
+  concurrency       = 0
+  autoscale {
+    max_slots = 100
+  }
+}
+`, context)
+}
+
+func testAccBigqueryReservation_withDisasterRecovery_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+  name           = "tf-test-reservation-%{random_suffix}"
+  location       = "us-west2"
+
+  // secondary_location is removed. Direct value update (e.g. "us-west1" to "us-east1") is not supported.
+
+  // Set to 0 for testing purposes
+  // In reality this would be larger than zero
+  slot_capacity     = 0
+  edition = "ENTERPRISE_PLUS"
+  ignore_idle_slots = true
+  concurrency       = 0
+  autoscale {
+    max_slots = 100
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add support for the managed disaster recovery feature in `google_bigquery_reservation`. 
Public user guide: https://cloud.google.com/bigquery/docs/managed-disaster-recovery.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added support for the managed disaster recovery feature in google_bigquery_reservation
```
