### PR TITLE
Allow setting SSL type on connection profiles

### DIFF
--- a/mmv1/products/databasemigrationservice/ConnectionProfile.yaml
+++ b/mmv1/products/databasemigrationservice/ConnectionProfile.yaml
@@ -232,10 +232,11 @@ properties:
             type: Enum
             description: |
               The current connection profile state.
-            output: true
             enum_values:
               - 'SERVER_ONLY'
               - 'SERVER_CLIENT'
+              - 'REQUIRED'
+              - 'NONE'
           - name: 'clientKey'
             type: String
             description: |
@@ -326,10 +327,11 @@ properties:
             type: Enum
             description: |
               The current connection profile state.
-            output: true
             enum_values:
               - 'SERVER_ONLY'
               - 'SERVER_CLIENT'
+              - 'REQUIRED'
+              - 'NONE'
           - name: 'clientKey'
             type: String
             description: |

--- a/mmv1/products/databasemigrationservice/ConnectionProfile.yaml
+++ b/mmv1/products/databasemigrationservice/ConnectionProfile.yaml
@@ -71,6 +71,32 @@ examples:
       - 'postgresql.0.ssl.0.ca_certificate'
       - 'postgresql.0.ssl.0.client_certificate'
       - 'postgresql.0.ssl.0.client_key'
+  - name: 'database_migration_service_connection_profile_postgres_no_ssl'
+    primary_resource_id: 'postgresprofile'
+    vars:
+      sqldb: 'my-database'
+      sqldb_cert: 'my-cert'
+      sqldb_user: 'my-username'
+      sqldb_pass: 'my-password'
+      profile: 'my-profileid'
+    ignore_read_extra:
+      - 'postgresql.0.password'
+      - 'postgresql.0.ssl.0.ca_certificate'
+      - 'postgresql.0.ssl.0.client_certificate'
+      - 'postgresql.0.ssl.0.client_key'
+  - name: 'database_migration_service_connection_profile_postgres_required_ssl'
+    primary_resource_id: 'postgresprofile'
+    vars:
+      sqldb: 'my-database'
+      sqldb_cert: 'my-cert'
+      sqldb_user: 'my-username'
+      sqldb_pass: 'my-password'
+      profile: 'my-profileid'
+    ignore_read_extra:
+      - 'postgresql.0.password'
+      - 'postgresql.0.ssl.0.ca_certificate'
+      - 'postgresql.0.ssl.0.client_certificate'
+      - 'postgresql.0.ssl.0.client_key'
   - name: 'database_migration_service_connection_profile_oracle'
     primary_resource_id: 'oracleprofile'
     vars:
@@ -256,9 +282,8 @@ properties:
           - name: 'caCertificate'
             type: String
             description: |
-              Required. Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
+              Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
               The replica will use this certificate to verify it's connecting to the right host.
-            required: true
             immutable: true
             sensitive: true
             custom_flatten: 'templates/terraform/custom_flatten/database_migration_service_connection_profile_mysql_ssl_ca_certificate.go.tmpl'
@@ -355,9 +380,8 @@ properties:
           - name: 'caCertificate'
             type: String
             description: |
-              Required. Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
+              Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
               The replica will use this certificate to verify it's connecting to the right host.
-            required: true
             immutable: true
             sensitive: true
             custom_flatten: 'templates/terraform/custom_flatten/database_migration_service_connection_profile_postgresql_ssl_ca_certificate.go.tmpl'
@@ -458,9 +482,8 @@ properties:
           - name: 'caCertificate'
             type: String
             description: |
-              Required. Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
+              Input only. The x509 PEM-encoded certificate of the CA that signed the source database server's certificate.
               The replica will use this certificate to verify it's connecting to the right host.
-            required: true
             immutable: true
             sensitive: true
             custom_flatten: 'templates/terraform/custom_flatten/database_migration_service_connection_profile_oracle_ssl_ca_certificate.go.tmpl'

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_cloudsql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_cloudsql.tf.tmpl
@@ -44,6 +44,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
       client_key         = google_sql_ssl_cert.sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "{{index $.Vars "sqldb"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres.tf.tmpl
@@ -39,6 +39,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
       client_key = google_sql_ssl_cert.sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.sql_client_cert.cert
       ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "{{index $.Vars "sqldb"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
@@ -1,0 +1,47 @@
+resource "google_sql_database_instance" "postgresqldb" {
+  name             = "{{index $.Vars "sqldb"}}"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-13312"
+  }
+  deletion_protection = false
+}
+
+resource "google_sql_ssl_cert" "sql_client_cert" {
+  common_name = "{{index $.Vars "sqldb_cert"}}"
+  instance    = google_sql_database_instance.postgresqldb.name
+
+  depends_on = [google_sql_database_instance.postgresqldb]
+}
+
+resource "google_sql_user" "sqldb_user" {
+  name     = "{{index $.Vars "sqldb_user"}}"
+  instance = google_sql_database_instance.postgresqldb.name
+  password = "{{index $.Vars "sqldb_pass"}}"
+
+
+  depends_on = [google_sql_ssl_cert.sql_client_cert]
+}
+
+resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  connection_profile_id = "{{index $.Vars "profile"}}"
+  display_name = "{{index $.Vars "profile"}}_display"
+  labels = { 
+    foo = "bar" 
+  }
+  postgresql {
+    host = google_sql_database_instance.postgresqldb.ip_address.0.ip_address
+    port = 5432
+    username = google_sql_user.sqldb_user.name
+    password = google_sql_user.sqldb_user.password
+    ssl {
+      client_key = google_sql_ssl_cert.sql_client_cert.private_key
+      client_certificate = google_sql_ssl_cert.sql_client_cert.cert
+      ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
+    }
+    cloud_sql_id = "{{index $.Vars "sqldb"}}"
+  }
+  depends_on = [google_sql_user.sqldb_user]
+}

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_no_ssl.tf.tmpl
@@ -36,10 +36,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
     username = google_sql_user.sqldb_user.name
     password = google_sql_user.sqldb_user.password
     ssl {
-      client_key = google_sql_ssl_cert.sql_client_cert.private_key
-      client_certificate = google_sql_ssl_cert.sql_client_cert.cert
-      ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
-      type = "SERVER_CLIENT"
+      type = "NONE"
     }
     cloud_sql_id = "{{index $.Vars "sqldb"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
@@ -1,0 +1,47 @@
+resource "google_sql_database_instance" "postgresqldb" {
+  name             = "{{index $.Vars "sqldb"}}"
+  database_version = "POSTGRES_12"
+  settings {
+    tier = "db-custom-2-13312"
+  }
+  deletion_protection = false
+}
+
+resource "google_sql_ssl_cert" "sql_client_cert" {
+  common_name = "{{index $.Vars "sqldb_cert"}}"
+  instance    = google_sql_database_instance.postgresqldb.name
+
+  depends_on = [google_sql_database_instance.postgresqldb]
+}
+
+resource "google_sql_user" "sqldb_user" {
+  name     = "{{index $.Vars "sqldb_user"}}"
+  instance = google_sql_database_instance.postgresqldb.name
+  password = "{{index $.Vars "sqldb_pass"}}"
+
+
+  depends_on = [google_sql_ssl_cert.sql_client_cert]
+}
+
+resource "google_database_migration_service_connection_profile" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  connection_profile_id = "{{index $.Vars "profile"}}"
+  display_name = "{{index $.Vars "profile"}}_display"
+  labels = { 
+    foo = "bar" 
+  }
+  postgresql {
+    host = google_sql_database_instance.postgresqldb.ip_address.0.ip_address
+    port = 5432
+    username = google_sql_user.sqldb_user.name
+    password = google_sql_user.sqldb_user.password
+    ssl {
+      client_key = google_sql_ssl_cert.sql_client_cert.private_key
+      client_certificate = google_sql_ssl_cert.sql_client_cert.cert
+      ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
+    }
+    cloud_sql_id = "{{index $.Vars "sqldb"}}"
+  }
+  depends_on = [google_sql_user.sqldb_user]
+}

--- a/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_connection_profile_postgres_required_ssl.tf.tmpl
@@ -36,10 +36,7 @@ resource "google_database_migration_service_connection_profile" "{{$.PrimaryReso
     username = google_sql_user.sqldb_user.name
     password = google_sql_user.sqldb_user.password
     ssl {
-      client_key = google_sql_ssl_cert.sql_client_cert.private_key
-      client_certificate = google_sql_ssl_cert.sql_client_cert.cert
-      ca_certificate = google_sql_ssl_cert.sql_client_cert.server_ca_cert
-      type = "SERVER_CLIENT"
+      type = "REQUIRED"
     }
     cloud_sql_id = "{{index $.Vars "sqldb"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_migration_job_mysql_to_mysql.tf.tmpl
@@ -42,6 +42,7 @@ resource "google_database_migration_service_connection_profile" "source_cp" {
       client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "{{index $.Vars "source_csql"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_alloydb.tf.tmpl
@@ -42,6 +42,7 @@ resource "google_database_migration_service_connection_profile" "source_cp" {
       client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "{{index $.Vars "source_csql"}}"
   }

--- a/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres.tf.tmpl
@@ -42,6 +42,7 @@ resource "google_database_migration_service_connection_profile" "source_cp" {
       client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "{{index $.Vars "source_csql"}}"
   }

--- a/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
+++ b/mmv1/third_party/terraform/services/databasemigrationservice/resource_database_migration_service_migration_job_test.go
@@ -88,6 +88,7 @@ resource "google_database_migration_service_connection_profile" "source_cp" {
       client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "tf-test-source-csql%{random_suffix}"
   }
@@ -195,6 +196,7 @@ resource "google_database_migration_service_connection_profile" "source_cp" {
       client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
       client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
       ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
     }
     cloud_sql_id = "tf-test-source-csql%{random_suffix}"
   }


### PR DESCRIPTION
Cloud DMS API & UI started to support setting the SSL type on source connection profiles. This change allows setting the SSL type in the Terraform templates.

```release-note:enhancement
databasemigrationservice: added `ssl.type` as an input field to `google_database_migration_service_connection_profile` resource
```
