### PR TITLE
Make sure test file is removed after test run

### DIFF
--- a/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
+++ b/mmv1/third_party/terraform/services/storage/data_source_storage_bucket_object_content_test.go
@@ -50,6 +50,7 @@ func TestAccDataSourceStorageBucketObjectContent_FileContentBase64(t *testing.T)
 	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
 		t.Errorf("error writing file: %v", err)
 	}
+	defer os.Remove(testFile.Name()) // clean up
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes b/406422357

Basically, this file is created by the test and never removed. Because of where the file is created, even unit tests will leave the test file around. This is a problem for our internal release jobs because they run unit tests prior to packaging the build, and then hit a permission error when they come across the test file (presumably because it is either owned or permissioned differently).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
