### PR TITLE
Removed osconfig guestpolicies set_computed_name post_create

### DIFF
--- a/mmv1/products/osconfig/GuestPolicies.yaml
+++ b/mmv1/products/osconfig/GuestPolicies.yaml
@@ -38,8 +38,6 @@ timeouts:
   delete_minutes: 20
 identity:
   - guestPolicyId
-custom_code:
-  post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
 examples:
   - name: 'os_config_guest_policies_basic'
     primary_resource_id: 'guest_policies'


### PR DESCRIPTION
As far as I can tell this code is just completely unnecessary. The `name` field has the same format as self_link (which gets used to determine the id format). For example, from a recent [nightly test](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_OSCONFIG/353069?buildTab=artifacts) you can see that the name is in the format `Finished creating GuestPolicies "projects/653407317329/guestPolicies/tf-test-guest-policy6shqkt7xf4"`. Additionally, `guest_policy_id` is a required field and [always has been](https://github.com/GoogleCloudPlatform/magic-modules/commit/34fa2676afcd68b5adfc34e2a4299000dc8fca7d)

That said, if there's a concern, I could set id_format to `{{name}}` (which it used to be set to) to reduce the difference between the old / new code.

Part of https://github.com/hashicorp/terraform-provider-google/issues/22214

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
