### PR TITLE
Promote firewall policy with rules resources to GA

### DIFF
--- a/mmv1/products/compute/FirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/FirewallPolicyWithRules.yaml
@@ -17,7 +17,6 @@ api_resource_type_kind: FirewallPolicy
 description: |
   The Compute FirewallPolicy with rules resource. It declaratively manges all
   rules in the firewall policy.
-min_version: 'beta'
 docs:
 id_format: 'locations/global/firewallPolicies/{{policy_id}}'
 base_url: 'locations/global/firewallPolicies?parentId={{parent}}'
@@ -55,36 +54,30 @@ parameters:
     description: |
       The parent of this FirewallPolicy in the Cloud Resource Hierarchy.
       Format: organizations/{organization_id} or folders/{folder_id}
-    min_version: 'beta'
     required: true
     immutable: true
 properties:
   - name: 'creationTimestamp'
     type: String
     description: Creation timestamp in RFC3339 text format.
-    min_version: 'beta'
     output: true
   - name: 'shortName'
     type: String
     description: A textual name of the security policy.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'policyId'
     type: String
     description: The unique identifier for the resource. This identifier is defined by the server.
     api_name: id
-    min_version: 'beta'
     output: true
   - name: 'description'
     type: String
     description: An optional description of this resource.
-    min_version: 'beta'
   - name: 'rule'
     type: Array
     description: A list of firewall policy rules.
     api_name: rules
-    min_version: 'beta'
     required: true
     item_type:
       type: NestedObject
@@ -93,27 +86,23 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
         - name: 'priority'
           type: Integer
           description: |
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           required: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           required: true
           properties:
             - name: 'srcIpRanges'
@@ -121,7 +110,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destIpRanges'
@@ -129,7 +117,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcAddressGroups'
@@ -137,7 +124,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destAddressGroups'
@@ -145,7 +131,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcFqdns'
@@ -153,7 +138,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destFqdns'
@@ -161,7 +145,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcNetworkScope'
@@ -198,7 +181,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destRegionCodes'
@@ -208,7 +190,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcThreatIntelligences'
@@ -216,7 +197,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destThreatIntelligences'
@@ -224,7 +204,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'layer4Config'
@@ -232,7 +211,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               required: true
               item_type:
                 type: NestedObject
@@ -245,7 +223,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     required: true
                   - name: 'ports'
                     type: Array
@@ -256,7 +233,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     item_type:
                       type: String
         - name: 'action'
@@ -264,13 +240,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           required: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           enum_values:
             - 'INGRESS'
             - 'EGRESS'
@@ -280,14 +254,12 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           send_empty_value: true
         - name: 'targetServiceAccounts'
           type: Array
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           item_type:
             type: String
         - name: 'securityProfileGroup'
@@ -297,13 +269,11 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
         - name: 'targetResources'
           type: Array
           description: |
@@ -311,7 +281,6 @@ properties:
             This field allows you to control which network's VMs get
             this rule. If this field is left blank, all VMs
             within the organization will receive the rule.
-          min_version: 'beta'
           item_type:
             type: String
         - name: 'disabled'
@@ -321,11 +290,9 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
   - name: 'predefinedRules'
     type: Array
     description: A list of pre-define firewall policy rules.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -334,14 +301,12 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
           output: true
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
           output: true
         - name: 'priority'
           type: Integer
@@ -349,14 +314,12 @@ properties:
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           output: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           output: true
           properties:
             - name: 'srcIpRanges'
@@ -364,7 +327,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -373,7 +335,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -382,7 +343,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -391,7 +351,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -400,7 +359,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -409,7 +367,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -420,7 +377,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -431,7 +387,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -440,7 +395,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -449,7 +403,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -458,7 +411,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               output: true
               item_type:
                 type: NestedObject
@@ -471,7 +423,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     output: true
                   - name: 'ports'
                     type: Array
@@ -482,7 +433,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     output: true
                     item_type:
                       type: String
@@ -491,13 +441,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           output: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           output: true
           enum_values:
             - 'INGRESS'
@@ -508,14 +456,12 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           output: true
         - name: 'targetServiceAccounts'
           type: Array
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           output: true
           item_type:
             type: String
@@ -526,14 +472,12 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
           output: true
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
           output: true
         - name: 'targetResources'
           type: Array
@@ -542,7 +486,6 @@ properties:
             This field allows you to control which network's VMs get
             this rule. If this field is left blank, all VMs
             within the organization will receive the rule.
-          min_version: 'beta'
           output: true
           item_type:
             type: String
@@ -553,25 +496,20 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
           output: true
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLink'
     type: String
     description: Server-defined URL for the resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLinkWithId'
     type: String
     description: Server-defined URL for this resource with the resource id.
-    min_version: 'beta'
     output: true
   - name: 'ruleTupleCount'
     type: Integer
     description: Total count of all firewall policy rule tuples. A firewall policy can not exceed a set number of tuples.
-    min_version: 'beta'
     output: true

--- a/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
@@ -15,7 +15,6 @@
 name: 'NetworkFirewallPolicyWithRules'
 api_resource_type_kind: FirewallPolicy
 description: "The Compute NetworkFirewallPolicy with rules resource"
-min_version: 'beta'
 docs:
 base_url: 'projects/{{project}}/global/firewallPolicies'
 self_link: 'projects/{{project}}/global/firewallPolicies/{{name}}'
@@ -57,7 +56,6 @@ properties:
   - name: 'creationTimestamp'
     type: String
     description: Creation timestamp in RFC3339 text format.
-    min_version: 'beta'
     output: true
   - name: 'name'
     type: String
@@ -68,24 +66,20 @@ properties:
       the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
       which means the first character must be a lowercase letter, and all following characters must be a dash,
       lowercase letter, or digit, except the last character, which cannot be a dash.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'networkFirewallPolicyId'
     type: String
     description: The unique identifier for the resource. This identifier is defined by the server.
     api_name: id
-    min_version: 'beta'
     output: true
   - name: 'description'
     type: String
     description: An optional description of this resource.
-    min_version: 'beta'
   - name: 'rule'
     type: Array
     description: A list of firewall policy rules.
     api_name: rules
-    min_version: 'beta'
     required: true
     item_type:
       type: NestedObject
@@ -94,27 +88,23 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
         - name: 'priority'
           type: Integer
           description: |
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           required: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           required: true
           properties:
             - name: 'srcIpRanges'
@@ -122,7 +112,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destIpRanges'
@@ -130,7 +119,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcAddressGroups'
@@ -138,7 +126,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destAddressGroups'
@@ -146,7 +133,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcFqdns'
@@ -154,7 +140,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destFqdns'
@@ -162,7 +147,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcRegionCodes'
@@ -172,7 +156,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destRegionCodes'
@@ -182,7 +165,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcNetworkScope'
@@ -217,7 +199,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destThreatIntelligences'
@@ -225,7 +206,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'layer4Config'
@@ -233,7 +213,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               required: true
               item_type:
                 type: NestedObject
@@ -246,7 +225,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     required: true
                   - name: 'ports'
                     type: Array
@@ -257,7 +235,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     item_type:
                       type: String
             - name: 'srcSecureTag'
@@ -269,7 +246,6 @@ properties:
                 and there is no <code>srcIpRange</code>, this rule will be ignored.
                 Maximum number of source tag values allowed is 256.
               api_name: srcSecureTags
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -278,14 +254,12 @@ properties:
                     description: |
                       Name of the secure tag, created with TagManager's TagValue API.
                       @pattern tagValues/[0-9]+
-                    min_version: 'beta'
                   - name: 'state'
                     type: Enum
                     description: |
                       [Output Only] State of the secure tag, either `EFFECTIVE` or
                       `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                       or its network is deleted.
-                    min_version: 'beta'
                     output: true
                     enum_values:
                       - 'EFFECTIVE'
@@ -305,7 +279,6 @@ properties:
             to all instances on the specified network.
             Maximum number of target label tags allowed is 256.
           api_name: targetSecureTags
-          min_version: 'beta'
           item_type:
             type: NestedObject
             properties:
@@ -314,14 +287,12 @@ properties:
                 description: |
                   Name of the secure tag, created with TagManager's TagValue API.
                   @pattern tagValues/[0-9]+
-                min_version: 'beta'
               - name: 'state'
                 type: Enum
                 description: |
                   [Output Only] State of the secure tag, either `EFFECTIVE` or
                   `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                   or its network is deleted.
-                min_version: 'beta'
                 output: true
                 enum_values:
                   - 'EFFECTIVE'
@@ -331,13 +302,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           required: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           enum_values:
             - 'INGRESS'
             - 'EGRESS'
@@ -347,14 +316,12 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           send_empty_value: true
         - name: 'targetServiceAccounts'
           type: Array
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           item_type:
             type: String
         - name: 'securityProfileGroup'
@@ -364,13 +331,11 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
         - name: 'disabled'
           type: Boolean
           description: |
@@ -378,11 +343,9 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
   - name: 'predefinedRules'
     type: Array
     description: A list of firewall policy pre-defined rules.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -391,14 +354,12 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
           output: true
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
           output: true
         - name: 'priority'
           type: Integer
@@ -406,14 +367,12 @@ properties:
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           output: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           output: true
           properties:
             - name: 'srcIpRanges'
@@ -421,7 +380,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -430,7 +388,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -439,7 +396,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -448,7 +404,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -457,7 +412,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -466,7 +420,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -477,7 +430,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -488,7 +440,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -497,7 +448,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -506,7 +456,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -515,7 +464,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               output: true
               item_type:
                 type: NestedObject
@@ -528,7 +476,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     output: true
                   - name: 'ports'
                     type: Array
@@ -539,7 +486,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     output: true
                     item_type:
                       type: String
@@ -552,7 +498,6 @@ properties:
                 and there is no <code>srcIpRange</code>, this rule will be ignored.
                 Maximum number of source tag values allowed is 256.
               api_name: srcSecureTags
-              min_version: 'beta'
               output: true
               item_type:
                 type: NestedObject
@@ -562,7 +507,6 @@ properties:
                     description: |
                       Name of the secure tag, created with TagManager's TagValue API.
                       @pattern tagValues/[0-9]+
-                    min_version: 'beta'
                     output: true
                   - name: 'state'
                     type: Enum
@@ -570,7 +514,6 @@ properties:
                       [Output Only] State of the secure tag, either `EFFECTIVE` or
                       `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                       or its network is deleted.
-                    min_version: 'beta'
                     output: true
                     enum_values:
                       - 'EFFECTIVE'
@@ -590,7 +533,6 @@ properties:
             to all instances on the specified network.
             Maximum number of target label tags allowed is 256.
           api_name: targetSecureTags
-          min_version: 'beta'
           output: true
           item_type:
             type: NestedObject
@@ -600,7 +542,6 @@ properties:
                 description: |
                   Name of the secure tag, created with TagManager's TagValue API.
                   @pattern tagValues/[0-9]+
-                min_version: 'beta'
                 output: true
               - name: 'state'
                 type: Enum
@@ -608,7 +549,6 @@ properties:
                   [Output Only] State of the secure tag, either `EFFECTIVE` or
                   `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                   or its network is deleted.
-                min_version: 'beta'
                 output: true
                 enum_values:
                   - 'EFFECTIVE'
@@ -618,13 +558,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           output: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           output: true
           enum_values:
             - 'INGRESS'
@@ -635,7 +573,6 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           output: true
           send_empty_value: true
         - name: 'targetServiceAccounts'
@@ -643,7 +580,6 @@ properties:
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           output: true
           item_type:
             type: String
@@ -654,14 +590,12 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
           output: true
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
           output: true
         - name: 'disabled'
           type: Boolean
@@ -670,25 +604,20 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
           output: true
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLink'
     type: String
     description: Server-defined URL for the resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLinkWithId'
     type: String
     description: Server-defined URL for this resource with the resource id.
-    min_version: 'beta'
     output: true
   - name: 'ruleTupleCount'
     type: Integer
     description: Total count of all firewall policy rule tuples. A firewall policy can not exceed a set number of tuples.
-    min_version: 'beta'
     output: true

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
@@ -15,7 +15,6 @@
 name: 'RegionNetworkFirewallPolicyWithRules'
 api_resource_type_kind: FirewallPolicy
 description: "The Compute NetworkFirewallPolicy with rules resource"
-min_version: 'beta'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies'
 self_link: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{name}}'
@@ -57,7 +56,6 @@ parameters:
   - name: 'region'
     type: String
     description: The region of this resource.
-    min_version: 'beta'
     url_param_only: true
     immutable: true
     default_from_api: true
@@ -65,7 +63,6 @@ properties:
   - name: 'creationTimestamp'
     type: String
     description: Creation timestamp in RFC3339 text format.
-    min_version: 'beta'
     output: true
   - name: 'name'
     type: String
@@ -76,24 +73,20 @@ properties:
       the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?
       which means the first character must be a lowercase letter, and all following characters must be a dash,
       lowercase letter, or digit, except the last character, which cannot be a dash.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'networkFirewallPolicyId'
     type: String
     description: The unique identifier for the resource. This identifier is defined by the server.
     api_name: id
-    min_version: 'beta'
     output: true
   - name: 'description'
     type: String
     description: An optional description of this resource.
-    min_version: 'beta'
   - name: 'rule'
     type: Array
     description: A list of firewall policy rules.
     api_name: rules
-    min_version: 'beta'
     required: true
     item_type:
       type: NestedObject
@@ -102,27 +95,23 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
         - name: 'priority'
           type: Integer
           description: |
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           required: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           required: true
           properties:
             - name: 'srcIpRanges'
@@ -130,7 +119,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destIpRanges'
@@ -138,7 +126,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcAddressGroups'
@@ -146,7 +133,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destAddressGroups'
@@ -154,7 +140,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcFqdns'
@@ -162,7 +147,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destFqdns'
@@ -170,7 +154,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcNetworkScope'
@@ -207,7 +190,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destRegionCodes'
@@ -217,7 +199,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'srcThreatIntelligences'
@@ -225,7 +206,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'destThreatIntelligences'
@@ -233,7 +213,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               item_type:
                 type: String
             - name: 'layer4Config'
@@ -241,7 +220,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               required: true
               item_type:
                 type: NestedObject
@@ -254,7 +232,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     required: true
                   - name: 'ports'
                     type: Array
@@ -265,7 +242,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     item_type:
                       type: String
             - name: 'srcSecureTag'
@@ -277,7 +253,6 @@ properties:
                 and there is no <code>srcIpRange</code>, this rule will be ignored.
                 Maximum number of source tag values allowed is 256.
               api_name: srcSecureTags
-              min_version: 'beta'
               item_type:
                 type: NestedObject
                 properties:
@@ -286,14 +261,12 @@ properties:
                     description: |
                       Name of the secure tag, created with TagManager's TagValue API.
                       @pattern tagValues/[0-9]+
-                    min_version: 'beta'
                   - name: 'state'
                     type: Enum
                     description: |
                       [Output Only] State of the secure tag, either `EFFECTIVE` or
                       `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                       or its network is deleted.
-                    min_version: 'beta'
                     output: true
                     enum_values:
                       - 'EFFECTIVE'
@@ -313,7 +286,6 @@ properties:
             to all instances on the specified network.
             Maximum number of target label tags allowed is 256.
           api_name: targetSecureTags
-          min_version: 'beta'
           item_type:
             type: NestedObject
             properties:
@@ -322,14 +294,12 @@ properties:
                 description: |
                   Name of the secure tag, created with TagManager's TagValue API.
                   @pattern tagValues/[0-9]+
-                min_version: 'beta'
               - name: 'state'
                 type: Enum
                 description: |
                   [Output Only] State of the secure tag, either `EFFECTIVE` or
                   `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                   or its network is deleted.
-                min_version: 'beta'
                 output: true
                 enum_values:
                   - 'EFFECTIVE'
@@ -339,13 +309,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           required: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           enum_values:
             - 'INGRESS'
             - 'EGRESS'
@@ -355,14 +323,12 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           send_empty_value: true
         - name: 'targetServiceAccounts'
           type: Array
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           item_type:
             type: String
         - name: 'securityProfileGroup'
@@ -372,13 +338,11 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
         - name: 'disabled'
           type: Boolean
           description: |
@@ -386,11 +350,9 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
   - name: 'predefinedRules'
     type: Array
     description: A list of firewall policy pre-defined rules.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -399,14 +361,12 @@ properties:
           type: String
           description: |
             A description of the rule.
-          min_version: 'beta'
           output: true
         - name: 'ruleName'
           type: String
           description: |
             An optional name for the rule. This field is not a unique identifier
             and can be updated.
-          min_version: 'beta'
           output: true
         - name: 'priority'
           type: Integer
@@ -414,14 +374,12 @@ properties:
             An integer indicating the priority of a rule in the list. The priority must be a value
             between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
             highest priority and 2147483647 is the lowest priority.
-          min_version: 'beta'
           output: true
         - name: 'match'
           type: NestedObject
           description:
             A match condition that incoming traffic is evaluated against. If it
             evaluates to true, the corresponding 'action' is enforced.
-          min_version: 'beta'
           output: true
           properties:
             - name: 'srcIpRanges'
@@ -429,7 +387,6 @@ properties:
               description: |
                 Source IP address range in CIDR format. Required for
                 INGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -438,7 +395,6 @@ properties:
               description: |
                 Destination IP address range in CIDR format. Required for
                 EGRESS rules.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -447,7 +403,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic source.
                 Maximum number of source address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -456,7 +411,6 @@ properties:
               description: |
                 Address groups which should be matched against the traffic destination.
                 Maximum number of destination address groups is 10.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -465,7 +419,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic source. Maximum number of source fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -474,7 +427,6 @@ properties:
               description: |
                 Fully Qualified Domain Name (FQDN) which should be matched against
                 traffic destination. Maximum number of destination fqdn allowed is 100.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -485,7 +437,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of source region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -496,7 +447,6 @@ properties:
                 of traffic. Should be specified as 2 letter country code defined as per
                 ISO 3166 alpha-2 country codes. ex."US"
                 Maximum number of destination region codes allowed is 5000.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -505,7 +455,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic source.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -514,7 +463,6 @@ properties:
               description: |
                 Names of Network Threat Intelligence lists.
                 The IPs in these lists will be matched against traffic destination.
-              min_version: 'beta'
               output: true
               item_type:
                 type: String
@@ -523,7 +471,6 @@ properties:
               description: |
                 Pairs of IP protocols and ports that the rule should match.
               api_name: layer4Configs
-              min_version: 'beta'
               output: true
               item_type:
                 type: NestedObject
@@ -536,7 +483,6 @@ properties:
                       This value can either be one of the following well
                       known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp),
                       or the IP protocol number.
-                    min_version: 'beta'
                     output: true
                   - name: 'ports'
                     type: Array
@@ -547,7 +493,6 @@ properties:
                       applies to connections through any port.
                       Example inputs include: ["22"], ["80","443"], and
                       ["12345-12349"].
-                    min_version: 'beta'
                     output: true
                     item_type:
                       type: String
@@ -560,7 +505,6 @@ properties:
                 and there is no <code>srcIpRange</code>, this rule will be ignored.
                 Maximum number of source tag values allowed is 256.
               api_name: srcSecureTags
-              min_version: 'beta'
               output: true
               item_type:
                 type: NestedObject
@@ -570,7 +514,6 @@ properties:
                     description: |
                       Name of the secure tag, created with TagManager's TagValue API.
                       @pattern tagValues/[0-9]+
-                    min_version: 'beta'
                     output: true
                   - name: 'state'
                     type: Enum
@@ -578,7 +521,6 @@ properties:
                       [Output Only] State of the secure tag, either `EFFECTIVE` or
                       `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                       or its network is deleted.
-                    min_version: 'beta'
                     output: true
                     enum_values:
                       - 'EFFECTIVE'
@@ -598,7 +540,6 @@ properties:
             to all instances on the specified network.
             Maximum number of target label tags allowed is 256.
           api_name: targetSecureTags
-          min_version: 'beta'
           output: true
           item_type:
             type: NestedObject
@@ -608,7 +549,6 @@ properties:
                 description: |
                   Name of the secure tag, created with TagManager's TagValue API.
                   @pattern tagValues/[0-9]+
-                min_version: 'beta'
                 output: true
               - name: 'state'
                 type: Enum
@@ -616,7 +556,6 @@ properties:
                   [Output Only] State of the secure tag, either `EFFECTIVE` or
                   `INEFFECTIVE`. A secure tag is `INEFFECTIVE` when it is deleted
                   or its network is deleted.
-                min_version: 'beta'
                 output: true
                 enum_values:
                   - 'EFFECTIVE'
@@ -626,13 +565,11 @@ properties:
           description: |
             The Action to perform when the client connection triggers the rule. Can currently be either
             "allow", "deny", "apply_security_profile_group" or "goto_next".
-          min_version: 'beta'
           output: true
         - name: 'direction'
           type: Enum
           description: |
             The direction in which this rule applies. If unspecified an INGRESS rule is created.
-          min_version: 'beta'
           output: true
           enum_values:
             - 'INGRESS'
@@ -643,7 +580,6 @@ properties:
             Denotes whether to enable logging for a particular rule.
             If logging is enabled, logs will be exported to the
             configured export destination in Stackdriver.
-          min_version: 'beta'
           output: true
           send_empty_value: true
         - name: 'targetServiceAccounts'
@@ -651,7 +587,6 @@ properties:
           description: |
             A list of service accounts indicating the sets of
             instances that are applied with this rule.
-          min_version: 'beta'
           output: true
           item_type:
             type: String
@@ -662,14 +597,12 @@ properties:
             Example:
             https://networksecurity.googleapis.com/v1/projects/{project}/locations/{location}/securityProfileGroups/my-security-profile-group
             Must be specified if action is 'apply_security_profile_group'.
-          min_version: 'beta'
           output: true
         - name: 'tlsInspect'
           type: Boolean
           description: |
             Boolean flag indicating if the traffic should be TLS decrypted.
             It can be set only if action = 'apply_security_profile_group' and cannot be set for other actions.
-          min_version: 'beta'
           output: true
         - name: 'disabled'
           type: Boolean
@@ -678,25 +611,20 @@ properties:
             the firewall policy rule is not enforced and traffic behaves as if it did
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
-          min_version: 'beta'
           output: true
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLink'
     type: String
     description: Server-defined URL for the resource.
-    min_version: 'beta'
     output: true
   - name: 'selfLinkWithId'
     type: String
     description: Server-defined URL for this resource with the resource id.
-    min_version: 'beta'
     output: true
   - name: 'ruleTupleCount'
     type: Integer
     description: Total count of all firewall policy rule tuples. A firewall policy can not exceed a set number of tuples.
-    min_version: 'beta'
     output: true

--- a/mmv1/templates/terraform/examples/compute_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_firewall_policy_with_rules_full.tf.tmpl
@@ -1,9 +1,7 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   short_name  = "{{index $.Vars "fw_policy"}}"
   description = "Terraform test"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
@@ -14,7 +12,7 @@ resource "google_compute_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
     enable_logging   = true
     action           = "allow"
     direction        = "EGRESS"
-    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.project_id}/global/networks/default"]
+    target_resources = [google_compute_network.network.self_link]
 
     match {
       dest_ip_ranges            = ["11.100.0.1/32"]
@@ -70,47 +68,9 @@ resource "google_compute_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
       }
     }
   }
-
-  rule {
-    description    = "network scope rule 1"
-    rule_name      = "network scope 1"
-    priority       = 4000
-    enable_logging = false
-    action         = "allow"
-    direction      = "INGRESS"
-    match {
-      src_ip_ranges     = ["11.100.0.1/32"]
-      src_network_scope = "VPC_NETWORKS"
-      src_networks      = [google_compute_network.network.id]
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
-
-  rule {
-    description    = "network scope rule 2"
-    rule_name      = "network scope 2"
-    priority       = 5000
-    enable_logging = false
-    action         = "allow"
-    direction      = "EGRESS"
-    match {
-      dest_ip_ranges     = ["0.0.0.0/0"]
-      dest_network_scope = "INTERNET"
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "{{index $.Vars "address_group"}}"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   description = "Global address group"
@@ -121,7 +81,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "{{index $.Vars "security_profile_group"}}"
   parent                    = "organizations/{{index $.TestEnvVars "org_id"}}"
   description               = "my description"
@@ -129,7 +88,6 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "{{index $.Vars "security_profile"}}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
@@ -137,7 +95,6 @@ resource "google_network_security_security_profile" "security_profile_1" {
 }
 
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network"}}"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/compute_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_network_firewall_policy_with_rules_full.tf.tmpl
@@ -1,9 +1,7 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_network_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name = "{{index $.Vars "fw_policy"}}"
   description = "Terraform test"
 
@@ -76,48 +74,9 @@ resource "google_compute_network_firewall_policy_with_rules" "{{$.PrimaryResourc
       }
     }
   }
-
-  rule {
-    description    = "network scope rule 1"
-    rule_name      = "network scope 1"
-    priority       = 4000
-    enable_logging = false
-    action         = "allow"
-    direction      = "INGRESS"
-
-    match {
-      src_ip_ranges     = ["11.100.0.1/32"]
-      src_network_scope = "VPC_NETWORKS"
-      src_networks      = [google_compute_network.network.id]
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
-
-  rule {
-    description    = "network scope rule 2"
-    rule_name      = "network scope 2"
-    priority       = 5000
-    enable_logging = false
-    action         = "allow"
-    direction      = "EGRESS"
-    match {
-      dest_ip_ranges     = ["0.0.0.0/0"]
-      dest_network_scope = "INTERNET"
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "{{index $.Vars "address_group"}}"
   parent      = data.google_project.project.id
   description = "Global address group"
@@ -128,7 +87,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider    = google-beta
   description = "Tag key"
   parent      = data.google_project.project.id
   purpose     = "GCE_FIREWALL"
@@ -140,14 +98,12 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider    = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "{{index $.Vars "tag_value"}}"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "{{index $.Vars "security_profile_group"}}"
   parent                    = "organizations/{{index $.TestEnvVars "org_id"}}"
   description               = "my description"
@@ -155,15 +111,9 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "{{index $.Vars "security_profile"}}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   location    = "global"
 }
 
-resource "google_compute_network" "network" {
-  provider                = google-beta
-  name                    = "{{index $.Vars "network"}}"
-  auto_create_subnetworks = false
-}

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
@@ -1,9 +1,7 @@
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_region_network_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.Vars "fw_policy"}}"
   region      = "us-west2"
   description = "Terraform test"
@@ -58,49 +56,9 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
       }
     }
   }
-
-  rule {
-    description    = "network scope rule 1"
-    rule_name      = "network scope 1"
-    priority       = 4000
-    enable_logging = false
-    action         = "allow"
-    direction      = "INGRESS"
-
-    match {
-      src_ip_ranges     = ["11.100.0.1/32"]
-      src_network_scope = "VPC_NETWORKS"
-      src_networks      = [google_compute_network.network.id]
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
-
-  rule {
-    description    = "network scope rule 2"
-    rule_name      = "network scope 2"
-    priority       = 5000
-    enable_logging = false
-    action         = "allow"
-    direction      = "EGRESS"
-
-    match {
-      dest_ip_ranges     = ["0.0.0.0/0"]
-      dest_network_scope = "NON_INTERNET"
-
-      layer4_config {
-        ip_protocol = "tcp"
-        ports       = [8080]
-      }
-    }
-  }
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta 
   name        = "{{index $.Vars "address_group"}}"
   parent      = data.google_project.project.id
   description = "Regional address group"
@@ -111,7 +69,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider    = google-beta
   description = "Tag key"
   parent      = data.google_project.project.id
   purpose     = "GCE_FIREWALL"
@@ -122,14 +79,8 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider    = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "{{index $.Vars "tag_value"}}"
 }
 
-resource "google_compute_network" "network" {
-  provider                = google-beta
-  name                    = "{{index $.Vars "network"}}"
-  auto_create_subnetworks = false
-}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_with_rules_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 import (
 	"testing"
 
@@ -19,7 +18,7 @@ func TestAccComputeFirewallPolicyWithRules_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeFirewallPolicyWithRulesDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -45,14 +44,12 @@ func TestAccComputeFirewallPolicyWithRules_update(t *testing.T) {
 func testAccComputeFirewallPolicyWithRules_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules" {
   short_name = "tf-test-tf-fw-org-policy-with-rules%{random_suffix}"
   description = "Terraform test"
   parent = "organizations/%{org_id}"
-  provider = google-beta
 
   rule {
     description    = "tcp rule"
@@ -71,7 +68,7 @@ resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules
       dest_threat_intelligences = ["iplist-search-engines-crawlers", "iplist-tor-exit-nodes"]
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
-    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.project_id}/global/networks/default"]
+    target_resources = [google_compute_network.network.self_link]
   }
   rule {
     description    = "udp rule"
@@ -111,7 +108,6 @@ resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "organizations/%{org_id}"
   description = "Global address group"
@@ -122,7 +118,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "tf-test-tf-security-profile-group%{random_suffix}"
   parent                    = "organizations/%{org_id}"
   description               = "my description"
@@ -130,26 +125,29 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "tf-test-tf-security-profile%{random_suffix}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/%{org_id}"
   location    = "global"
 }
+
+resource "google_compute_network" "network" {
+  name                    = "tf-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
 `, context)
 }
 
 func testAccComputeFirewallPolicyWithRules_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules" {
   short_name = "tf-test-tf-fw-org-policy-with-rules%{random_suffix}"
   description = "Terraform test - update"
   parent = "organizations/%{org_id}"
-  provider = google-beta
 
   rule {
     description    = "tcp rule - update"
@@ -190,7 +188,6 @@ resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "organizations/%{org_id}"
   description = "Global address group"
@@ -201,7 +198,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "tf-test-tf-security-profile-group%{random_suffix}"
   parent                    = "organizations/%{org_id}"
   description               = "my description"
@@ -209,7 +205,6 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "tf-test-tf-security-profile%{random_suffix}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/%{org_id}"
@@ -217,5 +212,4 @@ resource "google_network_security_security_profile" "security_profile_1" {
 }
 `, context)
 }
-{{- end }}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_firewall_policy_with_rules_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 import (
 	"testing"
 
@@ -19,7 +18,7 @@ func TestAccComputeNetworkFirewallPolicyWithRules_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeNetworkFirewallPolicyWithRulesDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -45,13 +44,11 @@ func TestAccComputeNetworkFirewallPolicyWithRules_update(t *testing.T) {
 func testAccComputeNetworkFirewallPolicyWithRules_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_network_firewall_policy_with_rules" "network-firewall-policy-with-rules" {
   name = "tf-test-tf-fw-policy-with-rules%{random_suffix}"
   description = "Terraform test"
-  provider = google-beta
 
   rule {
     description    = "tcp rule"
@@ -115,7 +112,6 @@ resource "google_compute_network_firewall_policy_with_rules" "network-firewall-p
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "projects/${data.google_project.project.name}"
   description = "Global address group"
@@ -126,7 +122,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider    = google-beta
   description = "Tag key"
   parent      = "projects/${data.google_project.project.name}"
   purpose     = "GCE_FIREWALL"
@@ -137,14 +132,12 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider    = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "tf-test-tf-security-profile-group%{random_suffix}"
   parent                    = "organizations/%{org_id}"
   description               = "my description"
@@ -152,7 +145,6 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "tf-test-tf-security-profile%{random_suffix}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/%{org_id}"
@@ -164,13 +156,11 @@ resource "google_network_security_security_profile" "security_profile_1" {
 func testAccComputeNetworkFirewallPolicyWithRules_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-   provider    = google-beta 
 }
 
 resource "google_compute_network_firewall_policy_with_rules" "network-firewall-policy-with-rules" {
   name = "tf-test-tf-fw-policy-with-rules%{random_suffix}"
   description = "Terraform test - update"
-  provider    = google-beta
 
   rule {
     description    = "tcp rule - changed"
@@ -213,7 +203,6 @@ resource "google_compute_network_firewall_policy_with_rules" "network-firewall-p
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider    = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "projects/${data.google_project.project.name}"
   description = "Global address group"
@@ -224,7 +213,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider    = google-beta
   description = "Tag key"
   parent      = "projects/${data.google_project.project.name}"
   purpose     = "GCE_FIREWALL"
@@ -235,14 +223,12 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider    = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 
 resource "google_network_security_security_profile_group" "security_profile_group_1" {
-  provider                  = google-beta
   name                      = "tf-test-tf-security-profile-group%{random_suffix}"
   parent                    = "organizations/%{org_id}"
   description               = "my description"
@@ -250,7 +236,6 @@ resource "google_network_security_security_profile_group" "security_profile_grou
 }
 
 resource "google_network_security_security_profile" "security_profile_1" {
-  provider    = google-beta
   name        = "tf-test-tf-security-profile%{random_suffix}"
   type        = "THREAT_PREVENTION"
   parent      = "organizations/%{org_id}"
@@ -258,6 +243,5 @@ resource "google_network_security_security_profile" "security_profile_1" {
 }
 `, context)
 }
-{{- end }}
 
  

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_network_firewall_policy_with_rules_test.go.tmpl
@@ -1,5 +1,4 @@
 package compute_test
-{{- if ne $.TargetVersionName "ga" }}
 import (
 	"testing"
 
@@ -17,7 +16,7 @@ func TestAccComputeRegionNetworkFirewallPolicyWithRules_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionNetworkFirewallPolicyWithRulesDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -45,14 +44,12 @@ func TestAccComputeRegionNetworkFirewallPolicyWithRules_update(t *testing.T) {
 func testAccComputeRegionNetworkFirewallPolicyWithRules_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_region_network_firewall_policy_with_rules" "region-network-firewall-policy-with-rules" {
   name        = "tf-test-tf-region-fw-policy-with-rules%{random_suffix}"
   region      = "us-west2"
   description = "Terraform test"
-  provider    = google-beta
 
   rule {
     description    = "tcp rule"
@@ -100,7 +97,6 @@ resource "google_compute_region_network_firewall_policy_with_rules" "region-netw
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider  = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "projects/${data.google_project.project.name}"
   description = "Regional address group"
@@ -111,7 +107,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider   = google-beta
   description = "Tag key"
   parent      = "projects/${data.google_project.project.name}"
   purpose     = "GCE_FIREWALL"
@@ -122,7 +117,6 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider   = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
@@ -133,14 +127,12 @@ resource "google_tags_tag_value" "secure_tag_value_1" {
 func testAccComputeRegionNetworkFirewallPolicyWithRules_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 data "google_project" "project" {
-  provider = google-beta
 }
 
 resource "google_compute_region_network_firewall_policy_with_rules" "region-network-firewall-policy-with-rules" {
   name = "tf-test-tf-fw-policy-with-rules%{random_suffix}"
   description = "Terraform test - update"
   region = "us-west2"
-  provider = google-beta
 
   rule {
     description    = "tcp rule - changed"
@@ -180,7 +172,6 @@ resource "google_compute_region_network_firewall_policy_with_rules" "region-netw
 }
 
 resource "google_network_security_address_group" "address_group_1" {
-  provider  = google-beta
   name        = "tf-test-tf-address-group%{random_suffix}"
   parent      = "projects/${data.google_project.project.name}"
   description = "Regional address group"
@@ -191,7 +182,6 @@ resource "google_network_security_address_group" "address_group_1" {
 }
 
 resource "google_tags_tag_key" "secure_tag_key_1" {
-  provider   = google-beta
   description = "Tag key"
   parent      = "projects/${data.google_project.project.name}"
   purpose     = "GCE_FIREWALL"
@@ -202,12 +192,10 @@ resource "google_tags_tag_key" "secure_tag_key_1" {
 }
 
 resource "google_tags_tag_value" "secure_tag_value_1" {
-  provider   = google-beta
   description = "Tag value"
   parent      = google_tags_tag_key.secure_tag_key_1.id
   short_name  = "tf-test-tf-tag-value%{random_suffix}"
 }
 `, context)
 }
-{{- end }}
 


### PR DESCRIPTION
Promote firewall policy with rules resources to GA

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
- `google_compute_region_network_firewall_policy_with_rules`, `google_compute_network_firewall_policy_with_rules`,  `compute_firewall_policy_with_rules` GA promotion 
```
