### PR TITLE
added machine_type field in alloyDB instance's machine_config object

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -285,7 +285,13 @@ properties:
       - name: 'cpuCount'
         type: Integer
         description: "The number of CPU's in the VM instance."
-
+        default_from_api: true
+      - name: 'machineType'
+        type: String
+        description: |
+          Machine type of the VM instance.
+          E.g. "n2-highmem-4", "n2-highmem-8", "c4a-highmem-4-lssd".
+          `cpu_count` must match the number of vCPUs in the machine type.
         default_from_api: true
   - name: 'clientConnectionConfig'
     type: NestedObject

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -81,6 +81,7 @@ resource "google_alloydb_instance" "default" {
 
   machine_config {
     cpu_count = 4
+		machine_type = "n2-highmem-4"
   }
 
   labels = {
@@ -860,6 +861,7 @@ resource "google_alloydb_instance" "default" {
   instance_type = "PRIMARY"
   machine_config {
     cpu_count = 2
+		machine_type = "n2-highmem-2"
   }
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -81,7 +81,7 @@ resource "google_alloydb_instance" "default" {
 
   machine_config {
     cpu_count = 4
-		machine_type = "n2-highmem-4"
+    machine_type = "n2-highmem-4"
   }
 
   labels = {
@@ -861,7 +861,7 @@ resource "google_alloydb_instance" "default" {
   instance_type = "PRIMARY"
   machine_config {
     cpu_count = 2
-		machine_type = "n2-highmem-2"
+    machine_type = "n2-highmem-2"
   }
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
alloydb: added `machine_type` field to `google_alloydb_instance` resource
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22185