### PR TITLE
Add tags field to Certificate Manager for TagsR2401

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -300,3 +300,12 @@ properties:
                 address the configuration issues.
                 Not guaranteed to be stable. For programmatic access use `failure_reason` field.
               output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
+++ b/mmv1/products/certificatemanager/CertificateIssuanceConfig.yaml
@@ -126,3 +126,12 @@ properties:
               "projects/{project}/locations/{location}/caPools/{caPool}".
             required: true
             diff_suppress_func: 'tpgresource.CompareResourceNames'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/CertificateMap.yaml
+++ b/mmv1/products/certificatemanager/CertificateMap.yaml
@@ -111,3 +111,12 @@ properties:
             Proxy name must be in the format projects/*/locations/*/targetSslProxies/*.
             This field is part of a union field `target_proxy`: Only one of `targetHttpsProxy` or
             `targetSslProxy` may be set.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/DnsAuthorization.yaml
+++ b/mmv1/products/certificatemanager/DnsAuthorization.yaml
@@ -129,3 +129,12 @@ properties:
         description: |
           Data of the DNS Resource Record.
         output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/certificatemanager/TrustConfig.yaml
+++ b/mmv1/products/certificatemanager/TrustConfig.yaml
@@ -140,3 +140,12 @@ properties:
           description: |
             PEM certificate that is allowlisted. The certificate can be up to 5k bytes, and must be a parseable X.509 certificate.
           required: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+      The field is ignored (both PUT & PATCH) when empty.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificate_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificate_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificates-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificates-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerCertificateTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificate.certificate",
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificate" "certificate" {
+  name = "tf-certificate-%s"
+  description = "Global cert"
+  self_managed {
+    pem_certificate = file("test-fixtures/cert.pem")
+    pem_private_key = file("test-fixtures/private-key.pem")
+  }
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_certificatemap_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerCertificateMap_tags(t *testing.T) {
+	t.Parallel()
+	org := envvar.GetTestOrgFromEnv(t)
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "ccm-certificatemaps-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "ccm-certificatemaps-tagvalue", tagKey)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerCertificateMapTags(name, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_certificate_map.certificatemap",
+				ImportState:             true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerCertificateMapTags(name string, tags map[string]string) string {
+	r := fmt.Sprintf(`
+resource "google_certificate_manager_certificate_map" "certificatemap" {
+  name = "tf-certificate-map-%s"
+  description = "Global cert"
+tags = {`, name)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_dns_authorization_test.go
@@ -1,10 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package certificatemanager_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCertificateManagerDnsAuthorization_update(t *testing.T) {
@@ -65,4 +69,52 @@ resource "google_certificate_manager_dns_authorization" "default" {
   domain      = "%{random_suffix}.hashicorptest.com"
 }
 `, context)
+}
+
+func TestAccCertificateManagerDnsAuthorization_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "certificate-manager-dns-auth-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "certificate-manager-dns-auth-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerDnsAuthorizationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorizationTags(context, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_dns_authorization.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerDnsAuthorizationTags(context map[string]interface{}, tags map[string]string) string {
+	r := acctest.Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+        name          = "tf-test-dns-auth%{random_suffix}"
+        description = "The default dns"
+        labels = {
+                a = "a"
+        }
+        domain          = "%{random_suffix}.hashicorptest.com"
+tags = {`, context)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_issuance_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_issuance_config_test.go
@@ -1,0 +1,54 @@
+package certificatemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccCertificateManagerIssuanceConfig_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "certificate-manager-issuance-config-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "certificate-manager-issuance-config-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerIssuanceConfigTags(context, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_issuance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerIssuanceConfigTags(context map[string]interface{}, tags map[string]string) string {
+	r := acctest.Nprintf(`
+resource "google_certificate_manager_issuance_config" "default" {
+        name        = "tf-test-issuance-config%{random_suffix}"
+        description = "sample description for the issaunce config"
+        location    = "us-central1"
+tags = {`, context)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/resource_certificate_manager_trust_config_test.go
@@ -1,10 +1,12 @@
 package certificatemanager_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCertificateManagerTrustConfig_update(t *testing.T) {
@@ -93,4 +95,52 @@ resource "google_certificate_manager_trust_config" "default" {
   }
 }
 `, context)
+}
+
+func TestAccCertificateManagerTrustConfig_tags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "certificate-manager-trust-config-tagkey")
+	tagValue := acctest.BootstrapSharedTestTagValue(t, "certificate-manager-trust-config-tagvalue", tagKey)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCertificateManagerTrustConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerTrustConfigTags(context, map[string]string{org + "/" + tagKey: tagValue}),
+			},
+			{
+				ResourceName:            "google_certificate_manager_trust_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerTrustConfigTags(context map[string]interface{}, tags map[string]string) string {
+	r := acctest.Nprintf(`
+resource "google_certificate_manager_trust_config" "default" {
+        name        = "tf-test-trust-config%{random_suffix}"
+        description = "sample description for the trust config 2"
+        location    = "global"
+        allowlisted_certificates  {
+          pem_certificate = file("test-fixtures/cert.pem") 
+        }
+tags = {`, context)
+
+	l := ""
+	for key, value := range tags {
+		l += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	l += fmt.Sprintf("}\n}")
+	return r + l
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add tags field to service resource to allow setting tags on service resources at creation time.
Bug - b/337048407
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
Certificate Manager: added `tags` field to `Certificate Manager - Certificates, Certificate Map, Issuance config, Trust Config, DNS Authorization` to allow setting tags for services at creation time
```
