### PR TITLE
container: allow updating windows_node_config in place

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -630,41 +630,41 @@ func schemaNodeConfig() *schema.Schema {
 								Description: `Controls the maximum number of processes allowed to run in a pod.`,
 							},
 							"container_log_max_size": {
-                                                                Type:        schema.TypeString,
-                                                                Optional:    true,
-                                                                Description: `Defines the maximum size of the container log file before it is rotated.`,
-                                                        },
+                            	Type:        schema.TypeString,
+                            	Optional:    true,
+                            	Description: `Defines the maximum size of the container log file before it is rotated.`,
+                            },
 							"container_log_max_files": {
-                                                                Type:        schema.TypeInt,
-                                                                Optional:    true,
-                                                                Description: `Defines the maximum number of container log files that can be present for a container.`,
-                                                        },
+                            	Type:        schema.TypeInt,
+                            	Optional:    true,
+                            	Description: `Defines the maximum number of container log files that can be present for a container.`,
+                            },
 							"image_gc_low_threshold_percent": {
-                                                                Type:        schema.TypeInt,
-                                                                Optional:    true,
-                                                                Description: `Defines the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to.`,
-                                                        },
+                            	Type:        schema.TypeInt,
+                            	Optional:    true,
+                            	Description: `Defines the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to.`,
+                            },
 							"image_gc_high_threshold_percent": {
-                                                                Type:        schema.TypeInt,
-                                                                Optional:    true,
-                                                                Description: `Defines the percent of disk usage after which image garbage collection is always run.`,
-                                                        },
+                            	Type:        schema.TypeInt,
+                            	Optional:    true,
+                            	Description: `Defines the percent of disk usage after which image garbage collection is always run.`,
+                            },
 							"image_minimum_gc_age": {
-                                                                Type:        schema.TypeString,
-                                                                Optional:    true,
-                                                                Description: `Defines the minimum age for an unused image before it is garbage collected.`,
-                                                        },
+                            	Type:        schema.TypeString,
+                            	Optional:    true,
+                            	Description: `Defines the minimum age for an unused image before it is garbage collected.`,
+                            },
 							"image_maximum_gc_age": {
-                                                                Type:        schema.TypeString,
-                                                                Optional:    true,
-                                                                Description: `Defines the maximum age an image can be unused before it is garbage collected.`,
-                                                        },
+                            	Type:        schema.TypeString,
+                            	Optional:    true,
+                            	Description: `Defines the maximum age an image can be unused before it is garbage collected.`,
+                            },
 							"allowed_unsafe_sysctls": {
-                                                                Type:        schema.TypeList,
-                                                                Optional:    true,
-                                                                Description: `Defines a comma-separated allowlist of unsafe sysctls or sysctl patterns which can be set on the Pods.`,
+                                Type:        schema.TypeList,
+                                Optional:    true,
+                                Description: `Defines a comma-separated allowlist of unsafe sysctls or sysctl patterns which can be set on the Pods.`,
 								Elem:        &schema.Schema{Type: schema.TypeString},
-                                                        },
+                            },
 						},
 					},
 				},
@@ -723,7 +723,6 @@ func schemaNodeConfig() *schema.Schema {
 							"osversion": {
 								Type:         schema.TypeString,
 								Optional:     true,
-								ForceNew:     true,
 								Default:      "OS_VERSION_UNSPECIFIED",
 								Description:  `The OS Version of the windows nodepool.Values are OS_VERSION_UNSPECIFIED,OS_VERSION_LTSC2019 and OS_VERSION_LTSC2022`,
 								ValidateFunc: validation.StringInSlice([]string{"OS_VERSION_UNSPECIFIED", "OS_VERSION_LTSC2019", "OS_VERSION_LTSC2022"}, false),
@@ -748,8 +747,8 @@ func schemaNodeConfig() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"threads_per_core": {
 								Type:        schema.TypeInt,
-                                                                Required:    true,
-                                                                ForceNew:    true,
+                                Required:    true,
+                                ForceNew:    true,
 								Description: `The number of threads per physical core. To disable simultaneous multithreading (SMT) set this to 1. If unset, the maximum number of threads supported per core by the underlying processor is assumed.`,
 							},
 							"enable_nested_virtualization": {
@@ -857,10 +856,10 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored (both PUT & PATCH) when empty.`,
 				},
 				"enable_confidential_storage": {
-						Type:     schema.TypeBool,
-						Optional: true,
-						ForceNew: true,
-						Description: `If enabled boot disks are configured with confidential mode.`,
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Description: `If enabled boot disks are configured with confidential mode.`,
 				},
 				"local_ssd_encryption_mode": {
 					Type:             schema.TypeString,
@@ -1368,30 +1367,30 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 		kConfig.PodPidsLimit = int64(podPidsLimit.(int))
 	}
 	if containerLogMaxSize, ok := cfg["container_log_max_size"]; ok {
-                kConfig.ContainerLogMaxSize = containerLogMaxSize.(string)
-        }
+    	kConfig.ContainerLogMaxSize = containerLogMaxSize.(string)
+    }
 	if containerLogMaxFiles, ok := cfg["container_log_max_files"]; ok {
-                kConfig.ContainerLogMaxFiles = int64(containerLogMaxFiles.(int))
-        }
+    	kConfig.ContainerLogMaxFiles = int64(containerLogMaxFiles.(int))
+    }
 	if imageGcLowThresholdPercent, ok := cfg["image_gc_low_threshold_percent"]; ok {
-                kConfig.ImageGcLowThresholdPercent = int64(imageGcLowThresholdPercent.(int))
-        }
+    	kConfig.ImageGcLowThresholdPercent = int64(imageGcLowThresholdPercent.(int))
+    }
 	if imageGcHighThresholdPercent, ok := cfg["image_gc_high_threshold_percent"]; ok {
-                kConfig.ImageGcHighThresholdPercent = int64(imageGcHighThresholdPercent.(int))
-        }
+    	kConfig.ImageGcHighThresholdPercent = int64(imageGcHighThresholdPercent.(int))
+    }
 	if imageMinimumGcAge, ok := cfg["image_minimum_gc_age"]; ok {
-                kConfig.ImageMinimumGcAge = imageMinimumGcAge.(string)
-        }
+    	kConfig.ImageMinimumGcAge = imageMinimumGcAge.(string)
+    }
 	if imageMaximumGcAge, ok := cfg["image_maximum_gc_age"]; ok {
-                kConfig.ImageMaximumGcAge = imageMaximumGcAge.(string)
-        }
+    	kConfig.ImageMaximumGcAge = imageMaximumGcAge.(string)
+    }
 	if allowedUnsafeSysctls, ok := cfg["allowed_unsafe_sysctls"]; ok {
-	        sysctls := allowedUnsafeSysctls.([]interface{})
+	    sysctls := allowedUnsafeSysctls.([]interface{})
 		kConfig.AllowedUnsafeSysctls = make([]string, len(sysctls))
 		for i, s := range sysctls {
 		    kConfig.AllowedUnsafeSysctls[i] = s.(string)
 		}
-        }
+    }
 	return kConfig
 }
 
@@ -1686,7 +1685,7 @@ func flattenNodeConfig(c *container.NodeConfig, v interface{}) []map[string]inte
 		"local_nvme_ssd_block_config": flattenLocalNvmeSsdBlockConfig(c.LocalNvmeSsdBlockConfig),
 		"ephemeral_storage_local_ssd_config": flattenEphemeralStorageLocalSsdConfig(c.EphemeralStorageLocalSsdConfig),
 		"gcfs_config":              flattenGcfsConfig(c.GcfsConfig),
-		"gvnic":										flattenGvnic(c.Gvnic),
+		"gvnic":					flattenGvnic(c.Gvnic),
 		"reservation_affinity":     flattenGKEReservationAffinity(c.ReservationAffinity),
 		"service_account":          c.ServiceAccount,
 		"metadata":                 c.Metadata,
@@ -1704,7 +1703,7 @@ func flattenNodeConfig(c *container.NodeConfig, v interface{}) []map[string]inte
 		"effective_taints":         flattenEffectiveTaints(c.Taints),
 		"workload_metadata_config": flattenWorkloadMetadataConfig(c.WorkloadMetadataConfig),
 {{- if ne $.TargetVersionName "ga" }}
-		"sandbox_config": 			    flattenSandboxConfig(c.SandboxConfig),
+		"sandbox_config": 			flattenSandboxConfig(c.SandboxConfig),
 		"host_maintenance_policy":  flattenHostMaintenancePolicy(c.HostMaintenancePolicy),
 {{- end }}
 		"confidential_nodes":       flattenConfidentialNodes(c.ConfidentialNodes),

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -674,6 +674,11 @@ func TestAccContainerNodePool_withWindowsNodeConfig(t *testing.T) {
 			// Perform an update.
 			{
 				Config: testAccContainerNodePool_withWindowsNodeConfig(cluster, np, "OS_VERSION_LTSC2022"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_node_pool.with_windows_node_config", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_windows_node_config",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: allow updaing `windows_node_config` in place
```


tests and update logix exists, but the forcenew is extraneous. tested locally with flag and before to validate behavour change and that node pool is not recreated. other changes is just fmt