### PR TITLE
Update GMK Cluster terraform documentation to reflect only one subnet per network

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -85,7 +85,7 @@ properties:
             type: Array
             description: "Virtual Private Cloud (VPC) subnets where IP addresses for the Kafka
               cluster are allocated. To make the cluster available in a VPC, you must specify at least
-              one subnet per network. You must specify between 1 and 10 subnets.
+              one `network_configs` block. Max of 10 subnets per cluster.
               Additional subnets may be specified with additional `network_configs` blocks."
             required: true
             item_type:
@@ -95,9 +95,9 @@ properties:
                   type: String
                   description: "Name of the VPC subnet from which the cluster is accessible. Both broker and
                     bootstrap server IP addresses and DNS entries are automatically created
-                    in the subnet. The subnet must be located in the same region as the
-                    cluster. The project may differ. The name of the subnet must be
-                    in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
+                    in the subnet. There can only be one subnet per network, and the subnet
+                    must be located in the same region as the cluster. The project may differ.
+                    The name of the subnet must be in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
                   required: true
                   diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - name: 'kmsKey'


### PR DESCRIPTION
Update the doc string for `network_configs` and `subnet` to reflect that there can only be a single subnetwork specified per network.

```release-note:none
```
