### PR TITLE
Update google_network_management_connectivity_test

### DIFF
--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google Inc.
+# Copyright 2025 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -28,9 +28,9 @@ create_url: 'projects/{{project}}/locations/global/connectivityTests?testId={{na
 update_verb: 'PATCH'
 update_mask: true
 timeouts:
-  insert_minutes: 20
-  update_minutes: 20
-  delete_minutes: 20
+  insert_minutes: 5
+  update_minutes: 5
+  delete_minutes: 5
 autogen_async: true
 async:
   actions: ['create', 'delete', 'update']
@@ -76,32 +76,22 @@ properties:
     description: |
       Required. Source specification of the Connectivity Test.
 
-      You can use a combination of source IP address, virtual machine
-      (VM) instance, or Compute Engine network to uniquely identify the
-      source location.
+      You can use a combination of source IP address, URI of a supported
+      endpoint, project ID, or VPC network to identify the source location.
 
-      Examples: If the source IP address is an internal IP address within
-      a Google Cloud Virtual Private Cloud (VPC) network, then you must
-      also specify the VPC network. Otherwise, specify the VM instance,
-      which already contains its internal IP address and VPC network
-      information.
-
-      If the source of the test is within an on-premises network, then
-      you must provide the destination VPC network.
-
-      If the source endpoint is a Compute Engine VM instance with multiple
-      network interfaces, the instance itself is not sufficient to
-      identify the endpoint. So, you must also specify the source IP
-      address or VPC network.
-
-      A reachability analysis proceeds even if the source location is
-      ambiguous. However, the test result may include endpoints that
-      you don't intend to test.
+      Reachability analysis might proceed even if the source location is
+      ambiguous. However, the test result might include endpoints or use a source
+      that you don't intend to test.
     required: true
     update_mask_fields:
       - 'source.ipAddress'
       - 'source.port'
       - 'source.instance'
+      - 'source.gkeMasterCluster'
+      - 'source.cloudSqlInstance'
+      - 'source.cloudFunction'
+      - 'source.appEngineVersion'
+      - 'source.cloudRunRevision'
       - 'source.network'
       - 'source.networkType'
       - 'source.projectId'
@@ -109,22 +99,58 @@ properties:
       - name: 'ipAddress'
         type: String
         description: |-
-          The IP address of the endpoint, which can be an external or
-          internal IP. An IPv6 address is only allowed when the test's
-          destination is a global load balancer VIP.
+          The IP address of the endpoint, which can be an external or internal IP.
       - name: 'port'
         type: Integer
         description: |-
-          The IP protocol port of the endpoint. Only applicable when
-          protocol is TCP or UDP.
+          The IP protocol port of the endpoint. Only applicable when protocol is
+          TCP or UDP.
       - name: 'instance'
         type: String
         description: |-
           A Compute Engine instance URI.
+      - name: 'gkeMasterCluster'
+        type: String
+        description: |-
+          A cluster URI for Google Kubernetes Engine cluster control plane.
+      - name: 'cloudSqlInstance'
+        type: String
+        description: |-
+          A Cloud SQL instance URI.
+      - name: 'cloudFunction'
+        type: NestedObject
+        description: |-
+          A Cloud Function.
+        immutable: true
+        properties:
+          - name: 'uri'
+            type: String
+            description: |-
+              A Cloud Function name.
+      - name: 'appEngineVersion'
+        type: NestedObject
+        immutable: true
+        description: |-
+          An App Engine service version.
+        properties:
+          - name: 'uri'
+            type: String
+            description: |-
+              An App Engine service version name.
+      - name: 'cloudRunRevision'
+        type: NestedObject
+        immutable: true
+        description: |-
+          A Cloud Run revision.
+        properties:
+          - name: 'uri'
+            type: String
+            description: |-
+              A Cloud Run revision URI.
       - name: 'network'
         type: String
         description: |-
-          A Compute Engine network URI.
+          A VPC network URI.
       - name: 'networkType'
         type: Enum
         description: |-
@@ -135,75 +161,96 @@ properties:
       - name: 'projectId'
         type: String
         description: |-
-          Project ID where the endpoint is located. The Project ID can be
-          derived from the URI if you provide a VM instance or network URI.
-          The following are two cases where you must provide the project ID:
-
-          1. Only the IP address is specified, and the IP address is
-             within a GCP project.
-          2. When you are using Shared VPC and the IP address
-             that you provide is from the service project. In this case,
-             the network that the IP address resides in is defined in the
-             host project.
+          Project ID where the endpoint is located.
+          The project ID can be derived from the URI if you provide a endpoint or
+          network URI.
+          The following are two cases where you may need to provide the project ID:
+          1. Only the IP address is specified, and the IP address is within a Google
+          Cloud project.
+          2. When you are using Shared VPC and the IP address that you provide is
+          from the service project. In this case, the network that the IP address
+          resides in is defined in the host project.
   - name: 'destination'
     type: NestedObject
     description: |
       Required. Destination specification of the Connectivity Test.
 
-      You can use a combination of destination IP address, Compute
-      Engine VM instance, or VPC network to uniquely identify the
-      destination location.
+      You can use a combination of destination IP address, URI of a supported
+      endpoint, project ID, or VPC network to identify the destination location.
 
-      Even if the destination IP address is not unique, the source IP
-      location is unique. Usually, the analysis can infer the destination
-      endpoint from route information.
-
-      If the destination you specify is a VM instance and the instance has
-      multiple network interfaces, then you must also specify either a
-      destination IP address or VPC network to identify the destination
-      interface.
-
-      A reachability analysis proceeds even if the destination location
-      is ambiguous. However, the result can include endpoints that you
-      don't intend to test.
+      Reachability analysis proceeds even if the destination location is
+      ambiguous. However, the test result might include endpoints or use a
+      destination that you don't intend to test.
     required: true
     update_mask_fields:
       - 'destination.ipAddress'
       - 'destination.port'
       - 'destination.instance'
+      - 'destination.forwardingRule'
+      - 'destination.gkeMasterCluster'
+      - 'destination.fqdn'
+      - 'destination.cloudSqlInstance'
+      - 'destination.redisInstance'
+      - 'destination.redisCluster'
       - 'destination.network'
       - 'destination.projectId'
     properties:
       - name: 'ipAddress'
         type: String
         description: |-
-          The IP address of the endpoint, which can be an external or
-          internal IP. An IPv6 address is only allowed when the test's
-          destination is a global load balancer VIP.
+          The IP address of the endpoint, which can be an external or internal IP.
       - name: 'port'
         type: Integer
         description: |-
-          The IP protocol port of the endpoint. Only applicable when
-          protocol is TCP or UDP.
+          The IP protocol port of the endpoint. Only applicable when protocol is
+          TCP or UDP.
       - name: 'instance'
         type: String
         description: |-
           A Compute Engine instance URI.
+      - name: 'forwardingRule'
+        type: String
+        description: |-
+          Forwarding rule URI. Forwarding rules are frontends for load balancers,
+          PSC endpoints, and Protocol Forwarding. 
+      - name: 'gkeMasterCluster'
+        type: String
+        description: |-
+          A cluster URI for Google Kubernetes Engine cluster control plane.
+      - name: 'fqdn'
+        type: String
+        description: |-
+          A DNS endpoint of Google Kubernetes Engine cluster control plane.
+          Requires gke_master_cluster to be set, can't be used simultaneoulsly with
+          ip_address or network. Applicable only to destination endpoint.
+      - name: 'cloudSqlInstance'
+        type: String
+        description: |-
+          A Cloud SQL instance URI.
+      - name: 'redisInstance'
+        type: String
+        description: |-
+          A Redis Instance URI.
+      - name: 'redisCluster'
+        type: String
+        description: |-
+          A Redis Cluster URI.
       - name: 'network'
         type: String
         description: |-
-          A Compute Engine network URI.
+          A VPC network URI.
       - name: 'projectId'
         type: String
         description: |-
-          Project ID where the endpoint is located. The Project ID can be
-          derived from the URI if you provide a VM instance or network URI.
-          The following are two cases where you must provide the project ID:
-          1. Only the IP address is specified, and the IP address is within
-          a GCP project. 2. When you are using Shared VPC and the IP address
-          that you provide is from the service project. In this case, the
-          network that the IP address resides in is defined in the host
-          project.
+          Project ID where the endpoint is located.
+          The project ID can be derived from the URI if you provide a endpoint or
+          network URI.
+          The following are two cases where you may need to provide the project ID:
+          1. Only the IP address is specified, and the IP address is within a Google
+          Cloud project.
+          2. When you are using Shared VPC and the IP address that you provide is
+          from the service project. In this case, the network that the IP address
+          resides in is defined in the host project.
   - name: 'protocol'
     type: String
     description: |-
@@ -221,3 +268,12 @@ properties:
     type: KeyValueLabels
     description: |
       Resource labels to represent user-provided metadata.
+  - name: 'roundTrip'
+    type: Boolean
+    description: |-
+      Whether run analysis for the return path from destination to source.
+      Default value is false.
+  - name: 'bypassFirewallChecks'
+    type: Boolean
+    description: |-
+      Whether the analysis should skip firewall checking. Default value is false.

--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -56,6 +56,10 @@ examples:
       network: 'connectivity-vpc'
       source_addr: 'src-addr'
       dest_addr: 'dest-addr'
+  - name: 'network_management_connectivity_test_endpoints'
+    primary_resource_id: 'endpoints-test'
+    vars:
+      primary_resource_name: 'conn-test-endpoints'
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -216,7 +216,7 @@ properties:
         type: String
         description: |-
           Forwarding rule URI. Forwarding rules are frontends for load balancers,
-          PSC endpoints, and Protocol Forwarding. 
+          PSC endpoints, and Protocol Forwarding.
       - name: 'gkeMasterCluster'
         type: String
         description: |-

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_endpoints.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_endpoints.tf.tmpl
@@ -1,0 +1,28 @@
+resource "google_network_management_connectivity_test" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "primary_resource_name"}}"
+  source {
+    gke_master_cluster =  "projects/test-project/locations/us-central1/clusters/name"
+    cloud_sql_instance = "projects/test-project/instances/name"
+    app_engine_version {
+         uri = "apps/test-project/services/default/versions/name"
+    }
+    cloud_function {
+      uri = "projects/test-project/locations/us-central1/functions/name"
+    }
+    cloud_run_revision {
+        uri = "projects/test-project/locations/us-central1/revisions/name"
+    }
+    port = 80
+  }
+  destination {
+    port = 443
+    forwarding_rule = "projects/test-project/regions/us-central1/forwardingRules/name"
+    gke_master_cluster = "projects/test-project/locations/us-central1/clusters/name"
+    fqdn = "name.us-central1.gke.goog"
+    cloud_sql_instance = "projects/test-project/instances/name"
+    redis_instance = "projects/test-project/locations/us-central1/instances/name"
+    redis_cluster = "projects/test-project/locations/us-central1/clusters/name"
+  }
+  bypass_firewall_checks = true
+  round_trip = true
+}


### PR DESCRIPTION
<!--
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16908

Tested by generating Terraform providers and running `make test` and `make lint`. Also tested with local Terraform and manually verifying added/updated Connectivity Test resources.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networkmanagement: added `source.gkeMasterCluster`,  `source.cloudSqlInstance`, `source.cloudFunction`, `source.appEngineVersion`, `source.cloudRunRevision` fields to `google_network_management_connectivity_test` resource
```
```release-note:enhancement
networkmanagement: added `destination.forwardingRule`, `destination.gkeMasterCluster`, `destination.fqdn`, `destination.cloudSqlInstance`, `destination.redisInstance`, `destination.redisCluster`,  fields to `google_network_management_connectivity_test` resource
```
```release-note:enhancement
networkmanagement: added `roundTrip`, `bypassFirewallChecks` fields to `google_network_management_connectivity_test` resource
```
