### PR TITLE
location attribute incorrectly marked as optional for cross-cloud interconnect

### DIFF
--- a/mmv1/products/compute/Interconnect.yaml
+++ b/mmv1/products/compute/Interconnect.yaml
@@ -81,10 +81,11 @@ properties:
     type: ResourceRef
     description: |
       URL of the InterconnectLocation object that represents where this connection is to be provisioned.
-      Specifies the location inside Google's Networks, should not be passed in case of cross-cloud interconnect.
+      Specifies the location inside Google's Networks.
     immutable: true
     resource: 'InterconnectLocations'
     imports: 'selfLink'
+    required: true
   - name: 'linkType'
     type: Enum
     description: |


### PR DESCRIPTION
```release-note:enhancement
compute: marked `location` field as required in `google_compute_interconnect` resource
```

On the resource 'google_compute_interconnect', the attribute 'location' is incorrectly marked as optional, even for cross-cloud interconnect. It needs to be required.

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_interconnect
location - (Optional) URL of the InterconnectLocation object that represents where this connection is to be provisioned. Specifies the location inside Google's Networks, should not be passed in case of cross-cloud interconnect.

It should be marked as a required field, the customer has to provide a location for all interconnects regardless of whether it's cross cloud or not.