### PR TITLE
Clarify recommendation for simple map types

### DIFF
--- a/docs/content/develop/add-fields.md
+++ b/docs/content/develop/add-fields.md
@@ -167,6 +167,12 @@ Replace `String` in the field type with one of the following options:
     key_name: 'KEY_NAME'
     key_description: |
       MULTILINE_KEY_FIELD_DESCRIPTION
+  # Map of primitive values
+    value_type:
+      name: mapIntegerName
+      type: Integer
+
+  # Map of complex values
     value_type:
       name: mapObjectName
       type: NestedObject
@@ -177,7 +183,7 @@ Replace `String` in the field type with one of the following options:
           MULTI_LINE_FIELD_DESCRIPTION
 ```
 
-This type is only used for string -> complex type mappings, use "KeyValuePairs" for simple mappings. Complex maps can't be represented natively in Terraform, and this type is transformed into an associative array (TypeSet) with the key merged into the object alongside other top-level fields.
+This type is used for general-case string -> non-string type mappings, use "KeyValuePairs" for string -> string mappings. Complex maps can't be represented natively in Terraform, and this type is transformed into an associative array (TypeSet) with the key merged into the object alongside other top-level fields.
 
 For `key_name` and `key_description`, provide a domain-appropriate name and description. For example, a map that references a specific type of resource would generally use the singular resource kind as the key name (such as "topic" for PubSub Topic) and a descriptor of the expected format depending on the context (such as resourceId vs full resource name).
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes b/385136052

`KeyValuePairs` is strictly defined to mean string -> string, so for other simple map types like string -> int, we will recommend the Map type.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
