### PR TITLE
document sweeper field usage

### DIFF
--- a/docs/content/reference/resource.md
+++ b/docs/content/reference/resource.md
@@ -325,6 +325,139 @@ Example:
 mutex: 'alloydb/instance/{{name}}'
 ```
 
+## Sweeper customization
+
+Sweepers are a testing infrastructure mechanism that automatically clean up resources created during tests. They run before tests start and can be run manually to clean up dangling resources. Sweepers help prevent test failures due to resource quota limits and reduce cloud infrastructure costs by removing test resources that were not properly cleaned up.
+
+Sweeper generation is enabled by default, except in the following conditions which require customization here:
+- Resources with custom deletion code
+- Resources with parent-child relationships (unless the parent relationship is configured)
+- Resources with complex URL parameters that aren't simple region/project parameters
+
+Simply defining the sweeper block in a resource will override these exclusions and enable sweeper generation for that resource, even with minimal configuration.
+
+### `exclude_sweeper`
+
+If set to `true`, no sweeper will be generated for this resource. This is useful for resources that cannot or should not be automatically cleaned up.
+
+Default: `false`
+
+Example:
+
+```yaml
+exclude_sweeper: true
+```
+
+### `sweeper`
+
+Configures how test resources are swept (cleaned up) after tests. The sweeper system helps ensure resources created during tests are properly removed, even when tests fail unexpectedly. All fields within the `sweeper` block are optional, with reasonable defaults provided when not specified.
+
+- `identifier_field`: Specifies which field in the resource object should be used to identify resources for deletion. If not specified, defaults to "name" if present in the resource, otherwise falls back to "id".
+
+- `prefixes`: Specifies name prefixes that identify resources eligible for sweeping. Resources whose names start with any of these prefixes will be deleted. By default, resources with the `tf-test-` prefix are automatically eligible for sweeping even if no prefixes are specified.
+
+- `url_substitutions`: Allows customizing URL parameters when listing resources. Each map entry represents a set of key-value pairs to substitute in the URL template. This is commonly used to specify regions to sweep in. If not specified, the sweeper will only run in the default region (us-central1) and zone (us-central1-a).
+
+- `dependencies`: Lists other resource types that must be swept before this one. This ensures proper cleanup order for resources with dependencies. If not specified, no dependencies are assumed.
+
+- `parent`: Configures sweeping for resources that depend on parent resources (like a nodepool that belongs to a cluster).
+
+  Required fields:
+  - `resource_type`: The type of the parent resource (e.g., "google_container_cluster")
+  - `child_field`: The field in your resource that references the parent (e.g., "cluster")
+  - At least one of `parent_field` or `template` is required
+
+  Options for getting parent reference:
+  - `parent_field`: The field from parent to use (typically "name" or "id")
+  - `template`: A template string like "projects/{{project}}/locations/{{location}}/clusters/{{value}}" 
+  
+  Options for processing the parent field value:
+  - `parent_field_extract_name`: When set to true, extracts just the resource name from a self_link URL by taking the portion after the last slash. This is useful when the parent field contains a fully-qualified resource URL (like "https://www.googleapis.com/compute/v1/projects/my-project/global/networks/my-network" or "projects/my-project/zones/us-central1-a/instances/my-instance") but you only need the final resource name component ("my-network" or "my-instance").
+  
+  - `parent_field_regex`: A regex pattern with a capture group to extract a specific portion of the parent field value. This is useful when you need more control over extracting parts of complex resource identifiers. The pattern must contain at least one capture group (in parentheses), and the first capture group's match will be used as the extracted value.
+
+- `query_string`: Allows appending additional query parameters to the resource's delete URL when performing delete operations. Format should include the starting character, e.g., "?force=true" or "&verbose=true". If not specified, no additional query parameters are added.
+
+- `ensure_value`: Specifies a field that must be set to a specific value before deletion. Used for resources that have fields like 'deletionProtectionEnabled' that must be explicitly disabled before the resource can be deleted. All fields within the `ensure_value` block are required except `include_full_resource`:
+  
+  - `field`: The API field name that needs to be updated before deletion. Can include dot notation for nested fields (e.g., "settings.deletionProtectionEnabled").
+  
+  - `value`: The required value that `field` must be set to before deletion. For boolean fields use "true" or "false", for integers use string representation, for string fields use the exact string value required.
+  
+  - `include_full_resource`: Determines whether to send the entire resource object with the updated field (true) or to send just the field that needs updating (false). Some APIs require the full resource to be sent in update operations. Default: `false`.
+
+Examples:
+
+Basic sweeper configuration:
+
+```yaml
+sweeper:
+  prefixes:
+    - "tf-test-"
+    - "tmp-"
+```
+
+Sweeper with parent-child relationship (basic):
+
+```yaml
+sweeper:
+  dependencies: # sweep google_compute_instance before attempting to sweep this resource
+    - "google_compute_instance"
+  parent:
+    resource_type: "google_container_cluster"
+    parent_field: "name"
+    child_field: "cluster"
+```
+
+Sweeper with parent_field_extract_name:
+
+```yaml
+sweeper:
+  parent:
+    resource_type: "google_compute_network"
+    parent_field: "selfLink"  # Contains: "projects/my-project/global/networks/my-network"
+    parent_field_extract_name: true  # Extracts just "my-network"
+    child_field: "network"
+```
+
+Sweeper with parent template and pre-deletion field update:
+
+```yaml
+sweeper:
+  parent:
+    resource_type: "google_container_cluster"
+    template: "projects/{{project}}/locations/{{location}}/clusters/{{value}}"
+    parent_field: "displayName"  # Provides the value for {{value}}
+    child_field: "cluster"
+  ensure_value:
+    field: "deletionProtection"
+    value: "false"
+    include_full_resource: false
+
+```
+
+Sweeper with URL substitutions for multiple regions:
+
+```yaml
+sweeper:
+  url_substitutions:
+    - collection_id: default_collection
+      region: global
+    - collection_id: default_collection
+      region: eu
+```
+
+Sweeper with URL substitutions specifying only regions:
+
+```yaml
+sweeper:
+  identifier_field: "displayName"
+  url_substitutions:
+    - region: "us-central1"
+    - region: "us-east1"
+    - region: "europe-west1"
+```
+
 ## Fields
 
 ### `virtual_fields`

--- a/mmv1/api/resource/sweeper.go
+++ b/mmv1/api/resource/sweeper.go
@@ -18,98 +18,138 @@ import (
 	"strings"
 )
 
-// Sweeper provides configuration for the test sweeper to clean up test resources
+// Sweeper provides configuration for the test sweeper to clean up test resources.
+// Sweepers are a testing infrastructure mechanism that automatically clean up
+// resources created during tests. They run before tests start and can be run
+// manually to clean up dangling resources. Sweepers help prevent test failures
+// due to resource quota limits and reduce cloud infrastructure costs by removing
+// test resources that were not properly cleaned up.
+//
+// Sweeper generation is enabled by default, except for resources with custom
+// deletion code, parent-child relationships (unless configured via Parent), or
+// complex URL parameters. Defining the sweeper block overrides these exclusions.
 type Sweeper struct {
 	// IdentifierField specifies which field in the resource object should be used
-	// to identify resources for deletion (typically "name" or "id")
+	// to identify resources for deletion. If not specified, defaults to "name"
+	// if present in the resource, otherwise falls back to "id".
 	IdentifierField string `yaml:"identifier_field"`
 
-	// Regions defines which regions to run the sweeper in
-	// If empty, defaults to just us-central1
+	// Regions (deprecated - use url_substitutions) defines which regions to run
+	// the sweeper in. If empty, defaults to just us-central1. Note that
+	// URLSubstitutions provides more granular control over list request parameters,
+	// including regions.
 	Regions []string `yaml:"regions,omitempty"`
 
-	// Prefixes specifies name prefixes that identify resources eligible for sweeping
-	// Resources whose names start with any of these prefixes will be deleted
+	// Prefixes specifies name prefixes that identify resources eligible for sweeping.
+	// Resources whose names start with any of these prefixes will be deleted.
+	// By default, resources with the "tf-test-" prefix are automatically eligible
+	// for sweeping even if no prefixes are specified here.
 	Prefixes []string `yaml:"prefixes,omitempty"`
 
-	// URLSubstitutions allows customizing URL parameters when listing resources
-	// Each map entry represents a set of key-value pairs to substitute in the URL template
+	// URLSubstitutions allows customizing URL parameters when listing resources.
+	// Each map entry represents a set of key-value pairs to substitute in the
+	// base_url template when listing resources. This is commonly used to specify
+	// regions or other parameters required for the list API call. If not specified,
+	// the sweeper will typically only run in the default region (us-central1) and
+	// zone (us-central1-a), depending on the resource's base_url structure.
 	URLSubstitutions []map[string]string `yaml:"url_substitutions,omitempty"`
 
-	// Dependencies lists other resource types that must be swept before this one
+	// Dependencies lists other resource types (e.g., "google_compute_instance")
+	// that must be swept *before* this resource type. This ensures proper cleanup
+	// order for resources with dependencies. If not specified, no dependencies
+	// are assumed.
 	Dependencies []string `yaml:"dependencies,omitempty"`
 
-	// Parent defines the parent-child relationship for hierarchical resources
-	// When specified, the sweeper will first collect parent resources before listing child resources
+	// Parent configures sweeping for resources that depend on parent resources
+	// (like a nodepool that belongs to a cluster). When specified, the sweeper
+	// will first collect parent resources before listing and deleting child resources.
+	// See the ParentResource struct for configuration details.
 	Parent *ParentResource `yaml:"parent,omitempty"`
 
-	// QueryString allows appending additional query parameters to the resource's delete URL
-	// when performing delete operations required before deletion.
-	// Format should include the starting character, e.g. "?force=true" or "&verbose=true"
+	// QueryString allows appending additional query parameters to the resource's
+	// delete URL when performing delete operations. Format should include the
+	// starting character, e.g., "?force=true" or "&verbose=true". If not specified,
+	// no additional query parameters are added to the delete request.
 	QueryString string `yaml:"query_string,omitempty"`
 
-	// EnsureValue specifies a field that must be set to a specific value before deletion
-	// Used for resources that have fields like 'deletionProtectionEnabled' that must be
-	// explicitly disabled before the resource can be deleted.
-	// The template will automatically handle checking the current value and updating it
-	// if necessary before attempting deletion.
+	// EnsureValue specifies a field that must be set to a specific value before
+	// deletion can occur. This is used for resources that have fields like
+	// 'deletionProtection' that must be explicitly disabled before the API allows
+	// deletion. The sweeper automatically handles checking the current value and
+	// updating it if necessary before attempting deletion. See the EnsureValue
+	// struct for configuration details.
 	EnsureValue *EnsureValue `yaml:"ensure_value,omitempty"`
 }
 
-// EnsureValue specifies a field and value that must be set before a resource can be deleted
+// EnsureValue specifies a field and value that must be set before a resource can be deleted.
+// Used for resources that have fields like 'deletionProtectionEnabled' that must be
+// explicitly disabled before the resource can be deleted.
 type EnsureValue struct {
-	// Field is the API field name that needs to be updated before deletion
-	// Can include dot notation for nested fields (e.g., "settings.deletionProtectionEnabled")
-	// Example: "deletionProtectionEnabled" or "settings.deletionProtection"
+	// Field is the API field name that needs to be updated before deletion.
+	// Can include dot notation for nested fields (e.g., "settings.deletionProtectionEnabled").
 	Field string `yaml:"field,omitempty"`
 
-	// Value is the required value that Field must be set to before deletion
-	// For boolean fields use "true" or "false", for integers use string representation
-	// For string fields use the exact string value required
-	// The template will automatically convert this string to the appropriate type
-	// Example values: "false", "0", "DISABLED"
+	// Value is the required value that Field must be set to before deletion.
+	// For boolean fields use "true" or "false", for integers use string representation,
+	// for string fields use the exact string value required. The template automatically
+	// converts this string to the appropriate type in the API request.
+	// Example values: "false", "0", "DISABLED".
 	Value string `yaml:"value,omitempty"`
 
 	// IncludeFullResource determines whether to send the entire resource object
 	// with the updated field (true) or to send just the field that needs updating (false)
-	// Some APIs require the full resource to be sent in update operations
-	// Defaults to false if not specified
+	// in the update request payload. Some APIs require the full resource to be sent
+	// in update operations. Defaults to false if not specified.
 	IncludeFullResource bool `yaml:"include_full_resource,omitempty"`
 }
 
-// ParentResource specifies how to handle parent-child resource dependencies
+// ParentResource specifies how to handle parent-child resource dependencies during sweeping.
+// It defines how to identify and reference the parent resource when listing or processing
+// child resources.
 type ParentResource struct {
-	// ResourceType is the parent resource type that will be used to find the parent sweeper
-	// Example: "GoogleContainerCluster"
+	// ResourceType is the type name of the parent resource (e.g., "google_container_cluster")
+	// used to find the corresponding parent sweeper logic.
 	ResourceType string `yaml:"resource_type"`
 
-	// ParentField specifies which field to extract from the parent resource
-	// Example: "name" or "id"
-	// Required unless Template is provided
+	// ParentField specifies which field to extract from the parent resource object.
+	// This value is then used either directly as the parent identifier or as input
+	// for the Template. Example: "name" or "id".
+	// Required unless Template is provided.
 	ParentField string `yaml:"parent_field"`
 
-	// ParentFieldRegex is a regex pattern to apply to the parent field value
-	// The first capture group will be used as the final value
+	// ParentFieldRegex is a regex pattern with at least one capture group used to
+	// extract a specific portion of the ParentField value. The first capture group's
+	// match will be used as the final value for substitution in the Template's
+	// {{value}} placeholder or as the parent identifier if Template is not used.
 	ParentFieldRegex string `yaml:"parent_field_regex"`
 
-	// ParentFieldExtractName when true indicates the parent field contains a self-link
-	// and only the resource name (portion after the last slash) should be used
+	// ParentFieldExtractName, when true, indicates the ParentField contains a self_link
+	// URL (e.g., "projects/p/zones/z/instances/i"). It extracts just the final
+	// resource name component ("i") from the URL path. This extracted name is then used
+	// for substitution in the Template's {{value}} placeholder or as the parent
+	// identifier if Template is not used.
 	ParentFieldExtractName bool `yaml:"parent_field_extract_name"`
 
-	// ChildField is the field in the child resource that needs to reference the parent
-	// Example: "cluster", "instance", etc.
+	// ChildField is the field name within the *child* resource's API list/get URL
+	// (defined in base_url/self_link) that needs to be populated with the identifier
+	// derived from the parent resource (via ParentField/Template).
+	// Example: "cluster", "instance".
 	ChildField string `yaml:"child_field"`
 
-	// Template provides a format string to construct the parent reference
-	// Variables in {{brackets}} will be replaced with values from the parent resource
-	// The special placeholder {{value}} is populated with the processed parent field value
+	// Template provides a format string to construct the parent reference identifier
+	// needed in the child resource's URL. Variables in {{curly_braces}} are replaced
+	// with values from the parent resource object (e.g., {{project}}, {{location}}).
+	// The special placeholder {{value}} is populated with the processed parent field
+	// value (obtained from ParentField, potentially modified by ParentFieldRegex or
+	// ParentFieldExtractName).
 	// Example: "projects/{{project}}/locations/{{location}}/clusters/{{value}}"
-	// If specified, takes precedence over direct field mapping
+	// If specified, Template takes precedence over using the raw ParentField value.
+	// At least one of ParentField or Template is required.
 	Template string `yaml:"template"`
 }
 
 // EnvVarInterpolate takes a string and replaces any environment variable patterns
-// with their corresponding function calls, returning a valid Go expression
+// with their corresponding function calls, returning a valid Go expression.
 func (s Sweeper) EnvVarInterpolate(value string) string {
 	// For exact matches, return the function directly
 	switch value {


### PR DESCRIPTION
Documenting sweeper field usage. Still need to document how to run sweepers but i want to simplify the execution pattern for them first. It's kinda weird right now.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
