### PR TITLE
Add Terraform support for antivirus threat override

### DIFF
--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -188,6 +188,35 @@ properties:
                 - 'UNKNOWN'
                 - 'VULNERABILITY'
                 - 'SPYWARE'
+      - name: 'antivirusOverrides'
+        type: Array
+        is_set: true
+        description: |
+          Defines what action to take for antivirus threats per protocol.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'protocol'
+              type: Enum
+              description: Required protocol to match.
+              required: true
+              enum_values:
+                - 'SMTP'
+                - 'SMB'
+                - 'POP3'
+                - 'IMAP'
+                - 'HTTP2'
+                - 'HTTP'
+                - 'FTP'
+            - name: 'action'
+              type: Enum
+              description: Threat action override. For some threat types, only a subset of actions applies.
+              required: true
+              enum_values:
+                - 'ALERT'
+                - 'ALLOW'
+                - 'DEFAULT_ACTION'
+                - 'DENY'
     conflicts:
       - 'customMirroringProfile'
       - 'customInterceptProfile'

--- a/mmv1/templates/terraform/examples/network_security_security_profile_overrides.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_overrides.tf.tmpl
@@ -19,5 +19,10 @@ resource "google_network_security_security_profile" "{{$.PrimaryResourceId}}" {
       action    = "ALLOW"
       threat_id = "280647"
     }
+
+    antivirus_overrides {
+      protocol = "SMTP"
+      action   = "ALLOW"
+    }
   }
 }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
@@ -135,17 +135,17 @@ resource "google_network_security_security_profile" "foobar" {
     threat_prevention_profile {
         antivirus_overrides {
             action   = "ALLOW"
-            severity = "FTP"
+            protocol = "FTP"
         }
 
         antivirus_overrides {
             action   = "DENY"
-            severity = "HTTP"
+            protocol = "HTTP"
         }
 
 		antivirus_overrides {
             action   = "ALERT"
-            severity = "HTTP2"
+            protocol = "HTTP2"
         }
     }
 }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
@@ -64,6 +64,25 @@ func TestAccNetworkSecuritySecurityProfiles_antivirusOverrides(t *testing.T) {
 			},
 			{
 				Config: testAccNetworkSecuritySecurityProfiles_antivirusOverrides(orgId, randomSuffix),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_security_profile.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_network_security_security_profile.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecuritySecurityProfiles_basic(orgId, randomSuffix),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_security_security_profile.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:            "google_network_security_security_profile.foobar",
@@ -143,7 +162,7 @@ resource "google_network_security_security_profile" "foobar" {
             protocol = "HTTP"
         }
 
-		antivirus_overrides {
+        antivirus_overrides {
             action   = "ALERT"
             protocol = "HTTP2"
         }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_security_profile_test.go.tmpl
@@ -42,6 +42,39 @@ func TestAccNetworkSecuritySecurityProfiles_update(t *testing.T) {
 	})
 }
 
+func TestAccNetworkSecuritySecurityProfiles_antivirusOverrides(t *testing.T) {
+	t.Parallel()
+
+	orgId := envvar.GetTestOrgFromEnv(t)
+	randomSuffix := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkSecuritySecurityProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkSecuritySecurityProfiles_basic(orgId, randomSuffix),
+			},
+			{
+				ResourceName:            "google_network_security_security_profile.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetworkSecuritySecurityProfiles_antivirusOverrides(orgId, randomSuffix),
+			},
+			{
+				ResourceName:            "google_network_security_security_profile.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccNetworkSecuritySecurityProfiles_basic(orgId string, randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_network_security_security_profile" "foobar" {
@@ -80,6 +113,39 @@ resource "google_network_security_security_profile" "foobar" {
         severity_overrides {
             action   = "DENY"
             severity = "HIGH"
+        }
+    }
+}
+`, randomSuffix, orgId)
+}
+
+func testAccNetworkSecuritySecurityProfiles_antivirusOverrides(orgId string, randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_network_security_security_profile" "foobar" {
+    name        = "tf-test-my-security-profile%s"
+    parent      = "organizations/%s"
+    location    = "global"
+    description = "My security profile. Update"
+    type        = "THREAT_PREVENTION"
+
+    labels = {
+        foo = "foo"
+    }
+
+    threat_prevention_profile {
+        antivirus_overrides {
+            action   = "ALLOW"
+            severity = "FTP"
+        }
+
+        antivirus_overrides {
+            action   = "DENY"
+            severity = "HTTP"
+        }
+
+		antivirus_overrides {
+            action   = "ALERT"
+            severity = "HTTP2"
         }
     }
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
networksecurity: added `antivirus_overrides` field to `google_network_security_security_profile.threat_prevention_profile` resource
```
