### PR TITLE
Adds `trial_config` field to Storage Intelligence Resources.

### DIFF
--- a/mmv1/products/storagecontrol/FolderIntelligenceConfig.yaml
+++ b/mmv1/products/storagecontrol/FolderIntelligenceConfig.yaml
@@ -187,3 +187,14 @@ properties:
         output: true
         description: |
           The `StorageIntelligence` edition that is applicable for the resource.
+  - name: 'trialConfig'
+    output: true
+    description: |
+      The trial configuration of the Storage Intelligence resource.
+    type: NestedObject
+    properties:
+      - name: expireTime
+        type: String
+        output: true
+        description: |
+          The time at which the trial expires.

--- a/mmv1/products/storagecontrol/OrganizationIntelligenceConfig.yaml
+++ b/mmv1/products/storagecontrol/OrganizationIntelligenceConfig.yaml
@@ -186,3 +186,14 @@ properties:
         output: true
         description: |
           The `StorageIntelligence` edition that is applicable for the resource.
+  - name: 'trialConfig'
+    output: true
+    description: |
+      The trial configuration of the Storage Intelligence resource.
+    type: NestedObject
+    properties:
+      - name: expireTime
+        type: String
+        output: true
+        description: |
+          The time at which the trial expires.

--- a/mmv1/products/storagecontrol/ProjectIntelligenceConfig.yaml
+++ b/mmv1/products/storagecontrol/ProjectIntelligenceConfig.yaml
@@ -187,3 +187,14 @@ properties:
         output: true
         description: |
           The `StorageIntelligence` edition that is applicable for the resource.
+  - name: 'trialConfig'
+    output: true
+    description: |
+      The trial configuration of the Storage Intelligence resource.
+    type: NestedObject
+    properties:
+      - name: expireTime
+        type: String
+        output: true
+        description: |
+          The time at which the trial expires.


### PR DESCRIPTION
Adds output only `trial_config` field to the Storage Intelligence resources.

Public API documentation is not yet updated with the field description but the change has rolled out and field is visible in API responses.

```release-note:enhancement
storagecontrol: added  to `trial_config` field to `google_storage_control_project_intelligence_config` resource
```

```release-note:enhancement
storagecontrol: added  to `trial_config` field to `google_storage_control_folder_intelligence_config` resource
```
```release-note:enhancement
storagecontrol: added  to `trial_config` field to `google_storage_control_organization_intelligence_config` resource
```