### PR TITLE
Increase timeout for discovery_engine_target_site

### DIFF
--- a/mmv1/products/discoveryengine/TargetSite.yaml
+++ b/mmv1/products/discoveryengine/TargetSite.yaml
@@ -30,19 +30,16 @@ immutable: true
 import_format:
   - 'projects/{{project}}/locations/{{location}}/collections/default_collection/dataStores/{{data_store_id}}/siteSearchEngine/targetSites/{{target_site_id}}'
 timeouts:
-  insert_minutes: 60
-  update_minutes: 60
-  delete_minutes: 60
+  # 8 hour timeout to allow for indexing/unindexing as needed
+  insert_minutes: 480
+  update_minutes: 480
+  delete_minutes: 480
 autogen_async: false
 async:
   actions: ['create', 'delete', 'update']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'
-    timeouts:
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
   result:
     resource_inside_response: true
 custom_code:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

b/401471256

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
discoveryengine: fix `google_discovery_engine_target_site` operations to allow for enough time to index before timing out
```
