### PR TITLE
feat: add support for managedPrivateNetwork in AwsS3Data storage transfer jobs

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
@@ -745,6 +745,11 @@ func awsS3DataSchema() *schema.Resource {
 				ExactlyOneOf: awsS3AuthKeys,
 				Description:  `The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.`,
 			},
+			"private_network": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Description:  `Egress bytes over a Google-managed private network. This network is shared between other users of Storage Transfer Service.`,
+			},
 		},
 	}
 }
@@ -1316,18 +1321,20 @@ func expandAwsS3Data(awsS3Datas []interface{}) *storagetransfer.AwsS3Data {
 
 	awsS3Data := awsS3Datas[0].(map[string]interface{})
 	return &storagetransfer.AwsS3Data{
-		BucketName:   awsS3Data["bucket_name"].(string),
-		AwsAccessKey: expandAwsAccessKeys(awsS3Data["aws_access_key"].([]interface{})),
-		RoleArn:      awsS3Data["role_arn"].(string),
-		Path:         awsS3Data["path"].(string),
+		BucketName:            awsS3Data["bucket_name"].(string),
+		AwsAccessKey:          expandAwsAccessKeys(awsS3Data["aws_access_key"].([]interface{})),
+		RoleArn:               awsS3Data["role_arn"].(string),
+		Path:                  awsS3Data["path"].(string),
+		ManagedPrivateNetwork: awsS3Data["private_network"].(bool),
 	}
 }
 
 func flattenAwsS3Data(awsS3Data *storagetransfer.AwsS3Data, d *schema.ResourceData) []map[string]interface{} {
 	data := map[string]interface{}{
-		"bucket_name": awsS3Data.BucketName,
-		"path":        awsS3Data.Path,
-		"role_arn":    awsS3Data.RoleArn,
+		"bucket_name":     awsS3Data.BucketName,
+		"path":            awsS3Data.Path,
+		"role_arn":        awsS3Data.RoleArn,
+		"private_network": awsS3Data.ManagedPrivateNetwork,
 	}
 	if _, exist := d.GetOk("transfer_spec.0.aws_s3_data_source.0.aws_access_key"); exist{
 		data["aws_access_key"] = flattenAwsAccessKeys(d)

--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job_meta.yaml.tmpl
@@ -46,6 +46,7 @@ fields:
   - field: 'transfer_spec.aws_s3_data_source.aws_access_key.secret_access_key'
   - field: 'transfer_spec.aws_s3_data_source.bucket_name'
   - field: 'transfer_spec.aws_s3_data_source.path'
+  - field: 'transfer_spec.aws_s3_data_source.private_network'
   - field: 'transfer_spec.aws_s3_data_source.role_arn'
   - field: 'transfer_spec.azure_blob_storage_data_source.azure_credentials.sas_token'
   - field: 'transfer_spec.azure_blob_storage_data_source.container'

--- a/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -260,6 +260,8 @@ A duration in seconds with up to nine fractional digits, terminated by 's'. Exam
 
 * `role_arn` - (Optional) The Amazon Resource Name (ARN) of the role to support temporary credentials via 'AssumeRoleWithWebIdentity'. For more information about ARNs, see [IAM ARNs](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns). When a role ARN is provided, Transfer Service fetches temporary credentials for the session using a 'AssumeRoleWithWebIdentity' call for the provided role using the [GoogleServiceAccount][] for this project.
 
+* `private_network` - (Optional) Egress bytes over a Google-managed private network. This network is shared between other users of Storage Transfer Service. Defaults to false.
+
 The `aws_access_key` block supports:
 
 * `access_key_id` - (Required) AWS Key ID.


### PR DESCRIPTION
```release-note:enhancement
storagetransfer: added `private_network` field to `google_storage_transfer_job` resource
```

Adds support for `managedPrivateNetwork` field [from the API ](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/TransferSpec#AwsS3Data)that allows transfers from AWS to GCP using the google private network. 