### PR TITLE
monitoring: added `password_wo` write-only field to `google_monitoring_uptime_check_config`

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -248,8 +248,6 @@ properties:
               - 'password'
               - 'password_wo'
             sensitive: true
-            conflicts:
-              - 'password_wo'
             custom_flatten: 'templates/terraform/custom_flatten/uptime_check_http_password.tmpl'
           - name: 'passwordWo'
             type: String
@@ -258,15 +256,15 @@ properties:
               - 'passwordWo'
               - 'password'
             required_with:
-              - 'passwordWoVersion'
+              - 'http_check.0.auth_info.0.password_wo_version'
             write_only: true
-            conflicts:
-              - 'password'
           - name: 'passwordWoVersion'
             type: String
             immutable: true
             ignore_read: true
             description: The password write-only version.
+            required_with:
+              - 'http_check.0.auth_info.0.password_wo'
           - name: 'username'
             type: String
             description: The username to authenticate.

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -50,6 +50,12 @@ examples:
       display_name: 'http-uptime-check'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'uptime_check_config_http_password_wo'
+    primary_resource_id: 'http'
+    vars:
+      display_name: 'http-uptime-check'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
   - name: 'uptime_check_config_status_code'
     primary_resource_id: 'status_code'
     vars:
@@ -238,7 +244,9 @@ properties:
           - name: 'password'
             type: String
             description: The password to authenticate.
-            required: true
+            exactly_one_of:
+              - 'password'
+              - 'password_wo'
             sensitive: true
             conflicts:
               - 'password_wo'
@@ -246,6 +254,9 @@ properties:
           - name: 'passwordWo'
             type: String
             description: The password to authenticate.
+            exactly_one_of:
+              - 'passwordWo'
+              - 'password'
             required_with:
               - 'passwordWoVersion'
             write_only: true

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -35,6 +35,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  encoder: 'templates/terraform/encoders/uptime_check_config.go.tmpl'
   constants: 'templates/terraform/constants/monitoring_uptime_check_config.go.tmpl'
   post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_delete: 'templates/terraform/custom_delete/monitoring_uptime_check_config.go.tmpl'
@@ -239,7 +240,22 @@ properties:
             description: The password to authenticate.
             required: true
             sensitive: true
+            conflicts:
+              - 'password_wo'
             custom_flatten: 'templates/terraform/custom_flatten/uptime_check_http_password.tmpl'
+          - name: 'passwordWo'
+            type: String
+            description: The password to authenticate.
+            required_with:
+              - 'passwordWoVersion'
+            write_only: true
+            conflicts:
+              - 'password'
+          - name: 'passwordWoVersion'
+            type: String
+            immutable: true
+            ignore_read: true
+            description: The password write-only version.
           - name: 'username'
             type: String
             description: The username to authenticate.

--- a/mmv1/templates/terraform/encoders/uptime_check_config.go.tmpl
+++ b/mmv1/templates/terraform/encoders/uptime_check_config.go.tmpl
@@ -1,0 +1,15 @@
+// remove passwordWoVersion from the request body
+if v, ok := obj["httpCheck"]; ok {
+    httpCheck := v.(map[string]interface{})
+    if authInfo, ok := httpCheck["authInfo"].(map[string]interface{}); ok {
+        delete(authInfo, "passwordWoVersion")
+        if len(authInfo) > 0 {
+            httpCheck["authInfo"] = authInfo
+        } else {
+            delete(httpCheck, "authInfo")
+        }
+        obj["httpCheck"] = httpCheck
+    }
+}
+
+return obj, nil

--- a/mmv1/templates/terraform/examples/uptime_check_config_http_password_wo.tf.tmpl
+++ b/mmv1/templates/terraform/examples/uptime_check_config_http_password_wo.tf.tmpl
@@ -1,0 +1,44 @@
+resource "google_monitoring_uptime_check_config" "{{$.PrimaryResourceId}}" {
+  display_name = "{{index $.Vars "display_name"}}"
+  timeout      = "60s"
+  user_labels  = {
+    example-key = "example-value"
+  }
+
+  http_check {
+    path = "some-path"
+    port = "8010"
+    request_method = "POST"
+    content_type = "USER_PROVIDED"
+    custom_content_type = "application/json"
+    body = "Zm9vJTI1M0RiYXI="
+    ping_config {
+      pings_count = 1
+    }
+    auth_info {
+      username = "name"
+      password_wo = "password1"
+      password_wo_version = "1"
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = "{{index $.TestEnvVars "project_id"}}"
+      host       = "192.168.1.1"
+    }
+  }
+
+  content_matchers {
+    content = "\"example\""
+    matcher = "MATCHES_JSON_PATH"
+    json_path_matcher {
+      json_path = "$.path"
+      json_matcher = "EXACT_MATCH"
+    }
+  }
+
+  checker_type = "STATIC_IP_CHECKERS"
+}
+

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_uptime_check_config_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_uptime_check_config_test.go
@@ -41,6 +41,38 @@ func TestAccMonitoringUptimeCheckConfig_update(t *testing.T) {
 	})
 }
 
+func TestAccMonitoringUptimeCheckConfig_update_wo(t *testing.T) {
+	t.Parallel()
+	project := envvar.GetTestProjectFromEnv()
+	host := "192.168.1.1"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMonitoringUptimeCheckConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitoringUptimeCheckConfig_update_wo(acctest.RandString(t, 4), "60s", "mypath", "password1", "1", project, host),
+			},
+			{
+				ResourceName:            "google_monitoring_uptime_check_config.http",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
+			},
+			{
+				Config: testAccMonitoringUptimeCheckConfig_update_wo(acctest.RandString(t, 4), "60s", "", "password2", "2", project, host),
+			},
+			{
+				ResourceName:            "google_monitoring_uptime_check_config.http",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"http_check.0.auth_info.0.password"},
+			},
+		},
+	})
+}
+
 func TestAccMonitoringUptimeCheckConfig_noProjectId(t *testing.T) {
 	t.Parallel()
 	host := "192.168.1.1"
@@ -173,6 +205,41 @@ resource "google_monitoring_uptime_check_config" "http" {
   }
 }
 `, suffix, period, path, pwd, project, host,
+	)
+}
+
+func testAccMonitoringUptimeCheckConfig_update_wo(suffix, period, path, pwd_wo, pwd_wo_version, project, host string) string {
+	return fmt.Sprintf(`
+resource "google_monitoring_uptime_check_config" "http" {
+  display_name = "http-uptime-check-%s"
+  timeout      = "60s"
+  period       = "%s"
+
+  http_check {
+    path = "/%s"
+    port = "8010"
+    request_method = "GET"
+    auth_info {
+      username = "name"
+      password_wo = "%s"
+	  password_wo_version = "%s"
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = "%s"
+      host       = "%s"
+    }
+  }
+
+  content_matchers {
+    content = "example"
+    matcher = "CONTAINS_STRING"
+  }
+}
+`, suffix, period, path, pwd_wo, pwd_wo_version, project, host,
 	)
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Passing Test:
```hcl
󰀵 mau  …/terraform-provider-google   main $!?⇣   v1.23.4   11:46   envchain GCLOUD make test TEST=./google/services/monitoring TESTARGS='--run TestAccMonitoringUptimeCheckConfig_update_wo'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
go test --run TestAccMonitoringUptimeCheckConfig_update_wo -timeout=30s ./google/services/monitoring
ok      github.com/hashicorp/terraform-provider-google/google/services/monitoring       1.503s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
monitoring: added `password_wo` write-only field and `password_wo_version` field to `google_monitoring_uptime_check_config` resource
```
