### PR TITLE
Scope down RNEG lifecycle rule recommendation

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -19,9 +19,11 @@ description: |
   A regional NEG that can support Serverless Products, proxying traffic to
   external backends and providing traffic to the PSC port mapping endpoints.
 
-  Recreating a region network endpoint group that's in use by another resource will give a
-  `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
-  to avoid this type of error.
+  When in use by a resource that can be updated, recreating a RegionNetworkEndpointGroup
+  will give a `resourceInUseByAnotherResource` error because Terraform will attempt to
+  delete the   RegionNetworkEndpointGroup first, but an in-use RegionNetworkEndpointGroup
+  can't be deleted in the API. Use `lifecycle.create_before_destroy` to reorder the plan
+  and create the new resource first, allowing the deletion to go through successfully.
 references:
   guides:
     'Serverless NEGs Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts'

--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -21,9 +21,11 @@ description: |
 
   When in use by a resource that can be updated, recreating a RegionNetworkEndpointGroup
   will give a `resourceInUseByAnotherResource` error because Terraform will attempt to
-  delete the   RegionNetworkEndpointGroup first, but an in-use RegionNetworkEndpointGroup
+  delete the  RegionNetworkEndpointGroup first, but an in-use RegionNetworkEndpointGroup
   can't be deleted in the API. Use `lifecycle.create_before_destroy` to reorder the plan
   and create the new resource first, allowing the deletion to go through successfully.
+  This is only recommended when strictly necessary, as the `create_before_destroy`
+  directive can be passed onto further dependencies, creating unexpected plans.
 references:
   guides:
     'Serverless NEGs Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/serverless-neg-concepts'


### PR DESCRIPTION
`lifecycle.create_before_destroy` reorders the plan and can be passed through to other resources with dependencies on the initial resource. We want users to use it only when strictly required.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
