### PR TITLE
feat: support new output-only field dns_names for Cloud SQL instances

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1031,8 +1031,30 @@ is set to true. Defaults to ZONAL.`,
 			"dns_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: `The dns name of the instance.`,
+				Description: `The instance-level dns name of the instance for PSC instances or public IP CAS instances.`,
 			},
+                        "dns_names": {
+                                 Type:        schema.TypeList,
+                                 Computed:    true,
+                                 Elem: &schema.Resource{
+                                         Schema: map[string]*schema.Schema{
+                                                 "name": {
+                                                         Type:     schema.TypeString,
+                                                         Computed: true,
+                                                 },
+                                                 "connection_type": {
+                                                         Type:     schema.TypeString,
+                                                         Computed: true,
+                                                 },
+                                                 "dns_scope": {
+                                                         Type:     schema.TypeString,
+                                                         Computed: true,
+                                                 },
+  
+                                         },
+                                 },
+                                 Description: `The list of DNS names used by this instance. Different connection types for an instance may have different DNS names. DNS names can apply to an individual instance or a cluster of instances.`,
+                         },
 			"restore_backup_context": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1833,6 +1855,9 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("dns_name", instance.DnsName); err != nil {
 		return fmt.Errorf("Error setting dns_name: %s", err)
 	}
+        if err := d.Set("dns_names", flattenDnsNames(instance.DnsNames)); err != nil {
+                return fmt.Errorf("Error setting dns_names: %s", err)
+        }
 	d.SetId(instance.Name)
 
 	return nil
@@ -2609,6 +2634,23 @@ func flattenIpAddresses(ipAddresses []*sqladmin.IpMapping) []map[string]interfac
 	}
 
 	return ips
+}
+
+
+func flattenDnsNames(dnsNames []*sqladmin.DnsNameMapping) []map[string]interface{} {
+        var dns []map[string]interface{}
+ 
+        for _, mapping := range dnsNames {
+                data := map[string]interface{}{
+                        "name":            mapping.Name,
+                        "connection_type": mapping.ConnectionType,
+                        "dns_scope":       mapping.DnsScope,
+                }
+
+                dns = append(dns, data)
+        }
+ 
+        return dns
 }
 
 func flattenServerCaCerts(caCerts []*sqladmin.SslCert) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml
@@ -14,6 +14,7 @@ fields:
   - field: 'database_version'
   - field: 'deletion_protection'
   - field: 'dns_name'
+  - field: 'dns_names'
   - field: 'encryption_key_name'
   - field: 'first_ip_address'
   - field: 'instance_type'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2929,6 +2929,9 @@ func TestAccSqlDatabaseInstance_useCasBasedServerCa(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_mode", "GOOGLE_MANAGED_CAS_CA"),
 					resource.TestCheckResourceAttr(resourceName, "settings.0.ip_configuration.0.server_ca_pool", ""),
+					resource.TestCheckResourceAttr(resourceName, "dns_names.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_names.0.connection_type", "PUBLIC"),
+					resource.TestCheckResourceAttr(resourceName, "dns_names.0.dns_scope", "INSTANCE"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -583,6 +583,16 @@ connection strings. For example, when connecting with [Cloud SQL Proxy](https://
 
 * `dns_name` - The DNS name of the instance. See [Connect to an instance using Private Service Connect](https://cloud.google.com/sql/docs/mysql/configure-private-service-connect#view-summary-information-cloud-sql-instances-psc-enabled) for more details.
 
+* `dns_names` - The list of DNS names used by this instance. Different connection types for an instance may have different DNS names. DNS names can apply to an individual instance or a cluster of instances. 
+
+* `dns_names.0.name` - The DNS name.
+
+* `dns_names.0.connection_type` - The connection type of the DNS name. Can be either `PUBLIC`, `PRIVATE_SERVICES_ACCESS`, or `PRIVATE_SERVICE_CONNECT`.
+
+* `dns_names.0.dns_scope` - The scope that the DNS name applies to.
+
+  * An `INSTANCE` DNS name applies to an individual Cloud SQL instance.
+
 * `service_account_email_address` - The service account email address assigned to the
 instance.
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: added output-only field `dns_names` to `google_sql_database_instance` resource
```
