### PR TITLE
Fixes issue #21773 for Eventarc test failures due to beta-only resources

### DIFF
--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_google_api_source_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_google_api_source_test.go.tmpl
@@ -1,4 +1,5 @@
 package eventarc_test
+{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"fmt"
@@ -14,6 +15,8 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// This test is beta-only due to the dependency on google_project_service_identity,
+// but enables testing updates to the message_bus field in GoogleApiSource.
 func TestAccEventarcGoogleApiSource_update(t *testing.T) {
 	t.Parallel()
 
@@ -27,7 +30,7 @@ func TestAccEventarcGoogleApiSource_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckEventarcGoogleApiSourceDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
@@ -79,6 +82,7 @@ func TestAccEventarcGoogleApiSource_update(t *testing.T) {
 func testAccEventarcGoogleApiSource_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
+  provider        = google-beta
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
@@ -92,24 +96,28 @@ resource "time_sleep" "wait_create_project" {
 }
 
 resource "google_project_service" "compute" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "compute.googleapis.com"
   depends_on = [time_sleep.wait_create_project]
 }
 
 resource "google_project_service" "servicenetworking" {
-  project   = google_project.project.project_id
-  service   = "servicenetworking.googleapis.com"
+  provider   = google-beta
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
   depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "cloudkms.googleapis.com"
   depends_on = [google_project_service.servicenetworking]
 }
 
 resource "google_project_service" "eventarc" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [google_project_service.kms]
@@ -121,6 +129,7 @@ resource "time_sleep" "wait_enable_service" {
 }
 
 resource "google_kms_key_ring" "keyring" {
+  provider   = google-beta
   name       = "keyring"
   location   = "%{region}"
   project    = google_project.project.project_id
@@ -128,11 +137,13 @@ resource "google_kms_key_ring" "keyring" {
 }
 
 resource "google_kms_crypto_key" "key" {
+  provider = google-beta
   name     = "key1"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_project_service_identity" "eventarc_sa" {
+  provider   = google-beta
   service    = "eventarc.googleapis.com"
   project    = google_project.project.project_id
   depends_on = [time_sleep.wait_enable_service]
@@ -144,6 +155,7 @@ resource "time_sleep" "wait_create_sa" {
 }
 
 resource "google_kms_crypto_key_iam_member" "eventarc_sa_keyuser" {
+  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = google_project_service_identity.eventarc_sa.member
@@ -156,6 +168,7 @@ resource "time_sleep" "wait_propagate_iam" {
 }
 
 resource "google_eventarc_message_bus" "message_bus" {
+  provider       = google-beta
   location       = "%{region}"
   message_bus_id = "tf-test-messagebus%{random_suffix}"
   project        = google_project.project.project_id
@@ -163,6 +176,7 @@ resource "google_eventarc_message_bus" "message_bus" {
 }
 
 resource "google_eventarc_google_api_source" "primary" {
+  provider             = google-beta
   location             = "%{region}"
   google_api_source_id = "tf-test-googleapisource%{random_suffix}"
   project              = google_project.project.project_id
@@ -187,6 +201,7 @@ resource "google_eventarc_google_api_source" "primary" {
 func testAccEventarcGoogleApiSource_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
+  provider        = google-beta
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
@@ -195,29 +210,34 @@ resource "google_project" "project" {
 }
 
 resource "google_project_service" "compute" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "compute.googleapis.com"
 }
 
 resource "google_project_service" "servicenetworking" {
-  project   = google_project.project.project_id
-  service   = "servicenetworking.googleapis.com"
+  provider   = google-beta
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
   depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "cloudkms.googleapis.com"
   depends_on = [google_project_service.servicenetworking]
 }
 
 resource "google_project_service" "eventarc" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [google_project_service.kms]
 }
 
 resource "google_kms_key_ring" "keyring" {
+  provider   = google-beta
   name       = "keyring"
   location   = "%{region}"
   project    = google_project.project.project_id
@@ -225,28 +245,33 @@ resource "google_kms_key_ring" "keyring" {
 }
 
 resource "google_kms_crypto_key" "key" {
+  provider = google-beta
   name     = "key1"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key" "key_update" {
+  provider = google-beta
   name     = "key2"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_project_service_identity" "eventarc_sa" {
+  provider   = google-beta
   service    = "eventarc.googleapis.com"
   project    = google_project.project.project_id
   depends_on = [google_project_service.eventarc]
 }
 
 resource "google_kms_crypto_key_iam_member" "eventarc_sa_keyuser" {
+  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = google_project_service_identity.eventarc_sa.member
 }
 
 resource "google_kms_crypto_key_iam_member" "eventarc_sa_keyuser_update" {
+  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key_update.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = google_project_service_identity.eventarc_sa.member
@@ -259,6 +284,7 @@ resource "time_sleep" "wait_propagate_iam_update" {
 
 # Create a separate project to contain another MessageBus.
 resource "google_project" "project_update" {
+  provider        = google-beta
   project_id      = "tf-test2%{random_suffix}"
   name            = "tf-test2%{random_suffix}"
   org_id          = "%{org_id}"
@@ -272,6 +298,7 @@ resource "time_sleep" "wait_create_project_update" {
 }
 
 resource "google_project_service" "eventarc_update" {
+  provider   = google-beta
   project    = google_project.project_update.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [time_sleep.wait_create_project_update]
@@ -283,6 +310,7 @@ resource "time_sleep" "wait_enable_service_update" {
 }
 
 resource "google_project_service_identity" "eventarc_sa_update" {
+  provider   = google-beta
   project    = google_project.project_update.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [time_sleep.wait_enable_service_update]
@@ -294,6 +322,7 @@ resource "time_sleep" "wait_create_sa_update" {
 }
 
 resource "google_eventarc_message_bus" "message_bus_update" {
+  provider       = google-beta
   location       = "%{region}"
   message_bus_id = "tf-test-messagebus2%{random_suffix}"
   project        = google_project.project_update.project_id
@@ -301,6 +330,7 @@ resource "google_eventarc_message_bus" "message_bus_update" {
 }
 
 resource "google_eventarc_google_api_source" "primary" {
+  provider             = google-beta
   location             = "%{region}"
   google_api_source_id = "tf-test-googleapisource%{random_suffix}"
   project              = google_project.project.project_id
@@ -325,6 +355,7 @@ resource "google_eventarc_google_api_source" "primary" {
 func testAccEventarcGoogleApiSource_unset(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_project" "project" {
+  provider        = google-beta
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
@@ -333,29 +364,34 @@ resource "google_project" "project" {
 }
 
 resource "google_project_service" "compute" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "compute.googleapis.com"
 }
 
 resource "google_project_service" "servicenetworking" {
-  project   = google_project.project.project_id
-  service   = "servicenetworking.googleapis.com"
+  provider   = google-beta
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
   depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "cloudkms.googleapis.com"
   depends_on = [google_project_service.servicenetworking]
 }
 
 resource "google_project_service" "eventarc" {
+  provider   = google-beta
   project    = google_project.project.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [google_project_service.kms]
 }
 
 resource "google_kms_key_ring" "keyring" {
+  provider   = google-beta
   name       = "keyring"
   location   = "%{region}"
   project    = google_project.project.project_id
@@ -363,34 +399,40 @@ resource "google_kms_key_ring" "keyring" {
 }
 
 resource "google_kms_crypto_key" "key" {
+  provider = google-beta
   name     = "key1"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_kms_crypto_key" "key_update" {
+  provider = google-beta
   name     = "key2"
   key_ring = google_kms_key_ring.keyring.id
 }
 
 resource "google_project_service_identity" "eventarc_sa" {
+  provider   = google-beta
   service    = "eventarc.googleapis.com"
   project    = google_project.project.project_id
   depends_on = [google_project_service.eventarc]
 }
 
 resource "google_kms_crypto_key_iam_member" "eventarc_sa_keyuser" {
+  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = google_project_service_identity.eventarc_sa.member
 }
 
 resource "google_kms_crypto_key_iam_member" "eventarc_sa_keyuser_update" {
+  provider      = google-beta
   crypto_key_id = google_kms_crypto_key.key_update.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member        = google_project_service_identity.eventarc_sa.member
 }
 
 resource "google_project" "project_update" {
+  provider        = google-beta
   project_id      = "tf-test2%{random_suffix}"
   name            = "tf-test2%{random_suffix}"
   org_id          = "%{org_id}"
@@ -399,17 +441,20 @@ resource "google_project" "project_update" {
 }
 
 resource "google_project_service" "eventarc_update" {
+  provider   = google-beta
   project    = google_project.project_update.project_id
   service    = "eventarc.googleapis.com"
 }
 
 resource "google_project_service_identity" "eventarc_sa_update" {
+  provider   = google-beta
   project    = google_project.project_update.project_id
   service    = "eventarc.googleapis.com"
   depends_on = [google_project_service.eventarc_update]
 }
 
 resource "google_eventarc_message_bus" "message_bus_update" {
+  provider       = google-beta
   location       = "%{region}"
   message_bus_id = "tf-test-messagebus2%{random_suffix}"
   project        = google_project.project_update.project_id
@@ -417,6 +462,7 @@ resource "google_eventarc_message_bus" "message_bus_update" {
 }
 
 resource "google_eventarc_google_api_source" "primary" {
+  provider             = google-beta
   location             = "%{region}"
   google_api_source_id = "tf-test-googleapisource%{random_suffix}"
   project              = google_project.project.project_id
@@ -438,7 +484,7 @@ func testAccCheckEventarcGoogleApiSourceDestroyProducer(t *testing.T) func(s *te
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{EventarcBasePath}}projects/{{project}}/locations/{{location}}/googleApiSources/{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}EventarcBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/googleApiSources/{{"{{"}}name{{"}}"}}")
 			if err != nil {
 				return err
 			}
@@ -464,3 +510,5 @@ func testAccCheckEventarcGoogleApiSourceDestroyProducer(t *testing.T) func(s *te
 		return nil
 	}
 }
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
@@ -17,14 +17,14 @@ import (
 // We make sure not to run tests in parallel, since only one MessageBus per project is supported.
 func TestAccEventarcMessageBus(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"basic":            testAccEventarcMessageBus_basic,
-		"cryptoKey":        testAccEventarcMessageBus_cryptoKey,
-		"update":           testAccEventarcMessageBus_update,
-		"googleApiSource":  testAccEventarcMessageBus_googleApiSource,
+		"basic":                 testAccEventarcMessageBus_basic,
+		"cryptoKey":             testAccEventarcMessageBus_cryptoKey,
+		"update":                testAccEventarcMessageBus_update,
+		"googleApiSource":       testAccEventarcMessageBus_googleApiSource,
 		"updateGoogleApiSource": testAccEventarcMessageBus_updateGoogleApiSource,
-		"pipeline":         testAccEventarcMessageBus_pipeline,
-		"enrollment":       testAccEventarcMessageBus_enrollment,
-		"updateEnrollment": testAccEventarcMessageBus_updateEnrollment,
+		"pipeline":              testAccEventarcMessageBus_pipeline,
+		"enrollment":            testAccEventarcMessageBus_enrollment,
+		"updateEnrollment":      testAccEventarcMessageBus_updateEnrollment,
 	}
 
 	for name, tc := range testCases {

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
@@ -21,6 +21,7 @@ func TestAccEventarcMessageBus(t *testing.T) {
 		"cryptoKey":        testAccEventarcMessageBus_cryptoKey,
 		"update":           testAccEventarcMessageBus_update,
 		"googleApiSource":  testAccEventarcMessageBus_googleApiSource,
+		"updateGoogleApiSource": testAccEventarcMessageBus_updateGoogleApiSource,
 		"pipeline":         testAccEventarcMessageBus_pipeline,
 		"enrollment":       testAccEventarcMessageBus_enrollment,
 		"updateEnrollment": testAccEventarcMessageBus_updateEnrollment,
@@ -287,6 +288,120 @@ resource "google_eventarc_google_api_source" "primary" {
     log_severity = "DEBUG"
   }
 }
+resource "google_eventarc_message_bus" "message_bus" {
+  location       = "%{region}"
+  message_bus_id = "tf-test-messagebus%{random_suffix}"
+}
+`, context)
+}
+
+// Although this test is defined in resource_eventarc_message_bus_test, it is primarily
+// concerned with testing the GoogleApiSource resource, which depends on a singleton MessageBus.
+//
+// The update test in resource_eventarc_google_api_source_test.go.tmpl depends on
+// beta-only resources (google_project_service_identity) to test all modifiable
+// fields in GoogleApiSource. In GA, it's not possible for us to test updating
+// the message_bus field, so we have the simpler test definition below with a
+// singleton MessageBus.
+func testAccEventarcMessageBus_updateGoogleApiSource(t *testing.T) {
+	region := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"project_number": envvar.GetTestProjectNumberFromEnv(),
+		"key1":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-googleapisource-key1").CryptoKey.Name,
+		"key2":           acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", region, "tf-bootstrap-eventarc-googleapisource-key2").CryptoKey.Name,
+		"region":         region,
+		"random_suffix":  acctest.RandString(t, 10),
+	}
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-eventarc.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckEventarcMessageBusDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEventarcMessageBus_googleApiSourceCfg(context),
+			},
+			{
+				ResourceName:            "google_eventarc_google_api_source.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "annotations"},
+			},
+			{
+				Config: testAccEventarcMessageBus_updateGoogleApiSourceCfg(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_eventarc_google_api_source.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_eventarc_google_api_source.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "annotations"},
+			},
+			{
+				Config: testAccEventarcMessageBus_unsetGoogleApiSourceCfg(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_eventarc_google_api_source.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_eventarc_google_api_source.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "annotations"},
+			},
+		},
+	})
+}
+
+func testAccEventarcMessageBus_updateGoogleApiSourceCfg(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_eventarc_google_api_source" "primary" {
+  location             = "%{region}"
+  google_api_source_id = "tf-test-googleapisource%{random_suffix}"
+  display_name         = "updated google api source"
+  destination          = google_eventarc_message_bus.message_bus.id
+  crypto_key_name      = "%{key2}"
+  labels = {
+    updated_label = "updated-test-eventarc-label"
+  }
+  annotations = {
+    updated_test_annotation = "updated-test-eventarc-annotation"
+  }
+  logging_config {
+    log_severity = "ALERT"
+  }
+}
+
+resource "google_eventarc_message_bus" "message_bus" {
+  location       = "%{region}"
+  message_bus_id = "tf-test-messagebus%{random_suffix}"
+}
+`, context)
+}
+
+func testAccEventarcMessageBus_unsetGoogleApiSourceCfg(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_eventarc_google_api_source" "primary" {
+  location             = "%{region}"
+  google_api_source_id = "tf-test-googleapisource%{random_suffix}"
+  destination          = google_eventarc_message_bus.message_bus.id
+  logging_config {
+    log_severity = "NONE"
+  }
+}
+
 resource "google_eventarc_message_bus" "message_bus" {
   location       = "%{region}"
   message_bus_id = "tf-test-messagebus%{random_suffix}"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21773

Marks the full GoogleApiSource update test as beta-only, since it relies on the beta-only resource `google_project_service_identity`. Adds a GA test for GoogleApiSource update without updating the message_bus field, which can only be done in the beta-only test.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
