### PR TITLE
Add new Firestore index and database options

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -124,6 +124,17 @@ examples:
       - 'project'
       - 'etag'
       - 'deletion_policy'
+  - name: 'firestore_database_enterprise'
+    primary_resource_id: 'enterprise-db'
+    vars:
+      database_id: 'database-id'
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'project'
+      - 'etag'
+      - 'deletion_policy'
 virtual_fields:
   - name: 'deletion_policy'
     description: |
@@ -166,6 +177,17 @@ properties:
     enum_values:
       - 'FIRESTORE_NATIVE'
       - 'DATASTORE_MODE'
+  - name: 'databaseEdition'
+    type: Enum
+    description: |
+      The database edition.
+    required: false
+    default_from_api: true
+    # Picking a database edition is an irreversible decision
+    immutable: true
+    enum_values:
+      - 'STANDARD'
+      - 'ENTERPRISE'
   - name: 'concurrencyMode'
     type: Enum
     description: |

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -81,6 +81,12 @@ examples:
       database_id: 'database-id'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_mongodb_compatible_scope'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id-mongodb-compatible'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
 parameters:
 properties:
   - name: 'name'
@@ -119,6 +125,7 @@ properties:
     enum_values:
       - 'ANY_API'
       - 'DATASTORE_MODE_API'
+      - 'MONGODB_COMPATIBLE_API'
   - name: 'fields'
     type: Array
     description: |

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -87,6 +87,12 @@ examples:
       database_id: 'database-id-mongodb-compatible'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_sparse_any'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id-sparse-any'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
 parameters:
 properties:
   - name: 'name'
@@ -126,6 +132,27 @@ properties:
       - 'ANY_API'
       - 'DATASTORE_MODE_API'
       - 'MONGODB_COMPATIBLE_API'
+  - name: 'density'
+    type: Enum
+    description: |
+      The density configuration for this index.
+    immutable: true
+    default_from_api: true
+    enum_values:
+      - SPARSE_ALL
+      - SPARSE_ANY
+      - DENSE
+  - name: 'multikey'
+    type: Boolean
+    default_value: false
+    description:
+      Optional. Whether the index is multikey. By default, the index
+      is not multikey. For non-multikey indexes, none of the paths in the
+      index definition reach or traverse an array, except via an explicit
+      array index. For multikey indexes, at most one of the paths in the index
+      definition reach or traverse an array, except via an explicit array
+      index. Violations will result in errors. Note this field only applies to
+      indexes with MONGODB_COMPATIBLE_API ApiScope.
   - name: 'fields'
     type: Array
     description: |

--- a/mmv1/templates/terraform/examples/firestore_database_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database_enterprise.tf.tmpl
@@ -1,0 +1,8 @@
+resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
+	project                  = "{{index $.TestEnvVars "project_id"}}"
+	name                     = "{{index $.Vars "database_id"}}"
+	location_id              = "nam5"
+	type                     = "FIRESTORE_NATIVE"
+	database_edition         = "ENTERPRISE"
+	deletion_policy          = "DELETE"
+}

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.tmpl
@@ -9,12 +9,13 @@ resource "google_firestore_database" "database" {
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
-  project     = "{{index $.TestEnvVars "project_id"}}"
+  project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
   collection = "atestcollection"
 
   query_scope = "COLLECTION_RECURSIVE"
-  api_scope = "DATASTORE_MODE_API"
+  api_scope   = "DATASTORE_MODE_API"
+  density     = "SPARSE_ALL"
 
   fields {
     field_path = "name"

--- a/mmv1/templates/terraform/examples/firestore_index_mongodb_compatible_scope.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_mongodb_compatible_scope.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_firestore_database" "database" {
+	project                  = "{{index $.TestEnvVars "project_id"}}"
+	name                     = "{{index $.Vars "database_id"}}"
+	location_id              = "nam5"
+	type                     = "FIRESTORE_NATIVE"
+	database_edition         = "ENTERPRISE"
+
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+	deletion_policy         = "DELETE"
+}
+
+resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
+	project     = "{{index $.TestEnvVars "project_id"}}"
+	database   = google_firestore_database.database.name
+	collection = "atestcollection"
+
+	api_scope   = "MONGODB_COMPATIBLE_API"
+	query_scope = "COLLECTION_GROUP"
+
+	fields {
+		field_path = "name"
+		order      = "ASCENDING"
+	}
+
+	fields {
+		field_path = "description"
+		order      = "DESCENDING"
+	}
+}

--- a/mmv1/templates/terraform/examples/firestore_index_sparse_any.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_sparse_any.tf.tmpl
@@ -17,7 +17,7 @@ resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
 	api_scope   = "MONGODB_COMPATIBLE_API"
 	query_scope = "COLLECTION_GROUP"
 	multikey    = true
-	density     = "DENSE"
+	density     = "SPARSE_ANY"
 
 	fields {
 		field_path = "name"


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
firestore: added `density` and `multikey` fields to `google_firestore_index` resource
```
```release-note:enhancement
firestore: added `MONGODB_COMPATIBLE_API` enum option to `apiScope` field of `google_firestore_index` resource
```
```release-note:enhancement
firestore: added `databaseEdition` field to `google_firestore_database` resource
```
