### PR TITLE
Feature gap: Add `match.srcSecureTags` & `targetSecureTags` to FirewallPolicyRule

### DIFF
--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -165,6 +165,29 @@ properties:
                 Example inputs include: ["22"], ["80","443"], and ["12345-12349"].
               item_type:
                 type: String
+      - name: 'srcSecureTags'
+        type: Array
+        send_empty_value: true
+        description: |
+          firewallPolicies.list of secure tag values, which should be matched at the source of the traffic.
+          For INGRESS rule, if all the srcSecureTag are INEFFECTIVE, and there is no srcIpRange,
+          this rule will be ignored. Maximum number of source tag values allowed is 256.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'name'
+              type: String
+              description: |
+                Name of the secure tag, created with TagManager's TagValue API.
+              diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+            - name: 'state'
+              type: Enum
+              description: |
+                State of the secure tag, either EFFECTIVE or INEFFECTIVE. A secure tag is INEFFECTIVE when it is deleted or its network is deleted.
+              output: true
+              enum_values:
+                - 'EFFECTIVE'
+                - 'INEFFECTIVE'
       - name: 'destAddressGroups'
         type: Array
         send_empty_value: true
@@ -274,6 +297,32 @@ properties:
       A list of service accounts indicating the sets of instances that are applied with this rule.
     item_type:
       type: String
+  - name: 'targetSecureTags'
+    type: Array
+    send_empty_value: true
+    description: |
+      A list of secure tags that controls which instances the firewall rule applies to. If targetSecureTag are specified,
+      then the firewall rule applies only to instances in the VPC network that have one of those EFFECTIVE secure tags,
+      if all the targetSecureTag are in INEFFECTIVE state, then this rule will be ignored. targetSecureTag may not be
+      set at the same time as targetServiceAccounts. If neither targetServiceAccounts nor targetSecureTag are specified,
+      the firewall rule applies to all instances on the specified network.
+      Maximum number of target label tags allowedis 256.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            Name of the secure tag, created with TagManager's TagValue API.
+          diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+        - name: 'state'
+          type: Enum
+          description: |
+            State of the secure tag, either EFFECTIVE or INEFFECTIVE. A secure tag is INEFFECTIVE when it is deleted or its network is deleted.
+          output: true
+          enum_values:
+            - 'EFFECTIVE'
+            - 'INEFFECTIVE'
   - name: 'disabled'
     type: Boolean
     description: |

--- a/mmv1/templates/terraform/examples/firewall_policy_rule.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firewall_policy_rule.tf.tmpl
@@ -47,5 +47,25 @@ resource "google_compute_firewall_policy_rule" "{{$.PrimaryResourceId}}" {
       ip_protocol = "udp"
       ports       = [22]
     }
+
+    src_secure_tags {
+      name = google_tags_tag_value.basic_value.id
+    }
   }
+
+  target_secure_tags {
+    name = google_tags_tag_value.basic_value.id
+  }
+}
+
+resource "google_tags_tag_key" "basic_key" {
+  description = "For keyname resources."
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  short_name  = "{{index $.Vars "tag_key"}}"
+}
+
+resource "google_tags_tag_value" "basic_value" {
+  description = "For valuename resources."
+  parent      = google_tags_tag_key.basic_key.id
+  short_name  = "{{index $.Vars "tag_value"}}"
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `match.src_secure_tags.name` and `target_secure_tags.name` fields to `google_compute_firewall_policy_rule`
```
