### PR TITLE
Support custom subject alternative name for CloudSQL instances

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -82,7 +82,7 @@ var (
 		"settings.0.ip_configuration.0.ssl_mode",
 		"settings.0.ip_configuration.0.server_ca_mode",
 		"settings.0.ip_configuration.0.server_ca_pool",
-		"settings.0.ip_configuration.0.settings.0.ip_configuration.0.server_ca_pool",
+		"settings.0.ip_configuration.0.custom_subject_alternative_names",
 	}
 
 	maintenanceWindowKeys = []string{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -82,6 +82,7 @@ var (
 		"settings.0.ip_configuration.0.ssl_mode",
 		"settings.0.ip_configuration.0.server_ca_mode",
 		"settings.0.ip_configuration.0.server_ca_pool",
+		"settings.0.ip_configuration.0.settings.0.ip_configuration.0.server_ca_pool",
 	}
 
 	maintenanceWindowKeys = []string{
@@ -532,6 +533,16 @@ is set to true. Defaults to ZONAL.`,
 										Type:         schema.TypeString,
 										Optional:     true,
 										Description:  `The resource name of the server CA pool for an instance with "CUSTOMER_MANAGED_CAS_CA" as the "server_ca_mode".`,
+										AtLeastOneOf: ipConfigurationKeys,
+									},
+									"custom_subject_alternative_names": {
+										Type:         schema.TypeSet,
+										Optional:     true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+										Set:         schema.HashString,
+										Description:  `The custom subject alternative names for an instance with "CUSTOMER_MANAGED_CAS_CA" as the "server_ca_mode".`,
 										AtLeastOneOf: ipConfigurationKeys,
 									},
 								},
@@ -1489,6 +1500,7 @@ func expandIpConfiguration(configured []interface{}, databaseVersion string) *sq
 		SslMode:                                 _ipConfiguration["ssl_mode"].(string),
 		ServerCaMode:                            _ipConfiguration["server_ca_mode"].(string),
 		ServerCaPool:                            _ipConfiguration["server_ca_pool"].(string),
+		CustomSubjectAlternativeNames:           tpgresource.ConvertStringArr(_ipConfiguration["custom_subject_alternative_names"].(*schema.Set).List()),
 	}
 }
 
@@ -2443,6 +2455,7 @@ func flattenIpConfiguration(ipConfiguration *sqladmin.IpConfiguration, d *schema
 		"ssl_mode":                                      ipConfiguration.SslMode,
 		"server_ca_mode":                                ipConfiguration.ServerCaMode,
 		"server_ca_pool":                                ipConfiguration.ServerCaPool,
+		"custom_subject_alternative_names":		 ipConfiguration.CustomSubjectAlternativeNames,
 	}
 
 	if ipConfiguration.AuthorizedNetworks != nil {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2901,6 +2901,38 @@ func TestAccSqlDatabaseInstance_useCasBasedServerCa(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_useCustomSan(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+	resourceName := "google_sql_database_instance.instance"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_setCustomerManagedServerCa(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
+				Config: testGoogleSqlDatabaseInstance_setCustomSan(databaseName, "test.example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.serer_ca_mode", "GOOGLE_MANAGED_CAS_CA"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.custom_subject_alternative_names", "test.example.com"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_useCustomerManagedServerCa(t *testing.T) {
 	t.Parallel()
 
@@ -2911,6 +2943,7 @@ func TestAccSqlDatabaseInstance_useCustomerManagedServerCa(t *testing.T) {
 		"databaseName":    "tf-test-" + acctest.RandString(t, 10),
 		"casRandomSuffix": acctest.RandString(t, 10),
 	}
+
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3033,6 +3066,25 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, databaseName, serverCaMode)
+}
+
+func testGoogleSqlDatabaseInstance_setCustomSan(databaseName, customSan string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "POSTGRES_15"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled    = "true"
+      server_ca_mode  = "CUSTOMER_MANAGED_CAS_CA"
+      custom_subject_alternative_names = ["%s"]
+    }
+  }
+}
+`, databaseName, customSan)
 }
 
 func testGoogleSqlDatabaseInstance_setSslOptionsForPostgreSQL(databaseName string, databaseVersion string, sslMode string) string {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2919,7 +2919,7 @@ func TestAccSqlDatabaseInstance_useCustomSan(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
 				Config: testGoogleSqlDatabaseInstance_setCustomSan(databaseName, "test.example.com"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.serer_ca_mode", "GOOGLE_MANAGED_CAS_CA"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.serer_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.custom_subject_alternative_names", "test.example.com"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2907,7 +2907,7 @@ func TestAccSqlDatabaseInstance_useCustomSan(t *testing.T) {
 	databaseName := "tf-test-" + acctest.RandString(t, 10)
 	resourceName := "google_sql_database_instance.instance"
 	project := envvar.GetTestProjectFromEnv()
-	
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2910,7 +2910,7 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 		"projectID":       envvar.GetTestProjectFromEnv(),
 		"databaseName":    "tf-test-" + acctest.RandString(t, 10),
 		"casRandomSuffix": acctest.RandString(t, 10),
-		"customSan": "test.example.com",
+		"customSan":     "test.example.com",
 	}
 
 
@@ -2925,8 +2925,8 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "settings.0.ip_configuration.0.custom_subject_alternative_names.*", "test.example.com"),
-				),	
-			},			
+				),
+			},		
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2910,9 +2910,8 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 		"projectID":       envvar.GetTestProjectFromEnv(),
 		"databaseName":    "tf-test-" + acctest.RandString(t, 10),
 		"casRandomSuffix": acctest.RandString(t, 10),
-		"customSan":      "test.example.com",
+		"customSan":       "test.example.com",
 	}
-
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -2926,7 +2925,7 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "settings.0.ip_configuration.0.custom_subject_alternative_names.*", "test.example.com"),
 				),
-			},	
+			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2910,7 +2910,7 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 		"projectID":       envvar.GetTestProjectFromEnv(),
 		"databaseName":    "tf-test-" + acctest.RandString(t, 10),
 		"casRandomSuffix": acctest.RandString(t, 10),
-		"customSan":     "test.example.com",
+		"customSan":      "test.example.com",
 	}
 
 
@@ -2926,7 +2926,7 @@ func TestAccSqlDatabaseInstance_useCustomSubjectAlternateName(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "CUSTOMER_MANAGED_CAS_CA"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "settings.0.ip_configuration.0.custom_subject_alternative_names.*", "test.example.com"),
 				),
-			},		
+			},	
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go
@@ -2948,7 +2948,6 @@ func TestAccSqlDatabaseInstance_useCustomerManagedServerCa(t *testing.T) {
 		"casRandomSuffix": acctest.RandString(t, 10),
 	}
 
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -415,6 +415,8 @@ This setting can be updated, but it cannot be removed after it is set.
 
 * `server_ca_pool` - (Optional) The resource name of the server CA pool for an instance with `CUSTOMER_MANAGED_CAS_CA` as the `server_ca_mode`.
 
+* `custom_subject_alternative_names` - (Optional) The custom subject alternative names for an instance with `CUSTOMER_MANAGED_CAS_CA` as the `server_ca_mode`.
+
 * `allocated_ip_range` - (Optional) The name of the allocated ip range for the private ip CloudSQL instance. For example: "google-managed-services-default". If set, the instance ip will be created in the allocated range. The range name must comply with [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035). Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?.
 
 * `enable_private_path_for_google_cloud_services` - (Optional) Whether Google Cloud services such as BigQuery are allowed to access data in this Cloud SQL instance over a private IP connection. SQLSERVER database type is not supported.


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: added `custom_subject_alternative_names` field to `instances` resource
```
