### PR TITLE
Remove beta launch stage from cloudrunv2_service_gpu example

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
@@ -19,6 +19,7 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
     node_selector {
       accelerator = "nvidia-l4"
     }
+    gpu_zonal_redundancy_disabled = true
     scaling {
       max_instance_count = 1
     }

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
@@ -3,7 +3,6 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
-  launch_stage = "BETA"
 
   template {
     containers {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fix https://github.com/hashicorp/terraform-provider-google/issues/22067.

The GPU feature no longer requires beta launch stage.
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
