### PR TITLE
Add Backdate Duration to Issuance Policy

### DIFF
--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -129,6 +129,14 @@ properties:
                     - 'ECDSA_P256'
                     - 'ECDSA_P384'
                     - 'EDDSA_25519'
+      - name: 'backdateDuration'
+        type: String
+        description: |
+          The duration to backdate all certificates issued from this CaPool. If not set, the
+          certificates will be issued with a not_before_time of the issuance time (i.e. the current
+          time). If set, the certificates will be issued with a not_before_time of the issuance
+          time minus the backdate_duration. The not_after_time will be adjusted to preserve the
+          requested lifetime. The backdate_duration must be less than or equal to 48 hours.
       - name: 'maximumLifetime'
         type: String
         description: |

--- a/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.tmpl
+++ b/mmv1/templates/terraform/examples/privateca_capool_all_fields.tf.tmpl
@@ -22,6 +22,7 @@ resource "google_privateca_ca_pool" "{{$.PrimaryResourceId}}" {
         max_modulus_size = 10
       }
     }
+    backdate_duration = "3600s"
     maximum_lifetime = "50000s"
     allowed_issuance_modes {
       allow_csr_based_issuance = true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add backdateDuration field to the CaPool resource to support backdating of certificates.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
privateca: added the `backdate_duration` field to the `google_privateca_ca_pool` resource to add support for backdating the `not_before_time` of certificates
```
