### PR TITLE
Pub/Sub - Change Allowed Persistence Regions to Set in 'google_pubsub_topic'

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -130,6 +130,7 @@ properties:
     default_from_api: true
     properties:
       - name: 'allowedPersistenceRegions'
+        is_set: true
         type: Array
         description: |
           A list of IDs of GCP regions where messages that are published to


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21650

This resource field has a permadiff as it stands now. Changing its type to set should resolve this.

NOTE: This is a breaking change, but should be allowed in a minor release [as per the docs](https://googlecloudplatform.github.io/magic-modules/breaking-changes/make-a-breaking-change/#in-minor-releases).
```
