### PR TITLE
Fix expandNodeKubeletConfig unset field check.

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -917,7 +917,7 @@ func schemaNodePoolAutoConfigLinuxNodeConfig() *schema.Schema {
 	}
 }
 
-func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefaults {
+func expandNodeConfigDefaults(configured interface{}, d *schema.ResourceData) *container.NodeConfigDefaults {
 	configs := configured.([]interface{})
 	if len(configs) == 0 || configs[0] == nil {
 		return nil
@@ -926,12 +926,17 @@ func expandNodeConfigDefaults(configured interface{}) *container.NodeConfigDefau
 
 	nodeConfigDefaults := &container.NodeConfigDefaults{}
 	nodeConfigDefaults.ContainerdConfig = expandContainerdConfig(config["containerd_config"])
-	if v, ok := config["insecure_kubelet_readonly_port_enabled"]; ok {
-		nodeConfigDefaults.NodeKubeletConfig = &container.NodeKubeletConfig{
-			InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(v),
-			ForceSendFields:                    []string{"InsecureKubeletReadonlyPortEnabled"},
+
+	// Set a value of insecure_kubelet_readonly_port_enabled only if set in the upstream config.
+ 	if d.HasChange("node_pool_defaults.node_config_defaults.node_kubelet_config.insecure_kubelet_readonly_port_enabled") {
+		if v, ok := config["insecure_kubelet_readonly_port_enabled"]; ok {
+			nodeConfigDefaults.NodeKubeletConfig = &container.NodeKubeletConfig{
+				InsecureKubeletReadonlyPortEnabled: expandInsecureKubeletReadonlyPortEnabled(v),
+				ForceSendFields:                    []string{"InsecureKubeletReadonlyPortEnabled"},
+			}
 		}
 	}
+
 	if variant, ok := config["logging_variant"]; ok {
 		nodeConfigDefaults.LoggingConfig = &container.NodePoolLoggingConfig{
 			VariantConfig: &container.LoggingVariantConfig{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2663,7 +2663,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
         if v, ok := d.GetOk("node_pool_defaults"); ok {
-                cluster.NodePoolDefaults = expandNodePoolDefaults(v)
+                cluster.NodePoolDefaults = expandNodePoolDefaults(v, d)
         }
 
 	if v, ok := d.GetOk("node_config"); ok {
@@ -6090,7 +6090,7 @@ func expandContainerClusterAuthenticatorGroupsConfig(configured interface{}) *co
 	return result
 }
 
-func expandNodePoolDefaults(configured interface{}) *container.NodePoolDefaults {
+func expandNodePoolDefaults(configured interface{}, d *schema.ResourceData) *container.NodePoolDefaults {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
 		return nil
@@ -6098,7 +6098,7 @@ func expandNodePoolDefaults(configured interface{}) *container.NodePoolDefaults 
 	nodePoolDefaults := &container.NodePoolDefaults{}
 	config := l[0].(map[string]interface{})
 	if v, ok := config["node_config_defaults"]; ok && len(v.([]interface{})) > 0 {
-		nodePoolDefaults.NodeConfigDefaults = expandNodeConfigDefaults(v)
+		nodePoolDefaults.NodeConfigDefaults = expandNodeConfigDefaults(v, d)
 	}
 	return nodePoolDefaults
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -89,7 +89,7 @@ func TestAccContainerCluster_resourceManagerTags(t *testing.T) {
 
 	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
-	
+
 	bootstrapGkeTagManagerServiceAgents(t)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -12090,6 +12090,13 @@ resource "google_container_cluster" "primary" {
   name             = "%s"
   location         = "us-central1"
   enable_autopilot = true
+
+  # node_config_defaults is NOT allowed on Autopilot clusters.
+	# However, empty values for such a field should not cause failures.
+	node_pool_defaults {
+		node_config_defaults {
+		}
+	}
 
 	node_pool_auto_config {
     node_kubelet_config {


### PR DESCRIPTION
Use the schema.ResourceData.HasChange function on the Kubelet readonly port field to detect if the value of the readonly port field was actually set in this request.

GetOk would return a value if it was not present in the config.

Fixes #21227

```release-note:bug
container: fixed a bug in `google_container_cluster` where empty `node_pool_defaults.node_config_defaults` would break in Autopilot clusters. 
```
