### PR TITLE
Strip immutable from descriptions in autogen resources

### DIFF
--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -456,6 +456,7 @@ func trimDescription(description string) string {
 	description, _ = strings.CutPrefix(description, "Optional. ")
 	description, _ = strings.CutPrefix(description, "Output only. ")
 	description, _ = strings.CutPrefix(description, "Required. ")
+	description, _ = strings.CutPrefix(description, "Immutable. ")
 	lines := strings.Split(description, "\n")
 	var trimmedDescription []string
 	for _, line := range lines {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/13492 - after thinking about it some more, we should just have this in place - regardless of what we're generating from MMv1 today - so that we don't have to go in and fix them later if/when we start generating that string from MMv1.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
