### PR TITLE
Add deletion_protection field to Metastore Federation

### DIFF
--- a/mmv1/products/metastore/Federation.yaml
+++ b/mmv1/products/metastore/Federation.yaml
@@ -44,6 +44,7 @@ iam_policy:
     - 'projects/{{project}}/locations/{{location}}/federations/{{federation_id}}'
     - '{{federation_id}}'
 custom_code:
+  pre_delete: 'templates/terraform/pre_delete/metastore_federation.go.tmpl'
 examples:
   - name: 'dataproc_metastore_federation_basic'
     primary_resource_id: 'default'
@@ -51,12 +52,22 @@ examples:
     vars:
       federation_id: 'metastore-fed'
       service_id: 'metastore-service'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'dataproc_metastore_federation_bigquery'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
     vars:
       federation_id: 'metastore-fed'
       service_id: 'metastore-service'
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the federation. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the federation will fail.
+    type: Boolean
+    default_value: false
 parameters:
   - name: 'federationId'
     type: String

--- a/mmv1/templates/terraform/examples/dataproc_metastore_federation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_federation_basic.tf.tmpl
@@ -20,4 +20,5 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
     version           = "3.1.2"
     endpoint_protocol = "GRPC"
   }
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/metastore_federation.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/metastore_federation.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy metastore federation without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -1,0 +1,98 @@
+package dataprocmetastore_test
+
+import (
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"testing"
+	"regexp"
+        "fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccMetastoreFederation_deletionprotection(t *testing.T) {
+	t.Parallel()
+	
+	name := "tf-test-metastore-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetastoreFederationDeletionProtection(name, "us-central1"),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_federation.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+                                Config: testAccMetastoreFederationDeletionProtection(name, "us-west2"),
+                                ExpectError: regexp.MustCompile("deletion_protection"),
+                        },
+			{
+				Config: testAccMetastoreFederationDeletionProtectionFalse(name, "us-central1"),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_federation.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccMetastoreFederationDeletionProtection(name string, location string) string {
+
+	return fmt.Sprintf(`
+       resource "google_dataproc_metastore_service" "default" {
+         service_id = "%s"
+         location   = "us-central1"
+         tier       = "DEVELOPER"
+         hive_metastore_config {
+           version           = "3.1.2"
+           endpoint_protocol = "GRPC"
+         }
+         }
+       resource "google_dataproc_metastore_federation" "default" {
+          federation_id = "%s"
+          location      = "%s"
+          version       = "3.1.2"
+          deletion_protection = true
+          backend_metastores {
+            rank           = "1"
+            name           = google_dataproc_metastore_service.default.id
+            metastore_type = "DATAPROC_METASTORE" 
+         }
+}
+`,name, name, location)
+}
+
+func testAccMetastoreFederationDeletionProtectionFalse(name string, location string) string {
+
+	return fmt.Sprintf(`
+       resource "google_dataproc_metastore_service" "default" {
+         service_id = "%s"
+         location   = "us-central1"
+         tier       = "DEVELOPER"
+         hive_metastore_config {
+           version           = "3.1.2"
+           endpoint_protocol = "GRPC"
+         }
+         }
+       resource "google_dataproc_metastore_federation" "default" {
+          federation_id = "%s"
+          location      = "%s"
+          version       = "3.1.2"
+          deletion_protection = false
+          backend_metastores {
+            rank           = "1"
+            name           = google_dataproc_metastore_service.default.id
+            metastore_type = "DATAPROC_METASTORE" 
+         }
+}
+`,name, name, location)
+}
+	  

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -1,17 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package dataprocmetastore_test
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"testing"
 	"regexp"
-        "fmt"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccMetastoreFederation_deletionprotection(t *testing.T) {
 	t.Parallel()
-	
+
 	name := "tf-test-metastore-" + acctest.RandString(t, 10)
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -28,9 +30,9 @@ func TestAccMetastoreFederation_deletionprotection(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-                                Config: testAccMetastoreFederationDeletionProtection(name, "us-west2"),
-                                ExpectError: regexp.MustCompile("deletion_protection"),
-                        },
+				Config:      testAccMetastoreFederationDeletionProtection(name, "us-west2"),
+				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
 			{
 				Config: testAccMetastoreFederationDeletionProtectionFalse(name, "us-central1"),
 			},
@@ -67,7 +69,7 @@ func testAccMetastoreFederationDeletionProtection(name string, location string) 
             metastore_type = "DATAPROC_METASTORE" 
          }
 }
-`,name, name, location)
+`, name, name, location)
 }
 
 func testAccMetastoreFederationDeletionProtectionFalse(name string, location string) string {
@@ -93,6 +95,5 @@ func testAccMetastoreFederationDeletionProtectionFalse(name string, location str
             metastore_type = "DATAPROC_METASTORE" 
          }
 }
-`,name, name, location)
+`, name, name, location)
 }
-	  


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/366209903
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
metastore: added `deletion_protection` field to `google_dataproc_metastore_federation`
```
