### PR TITLE
docs(dns): dns managed zone descriptions updated for name and dnsName

### DIFF
--- a/mmv1/products/dns/ManagedZone.yaml
+++ b/mmv1/products/dns/ManagedZone.yaml
@@ -135,6 +135,7 @@ properties:
     type: String
     description: |
       The DNS name of this managed zone, for instance "example.com.".
+      Must end with a trailing dot.
     required: true
     immutable: true
   - name: 'dnssecConfig'
@@ -230,8 +231,9 @@ properties:
   - name: 'name'
     type: String
     description: |
-      User assigned name for this resource.
-      Must be unique within the project.
+      User assigned name for this resource. 
+      Must be unique within the project. 
+      The name must be 1-63 characters long, must begin with a letter, end with a letter or digit, and only contain lowercase letters, digits or dashes.
     required: true
     immutable: true
   - name: 'nameServers'


### PR DESCRIPTION
The API for (managedZones)[https://cloud.google.com/dns/docs/reference/rest/v1/managedZones] has restrictions on the Name for the resource and the dnsName has to end in a trailing dot. That should now also be apparent from the documentation of the properties, not just the examples.

```release-note:note
DNS: Updated description on Name and DNS Name properties for resource google_dns_managed_zone.
```
