### PR TITLE
add IPv6 related fields to data_source_google_compute_subnetwork

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork.go.tmpl
@@ -39,12 +39,24 @@ func DataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"external_ipv6_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"internal_ipv6_prefix": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"private_ip_google_access": {
 				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"stack_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ipv6_access_type": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"secondary_ip_range": {
@@ -111,6 +123,9 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	if err := d.Set("ip_cidr_range", subnetwork.IpCidrRange); err != nil {
 		return fmt.Errorf("Error setting ip_cidr_range: %s", err)
 	}
+	if err := d.Set("external_ipv6_prefix", subnetwork.ExternalIpv6Prefix); err != nil {
+		return fmt.Errorf("Error setting external_ipv6_prefix: %s", err)
+	}
 	if err := d.Set("internal_ipv6_prefix", subnetwork.InternalIpv6Prefix); err != nil {
 		return fmt.Errorf("Error setting internal_ipv6_prefix: %s", err)
 	}
@@ -136,6 +151,12 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error setting region: %s", err)
 	}
 	if err := d.Set("name", name); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
+	if err := d.Set("stack_type", subnetwork.StackType); err != nil {
+		return fmt.Errorf("Error setting stack_type: %s", err)
+	}
+	if err := d.Set("ipv6_access_type", subnetwork.Ipv6AccessType); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
 	if err := d.Set("secondary_ip_range", flattenSecondaryRanges(subnetwork.SecondaryIpRanges)); err != nil {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_subnetwork_test.go
@@ -50,7 +50,10 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"subnetwork_id",
 			"ip_cidr_range",
 			"private_ip_google_access",
+			"external_ipv6_prefix",
 			"internal_ipv6_prefix",
+			"stack_type",
+			"ipv6_access_type",
 			"secondary_ip_range",
 		}
 

--- a/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_subnetwork.html.markdown
@@ -47,6 +47,8 @@ In addition to the arguments listed above, the following attributes are exported
 * `ip_cidr_range` - The IP address range that machines in this
     network are assigned to, represented as a CIDR block.
 
+* `external_ipv6_prefix` - The external IPv6 address range that is assigned to this subnetwork.
+
 * `internal_ipv6_prefix` - The internal IPv6 address range that is assigned to this subnetwork.
 
 * `gateway_address` - The IP address of the gateway.
@@ -54,6 +56,10 @@ In addition to the arguments listed above, the following attributes are exported
 * `private_ip_google_access` - Whether the VMs in this subnet
     can access Google services without assigned external IP
     addresses.
+
+* `stack_type` - The stack type for the subnet. Possible values are: `IPV4_ONLY`, `IPV4_IPV6`, `IPV6_ONLY`.
+
+* `ipv6_access_type` - The access type of IPv6 address this subnet holds. Possible values are: `EXTERNAL`, `INTERNAL`.
 
 * `secondary_ip_range` - An array of configurations for secondary IP ranges for
     VM instances contained in this subnetwork. Structure is [documented below](#nested_secondary_ip_range).


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21260

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `external_ipv6_prefix`, `stack_type`, and `ipv6_access_type` fields to `data_source_google_compute_subnetwork` data source
```
