### PR TITLE
Feature gap: Add `backends.preference`, `maxStreamDuration` and `cdnPolicy.requestCoalescing` to BackendService

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -184,6 +184,19 @@ properties:
             0% of its available Capacity. Valid range is [0.0,1.0].
           send_empty_value: true
           default_value: 1.0
+        - name: 'preference'
+          type: Enum
+          description: |
+            This field indicates whether this backend should be fully utilized before sending traffic to backends
+            with default preference. The possible values are:
+              - PREFERRED: Backends with this preference level will be filled up to their capacity limits first,
+                based on RTT.
+              - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and
+                traffic would be assigned based on the load balancing algorithm you use. This is the default
+          enum_values:
+            - 'PREFERRED'
+            - 'DEFAULT'
+          default_value: 'DEFAULT'
         - name: 'description'
           type: String
           description: |
@@ -503,6 +516,13 @@ properties:
     description: 'Cloud CDN configuration for this BackendService.'
     default_from_api: true
     properties:
+      - name: 'requestCoalescing'
+        type: Boolean
+        description: |
+          If true then Cloud CDN will combine multiple concurrent cache fill requests into a small number of requests
+          to the origin.
+        default_from_api: true
+        send_empty_value: true
       - name: 'cacheKeyPolicy'
         type: NestedObject
         description: 'The CacheKeyPolicy for this CdnPolicy.'
@@ -1515,3 +1535,25 @@ properties:
           Reference to the BackendAuthenticationConfig resource from the networksecurity.googleapis.com namespace.
           Can be used in authenticating TLS connections to the backend, as specified by the authenticationMode field.
           Can only be specified if authenticationMode is not NONE.
+  - name: 'maxStreamDuration'
+    type: NestedObject
+    description: |
+      Specifies the default maximum duration (timeout) for streams to this service. Duration is computed from the
+      beginning of the stream until the response has been completely processed, including all retries. A stream that
+      does not complete in this duration is closed.
+      If not specified, there will be no timeout limit, i.e. the maximum duration is infinite.
+      This value can be overridden in the PathMatcher configuration of the UrlMap that references this backend service.
+      This field is only allowed when the loadBalancingScheme of the backend service is INTERNAL_SELF_MANAGED.
+    properties:
+      - name: 'seconds'
+        type: String
+        description: |
+          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive. (int64 format)
+        required: true
+      - name: 'nanos'
+        type: Integer
+        description: |
+          Span of time that's a fraction of a second at nanosecond resolution.
+          Durations less than one second are represented with a 0 seconds field and a positive nanos field.
+          Must be from 0 to 999,999,999 inclusive.
+

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -196,7 +196,6 @@ properties:
           enum_values:
             - 'PREFERRED'
             - 'DEFAULT'
-          default_value: 'DEFAULT'
         - name: 'description'
           type: String
           description: |
@@ -1488,6 +1487,29 @@ properties:
           - 'log_config.0.sample_rate'
         diff_suppress_func: 'suppressWhenDisabled'
         default_value: 1.0
+      - name: 'optionalMode'
+        type: Enum
+        description: |
+          Specifies the optional logging mode for the load balancer traffic.
+          Supported values: INCLUDE_ALL_OPTIONAL, EXCLUDE_ALL_OPTIONAL, CUSTOM.
+        enum_values:
+          - 'INCLUDE_ALL_OPTIONAL'
+          - 'EXCLUDE_ALL_OPTIONAL'
+          - 'CUSTOM'
+        at_least_one_of:
+          - 'log_config.0.enable'
+          - 'log_config.0.sample_rate'
+          - 'log_config.0.optional_mode'
+        default_from_api: true
+      - name: 'optionalFields'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and "logConfig.optionalMode"
+          was set to CUSTOM. Contains a list of optional fields you want to include in the logs.
+          For example: serverInstance, serverGkeDetails.cluster, serverGkeDetails.pod.podNamespace
+        item_type:
+          type: String
+        default_from_api: true
   - name: 'serviceLbPolicy'
     type: String
     description: |

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -188,7 +188,7 @@ properties:
           type: Enum
           description: |
             This field indicates whether this backend should be fully utilized before sending traffic to backends
-            with default preference. The possible values are:
+            with default preference. This field cannot be set when loadBalancingScheme is set to 'EXTERNAL'. The possible values are:
               - PREFERRED: Backends with this preference level will be filled up to their capacity limits first,
                 based on RTT.
               - DEFAULT: If preferred backends don't have enough capacity, backends in this layer would be used and

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1509,7 +1509,6 @@ properties:
           For example: serverInstance, serverGkeDetails.cluster, serverGkeDetails.pod.podNamespace
         item_type:
           type: String
-        default_from_api: true
   - name: 'serviceLbPolicy'
     type: String
     description: |

--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1556,4 +1556,3 @@ properties:
           Span of time that's a fraction of a second at nanosecond resolution.
           Durations less than one second are represented with a 0 seconds field and a positive nanos field.
           Must be from 0 to 999,999,999 inclusive.
-

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -146,6 +146,40 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(
+					serviceName, igName, itName, checkName, "DEFAULT", 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(
+					serviceName, igName, itName, checkName, "PREFERRED", 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_updateIAPEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -334,6 +368,14 @@ func TestAccComputeBackendService_withCdnPolicy(t *testing.T) {
 			},
 			{
 				Config: testAccComputeBackendService_withCdnPolicyUseOriginHeaders(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCdnPolicyRequestCoalescing(serviceName, checkName),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -943,6 +985,49 @@ func TestAccComputeBackendService_regionNegBackend(t *testing.T) {
 	})
 }
 {{- end }}
+
+func TestAccComputeBackendService_backendServiceMaxDuration(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix": suffix,
+		"seconds_rnd":   2000,
+		"nanos_rnd":     10000,
+	}
+
+	context2 := map[string]interface{}{
+		"random_suffix": suffix,
+		"seconds_rnd":   5000,
+		"nanos_rnd":     20000,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_backendServiceMaxDuration(context),
+			},
+			{
+				ResourceName:            "google_compute_backend_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "security_settings.0.aws_v4_authentication.0.access_key"},
+			},
+			{
+				Config: testAccComputeBackendService_backendServiceMaxDuration(context2),
+			},
+			{
+				ResourceName:            "google_compute_backend_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "security_settings.0.aws_v4_authentication.0.access_key"},
+			},
+		},
+	})
+}
 
 func testAccComputeBackendService_trafficDirectorBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
@@ -1597,6 +1682,32 @@ resource "google_compute_backend_service" "foobar" {
   health_checks = [google_compute_http_health_check.zero.self_link]
 
   cdn_policy {
+    cache_mode = "USE_ORIGIN_HEADERS"
+    cache_key_policy {
+      include_protocol       = true
+      include_host           = true
+      include_query_string   = true
+    }
+  }
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeBackendService_withCdnPolicyRequestCoalescing(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+
+  cdn_policy {
+    request_coalescing = true
     cache_mode = "USE_ORIGIN_HEADERS"
     cache_key_policy {
       include_protocol       = true
@@ -2428,3 +2539,83 @@ resource "google_compute_health_check" "default" {
 }
 `, context)
 }
+
+func testAccComputeBackendService_backendServiceMaxDuration(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_backend_service" "default" {
+  name          		= "tf-test-backend-service%{random_suffix}"
+  health_checks 		= [google_compute_health_check.health_check.id]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+  max_stream_duration {
+    seconds = "%{seconds_rnd}"
+    nanos   = %{nanos_rnd}
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name = "tf-test-health-check%{random_suffix}"
+  tcp_health_check {
+    port = 22
+  }
+}
+`, context)
+}
+
+func testAccComputeBackendService_withBackendAndPreference(
+	serviceName, igName, itName, checkName, preference string, timeout int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  protocol    = "TCP"
+  timeout_sec = %v
+  load_balancing_scheme = "INTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_instance_group_manager.foobar.instance_group
+	preference = "%s"
+  }
+
+  health_checks = [google_compute_health_check.health_check.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, timeout, preference, igName, itName, checkName)
+}
+

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -790,7 +790,7 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "INCLUDE_ALL_OPTIONAL", false),
+				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "INCLUDE_ALL_OPTIONAL", true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -798,7 +798,23 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "EXCLUDE_ALL_OPTIONAL", false),
+				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "EXCLUDE_ALL_OPTIONAL", true),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withLogConfig4(serviceName, checkName, true),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withLogConfig5(serviceName, checkName, true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -2256,6 +2272,60 @@ resource "google_compute_health_check" "zero" {
   }
 }
 `, serviceName, enabled, mode, checkName)
+}
+
+func testAccComputeBackendService_withLogConfig4(serviceName, checkName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          		= "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks 		= [google_compute_health_check.zero.self_link]
+
+  log_config {
+	enable      	= %t
+	optional_mode 	= "CUSTOM"
+	optional_fields = ["serverInstance"]
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, enabled, checkName)
+}
+
+func testAccComputeBackendService_withLogConfig5(serviceName, checkName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          		= "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks 		= [google_compute_health_check.zero.self_link]
+
+  log_config {
+	enable      	= %t
+	optional_mode 	= "CUSTOM"
+	optional_fields = ["serverInstance", "serverGkeDetails.cluster"]
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, enabled, checkName)
 }
 
 func testAccComputeBackendService_withCompressionMode(serviceName, checkName, compressionMode string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -762,6 +762,22 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "INCLUDE_ALL_OPTIONAL", false),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "EXCLUDE_ALL_OPTIONAL", false),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -2187,6 +2203,32 @@ resource "google_compute_http_health_check" "zero" {
   timeout_sec        = 1
 }
 `, serviceName, enabled, checkName)
+}
+
+func testAccComputeBackendService_withLogConfig3(serviceName, checkName, mode string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          		= "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks 		= [google_compute_health_check.zero.self_link]
+
+  log_config {
+	enable      	= %t
+	optional_mode 	= "%s"
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, enabled, mode, checkName)
 }
 
 func testAccComputeBackendService_withCompressionMode(serviceName, checkName, compressionMode string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -149,18 +149,14 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 	t.Parallel()
 
-	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	randomSuffix := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(
-					serviceName, igName, itName, checkName, "DEFAULT", 10),
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_MANAGED", "DEFAULT", 10),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -168,8 +164,39 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(
-					serviceName, igName, itName, checkName, "PREFERRED", 20),
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_MANAGED", "PREFERRED", 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_SELF_MANAGED", "DEFAULT", 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_SELF_MANAGED", "PREFERRED", 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "EXTERNAL_MANAGED", "DEFAULT", 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "EXTERNAL_MANAGED", "PREFERRED", 20),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -2603,8 +2630,7 @@ resource "google_compute_health_check" "health_check" {
 `, context)
 }
 
-func testAccComputeBackendService_withBackendAndPreference(
-	serviceName, igName, itName, checkName, preference string, timeout int64) string {
+func testAccComputeBackendService_withBackendAndPreference(suffix, loadBalancingScheme, preference string, timeout int64) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-11"
@@ -2612,11 +2638,11 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_backend_service" "lipsum" {
-  name        = "%s"
+  name        = "test-lipsum-backend-service-%s"
   description = "Hello World 1234"
   protocol    = "TCP"
   timeout_sec = %v
-  load_balancing_scheme = "INTERNAL_MANAGED"
+  load_balancing_scheme = "%s"
 
   backend {
     group = google_compute_instance_group_manager.foobar.instance_group
@@ -2627,7 +2653,7 @@ resource "google_compute_backend_service" "lipsum" {
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
-  name = "%s"
+  name = "test-foobar-instance-group-manager-%s"
   version {
     instance_template = google_compute_instance_template.foobar.self_link
     name              = "primary"
@@ -2638,7 +2664,7 @@ resource "google_compute_instance_group_manager" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-  name         = "%s"
+  name         = "test-foobar-instance-template-%s"
   machine_type = "e2-medium"
 
   network_interface {
@@ -2653,11 +2679,10 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_health_check" "health_check" {
-  name = "%s"
+  name = "test-health-check-%s"
   http_health_check {
     port = 80
   }
 }
-`, serviceName, timeout, preference, igName, itName, checkName)
+`, suffix, timeout, loadBalancingScheme, preference, suffix, suffix, suffix)
 }
-

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -805,22 +805,6 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccComputeBackendService_withLogConfig4(serviceName, checkName, true),
-			},
-			{
-				ResourceName:      "google_compute_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComputeBackendService_withLogConfig5(serviceName, checkName, true),
-			},
-			{
-				ResourceName:      "google_compute_backend_service.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
@@ -2272,60 +2256,6 @@ resource "google_compute_health_check" "zero" {
   }
 }
 `, serviceName, enabled, mode, checkName)
-}
-
-func testAccComputeBackendService_withLogConfig4(serviceName, checkName string, enabled bool) string {
-	return fmt.Sprintf(`
-resource "google_compute_backend_service" "foobar" {
-  name          		= "%s"
-  protocol              = "HTTP"
-  load_balancing_scheme = "INTERNAL_MANAGED"
-  health_checks 		= [google_compute_health_check.zero.self_link]
-
-  log_config {
-	enable      	= %t
-	optional_mode 	= "CUSTOM"
-	optional_fields = ["serverInstance"]
-  }
-}
-
-resource "google_compute_health_check" "zero" {
-  name               = "%s"
-  check_interval_sec = 1
-  timeout_sec        = 1
-
-  http_health_check {
-    port = 80
-  }
-}
-`, serviceName, enabled, checkName)
-}
-
-func testAccComputeBackendService_withLogConfig5(serviceName, checkName string, enabled bool) string {
-	return fmt.Sprintf(`
-resource "google_compute_backend_service" "foobar" {
-  name          		= "%s"
-  protocol              = "HTTP"
-  load_balancing_scheme = "INTERNAL_MANAGED"
-  health_checks 		= [google_compute_health_check.zero.self_link]
-
-  log_config {
-	enable      	= %t
-	optional_mode 	= "CUSTOM"
-	optional_fields = ["serverInstance", "serverGkeDetails.cluster"]
-  }
-}
-
-resource "google_compute_health_check" "zero" {
-  name               = "%s"
-  check_interval_sec = 1
-  timeout_sec        = 1
-
-  http_health_check {
-    port = 80
-  }
-}
-`, serviceName, enabled, checkName)
 }
 
 func testAccComputeBackendService_withCompressionMode(serviceName, checkName, compressionMode string) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `log_config.optional_mode`, `log_config.optional_fields`, `backend.preference`, `max_stream_duration` and `cdn_policy.request_coalescing` fields to `google_compute_backend_service` resource
```
