### PR TITLE
Add a test check function to get cai assets metadata

### DIFF
--- a/mmv1/third_party/terraform/acctest/tgc_utils.go
+++ b/mmv1/third_party/terraform/acctest/tgc_utils.go
@@ -13,18 +13,24 @@ import (
 
 // Hardcode the Terraform resource name -> API service name mapping temporarily.
 // TODO: [tgc] read the mapping from the resource metadata files.
-var CaiProductBackendNames = map[string]string{
-	"google_compute_instance": "compute",
-	"google_project":          "cloudresourcemanager",
+var ApiServiceNames = map[string]string{
+	"google_compute_instance": "compute.googleapis.com",
+	"google_project":          "cloudresourcemanager.googleapis.com",
 }
 
 // Gets the test metadata for tgc:
 //   - test config
 //   - cai asset name
 //     For example: //compute.googleapis.com/projects/ci-test-188019/zones/us-central1-a/instances/tf-test-mi3fqaucf8
-func GetTestMetadataForTgc(service, resourceType, resourceName, config string) resource.TestCheckFunc {
+func GetTestMetadataForTgc(service, address, config string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		address := fmt.Sprintf("%s.%s", resourceType, resourceName)
+		splits := strings.Split(address, ".")
+		if splits == nil || len(splits) < 2 {
+			return fmt.Errorf("The resource address %s is invalid.", address)
+		}
+		resourceType := splits[0]
+		resourceName := splits[1]
+
 		rState := s.RootModule().Resources[address]
 		if rState == nil || rState.Primary == nil {
 			return fmt.Errorf("The resource state is unavailable. Please check if the address %s.%s is correct.", resourceType, resourceName)
@@ -32,7 +38,7 @@ func GetTestMetadataForTgc(service, resourceType, resourceName, config string) r
 
 		// Convert the resource ID into CAI asset name
 		// and then print out the CAI asset name in the logs
-		if productName, ok := CaiProductBackendNames[resourceType]; !ok {
+		if apiServiceName, ok := ApiServiceNames[resourceType]; !ok {
 			return fmt.Errorf("The Cai product backend name for resource %s doesn't exist.", resourceType)
 		} else {
 			var rName string
@@ -43,10 +49,12 @@ func GetTestMetadataForTgc(service, resourceType, resourceName, config string) r
 				rName = rState.Primary.ID
 			}
 
-			caiAssetName := fmt.Sprintf("//%s.googleapis.com/%s", productName, rName)
+			caiAssetName := fmt.Sprintf("//%s/%s", apiServiceName, rName)
 			log.Printf("[DEBUG]TGC CAI asset name: %s", caiAssetName)
 		}
 
+		// The acceptance tests names will be also used for the tgc tests.
+		// "service" is logged and will be used to put the tgc tests into specific service packages.
 		log.Printf("[DEBUG]TGC Terraform service: %s", service)
 		log.Printf("[DEBUG]TGC Terraform resource: %s", resourceType)
 

--- a/mmv1/third_party/terraform/acctest/tgc_utils.go
+++ b/mmv1/third_party/terraform/acctest/tgc_utils.go
@@ -1,0 +1,65 @@
+package acctest
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+)
+
+var CaiProductBackendNames = map[string]string{
+	"compute":         "compute",
+	"resourcemanager": "cloudresourcemanager",
+}
+
+// Gets the test metadata for tgc:
+//   - test config
+//   - cai asset name
+//     For example: //compute.googleapis.com/projects/terraform-dev-zhenhuali/zones/us-central1-a/instances/tf-test-mi3fqaucf8
+func GetTestMetadataForTgc(service, resourceType, resourceName, config string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		address := fmt.Sprintf("%s.%s", resourceType, resourceName)
+		rState := s.RootModule().Resources[address]
+		if rState == nil || rState.Primary == nil {
+			return fmt.Errorf("The resource state is unavailable. Please check if the address %s.%s is correct.", resourceType, resourceName)
+		}
+
+		// Convert the resource ID into CAI asset name
+		// and then print out the CAI asset name in the logs
+		if productName, ok := CaiProductBackendNames[service]; !ok {
+			return fmt.Errorf("The Cai product backend name for service %s doesn't exist.", service)
+		} else {
+			var rName string
+			switch resourceType {
+			case "google_project":
+				rName = fmt.Sprintf("projects/%s", rState.Primary.Attributes["number"])
+			default:
+				rName = rState.Primary.ID
+			}
+
+			caiAssetName := fmt.Sprintf("//%s.googleapis.com/%s", productName, rName)
+			log.Printf("[DEBUG]TGC CAI asset name: %s", caiAssetName)
+		}
+
+		log.Printf("[DEBUG]TGC Terraform service: %s", service)
+		log.Printf("[DEBUG]TGC Terraform resource: %s", resourceType)
+
+		re := regexp.MustCompile(`\"(tf[-_]?test[-_]?.*?)([a-z0-9]+)\"`)
+		config = re.ReplaceAllString(config, `"${1}tgc"`)
+
+		// Replace resource name with the resource's real name
+		// For example, replace `"google_compute_instance" "foobar"` with `"google_compute_instance" "tf-test-mi3fqaucf8"`
+		n := tpgresource.GetResourceNameFromSelfLink(rState.Primary.ID)
+		old := fmt.Sprintf(`"%s" "%s"`, resourceType, resourceName)
+		new := fmt.Sprintf(`"%s" "%s"`, resourceType, n)
+		config = strings.Replace(config, old, new, 1)
+
+		log.Printf("[DEBUG]TGC raw_config starts %s", config)
+		log.Printf("[DEBUG]End of TGC raw_config")
+		return nil
+	}
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -63,6 +63,8 @@ func TestAccProject_create(t *testing.T) {
 				Config: testAccProject(pid, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+						testAccProject(pid, org)),
 				),
 			},
 		},
@@ -155,6 +157,14 @@ func TestAccProject_labels(t *testing.T) {
 					testAccCheckGoogleProjectHasNoLabels(t, "google_project.acceptance", pid),
 				),
 			},
+			{
+				Config: testAccProject_labels(pid, org, map[string]string{"label": "label-value"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectHasLabels(t, "google_project.acceptance", pid, map[string]string{"label": "label-value"}),
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+						testAccProject_labels(pid, org, map[string]string{"test": "that"})),
+				),
+			},
 		},
 	})
 }
@@ -188,6 +198,10 @@ func TestAccProject_parentFolder(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProject_parentFolder(pid, folderDisplayName, org),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+						testAccProject_parentFolder(pid, folderDisplayName, org)),
+				),
 			},
 		},
 	})
@@ -611,7 +625,8 @@ resource "google_project" "acceptance" {
 }
 
 func testAccProject_tagsAllowDestroy(pid, org string, tags map[string]string) string {
-	r := fmt.Sprintf(`resource "google_project" "acceptance" {
+	r := fmt.Sprintf(
+		`resource "google_project" "acceptance" {
 	 project_id = "%s"
   name       = "%s"
   org_id     = "%s"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -63,7 +63,7 @@ func TestAccProject_create(t *testing.T) {
 				Config: testAccProject(pid, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
-					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project.acceptance",
 						testAccProject(pid, org)),
 				),
 			},
@@ -161,7 +161,7 @@ func TestAccProject_labels(t *testing.T) {
 				Config: testAccProject_labels(pid, org, map[string]string{"label": "label-value"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectHasLabels(t, "google_project.acceptance", pid, map[string]string{"label": "label-value"}),
-					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project.acceptance",
 						testAccProject_labels(pid, org, map[string]string{"test": "that"})),
 				),
 			},
@@ -199,7 +199,7 @@ func TestAccProject_parentFolder(t *testing.T) {
 			{
 				Config: testAccProject_parentFolder(pid, folderDisplayName, org),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.GetTestMetadataForTgc("resourcemanager", "google_project", "acceptance",
+					acctest.GetTestMetadataForTgc("resourcemanager", "google_project.acceptance",
 						testAccProject_parentFolder(pid, folderDisplayName, org)),
 				),
 			},


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This change implements a check function to get and print out the CAI asset name and Terraform configuration of the created main resource in the test, and adds the check function to a couple of tests for `google_project`. These values will be extracted from nightly tests to get raw config and CAI asset.

The printed values are in https://paste.googleplex.com/5502359491575808. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
