### PR TITLE
Made firewall policy with rules ignore decoding operations on create

### DIFF
--- a/mmv1/templates/terraform/decoders/resource_compute_firewall_policy_with_rules.go.tmpl
+++ b/mmv1/templates/terraform/decoders/resource_compute_firewall_policy_with_rules.go.tmpl
@@ -1,3 +1,8 @@
+// If rules is nil, this is being called on a Create operation (and we don't want to do anything in that case.)
+if _, ok := res["rules"]; !ok {
+  return res, nil
+}
+
 rules, predefinedRules, err := firewallPolicyWithRulesSplitPredefinedRules(res["rules"].([]interface{}))
 
 if err != nil {


### PR DESCRIPTION
Technically, using standard operation handling would be better - but it turns out ~Compute has a special operation signature that's not compatible with generation.~ FirewallPolicyWithRules doesn't have a project in its signature - but the operation code for Compute expects a project to be present.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
