### PR TITLE
Set a default value for envs in Cloud Run Job

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -349,6 +349,10 @@ properties:
                         required: true
                       - name: 'value'
                         type: String
+                        # env is a set.
+                        # The env.value has value "" in Terraform state, but it has value nil in Terraform plan,
+                        # which causes the diffs for unchanged env. default_value: "" is to suppress the diffs.
+                        default_value: ""
                         description: |-
                           Literal value of the environment variable. Defaults to "" and the maximum allowed length is 32768 characters. Variable references are not supported in Cloud Run.
                         # exactly_one_of:


### PR DESCRIPTION
What?
- Make a similar change to https://github.com/GoogleCloudPlatform/magic-modules/pull/13363 but for the `google_cloud_run_v2_job` resource.
  - Fixes https://github.com/hashicorp/terraform-provider-google/issues/7467
  - Fixes https://github.com/hashicorp/terraform-provider-google/issues/10634


Why?
- Currently, when a new env variable is added to the `env` set, the `env` set is re-ordered which results in a large diff, see https://github.com/hashicorp/terraform-provider-google/issues/7467 for an example. The cause for this seems to be that in the Terraform state the env `value` is `""` when using a `value_source` (i.e. a reference to a `google_secret_manager_secret`), but in the plan the value is `nil` (as it has not been set), which then triggers all of the envs to have changed.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudrunv2: fixed the diffs for unchanged `template.template.containers.env` in `google_cloud_run_v2_job` resource
```
