### PR TITLE
Deprecate `run_as_service_account` field in client

### DIFF
--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -46,12 +46,19 @@ examples:
     vars:
       key_ring_name: 'my-keyring'
       crypto_key_name: 'my-crypto-key'
-      service_account_id: 'service-acc'
     test_vars_overrides:
       key_ring_name: '"tftest-shared-keyring-1"'
       crypto_key_name: '"tftest-shared-key-1"'
       kms_key: 'acctest.BootstrapKMSKeyInLocation(t, "us-east1")'
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-integrations.iam.gserviceaccount.com"
+        role: "roles/cloudkmskacls.serviceAgent"
     skip_vcr: true
+  - name: 'integrations_client_service_account'
+    primary_resource_id: 'example'
+    vars:
+      service_account_id: 'service-acc'
+    exclude_docs: true
 parameters:
   - name: 'location'
     type: String
@@ -113,3 +120,4 @@ properties:
       User input run-as service account, if empty, will bring up a new default service account.
     immutable: true
     ignore_read: true
+    deprecation_message: '`run_as_service_account` is deprecated and will be removed in a future major release.'

--- a/mmv1/templates/terraform/examples/integrations_client_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/integrations_client_full.tf.tmpl
@@ -15,15 +15,9 @@ data "google_kms_crypto_key_version" "test_key" {
   crypto_key = data.google_kms_crypto_key.cryptokey.id
 }
 
-resource "google_service_account" "service_account" {
-  account_id   = "{{index $.Vars "service_account_id"}}"
-  display_name = "Service Account"
-}
-
 resource "google_integrations_client" "{{$.PrimaryResourceId}}" {
   location = "us-east1"
   create_sample_integrations = true
-  run_as_service_account = google_service_account.service_account.email
   cloud_kms_config {
     kms_location = "us-east1"
     kms_ring = basename(data.google_kms_key_ring.keyring.id)

--- a/mmv1/templates/terraform/examples/integrations_client_service_account.tf.tmpl
+++ b/mmv1/templates/terraform/examples/integrations_client_service_account.tf.tmpl
@@ -1,0 +1,12 @@
+data "google_project" "default" {
+}
+
+resource "google_service_account" "service_account" {
+  account_id   = "{{index $.Vars "service_account_id"}}"
+  display_name = "Service Account"
+}
+
+resource "google_integrations_client" "{{$.PrimaryResourceId}}" {
+  location = "asia-east1"
+  run_as_service_account = google_service_account.service_account.email
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

Deprecate `run_as_service_account` field in `google_integrations_client`. Add iam binding for integration p4sa.

```release-note:deprecation
integrations: deprecated `run_as_service_account` field in `google_integrations_client` resource
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21887