### PR TITLE
Adding Tags field to GkeBackup for TagsR2401

### DIFF
--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -484,3 +484,11 @@ properties:
     description: |
       Detailed description of why BackupPlan is in its current state.
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.tmpl
@@ -28,54 +28,54 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 				Config: testAccGKEBackupBackupPlan_basic(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-      {
+			{
 				Config: testAccGKEBackupBackupPlan_permissive(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEBackupBackupPlan_full(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-      {
+			{
 				Config: testAccGKEBackupBackupPlan_rpo_daily_window(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEBackupBackupPlan_rpo_weekly_window(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-      {
+			{
 				Config: testAccGKEBackupBackupPlan_full(context),
 			},
 			{
-				ResourceName:      "google_gke_backup_backup_plan.backupplan",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
@@ -360,6 +360,77 @@ resource "google_gke_backup_backup_plan" "backupplan" {
   }
   labels = {
     "some-key-2": "some-value-2"
+  }
+}
+`, context)
+}
+
+func TestAccGKEBackupBackupPlan_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "datafusion-instances-tagkey")
+
+	context := map[string]interface{}{
+		"org":             envvar.GetTestOrgFromEnv(t),
+		"project":         envvar.GetTestProjectFromEnv(),
+		"random_suffix":   acctest.RandString(t, 10),
+		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"tagKey":          tagKey,
+		"tagValue":        acctest.BootstrapSharedTestTagValue(t, "gke_backup_backup_plan-tagvalue", tagKey),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEBackupBackupPlanDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEBackupBackupPlanTags(context),
+			},
+			{
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccGKEBackupBackupPlanTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "tf-test-testcluster%{random_suffix}"
+  location           = "us-central1"
+  initial_node_count = 1
+  workload_identity_config {
+    workload_pool = "%{project}.svc.id.goog"
+  }
+  addons_config {
+    gke_backup_agent_config {
+      enabled = true
+    }
+  }
+  deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
+}
+
+resource "google_gke_backup_backup_plan" "backupplan" {
+  name = "tf-test-testplan%{random_suffix}"
+  cluster = google_container_cluster.primary.id
+  location = "us-central1"
+  backup_config {
+    include_volume_data = false
+    include_secrets = false
+    all_namespaces = true
+  }
+  labels = {
+    "some-key-1": "some-value-1"
+  }
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
   }
 }
 `, context)


### PR DESCRIPTION
Add tags field to backup resource to allow setting tags on backup resources at creation time.
Bug - b/337048407

The contents of this code are entirely owned by Google LLC in accordance with the agreement between Google LLC and the third party submitting this code into Google's open source repository

Release Note Template for Downstream PRs 
```
GkeBackup: added `tags` field to `GkeBackup - Backup` to allow setting tags for services at creation time
```

