### PR TITLE
Add custom performance support for netapp storage pools

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -35,6 +35,7 @@ description: |
  the next apply. You can trigger a manual
  [zone switch](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/edit-or-delete-storage-pool#switch_active_and_replica_zones)
  via Terraform by swapping the value of the `zone` and `replica_zone` parameters in your HCL code.
+ Note: Custom Performance FLEX storage pools are supported in beta provider currently.
 
 references:
   guides:
@@ -172,3 +173,19 @@ properties:
       Optional. True if the storage pool supports Auto Tiering enabled volumes. Default is false.
       Auto-tiering can be enabled after storage pool creation but it can't be disabled once enabled.
     immutable: true
+  - name: 'customPerformanceEnabled'
+    type: Boolean
+    description: |
+      Optional. True if using Independent Scaling of capacity and performance (Hyperdisk). Default is false.
+    immutable: true
+    min_version: 'beta'
+  - name: 'totalThroughputMibps'
+    type: String
+    description: |
+      Optional. Custom Performance Total Throughput of the pool (in MiB/s).
+    min_version: 'beta'
+  - name: 'totalIops'
+    type: String
+    description: |
+      Optional. Custom Performance Total IOPS of the pool If not provided, it will be calculated based on the totalThroughputMibps
+    min_version: 'beta'

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -376,9 +376,6 @@ func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckNetappStoragePoolDestroyProducer(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_full(context),
@@ -424,7 +421,7 @@ data "google_compute_network" "default" {
 `, context)
 }
 
-func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(context map[string]interface{}) string {
+func testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
   provider = google-beta

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -421,7 +421,7 @@ resource "google_service_networking_connection" "default" {
 resource "google_netapp_storage_pool" "test_pool" {
   provider = google-beta
   name = "tf-test-pool%{random_suffix}"
-  location = "us-east4"
+  location = "us-east4-a"
   service_level = "FLEX"
   capacity_gib = "2048"
   network = google_compute_network.peering_network.id

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -433,7 +433,7 @@ resource "google_netapp_storage_pool" "test_pool" {
   description = "this is updated test description"
   custom_performance_enabled = true
   total_throughput_mibps = "200"
-  total_iops = "2000"
+  total_iops = "3200"
 }
 
 data "google_compute_network" "default" {

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -389,6 +389,15 @@ func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
 			},
+			{
+				Config: testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(context),
+			},
+			{
+				ResourceName:            "google_netapp_storage_pool.test_pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+			},
 		},
 	})
 }
@@ -406,6 +415,28 @@ resource "google_netapp_storage_pool" "test_pool" {
   custom_performance_enabled = true
   total_throughput_mibps = "64"
   total_iops = "1024"
+}
+
+data "google_compute_network" "default" {
+    provider = google-beta
+    name = "%{network_name}"
+}
+`, context)
+}
+
+func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "test_pool" {
+  provider = google-beta
+  name = "tf-test-pool%{random_suffix}"
+  location = "us-east4-a"
+  service_level = "FLEX"
+  capacity_gib = "2048"
+  network = data.google_compute_network.default.id
+  description = "this is updated test description"
+  custom_performance_enabled = true
+  total_throughput_mibps = "200"
+  total_iops = "2000"
 }
 
 data "google_compute_network" "default" {

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -409,6 +409,7 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 
 data "google_compute_network" "default" {
+    provider = google-beta
     name = "%{network_name}"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -364,3 +364,72 @@ data "google_compute_network" "default" {
 }
 `, context)
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t *testing.T) {
+	context := map[string]interface{}{
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-1", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckNetappStoragePoolDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_full(context),
+			},
+			{
+				ResourceName:            "google_netapp_storage_pool.test_pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "name", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "peering_network" {
+  provider = google-beta
+  name = "tf-test-network%{random_suffix}"
+}
+
+# Create an IP address
+resource "google_compute_global_address" "private_ip_alloc" {
+  provider = google-beta
+  name          = "tf-test-address%{random_suffix}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.peering_network.id
+}
+
+# Create a private connection
+resource "google_service_networking_connection" "default" {
+  provider = google-beta
+  network                 = google_compute_network.peering_network.id
+  service                 = "netapp.servicenetworking.goog"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
+}
+
+resource "google_netapp_storage_pool" "test_pool" {
+  provider = google-beta
+  name = "tf-test-pool%{random_suffix}"
+  location = "us-east4"
+  service_level = "FLEX"
+  capacity_gib = "2048"
+  network = google_compute_network.peering_network.id
+  description = "this is a test description"
+  custom_performance_enabled = true
+  total_throughput_mibps = "64"
+  total_iops = "1024"
+}
+`, context)
+}
+{{ end }}

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -395,40 +395,21 @@ func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t
 
 func testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "peering_network" {
-  provider = google-beta
-  name = "tf-test-network%{random_suffix}"
-}
-
-# Create an IP address
-resource "google_compute_global_address" "private_ip_alloc" {
-  provider = google-beta
-  name          = "tf-test-address%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.peering_network.id
-}
-
-# Create a private connection
-resource "google_service_networking_connection" "default" {
-  provider = google-beta
-  network                 = google_compute_network.peering_network.id
-  service                 = "netapp.servicenetworking.goog"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
-}
-
 resource "google_netapp_storage_pool" "test_pool" {
   provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east4-a"
   service_level = "FLEX"
   capacity_gib = "2048"
-  network = google_compute_network.peering_network.id
+  network = data.google_compute_network.default.id
   description = "this is a test description"
   custom_performance_enabled = true
   total_throughput_mibps = "64"
   total_iops = "1024"
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
 }
 `, context)
 }


### PR DESCRIPTION
```release-note:enhancement
netapp: added `custom_performance_enabled`, `total_throughput_mibps`, and `total_iops` fields to `google_netapp_storage_pool` resource (beta)
```
