### PR TITLE
Add 1 minute delay after project creation before running KMS KAJ test

### DIFF
--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -335,6 +336,10 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
+				// Give time for CSS to pickup the newly created project
+				PreConfig: func() {
+					time.Sleep(60 * time.Second)
+				},
 				Config: testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, allowedAccessReason),
 			},
 			{


### PR DESCRIPTION
I think this might be flaky because when CSS can't find a project, it returns unenrolled. So this passes when the CSS has registered the ephemeral project, but fails when the project is not registered yet.

Fixes: hashicorp/terraform-provider-google#21508

```release-note:none```
