### PR TITLE
Add enable_advanced_cluster to VMware user and  admin cluster resources.

### DIFF
--- a/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
@@ -690,4 +690,4 @@ properties:
   - type: Boolean
     name: enableAdvancedCluster
     description: If set, the advanced cluster feature is enabled.
-    output: true 
+    output: true

--- a/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
@@ -687,3 +687,7 @@ properties:
               type: String
               description: The lifecycle state of the condition.
               output: true
+  - type: Boolean
+    name: enableAdvancedCluster
+    description: If set, the advanced cluster feature is enabled.
+    output: true 

--- a/mmv1/products/gkeonprem/VmwareCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareCluster.yaml
@@ -554,6 +554,9 @@ properties:
   - name: 'enableControlPlaneV2'
     type: Boolean
     description: Enable control plane V2. Default to false.
+  - name: 'enableAdvancedCluster'
+    type: Boolean
+    description: Enable advanced cluster. Default to false.
   - name: 'disableBundledIngress'
     type: Boolean
     description: Disable bundled ingress.

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.tmpl
@@ -73,6 +73,7 @@ resource "google_gkeonprem_vmware_cluster" "{{$.PrimaryResourceId}}" {
   }
   vm_tracking_enabled = true
   enable_control_plane_v2 = true
+  enable_advanced_cluster = true
   upgrade_policy {
     control_plane_only = true
   }

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go.tmpl
@@ -371,6 +371,7 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLbStart(context map[
     }
     vm_tracking_enabled = true
     enable_control_plane_v2 = true
+    enable_advanced_cluster = true
     disable_bundled_ingress = true
     upgrade_policy {
       control_plane_only = true


### PR DESCRIPTION
Change-Id: Iea318acb481ea03264273b8ceb83d3ac8203cd71

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
gkeonprem: added `enable_advanced_cluster` field to `google_gkeonprem_vmware_cluster` resource
```

```release-note:enhancement
gkeonprem: added `enable_advanced_cluster` field to `google_gkeonprem_vmware_admin_cluster` resource
```
