### PR TITLE
Update basic GMK cluster terraform example to use auto rebalance

### DIFF
--- a/mmv1/templates/terraform/examples/managedkafka_cluster_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_basic.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
     }
   }
   rebalance_config {
-    mode = "NO_REBALANCE"
+    mode = "AUTO_REBALANCE_ON_SCALE_UP"
   }
   labels = {
     key = "value"


### PR DESCRIPTION
Change the default cluster terraform example to use "AUTO_REBALANCE_ON_SCALE_UP" instead of "NO_REBALANCE".

```release-note:none
```
