### PR TITLE
Add ddl update criteria to google_spanner_database docs

### DIFF
--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -117,10 +117,16 @@ properties:
   - name: 'ddl'
     type: Array
     description: |
-      An optional list of DDL statements to run inside the newly created
-      database. Statements can create tables, indexes, etc. These statements
-      execute atomically with the creation of the database: if there is an
-      error in any statement, the database is not created.
+      An optional list of DDL statements to run inside the database. Statements can create
+      tables, indexes, etc.
+      
+      During creation these statements execute atomically with the creation of the database
+      and if there is an error in any statement, the database is not created.
+
+      Terraform does not perform drift detection on this field and assumes that the values
+      recorded in state are accurate. Limited updates to this field are supported, and
+      newly appended DDL statements can be executed in an update. However, modifications
+      to prior statements will create a plan that marks the resource for recreation.
     api_name: extraStatements
     ignore_read: true
     update_url: 'projects/{{project}}/instances/{{instance}}/databases/{{name}}/ddl'

--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -119,7 +119,7 @@ properties:
     description: |
       An optional list of DDL statements to run inside the database. Statements can create
       tables, indexes, etc.
-      
+
       During creation these statements execute atomically with the creation of the database
       and if there is an error in any statement, the database is not created.
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14094

Debated adding a "complex case" workflow recommendation of using gcloud to make changes, marking `lifecycle.ignore_changes` in Terraform, and calling https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases/getDdl to record the creation statements in Terraform, but that should probably live in a c.g.c guide instead of the field ref.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
