### PR TITLE
Promote external catalog dataset options to google_bigquery_dataset GA

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -95,7 +95,6 @@ examples:
     primary_resource_id: 'dataset'
     vars:
       dataset_id: 'example_dataset'
-    min_version: 'beta'
   - name: 'bigquery_dataset_resource_tags'
     primary_resource_id: 'dataset'
     primary_resource_name: 'fmt.Sprintf("tf_test_dataset%s", context["random_suffix"])'
@@ -435,17 +434,14 @@ properties:
     description: |
       Options defining open source compatible datasets living in the BigQuery catalog. Contains
       metadata of open source database, schema or namespace represented by the current dataset.
-    min_version: beta
     properties:
       - name: 'parameters'
         type: KeyValuePairs
         description: |
           A map of key value pairs defining the parameters and properties of the open source schema.
           Maximum size of 2Mib.
-        min_version: beta
       - name: 'defaultStorageLocationUri'
         type: String
         description: |
           The storage location URI for all tables in the dataset. Equivalent to hive metastore's
           database locationUri. Maximum length of 1024 characters.
-        min_version: beta

--- a/mmv1/templates/terraform/examples/bigquery_dataset_external_catalog_dataset_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_external_catalog_dataset_options.tf.tmpl
@@ -1,6 +1,4 @@
 resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
-
   dataset_id    = "{{index $.Vars "dataset_id"}}"
   friendly_name = "test"
   description   = "This is a test description"

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
@@ -488,7 +488,6 @@ func TestAccBigQueryDataset_bigqueryDatasetExternalReferenceAws(t *testing.T) {
 	})
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func TestAccBigQueryDataset_externalCatalogDatasetOptions_update(t *testing.T) {
 	t.Parallel()
 
@@ -498,7 +497,7 @@ func TestAccBigQueryDataset_externalCatalogDatasetOptions_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -523,7 +522,6 @@ func TestAccBigQueryDataset_externalCatalogDatasetOptions_update(t *testing.T) {
 	})
 }
 
-{{- end }}
 func testAccAddTable(t *testing.T, datasetID string, tableID string) resource.TestCheckFunc {
 	// Not actually a check, but adds a table independently of terraform
 	return func(s *terraform.State) error {
@@ -966,8 +964,6 @@ resource "google_bigquery_dataset" "dataset" {
 func testAccBigQueryDataset_externalCatalogDatasetOptions_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "dataset" {
-  provider = google-beta
-
   dataset_id    = "dataset%{random_suffix}"
   friendly_name = "test"
   description   = "This is a test description"
@@ -986,8 +982,6 @@ resource "google_bigquery_dataset" "dataset" {
 func testAccBigQueryDataset_externalCatalogDatasetOptions_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "dataset" {
-  provider = google-beta
-
   dataset_id    = "dataset%{random_suffix}"
   friendly_name = "test"
   description   = "This is a test description"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Promote external catalog dataset options to google_bigquery_dataset GA.
Feature was added to the beta provider in https://github.com/GoogleCloudPlatform/magic-modules/pull/12113.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added `external_catalog_dataset_options` fields to `google_bigquery_dataset` resource (ga)
```
