### PR TITLE
Test failure ticket auto closure

### DIFF
--- a/.ci/magician/cmd/collect_nightly_test_status.go
+++ b/.ci/magician/cmd/collect_nightly_test_status.go
@@ -182,7 +182,7 @@ func createTestReport(pVersion provider.Version, tc TeamcityClient, gcs Cloudsto
 	}
 
 	// Upload test status data file to gcs bucket
-	objectName := pVersion.String() + "/" + testStatusFileName
+	objectName := fmt.Sprintf("test-metadata/%s/%s", pVersion.String(), testStatusFileName)
 	err = gcs.WriteToGCSBucket(NightlyDataBucket, objectName, testStatusFileName)
 	if err != nil {
 		return err

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -76,14 +76,12 @@ func (s testFailureRateLabel) String() string {
 }
 
 type testFailure struct {
-	TestName             string
-	AffectedResource     string
-	ErrorMessage         string
-	DebugLogLink         string
-	GaFailureRate        string
-	GaFailureRateLabel   testFailureRateLabel
-	BetaFailureRate      string
-	BetaFailureRateLabel testFailureRateLabel
+	TestName          string
+	AffectedResource  string
+	DebugLogLinks     map[provider.Version]string
+	ErrorMessageLinks map[provider.Version]string
+	FailureRates      map[provider.Version]string
+	FailureRateLabels map[provider.Version]testFailureRateLabel
 }
 
 // createTestFailureTicketCmd represents the createTestFailureTicket command
@@ -123,6 +121,8 @@ var createTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
+		date = time.Date(2025, 04, 06, 18, 0, 0, 0, loc)
+
 		return execCreateTestFailureTicket(date, gh, gcs)
 	},
 }
@@ -150,13 +150,13 @@ func execCreateTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 	for tName, tFailure := range testFailuresToday {
 		if _, ok := gaTestFailuresMap[tName]; ok {
 			gaRate, gaRateLabel := testFailureRate(gaTestFailuresMap[tName])
-			tFailure.GaFailureRate = gaRate
-			tFailure.GaFailureRateLabel = gaRateLabel
+			tFailure.FailureRates[provider.GA] = gaRate
+			tFailure.FailureRateLabels[provider.GA] = gaRateLabel
 		}
 		if _, ok := betaTestFailuresMap[tName]; ok {
 			betaRate, betaRateLabel := testFailureRate(betaTestFailuresMap[tName])
-			tFailure.BetaFailureRate = betaRate
-			tFailure.BetaFailureRateLabel = betaRateLabel
+			tFailure.FailureRates[provider.Beta] = betaRate
+			tFailure.FailureRateLabels[provider.Beta] = betaRateLabel
 		}
 	}
 
@@ -194,19 +194,30 @@ func lastNDaysTestFailureMap(pVersion provider.Version, n int, now time.Time, gc
 		for _, testInfo := range testInfoList {
 			testName := testInfo.Name
 			if _, ok := testFailuresMap[testName]; !ok {
-				testFailuresMap[testName] = make([]bool, TotalDays)
+				testFailuresMap[testName] = make([]bool, n)
 			}
 			testFailuresMap[testName][i] = testInfo.Status == "FAILURE"
 
 			if i == 0 && testInfo.Status == "FAILURE" {
 				if _, ok := testFailuresToday[testName]; !ok {
 					testFailuresToday[testName] = &testFailure{
-						TestName:         testName,
-						AffectedResource: convertTestNameToResource(testName),
-						ErrorMessage:     testInfo.ErrorMessage,
-						DebugLogLink:     testInfo.LogLink,
+						TestName:          testName,
+						AffectedResource:  convertTestNameToResource(testName),
+						ErrorMessageLinks: map[provider.Version]string{provider.GA: "", provider.Beta: ""},
+						DebugLogLinks:     map[provider.Version]string{provider.GA: "", provider.Beta: ""},
+						FailureRates:      map[provider.Version]string{provider.GA: "N/A", provider.Beta: "N/A"},
+						FailureRateLabels: map[provider.Version]testFailureRateLabel{provider.GA: testFailure0, provider.Beta: testFailure0},
 					}
 				}
+				// store error message
+				d := date.Format("2006-01-02")
+				fileName := fmt.Sprintf("%s-%s-%s.txt", testName, pVersion, d)
+				errorMessageLink, err := storeErrorMessage(pVersion, gcs, testInfo.ErrorMessage, fileName, d)
+				if err != nil {
+					return err
+				}
+				testFailuresToday[testName].ErrorMessageLinks[pVersion] = errorMessageLink
+				testFailuresToday[testName].DebugLogLinks[pVersion] = testInfo.LogLink
 			}
 		}
 	}
@@ -214,6 +225,9 @@ func lastNDaysTestFailureMap(pVersion provider.Version, n int, now time.Time, gc
 }
 
 func testFailureRate(testFailures []bool) (string, testFailureRateLabel) {
+	if testFailures == nil || len(testFailures) == 0 {
+		return "N/A", testFailure0
+	}
 	n := len(testFailures)
 	failCount := 0
 	last3DaysFailed := true
@@ -253,7 +267,7 @@ func getTestInfoList(pVersion provider.Version, date time.Time, gcs Cloudstorage
 	lookupDate := date.Format("2006-01-02")
 
 	testStatusFileName := fmt.Sprintf("%s-%s.json", lookupDate, pVersion.String())
-	objectName := pVersion.String() + "/" + testStatusFileName
+	objectName := fmt.Sprintf("test-metadata/%s/%s", pVersion.String(), testStatusFileName)
 
 	var testInfoList []TestInfo
 	err := gcs.DownloadFile(NightlyDataBucket, objectName, testStatusFileName)
@@ -269,7 +283,7 @@ func getTestInfoList(pVersion provider.Version, date time.Time, gcs Cloudstorage
 }
 
 func shouldCreateTicket(testfailure testFailure, existTestNames []string, todayClosedTestNames []string) bool {
-	if testfailure.GaFailureRateLabel == testFailureNone && testfailure.BetaFailureRateLabel == testFailureNone {
+	if testfailure.FailureRateLabels[provider.GA] == testFailureNone && testfailure.FailureRateLabels[provider.Beta] == testFailureNone {
 		return false
 	}
 	for _, t := range existTestNames {
@@ -283,7 +297,7 @@ func shouldCreateTicket(testfailure testFailure, existTestNames []string, todayC
 		}
 	}
 
-	if testfailure.GaFailureRateLabel == testFailure100 || testfailure.BetaFailureRateLabel == testFailure100 || testfailure.GaFailureRateLabel == testFailure50 || testfailure.BetaFailureRateLabel == testFailure50 {
+	if testfailure.FailureRateLabels[provider.GA] >= testFailure50 || testfailure.FailureRateLabels[provider.Beta] >= testFailure50 {
 		return true
 	}
 
@@ -390,10 +404,10 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		return fmt.Errorf("error formatting issue body: %w", err)
 	}
 
-	failureRatelabel := testFailure.GaFailureRateLabel.String()
+	failureRatelabel := testFailure.FailureRateLabels[provider.GA].String()
 
-	if testFailure.BetaFailureRateLabel > testFailure.GaFailureRateLabel {
-		failureRatelabel = testFailure.BetaFailureRateLabel.String()
+	if testFailure.FailureRateLabels[provider.Beta] > testFailure.FailureRateLabels[provider.GA] {
+		failureRatelabel = testFailure.FailureRateLabels[provider.Beta].String()
 	}
 
 	ticketLabels := []string{
@@ -441,37 +455,67 @@ func formatIssueBody(testFailure testFailure) (string, error) {
 func testNamesFromIssues(issues []*github.Issue) ([]string, error) {
 	var testNames []string
 	for _, issue := range issues {
-		if issue.IsPullRequest() {
-			continue
+		tns, err := testNamesFromIssue(issue)
+		if err != nil {
+			return testNames, err
 		}
+		testNames = append(testNames, tns...)
+	}
+	return testNames, nil
+}
 
-		affectedTests := strings.ReplaceAll(issue.GetBody(), "<!-- List all impacted tests for searchability. The title of the issue can instead list one or more groups of tests, or describe the overall root cause. -->", "")
-		impactTestRegexp := regexp.MustCompile(`Impacted tests:?[\r?\n]+((?:-? ?TestAcc[^\r\n]*\r?\n)*)`)
-		matches := impactTestRegexp.FindStringSubmatch(affectedTests)
+func testNamesFromIssue(issue *github.Issue) ([]string, error) {
+	var testNames []string
+	if issue.IsPullRequest() {
+		return testNames, nil
+	}
 
-		if len(matches) > 1 {
-			tests := strings.Split(matches[1], "\r\n")
+	affectedTests := strings.ReplaceAll(issue.GetBody(), "<!-- List all impacted tests for searchability. The title of the issue can instead list one or more groups of tests, or describe the overall root cause. -->", "")
+	impactTestRegexp := regexp.MustCompile(`Impacted tests:?[\r?\n]+((?:-? ?TestAcc[^\r\n]*\r?\n)*)`)
+	matches := impactTestRegexp.FindStringSubmatch(affectedTests)
 
-			for _, test := range tests {
-				subtests := strings.Split(test, "\n")
-				for _, subtest := range subtests {
-					if strings.HasPrefix(subtest, "- ") {
-						subtest = strings.TrimSpace(subtest[2:])
-						subtestParts := strings.Fields(subtest)
-						subtest = subtestParts[0]
+	if len(matches) > 1 {
+		tests := strings.Split(matches[1], "\r\n")
+
+		for _, test := range tests {
+			subtests := strings.Split(test, "\n")
+			for _, subtest := range subtests {
+				if strings.HasPrefix(subtest, "- ") {
+					subtest = strings.TrimSpace(subtest[2:])
+					subtestParts := strings.Fields(subtest)
+					subtest = subtestParts[0]
+					testNames = append(testNames, subtest)
+				} else {
+					singleTestRegexp := regexp.MustCompile(`TestAcc[^\r\n]*`)
+					if singleTestRegexp.MatchString(subtest) {
 						testNames = append(testNames, subtest)
-					} else {
-						singleTestRegexp := regexp.MustCompile(`TestAcc[^\r\n]*`)
-						if singleTestRegexp.MatchString(subtest) {
-							testNames = append(testNames, subtest)
-						}
 					}
 				}
 			}
-
 		}
+
 	}
 	return testNames, nil
+}
+
+func storeErrorMessage(pVersion provider.Version, gcs CloudstorageClient, errorMessage, fileName, date string) (string, error) {
+	// write error message to file
+	data := []byte(errorMessage)
+	err := os.WriteFile(fileName, data, 0644)
+	if err != nil {
+		return "", fmt.Errorf("failed to write error message to file %s : %w", fileName, err)
+	}
+
+	// upload file to GCS
+	objectName := fmt.Sprintf("test-errors/%s/%s/%s", pVersion.String(), date, fileName)
+	err = gcs.WriteToGCSBucket(NightlyDataBucket, objectName, fileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload error message file %s to GCS bucket: %w", objectName, err)
+	}
+
+	// compute object view path
+	link := fmt.Sprintf("https://storage.cloud.google.com/%s/%s", NightlyDataBucket, objectName)
+	return link, nil
 }
 
 func init() {

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -121,8 +121,6 @@ var createTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		date = time.Date(2025, 04, 06, 18, 0, 0, 0, loc)
-
 		return execCreateTestFailureTicket(date, gh, gcs)
 	},
 }

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -68,8 +68,6 @@ var manageTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		date = time.Date(2025, 04, 06, 18, 0, 0, 0, loc)
-
 		return execManageTestFailureTicket(date, gh, gcs)
 	},
 }
@@ -147,10 +145,16 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 			Body: github.String(comment),
 		}
 		_, _, err = gh.Issues.CreateComment(ctx, GithubOwner, GithubRepo, ticketNumber, issueComment)
+		if err != nil {
+			return fmt.Errorf("error posting comment to issue %d: %w", ticketNumber, err)
+		}
 		issueRquest := &github.IssueRequest{
 			State: github.String("closed"),
 		}
 		_, _, err = gh.Issues.Edit(ctx, GithubOwner, GithubRepo, ticketNumber, issueRquest)
+		if err != nil {
+			return fmt.Errorf("error closing issue %d: %w", ticketNumber, err)
+		}
 	}
 
 	return nil

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -18,6 +18,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"magician/cloudstorage"
+	"magician/provider"
 	"os"
 	"time"
 
@@ -40,6 +42,7 @@ var manageTestFailureTicketCmd = &cobra.Command{
 	 It performs the following operations:
 	 1. Lists out GitHub issues with test-failure and forward/review labels.
 	 2. Removes forward/review labels from these issues.
+	 3. Closes 100% test ticket if it starts to pass for 3 days
  
 	 The following environment variables are required:
  ` + listMTFTRequiredEnvironmentVariables(),
@@ -55,6 +58,8 @@ var manageTestFailureTicketCmd = &cobra.Command{
 
 		gh := github.NewClient(nil).WithAuthToken(env["GITHUB_TOKEN"])
 
+		gcs := cloudstorage.NewClient()
+
 		now := time.Now()
 
 		loc, err := time.LoadLocation("America/Los_Angeles")
@@ -63,7 +68,9 @@ var manageTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		return execManageTestFailureTicket(date, gh)
+		date = time.Date(2025, 04, 06, 18, 0, 0, 0, loc)
+
+		return execManageTestFailureTicket(date, gh, gcs)
 	},
 }
 
@@ -75,8 +82,10 @@ func listMTFTRequiredEnvironmentVariables() string {
 	return result
 }
 
-func execManageTestFailureTicket(now time.Time, gh *github.Client) error {
+func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs CloudstorageClient) error {
 	ctx := context.Background()
+
+	// Get test tickets with "forward/review" labels
 	opts := &github.IssueListByRepoOptions{
 		State:       "open",
 		Labels:      []string{"test-failure", "forward/review"},
@@ -94,7 +103,103 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client) error {
 			return err
 		}
 	}
+
+	// Get Test status for past 3 days
+	gaTestFailuresMap := make(map[string][]bool)
+	betaTestFailuresMap := make(map[string][]bool)
+
+	lastNDaysTestNonSuccessMap(provider.GA, 3, now, gcs, gaTestFailuresMap)
+	lastNDaysTestNonSuccessMap(provider.Beta, 3, now, gcs, betaTestFailuresMap)
+
+	// Get 100% failing test tickets
+	opts = &github.IssueListByRepoOptions{
+		State:       "open",
+		Labels:      []string{"test-failure-100"},
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	issues, err = ListIssuesWithOpts(ctx, gh, opts)
+	if err != nil {
+		return err
+	}
+
+	var shouldCloseTickets []int // store GH issue number
+
+	for _, issue := range issues {
+		// Get failing test names
+		tests, err := testNamesFromIssue(issue)
+		if err != nil {
+			return err
+		}
+		if len(tests) == 0 {
+			fmt.Println("No tests found for issue ", issue.GetNumber())
+			continue
+		}
+
+		if shouldCloseTestTicket(tests, gaTestFailuresMap, betaTestFailuresMap) {
+			shouldCloseTickets = append(shouldCloseTickets, issue.GetNumber())
+		}
+	}
+
+	comment := "All failing tests listed in this ticket have passed in the last three consecutive nightly runs. Closing the ticket."
+	for _, ticketNumber := range shouldCloseTickets {
+		fmt.Println("Closing ticket ", ticketNumber)
+		issueComment := &github.IssueComment{
+			Body: github.String(comment),
+		}
+		_, _, err = gh.Issues.CreateComment(ctx, GithubOwner, GithubRepo, ticketNumber, issueComment)
+		issueRquest := &github.IssueRequest{
+			State: github.String("closed"),
+		}
+		_, _, err = gh.Issues.Edit(ctx, GithubOwner, GithubRepo, ticketNumber, issueRquest)
+	}
+
 	return nil
+}
+
+func lastNDaysTestNonSuccessMap(pVersion provider.Version, n int, now time.Time, gcs CloudstorageClient, testFailuresMap map[string][]bool) error {
+	for i := 0; i < n; i++ {
+		date := now.AddDate(0, 0, -i)
+		testInfoList, err := getTestInfoList(pVersion, date, gcs)
+		if err != nil {
+			return fmt.Errorf("error getting test info list: %w", err)
+		}
+		for _, testInfo := range testInfoList {
+			testName := testInfo.Name
+			if _, ok := testFailuresMap[testName]; !ok {
+				testFailuresMap[testName] = make([]bool, n)
+			}
+			testFailuresMap[testName][i] = (testInfo.Status == "FAILURE" || testInfo.Status == "UNKNOWN") // failed or skipped
+		}
+	}
+	return nil
+}
+
+func shouldCloseTestTicket(tests []string, gaTestFailuresMap, betaTestFailuresMap map[string][]bool) bool {
+	for _, test := range tests {
+		gaFailures, foundGaTest := gaTestFailuresMap[test]
+		betaFailures, foundBetaTest := betaTestFailuresMap[test]
+
+		if !foundGaTest && !foundBetaTest {
+			fmt.Printf("test %s not found in either GA or Beta, might be skipped\n", test)
+			return false
+		}
+
+		if foundGaTest {
+			for _, fail := range gaFailures {
+				if fail {
+					return false
+				}
+			}
+		}
+		if foundBetaTest {
+			for _, fail := range betaFailures {
+				if fail {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 func init() {

--- a/.ci/magician/cmd/templates/TEST_FAILURE_ISSUE.md.tmpl
+++ b/.ci/magician/cmd/templates/TEST_FAILURE_ISSUE.md.tmpl
@@ -19,7 +19,9 @@
 
 {{ range $providerVersion, $errorMessageLink := .ErrorMessageLinks }}
 
+{{ if $errorMessageLink }}
 - [{{ $providerVersion }} error message]({{ $errorMessageLink }})
+{{ end }}
 
 {{ end }}
 
@@ -28,6 +30,8 @@
 
 {{ range $providerVersion, $debugLogLink := .DebugLogLinks }}
 
+{{ if $debugLogLink }}
 - [{{ $providerVersion }} debug log]({{ $debugLogLink }})
+{{ end }}
 
 {{ end }}

--- a/.ci/magician/cmd/templates/TEST_FAILURE_ISSUE.md.tmpl
+++ b/.ci/magician/cmd/templates/TEST_FAILURE_ISSUE.md.tmpl
@@ -9,18 +9,25 @@
 
 ### Failure rates
 
-- GA: {{.GaFailureRate}}
-- Beta: {{.BetaFailureRate}}
+{{ range $providerVersion, $failureRate := .FailureRates }}
 
+- {{ $providerVersion }}: {{ $failureRate }}
+
+{{ end }}
 
 ### Message(s)
 
-```
-{{.ErrorMessage}}
+{{ range $providerVersion, $errorMessageLink := .ErrorMessageLinks }}
 
-```
+- [{{ $providerVersion }} error message]({{ $errorMessageLink }})
+
+{{ end }}
 
 
 ### Test Debug Log
 
-- [link]({{.DebugLogLink}})
+{{ range $providerVersion, $debugLogLink := .DebugLogLinks }}
+
+- [{{ $providerVersion }} debug log]({{ $debugLogLink }})
+
+{{ end }}


### PR DESCRIPTION
This PR introduces two improvements:

1. stores detailed error messages in dedicated GSC files and links to these files are shared in tickets to prevent public exposure of potentially sensitive error details for security concerns. [Example Issue](https://github.com/hashicorp/terraform-provider-google/issues/22255)
2. automatically closes 100% failing test ticket after 3 consecutive successful nightly test runs


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
