### PR TITLE
Make `size` and `labels` updatable for `google_compute_instance` under `initialize_params`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -296,7 +297,6 @@ func ResourceComputeInstance() *schema.Resource {
 										Optional:     true,
 										AtLeastOneOf: initializeParamsKeys,
 										Computed:     true,
-										ForceNew:     true,
 										ValidateFunc: validation.IntAtLeast(1),
 										Description:  `The size of the image in gigabytes.`,
 									},
@@ -325,7 +325,6 @@ func ResourceComputeInstance() *schema.Resource {
 										Optional:     true,
 										AtLeastOneOf: initializeParamsKeys,
 										Computed:     true,
-										ForceNew:     true,
 										Description:  `A set of key/value label pairs assigned to the disk.`,
 									},
 
@@ -2508,6 +2507,41 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
+	if d.HasChange("boot_disk") {
+		//default behavior for the disk is to have the same name as the instance
+		diskName := instance.Name
+		if v := tpgresource.GetResourceNameFromSelfLink(d.Get("boot_disk.0.source").(string)); v != diskName {
+			diskName = v
+		}
+
+		disk, err := config.NewComputeClient(userAgent).Disks.Get(project, zone, diskName).Do()
+		if err != nil {
+			return fmt.Errorf("Error getting boot disk: %s", err)
+		}
+
+		obj := make(map[string]interface{})
+
+		if d.HasChange("boot_disk.0.initialize_params") {
+			if d.HasChange("boot_disk.0.initialize_params.0.size") {
+				obj["sizeGb"] = d.Get("boot_disk.0.initialize_params.0.size").(int)
+				url := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/disks/{{"{{"}}name{{"}}"}}/resize"
+				err := updateDisk(d, config, userAgent, project, url, obj)
+				if err != nil {
+					return err
+				}
+			}
+			if d.HasChange("boot_disk.0.initialize_params.0.labels") {
+				obj["labels"] = tpgresource.ConvertStringMap(d.Get("boot_disk.0.initialize_params.0.labels").(map[string]interface{}))
+				obj["labelFingerprint"] = disk.LabelFingerprint
+				url := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/disks/{{"{{"}}name{{"}}"}}/setLabels"
+				err := updateDisk(d, config, userAgent, project, url, obj)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	if d.HasChange("attached_disk") {
 		o, n := d.GetChange("attached_disk")
 
@@ -3539,3 +3573,37 @@ func CheckForCommonAliasIp(old, new *compute.NetworkInterface) []*compute.AliasI
 	}
 	return resultAliasIpRanges
 }
+
+func updateDisk(d *schema.ResourceData, config *transport_tpg.Config, userAgent, project, patchUrl string, obj map[string]interface{}) error {
+	billingProject := project
+	url, err := tpgresource.ReplaceVars(d, config, patchUrl)
+	if err != nil {
+		return err
+	}
+	headers := make(http.Header)
+	if bp, err := tpgresource.GetBillingProject(d, config); err != nil {
+		billingProject = bp
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating Disk %q: %s", d.Id(), err)
+	}
+	err = ComputeOperationWaitTime(
+		config, res, project, "Updating Disk", userAgent,
+		d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -919,6 +919,45 @@ func TestAccComputeInstance_attachedDisk_modeRo(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_bootDiskUpdate(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	context1 := map[string]interface{}{
+		"instance_name": fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"disk_size":     10,
+		"labels":        "bar",
+	}
+
+	context2 := map[string]interface{}{
+		"instance_name": context1["instance_name"].(string),
+		"disk_size":     20,
+		"labels":        "baz",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bootDiskUpdate(context1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_bootDiskUpdate(context2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_attachedDiskUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -6984,6 +7023,35 @@ resource "google_compute_resource_policy" "instance_schedule2" {
   }
 }
 `, instance, schedule1, schedule2)
+}
+
+func testAccComputeInstance_bootDiskUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+	initialize_params {
+	  image = data.google_compute_image.my_image.self_link
+	  size = %{disk_size}
+	  labels = {
+		  "foo" = "%{labels}"
+	  }
+	}
+  }
+
+  network_interface {
+	network = "default"
+  }
+}
+`, context)
 }
 
 func testAccComputeInstance_attachedDisk(disk, instance string) string {


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/6087
closes https://github.com/hashicorp/terraform-provider-google/issues/17044
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: size and labels under initialize_params are now updatable on `google_compute_instance`
```
