### PR TITLE
Factored setting of post-create id format fields into a separate function

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -294,42 +294,11 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
     // Set computed resource properties from create API response so that they're available on the subsequent Read
     // call.
-{{- /* Don't render decoder for PollAsync resources - their decoders are expected to return `nil` until the resource completion completes, but we need to set their computed fields in order to call PollRead - so there can never be a dependency on the decoder. */}}
-{{- if and $.CustomCode.Decoder (or (not $.GetAsync) (not ($.GetAsync.IsA "PollAsync"))) }}
-    res, err = resource{{ $.ResourceName -}}Decoder(d, meta, res)
+    err = resource{{ $.ResourceName }}PostCreateSetComputedFields(d, meta, res)
     if err != nil {
-        return fmt.Errorf("decoding response: %w", err)
+        return fmt.Errorf("setting computed ID format fields: %w", err)
     }
-    if res == nil {
-        return fmt.Errorf("decoding response, could not find object")
-    }
-{{- end }}
-{{- $renderedIdFromName := "false" }}
-{{- range $prop := $.GettableProperties }}
-{{- /* Check if prop is potentially computed */}}
-{{-   if and ($.InIdFormat $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
-{{-     if and (eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl") (eq $renderedIdFromName "false") }}
-    // Setting `name` field so that `id_from_name` flattener will work properly.
-    if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(res["name"], d, config)); err != nil {
-        return fmt.Errorf(`Error setting computed identity field "name": %s`, err)
-    }
-    {{- $renderedIdFromName = "true" }}
-{{-     end }}
-{{-     if and $prop.Output (not $prop.IgnoreRead) }}
-    if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
-        return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
-    }
-{{-     else if and $prop.DefaultFromApi (not $prop.IgnoreRead) }}
-    // {{ underscore $prop.Name }} is set by API when unset
-    if tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("{{ underscore $prop.Name }}"))) {
-        if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
-            return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
-        }
-    }
-{{-     end }}
-{{-   end }}{{/* prop is potentially computed */}}
-{{- end }}{{/* range */}}
-{{- end}}{{/* Set computed resource properties... */}}
+{{- end}}
 
     // Store the ID now
     id, err := tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(d, config, "{{ $.IdFormat -}}")
@@ -1232,4 +1201,45 @@ func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta
 {{- if and $.SchemaVersion $.StateUpgraders }}
 
     {{ $.CustomTemplate $.StateMigrationFile false -}}
+{{- end }}
+{{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
+func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.ResourceData, meta interface{}, res map[string]interface{}) error {
+    config := meta.(*transport_tpg.Config)
+    {{- /* Don't render decoder for PollAsync resources - their decoders are expected to return `nil` until the resource completion completes, but we need to set their computed fields in order to call PollRead - so there can never be a dependency on the decoder. */}}
+    {{- if and $.CustomCode.Decoder (or (not $.GetAsync) (not ($.GetAsync.IsA "PollAsync"))) }}
+    res, err := resource{{ $.ResourceName -}}Decoder(d, meta, res)
+    if err != nil {
+        return fmt.Errorf("decoding response: %w", err)
+    }
+    if res == nil {
+        return fmt.Errorf("decoding response, could not find object")
+    }
+    {{- end }}
+    {{- $renderedIdFromName := "false" }}
+    {{- range $prop := $.GettableProperties }}
+    {{- /* Check if prop is potentially computed */}}
+    {{-   if and ($.InIdFormat $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
+    {{-     if and (eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl") (eq $renderedIdFromName "false") }}
+    // Setting `name` field so that `id_from_name` flattener will work properly.
+    if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(res["name"], d, config)); err != nil {
+        return fmt.Errorf(`Error setting computed identity field "name": %s`, err)
+    }
+    {{-       $renderedIdFromName = "true" }}
+    {{-     end }}
+    {{-     if and $prop.Output (not $prop.IgnoreRead) }}
+    if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
+        return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
+    }
+    {{-     else if and $prop.DefaultFromApi (not $prop.IgnoreRead) }}
+    // {{ underscore $prop.Name }} is set by API when unset
+    if tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("{{ underscore $prop.Name }}"))) {
+        if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config)); err != nil {
+            return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
+        }
+    }
+    {{-     end }}
+    {{-   end }}{{/* prop is potentially computed */}}
+    {{- end }}{{/* range */}}
+    return nil
+}
 {{- end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR doesn't change any functionality - just moves it into a separate function. This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/13520 and prepares for changes that will be required for https://github.com/GoogleCloudPlatform/magic-modules/pull/13537 (which uses OpAsync - we will need to first convert OpAsync cases to use this function as well).

I've factored this change into a standalone PR so that it'll be easier to review.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
