### PR TITLE
Made opasync set computed idformat fields if required instead of identity fields

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -309,9 +309,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
 {{if and $.GetAsync ($.GetAsync.Allow "Create") -}}
 {{  if ($.GetAsync.IsA "OpAsync") -}}
-{{    if and $.GetAsync.Result.ResourceInsideResponse (or $.GetIdentity $.HasComputedIdFormatFields) -}}
-    // Use the resource in the operation response to populate
-    // identity fields and d.Id() before read
+{{    if and $.GetAsync.Result.ResourceInsideResponse $.HasComputedIdFormatFields -}}
+    // Set computed resource properties from create API response so that they're available on the subsequent Read
+    // call.
     var opRes map[string]interface{}
     err = {{ $.ClientNamePascal -}}OperationWaitTimeWithResponse(
     config, res, &opRes, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Creating {{ $.Name -}}", userAgent,
@@ -328,68 +328,10 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
     }
 
-{{if $.CustomCode.Decoder -}}
-    opRes, err = resource{{ $.ResourceName -}}Decoder(d, meta, opRes)
+    err = resource{{ $.ResourceName }}PostCreateSetComputedFields(d, meta, res)
     if err != nil {
-        return fmt.Errorf("Error decoding response from operation: %s", err)
+        return fmt.Errorf("setting computed ID format fields: %w", err)
     }
-    if opRes == nil {
-        return fmt.Errorf("Error decoding response from operation, could not find object")
-    }
-{{- end}}
-
-{{if $.NestedQuery -}}
-{{if $.NestedQuery.Keys -}}
-    if _, ok := opRes["{{ index $.NestedQuery.Keys 0 -}}"]; ok {
-        opRes, err = flattenNested{{ $.ResourceName -}}(d, meta, opRes)
-        if err != nil {
-            return fmt.Errorf("Error getting nested object from operation response: %s", err)
-        }
-        if opRes == nil {
-            // Object isn't there any more - remove it from the state.
-            return fmt.Errorf("Error decoding response from operation, could not find nested object")
-        }
-    }
-{{- end}}
-{{- end}}
-    {{- if $.HasComputedIdFormatFields}}
-    {{- $renderedIdFromName := "false" }}
-    {{- range $prop := $.GettableProperties }}
-    {{- /* Check if prop is potentially computed */}}
-    {{-   if and ($.InIdFormat $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
-    {{-     if and (eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl") (eq $renderedIdFromName "false") }}
-    // Setting `name` field so that `id_from_name` flattener will work properly.
-    if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(opRes["name"], d, config)); err != nil {
-        return err
-    }
-    {{-       $renderedIdFromName = "true" }}
-    {{-     end }}
-    {{-     if and $prop.Output (not $prop.IgnoreRead) }}
-    if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(opRes["{{ $prop.ApiName -}}"], d, config)); err != nil {
-        return err
-    }
-    {{-     else if and $prop.DefaultFromApi (not $prop.IgnoreRead) }}
-    // {{ underscore $prop.Name }} is set by API when unset
-    if tpgresource.IsEmptyValue(reflect.ValueOf(d.Get("{{ underscore $prop.Name }}"))) {
-        if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(opRes["{{ $prop.ApiName -}}"], d, config)); err != nil {
-            return fmt.Errorf(`Error setting computed identity field "{{ underscore $prop.Name }}": %s`, err)
-        }
-    }
-    {{-     end }}
-    {{-   end }}{{/* prop is potentially computed */}}
-    {{- end }}{{/* range */}}
-    {{- else}}
-{{- /*
-    Temporarily keeping these resources the same - but setting properties here should be unnecessary because the impacted fields aren't expected to change as a result of the API request. Will remove in a separate step for clarity.
- */}}
-{{- range $prop := $.GettableProperties }}
-{{-  if $.IsInIdentity $prop }}
-    if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(opRes["{{ $prop.ApiName -}}"], d, config)); err != nil {
-        return err
-    }
-{{- end}}
-{{- end}}
-    {{- end}}
 
     // This may have caused the ID to update - update it if so.
     id, err = tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(d, config, "{{ $.IdFormat -}}")
@@ -1233,7 +1175,7 @@ func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta
 
     {{ $.CustomTemplate $.StateMigrationFile false -}}
 {{- end }}
-{{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
+{{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.Allow "Create") (or ($.GetAsync.IsA "PollAsync") (and ($.GetAsync.IsA "OpAsync") $.GetAsync.Result.ResourceInsideResponse)))))}}
 func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.ResourceData, meta interface{}, res map[string]interface{}) error {
     config := meta.(*transport_tpg.Config)
     {{- /* Don't render decoder for PollAsync resources - their decoders are expected to return `nil` until the resource completion completes, but we need to set their computed fields in order to call PollRead - so there can never be a dependency on the decoder. */}}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -328,7 +328,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
     }
 
-    err = resource{{ $.ResourceName }}PostCreateSetComputedFields(d, meta, res)
+    err = resource{{ $.ResourceName }}PostCreateSetComputedFields(d, meta, opRes)
     if err != nil {
         return fmt.Errorf("setting computed ID format fields: %w", err)
     }


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/13619 (and part of https://github.com/hashicorp/terraform-provider-google/issues/22214). It makes resources automatically set fields from id_format instead of using the concept of "identity" fields. This involves switching them over to using the function introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/13619 (which is also used by pollasync and non-async Create behavior.)

The follow resources needed additional special attention:

-  spanner database. post_create relied specifically on accessing opRes, but `name` is not actually a computed field on that resource so after this change opRes is no longer set. Changed to read name from `res` instead.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
