### PR TITLE
Made add-resource always show current year

### DIFF
--- a/docs/content/develop/add-resource.md
+++ b/docs/content/develop/add-resource.md
@@ -50,7 +50,7 @@ For more information about types of resources and the generation process overall
 1. Using an editor of your choice, in the appropriate [product folder]({{<ref "/#mmv1" >}}), create a file called `RESOURCE_NAME.yaml`. Replace `RESOURCE_NAME` with the name of the API resource you are adding support for. For example, a configuration file for [NatAddress](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.instances.natAddresses) would be called `NatAddress.yaml`.
 2. Copy the following template into the new file:
    ```yaml
-   # Copyright 2024 Google Inc.
+   # Copyright {{< now >}} Google Inc.
    # Licensed under the Apache License, Version 2.0 (the "License");
    # you may not use this file except in compliance with the License.
    # You may obtain a copy of the License at

--- a/docs/layouts/shortcodes/now.html
+++ b/docs/layouts/shortcodes/now.html
@@ -1,0 +1,1 @@
+{{ time.Now.Year }}


### PR DESCRIPTION
Technically this is the current build year, but since we build the docs on every merge to main it should be good enough

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

<img width="756" alt="Screenshot 2025-04-01 at 9 43 31 AM" src="https://github.com/user-attachments/assets/faf5bcb2-4b21-4edd-b707-3998f2ba4e16" />

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
