### PR TITLE
Remove v1 version guards for GKE auto-monitoring

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1289,7 +1289,6 @@ func ResourceContainerCluster() *schema.Resource {
 										Required:    true,
 										Description: `Whether or not the managed collection is enabled.`,
 									},
-									{{- if ne $.TargetVersionName "ga" }}
 									"auto_monitoring_config": {
 										Type:        schema.TypeList,
 										Optional:    true,
@@ -1307,7 +1306,6 @@ func ResourceContainerCluster() *schema.Resource {
 											},
 										},
 									},
-									{{- end }}
 								},
 							},
 						},
@@ -6007,7 +6005,6 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		mc.ManagedPrometheusConfig = &container.ManagedPrometheusConfig{
 			Enabled: managed_prometheus["enabled"].(bool),
 		}
-		{{- if ne $.TargetVersionName "ga" }}
 		if autoMonitoring, ok := managed_prometheus["auto_monitoring_config"]; ok {
 		    if autoMonitoringList, ok := autoMonitoring.([]interface{}); ok {
 		        if len(autoMonitoringList) > 0 {
@@ -6020,7 +6017,6 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 		        }
 		    }
 		}
-		{{- end }}
 	}
 
 	if v, ok := config["advanced_datapath_observability_config"]; ok && len(v.([]interface{})) > 0 {
@@ -7018,7 +7014,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
     result := make(map[string]interface{})
     result["enabled"] = c.Enabled
 
-    {{- if ne $.TargetVersionName "ga" }}
     autoMonitoringList := []map[string]interface{}{}
     if c.AutoMonitoringConfig != nil && c.AutoMonitoringConfig.Scope != "" {
         autoMonitoringMap := map[string]interface{}{
@@ -7028,7 +7023,6 @@ func flattenManagedPrometheusConfig(c *container.ManagedPrometheusConfig) []map[
     }
 
     result["auto_monitoring_config"] = autoMonitoringList
-    {{- end }}
 
     return []map[string]interface{}{result}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -4127,7 +4127,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{{- if ne $.TargetVersionName "ga" }}
 			{
 				Config: testAccContainerCluster_withMonitoringConfigScopeAll(clusterName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
@@ -4152,7 +4151,6 @@ func TestAccContainerCluster_withMonitoringConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{{- end }}
 			// Back to basic settings to test setting Prometheus on its own
 			{
 				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
@@ -11287,7 +11285,6 @@ resource "google_container_cluster" "primary" {
 `, name, networkName, subnetworkName)
 }
 
-{{- if ne $.TargetVersionName "ga" }}								
 func testAccContainerCluster_withMonitoringConfigScopeAll(name, networkName, subnetworkName string) string {
        return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -11329,7 +11326,6 @@ resource "google_container_cluster" "primary" {
 }
 `, name, networkName, subnetworkName)
 }
-{{- end }}
 
 func testAccContainerCluster_withMonitoringConfigAdvancedDatapathObservabilityConfigEnabled(name string) string {
        return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -666,7 +666,7 @@ This block also contains several computed attributes, documented below.
 <a name="nested_managed_prometheus"></a>The `managed_prometheus` block supports:
 
 * `enabled` - (Required) Whether or not the managed collection is enabled.
-* `auto_monitoring_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for GKE Auto-Monitoring.
+* `auto_monitoring_config` - (Optional) Configuration options for GKE Auto-Monitoring.
 
 <a name="auto_monitoring_config"></a>The `auto_monitoring_config` block supports:
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
container: added `auto_monitoring_config` field and subfields to the `google_container_cluster` (GA promotion)
```
