### PR TITLE
Add location specific sweepers for network policy and network peering

### DIFF
--- a/mmv1/products/vmwareengine/NetworkPeering.yaml
+++ b/mmv1/products/vmwareengine/NetworkPeering.yaml
@@ -38,6 +38,8 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+# There is a handwritten sweeper that provides a list of locations to sweep
+exclude_sweeper: true
 examples:
   - name: 'vmware_engine_network_peering_ven'
     primary_resource_id: 'vmw-engine-network-peering'

--- a/mmv1/products/vmwareengine/NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/NetworkPolicy.yaml
@@ -42,6 +42,8 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+# There is a handwritten sweeper that provides a list of locations to sweep
+exclude_sweeper: true
 examples:
   - name: 'vmware_engine_network_policy_basic'
     skip_test: https://github.com/hashicorp/terraform-provider-google/issues/20719

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_sweeper.go
@@ -1,0 +1,130 @@
+package vmwareengine
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepersLegacy("VmwareengineNetworkPeering", testSweepVmwareengineNetworkPeering)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareengineNetworkPeering(region string) error {
+	resourceName := "VmwareengineNetworkPeering"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// List of location values includes:
+	//   * global location - network peering is a global resource
+	locations := []string{region, "global"}
+	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
+	for _, location := range locations {
+		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
+
+		// Setup variables to replace in list template
+		d := &tpgresource.ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"project":         config.Project,
+				"region":          location,
+				"location":        location,
+				"zone":            "-",
+				"billing_account": billingId,
+			},
+		}
+
+		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/networkPeerings", "?")[0]
+		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			continue
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    listUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+			continue
+		}
+
+		resourceList, ok := res["networkPeerings"]
+		if !ok {
+			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+			continue
+		}
+
+		rl := resourceList.([]interface{})
+
+		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+		// Keep count of items that aren't sweepable for logging.
+		nonPrefixCount := 0
+		for _, ri := range rl {
+			obj := ri.(map[string]interface{})
+			if obj["name"] == nil {
+				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+				continue
+			}
+
+			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+			// Skip resources that shouldn't be sweeped
+			if !sweeper.IsSweepableTestResource(name) {
+				nonPrefixCount++
+				continue
+			}
+
+			deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/networkPeerings/{{name}}"
+			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+				continue
+			}
+			deleteUrl = deleteUrl + name
+
+			// Don't wait on operations as we may have a lot to delete
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   config.Project,
+				RawURL:    deleteUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+			} else {
+				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			}
+		}
+
+		if nonPrefixCount > 0 {
+			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+		}
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_sweeper.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_sweeper.go
@@ -1,0 +1,132 @@
+package vmwareengine
+
+import (
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/sweeper"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	sweeper.AddTestSweepersLegacy("VmwareengineNetworkPolicy", testSweepVmwareengineNetworkPolicy)
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepVmwareengineNetworkPolicy(region string) error {
+	resourceName := "VmwareengineNetworkPolicy"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	t := &testing.T{}
+	billingId := envvar.GetTestBillingAccountFromEnv(t)
+
+	// List of location values includes:
+	//   * zones used for this resource type's acc tests in the past
+	//   * the 'region' passed to the sweeper
+	locations := []string{region, "us-central1", "southamerica-west1", "me-west1"}
+	log.Printf("[INFO][SWEEPER_LOG] Sweeping will include these locations: %v.", locations)
+
+	for _, location := range locations {
+		log.Printf("[INFO][SWEEPER_LOG] Beginning the process of sweeping location '%s'.", location)
+
+		// Setup variables to replace in list template
+		d := &tpgresource.ResourceDataMock{
+			FieldsInSchema: map[string]interface{}{
+				"project":         config.Project,
+				"region":          location,
+				"location":        location,
+				"zone":            "-",
+				"billing_account": billingId,
+			},
+		}
+
+		listTemplate := strings.Split("https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/networkPolicies", "?")[0]
+		listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+			continue
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    listUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+			continue
+		}
+
+		resourceList, ok := res["networkPolicies"]
+		if !ok {
+			log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+			continue
+		}
+
+		rl := resourceList.([]interface{})
+
+		log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+		// Keep count of items that aren't sweepable for logging.
+		nonPrefixCount := 0
+		for _, ri := range rl {
+			obj := ri.(map[string]interface{})
+			if obj["name"] == nil {
+				log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+				continue
+			}
+
+			name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+			// Skip resources that shouldn't be sweeped
+			if !sweeper.IsSweepableTestResource(name) {
+				nonPrefixCount++
+				continue
+			}
+
+			deleteTemplate := "https://vmwareengine.googleapis.com/v1/projects/{{project}}/locations/{{location}}/networkPolicies/{{name}}"
+			deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+				continue
+			}
+			deleteUrl = deleteUrl + name
+
+			// Don't wait on operations as we may have a lot to delete
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   config.Project,
+				RawURL:    deleteUrl,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+			} else {
+				log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+			}
+		}
+
+		if nonPrefixCount > 0 {
+			log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add test sweepers for  network policy (location: me-west1) and network peering (location: global)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
