### PR TITLE
Add pathMatchers[].routeRules[].customErrorResponsePolicy field to google_compute_url_map

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -1729,6 +1729,60 @@ properties:
                       prior to redirecting the request. If set to false, the query portion of the
                       original URL is retained. Defaults to false.
                     default_value: false
+              - name: 'customErrorResponsePolicy'
+                type: NestedObject
+                description: |
+                  customErrorResponsePolicy specifies how the Load Balancer returns error responses when BackendService or BackendBucket responds with an error.
+                min_version: 'beta'
+                properties:
+                  - name: 'errorResponseRule'
+                    type: Array
+                    description: |
+                      Specifies rules for returning error responses.
+                      In a given policy, if you specify rules for both a range of error codes as well as rules for specific error codes then rules with specific error codes have a higher priority.
+                      For example, assume that you configure a rule for 401 (Un-authorized) code, and another for all 4 series error codes (4XX).
+                      If the backend service returns a 401, then the rule for 401 will be applied. However if the backend service returns a 403, the rule for 4xx takes effect.
+                    api_name: errorResponseRules
+                    item_type:
+                      type: NestedObject
+                      properties:
+                        - name: 'matchResponseCodes'
+                          type: Array
+                          description: |
+                            Valid values include:
+
+                            - A number between 400 and 599: For example 401 or 503, in which case the load balancer applies the policy if the error code exactly matches this value.
+                            - 5xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 500 to 599.
+                            - 4xx: Load Balancer will apply the policy if the backend service responds with any response code in the range of 400 to 499.
+
+                            Values must be unique within matchResponseCodes and across all errorResponseRules of CustomErrorResponsePolicy.
+                          item_type:
+                            type: String
+                        - name: 'path'
+                          type: String
+                          description: |
+                            The full path to a file within backendBucket . For example: /errors/defaultError.html
+                            path must start with a leading slash. path cannot have trailing slashes.
+                            If the file is not available in backendBucket or the load balancer cannot reach the BackendBucket, a simple Not Found Error is returned to the client.
+                            The value must be from 1 to 1024 characters
+                        - name: 'overrideResponseCode'
+                          type: Integer
+                          description: |
+                            The HTTP status code returned with the response containing the custom error content.
+                            If overrideResponseCode is not supplied, the same response code returned by the original backend bucket or backend service is returned to the client.
+                  - name: 'errorService'
+                    type: ResourceRef
+                    description: |
+                      The full or partial URL to the BackendBucket resource that contains the custom error content. Examples are:
+
+                      https://www.googleapis.com/compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      compute/v1/projects/project/global/backendBuckets/myBackendBucket
+                      global/backendBuckets/myBackendBucket
+
+                      If errorService is not specified at lower levels like pathMatcher, pathRule and routeRule, an errorService specified at a higher level in the UrlMap will be used. If UrlMap.defaultCustomErrorResponsePolicy contains one or more errorResponseRules[], it must specify errorService.
+                      If load balancer cannot reach the backendBucket, a simple Not Found Error will be returned, with the original response code (or overrideResponseCode if configured).
+                    resource: 'BackendBucket'
+                    imports: 'selfLink'
         - name: 'defaultUrlRedirect'
           type: NestedObject
           # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
@@ -397,6 +397,38 @@ func TestAccComputeUrlMap_urlMapCustomErrorResponsePolicyUpdate(t *testing.T) {
 }
 {{- end }}
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeUrlMap_routeRulesCustomErrorResponsePolicy(t *testing.T) {
+	t.Parallel()
+
+	randString := acctest.RandString(t, 10)
+	
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeUrlMap_routeRulesCustomErrorResponsePolicy(randString),
+			},
+			{
+				ResourceName:      "google_compute_url_map.url_map",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeUrlMap_routeRulesCustomErrorResponsePolicyUpdated(randString),
+			},
+			{
+				ResourceName:      "google_compute_url_map.url_map",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+{{- end }}
+
 func testAccComputeUrlMap_basic1(bsName, hcName, umName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1908,5 +1940,176 @@ resource "google_storage_bucket" "error" {
   location    = "US"
 }
 `, context)
+}
+{{- end }}
+
+{{ if ne $.TargetVersionName `ga` -}}
+func testAccComputeUrlMap_routeRulesCustomErrorResponsePolicy(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_http_health_check" "http_hc_%s" {
+  provider           = google-beta
+  name               = "http-hc-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_service" "backend_service_%s" {
+  provider    = google-beta
+  name        = "backend-service-%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  health_checks = [google_compute_http_health_check.http_hc_%s.id]
+}
+
+resource "google_storage_bucket" "sb_%s" {
+  provider    = google-beta
+  name        = "sb-%s"
+  location    = "US"
+  force_destroy = true
+}
+
+resource "google_compute_backend_bucket" "backend_bucket_%s" {
+  provider    = google-beta
+  name        = "backend-bucket-%s"
+  bucket_name = google_storage_bucket.sb_%s.name
+  enable_cdn  = true
+}
+
+resource "google_compute_url_map" "url_map" {
+  provider        = google-beta
+  name            = "url-map-%s"
+  default_service = google_compute_backend_service.backend_service_%s.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_bucket.backend_bucket_%s.id
+
+    route_rules {
+      match_rules {
+        path_template_match = "/xyzwebservices/v2/xyz/users/{username=*}/carts/{cartid=**}"
+      }
+      service = google_compute_backend_service.backend_service_%s.id
+      priority = 1
+      route_action {
+        url_rewrite {
+          path_template_rewrite = "/{username}-{cartid}/"
+        }
+      }
+    }
+
+    route_rules {
+      match_rules {
+        path_template_match = "/xyzwebservices/v2/xyz/users/*/accountinfo/*"
+      }
+      service = google_compute_backend_service.backend_service_%s.id
+      priority = 2
+
+      custom_error_response_policy {
+        error_response_rule {
+          match_response_codes = ["4xx"] # Catch all 4xx responses under /private/*
+          path = "/login.html" # Serve /login.html from the error service
+          override_response_code = 401
+        }
+        error_service = google_compute_backend_bucket.backend_bucket_%s.id
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_routeRulesCustomErrorResponsePolicyUpdated(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_http_health_check" "http_hc_%s" {
+  provider           = google-beta
+  name               = "http-hc-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_backend_service" "backend_service_%s" {
+  provider    = google-beta
+  name        = "backend-service-%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  health_checks = [google_compute_http_health_check.http_hc_%s.id]
+}
+
+resource "google_storage_bucket" "sb_%s" {
+  provider    = google-beta
+  name        = "sb-%s"
+  location    = "US"
+  force_destroy = true
+}
+
+resource "google_compute_backend_bucket" "backend_bucket_%s" {
+  provider    = google-beta
+  name        = "backend-bucket-%s"
+  bucket_name = google_storage_bucket.sb_%s.name
+  enable_cdn  = true
+}
+
+resource "google_compute_url_map" "url_map" {
+  provider        = google-beta
+  name            = "url-map-%s"
+  default_service = google_compute_backend_service.backend_service_%s.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "mysite"
+  }
+
+  path_matcher {
+    name            = "mysite"
+    default_service = google_compute_backend_bucket.backend_bucket_%s.id
+
+    route_rules {
+      match_rules {
+        path_template_match = "/xyzwebservices/v2/xyz/users/{username=*}/carts/{cartid=**}"
+      }
+      service = google_compute_backend_service.backend_service_%s.id
+      priority = 1
+      route_action {
+        url_rewrite {
+          path_template_rewrite = "/{username}-{cartid}/"
+        }
+      }
+    }
+
+    route_rules {
+      match_rules {
+        path_template_match = "/xyzwebservices/v2/xyz/users/*/accountinfo/*"
+      }
+      service = google_compute_backend_service.backend_service_%s.id
+      priority = 2
+
+      custom_error_response_policy {
+        error_response_rule {
+          match_response_codes = ["4xx", "5xx"] # Updated to catch both 4xx and 5xx
+          path = "/error.html" # Updated path
+          override_response_code = 503 # Updated response code
+        }
+        error_response_rule {
+          match_response_codes = ["404"] # Added a specific rule for 404
+          path = "/not-found.html"
+          override_response_code = 404
+        }
+        error_service = google_compute_backend_bucket.backend_bucket_%s.id
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix, suffix)
 }
 {{- end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds pathMatchers[].routeRules[].customErrorResponsePolicy to google_compute_url_map

### Related Issues

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/20100

### Release Note

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `pathMatchers[].routeRules[].customErrorResponsePolicy` field to `google_compute_url_map`
```