### PR TITLE
Suppress diffs in the Fleet block between null vs {} vs {project = ""}

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2314,7 +2314,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				Description: `Fleet configuration of the cluster.`,
-				DiffSuppressFunc: suppressDiffForPreRegisteredFleet,
+				DiffSuppressFunc: SuppressDiffForPreRegisteredFleet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"encoding/json"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-version"
@@ -132,15 +133,16 @@ var (
 			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)
 			return true
 		}
-		// Suppress if both old and new project fields are empty		
+		// Suppress if both old and new project fields are empty
 		var oldList, newList []map[string]interface{}
-		if err := json.Unmarshal([]byte(old), &oldList); err != nil {
-			return false
-		}
-		if err := json.Unmarshal([]byte(new), &newList); err != nil {
-			return false
-		}
-		
+    		if err := json.Unmarshal([]byte(oldValue), &oldList); err != nil {
+			log.Printf("[DEBUG] fleet suppress error unmarshalling old value: %v", err)
+        		return false
+    		}
+		if err := json.Unmarshal([]byte(newValue), &newList); err != nil {
+			log.Printf("[DEBUG] fleet suppress error unmarshalling old value: %v", err)
+        		return false
+   		}
 		var oldProject, newProject string
 		if len(oldList) == 1 {
 			if p, ok := oldList[0]["project"].(string); ok {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -127,7 +127,7 @@ var (
 		return false
 	})
 
-	suppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	SuppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 		// Suppress if the cluster has been pre registered to fleet.		
 		if v, _ := d.Get("fleet.0.pre_registered").(bool); v {
 			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -126,7 +126,7 @@ var (
 		return false
 	})
 
-	SuppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+	suppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 		// Suppress if the cluster has been pre registered to fleet.		
 		if v, _ := d.Get("fleet.0.pre_registered").(bool); v {
 			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)
@@ -2301,7 +2301,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				MaxItems:    1,
 				Description: `Fleet configuration of the cluster.`,
-				DiffSuppressFunc: SuppressDiffForPreRegisteredFleet,
+				DiffSuppressFunc: suppressDiffForPreRegisteredFleet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"project": {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -127,11 +127,32 @@ var (
 	})
 
 	suppressDiffForPreRegisteredFleet = schema.SchemaDiffSuppressFunc(func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+		// Suppress if the cluster has been pre registered to fleet.		
 		if v, _ := d.Get("fleet.0.pre_registered").(bool); v {
 			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)
 			return true
 		}
-		return false
+		// Suppress if both old and new project fields are empty		
+		var oldList, newList []map[string]interface{}
+		if err := json.Unmarshal([]byte(old), &oldList); err != nil {
+			return false
+		}
+		if err := json.Unmarshal([]byte(new), &newList); err != nil {
+			return false
+		}
+		
+		var oldProject, newProject string
+		if len(oldList) == 1 {
+			if p, ok := oldList[0]["project"].(string); ok {
+				oldProject = p
+			}
+		}
+		if len(newList) == 1 {
+			if p, ok := newList[0]["project"].(string); ok {
+				newProject = p
+			}
+		}
+		return oldProject == "" && newProject == ""
 	})
 )
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
-	"encoding/json"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-version"
@@ -133,28 +132,16 @@ var (
 			log.Printf("[DEBUG] fleet suppress pre_registered: %v\n", v)
 			return true
 		}
-		// Suppress if both old and new project fields are empty
-		var oldList, newList []map[string]interface{}
-    		if err := json.Unmarshal([]byte(oldValue), &oldList); err != nil {
-			log.Printf("[DEBUG] fleet suppress error unmarshalling old value: %v", err)
-        		return false
-    		}
-		if err := json.Unmarshal([]byte(newValue), &newList); err != nil {
-			log.Printf("[DEBUG] fleet suppress error unmarshalling new value: %v", err)
-        		return false
-   		}
-		var oldProject, newProject string
-		if len(oldList) == 1 {
-			if p, ok := oldList[0]["project"].(string); ok {
-				oldProject = p
-			}
-		}
-		if len(newList) == 1 {
-			if p, ok := newList[0]["project"].(string); ok {
-				newProject = p
-			}
-		}
-		return oldProject == "" && newProject == ""
+		// Suppress the addition of a fleet block (count changes 0 -> 1) if the "project" field being added is null or empty.
+                if k == "fleet.#" && oldValue == "0" && newValue == "1" { 
+                        // When transitioning from 0->1 blocks, d.Get/d.GetOk effectively reads the 'new' config value.
+                        projectVal, projectIsSet := d.GetOk("fleet.0.project")
+                        if !projectIsSet || projectVal.(string) == "" {
+                                log.Printf("[DEBUG] Suppressing diff for 'fleet.#' (0 -> 1) because fleet.0.project is null or empty in config.\n")
+                                return true
+                        }
+                }
+                return false
 	})
 )
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -140,7 +140,7 @@ var (
         		return false
     		}
 		if err := json.Unmarshal([]byte(newValue), &newList); err != nil {
-			log.Printf("[DEBUG] fleet suppress error unmarshalling old value: %v", err)
+			log.Printf("[DEBUG] fleet suppress error unmarshalling new value: %v", err)
         		return false
    		}
 		var oldProject, newProject string

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5462,56 +5462,6 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 		},
 	})
 }
-func TestSuppressDiffForPreRegisteredFleet(t *testing.T) {
-	t.Parallel()
-	cases := map[string]struct {
-		Old, New           string
-		ExpectSuppress     bool
-	}{
-		"both unset": {
-			Old:            `null`,
-			New:            `null`,
-			ExpectSuppress: true,
-		},
-		"empty list vs empty project": {
-			Old:            `[]`,
-			New:            `[{"project": ""}]`,
-			ExpectSuppress: true,
-		},
-		"both empty project": {
-			Old:            `[{"project": ""}]`,
-			New:            `[{"project": ""}]`,
-			ExpectSuppress: true,
-		},
-		"equal project value": {
-			Old:            `[{"project": "my-project"}]`,
-			New:            `[{"project": "my-project"}]`,
-			ExpectSuppress: true,
-		},
-		"different project values": {
-			Old:            `[{"project": "old-project"}]`,
-			New:            `[{"project": "new-project"}]`,
-			ExpectSuppress: false,
-		},
-		"project vs no project": {
-			Old:            `[{"project": "my-project"}]`,
-			New:            `[]`,
-			ExpectSuppress: false,
-		},
-		"invalid JSON": {
-			Old:            `invalid-json`,
-			New:            `[{"project": ""}]`,
-			ExpectSuppress: false,
-		},
-	}
-
-	for name, tc := range cases {
-		result := container.SuppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
-		if result != tc.ExpectSuppress {
-			t.Errorf("case %q: expected %v, got %v", name, tc.ExpectSuppress, result)
-		}
-	}
-}
 
 func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5462,6 +5462,56 @@ func TestAccContainerCluster_withSecurityPostureConfig(t *testing.T) {
 		},
 	})
 }
+func TestSuppressDiffForPreRegisteredFleet(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		Old, New           string
+		ExpectSuppress     bool
+	}{
+		"both unset": {
+			Old:            `null`,
+			New:            `null`,
+			ExpectSuppress: true,
+		},
+		"empty list vs empty project": {
+			Old:            `[]`,
+			New:            `[{"project": ""}]`,
+			ExpectSuppress: true,
+		},
+		"both empty project": {
+			Old:            `[{"project": ""}]`,
+			New:            `[{"project": ""}]`,
+			ExpectSuppress: true,
+		},
+		"equal project value": {
+			Old:            `[{"project": "my-project"}]`,
+			New:            `[{"project": "my-project"}]`,
+			ExpectSuppress: true,
+		},
+		"different project values": {
+			Old:            `[{"project": "old-project"}]`,
+			New:            `[{"project": "new-project"}]`,
+			ExpectSuppress: false,
+		},
+		"project vs no project": {
+			Old:            `[{"project": "my-project"}]`,
+			New:            `[]`,
+			ExpectSuppress: false,
+		},
+		"invalid JSON": {
+			Old:            `invalid-json`,
+			New:            `[{"project": ""}]`,
+			ExpectSuppress: false,
+		},
+	}
+
+	for name, tc := range cases {
+		result := suppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
+		if result != tc.ExpectSuppress {
+			t.Errorf("case %q: expected %v, got %v", name, tc.ExpectSuppress, result)
+		}
+	}
+}
 
 func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 	t.Parallel()
@@ -5492,6 +5542,15 @@ func TestAccContainerCluster_withFleetConfig(t *testing.T) {
 			},
 			{
 				Config: testAccContainerCluster_DisableFleet(clusterName, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_WithEmptyFleetProject(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -5597,6 +5656,37 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
 
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, resource_name, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "gke_cluster" {
+  name     = "%s"
+  location = "us-central1"
+
+  min_master_version = "1.10.9-gke.5"
+  node_version       = "1.10.6-gke.11"
+  initial_node_count = 1
+}
+	`, name)
+}
+
+func testAccContainerCluster_WithEmptyFleetProject(resource_name, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  fleet {
+    project = ""
+  }
   network    = "%s"
   subnetwork = "%s"
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5506,7 +5506,7 @@ func TestSuppressDiffForPreRegisteredFleet(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		result := suppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
+		result := container.suppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
 		if result != tc.ExpectSuppress {
 			t.Errorf("case %q: expected %v, got %v", name, tc.ExpectSuppress, result)
 		}
@@ -5662,19 +5662,6 @@ resource "google_container_cluster" "primary" {
   deletion_protection = false
 }
 `, resource_name, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "gke_cluster" {
-  name     = "%s"
-  location = "us-central1"
-
-  min_master_version = "1.10.9-gke.5"
-  node_version       = "1.10.6-gke.11"
-  initial_node_count = 1
-}
-	`, name)
 }
 
 func testAccContainerCluster_WithEmptyFleetProject(resource_name, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5506,7 +5506,7 @@ func TestSuppressDiffForPreRegisteredFleet(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		result := container.suppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
+		result := container.SuppressDiffForPreRegisteredFleet("fleet", tc.Old, tc.New, nil)
 		if result != tc.ExpectSuppress {
 			t.Errorf("case %q: expected %v, got %v", name, tc.ExpectSuppress, result)
 		}


### PR DESCRIPTION
Suppress diffs as long as the project field is missing or empty ("") in both old and new fleet blocks. The rest fields are "Computed" only, and we don't need to compare them.

Fixes reported customer issue [b/403163416](url).
Tested with locally built provider: [internal test google doc](https://docs.google.com/document/d/1c-Wy7ZHopNLhMO___McQ9c1ZyD5K_ee7Nd_sxwUp5M8/edit?tab=t.0)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
container: fixed `google_container_cluster` diff logic to correctly handle equivalent empty values in the fleet block
```
