### PR TITLE
Fix an unsafe type assertion in google_artifact_registry_repository

### DIFF
--- a/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
+++ b/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
@@ -92,8 +92,15 @@ func durationDiffSuppress(k, oldr, newr string, d *schema.ResourceData) bool {
 }
 
 func mapHashID(v any) int {
-	obj := v.(map[string]any)
-	return schema.HashString(obj["id"])
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return 0
+	}
+	s, ok := obj["id"].(string)
+	if !ok {
+		return 0
+	}
+	return schema.HashString(s)
 }
 
 func isDefaultEnum(val any) bool {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21900 which is really a dupe of https://github.com/hashicorp/terraform-provider-google/issues/21348.  The latter also mentions a [perma-lack-of-diff](https://github.com/hashicorp/terraform-provider-google/issues/21348#issuecomment-2658743809) which this PR doesn't address (but the [pending PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/13237) for the latter does). This PR only gets past the panic, but the lack of diff should be able to be worked around by changing the id of the policy a la:

```
   cleanup_policies {
     id     = "delete_older"
     action = "DELETE"
     condition {
       older_than = "62d"
     }
   }
```

to:

```
   cleanup_policies {
     id     = "delete_much_older"
     action = "DELETE"
     condition {
       older_than = "162d"
     }
   }
```

```release-note: bug
artifactregistry: fixed type assertion panic `google_artifact_registry_repository`
```
