### PR TITLE
Strip redundant information from descriptions in autogen resources

### DIFF
--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -304,7 +304,7 @@ func parseOpenApi(resourcePath, resourceName string, root *openapi3.T) []any {
 		if strings.TrimSpace(description) == "" {
 			description = "No description"
 		}
-		paramObj.Description = trimSpacesFromDescription(description)
+		paramObj.Description = trimDescription(description)
 
 		if param.Value.Name == "requestId" || param.Value.Name == "validateOnly" || paramObj.Name == "" {
 			continue
@@ -410,7 +410,7 @@ func writeObject(name string, obj *openapi3.SchemaRef, objType openapi3.Types, u
 		description = "No description"
 	}
 
-	field.Description = trimSpacesFromDescription(description)
+	field.Description = trimDescription(description)
 
 	if urlParam {
 		field.UrlParamOnly = true
@@ -451,7 +451,12 @@ func buildProperties(props openapi3.Schemas, required []string) []*api.Type {
 
 // Trims whitespace from the ends of lines in a description to force multiline
 // formatting for strings with newlines present
-func trimSpacesFromDescription(description string) string {
+// Also trim "Output only." and "Required." from descriptions as this gets duplicated
+func trimDescription(description string) string {
+	description, _ = strings.CutPrefix(description, "Optional. ")
+	description, _ = strings.CutPrefix(description, "Output only. ")
+	description, _ = strings.CutPrefix(description, "Required. ")
+	description, _ = strings.CutPrefix(description, "Immutable. ")
 	lines := strings.Split(description, "\n")
 	var trimmedDescription []string
 	for _, line := range lines {

--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -456,7 +456,6 @@ func trimDescription(description string) string {
 	description, _ = strings.CutPrefix(description, "Optional. ")
 	description, _ = strings.CutPrefix(description, "Output only. ")
 	description, _ = strings.CutPrefix(description, "Required. ")
-	description, _ = strings.CutPrefix(description, "Immutable. ")
 	lines := strings.Split(description, "\n")
 	var trimmedDescription []string
 	for _, line := range lines {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Remove boilerplate from descriptions. This gets autogenerated in here during OpenAPI creation, and we add it again during MMv1 generation, so strip it before we make the MMv1 YAML

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
