### PR TITLE
Set google_compute_region_url_map > path_matcher > default_service to required.

### DIFF
--- a/mmv1/products/compute/RegionUrlMap.yaml
+++ b/mmv1/products/compute/RegionUrlMap.yaml
@@ -244,6 +244,7 @@ properties:
           # exactly_one_of:
           #   - path_matchers.0.default_service
           #   - path_matchers.0.default_url_redirect
+          required: true
           resource: 'RegionBackendService'
           imports: 'selfLink'
         - name: 'description'

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -303,6 +303,7 @@ properties:
           #   - path_matchers.0.default_service
           #   - path_matchers.0.default_url_redirect
           #   - path_matchers.0.default_route_action.0.weighted_backend_services
+          required: true
           custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
           resource: 'BackendService'
           imports: 'selfLink'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR sets google_compute_region_url_map > path_matcher > default_service to required. 

### Related Issues

- Resolves: https://github.com/hashicorp/terraform-provider-google/issues/21069

```release-note:bug
compute: fixed `google_compute_url_map.path_matcher.default_service` to be required
```