### PR TITLE
Add Tags field to metastore fedeartion

### DIFF
--- a/mmv1/products/metastore/Federation.yaml
+++ b/mmv1/products/metastore/Federation.yaml
@@ -44,7 +44,6 @@ iam_policy:
     - 'projects/{{project}}/locations/{{location}}/federations/{{federation_id}}'
     - '{{federation_id}}'
 custom_code:
-  pre_delete: 'templates/terraform/pre_delete/metastore_federation.go.tmpl'
 examples:
   - name: 'dataproc_metastore_federation_basic'
     primary_resource_id: 'default'
@@ -52,22 +51,12 @@ examples:
     vars:
       federation_id: 'metastore-fed'
       service_id: 'metastore-service'
-    ignore_read_extra:
-      - 'deletion_protection'
   - name: 'dataproc_metastore_federation_bigquery'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-fed%s", context["random_suffix"])'
     vars:
       federation_id: 'metastore-fed'
       service_id: 'metastore-service'
-virtual_fields:
-  - name: 'deletion_protection'
-    description: |
-      Whether Terraform will be prevented from destroying the federation. Defaults to false.
-      When the field is set to true in Terraform state, a `terraform apply`
-      or `terraform destroy` that would delete the federation will fail.
-    type: Boolean
-    default_value: false
 parameters:
   - name: 'federationId'
     type: String
@@ -155,3 +144,9 @@ properties:
             - 'METASTORE_TYPE_UNSPECIFIED'
             - 'DATAPROC_METASTORE'
             - 'BIGQUERY'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_federation_test.go
@@ -1,99 +1,67 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
 package dataprocmetastore_test
 
 import (
-	"fmt"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"regexp"
-	"testing"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"testing"
 )
 
-func TestAccMetastoreFederation_deletionprotection(t *testing.T) {
+func TestAccMetastoreFederation_tags(t *testing.T) {
 	t.Parallel()
 
-	name := "tf-test-metastore-" + acctest.RandString(t, 10)
+	tagKey := acctest.BootstrapSharedTestTagKey(t, "dataproc_metastore_federation-tagkey")
+	context := map[string]interface{}{
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestTagValue(t, "dataproc_metastore_federation-tagvalue", tagKey),
+		"random_suffix": acctest.RandString(t, 10),
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMetastoreFederationDeletionProtection(name, "us-central1"),
+				Config: testAccMetastoreFederationTags(context),
 			},
 			{
 				ResourceName:            "google_dataproc_metastore_federation.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config:      testAccMetastoreFederationDeletionProtection(name, "us-west2"),
-				ExpectError: regexp.MustCompile("deletion_protection"),
-			},
-			{
-				Config: testAccMetastoreFederationDeletionProtectionFalse(name, "us-central1"),
-			},
-			{
-				ResourceName:            "google_dataproc_metastore_federation.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"tags"},
 			},
 		},
 	})
 }
 
-func testAccMetastoreFederationDeletionProtection(name string, location string) string {
+func testAccMetastoreFederationTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+		resource "google_dataproc_metastore_service" "default" {
+			service_id = "tf-test-service-%{random_suffix}"
+			location   = "us-central1"
+			tier       = "DEVELOPER"
 
-	return fmt.Sprintf(`
-       resource "google_dataproc_metastore_service" "default" {
-         service_id = "%s"
-         location   = "us-central1"
-         tier       = "DEVELOPER"
-         hive_metastore_config {
-           version           = "3.1.2"
-           endpoint_protocol = "GRPC"
-         }
-         }
-       resource "google_dataproc_metastore_federation" "default" {
-          federation_id = "%s"
-          location      = "%s"
-          version       = "3.1.2"
-          deletion_protection = true
-          backend_metastores {
-            rank           = "1"
-            name           = google_dataproc_metastore_service.default.id
-            metastore_type = "DATAPROC_METASTORE" 
-         }
-}
-`, name, name, location)
-}
+			hive_metastore_config {
+				version           = "3.1.2"
+				endpoint_protocol = "GRPC"
+			}
+		}
 
-func testAccMetastoreFederationDeletionProtectionFalse(name string, location string) string {
+		resource "google_dataproc_metastore_federation" "default" {
+			location      = "us-central1"
+			federation_id = "tf-test-federation-%{random_suffix}"
+			version       = "3.1.2"
 
-	return fmt.Sprintf(`
-       resource "google_dataproc_metastore_service" "default" {
-         service_id = "%s"
-         location   = "us-central1"
-         tier       = "DEVELOPER"
-         hive_metastore_config {
-           version           = "3.1.2"
-           endpoint_protocol = "GRPC"
-         }
-         }
-       resource "google_dataproc_metastore_federation" "default" {
-          federation_id = "%s"
-          location      = "%s"
-          version       = "3.1.2"
-          deletion_protection = false
-          backend_metastores {
-            rank           = "1"
-            name           = google_dataproc_metastore_service.default.id
-            metastore_type = "DATAPROC_METASTORE" 
-         }
-}
-`, name, name, location)
+			backend_metastores {
+				rank           = "1"
+				name           = google_dataproc_metastore_service.default.id
+				metastore_type = "DATAPROC_METASTORE"
+			}
+
+			tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
+		}
+	`, context)
+
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add tags field to federation resource to allow setting tags on federation resources at creation time.
Part of b/367307391

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
metastore: added `tags` field to `metastore_federation` to allow setting tags for federations at creation time
```
