### PR TITLE
Promote external catalog table options and foreign type info and definition to google_bigquery_table GA

### DIFF
--- a/mmv1/products/bigquery/Table.yaml
+++ b/mmv1/products/bigquery/Table.yaml
@@ -277,12 +277,10 @@ properties:
                 Definition of the foreign data type.
                 Only valid for top-level schema fields (not nested fields).
                 If the type is FOREIGN, this field is required.
-              min_version: beta
   - name: 'schemaForeignTypeInfo'
     type: NestedObject
     description: |
       Specifies metadata of the foreign data type definition in field schema.
-    min_version: beta
     properties:
       - name: 'typeSystem'
         type: Enum
@@ -291,7 +289,6 @@ properties:
         required: true
         enum_values:
           - 'HIVE'
-        min_version: beta
   - name: 'encryptionConfiguration'
     type: NestedObject
     description: Custom encryption configuration
@@ -577,51 +574,43 @@ properties:
     type: NestedObject
     description: |
       Options defining open source compatible table.
-    min_version: beta
     properties:
       - name: 'parameters'
         type: KeyValuePairs
         description: |
           A map of key value pairs defining the parameters and properties of the open source table.
           Corresponds with hive meta store table parameters. Maximum size of 4Mib.
-        min_version: beta
       - name: 'storageDescriptor'
         type: NestedObject
         description: |
           A storage descriptor containing information about the physical storage of this table.
-        min_version: beta
         properties:
           - name: 'storageUri'
             type: String
             description: |
               The physical location of the table (e.g. `gs://spark-dataproc-data/pangea-data/case_sensitive/`
               or `gs://spark-dataproc-data/pangea-data/*`). The maximum length is 2056 bytes.
-            min_version: beta
           - name: 'inputFormat'
             type: String
             description: |
               Specifies the fully qualified class name of the InputFormat
               (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat").
               The maximum length is 128 characters.
-            min_version: beta
           - name: 'outputFormat'
             type: String
             description: |
               Specifies the fully qualified class name of the OutputFormat
               (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat").
               The maximum length is 128 characters.
-            min_version: beta
           - name: 'serdeInfo'
             type: NestedObject
             description: |
               Serializer and deserializer information.
-            min_version: beta
             properties:
               - name: 'name'
                 type: String
                 description: |
                   Name of the SerDe. The maximum length is 256 characters.
-                min_version: beta
               - name: 'serializationLibrary'
                 type: String
                 description: |
@@ -630,13 +619,11 @@ properties:
                   underlying low-level input and output format structures.
                   The maximum length is 256 characters.
                 required: true
-                min_version: beta
               - name: 'parameters'
                 type: KeyValuePairs
                 description: |
                   Key-value pairs that define the initialization parameters for the serialization
                   library. Maximum size 10 Kib.
-                min_version: beta
       - name: 'connectionId'
         type: String
         description: |
@@ -644,7 +631,6 @@ properties:
           Azure Blob, Cloud Storage, or S3. The connection is needed to read the open source table
           from BigQuery Engine. The connection_id can have the form `<project_id>.<location_id>.<connection_id>`
           or `projects/<project_id>/locations/<location_id>/connections/<connection_id>`.
-        min_version: beta
 virtual_fields:
   - name: 'table_metadata_view'
     type: String

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -96,14 +96,12 @@ func jsonCompareWithMapKeyOverride(key string, a, b interface{}, compareMapKeyVa
 			unionOfKeys[subKey] = true
 		}
 
-		{{- if ne $.TargetVersionName "ga" }}
 		// Disregard "type" and "fields" if "foreignTypeDefinition" is present since they may have been modified by the server.
 		if _, ok := unionOfKeys["foreignTypeDefinition"]; ok {
 			delete(unionOfKeys, "type")
 			delete(unionOfKeys, "fields")
 		}
 
-		{{- end }}
 		for subKey := range unionOfKeys {
 			eq := compareMapKeyVal(subKey, objectA, objectB)
 			if !eq {
@@ -332,14 +330,12 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}, isExternalTab
 			unionOfKeys[key] = true
 		}
 
-		{{- if ne $.TargetVersionName "ga" }}
 		// Disregard "type" and "fields" if "foreignTypeDefinition" is present since they may have been modified by the server.
 		if _, ok := unionOfKeys["foreignTypeDefinition"]; ok {
 			delete(unionOfKeys, "type")
 			delete(unionOfKeys, "fields")
 		}
 
-		{{- end }}
 		for key := range unionOfKeys {
 			valOld := objectOld[key]
 			valNew := objectNew[key]
@@ -1010,7 +1006,6 @@ func ResourceBigQueryTable() *schema.Resource {
 				DiffSuppressFunc: bigQueryTableSchemaDiffSuppress,
 				Description:      `A JSON schema for the table.`,
 			},
-			{{- if ne $.TargetVersionName "ga" }}
 			// SchemaForeignTypeInfo: [Optional] Specifies metadata of the foreign data type definition in field schema.
 			"schema_foreign_type_info": {
 				Type:        schema.TypeList,
@@ -1029,7 +1024,6 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
-			{{- end }}
 			// View: [Optional] If specified, configures this table as a view.
 			"view": {
 				Type:        schema.TypeList,
@@ -1495,7 +1489,6 @@ func ResourceBigQueryTable() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `The tags attached to this table. Tag keys are globally unique. Tag key is expected to be in the namespaced format, for example "123456789012/environment" where 123456789012 is the ID of the parent organization or project resource for this tag key. Tag value is expected to be the short name, for example "Production".`,
 			},
-			{{- if ne $.TargetVersionName "ga" }}
 			// ExternalCatalogTableOptions: [Optional] Options defining open source compatible table.
 			"external_catalog_table_options": {
 				Type:        schema.TypeList,
@@ -1580,7 +1573,6 @@ func ResourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
-			{{- end }}
 		},
 		UseJSONNumber: true,
 	}
@@ -1670,14 +1662,12 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		table.Schema = schema
 	}
 
-	{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := d.GetOk("schema_foreign_type_info"); ok {
 		if table.Schema != nil {
 			table.Schema.ForeignTypeInfo = expandForeignTypeInfo(v)
 		}
 	}
 
-	{{- end }}
 	if v, ok := d.GetOk("time_partitioning"); ok {
 		table.TimePartitioning = expandTimePartitioning(v)
 	}
@@ -1713,12 +1703,10 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 
 	table.ResourceTags = tpgresource.ExpandStringMap(d, "resource_tags")
 
-	{{- if ne $.TargetVersionName "ga" }}
 	if v, ok := d.GetOk("external_catalog_table_options"); ok {
 		table.ExternalCatalogTableOptions = expandExternalCatalogTableOptions(v)
 	}
 
-	{{- end }}
 	return table, nil
 }
 
@@ -1986,14 +1974,12 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("schema", schema); err != nil {
 			return fmt.Errorf("Error setting schema: %s", err)
 		}
-		{{- if ne $.TargetVersionName "ga" }}
 		if res.Schema.ForeignTypeInfo != nil {
 			foreignTypeInfo := flattenForeignTypeInfo(res.Schema.ForeignTypeInfo)
 			if err := d.Set("schema_foreign_type_info", foreignTypeInfo); err != nil {
 				return fmt.Errorf("Error setting schema_foreign_type_info: %s", err)
 			}
 		}
-		{{- end }}
 	}
 
 	if res.View != nil {
@@ -2049,7 +2035,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	{{- if ne $.TargetVersionName "ga" }}
 	if res.ExternalCatalogTableOptions != nil {
 		externalCatalogTableOptions := flattenExternalCatalogTableOptions(res.ExternalCatalogTableOptions)
 
@@ -2058,7 +2043,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	{{- end }}
 	return nil
 }
 
@@ -2806,7 +2790,6 @@ func schemaHasRequiredFields(schema *bigquery.TableSchema) bool {
 	return false
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func expandForeignTypeInfo(configured interface{}) *bigquery.ForeignTypeInfo {
 	if len(configured.([]interface{})) == 0 {
 		return nil
@@ -2831,7 +2814,6 @@ func flattenForeignTypeInfo(fti *bigquery.ForeignTypeInfo) []map[string]interfac
 	return []map[string]interface{}{result}
 }
 
-{{- end }}
 func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 	raw := configured.([]interface{})[0].(map[string]interface{})
 	tp := &bigquery.TimePartitioning{Type: raw["type"].(string)}
@@ -3238,7 +3220,6 @@ func flattenTableReplicationInfo(tableReplicationInfo map[string]interface{}) []
 	return []map[string]interface{}{result}
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func expandExternalCatalogTableOptions(configured interface{}) *bigquery.ExternalCatalogTableOptions {
 	if len(configured.([]interface{})) == 0 {
 		return nil
@@ -3385,7 +3366,7 @@ func flattenSerDeInfo(si *bigquery.SerDeInfo) []map[string]interface{} {
 
 	return []map[string]interface{}{result}
 }
-{{- end }}
+
 func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1847,20 +1847,19 @@ func TestAccBigQueryTable_ResourceTags(t *testing.T) {
 	})
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func TestAccBigQueryTable_externalCatalogTableOptions(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":      envvar.GetTestProjectFromEnv(),
-		"dataset_id":      fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10)),
-		"table_id":        fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10)),
-		"connection_id":        fmt.Sprintf("tf_test_connection_%s", acctest.RandString(t, 10)),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+		"dataset_id":    fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10)),
+		"table_id":      fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10)),
+		"connection_id": fmt.Sprintf("tf_test_connection_%s", acctest.RandString(t, 10)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1889,14 +1888,14 @@ func TestAccBigQueryTable_foreignTypeInfo(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project_id":      envvar.GetTestProjectFromEnv(),
-		"dataset_id":      fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10)),
-		"table_id":        fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10)),
+		"project_id": envvar.GetTestProjectFromEnv(),
+		"dataset_id": fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10)),
+		"table_id":   fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -1912,7 +1911,6 @@ func TestAccBigQueryTable_foreignTypeInfo(t *testing.T) {
 	})
 }
 
-{{- end }}
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -4638,27 +4636,20 @@ resource "google_bigquery_table" "test" {
 `, context)
 }
 
-{{- if ne $.TargetVersionName "ga" }}
 func testAccBigQueryTable_externalCatalogTableOptions_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "test" {
-  provider = google-beta
-
   dataset_id = "%{dataset_id}"
   location = "EU"
 }
 
 resource "google_bigquery_connection" "test" {
-  provider = google-beta
-
   connection_id = "%{connection_id}"
   location = "EU"
   cloud_resource {}
 }
 
 resource "google_bigquery_table" "test" {
-  provider = google-beta
-
   deletion_protection = false
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
@@ -4697,23 +4688,17 @@ EOF
 func testAccBigQueryTable_externalCatalogTableOptions_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "test" {
-  provider = google-beta
-
   dataset_id = "%{dataset_id}"
   location = "EU"
 }
 
 resource "google_bigquery_connection" "test" {
-  provider = google-beta
-
   connection_id = "%{connection_id}"
   location = "EU"
   cloud_resource {}
 }
 
 resource "google_bigquery_table" "test" {
-  provider = google-beta
-
   deletion_protection = false
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
@@ -4749,15 +4734,11 @@ EOF
 func testAccBigQueryTable_foreignTypeInfo_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "test" {
-  provider = google-beta
-
   dataset_id = "%{dataset_id}"
   location = "EU"
 }
 
 resource "google_bigquery_table" "test" {
-  provider = google-beta
-
   deletion_protection = false
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
   table_id   = "%{table_id}"
@@ -4779,7 +4760,6 @@ EOF
 `, context)
 }
 
-{{- end }}
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b
 lifelock,LifeLock,,web,Tempe,AZ,1-Oct-06,6000000,USD,a
 lifelock,LifeLock,,web,Tempe,AZ,1-Jan-08,25000000,USD,c

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -143,10 +143,8 @@ The following arguments are supported:
     with `external_data_configuration.schema`. Otherwise, schemas must be
     specified with this top-level field.
 
-* `schema_foreign_type_info` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Specifies metadata of the foreign data type definition in field schema.
-  Structure is [documented below](#nested_schema_foreign_type_info).
+* `schema_foreign_type_info` - (Optional) Specifies metadata of the foreign data
+    type definition in field schema. Structure is [documented below](#nested_schema_foreign_type_info).
 
 * `time_partitioning` - (Optional) If specified, configures time-based
     partitioning for this table. Structure is [documented below](#nested_time_partitioning).
@@ -188,10 +186,8 @@ The following arguments are supported:
     expected to be the short name, for example "Production". See [Tag definitions](https://cloud.google.com/iam/docs/tags-access-control#definitions)
     for more details.
 
-* `external_catalog_table_options` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-    Options defining open source compatible table.
-    Structure is [documented below](#nested_external_catalog_table_options).
+* `external_catalog_table_options` - (Optional) Options defining open source
+    compatible table. Structure is [documented below](#nested_external_catalog_table_options).
 
 <a name="nested_external_data_configuration"></a>The `external_data_configuration` block supports:
 
@@ -382,9 +378,8 @@ The following arguments are supported:
 
 <a name="nested_schema_foreign_type_info"></a>The `schema_foreign_type_info` block supports:
 
-* `type_system` - (Required, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Specifies the system which defines the foreign data type.
+* `type_system` - (Required) Specifies the system which defines the foreign data
+    type.
 
 <a name="nested_time_partitioning"></a>The `time_partitioning` block supports:
 
@@ -519,64 +514,45 @@ The following arguments are supported:
 
 <a name="nested_external_catalog_table_options"></a>The `external_catalog_table_options` block supports:
 
-* `parameters` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  A map of key value pairs defining the parameters and properties of the open
-  source table. Corresponds with hive meta store table parameters. Maximum size
-  of 4Mib.
-* `storage_descriptor` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  A storage descriptor containing information about the physical storage of this
-  table.
-  Structure is [documented below](#nested_storage_descriptor).
-* `connection_id` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  The connection specifying the credentials to be used to read external storage,
-  such as Azure Blob, Cloud Storage, or S3. The connection is needed to read the
-  open source table from BigQuery Engine. The connection_id can have the form
-  `<project_id>.<location_id>.<connection_id>` or `projects/<project_id>/locations/<location_id>/connections/<connection_id>`.
+* `parameters` - (Optional) A map of key value pairs defining the parameters and
+  properties of the open source table. Corresponds with hive meta store table
+  parameters. Maximum size of 4Mib.
+* `storage_descriptor` - (Optional) A storage descriptor containing information
+  about the physical storage of this table. Structure is [documented below](#nested_storage_descriptor).
+* `connection_id` - (Optional) The connection specifying the credentials to be
+  used to read external storage, such as Azure Blob, Cloud Storage, or S3. The
+  connection is needed to read the open source table from BigQuery Engine. The
+  connection_id can have the form `<project_id>.<location_id>.<connection_id>`
+  or `projects/<project_id>/locations/<location_id>/connections/<connection_id>`.
 
 <a name="nested_storage_descriptor"></a>The `storage_descriptor` block supports:
 
-* `location_uri` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  The physical location of the table (e.g. 'gs://spark-dataproc-data/pangea-data/case_sensitive/' or 'gs://spark-dataproc-data/pangea-data/*').
-  The maximum length is 2056 bytes.
+* `location_uri` - (Optional) The physical location of the table (e.g.
+  'gs://spark-dataproc-data/pangea-data/case_sensitive/' or
+  'gs://spark-dataproc-data/pangea-data/*'). The maximum length is 2056 bytes.
 
-* `input_format` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Specifies the fully qualified class name of the InputFormat (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat").
-  The maximum length is 128 characters.
+* `input_format` - (Optional) Specifies the fully qualified class name of the
+  InputFormat (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"). The
+  maximum length is 128 characters.
 
-* `output_format` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Specifies the fully qualified class name of the OutputFormat (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat").
-  The maximum length is 128 characters.
+* `output_format` - (Optional) Specifies the fully qualified class name of the
+  OutputFormat (e.g. "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat"). The
+  maximum length is 128 characters.
 
-* `serde_info` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Serializer and deserializer information.
-  Structure is [documented below](#nested_serde_info).
+* `serde_info` - (Optional) Serializer and deserializer information. Structure
+  is [documented below](#nested_serde_info).
 
 <a name="nested_serde_info"></a>The `serde_info` block supports:
 
-* `name` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Name of the SerDe.
-  The maximum length is 256 characters.
+* `name` - (Optional) Name of the SerDe. The maximum length is 256 characters.
 
-* `serialization_library` - (Required, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Specifies a fully-qualified class name of the serialization library that is
-  responsible for the translation of data between table representation and the
-  underlying low-level input and output format structures.
-  The maximum length is 256 characters.
+* `serialization_library` - (Required) Specifies a fully-qualified class name of
+  the serialization library that is responsible for the translation of data
+  between table representation and the underlying low-level input and output
+  format structures. The maximum length is 256 characters.
 
-* `parameters` - (Optional, [Beta]
-(https://terraform.io/docs/providers/google/guides/provider_versions.html))
-  Key-value pairs that define the initialization parameters for the
-  serialization library.
-  Maximum size 10 Kib.
+* `parameters` - (Optional) Key-value pairs that define the initialization
+  parameters for the serialization library. Maximum size 10 Kib.
 
 ## Attributes Reference
 


### PR DESCRIPTION

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Promote external catalog table options and foreign type info and definition to google_bigquery_table GA.
Feature was added to the beta provider in https://github.com/GoogleCloudPlatform/magic-modules/pull/12528 and https://github.com/GoogleCloudPlatform/magic-modules/pull/12659.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added `external_catalog_table_options` and `schema_foreign_type_info` fields to  `google_bigquery_table` resource (GA)
```
