### PR TITLE
Add deletion_protection field to Metastore Service

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -32,6 +32,16 @@ timeouts:
   update_minutes: 75
   delete_minutes: 75
 autogen_async: true
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the service. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the service will fail.
+    type: Boolean
+    default_value: false
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: 'templates/terraform/pre_delete/metastore_service.go.tmpl'
 async:
   actions: ['create', 'delete', 'update']
   type: 'OpAsync'
@@ -57,6 +67,8 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-srv%s", context["random_suffix"])'
     vars:
       metastore_service_name: 'metastore-srv'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'dataproc_metastore_service_deletion_protection'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-srv%s", context["random_suffix"])'

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.tmpl
@@ -16,4 +16,5 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
   labels = {
     env = "test"
   }
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/metastore_service.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/metastore_service.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy metastore service without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.tmpl
@@ -3,6 +3,7 @@ package dataprocmetastore_test
 import (
 	"fmt"
 	"testing"
+	"regexp"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,6 +26,7 @@ func TestAccDataprocMetastoreService_updateAndImport(t *testing.T) {
 				ResourceName:      "google_dataproc_metastore_service.my_metastore",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccDataprocMetastoreService_updateAndImport(name, tier[1]),
@@ -33,6 +35,7 @@ func TestAccDataprocMetastoreService_updateAndImport(t *testing.T) {
 				ResourceName:      "google_dataproc_metastore_service.my_metastore",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -44,6 +47,7 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 	service_id = "%s"
 	location   = "us-central1"
 	tier       = "%s"
+	deletion_protection = false
 
 	hive_metastore_config {
 		version = "2.3.6"
@@ -166,4 +170,48 @@ resource "google_storage_bucket" "bucket" {
   location = "us-central1"
 }
 `, context)
+}
+
+func TestAccDataprocMetastoreService_updateLocation_deletionProtection(t *testing.T) {
+        t.Parallel()
+
+        name := "tf-test-metastore-" + acctest.RandString(t, 10)
+        tier := [2]string{"DEVELOPER", "ENTERPRISE"}
+
+        acctest.VcrTest(t, resource.TestCase{
+                PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+                ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccDataprocMetastoreService_updateLocation_deletionProtection(name, "us-central1", tier[0]),
+                        },
+                        {
+                                ResourceName:            "google_dataproc_metastore_service.my_metastore",
+                                ImportState:             true,
+                                ImportStateVerify:       true,
+                                ImportStateVerifyIgnore: []string{"deletion_protection"},
+                        },
+                        {
+                                Config: testAccDataprocMetastoreService_updateLocation_deletionProtection(name, "us-west2", tier[1]),
+                                ExpectError: regexp.MustCompile("deletion_protection"),
+                        },
+                        {
+                                Config: testAccDataprocMetastoreService_updateAndImport(name, tier[0]),
+                        },
+                },
+        })
+}
+
+func testAccDataprocMetastoreService_updateLocation_deletionProtection(name, location, tier string) string {
+        return fmt.Sprintf(`
+resource "google_dataproc_metastore_service" "my_metastore" {
+        service_id = "%s"
+        location   = "%s"
+        tier       = "%s"
+        deletion_protection = true
+        hive_metastore_config {
+                version = "2.3.6"
+        }
+}
+`, name, location, tier)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/366197455

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
Metastore: added `deletion_protection` field to `dataproc_metastore_service` to make deleting them require an explicit intent. `google_active_directory_domain` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```
