### PR TITLE
Rename KAJ field to run presubmit

### DIFF
--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
@@ -327,7 +327,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	allowedAccessReason := "CUSTOMER_INITIATED_SUPPORT"
+	allowedAccessReason := "THIRD_PARTY_DATA_REQUEST"
 	updatedAllowedAccessReason := "GOOGLE_INITIATED_SERVICE"
 
 	acctest.VcrTest(t, resource.TestCase{


### PR DESCRIPTION
Fixes: hashicorp/terraform-provider-google#17164

```release-note:enhancement
cloudkms: small test change to make presubmit run
```