### PR TITLE
Add the CONTINUOUS job type to google_bigquery_reservation_assignment documentation

### DIFF
--- a/mmv1/products/bigqueryreservation/ReservationAssignment.yaml
+++ b/mmv1/products/bigqueryreservation/ReservationAssignment.yaml
@@ -84,7 +84,7 @@ properties:
   - name: 'jobType'
     type: String
     description: |
-      Types of job, which could be specified when using the reservation. Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY
+      Types of job, which could be specified when using the reservation. Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY, CONTINUOUS
     required: true
   - name: 'state'
     type: String


### PR DESCRIPTION

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

API reference doc: https://cloud.google.com/bigquery/docs/reference/reservations/rpc/google.cloud.bigquery.reservation.v1#google.cloud.bigquery.reservation.v1.Assignment.JobType. The value already works in practice, is just missing documentation.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
