### PR TITLE
Removed monitoring notificationchannel set_computed_name post_create

### DIFF
--- a/mmv1/products/monitoring/NotificationChannel.yaml
+++ b/mmv1/products/monitoring/NotificationChannel.yaml
@@ -52,7 +52,6 @@ custom_code:
   constants: 'templates/terraform/constants/monitoring_notification_channel.go.tmpl'
   encoder: 'templates/terraform/encoders/monitoring_notification_channel.go.tmpl'
   decoder: 'templates/terraform/decoders/monitoring_notification_channel.go.tmpl'
-  post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_import: 'templates/terraform/custom_import/self_link_as_name_set_project.go.tmpl'
 custom_diff:
   - 'sensitiveLabelCustomizeDiff'


### PR DESCRIPTION
This is now duplicate code. Part of https://github.com/hashicorp/terraform-provider-google/issues/22214

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
