### PR TITLE
feat(LbTrafficExtension): Add LBTrafficExtension metadata support

### DIFF
--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -86,6 +86,9 @@ properties:
   - name: 'labels'
     type: KeyValueLabels
     description: 'Set of labels associated with the LbTrafficExtension resource.'
+  - name: 'metadata'
+    type: Object
+    description: 'Set of metadata associated with the LbTrafficExtension resource.'
   - name: 'forwardingRules'
     type: Array
     description: |

--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -86,9 +86,6 @@ properties:
   - name: 'labels'
     type: KeyValueLabels
     description: 'Set of labels associated with the LbTrafficExtension resource.'
-  - name: 'metadata'
-    type: Object
-    description: 'Set of metadata associated with the LbTrafficExtension resource.'
   - name: 'forwardingRules'
     type: Array
     description: |
@@ -105,6 +102,7 @@ properties:
       Match conditions for each extension chain are evaluated in sequence for a given request.
       The first extension chain that has a condition that matches the request is executed.
       Any subsequent extension chains do not execute. Limited to 5 extension chains per resource.
+      Further information can be found at https://cloud.google.com/service-extensions/docs/reference/rest/v1/ExtensionChain
     required: true
     item_type:
       type: NestedObject
@@ -134,6 +132,7 @@ properties:
             A set of extensions to execute for the matching request.
             At least one extension is required. Up to 3 extensions can be defined for each extension chain for
             LbTrafficExtension resource. LbRouteExtension chains are limited to 1 extension per extension chain.
+            Further documentation to be found at https://cloud.google.com/service-extensions/docs/reference/rest/v1/ExtensionChain#Extension
           required: true
           item_type:
             type: NestedObject
@@ -188,6 +187,13 @@ properties:
                 item_type:
                   type: String
                 min_size: 1
+              - name: 'metadata'
+                type: KeyValuePairs
+                description: |
+                  Metadata associated with the extension. This field is used to pass metadata to the extension service.
+                  You can set up key value pairs for metadata as you like and need.
+                  f.e. {"key": "value", "key2": "value2"}.
+
   - name: 'loadBalancingScheme'
     type: Enum
     description: |

--- a/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
@@ -202,6 +202,10 @@ resource "google_network_services_lb_traffic_extension" "{{$.PrimaryResourceId}}
 
           supported_events = ["REQUEST_HEADERS"]
           forward_headers = ["custom-header"]
+          metadata = {
+            "key1" = "value1"
+            "key2" = "value2"
+          }
       }
   }
 

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
@@ -248,7 +248,7 @@ resource "google_network_services_lb_traffic_extension" "default" {
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["custom-header"]
       metadata = {
-        "exampleId": "test"
+        "exampleId" = "test"
       }
     }
   }
@@ -567,7 +567,7 @@ resource "google_network_services_lb_traffic_extension" "default" {
       supported_events = ["REQUEST_HEADERS"]
       forward_headers = ["custom-header"]
       metadata = {
-        "exampleId": "test"
+        "exampleId" = "test"
       }
     }
   }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
@@ -230,6 +230,7 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
   load_balancing_scheme = "INTERNAL_MANAGED"
   forwarding_rules      = [google_compute_forwarding_rule.default.self_link]
+  metadata              = {"exampleId": "test"}
 
   extension_chains {
     name = "chain1"
@@ -546,6 +547,7 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
   load_balancing_scheme = "INTERNAL_MANAGED"
   forwarding_rules      = [google_compute_forwarding_rule.default.self_link]
+  metadata              = {"exampleId": "test"}
 
   extension_chains {
     name = "chain1"

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
@@ -230,7 +230,6 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
   load_balancing_scheme = "INTERNAL_MANAGED"
   forwarding_rules      = [google_compute_forwarding_rule.default.self_link]
-  metadata              = {"exampleId": "test"}
 
   extension_chains {
     name = "chain1"
@@ -248,6 +247,9 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["custom-header"]
+      metadata = {
+        "exampleId": "test"
+      }
     }
   }
 
@@ -547,7 +549,6 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
   load_balancing_scheme = "INTERNAL_MANAGED"
   forwarding_rules      = [google_compute_forwarding_rule.default.self_link]
-  metadata              = {"exampleId": "test"}
 
   extension_chains {
     name = "chain1"
@@ -565,6 +566,9 @@ resource "google_network_services_lb_traffic_extension" "default" {
 
       supported_events = ["REQUEST_HEADERS"]
       forward_headers = ["custom-header"]
+      metadata = {
+        "exampleId": "test"
+      }
     }
   }
 


### PR DESCRIPTION
The GCP LbTrafficExtension supports to give an object of metadata on setup.
This behaviour shall be added with this change.

You can setup an loadbalancer traffic extension with a `traffic.yml` like this:
```yaml
name: queueit-traffic-extension
forwardingRules:
  - https://www.googleapis.com/compute/v1/projects/[PROJECT]/regions/global/forwardingRules/[GCP_FORWARD_RULE]
loadBalancingScheme: EXTERNAL_MANAGED
extensionChains:
  - name: "chain1"
    matchCondition:
      celExpression: 'request.host = 'example.com'
    extensions:
      - name: 'cloud-connector'
        authority: [AUTHORITY]
        service: https://www.googleapis.com/compute/v1/projects/[PROJECT]/regions/global/backendServices/[BACKEND_SERVICE]
        failOpen: true
        timeout: 1s
        supportedEvents:
          - REQUEST_HEADERS
          - REQUEST_BODY
          - RESPONSE_HEADERS
        metadata:
          "customerId": "test"
          "key": "value"
```

Which will be added to metadata in the traffic service extension. The metadata object need to be a JSON object to be valid. Afterwards the command:

```bash
$ gcloud service-extensions lb-traffic-extensions import test-traffic-extension --source=traffic.yaml --location=global
```

will successfully create an extension including the metadata.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `metadata` field to `google_networkservices_lbtrafficextension` resource
```
