### PR TITLE
Make multiple secondary cluster operations non-concurrent

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -32,6 +32,7 @@ docs:
       3. Verify the sync of terraform state by running `terraform plan` and ensure that the infrastructure matches the configuration and no changes are required.
 base_url: 'projects/{{project}}/locations/{{location}}/clusters'
 self_link: 'projects/{{project}}/locations/{{location}}/clusters/{{cluster_id}}'
+mutex: 'projects/{{project}}'
 create_url: 'projects/{{project}}/locations/{{location}}/clusters?clusterId={{cluster_id}}'
 update_verb: 'PATCH'
 update_mask: true


### PR DESCRIPTION
fixed b/402516733
Make multiple secondary cluster operations non-concurrent

```release-note:enhancement
alloydb: added a mutex to `google_alloydb_cluster` to prevent conflicts among multiple cluster operations
```