### PR TITLE
feat: Add targetSecureTags field to FirewallPolicyRule resource

### DIFF
--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -303,4 +303,3 @@ properties:
           enum_values:
             - 'EFFECTIVE'
             - 'INEFFECTIVE'
-            

--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -303,3 +303,4 @@ properties:
           enum_values:
             - 'EFFECTIVE'
             - 'INEFFECTIVE'
+            

--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -285,8 +285,8 @@ properties:
     send_empty_value: true
     description: |
       A list of secure tags that controls which instances the firewall rule applies to.
-      If targetSecureTag are specified, then the firewall rule applies only to instances in the parent node that have one of those EFFECTIVE secure tags, if all the targetSecureTag are in INEFFECTIVE state, then this rule will be ignored.
-      targetSecureTag may not be set at the same time as targetServiceAccounts. If neither targetServiceAccounts nor targetSecureTag are specified, the firewall rule applies to all instances under specified parent node. Maximum number of target label tags allowed is 256.
+      If targetSecureTag are specified, then the firewall rule applies only to instances in the VPC network that have one of those EFFECTIVE secure tags, if all the targetSecureTag are in INEFFECTIVE state, then this rule will be ignored.
+      targetSecureTag may not be set at the same time as targetServiceAccounts. If neither targetServiceAccounts nor targetSecureTag are specified, the firewall rule applies to all instances on the specified network. Maximum number of target label tags allowed is 256.
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -280,3 +280,26 @@ properties:
       Denotes whether the firewall policy rule is disabled.
       When set to true, the firewall policy rule is not enforced and traffic behaves as if it did not exist.
       If this is unspecified, the firewall policy rule will be enabled.
+  - name: 'targetSecureTags'
+    type: Array
+    send_empty_value: true
+    description: |
+      A list of secure tags that controls which instances the firewall rule applies to.
+      If targetSecureTag are specified, then the firewall rule applies only to instances in the parent node that have one of those EFFECTIVE secure tags, if all the targetSecureTag are in INEFFECTIVE state, then this rule will be ignored.
+      targetSecureTag may not be set at the same time as targetServiceAccounts. If neither targetServiceAccounts nor targetSecureTag are specified, the firewall rule applies to all instances under specified parent node. Maximum number of target label tags allowed is 256.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            Name of the secure tag, created with TagManager's TagValue API.
+          diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+        - name: 'state'
+          type: Enum
+          description: |
+            State of the secure tag, either EFFECTIVE or INEFFECTIVE. A secure tag is INEFFECTIVE when it is deleted or its network is deleted.
+          output: true
+          enum_values:
+            - 'EFFECTIVE'
+            - 'INEFFECTIVE'

--- a/mmv1/templates/terraform/examples/firewall_policy_rule_secure_tag.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firewall_policy_rule_secure_tag.tf.tmpl
@@ -1,0 +1,84 @@
+resource "google_network_security_address_group" "basic_global_networksecurity_address_group" {
+  name        = "{{index $.Vars "address_group"}}"
+  parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
+  description = "Sample global networksecurity_address_group"
+  location    = "global"
+  items       = ["208.80.154.224/32"]
+  type        = "IPV4"
+  capacity    = 100
+}
+
+resource "google_folder" "folder" {
+  display_name        = "{{index $.Vars "folder"}}"
+  parent              = "organizations/{{index $.TestEnvVars "org_id"}}"
+  deletion_protection = false
+}
+
+resource "google_compute_firewall_policy" "default" {
+  parent      = google_folder.folder.id
+  short_name  = "{{index $.Vars "fw_policy"}}"
+  description = "Resource created for Terraform acceptance testing"
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  project                 = data.google_project.project.project_id
+  name                    = "{{index $.Vars "network"}}"
+  auto_create_subnetworks = true
+}
+
+resource "google_tags_tag_key" "secure_tag_key_1" {
+  provider    = google-beta
+  description = "Tag key"
+  parent      = google_folder.folder.id
+  purpose     = "GCE_FIREWALL"
+  short_name  = "{{index $.Vars "tag_key"}}"
+
+  purpose_data = {
+    network = "${google_compute_network.network.name}/default"
+  }
+}
+
+resource "google_tags_tag_value" "secure_tag_value_1" {
+  provider    = google-beta
+  description = "Tag value"
+  parent      = google_tags_tag_key.secure_tag_key_1.id
+  short_name  = "{{index $.Vars "tag_value"}}"
+}
+
+resource "google_compute_firewall_policy_rule" "{{$.PrimaryResourceId}}" {
+  firewall_policy         = google_compute_firewall_policy.default.name
+  description             = "Resource created for Terraform acceptance testing"
+  priority                = 9000
+  enable_logging          = true
+  action                  = "allow"
+  direction               = "EGRESS"
+  disabled                = false
+
+  match {
+    dest_ip_ranges            = ["11.100.0.1/32"]
+    dest_fqdns                = []
+    dest_region_codes         = ["US"]
+    dest_threat_intelligences = ["iplist-known-malicious-ips"]
+    src_address_groups        = []
+    dest_address_groups       = [google_network_security_address_group.basic_global_networksecurity_address_group.id]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = [8080]
+    }
+
+    layer4_configs {
+      ip_protocol = "udp"
+      ports       = [22]
+    }
+  }
+
+  target_secure_tag {
+    name = google_tags_tag_value.secure_tag_value_1.id
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `targetSecureTags` fields to `google_compute_firewall_policy_rule ` resource
```
