### PR TITLE
Promote Global & Regional Parameter Manager Resources & Datasources to GA

### DIFF
--- a/mmv1/products/parametermanager/Parameter.yaml
+++ b/mmv1/products/parametermanager/Parameter.yaml
@@ -15,7 +15,6 @@
 name: 'Parameter'
 description: |
   A Parameter resource is a logical parameter.
-min_version: 'beta'
 references:
   guides:
   api: 'https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters'
@@ -34,17 +33,14 @@ timeouts:
 examples:
   - name: 'parameter_config_basic'
     primary_resource_id: 'parameter-basic'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
   - name: 'parameter_with_format'
     primary_resource_id: 'parameter-with-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
   - name: 'parameter_with_labels'
     primary_resource_id: 'parameter-with-labels'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
   - name: 'parameter_with_kms_key'

--- a/mmv1/products/parametermanager/ParameterVersion.yaml
+++ b/mmv1/products/parametermanager/ParameterVersion.yaml
@@ -15,7 +15,6 @@
 name: 'ParameterVersion'
 description: |
   A Parameter Version resource that stores the actual value of the parameter.
-min_version: 'beta'
 references:
   guides:
   api: 'https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions'
@@ -34,13 +33,11 @@ timeouts:
 examples:
   - name: 'parameter_version_basic'
     primary_resource_id: 'parameter-version-basic'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
       parameter_version_id: 'parameter_version'
   - name: 'parameter_version_with_json_format'
     primary_resource_id: 'parameter-version-with-json-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
       parameter_version_id: 'parameter_version'
@@ -57,7 +54,6 @@ examples:
         role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   - name: 'parameter_version_with_yaml_format'
     primary_resource_id: 'parameter-version-with-yaml-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'parameter'
       parameter_version_id: 'parameter_version'

--- a/mmv1/products/parametermanager/product.yaml
+++ b/mmv1/products/parametermanager/product.yaml
@@ -17,5 +17,7 @@ display_name: 'Parameter Manager'
 versions:
   - name: 'beta'
     base_url: 'https://parametermanager.googleapis.com/v1/'
+  - name: 'ga'
+    base_url: 'https://parametermanager.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/parametermanagerregional/RegionalParameter.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameter.yaml
@@ -16,7 +16,6 @@ name: 'RegionalParameter'
 api_resource_type_kind: Parameter
 description: |
   A Regional Parameter is a logical regional parameter.
-min_version: 'beta'
 references:
   guides:
   api: 'https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters'
@@ -35,17 +34,14 @@ timeouts:
 examples:
   - name: 'regional_parameter_basic'
     primary_resource_id: 'regional-parameter-basic'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
   - name: 'regional_parameter_with_format'
     primary_resource_id: 'regional-parameter-with-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
   - name: 'regional_parameter_with_labels'
     primary_resource_id: 'regional-parameter-with-labels'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
 parameters:

--- a/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
@@ -16,7 +16,6 @@ name: 'RegionalParameterVersion'
 api_resource_type_kind: ParameterVersion
 description: |
   A Regional Parameter Version resource that stores the actual value of the regional parameter.
-min_version: 'beta'
 references:
   guides:
   api: 'https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions'
@@ -35,19 +34,16 @@ timeouts:
 examples:
   - name: 'regional_parameter_version_basic'
     primary_resource_id: 'regional-parameter-version-basic'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
       parameter_version_id: 'regional_parameter_version'
   - name: 'regional_parameter_version_with_json_format'
     primary_resource_id: 'regional-parameter-version-with-json-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
       parameter_version_id: 'regional_parameter_version'
   - name: 'regional_parameter_version_with_yaml_format'
     primary_resource_id: 'regional-parameter-version-with-yaml-format'
-    min_version: 'beta'
     vars:
       parameter_id: 'regional_parameter'
       parameter_version_id: 'regional_parameter_version'

--- a/mmv1/products/parametermanagerregional/product.yaml
+++ b/mmv1/products/parametermanagerregional/product.yaml
@@ -19,5 +19,8 @@ versions:
   - name: 'beta'
     base_url: 'https://parametermanager.{{location}}.rep.googleapis.com/v1/'
     cai_base_url: 'https://parametermanager.googleapis.com/v1/'
+  - name: 'ga'
+    base_url: 'https://parametermanager.{{location}}.rep.googleapis.com/v1/'
+    cai_base_url: 'https://parametermanager.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/templates/terraform/examples/parameter_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_config_basic.tf.tmpl
@@ -1,4 +1,3 @@
 resource "google_parameter_manager_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
 }

--- a/mmv1/templates/terraform/examples/parameter_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_basic.tf.tmpl
@@ -1,10 +1,8 @@
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
 }
 
 resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = "app-parameter-version-data"

--- a/mmv1/templates/terraform/examples/parameter_version_with_json_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_with_json_format.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   format = "JSON"
 }
 
 resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = jsonencode({

--- a/mmv1/templates/terraform/examples/parameter_version_with_kms_key.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_with_kms_key.tf.tmpl
@@ -1,16 +1,11 @@
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider  = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
-
   kms_key = "{{index $.Vars "kms_key"}}"
 }
 
 resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = "app-parameter-version-data"

--- a/mmv1/templates/terraform/examples/parameter_version_with_yaml_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_with_yaml_format.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   format = "YAML"
 }
 
 resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = yamlencode({

--- a/mmv1/templates/terraform/examples/parameter_with_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_with_format.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_parameter_manager_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   format = "JSON"
 }

--- a/mmv1/templates/terraform/examples/parameter_with_kms_key.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_with_kms_key.tf.tmpl
@@ -1,10 +1,6 @@
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "{{$.PrimaryResourceId}}" {
-  provider  = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
-
   kms_key = "{{index $.Vars "kms_key"}}"
 }

--- a/mmv1/templates/terraform/examples/parameter_with_labels.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_with_labels.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_parameter_manager_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
 
   labels = {

--- a/mmv1/templates/terraform/examples/regional_parameter_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_parameter_manager_regional_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   location = "us-central1"
 }

--- a/mmv1/templates/terraform/examples/regional_parameter_version_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_version_basic.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = "regional-parameter-version-data"

--- a/mmv1/templates/terraform/examples/regional_parameter_version_with_json_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_version_with_json_format.tf.tmpl
@@ -1,12 +1,10 @@
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   format = "JSON"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = jsonencode({

--- a/mmv1/templates/terraform/examples/regional_parameter_version_with_yaml_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_version_with_yaml_format.tf.tmpl
@@ -1,12 +1,10 @@
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   format = "YAML"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
   parameter_data = yamlencode({

--- a/mmv1/templates/terraform/examples/regional_parameter_with_format.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_with_format.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_parameter_manager_regional_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   location = "us-central1"
   format = "JSON"

--- a/mmv1/templates/terraform/examples/regional_parameter_with_labels.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_with_labels.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_parameter_manager_regional_parameter" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   parameter_id = "{{index $.Vars "parameter_id"}}"
   location = "us-central1"
 

--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -188,7 +188,6 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_organizations":                             resourcemanager.DataSourceGoogleOrganizations(),
 	"google_organization_iam_custom_role":              resourcemanager.DataSourceGoogleOrganizationIamCustomRole(),
 	"google_organization_iam_custom_roles":             resourcemanager.DataSourceGoogleOrganizationIamCustomRoles(),
-	{{- if ne $.TargetVersionName "ga" }}
 	"google_parameter_manager_parameter":               parametermanager.DataSourceParameterManagerParameter(),
 	"google_parameter_manager_parameters":              parametermanager.DataSourceParameterManagerParameters(),
 	"google_parameter_manager_parameter_version":       parametermanager.DataSourceParameterManagerParameterVersion(),
@@ -197,7 +196,6 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_parameter_manager_regional_parameters":     parametermanagerregional.DataSourceParameterManagerRegionalRegionalParameters(),
 	"google_parameter_manager_regional_parameter_version": parametermanagerregional.DataSourceParameterManagerRegionalRegionalParameterVersion(),
 	"google_parameter_manager_regional_parameter_version_render":parametermanagerregional.DataSourceParameterManagerRegionalRegionalParameterVersionRender(),
-	{{- end }}
 	"google_privateca_certificate_authority":           privateca.DataSourcePrivatecaCertificateAuthority(),
 	"google_privileged_access_manager_entitlement":     privilegedaccessmanager.DataSourceGooglePrivilegedAccessManagerEntitlement(),
 	"google_project":                                   resourcemanager.DataSourceGoogleProject(),

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager
-{{ if ne $.TargetVersionName `ga` -}}
 
 import (
 	"fmt"
@@ -41,5 +40,3 @@ func dataSourceParameterManagerParameterRead(d *schema.ResourceData, meta interf
 	}
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{ if ne $.TargetVersionName `ga` -}}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccDataSourceParameterManagerParameter_basic(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +35,6 @@ func TestAccDataSourceParameterManagerParameter_basic(t *testing.T) {
 func testAccDataSourceParameterManagerParameter_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
 
@@ -50,10 +48,7 @@ resource "google_parameter_manager_parameter" "parameter" {
 }
 
 data "google_parameter_manager_parameter" "parameter-datasource" {
-  provider = google-beta
   parameter_id = google_parameter_manager_parameter.parameter.parameter_id
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"encoding/base64"
@@ -168,5 +167,3 @@ func dataSourceParameterManagerParameterVersionRead(d *schema.ResourceData, meta
 	d.SetId(nameValue.(string))
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_render.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_render.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"encoding/base64"
@@ -154,5 +153,3 @@ func dataSourceParameterManagerParameterVersionRenderRead(d *schema.ResourceData
 	d.SetId(nameValue.(string))
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_render_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_render_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"errors"
@@ -21,7 +20,7 @@ func TestAccDataSourceParameterManagerParameterVersionRender_basicWithResourceRe
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -38,13 +37,11 @@ func TestAccDataSourceParameterManagerParameterVersionRender_basicWithResourceRe
 func testAccParameterManagerParameterVersionRender_basicWithResourceReference(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
 }
 
 resource "google_secret_manager_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf-temp-secret-basic%{random_suffix}"
   replication {
     auto {}
@@ -52,20 +49,17 @@ resource "google_secret_manager_secret" "secret-basic" {
 }
 
 resource "google_secret_manager_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret-basic.id
   secret_data = "parameter-version-data"
 }
 
 resource "google_secret_manager_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.secret-basic.secret_id
   role = "roles/secretmanager.secretAccessor"
   member = "${google_parameter_manager_parameter.parameter-basic.policy_member[0].iam_policy_uid_principal}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -74,7 +68,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-basic" 
 }
 
 data "google_parameter_manager_parameter_version_render" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter_version.parameter-version-basic.parameter
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-basic.parameter_version_id
 }
@@ -90,7 +83,7 @@ func TestAccDataSourceParameterManagerParameterVersionRender_withJsonData(t *tes
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -107,13 +100,11 @@ func TestAccDataSourceParameterManagerParameterVersionRender_withJsonData(t *tes
 func testAccParameterManagerParameterVersionRender_withJsonData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 }
 
 resource "google_secret_manager_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf-temp-secret-json-data%{random_suffix}"
   replication {
     auto {}
@@ -121,20 +112,17 @@ resource "google_secret_manager_secret" "secret-basic" {
 }
 
 resource "google_secret_manager_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret-basic.id
   secret_data = "parameter-version-data"
 }
 
 resource "google_secret_manager_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.secret-basic.secret_id
   role = "roles/secretmanager.secretAccessor"
   member = "${google_parameter_manager_parameter.parameter-basic.policy_member[0].iam_policy_uid_principal}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = jsonencode({
@@ -143,7 +131,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-with-js
 }
 
 data "google_parameter_manager_parameter_version_render" "parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-with-json-data.parameter_version_id
 }
@@ -159,7 +146,7 @@ func TestAccDataSourceParameterManagerParameterVersionRender_withYamlData(t *tes
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -176,13 +163,11 @@ func TestAccDataSourceParameterManagerParameterVersionRender_withYamlData(t *tes
 func testAccParameterManagerParameterVersionRender_withYamlData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
 }
 
 resource "google_secret_manager_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf-temp-secret-yaml-data%{random_suffix}"
   replication {
     auto {}
@@ -190,20 +175,17 @@ resource "google_secret_manager_secret" "secret-basic" {
 }
 
 resource "google_secret_manager_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_secret.secret-basic.id
   secret_data = "parameter-version-data"
 }
 
 resource "google_secret_manager_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_secret.secret-basic.secret_id
   role = "roles/secretmanager.secretAccessor"
   member = "${google_parameter_manager_parameter.parameter-basic.policy_member[0].iam_policy_uid_principal}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -212,7 +194,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-with-ya
 }
 
 data "google_parameter_manager_parameter_version_render" "parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-with-yaml-data.parameter_version_id
 }
@@ -241,5 +222,3 @@ func testAccCheckParameterManagerRenderedParameterDataMatchesDataSourceRenderedD
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameter_version_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"errors"
@@ -21,7 +20,7 @@ func TestAccDataSourceParameterManagerParameterVersion_basicWithResourceReferenc
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -38,19 +37,16 @@ func TestAccDataSourceParameterManagerParameterVersion_basicWithResourceReferenc
 func testAccParameterManagerParameterVersion_basicWithResourceReference(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = "test-parameter-data-with-resource-reference"
 }
 
 data "google_parameter_manager_parameter_version" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter_version.parameter-version-basic.parameter
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-basic.parameter_version_id
 }
@@ -66,7 +62,7 @@ func TestAccDataSourceParameterManagerParameterVersion_basicWithParameterName(t 
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -83,19 +79,16 @@ func TestAccDataSourceParameterManagerParameterVersion_basicWithParameterName(t 
 func testAccParameterManagerParameterVersion_basicWithParameterName(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = "test-parameter-data-with-parameter-name"
 }
 
 data "google_parameter_manager_parameter_version" "parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-basic.parameter_version_id
 }
@@ -111,7 +104,7 @@ func TestAccDataSourceParameterManagerParameterVersion_withJsonData(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -128,13 +121,11 @@ func TestAccDataSourceParameterManagerParameterVersion_withJsonData(t *testing.T
 func testAccParameterManagerParameterVersion_withJsonData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = jsonencode({
@@ -144,7 +135,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-with-js
 }
 
 data "google_parameter_manager_parameter_version" "parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter_version.parameter-version-with-json-data.parameter
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-with-json-data.parameter_version_id
 }
@@ -160,7 +150,7 @@ func TestAccDataSourceParameterManagerParameterVersion_withYamlData(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -177,13 +167,11 @@ func TestAccDataSourceParameterManagerParameterVersion_withYamlData(t *testing.T
 func testAccParameterManagerParameterVersion_withYamlData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -193,7 +181,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-with-ya
 }
 
 data "google_parameter_manager_parameter_version" "parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter_version.parameter-version-with-yaml-data.parameter
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-with-yaml-data.parameter_version_id
 }
@@ -217,7 +204,7 @@ func TestAccDataSourceParameterManagerParameterVersion_withKmsKey(t *testing.T) 
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -233,19 +220,15 @@ func TestAccDataSourceParameterManagerParameterVersion_withKmsKey(t *testing.T) 
 
 func testAccParameterManagerParameterVersion_withKmsKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
   kms_key = "%{kms_key}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-with-kms-key" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -255,7 +238,6 @@ resource "google_parameter_manager_parameter_version" "parameter-version-with-km
 }
 
 data "google_parameter_manager_parameter_version" "parameter-version-with-kms-key" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter_version.parameter-version-with-kms-key.parameter
   parameter_version_id = google_parameter_manager_parameter_version.parameter-version-with-kms-key.parameter_version_id
 }
@@ -298,5 +280,3 @@ func testAccCheckParameterManagerParameterDataDataSourceMatchesResource(dataSour
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameters.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameters.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"fmt"
@@ -165,5 +164,3 @@ func getDataFromName(v interface{}, part int) string {
 	split := strings.Split(name, "/")
 	return split[part]
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameters_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/data_source_parameter_manager_parameters_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"errors"
@@ -21,7 +20,7 @@ func TestAccDataSourceParameterManagerParameters_basic(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -43,12 +42,11 @@ func TestAccDataSourceParameterManagerParameters_basic(t *testing.T) {
 
 func testAccDataSourceParameterManagerParameters_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-provider "google-beta" {
+provider "google" {
   add_terraform_attribution_label = false
 }
 
 resource "google_parameter_manager_parameter" "parameters" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "YAML"
 
@@ -62,7 +60,6 @@ resource "google_parameter_manager_parameter" "parameters" {
 }
 
 data "google_parameter_manager_parameters" "parameters-datasource" {
-  provider = google-beta
   depends_on = [
     google_parameter_manager_parameter.parameters
   ]
@@ -79,7 +76,7 @@ func TestAccDataSourceParameterManagerParameters_filter(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -102,12 +99,11 @@ func TestAccDataSourceParameterManagerParameters_filter(t *testing.T) {
 
 func testAccDataSourceParameterManagerParameters_filter(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-provider "google-beta" {
+provider "google" {
   add_terraform_attribution_label = false
 }
 
 resource "google_parameter_manager_parameter" "parameters-1" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 
@@ -117,7 +113,6 @@ resource "google_parameter_manager_parameter" "parameters-1" {
 }
 
 resource "google_parameter_manager_parameter" "parameters-2" {
-  provider = google-beta
   parameter_id = "tf_test_parameter_2_%{random_suffix}"
   format = "YAML"
 
@@ -127,7 +122,6 @@ resource "google_parameter_manager_parameter" "parameters-2" {
 }
 
 data "google_parameter_manager_parameters" "parameters-datasource-filter" {
-  provider = google-beta
   filter = "format:JSON"
   depends_on = [
     google_parameter_manager_parameter.parameters-1,
@@ -250,5 +244,3 @@ func checkResourceAbsentInDataSourceAfterFilterApplied(dsAttr, rsAttr map[string
 	}
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -18,7 +17,7 @@ func TestAccParameterManagerParameter_labelsUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -64,7 +63,6 @@ func TestAccParameterManagerParameter_labelsUpdate(t *testing.T) {
 func testAccParameterManagerParameter_withoutLabels(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 }
@@ -74,7 +72,6 @@ resource "google_parameter_manager_parameter" "parameter-with-labels" {
 func testAccParameterManagerParameter_labelsUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 
@@ -92,7 +89,6 @@ resource "google_parameter_manager_parameter" "parameter-with-labels" {
 func testAccParameterManagerParameter_labelsUpdateOther(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 
@@ -124,7 +120,7 @@ func TestAccParameterManagerParameter_kmsKeyUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -184,12 +180,9 @@ func TestAccParameterManagerParameter_kmsKeyUpdate(t *testing.T) {
 
 func testAccParameterManagerParameter_withoutkmsKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-	provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 }
@@ -198,12 +191,9 @@ resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
 
 func testAccParameterManagerParameter_kmsKeyUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 
@@ -214,12 +204,9 @@ resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
 
 func testAccParameterManagerParameter_kmsKeyUpdateOther(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-data "google_project" "project" {
-  provider = google-beta
-}
+data "google_project" "project" {}
 
 resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   format = "JSON"
 
@@ -227,5 +214,3 @@ resource "google_parameter_manager_parameter" "parameter-with-kms-key" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanager/resource_parameter_manager_parameter_version_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanager_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccParameterManagerParameterVersion_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -54,12 +53,10 @@ func TestAccParameterManagerParameterVersion_update(t *testing.T) {
 func testAccParameterManagerParameterVersion_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-update" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-update" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-update.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = "parameter-version-data"
@@ -70,12 +67,10 @@ resource "google_parameter_manager_parameter_version" "parameter-version-update"
 func testAccParameterManagerParameterVersion_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_parameter" "parameter-update" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
 }
 
 resource "google_parameter_manager_parameter_version" "parameter-version-update" {
-  provider = google-beta
   parameter = google_parameter_manager_parameter.parameter-update.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = "parameter-version-data"
@@ -83,5 +78,3 @@ resource "google_parameter_manager_parameter_version" "parameter-version-update"
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"fmt"
@@ -42,5 +41,3 @@ func dataSourceParameterManagerRegionalRegionalParameterRead(d *schema.ResourceD
 	}
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameter_basic(t *testing
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +35,6 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameter_basic(t *testing
 func testAccDataSourceParameterManagerRegionalRegionalParameter_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
@@ -51,11 +49,8 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter" {
 }
 
 data "google_parameter_manager_regional_parameter" "regional-parameter-datasource" {
-  provider = google-beta
   parameter_id = google_parameter_manager_regional_parameter.regional-parameter.parameter_id
   location = google_parameter_manager_regional_parameter.regional-parameter.location
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"encoding/base64"
@@ -175,5 +174,3 @@ func dataSourceParameterManagerRegionalRegionalParameterVersionRead(d *schema.Re
 	d.SetId(nameValue.(string))
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_render.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_render.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional
-{{ if ne $.TargetVersionName `ga` -}}
 
 import (
 	"encoding/base64"
@@ -172,5 +171,3 @@ func dataSourceParameterManagerRegionalRegionalParameterVersionRenderRead(d *sch
 	d.SetId(nameValue.(string))
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_render_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_render_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{ if ne $.TargetVersionName `ga` -}}
 
 import (
 	"errors"
@@ -22,7 +21,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_bas
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -48,26 +47,22 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_bas
 func testAccParameterManagerRegionalRegionalParameterVersionRender_basicWithResourceReferenceWithoutDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -75,7 +70,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -88,26 +82,22 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 func testAccParameterManagerRegionalRegionalParameterVersionRender_basicWithResourceReferenceWithDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -115,7 +105,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -124,7 +113,6 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 
 data "google_parameter_manager_regional_parameter_version_render" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter_version.regional-parameter-version-basic.parameter
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-basic.parameter_version_id
 }
@@ -140,7 +128,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_wit
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -166,26 +154,22 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_wit
 func testAccParameterManagerRegionalRegionalParameterVersionRender_withJsonDataWithoutDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "JSON"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret_json_data%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -193,7 +177,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = jsonencode({
@@ -206,26 +189,22 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 func testAccParameterManagerRegionalRegionalParameterVersionRender_withJsonDataWithDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "JSON"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret_json_data%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -233,7 +212,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = jsonencode({
@@ -242,7 +220,6 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 
 data "google_parameter_manager_regional_parameter_version_render" "regional-parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-json-data.parameter_version_id
   location = "us-central1"
@@ -259,7 +236,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_wit
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -285,26 +262,22 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersionRender_wit
 func testAccParameterManagerRegionalRegionalParameterVersionRender_withYamlDataWithoutDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret_yaml_data%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -312,7 +285,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -325,26 +297,22 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 func testAccParameterManagerRegionalRegionalParameterVersionRender_withYamlDataWithDatasource(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
 }
 
 resource "google_secret_manager_regional_secret" "secret-basic" {
-  provider = google-beta
   secret_id = "tf_temp_secret_yaml_data%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_secret_manager_regional_secret_version" "secret-version-basic" {
-  provider = google-beta
   secret = google_secret_manager_regional_secret.secret-basic.id
   secret_data = "regional-parameter-version-data"
 }
 
 resource "google_secret_manager_regional_secret_iam_member" "member" {
-  provider = google-beta
   secret_id = google_secret_manager_regional_secret.secret-basic.secret_id
   location = google_secret_manager_regional_secret.secret-basic.location
   role = "roles/secretmanager.secretAccessor"
@@ -352,7 +320,6 @@ resource "google_secret_manager_regional_secret_iam_member" "member" {
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -361,7 +328,6 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 
 data "google_parameter_manager_regional_parameter_version_render" "regional-parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-yaml-data.parameter_version_id
   location = "us-central1"
@@ -391,5 +357,3 @@ func testAccCheckParameterManagerRegionalRegionalRenderedParameterDataMatchesDat
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameter_version_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"errors"
@@ -21,7 +20,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_basicWith
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -38,20 +37,17 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_basicWith
 func testAccParameterManagerRegionalRegionalParameterVersion_basicWithResourceReference(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = "test-regional-parameter-data-with-resource-reference"
 }
 
 data "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter_version.regional-parameter-version-basic.parameter
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-basic.parameter_version_id
 }
@@ -67,7 +63,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_basicWith
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -84,20 +80,17 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_basicWith
 func testAccParameterManagerRegionalRegionalParameterVersion_basicWithParameterName(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = "test-regional-parameter-data-with-regional-parameter-name"
 }
 
 data "google_parameter_manager_regional_parameter_version" "regional-parameter-version-basic" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.parameter_id
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-basic.parameter_version_id
   location = "us-central1"
@@ -114,7 +107,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_withJsonD
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -131,7 +124,6 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_withJsonD
 func testAccParameterManagerRegionalRegionalParameterVersion_withJsonData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   format = "JSON"
   location = "us-central1"
@@ -139,7 +131,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter-basic
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = jsonencode({
@@ -149,7 +140,6 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 
 data "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-json-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-json-data.parameter
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-json-data.parameter_version_id
 }
@@ -165,7 +155,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_withYamlD
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -182,14 +172,12 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameterVersion_withYamlD
 func testAccParameterManagerRegionalRegionalParameterVersion_withYamlData(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   format = "YAML"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = yamlencode({
@@ -199,7 +187,6 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 
 data "google_parameter_manager_regional_parameter_version" "regional-parameter-version-with-yaml-data" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-yaml-data.parameter
   parameter_version_id = google_parameter_manager_regional_parameter_version.regional-parameter-version-with-yaml-data.parameter_version_id
 }
@@ -242,5 +229,3 @@ func testAccCheckParameterManagerRegionalRegionalParameterDataDataSourceMatchesR
 		return nil
 	}
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameters.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameters.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"fmt"
@@ -169,5 +168,3 @@ func getDataFromName(v interface{}, part int) string {
 	split := strings.Split(name, "/")
 	return split[part]
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameters_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/data_source_parameter_manager_regional_parameters_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"errors"
@@ -21,7 +20,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameters_basic(t *testin
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -43,12 +42,11 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameters_basic(t *testin
 
 func testAccDataSourceParameterManagerRegionalRegionalParameters_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-provider "google-beta" {
+provider "google" {
   add_terraform_attribution_label = false
 }
 
 resource "google_parameter_manager_regional_parameter" "regional-parameters" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   format = "YAML"
   location = "us-central1"
@@ -63,7 +61,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameters" {
 }
 
 data "google_parameter_manager_regional_parameters" "regional-parameters-datasource" {
-  provider = google-beta
   depends_on = [
     google_parameter_manager_regional_parameter.regional-parameters
   ]
@@ -81,7 +78,7 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameters_filter(t *testi
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -104,12 +101,11 @@ func TestAccDataSourceParameterManagerRegionalRegionalParameters_filter(t *testi
 
 func testAccDataSourceParameterManagerRegionalRegionalParameters_filter(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-provider "google-beta" {
+provider "google" {
   add_terraform_attribution_label = false
 }
 
 resource "google_parameter_manager_regional_parameter" "regional-parameters-1" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   format = "JSON"
   location = "us-central1"
@@ -120,7 +116,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameters-1" {
 }
 
 resource "google_parameter_manager_regional_parameter" "regional-parameters-2" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter_2_%{random_suffix}"
   format = "YAML"
   location = "us-central1"
@@ -131,7 +126,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameters-2" {
 }
 
 data "google_parameter_manager_regional_parameters" "regional-parameters-datasource-filter" {
-  provider = google-beta
   filter = "format:JSON"
   location = "us-central1"
 
@@ -256,5 +250,3 @@ func checkResourceAbsentInDataSourceAfterFilterApplied(dsAttr, rsAttr map[string
 	}
 	return nil
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccParameterManagerRegionalRegionalParameter_import(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -36,7 +35,6 @@ func TestAccParameterManagerRegionalRegionalParameter_import(t *testing.T) {
 func testAccParameterManagerRegionalRegionalParameter_import(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-import" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "YAML"
@@ -61,7 +59,7 @@ func TestAccParameterManagerRegionalRegionalParameter_labelsUpdate(t *testing.T)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -107,7 +105,6 @@ func TestAccParameterManagerRegionalRegionalParameter_labelsUpdate(t *testing.T)
 func testAccParameterManagerRegionalRegionalParameter_withoutLabels(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "JSON"
@@ -118,7 +115,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter-with-
 func testAccParameterManagerRegionalRegionalParameter_labelsUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "JSON"
@@ -137,7 +133,6 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter-with-
 func testAccParameterManagerRegionalRegionalParameter_labelsUpdateOther(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-with-labels" {
-  provider = google-beta
   parameter_id = "tf_test_parameter%{random_suffix}"
   location = "us-central1"
   format = "JSON"
@@ -152,5 +147,3 @@ resource "google_parameter_manager_regional_parameter" "regional-parameter-with-
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/resource_parameter_manager_regional_parameter_version_test.go.tmpl
@@ -1,5 +1,4 @@
 package parametermanagerregional_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -17,7 +16,7 @@ func TestAccParameterManagerRegionalRegionalParameterVersion_update(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckParameterManagerRegionalRegionalParameterVersionDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -54,13 +53,11 @@ func TestAccParameterManagerRegionalRegionalParameterVersion_update(t *testing.T
 func testAccParameterManagerRegionalRegionalParameterVersion_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-update" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-update" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-update.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = "regional-parameter-version-data"
@@ -71,13 +68,11 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 func testAccParameterManagerRegionalRegionalParameterVersion_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_parameter_manager_regional_parameter" "regional-parameter-update" {
-  provider = google-beta
   parameter_id = "tf_test_regional_parameter%{random_suffix}"
   location = "us-central1"
 }
 
 resource "google_parameter_manager_regional_parameter_version" "regional-parameter-version-update" {
-  provider = google-beta
   parameter = google_parameter_manager_regional_parameter.regional-parameter-update.id
   parameter_version_id = "tf_test_regional_parameter_version%{random_suffix}"
   parameter_data = "regional-parameter-version-data"
@@ -85,5 +80,3 @@ resource "google_parameter_manager_regional_parameter_version" "regional-paramet
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Use this data source to get information about a Parameter Manager Parameter.
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ## Example Usage 
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Get the value and metadata from a Parameter Manager Parameter version. For more information see the [official documentation](https://cloud.google.com/secret-manager/parameter-manager/docs/overview)  and [API](https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions).
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version_render.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameter_version_render.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 Get the value and metadata from a Parameter Manager Parameter version with render payload data. For this datasource to work as expected, the principal of the parameter must be provided with the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor) role. For more information see the [official documentation](https://cloud.google.com/secret-manager/parameter-manager/docs/overview)  and [API](https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions/render).
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
 
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameters.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_parameters.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Use this data source to list the Parameter Manager Parameters.
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ## Example Usage 
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Use this data source to get information about a Parameter Manager Regional Parameter.
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ## Example Usage 
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Get the value and metadata from a Parameter Manager Regional Parameter version. For more information see the [official documentation](https://cloud.google.com/secret-manager/parameter-manager/docs/overview) and [API](https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions).
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ## Example Usage
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version_render.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameter_version_render.html.markdown
@@ -8,9 +8,6 @@ description: |-
 
 Get the value and metadata from a Parameter Manager Regional Parameter version with rendered payload data. For this datasource to work as expected, the principal of the parameter must be provided with the [Secret Manager Secret Accessor](https://cloud.google.com/secret-manager/docs/access-control#secretmanager.secretAccessor) role. For more information see the [official documentation](https://cloud.google.com/secret-manager/parameter-manager/docs/overview)  and [API](https://cloud.google.com/secret-manager/parameter-manager/docs/reference/rest/v1/projects.locations.parameters.versions/render).
 
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
-
 ~> **Warning:** To use this data source, we must grant the `Secret Manager Secret Accessor` role to the principal of the parameter. Please note that it can take up to 7 minutes for the role to take effect. Hence, we might need to wait approximately 7 minutes after granting  `Secret Manager Secret Accessor` role to the principal of the parameter. For more information see the [access change propagation documentation](https://cloud.google.com/iam/docs/access-change-propagation).
 
 ## Example Usage

--- a/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameters.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/parameter_manager_regional_parameters.html.markdown
@@ -6,10 +6,7 @@ description: |-
 
 # google_parameter_manager_regional_parameters
 
-Use this data source to list the Parameter Manager Regional Parameters
-
-~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta datasources.
+Use this data source to list the Parameter Manager Regional Parameters.
 
 ## Example Usage
 


### PR DESCRIPTION
Promoted all the global and regional parameter manager resources and datasources to GA.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_parameter_manager_parameter` (ga)
```
```release-note:new-datasource
`google_parameter_manager_parameters` (ga)
```
```release-note:new-datasource
`google_parameter_manager_parameter_version` (ga)
```
```release-note:new-datasource
`google_parameter_manager_parameter_version_render` (ga)
```
```release-note:new-datasource
`google_parameter_manager_regional_parameter` (ga)
```
```release-note:new-datasource
`google_parameter_manager_regional_parameters` (ga)
```
```release-note:new-datasource
`google_parameter_manager_regional_parameter_version` (ga)
```
```release-note:new-datasource
`google_parameter_manager_regional_parameter_version_render` (ga)
```

```release-note:new-resource
`google_parameter_manager_parameter` (ga)
```
```release-note:new-resource
`google_parameter_manager_parameter_version` (ga)
```
```release-note:new-resource
`google_parameter_manager_regional_parameter` (ga)
```
```release-note:new-resource
`google_parameter_manager_regional_parameter_version` (ga)
```
