### PR TITLE
Clarify lifecycle of `google_secret_manager_secret_version` and `google_secret_manager_regional_secret_version` resource in documentation

### DIFF
--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -20,6 +20,12 @@ references:
     'Create and deploy a Secret Version': 'https://cloud.google.com/secret-manager/docs/add-secret-version'
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions'
 docs:
+  warning: |
+    The behavior of the `secret_data` field is [force new](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew).
+    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate 
+    this, use the `create_before_destroy` field within the lifecycle block.
+
+    For more details, refer to the [Terraform lifecycle documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#the-lifecycle-meta-argument).
   optional_properties: |
     * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is.
 base_url: '{{name}}'

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -22,7 +22,7 @@ references:
 docs:
   warning: |
     The behavior of the `secret_data` field is [force new](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew).
-    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate 
+    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate
     this, use the `create_before_destroy` field within the lifecycle block.
 
     For more details, refer to the [Terraform lifecycle documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#the-lifecycle-meta-argument).

--- a/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
@@ -21,6 +21,12 @@ references:
     'Create and deploy a Regional Secret Version': 'https://cloud.google.com/secret-manager/regional-secrets/add-secret-version-rs'
   api: 'https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.locations.secrets.versions'
 docs:
+  warning: |
+    The behavior of the `secret_data` field is [force new](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew).
+    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate 
+    this, use the `create_before_destroy` field within the lifecycle block.
+
+    For more details, refer to the [Terraform lifecycle documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#the-lifecycle-meta-argument).
   optional_properties: |
     * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is.
 base_url: '{{name}}'

--- a/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
@@ -23,7 +23,7 @@ references:
 docs:
   warning: |
     The behavior of the `secret_data` field is [force new](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew).
-    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate 
+    While updating this field, Terraform deletes the existing resource and then creates a new one, which may cause potential outages. To mitigate
     this, use the `create_before_destroy` field within the lifecycle block.
 
     For more details, refer to the [Terraform lifecycle documentation](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#the-lifecycle-meta-argument).


### PR DESCRIPTION
Updated the documentation for `google_secret_manager_secret_version` and `google_secret_manager_regional_secret_version` resources to clarify their lifecycle.
fixes https://github.com/hashicorp/terraform-provider-google/issues/21806

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: note
secretmanager: Updated the documentation for the clarification of `google_secret_manager_secret_version` and `google_secret_manager_regional_secret_version` resources
```
