### PR TITLE
Add tags field to Metastore Federation for TagsR2401

### DIFF
--- a/mmv1/products/metastore/Federation.yaml
+++ b/mmv1/products/metastore/Federation.yaml
@@ -144,3 +144,9 @@ properties:
             - 'METASTORE_TYPE_UNSPECIFIED'
             - 'DATAPROC_METASTORE'
             - 'BIGQUERY'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -10,12 +10,12 @@ import (
 func TestAccMetastoreFederation_tags(t *testing.T) {
 	t.Parallel()
 
-	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "dataproc_metastore_federation-tagkey")
 	context := map[string]interface{}{
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestTagValue(t, "dataproc_metastore_federation-tagvalue", tagKey),
 		"random_suffix": acctest.RandString(t, 10),
-		"tag_key":       org + "/" + acctest.BootstrapSharedTestTagKey(t, "metastore-federations-tagkey"),
-		"tag_value":     acctest.BootstrapSharedTestTagValue(t, "metastore-federations-tagvalue", acctest.BootstrapSharedTestTagKey(t, "metastore-federations-tagkey")),
-	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -35,7 +35,7 @@ func TestAccMetastoreFederation_tags(t *testing.T) {
 }
 
 func testAccMetastoreFederationTags(context map[string]interface{}) string {
-	r := acctest.Nprintf(`
+	return acctest.Nprintf(`
 		resource "google_dataproc_metastore_service" "default" {
 			service_id = "tf-test-service-%{random_suffix}"
 			location   = "us-central1"
@@ -59,10 +59,9 @@ func testAccMetastoreFederationTags(context map[string]interface{}) string {
 			}
 
 			tags = {
-				"%{tag_key}" = "%{tag_value}"
-			}
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
 		}
 	`, context)
 
-	return r
 }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -16,7 +16,7 @@ func TestAccMetastoreFederation_tags(t *testing.T) {
 		"tagKey":        tagKey,
 		"tagValue":      acctest.BootstrapSharedTestTagValue(t, "dataproc_metastore_federation-tagvalue", tagKey),
 		"random_suffix": acctest.RandString(t, 10),
-
+	}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -1,0 +1,68 @@
+package dataprocmetastore_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"testing"
+)
+
+func TestAccMetastoreFederation_tags(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"tag_key":       org + "/" + acctest.BootstrapSharedTestTagKey(t, "metastore-federations-tagkey"),
+		"tag_value":     acctest.BootstrapSharedTestTagValue(t, "metastore-federations-tagvalue", acctest.BootstrapSharedTestTagKey(t, "metastore-federations-tagkey")),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetastoreFederationTags(context),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_federation.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccMetastoreFederationTags(context map[string]interface{}) string {
+	r := acctest.Nprintf(`
+		resource "google_dataproc_metastore_service" "default" {
+			service_id = "tf-test-service-%{random_suffix}"
+			location   = "us-central1"
+			tier       = "DEVELOPER"
+
+			hive_metastore_config {
+				version           = "3.1.2"
+				endpoint_protocol = "GRPC"
+			}
+		}
+
+		resource "google_dataproc_metastore_federation" "default" {
+			location      = "us-central1"
+			federation_id = "tf-test-federation-%{random_suffix}"
+			version       = "3.1.2"
+
+			backend_metastores {
+				rank           = "1"
+				name           = google_dataproc_metastore_service.default.id
+				metastore_type = "DATAPROC_METASTORE"
+			}
+
+			tags = {
+				"%{tag_key}" = "%{tag_value}"
+			}
+		}
+	`, context)
+
+	return r
+}


### PR DESCRIPTION
Add tags field to federation resource to allow setting tags on federation resources at creation time.
Part of b/367307391

The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository


**Release Note Template for Downstream PRs (will be copied)**
```
metastore: added `tags` field to `metastore_federation` to allow setting tags for federations at creation time
```
