### PR TITLE
Add response_type to google_identity_platform_oauth_idp_config

### DIFF
--- a/mmv1/products/identityplatform/OauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/OauthIdpConfig.yaml
@@ -69,3 +69,18 @@ properties:
     type: String
     description: |
       The client secret of the OAuth client, to enable OIDC code flow.
+  - name: 'responseType'
+    type: NestedObject
+    description: |
+      The response type to request for in the OAuth authorization flow. 
+      You can set either idToken or code to true, but not both. 
+      Setting both types to be simultaneously true ({code: true, idToken: true}) is not yet supported.
+    properties: 
+      - name: 'idToken'
+        type: Boolean
+        description: |
+          If true, ID token is returned from IdP's authorization endpoint.
+      - name: 'code'
+        type: Boolean
+        description: |
+          If true, authorization code is returned from IdP's authorization endpoint.          

--- a/mmv1/products/identityplatform/OauthIdpConfig.yaml
+++ b/mmv1/products/identityplatform/OauthIdpConfig.yaml
@@ -72,10 +72,10 @@ properties:
   - name: 'responseType'
     type: NestedObject
     description: |
-      The response type to request for in the OAuth authorization flow. 
-      You can set either idToken or code to true, but not both. 
+      The response type to request for in the OAuth authorization flow.
+      You can set either idToken or code to true, but not both.
       Setting both types to be simultaneously true ({code: true, idToken: true}) is not yet supported.
-    properties: 
+    properties:
       - name: 'idToken'
         type: Boolean
         description: |
@@ -83,4 +83,4 @@ properties:
       - name: 'code'
         type: Boolean
         description: |
-          If true, authorization code is returned from IdP's authorization endpoint.          
+          If true, authorization code is returned from IdP's authorization endpoint.

--- a/mmv1/templates/terraform/examples/identity_platform_oauth_idp_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/identity_platform_oauth_idp_config_basic.tf.tmpl
@@ -5,4 +5,8 @@ resource "google_identity_platform_oauth_idp_config" "{{$.PrimaryResourceId}}" {
   issuer        = "issuer"
   enabled       = true
   client_secret = "secret"
+  response_type {
+    id_token = true
+    code = false
+  }
 }

--- a/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_oauth_idp_config_test.go
+++ b/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_oauth_idp_config_test.go
@@ -48,6 +48,10 @@ resource "google_identity_platform_oauth_idp_config" "oauth_idp_config" {
   issuer        = "issuer"
   enabled       = true
   client_secret = "secret"
+  response_type {
+    id_token = false
+    code = true
+  }
 }
 `, context)
 }
@@ -61,6 +65,10 @@ resource "google_identity_platform_oauth_idp_config" "oauth_idp_config" {
   issuer        = "different-issuer"
   enabled       = false
   client_secret = "secret2"
+  response_type {
+    id_token = true
+    code = false
+  }
 }
 `, context)
 }


### PR DESCRIPTION
Fix https://github.com/hashicorp/terraform-provider-google/issues/9385

Adding new field to the resource that's available in API, but not in TF.
API Documentation - https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects.oauthIdpConfigs#oauthresponsetype

```release-note:enhancement
identityplatform: Added `response_type` field to `google_identity_platform_oauth_idp_config`
```
