### PR TITLE
Corrected usages of project.name that should be project.project_id

### DIFF
--- a/mmv1/templates/terraform/examples/compute_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_firewall_policy_with_rules_full.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_compute_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
     enable_logging   = true
     action           = "allow"
     direction        = "EGRESS"
-    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.name}/global/networks/default"]
+    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.project_id}/global/networks/default"]
 
     match {
       dest_ip_ranges            = ["11.100.0.1/32"]

--- a/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_with_rules_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_with_rules_test.go.tmpl
@@ -71,7 +71,7 @@ resource "google_compute_firewall_policy_with_rules" "firewall-policy-with-rules
       dest_threat_intelligences = ["iplist-search-engines-crawlers", "iplist-tor-exit-nodes"]
       dest_address_groups = [google_network_security_address_group.address_group_1.id]
     }
-    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.name}/global/networks/default"]
+    target_resources = ["https://www.googleapis.com/compute/beta/projects/${data.google_project.project.project_id}/global/networks/default"]
   }
   rule {
     description    = "udp rule"


### PR DESCRIPTION
This isn't a problem for our test envs where those values are the same but can be a problem for local test runs

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
