### PR TITLE
Removed monitoring uptimecheckconfig set_computed_name post_create

### DIFF
--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -37,7 +37,6 @@ timeouts:
 custom_code:
   encoder: 'templates/terraform/encoders/uptime_check_config.go.tmpl'
   constants: 'templates/terraform/constants/monitoring_uptime_check_config.go.tmpl'
-  post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_delete: 'templates/terraform/custom_delete/monitoring_uptime_check_config.go.tmpl'
   custom_import: 'templates/terraform/custom_import/self_link_as_name.tmpl'
 error_retry_predicates:


### PR DESCRIPTION
This is now duplicate code. Part of https://github.com/hashicorp/terraform-provider-google/issues/22214

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
