### PR TITLE
Move Private NAT APIs from beta to GA

### DIFF
--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -96,7 +96,6 @@ examples:
     exclude_test: true
   - name: 'router_nat_private'
     primary_resource_id: 'nat_type'
-    min_version: 'beta'
     vars:
       router_name: 'my-router'
       nat_name: 'my-router-nat'
@@ -430,7 +429,6 @@ properties:
                   These subnetworks must have purpose set to PRIVATE_NAT.
                   This field is used for private NAT.
               is_set: true
-              min_version: 'beta'
               set_hash_func: computeRouterNatRulesSubnetHash
               custom_flatten: 'templates/terraform/custom_flatten/nat_rules_subnets_set.tmpl'
               custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
@@ -448,7 +446,6 @@ properties:
                 This is only supported on patch/update, and these subnetworks must have previously been used as active ranges in this NAT Rule.
                 This field is used for private NAT.
               is_set: true
-              min_version: 'beta'
               set_hash_func: computeRouterNatRulesSubnetHash
               custom_flatten: 'templates/terraform/custom_flatten/nat_rules_subnets_set.tmpl'
               custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
@@ -473,7 +470,6 @@ properties:
       If unspecified, it defaults to PUBLIC.
       If `PUBLIC` NAT used for public IP translation.
       If `PRIVATE` NAT used for private IP translation.
-    min_version: 'beta'
     immutable: true
     default_value: "PUBLIC"
     enum_values:

--- a/mmv1/templates/terraform/constants/router_nat.go.tmpl
+++ b/mmv1/templates/terraform/constants/router_nat.go.tmpl
@@ -96,11 +96,9 @@ func computeRouterNatIPsHash(v interface{}) int {
 	return schema.HashString(tpgresource.GetResourceNameFromSelfLink(val))
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func computeRouterNatRulesSubnetHash(v interface{}) int {
 	return computeRouterNatIPsHash(v)
 }
-{{- end }}
 
 func computeRouterNatRulesHash(v interface{}) int {
 	obj := v.(map[string]interface{})
@@ -116,10 +114,8 @@ func computeRouterNatRulesHash(v interface{}) int {
 
 	sourceNatActiveIpHash := 0
 	sourceNatDrainIpHash := 0
-	{{- if ne $.TargetVersionName "ga" }}
 	sourceNatActiveRangeHash := 0
 	sourceNatDrainRangeHash := 0
-	{{- end }}
 	routerNatRulesHash := 0
 
 	if obj["action"] != nil {
@@ -145,7 +141,6 @@ func computeRouterNatRulesHash(v interface{}) int {
 				}
 			}
 
-			{{ if ne $.TargetVersionName `ga` -}}
 			sourceNatActiveRanges := action["source_nat_active_ranges"]
 			if sourceNatActiveRanges != nil {
 				sourceNatActiveRangesSet := sourceNatActiveRanges.(*schema.Set)
@@ -163,13 +158,9 @@ func computeRouterNatRulesHash(v interface{}) int {
 					sourceNatDrainRangeHash += schema.HashString(sourceNatDrainRangeStr)
 				}
 			}
-			{{- end }}
 		}
 	}
 
-	routerNatRulesHash = ruleNumber + descriptionHash + schema.HashString(match) + sourceNatActiveIpHash + sourceNatDrainIpHash
-	{{- if ne $.TargetVersionName "ga" }}
-	routerNatRulesHash += sourceNatActiveRangeHash + sourceNatDrainRangeHash
-	{{- end }}
+	routerNatRulesHash = ruleNumber + descriptionHash + schema.HashString(match) + sourceNatActiveIpHash + sourceNatDrainIpHash + sourceNatActiveRangeHash + sourceNatDrainRangeHash
 	return routerNatRulesHash
 }

--- a/mmv1/templates/terraform/constants/router_nat_validate_action_active_range.go.tmpl
+++ b/mmv1/templates/terraform/constants/router_nat_validate_action_active_range.go.tmpl
@@ -1,4 +1,3 @@
-{{- if ne $.TargetVersionName "ga" -}}
 natType := d.Get("type").(string)
 if natType == "PRIVATE" {
 	rules := d.Get("rules").(*schema.Set)
@@ -25,4 +24,3 @@ if natType == "PRIVATE" {
 		}
 	}
 }
-{{- end }}

--- a/mmv1/templates/terraform/examples/router_nat_private.tf.tmpl
+++ b/mmv1/templates/terraform/examples/router_nat_private.tf.tmpl
@@ -1,12 +1,8 @@
 resource "google_compute_network" "net" {
-  provider = google-beta
-
   name     = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  provider      = google-beta
-
   name          = "{{index $.Vars "subnet_name"}}"
   network       = google_compute_network.net.id
   ip_cidr_range = "10.0.0.0/16"
@@ -15,23 +11,17 @@ resource "google_compute_subnetwork" "subnet" {
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
-
   name     = "{{index $.Vars "router_name"}}"
   region   = google_compute_subnetwork.subnet.region
   network  = google_compute_network.net.id
 }
 
 resource "google_network_connectivity_hub" "hub" {
-  provider    = google-beta
-
   name        = "{{index $.Vars "hub_name"}}"
   description = "vpc hub for inter vpc nat"
 }
 
 resource "google_network_connectivity_spoke" "spoke" {
-  provider    = google-beta
-
   name        = "{{index $.Vars "spoke_name"}}"
   location    = "global"
   description = "vpc spoke for inter vpc nat"
@@ -46,8 +36,6 @@ resource "google_network_connectivity_spoke" "spoke" {
 }
 
 resource "google_compute_router_nat" "{{$.PrimaryResourceId}}" {
-  provider                            = google-beta
-
   name                                = "{{index $.Vars "nat_name"}}"
   router                              = google_compute_router.router.name
   region                              = google_compute_router.router.region

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_nat_test.go.tmpl
@@ -2,9 +2,7 @@ package compute_test
 
 import (
 	"fmt"
-{{- if ne $.TargetVersionName "ga" }}
 	"regexp"
-{{- end }}
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -225,7 +223,6 @@ func TestAccComputeRouterNat_withPortAllocationMethods(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 	t.Parallel()
 
@@ -274,7 +271,6 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 	})
 }
 
-{{ end }}
 
 func TestAccComputeRouterNat_withNatRules(t *testing.T) {
 	t.Parallel()
@@ -484,7 +480,6 @@ func TestAccComputeRouterNat_AutoNetworkTier(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeRouterNat_withPrivateNat(t *testing.T) {
 	t.Parallel()
 
@@ -687,7 +682,6 @@ func TestAccComputeRouterNat_withPrivateNatAndEmptyActionActiveRanges(t *testing
 		},
 	})
 }
-{{- end }}
 
 func TestAccComputeRouterNat_withAddressCountDecrease(t *testing.T) {
 	t.Parallel()
@@ -1406,7 +1400,6 @@ resource "google_compute_router" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeRouterNatWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 %s
@@ -1515,7 +1508,6 @@ resource "google_compute_router_nat" "foobar" {
 }
 `, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
-{{- end }}
 
 func testAccComputeRouterNatRulesBasic_omitRules(routerName string) string {
 	return fmt.Sprintf(`
@@ -1893,7 +1885,6 @@ resource "google_compute_router" "foobar" {
 `, routerName, routerName, routerName, routerName, routerName, hubName, routerName, routerName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeRouterNatPrivateType(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -2041,8 +2032,6 @@ resource "google_compute_router_nat" "foobar" {
 }
 `, testAccComputeRouterNatBaseResourcesWithPrivateNatSubnetworks(routerName, hubName), routerName, ruleNumber, ruleDescription, match)
 }
-
-{{ end }}
 
 func testAccComputeRouterNatWitAutoNetworkTier(routerName, hubName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--
Move Private NAT APIs from beta to GA

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22254
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: Moved Private NAT APIs of `google_compute_router_nat` resource from beta to GA 
```
