### PR TITLE
feat(dataplex): add `notification_report` to `google_dataplex_datascan` resource

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -267,6 +267,48 @@ properties:
                 description: |
                   The BigQuery table to export DataQualityScan results to.
                   Format://bigquery.googleapis.com/projects/PROJECT_ID/datasets/DATASET_ID/tables/TABLE_ID
+          - name: 'notificationReport'
+            type: NestedObject
+            description: |
+              The configuration of notification report post scan action.
+            properties:
+              - name: 'recipients'
+                type: NestedObject
+                description: |
+                  The individuals or groups who are designated to receive notifications upon triggers.
+                required: true
+                properties:
+                  - name: 'emails'
+                    type: Array
+                    description: |
+                      The email recipients who will receive the DataQualityScan results report.
+                    item_type: 
+                      type: String
+              - name: 'scoreThresholdTrigger'
+                type: NestedObject
+                description: |
+                  This trigger is triggered when the DQ score in the job result is less than a specified input score.
+                properties:
+                  - name: 'scoreThreshold'
+                    type: Double
+                    description: |
+                      The score range is in [0,100].
+              - name: 'jobFailureTrigger'
+                type: NestedObject
+                description: |
+                  This trigger is triggered when the scan job itself fails, regardless of the result.
+                send_empty_value: true
+                allow_empty_object: true
+                properties:
+                  []
+              - name: 'jobEndTrigger'
+                type: NestedObject
+                description: |
+                  This trigger is triggered whenever a scan job run ends, regardless of the result.
+                send_empty_value: true
+                allow_empty_object: true
+                properties:
+                  []
       - name: 'rules'
         type: Array
         description: |

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -282,7 +282,7 @@ properties:
                     type: Array
                     description: |
                       The email recipients who will receive the DataQualityScan results report.
-                    item_type: 
+                    item_type:
                       type: String
               - name: 'scoreThresholdTrigger'
                 type: NestedObject

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.tmpl
@@ -23,6 +23,17 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
   data_quality_spec {
     sampling_percent = 5
     row_filter = "station_id > 1000"
+    post_scan_actions {
+      notification_report {
+        recipients {
+          emails = ["jane.doe@example.com"]
+        }
+        score_threshold_trigger {
+          score_threshold = 86
+        }
+      }
+    }
+    
     rules {
       column = "address"
       dimension = "VALIDITY"


### PR DESCRIPTION
Closes [#22068](https://github.com/hashicorp/terraform-provider-google/issues/22068)

```release-note:enhancement
dataplex: added `notification_report` field to `google_dataplex_datascan` resource
```