### PR TITLE
Add Operation to healthcare pipeline job creation and update

### DIFF
--- a/mmv1/products/healthcare/PipelineJob.yaml
+++ b/mmv1/products/healthcare/PipelineJob.yaml
@@ -29,6 +29,14 @@ update_verb: PATCH
 update_mask: true
 id_format: '{{dataset}}/pipelineJobs/{{name}}'
 import_format: ['{{%dataset}}/pipelineJobs/{{name}}', '{{name}}', '{{dataset}}/pipelineJobs?pipelineJobId={{name}}']
+autogen_async: true
+async:
+  actions: ['create', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
 examples:
   - name: 'healthcare_pipeline_job_reconciliation'
     primary_resource_id: 'example-pipeline'
@@ -43,6 +51,8 @@ examples:
       backfill_pipeline_name: 'example_backfill_pipeline'
       dataset_name: 'example_dataset'
       mapping_pipeline_name: 'example_mapping_pipeline'
+      fhir_store_name: 'fhir_store'
+      bucket_name: 'example_bucket_name'
   - name: 'healthcare_pipeline_job_whistle_mapping'
     primary_resource_id: 'example-mapping-pipeline'
     vars:

--- a/mmv1/products/healthcare/PipelineJob.yaml
+++ b/mmv1/products/healthcare/PipelineJob.yaml
@@ -51,9 +51,6 @@ examples:
       backfill_pipeline_name: 'example_backfill_pipeline'
       dataset_name: 'example_dataset'
       mapping_pipeline_name: 'example_mapping_pipeline_job'
-      source_fhirstore_name: 'source_fhir_store'
-      dest_fhirstore_name: 'dest_fhir_store'
-      bucket_name: 'example_bucket_name'
   - name: 'healthcare_pipeline_job_whistle_mapping'
     primary_resource_id: 'example-mapping-pipeline'
     vars:

--- a/mmv1/products/healthcare/PipelineJob.yaml
+++ b/mmv1/products/healthcare/PipelineJob.yaml
@@ -50,8 +50,9 @@ examples:
     vars:
       backfill_pipeline_name: 'example_backfill_pipeline'
       dataset_name: 'example_dataset'
-      mapping_pipeline_name: 'example_mapping_pipeline'
-      fhir_store_name: 'fhir_store'
+      mapping_pipeline_name: 'example_mapping_pipeline_job'
+      source_fhirstore_name: 'source_fhir_store'
+      dest_fhirstore_name: 'dest_fhir_store'
       bucket_name: 'example_bucket_name'
   - name: 'healthcare_pipeline_job_whistle_mapping'
     primary_resource_id: 'example-mapping-pipeline'

--- a/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
+++ b/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_healthcare_pipeline_job" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   dataset = google_healthcare_dataset.dataset.id
   backfill_pipeline_job {
-    mapping_pipeline_job = "${google_healthcare_dataset.dataset.id}/pipelinejobs/{{index $.Vars "mapping_pipeline_name"}}"
+    mapping_pipeline_job = "${google_healthcare_pipeline_job.example-mapping-pipeline.name}"
   }      
 }
 
@@ -39,8 +39,16 @@ resource "google_healthcare_pipeline_job" "example-mapping-pipeline" {
   }
 }
 
-resource "google_healthcare_fhir_store" "fhirstore" {
-  name    = "{{index $.Vars "fhir_store_name"}}"
+resource "google_healthcare_fhir_store" "source_fhirstore" {
+  name    = "{{index $.Vars "source_fhirstore_name"}}"
+  dataset = google_healthcare_dataset.dataset.id
+  version = "R4"
+  enable_update_create          = true
+  disable_referential_integrity = true
+}
+
+resource "google_healthcare_fhir_store" "dest_fhirstore" {
+  name    = "{{index $.Vars "dest_fhirstore_name"}}"
   dataset = google_healthcare_dataset.dataset.id
   version = "R4"
   enable_update_create          = true
@@ -48,19 +56,19 @@ resource "google_healthcare_fhir_store" "fhirstore" {
 }
 
 resource "google_storage_bucket" "bucket" {
-    name          = "{{index $.Vars "bucket_name"}}"
-    location      = "us-central1"
-    uniform_bucket_level_access = true
+  name          = "{{index $.Vars "bucket_name"}}"
+  location      = "us-central1"
+  uniform_bucket_level_access = true
 }
 
-resource "google_storage_bucket_object" "merge_file" {
-  name    = "merge.wstl"
+resource "google_storage_bucket_object" "mapping_file" {
+  name    = "mapping.wstl"
   content = " "
   bucket  = google_storage_bucket.bucket.name
 }
 
 resource "google_storage_bucket_iam_member" "hsa" {
-    bucket = google_storage_bucket.bucket.name
-    role   = "roles/storage.objectUser"
-    member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectUser"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
+++ b/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
@@ -3,72 +3,11 @@ resource "google_healthcare_pipeline_job" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   dataset = google_healthcare_dataset.dataset.id
   backfill_pipeline_job {
-    mapping_pipeline_job = "${google_healthcare_pipeline_job.example-mapping-pipeline.id}"
+    mapping_pipeline_job = "${google_healthcare_dataset.dataset.id}/pipelineJobs/{{index $.Vars "mapping_pipeline_name"}}"
   }      
 }
 
 resource "google_healthcare_dataset" "dataset" {
   name     = "{{index $.Vars "dataset_name"}}"
   location = "us-central1"
-}
-
-data "google_project" "project" {
-}
-
-resource "google_healthcare_pipeline_job" "example-mapping-pipeline" {
-  name  = "{{index $.Vars "mapping_pipeline_name"}}"
-  location = "us-central1"
-  dataset = google_healthcare_dataset.dataset.id
-  disable_lineage = true
-  labels = {
-    example_label_key = "example_label_value"
-  }
-  mapping_pipeline_job {
-    mapping_config {
-      whistle_config_source {
-        uri = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.mapping_file.name}"
-        import_uri_prefix = "gs://${google_storage_bucket.bucket.name}"
-      }
-      description = "example description for mapping configuration"
-    }
-    fhir_streaming_source {
-      fhir_store = "${google_healthcare_dataset.dataset.id}/fhirStores/${google_healthcare_fhir_store.source_fhirstore.name}"
-      description = "example description for streaming fhirstore"
-    }
-    fhir_store_destination = "${google_healthcare_dataset.dataset.id}/fhirStores/${google_healthcare_fhir_store.dest_fhirstore.name}"
-  }
-}
-
-resource "google_healthcare_fhir_store" "source_fhirstore" {
-  name    = "{{index $.Vars "source_fhirstore_name"}}"
-  dataset = google_healthcare_dataset.dataset.id
-  version = "R4"
-  enable_update_create          = true
-  disable_referential_integrity = true
-}
-
-resource "google_healthcare_fhir_store" "dest_fhirstore" {
-  name    = "{{index $.Vars "dest_fhirstore_name"}}"
-  dataset = google_healthcare_dataset.dataset.id
-  version = "R4"
-  enable_update_create          = true
-  disable_referential_integrity = true
-}
-
-resource "google_storage_bucket" "bucket" {
-  name          = "{{index $.Vars "bucket_name"}}"
-  location      = "us-central1"
-  uniform_bucket_level_access = true
-}
-
-resource "google_storage_bucket_object" "mapping_file" {
-  name    = "mapping.wstl"
-  content = " "
-  bucket  = google_storage_bucket.bucket.name
-}
-
-resource "google_storage_bucket_iam_member" "hsa" {
-  bucket = google_storage_bucket.bucket.name
-  role   = "roles/storage.objectUser"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
 }

--- a/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
+++ b/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_healthcare_pipeline_job" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   dataset = google_healthcare_dataset.dataset.id
   backfill_pipeline_job {
-    mapping_pipeline_job = "${google_healthcare_pipeline_job.example-mapping-pipeline.name}"
+    mapping_pipeline_job = "${google_healthcare_pipeline_job.example-mapping-pipeline.id}"
   }      
 }
 

--- a/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
+++ b/mmv1/templates/terraform/examples/healthcare_pipeline_job_backfill.tf.tmpl
@@ -11,3 +11,56 @@ resource "google_healthcare_dataset" "dataset" {
   name     = "{{index $.Vars "dataset_name"}}"
   location = "us-central1"
 }
+
+data "google_project" "project" {
+}
+
+resource "google_healthcare_pipeline_job" "example-mapping-pipeline" {
+  name  = "{{index $.Vars "mapping_pipeline_name"}}"
+  location = "us-central1"
+  dataset = google_healthcare_dataset.dataset.id
+  disable_lineage = true
+  labels = {
+    example_label_key = "example_label_value"
+  }
+  mapping_pipeline_job {
+    mapping_config {
+      whistle_config_source {
+        uri = "gs://${google_storage_bucket.bucket.name}/${google_storage_bucket_object.mapping_file.name}"
+        import_uri_prefix = "gs://${google_storage_bucket.bucket.name}"
+      }
+      description = "example description for mapping configuration"
+    }
+    fhir_streaming_source {
+      fhir_store = "${google_healthcare_dataset.dataset.id}/fhirStores/${google_healthcare_fhir_store.source_fhirstore.name}"
+      description = "example description for streaming fhirstore"
+    }
+    fhir_store_destination = "${google_healthcare_dataset.dataset.id}/fhirStores/${google_healthcare_fhir_store.dest_fhirstore.name}"
+  }
+}
+
+resource "google_healthcare_fhir_store" "fhirstore" {
+  name    = "{{index $.Vars "fhir_store_name"}}"
+  dataset = google_healthcare_dataset.dataset.id
+  version = "R4"
+  enable_update_create          = true
+  disable_referential_integrity = true
+}
+
+resource "google_storage_bucket" "bucket" {
+    name          = "{{index $.Vars "bucket_name"}}"
+    location      = "us-central1"
+    uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket_object" "merge_file" {
+  name    = "merge.wstl"
+  content = " "
+  bucket  = google_storage_bucket.bucket.name
+}
+
+resource "google_storage_bucket_iam_member" "hsa" {
+    bucket = google_storage_bucket.bucket.name
+    role   = "roles/storage.objectUser"
+    member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-healthcare.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
fixes https://github.com/hashicorp/terraform-provider-google/issues/20943
part of https://github.com/hashicorp/terraform-provider-google/issues/21294

Add Operation to healthcare pipeline job creation and update, as the response of CREATE and PATCH is an operation.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
healthcare: made `google_healthcare_pipeline_job` wait for creation and update operation to complete
```
