### PR TITLE
Add initial variant patterns

### DIFF
--- a/docs/content/reference/metadata.md
+++ b/docs/content/reference/metadata.md
@@ -31,6 +31,10 @@ The version of the API used for this resource e.g., "v2".
 
 The API "resource type kind" used for this resource e.g., "Function".
 
+### `api_variant_patterns`
+
+The API URL patterns used by this resource that represent variants e.g., "folders/{folder}/feeds/{feed}". Each pattern must match the value defined in the API exactly. The use of `api_variant_patterns` is only meaningful when the resource type has multiple parent types available.
+
 ### `fields`
 
 The list of fields used by this resource. Each field can contain the following attributes:

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -341,6 +341,14 @@ type Resource struct {
 	// fine-grained resources and legacy resources.
 	ApiResourceTypeKind string `yaml:"api_resource_type_kind,omitempty"`
 
+	// The API URL patterns used by this resource that represent variants e.g.,
+	// "folders/{folder}/feeds/{feed}". Each pattern must match the value
+	// defined in the API exactly. The use of `api_variant_patterns` is only
+	// meaningful when the resource type has multiple parent types available.
+	// This is commonly used for resources that have a project, folder, and
+	// organization variant, however most resources do not need it.
+	ApiVariantPatterns []string `yaml:"api_variant_patterns,omitempty"`
+
 	ImportPath     string `yaml:"-"`
 	SourceYamlFile string `yaml:"-"`
 }

--- a/mmv1/products/accessapproval/FolderSettings.yaml
+++ b/mmv1/products/accessapproval/FolderSettings.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderSettings'
 api_resource_type_kind: AccessApprovalSettings
+api_variant_patterns:
+  - 'folders/{folder}/accessApprovalSettings'
 legacy_name: 'google_folder_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/accessapproval/OrganizationSettings.yaml
+++ b/mmv1/products/accessapproval/OrganizationSettings.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSettings'
 api_resource_type_kind: AccessApprovalSettings
+api_variant_patterns:
+  - 'organizations/{organization}/accessApprovalSettings'
 legacy_name: 'google_organization_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/accessapproval/ProjectSettings.yaml
+++ b/mmv1/products/accessapproval/ProjectSettings.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectSettings'
 api_resource_type_kind: AccessApprovalSettings
+api_variant_patterns:
+  - 'projects/{project}/accessApprovalSettings'
 legacy_name: 'google_project_access_approval_settings'
 description: |
   Access Approval enables you to require your explicit approval whenever Google support and engineering need to access your customer content.

--- a/mmv1/products/apihub/HostProjectRegistration.yaml
+++ b/mmv1/products/apihub/HostProjectRegistration.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: HostProjectRegistration
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/hostProjectRegistrations/{hostproject}'
 description: |-
   Host project registration refers to the registration of a Google cloud project with API hub as a host project.
   This is the project where API hub is provisioned.

--- a/mmv1/products/apphub/Service.yaml
+++ b/mmv1/products/apphub/Service.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Service'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/applications/{application}/services/{service}'
 description: 'Service is a network/api interface that exposes some functionality to clients for consumption over the network.
   Service typically has one or more Workloads behind it. It registers identified service to the Application.'
 docs:

--- a/mmv1/products/apphub/Workload.yaml
+++ b/mmv1/products/apphub/Workload.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Workload'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/applications/{application}/workloads/{workload}'
 description: 'Workload represents a binary deployment (such as Managed Instance Groups (MIGs), GKE deployments, etc.) that performs the smallest logical subset of business functionality.
   It registers identified workload to the Application.'
 docs:

--- a/mmv1/products/cloudasset/FolderFeed.yaml
+++ b/mmv1/products/cloudasset/FolderFeed.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderFeed'
 api_resource_type_kind: Feed
+api_variant_patterns:
+  - 'folders/{folder}/feeds/{feed}'
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudasset/OrganizationFeed.yaml
+++ b/mmv1/products/cloudasset/OrganizationFeed.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationFeed'
 api_resource_type_kind: Feed
+api_variant_patterns:
+  - 'organizations/{organization}/feeds/{feed}'
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudasset/ProjectFeed.yaml
+++ b/mmv1/products/cloudasset/ProjectFeed.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectFeed'
 api_resource_type_kind: Feed
+api_variant_patterns:
+  - 'projects/{project}/feeds/{feed}'
 description: |
   Describes a Cloud Asset Inventory feed used to to listen to asset updates.
 references:

--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'Trigger'
 api_resource_type_kind: BuildTrigger
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/triggers/{trigger}'
 description: |
   Configuration for an automated build in response to source repository changes.
 references:

--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Autoscaler'
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/autoscalers/{autoscaler}'
 kind: 'compute#autoscaler'
 description: |
   Represents an Autoscaler resource.

--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'ForwardingRule'
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/forwardingRules/{forwardingRule}'
 kind: 'compute#forwardingRule'
 description: |
   A ForwardingRule resource. A ForwardingRule resource specifies which pool

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'GlobalForwardingRule'
 api_resource_type_kind: ForwardingRule
+api_variant_patterns:
+  - 'projects/{project}/global/forwardingRules/{forwardingRule}'
 kind: 'compute#forwardingRule'
 description: |
   Represents a GlobalForwardingRule resource. Global forwarding rules are

--- a/mmv1/products/compute/HealthCheck.yaml
+++ b/mmv1/products/compute/HealthCheck.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'HealthCheck'
+api_variant_patterns:
+  - 'projects/{project}/global/healthChecks/{healthCheck}'
 kind: 'compute#healthCheck'
 description: |
   Health Checks determine whether instances are responsive and able to do work.

--- a/mmv1/products/compute/InstanceGroupMembership.yaml
+++ b/mmv1/products/compute/InstanceGroupMembership.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'InstanceGroupMembership'
 api_resource_type_kind: InstanceGroup
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}'
 kind: 'compute#instanceGroup'
 description: |
   Represents the Instance membership to the Instance Group.

--- a/mmv1/products/compute/InstanceGroupNamedPort.yaml
+++ b/mmv1/products/compute/InstanceGroupNamedPort.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'InstanceGroupNamedPort'
 api_resource_type_kind: InstanceGroup
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}'
 description: |
   Mange the named ports setting for a managed instance group without
   managing the group as whole. This resource is primarily intended for use

--- a/mmv1/products/compute/InstantSnapshot.yaml
+++ b/mmv1/products/compute/InstantSnapshot.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'InstantSnapshot'
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instantSnapshots/{instantSnapshot}'
 kind: 'compute#instantSnapshot'
 description: |
   Represents an instant snapshot resource.

--- a/mmv1/products/compute/PerInstanceConfig.yaml
+++ b/mmv1/products/compute/PerInstanceConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'PerInstanceConfig'
 api_resource_type_kind: InstanceGroupManager
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}'
 description: |
   A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
   across instance group manager operations and can define stateful disks or metadata that are unique to the instance.

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'RegionAutoscaler'
 api_resource_type_kind: Autoscaler
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/autoscalers/{autoscaler}'
 kind: 'compute#autoscaler'
 description: |
   Represents an Autoscaler resource.

--- a/mmv1/products/compute/RegionHealthCheck.yaml
+++ b/mmv1/products/compute/RegionHealthCheck.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'RegionHealthCheck'
 api_resource_type_kind: HealthCheck
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/healthChecks/{healthCheck}'
 kind: 'compute#healthCheck'
 description: |
   Health Checks determine whether instances are responsive and able to do work.

--- a/mmv1/products/compute/RegionInstanceGroupManager.yaml
+++ b/mmv1/products/compute/RegionInstanceGroupManager.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'RegionInstanceGroupManager'
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
 kind: 'compute#instanceGroupManager'
 description: |
   Creates a managed instance group using the information that you specify in

--- a/mmv1/products/compute/RegionPerInstanceConfig.yaml
+++ b/mmv1/products/compute/RegionPerInstanceConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'RegionPerInstanceConfig'
 api_resource_type_kind: InstanceGroupManager
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
 description: |
   A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
   across instance group manager operations and can define stateful disks or metadata that are unique to the instance.

--- a/mmv1/products/dataproc/AutoscalingPolicy.yaml
+++ b/mmv1/products/dataproc/AutoscalingPolicy.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'AutoscalingPolicy'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/autoscalingPolicies/{autoscalingPolicy}'
 description: |
   Describes an autoscaling policy for Dataproc cluster autoscaler.
 docs:

--- a/mmv1/products/dataproc/Batch.yaml
+++ b/mmv1/products/dataproc/Batch.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Batch'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/batches/{batch}'
 description: |
   Dataproc Serverless Batches lets you run Spark workloads without requiring you to
   provision and manage your own Dataproc cluster.

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'DataStore'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore}'
 description: |
   Data store is a collection of websites and documents used to find answers for
   end-user's questions in Discovery Engine (a.k.a. Vertex AI Search and

--- a/mmv1/products/discoveryengine/Schema.yaml
+++ b/mmv1/products/discoveryengine/Schema.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Schema'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore}/schemas/{schema}'
 description: |
   Schema defines the structure and layout of a type of document data.
 references:

--- a/mmv1/products/discoveryengine/TargetSite.yaml
+++ b/mmv1/products/discoveryengine/TargetSite.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'TargetSite'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore}/siteSearchEngine/targetSites/{targetSite}'
 description: |
   TargetSite represents a URI pattern that the users want to confine their
   search.

--- a/mmv1/products/documentaiwarehouse/DocumentSchema.yaml
+++ b/mmv1/products/documentaiwarehouse/DocumentSchema.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'DocumentSchema'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/documentSchemas/{documentSchema}'
 description: |
   A document schema is used to define document structure.
 references:

--- a/mmv1/products/essentialcontacts/Contact.yaml
+++ b/mmv1/products/essentialcontacts/Contact.yaml
@@ -13,6 +13,10 @@
 
 ---
 name: 'Contact'
+api_variant_patterns:
+  - 'folders/{folder}/contacts/{contact}'
+  - 'organizations/{organization}/contacts/{contact}'
+  - 'projects/{project}/contacts/{contact}'
 description: |
   A contact that will receive notifications from Google Cloud.
 references:

--- a/mmv1/products/firebaseappcheck/RecaptchaV3Config.yaml
+++ b/mmv1/products/firebaseappcheck/RecaptchaV3Config.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'RecaptchaV3Config'
 api_resource_type_kind: RecaptchaConfig
+api_variant_patterns:
+  - 'projects/{project}/apps/{app}/recaptchaV3Config'
 description: |
   An app's reCAPTCHA V3 configuration object.
 references:

--- a/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
+++ b/mmv1/products/gemini/DataSharingWithGoogleSettingBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: DataSharingWithGoogleSettingBinding
 api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/dataSharingWithGoogleSettings/{dataSharingWithGoogleSetting}/settingBindings/{settingBinding}'
 description: The resource for managing DataSharingWithGoogle setting bindings for Admin Control.
 references:
   guides:

--- a/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSettingBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: GeminiGcpEnablementSettingBinding
 api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/geminiGcpEnablementSettings/{geminiGcpEnablementSetting}/settingBindings/{settingBinding}'
 description: The resource for managing GeminiGcpEnablementSetting setting bindings for Admin Control.
 references:
   guides:

--- a/mmv1/products/gemini/LoggingSettingBinding.yaml
+++ b/mmv1/products/gemini/LoggingSettingBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: LoggingSettingBinding
 api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/loggingSettings/{loggingSetting}/settingBindings/{settingBinding}'
 description: The resource for managing Logging setting bindings for Admin Control.
 references:
   guides:

--- a/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
+++ b/mmv1/products/gemini/ReleaseChannelSettingBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: ReleaseChannelSettingBinding
 api_resource_type_kind: SettingBinding
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/releaseChannelSettings/{releaseChannelSetting}/settingBindings/{settingBinding}'
 description: The resource for managing ReleaseChannel setting bindings for Admin Control.
 references:
   guides:

--- a/mmv1/products/iam3/FoldersPolicyBinding.yaml
+++ b/mmv1/products/iam3/FoldersPolicyBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FoldersPolicyBinding'
 api_resource_type_kind: PolicyBinding
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/policyBindings/{policyBinding}'
 description: |
   A policy binding to a folder. This is a Terraform resource, and maps to a policy binding resource in GCP.
 references:

--- a/mmv1/products/iam3/OrganizationsPolicyBinding.yaml
+++ b/mmv1/products/iam3/OrganizationsPolicyBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationsPolicyBinding'
 api_resource_type_kind: PolicyBinding
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/policyBindings/{policyBinding}'
 description: |
   A policy binding to an organization. This is a Terraform resource, and maps to a policy binding resource in GCP.
 references:

--- a/mmv1/products/iam3/ProjectsPolicyBinding.yaml
+++ b/mmv1/products/iam3/ProjectsPolicyBinding.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectsPolicyBinding'
 api_resource_type_kind: PolicyBinding
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/policyBindings/{policyBinding}'
 description: |
   A policy binding to a project. This is a Terraform resource, and maps to a policy binding resource in GCP.
 references:

--- a/mmv1/products/integrations/AuthConfig.yaml
+++ b/mmv1/products/integrations/AuthConfig.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'AuthConfig'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/authConfigs/{authConfig}'
 description: |
   The AuthConfig resource use to hold channels and connection config data.
 references:

--- a/mmv1/products/logging/FolderSettings.yaml
+++ b/mmv1/products/logging/FolderSettings.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderSettings'
 api_resource_type_kind: Settings
+api_variant_patterns:
+  - 'folders/{folder}/settings'
 description: |
   Default resource settings control whether CMEK is required for new log buckets. These settings also determine the storage location for the _Default and _Required log buckets, and whether the _Default sink is enabled or disabled.
 references:

--- a/mmv1/products/logging/LinkedDataset.yaml
+++ b/mmv1/products/logging/LinkedDataset.yaml
@@ -14,6 +14,11 @@
 ---
 name: 'LinkedDataset'
 api_resource_type_kind: Link
+api_variant_patterns:
+  - 'billingAccounts/{billingAccount}/locations/{location}/buckets/{bucket}/links/{link}'
+  - 'folders/{folder}/locations/{location}/buckets/{bucket}/links/{link}'
+  - 'organizations/{organization}/locations/{location}/buckets/{bucket}/links/{link}'
+  - 'projects/{project}/locations/{location}/buckets/{bucket}/links/{link}'
 description: |
   Describes a BigQuery linked dataset
 references:

--- a/mmv1/products/logging/LogView.yaml
+++ b/mmv1/products/logging/LogView.yaml
@@ -13,6 +13,11 @@
 
 ---
 name: 'LogView'
+api_variant_patterns:
+  - 'billingAccounts/{billingAccount}/locations/{location}/buckets/{bucket}/views/{view}'
+  - 'folders/{folder}/locations/{location}/buckets/{bucket}/views/{view}'
+  - 'organizations/{organization}/locations/{location}/buckets/{bucket}/views/{view}'
+  - 'projects/{project}/locations/{location}/buckets/{bucket}/views/{view}'
 description: 'Describes a view over log entries in a bucket.'
 references:
   guides:

--- a/mmv1/products/logging/OrganizationSettings.yaml
+++ b/mmv1/products/logging/OrganizationSettings.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSettings'
 api_resource_type_kind: Settings
+api_variant_patterns:
+  - 'organizations/{organization}/settings'
 description: |
   Default resource settings control whether CMEK is required for new log buckets. These settings also determine the storage location for the _Default and _Required log buckets, and whether the _Default sink is enabled or disabled.
 references:

--- a/mmv1/products/netapp/Backup.yaml
+++ b/mmv1/products/netapp/Backup.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Backup'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/backupVaults/{backupVault}/backups/{backup}'
 description: |
   NetApp Volumes supports volume backups, which are copies of your volumes
   stored independently from the volume. Backups are stored in backup vaults,

--- a/mmv1/products/orgpolicy/Policy.yaml
+++ b/mmv1/products/orgpolicy/Policy.yaml
@@ -13,6 +13,10 @@
 
 ---
 name: 'Policy'
+api_variant_patterns:
+  - 'folders/{folder}/policies/{policy}'
+  - 'organizations/{organization}/policies/{policy}'
+  - 'projects/{project}/policies/{policy}'
 description: "Defines an organization policy which is used to specify constraints for configurations of Google Cloud resources."
 references:
   guides:

--- a/mmv1/products/osconfig/GuestPolicies.yaml
+++ b/mmv1/products/osconfig/GuestPolicies.yaml
@@ -14,6 +14,10 @@
 ---
 name: 'GuestPolicies'
 api_resource_type_kind: GuestPolicy
+api_variant_patterns:
+  - 'folders/{folder}/guestPolicies/{guestPolicy}'
+  - 'organizations/{organization}/guestPolicies/{guestPolicy}'
+  - 'projects/{project}/guestPolicies/{guestPolicy}'
 description: |
   An OS Config resource representing a guest configuration policy. These policies represent
   the desired state for VM instance guest environments including packages to install or remove,

--- a/mmv1/products/osconfigv2/PolicyOrchestrator.yaml
+++ b/mmv1/products/osconfigv2/PolicyOrchestrator.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: PolicyOrchestrator
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/policyOrchestrators/{policyOrchestrator}'
 description: |
   PolicyOrchestrator helps managing project+zone level policy resources (e.g.
   OS Policy Assignments), by providing tools to create, update and delete them

--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -13,6 +13,10 @@
 
 ---
 name: 'Entitlement'
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/entitlements/{entitlement}'
+  - 'organizations/{organization}/locations/{location}/entitlements/{entitlement}'
+  - 'projects/{project}/locations/{location}/entitlements/{entitlement}'
 description: |
   An Entitlement defines the eligibility of a set of users to obtain a predefined access for some time possibly after going through an approval workflow.
 references:

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Secret'
+api_variant_patterns:
+  - 'projects/{project}/secrets/{secret}'
 description: |
   A Secret is a logical secret whose value and versions can be accessed.
 references:

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'SecretVersion'
+api_variant_patterns:
+  - 'projects/{project}/secrets/{secret}/versions/{version}'
 description: |
   A secret version resource.
 references:

--- a/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycenter/EventThreatDetectionCustomModule.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'EventThreatDetectionCustomModule'
+api_variant_patterns:
+  - 'organizations/{organization}/eventThreatDetectionSettings/customModules/{customModule}'
 description: |
   Represents an instance of an Event Threat Detection custom module, including
   its full module name, display name, enablement state, andlast updated time.

--- a/mmv1/products/securitycenter/FolderCustomModule.yaml
+++ b/mmv1/products/securitycenter/FolderCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'folders/{folder}/securityHealthAnalyticsSettings/customModules/{customModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/FolderNotificationConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderNotificationConfig'
 api_resource_type_kind: NotificationConfig
+api_variant_patterns:
+  - 'folders/{folder}/notificationConfigs/{notificationConfig}'
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenter/FolderSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenter/FolderSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'folders/{folder}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenter/MuteConfig.yaml
+++ b/mmv1/products/securitycenter/MuteConfig.yaml
@@ -13,6 +13,10 @@
 
 ---
 name: 'MuteConfig'
+api_variant_patterns:
+  - 'folders/{folder}/muteConfigs/{muteConfig}'
+  - 'organizations/{organization}/muteConfigs/{muteConfig}'
+  - 'projects/{project}/muteConfigs/{muteConfig}'
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenter/NotificationConfig.yaml
+++ b/mmv1/products/securitycenter/NotificationConfig.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'NotificationConfig'
+api_variant_patterns:
+  - 'organizations/{organization}/notificationConfigs/{notificationConfig}'
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenter/OrganizationCustomModule.yaml
+++ b/mmv1/products/securitycenter/OrganizationCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'organizations/{organization}/securityHealthAnalyticsSettings/customModules/{customModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/OrganizationSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenter/OrganizationSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'organizations/{organization}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenter/ProjectCustomModule.yaml
+++ b/mmv1/products/securitycenter/ProjectCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'projects/{project}/securityHealthAnalyticsSettings/customModules/{customModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenter/ProjectNotificationConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectNotificationConfig'
 api_resource_type_kind: NotificationConfig
+api_variant_patterns:
+  - 'projects/{project}/notificationConfigs/{notificationConfig}'
 description: |
   A Cloud Security Command Center (Cloud SCC) notification configs. A
   notification config is a Cloud SCC resource that contains the

--- a/mmv1/products/securitycenter/ProjectSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenter/ProjectSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'projects/{project}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenter/Source.yaml
+++ b/mmv1/products/securitycenter/Source.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Source'
+api_variant_patterns:
+  - 'organizations/{organization}/sources/{source}'
 description: |
   A Cloud Security Command Center's (Cloud SCC) finding source. A finding
   source is an entity or a mechanism that can produce a finding. A source is

--- a/mmv1/products/securitycentermanagement/FolderSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/FolderSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderSecurityHealthAnalyticsCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/securityHealthAnalyticsCustomModules/{securityHealthAnalyticsCustomModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/OrganizationEventThreatDetectionCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/OrganizationEventThreatDetectionCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationEventThreatDetectionCustomModule'
 api_resource_type_kind: EventThreatDetectionCustomModule
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/eventThreatDetectionCustomModules/{eventThreatDetectionCustomModule}'
 description: |
   Represents an instance of an Event Threat Detection custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/OrganizationSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/OrganizationSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSecurityHealthAnalyticsCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/securityHealthAnalyticsCustomModules/{securityHealthAnalyticsCustomModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycentermanagement/ProjectSecurityHealthAnalyticsCustomModule.yaml
+++ b/mmv1/products/securitycentermanagement/ProjectSecurityHealthAnalyticsCustomModule.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectSecurityHealthAnalyticsCustomModule'
 api_resource_type_kind: SecurityHealthAnalyticsCustomModule
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/securityHealthAnalyticsCustomModules/{securityHealthAnalyticsCustomModule}'
 description: |
   Represents an instance of a Security Health Analytics custom module, including
   its full module name, display name, enablement state, and last updated time.

--- a/mmv1/products/securitycenterv2/FolderMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/FolderMuteConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderMuteConfig'
 api_resource_type_kind: MuteConfig
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/muteConfigs/{muteConfig}'
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/FolderNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/FolderNotificationConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderNotificationConfig'
 api_resource_type_kind: NotificationConfig
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/notificationConfigs/{notificationConfig}'
 description:
   This is a continuous export that exports findings to a Pub/Sub topic.
 references:

--- a/mmv1/products/securitycenterv2/FolderSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/FolderSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FolderSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenterv2/OrganizationMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationMuteConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationMuteConfig'
 api_resource_type_kind: MuteConfig
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/muteConfigs/{muteConfig}'
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/OrganizationNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationNotificationConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationNotificationConfig'
 api_resource_type_kind: NotificationConfig
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/notificationConfigs/{notificationConfig}'
 description:
   This is a continuous export that exports findings to a Pub/Sub topic.
 references:

--- a/mmv1/products/securitycenterv2/OrganizationSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenterv2/OrganizationSccBigQueryExports.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationSccBigQueryExports.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSccBigQueryExports'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securitycenterv2/OrganizationSource.yaml
+++ b/mmv1/products/securitycenterv2/OrganizationSource.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'OrganizationSource'
 api_resource_type_kind: Source
+api_variant_patterns:
+  - 'organizations/{organization}/sources/{source}'
 description: |
   A Cloud Security Command Center's (Cloud SCC) finding source. A finding
   source is an entity or a mechanism that can produce a finding. A source is

--- a/mmv1/products/securitycenterv2/ProjectMuteConfig.yaml
+++ b/mmv1/products/securitycenterv2/ProjectMuteConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectMuteConfig'
 api_resource_type_kind: MuteConfig
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/muteConfigs/{muteConfig}'
 description: |
   Mute Findings is a volume management feature in Security Command Center
   that lets you manually or programmatically hide irrelevant findings,

--- a/mmv1/products/securitycenterv2/ProjectNotificationConfig.yaml
+++ b/mmv1/products/securitycenterv2/ProjectNotificationConfig.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectNotificationConfig'
 api_resource_type_kind: NotificationConfig
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/notificationConfigs/{notificationConfig}'
 description:
   This is a continuous export that exports findings to a Pub/Sub topic.
 references:

--- a/mmv1/products/securitycenterv2/ProjectSccBigQueryExport.yaml
+++ b/mmv1/products/securitycenterv2/ProjectSccBigQueryExport.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'ProjectSccBigQueryExport'
 api_resource_type_kind: BigQueryExport
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/bigQueryExports/{bigQueryExport}'
 description: |
   A Cloud Security Command Center (Cloud SCC) Big Query Export Config.
   It represents exporting Security Command Center data, including assets, findings, and security marks

--- a/mmv1/products/securityposture/PostureDeployment.yaml
+++ b/mmv1/products/securityposture/PostureDeployment.yaml
@@ -13,6 +13,10 @@
 
 ---
 name: 'PostureDeployment'
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/postureDeployments/{postureDeployment}'
+  - 'organizations/{organization}/locations/{location}/postureDeployments/{postureDeployment}'
+  - 'projects/{project}/locations/{location}/postureDeployments/{postureDeployment}'
 description: |
   Represents a deployment of a security posture on a resource. A posture contains user curated policy sets. A posture can
   be deployed on a project or on a folder or on an organization. To deploy a posture we need to populate the posture's name

--- a/mmv1/products/vertexai/Dataset.yaml
+++ b/mmv1/products/vertexai/Dataset.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Dataset'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/datasets/{dataset}'
 description: |-
   A collection of DataItems and Annotations on them.
 references:

--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: 'Endpoint'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/endpoints/{endpoint}'
 description:
   'Models are deployed into it, and afterwards Endpoint is called to obtain
   predictions and explanations.'

--- a/mmv1/products/vertexai/FeatureGroupFeature.yaml
+++ b/mmv1/products/vertexai/FeatureGroupFeature.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FeatureGroupFeature'
 api_resource_type_kind: Feature
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/featureGroups/{featureGroup}/features/{feature}'
 description: Vertex AI Feature Group Feature is feature metadata information.
 references:
   guides:

--- a/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytypeFeature.yaml
@@ -14,6 +14,8 @@
 ---
 name: 'FeaturestoreEntitytypeFeature'
 api_resource_type_kind: Feature
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/featurestores/{featurestore}/entityTypes/{entityType}/features/{feature}'
 description: |-
   Feature Metadata information that describes an attribute of an entity type. For example, apple is an entity type, and color is a feature that describes apple.
 references:

--- a/mmv1/templates/terraform/metadata.yaml.tmpl
+++ b/mmv1/templates/terraform/metadata.yaml.tmpl
@@ -4,6 +4,12 @@ source_file: '{{ $.SourceYamlFile }}'
 api_service_name: '{{ $.ProductMetadata.ServiceName }}'
 api_version: '{{ or $.ProductMetadata.ServiceVersion $.ServiceVersion }}'
 api_resource_type_kind: '{{ or $.ApiResourceTypeKind $.Name }}'
+{{- if gt (len $.ApiVariantPatterns) 0 }}
+api_variant_patterns:
+  {{- range $v := $.ApiVariantPatterns }}
+  - '{{ $v }}'
+  {{- end }}
+{{- end }}
 {{- if $.AutogenStatus }}
 autogen_status: true
 {{- end }}

--- a/mmv1/third_party/terraform/services/assuredworkloads/resource_assured_workloads_workload_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/assuredworkloads/resource_assured_workloads_workload_meta.yaml.tmpl
@@ -7,6 +7,8 @@ api_version: 'v1beta1'
 api_version: 'v1'
 {{- end }}
 api_resource_type_kind: 'Workload'
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/workloads/{workload}'
 fields:
   - field: 'billing_account'
   - field: 'compliance_regime'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
@@ -7,6 +7,8 @@ api_version: 'beta'
 api_version: 'v1'
 {{- end }}
 api_resource_type_kind: 'InstanceGroupManager'
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}'
 fields:
   - field: 'all_instances_config.labels'
   - field: 'all_instances_config.metadata'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_meta.yaml.tmpl
@@ -7,6 +7,8 @@ api_version: 'beta'
 api_version: 'v1'
 {{- end }}
 api_resource_type_kind: 'InstanceGroup'
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroups/{instanceGroup}'
 fields:
   - field: 'description'
   - field: 'instances'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
@@ -7,6 +7,8 @@ api_version: 'beta'
 api_version: 'v1'
 {{- end }}
 api_resource_type_kind: 'InstanceGroupManager'
+api_variant_patterns:
+  - 'projects/{project}/regions/{region}/instanceGroupManagers/{instanceGroupManager}'
 fields:
   - field: 'all_instances_config.labels'
   - field: 'all_instances_config.metadata'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -7,6 +7,8 @@ api_version: 'v1beta1'
 api_version: 'v1'
 {{- end }}
 api_resource_type_kind: 'Cluster'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/clusters/{cluster}'
 fields:
   - field: 'addons_config.cloudrun_config.disabled'
     api_field: 'addons_config.cloud_run_config.disabled'

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_workflow_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_workflow_template_meta.yaml.tmpl
@@ -3,6 +3,8 @@ generation_type: 'dcl'
 api_service_name: 'dataproc.googleapis.com'
 api_version: 'v1'
 api_resource_type_kind: 'WorkflowTemplate'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/workflowTemplates/{workflowTemplate}'
 fields:
   - field: 'create_time'
   - field: 'dag_timeout'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_bucket_config_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_bucket_config_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogBucket'
+api_variant_patterns:
+  - 'billingAccounts/{billingAccount}/locations/{location}/buckets/{bucket}'
 fields:
   - field: 'billing_account'
   - field: 'bucket_id'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_exclusion_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_exclusion_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogExclusion'
+api_variant_patterns:
+  - 'billingAccounts/{billingAccount}/exclusions/{exclusion}'
 fields:
   - field: 'billing_account'
   - field: 'description'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_sink_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_billing_account_sink_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogSink'
+api_variant_patterns:
+  - 'billingAccounts/{billingAccount}/sinks/{sink}'
 fields:
   - field: 'bigquery_options.use_partitioned_tables'
   - field: 'billing_account'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_bucket_config_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_bucket_config_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogBucket'
+api_variant_patterns:
+  - 'folders/{folder}/locations/{location}/buckets/{bucket}'
 fields:
   - field: 'bucket_id'
   - field: 'cmek_settings.kms_key_name'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_exclusion_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_exclusion_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogExclusion'
+api_variant_patterns:
+  - 'folders/{folder}/exclusions/{exclusion}'
 fields:
   - field: 'description'
   - field: 'disabled'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_folder_sink_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogSink'
+api_variant_patterns:
+  - 'folders/{folder}/sinks/{sink}'
 fields:
   - field: 'bigquery_options.use_partitioned_tables'
   - field: 'description'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_bucket_config_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_bucket_config_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogBucket'
+api_variant_patterns:
+  - 'organizations/{organization}/locations/{location}/buckets/{bucket}'
 fields:
   - field: 'bucket_id'
   - field: 'cmek_settings.kms_key_name'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_exclusion_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_exclusion_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogExclusion'
+api_variant_patterns:
+  - 'organizations/{organization}/exclusions/{exclusion}'
 fields:
   - field: 'description'
   - field: 'disabled'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_organization_sink_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogSink'
+api_variant_patterns:
+  - 'organizations/{organization}/sinks/{sink}'
 fields:
   - field: 'bigquery_options.use_partitioned_tables'
   - field: 'description'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_bucket_config_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogBucket'
+api_variant_patterns:
+  - 'projects/{project}/locations/{location}/buckets/{bucket}'
 fields:
   - field: 'bucket_id'
   - field: 'cmek_settings.kms_key_name'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_exclusion_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_exclusion_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogExclusion'
+api_variant_patterns:
+  - 'projects/{project}/exclusions/{exclusion}'
 fields:
   - field: 'description'
   - field: 'disabled'

--- a/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_meta.yaml
+++ b/mmv1/third_party/terraform/services/logging/resource_logging_project_sink_meta.yaml
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'logging.googleapis.com'
 api_version: 'v2'
 api_resource_type_kind: 'LogSink'
+api_variant_patterns:
+  - 'projects/{project}/sinks/{sink}'
 fields:
   - field: 'bigquery_options.use_partitioned_tables'
   - field: 'custom_writer_identity'

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_meta.yaml.tmpl
@@ -3,6 +3,8 @@ generation_type: 'handwritten'
 api_service_name: 'serviceusage.googleapis.com'
 api_version: 'v1'
 api_resource_type_kind: 'Service'
+api_variant_patterns:
+  - 'projects/{project}/services/{service}'
 fields:
 {{- if ne $.TargetVersionName "ga" }}
   - field: 'check_if_service_has_usage_on_destroy'

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_project_service_identity_meta.yaml.tmpl
@@ -4,6 +4,8 @@ generation_type: 'handwritten'
 api_service_name: 'serviceusage.googleapis.com'
 api_version: 'v1'
 api_resource_type_kind: 'Service'
+api_variant_patterns:
+  - 'projects/{project}/services/{service}'
 fields:
   - field: 'email'
   - field: 'member'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds the new `api_variant_patterns` field to mmv1 and metadata yaml files. Its use is described in go/terraform-resource-variant-coverage, which is basically to capture the distinction of resource "variants".

This should capture all variants that we have clear data for, however when we start matching these values to the API, we should be able to see if there are any remaining gaps.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
