### PR TITLE
Fix issue labeler backfill

### DIFF
--- a/tools/issue-labeler/labeler/backfill.go
+++ b/tools/issue-labeler/labeler/backfill.go
@@ -54,7 +54,7 @@ func GetIssues(repository, since string) ([]*github.Issue, error) {
 	allIssues = append(allIssues, issues...)
 
 	for {
-		// use link headers instead of page parameter based pagination as 
+		// use link headers instead of page parameter based pagination as
 		// it is not supported for large datasets
 		nextURL := getNextPageURL(resp.Response)
 		if nextURL == "" {

--- a/tools/issue-labeler/labeler/backfill.go
+++ b/tools/issue-labeler/labeler/backfill.go
@@ -54,6 +54,8 @@ func GetIssues(repository, since string) ([]*github.Issue, error) {
 	allIssues = append(allIssues, issues...)
 
 	for {
+		// use link headers instead of page parameter based pagination as 
+		// it is not supported for large datasets
 		nextURL := getNextPageURL(resp.Response)
 		if nextURL == "" {
 			break


### PR DESCRIPTION
Currently the `Issue Labeler Backfill` GHA is failing with error `getting github issues: listing issues: GET https://api.github.com/repos/hashicorp/terraform-provider-google/issues?direction=desc&page=100&per_page=100&since=1973-01-01T00%3A00%3A00Z&sort=updated&state=all: 422 Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before) []`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
