### PR TITLE
container: allow updating storage_pools

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -470,7 +470,6 @@ func schemaNodeConfig() *schema.Schema {
 
 				"storage_pools": {
 					Type:     schema.TypeList,
-					ForceNew: true,
 					Optional: true,
 					Elem:     &schema.Schema{Type: schema.TypeString},
 					Description: `The list of Storage Pools where boot disks are provisioned.`,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -13350,6 +13350,18 @@ func TestAccContainerCluster_storagePoolsWithNodeConfig(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
+			{
+				Config: testAccContainerCluster_storagePoolsWithNodeConfigUpdate(cluster, location, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.storage_pools_with_node_config", "node_config.0.storage_pools.#", "0"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.storage_pools_with_node_config",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
 		},
 	})
 }
@@ -13374,6 +13386,27 @@ resource "google_container_cluster" "storage_pools_with_node_config" {
   deletion_protection = false
 }
 `, cluster, location, storagePoolResourceName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_storagePoolsWithNodeConfigUpdate(cluster, location, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "storage_pools_with_node_config" {
+  name     = "%s"
+  location = "%s"
+
+  initial_node_count = 1
+  node_config {
+    machine_type = "c3-standard-4"
+    image_type   = "COS_CONTAINERD"
+    disk_type    = "hyperdisk-balanced"
+  }
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, cluster, location, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: allowed in-place update for `node_config.storage_pools` field in `google_container_node_pool` resource
```

```release-note:enhancement
container: allowed in-place update for `node_config.storage_pools` field in `google_container_cluster` resource
```

Update func already implemented, but the force new on storage_pools was kept erroneously 
