### PR TITLE
Fix perma-diff in google_identity_platform_config for default false values

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -208,7 +208,7 @@ properties:
         type: NestedObject
         description: |
           The user credentials to include in the JWT payload that is sent to the registered Blocking Functions.
-        custom_flatten: 'templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl'  
+        custom_flatten: 'templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl'
         properties:
           - name: 'idToken'
             type: Boolean
@@ -381,7 +381,7 @@ properties:
     type: NestedObject
     description: |
       Configuration related to multi-tenant functionality.
-    custom_flatten:  
+    custom_flatten: 'templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl'
     properties:
       - name: 'allowTenants'
         type: Boolean

--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -208,6 +208,7 @@ properties:
         type: NestedObject
         description: |
           The user credentials to include in the JWT payload that is sent to the registered Blocking Functions.
+        custom_flatten: 'templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl'  
         properties:
           - name: 'idToken'
             type: Boolean
@@ -380,6 +381,7 @@ properties:
     type: NestedObject
     description: |
       Configuration related to multi-tenant functionality.
+    custom_flatten:  
     properties:
       - name: 'allowTenants'
         type: Boolean

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
@@ -3,8 +3,8 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 
 	if v == nil {
 		transformed["id_token"] = false
-        transformed["access_token"] = false
-        transformed["refresh_token"] = false
+    transformed["access_token"] = false
+    transformed["refresh_token"] = false
 	} else {
 		original := v.(map[string]interface{})
 
@@ -14,13 +14,13 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			transformed["id_token"] = original["idToken"]
 		}
 
-        if original["accessToken"] == nil {
+    if original["accessToken"] == nil {
 			transformed["access_token"] = false
 		} else {
 			transformed["access_token"] = original["accessToken"]
 		}
 
-        if original["refreshToken"] == nil {
+    if original["refreshToken"] == nil {
 			transformed["refresh_token"] = false
 		} else {
 			transformed["refresh_token"] = original["refreshToken"]

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
@@ -1,0 +1,29 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	transformed := make(map[string]interface{})
+
+	if v == nil {
+		return nil
+	} else {
+		original := v.(map[string]interface{})
+
+		if original["idToken"] == nil {
+			transformed["id_token"] = false
+		} else {
+			transformed["id_token"] = original["idToken"]
+		}
+
+        if original["accessToken"] == nil {
+			transformed["access_token"] = false
+		} else {
+			transformed["access_token"] = original["accessToken"]
+		}
+
+        if original["refreshToken"] == nil {
+			transformed["refresh_token"] = false
+		} else {
+			transformed["refresh_token"] = original["refreshToken"]
+		}
+	}
+
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
@@ -2,7 +2,9 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	transformed := make(map[string]interface{})
 
 	if v == nil {
-		return nil
+		transformed["id_token"] = false
+        transformed["access_token"] = false
+        transformed["refresh_token"] = false
 	} else {
 		original := v.(map[string]interface{})
 

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_forward_inbound_credentials.go.tmpl
@@ -1,31 +1,31 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	transformed := make(map[string]interface{})
+  transformed := make(map[string]interface{})
 
-	if v == nil {
-		transformed["id_token"] = false
+  if v == nil {
+    transformed["id_token"] = false
     transformed["access_token"] = false
     transformed["refresh_token"] = false
-	} else {
-		original := v.(map[string]interface{})
+  } else {
+    original := v.(map[string]interface{})
 
-		if original["idToken"] == nil {
-			transformed["id_token"] = false
-		} else {
-			transformed["id_token"] = original["idToken"]
-		}
+    if original["idToken"] == nil {
+      transformed["id_token"] = false
+    } else {
+      transformed["id_token"] = original["idToken"]
+    }
 
     if original["accessToken"] == nil {
-			transformed["access_token"] = false
-		} else {
-			transformed["access_token"] = original["accessToken"]
-		}
+      transformed["access_token"] = false
+    } else {
+      transformed["access_token"] = original["accessToken"]
+    }
 
     if original["refreshToken"] == nil {
-			transformed["refresh_token"] = false
-		} else {
-			transformed["refresh_token"] = original["refreshToken"]
-		}
-	}
+      transformed["refresh_token"] = false
+    } else {
+      transformed["refresh_token"] = original["refreshToken"]
+    }
+  }
 
-	return []interface{}{transformed}
+  return []interface{}{transformed}
 }

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -1,0 +1,17 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	transformed := make(map[string]interface{})
+
+	if v == nil {
+		return nil
+	} else {
+		original := v.(map[string]interface{})
+
+		if original["allowTenants"] == nil {
+			transformed["allow_tenants"] = false
+		} else {
+			transformed["allow_tenants"] = original["allowTenants"]
+		}
+	}
+
+	return []interface{}{transformed}
+}

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -12,9 +12,9 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 			transformed["allow_tenants"] = original["allowTenants"]
 		}
 
-        if original["defaultTenantLocation"] != nil {
-            transformed["default_tenant_location"] = original["defaultTenantLocation"]
-        }
+    if original["defaultTenantLocation"] != nil {
+      transformed["default_tenant_location"] = original["defaultTenantLocation"]
+    }
 	}
 
 	return []interface{}{transformed}

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -11,6 +11,10 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 		} else {
 			transformed["allow_tenants"] = original["allowTenants"]
 		}
+
+        if original["defaultTenantLocation"] != nil {
+            transformed["default_tenant_location"] = original["defaultTenantLocation"]
+        }
 	}
 
 	return []interface{}{transformed}

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -1,21 +1,21 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	transformed := make(map[string]interface{})
+  transformed := make(map[string]interface{})
 
-	if v == nil {
-		return nil
-	} else {
-		original := v.(map[string]interface{})
+  if v == nil {
+    return nil
+  } else {
+    original := v.(map[string]interface{})
 
-		if original["allowTenants"] == nil {
-			transformed["allow_tenants"] = false
-		} else {
-			transformed["allow_tenants"] = original["allowTenants"]
-		}
+    if original["allowTenants"] == nil {
+      transformed["allow_tenants"] = false
+    } else {
+      transformed["allow_tenants"] = original["allowTenants"]
+    }
 
     if original["defaultTenantLocation"] != nil {
       transformed["default_tenant_location"] = original["defaultTenantLocation"]
     }
-	}
+  }
 
-	return []interface{}{transformed}
+  return []interface{}{transformed}
 }

--- a/mmv1/templates/terraform/examples/identity_platform_config_with_false_values.tf.tmpl
+++ b/mmv1/templates/terraform/examples/identity_platform_config_with_false_values.tf.tmpl
@@ -33,7 +33,7 @@ resource "google_identity_platform_config" "default" {
   blocking_functions {
     triggers {
       event_type   = "beforeSignIn"
-      function_uri = "https://test.cloudfunctions.test/function-1"
+      function_uri = "https://us-east1-{{index $.Vars "project_id"}}.cloudfunctions.net/before-sign-in"
     }
     forward_inbound_credentials {
       refresh_token = false

--- a/mmv1/templates/terraform/examples/identity_platform_config_with_false_values.tf.tmpl
+++ b/mmv1/templates/terraform/examples/identity_platform_config_with_false_values.tf.tmpl
@@ -18,6 +18,7 @@ resource "google_identity_platform_config" "default" {
   project = google_project.default.project_id
   autodelete_anonymous_users = false
   sign_in {
+    allow_duplicate_emails = false
    
     anonymous {
         enabled = false
@@ -27,6 +28,31 @@ resource "google_identity_platform_config" "default" {
     }
     phone_number {
         enabled = false
+    }
+  }
+  blocking_functions {
+    triggers {
+      event_type   = "beforeSignIn"
+      function_uri = "https://test.cloudfunctions.test/function-1"
+    }
+    forward_inbound_credentials {
+      refresh_token = false
+      access_token  = false
+      id_token      = false
+    }
+  }
+  client {
+    permissions {
+      disabled_user_signup = false
+      disabled_user_deletion = false
+    }
+  }
+  multi_tenant {
+    allow_tenants = false
+  }
+  monitoring {
+    request_logging {
+      enabled = false
     }
   }
 }


### PR DESCRIPTION
Fix [#20406](https://github.com/hashicorp/terraform-provider-google/issues/20406)

Customer reported that google_identity_platform_config always shows a diff if the values are set to false for blockingFunctions.forwardInboundCredentials. Tried reproducing the issue for all the properties in the google_identity_platform_config resource and the plan always shows a diff, even though the value set is the same as the actual value of the config.

```
       # (3 unchanged attributes hidden)

      ~ blocking_functions {
          + forward_inbound_credentials {
              + access_token  = false
              + id_token      = false
              + refresh_token = false
            }

            # (1 unchanged block hidden)
        }

      + multi_tenant {
          + allow_tenants = false
        }

        # (5 unchanged blocks hidden)
``` 
Above is the diff that is always present if the value set to these properties are false.

This PR fixes this perma-diff by implementing custom_flatten to prevent this from happening. Also added test to cover all such parameters to make sure that Config resource is covered.

Similar fix in the past - https://github.com/GoogleCloudPlatform/magic-modules/pull/12255

**Release Note Template for Downstream PRs (will be copied)**


```release-note:bug
identityplatform: Fixed perma-diff in `google_identity_platform_config`
```
