### PR TITLE
compute: Documented empty string for `load_balancing_scheme`

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -368,6 +368,10 @@ properties:
     description: |
       Specifies the forwarding rule type.
 
+      Note that an empty string value (`""`) is also supported for some use
+      cases, for example PSC (private service connection) regional forwarding
+      rules.
+
       For more information about forwarding rules, refer to
       [Forwarding rule concepts](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts).
     default_value: "EXTERNAL"


### PR DESCRIPTION
While it's not listed in the possible enum values, empty string is also used in certain situations as a valid value for a
compute_forwarding_rule's `load_balancing_scheme`. Since the valid values are auto-generated, add a note about the empty string as well.

This can be confusing, since using `null` or unsetting the value will result in the default (`"EXTERNAL"`).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22098

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
