### PR TITLE
Support for Tags

### DIFF
--- a/mmv1/products/datafusion/Instance.yaml
+++ b/mmv1/products/datafusion/Instance.yaml
@@ -375,3 +375,12 @@ properties:
           enum_values:
             - 'ENABLED'
             - 'DISABLED'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
+++ b/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataFusionInstance_update(t *testing.T) {
@@ -207,4 +208,50 @@ resource "google_data_fusion_instance" "basic_instance" {
   version = "%{version}"
 }
 `, context)
+}
+
+func TestAccDatafusionInstance_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"version":       "6.9.1",
+	}
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "datafusion-instances-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "datafusion-instances-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataFusionInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatafusionInstanceTags(context, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_data_fusion_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccDatafusionInstanceTags(context map[string]interface{},tags map[string]string) string {
+
+	r := acctest.Nprintf(`
+	resource "google_data_fusion_instance" "instance" {
+        name   = "my-instance"
+        region = "us-central1"
+        type   = "BASIC"
+	  tags = {`, context)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on instance resources at creation time.
Part of b/337048265

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

```datafusion: added `tags` field to `datafusion_instance` to allow setting tags for instances at creation time```
