### PR TITLE
Add resource_manager_tags to google_dataproc_cluster resource

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -63,6 +63,7 @@ var (
 		"cluster_config.0.gce_cluster_config.0.reservation_affinity",
 		"cluster_config.0.gce_cluster_config.0.node_group_affinity",
 		"cluster_config.0.gce_cluster_config.0.confidential_instance_config",
+		"cluster_config.0.gce_cluster_config.0.resource_manager_tags",
 	}
 
 	schieldedInstanceConfigKeys = []string{
@@ -781,6 +782,15 @@ func ResourceDataprocCluster() *schema.Resource {
 												},
 											},
 										},
+									},
+									"resource_manager_tags": {
+										Type:         schema.TypeMap,
+										Optional:     true,
+										AtLeastOneOf: gceClusterConfigKeys,
+										Computed:     true,
+										ForceNew:     true,
+										Description:  `Define the map of resource manager tags i.e., secure tags on dataproc cluster's compute instances`,
+										Elem:         &schema.Schema{Type: schema.TypeString},
 									},
 								},
 							},
@@ -2238,6 +2248,9 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 	if v, ok := cfg["metadata"]; ok {
 		conf.Metadata = tpgresource.ConvertStringMap(v.(map[string]interface{}))
 	}
+	if v, ok := cfg["resource_manager_tags"]; ok {
+		conf.ResourceManagerTags = tpgresource.ConvertStringMap(v.(map[string]interface{}))
+	}
 	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.shielded_instance_config"); ok {
 		cfgSic := v.([]interface{})[0].(map[string]interface{})
 		conf.ShieldedInstanceConfig = &dataproc.ShieldedInstanceConfig{}
@@ -3186,11 +3199,12 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 	}
 
 	gceConfig := map[string]interface{}{
-		"tags":             schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(gcc.Tags)),
-		"service_account":  gcc.ServiceAccount,
-		"zone":             tpgresource.GetResourceNameFromSelfLink(gcc.ZoneUri),
-		"internal_ip_only": gcc.InternalIpOnly,
-		"metadata":         gcc.Metadata,
+		"tags":                  schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(gcc.Tags)),
+		"service_account":       gcc.ServiceAccount,
+		"zone":                  tpgresource.GetResourceNameFromSelfLink(gcc.ZoneUri),
+		"internal_ip_only":      gcc.InternalIpOnly,
+		"metadata":              gcc.Metadata,
+		"resource_manager_tags": gcc.ResourceManagerTags,
 	}
 
 	if gcc.NetworkUri != "" {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
@@ -40,6 +40,7 @@ fields:
   - field: 'cluster_config.gce_cluster_config.subnetwork'
   - field: 'cluster_config.gce_cluster_config.tags'
   - field: 'cluster_config.gce_cluster_config.zone'
+  - field: 'cluster_config.gce_cluster_config.resource_manager_tags'
   - field: 'cluster_config.initialization_action.script'
   - field: 'cluster_config.initialization_action.timeout_sec'
   - field: 'cluster_config.lifecycle_config.auto_delete_time'

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -370,9 +370,7 @@ func TestAccDataprocCluster_withResourceManagerTags(t *testing.T) {
 				Config: testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.name", "wrench"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.mass", "1.3kg"),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.count", "3"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.tagKeys/281483279496796", "tagValues/281481166421903"),
 				),
 			},
 		},
@@ -1717,9 +1715,7 @@ func testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName s
 		zone = "us-central1-a"
 
 		resource_manager_tags = {
-			name  = "wrench"
-			mass  = "1.3kg"
-			count = "3"
+			"tagKeys/281483279496796" = "tagValues/281481166421903"
 		}
 		}
 	}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -357,6 +357,7 @@ func TestAccDataprocCluster_withResourceManagerTags(t *testing.T) {
 
 	var cluster dataproc.Cluster
 	randString := acctest.RandString(t, 10)
+	project_id := envvar.GetTestProjectFromEnv()
 	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
 	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
@@ -367,10 +368,10 @@ func TestAccDataprocCluster_withResourceManagerTags(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName),
+				Config: testAccDataprocCluster_withResourceManagerTags(project_id,randString, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
-					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.tagKeys/281483279496796", "tagValues/281481166421903"),
+					resource.TestCheckResourceAttrSet("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.%"),
 				),
 			},
 		},
@@ -1703,24 +1704,55 @@ resource "google_dataproc_cluster" "basic" {
 `, rnd, subnetworkName)
 }
 
-func testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName string) string {
+func testAccDataprocCluster_withResourceManagerTags(project_id, randString, subnetworkName string) string {
 	return fmt.Sprintf(`
+
+	data "google_project" "project" {
+		project_id = "%s"
+	}
+
+	resource "google_tags_tag_key" "key" {
+	parent      = "projects/${data.google_project.project.number}"
+	short_name  = "testkey"
+	description = "For keyname resources."
+	}
+
+	resource "google_tags_tag_value" "value" {
+	parent      = google_tags_tag_key.key.id
+	short_name  = "testvalue"
+	description = "For valuename resources."
+	}
+
+	resource "google_tags_tag_binding" "binding" {
+	parent    = "//cloudresourcemanager.googleapis.com/projects/${data.google_project.project.number}"
+	tag_value = google_tags_tag_value.value.id
+	}
+
+
 	resource "google_dataproc_cluster" "basic" {
-	name   = "tf-test-dataproc-%s"
-	region = "us-central1"
+		provider = google-beta
+		name     = "tf-test-dataproc-%s"
+		region   = "us-central1"
 
-	cluster_config {
-		gce_cluster_config {
-		subnetwork = "%s"
-		zone = "us-central1-a"
-
-		resource_manager_tags = {
-			"tagKeys/281483279496796" = "tagValues/281481166421903"
+		cluster_config {
+			master_config {
+				num_instances = 1
+				machine_type  = "e2-medium"
+			}
+			worker_config {
+				num_instances = 2
+				machine_type  = "e2-medium"
+			}
+			gce_cluster_config {
+				subnetwork       = "%s"
+				zone             = "us-central1-a"
+				internal_ip_only = true
+				resource_manager_tags = {
+					"${google_tags_tag_key.key.id}" = "${google_tags_tag_value.value.id}"
+				}
+			}
 		}
-		}
-	}
-	}
-	`, randString, subnetworkName)
+	}`, project_id, randString, subnetworkName)
 }
 
 func testAccDataprocCluster_withMinNumInstances(rnd, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go.tmpl
@@ -352,6 +352,33 @@ func TestAccDataprocCluster_withMetadataAndTags(t *testing.T) {
 	})
 }
 
+func TestAccDataprocCluster_withResourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	var cluster dataproc.Cluster
+	randString := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.name", "wrench"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.mass", "1.3kg"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.resource_manager_tags.count", "3"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataprocCluster_withMinNumInstances(t *testing.T) {
 	t.Parallel()
 
@@ -1676,6 +1703,28 @@ resource "google_dataproc_cluster" "basic" {
   }
 }
 `, rnd, subnetworkName)
+}
+
+func testAccDataprocCluster_withResourceManagerTags(randString, subnetworkName string) string {
+	return fmt.Sprintf(`
+	resource "google_dataproc_cluster" "basic" {
+	name   = "tf-test-dataproc-%s"
+	region = "us-central1"
+
+	cluster_config {
+		gce_cluster_config {
+		subnetwork = "%s"
+		zone = "us-central1-a"
+
+		resource_manager_tags = {
+			name  = "wrench"
+			mass  = "1.3kg"
+			count = "3"
+		}
+		}
+	}
+	}
+	`, randString, subnetworkName)
 }
 
 func testAccDataprocCluster_withMinNumInstances(rnd, subnetworkName string) string {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21918

```release-note: enhancement
dataproc: added `resource_manager_tags` field to `google_dataproc_cluster` resource
```
