### PR TITLE
Added NestedQuery handling to PostCreateSetComputedFields

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1215,6 +1215,20 @@ func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.Resource
         return fmt.Errorf("decoding response, could not find object")
     }
     {{- end }}
+    {{- if $.NestedQuery}}
+    {{- if $.NestedQuery.Keys}}
+    if _, ok := res["{{ index $.NestedQuery.Keys 0 -}}"]; ok {
+        res, err := flattenNested{{ $.ResourceName -}}(d, meta, res)
+        if err != nil {
+            return fmt.Errorf("Error getting nested object from operation response: %s", err)
+        }
+        if res == nil {
+            // Object isn't there any more - remove it from the state.
+            return fmt.Errorf("Error decoding response from operation, could not find nested object")
+        }
+    }
+    {{- end}}
+    {{- end}}
     {{- $renderedIdFromName := "false" }}
     {{- range $prop := $.GettableProperties }}
     {{- /* Check if prop is potentially computed */}}


### PR DESCRIPTION
This provides equivalence to the [existing equivalent async code](https://github.com/GoogleCloudPlatform/magic-modules/blob/e86065da4393b10a1a9c1f5cc97317f7a4472748/mmv1/templates/terraform/resource.go.tmpl#L341-L354). It doesn't actually do anything because none of the impacted resources actually have a create method that returns a list of resources. Making this change separately to make these resources easier to review.

Nightly test debug logs:

- BigqueryReservation ReservationAssignment: https://hashicorp.teamcity.com/repository/download/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_BIGQUERYRESERVATION/356036:id/debug-google-beta-cd46538-356036-TestAccBigqueryReservationReservationAssignment_bigqueryReservationAssignmentBasicExample.txt
- DataCatalog Tag: https://hashicorp.teamcity.com/repository/download/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_GOOGLEBETA_PACKAGE_DATACATALOG/355872:id/debug-google-beta-cd46538-355872-TestAccDataCatalogTag_update.txt
- ResourceManager Lien: https://hashicorp.teamcity.com/repository/download/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_RESOURCEMANAGER/356060:id/debug-google-1c766ae-356060-TestAccResourceManagerLien_basic.txt

Part of https://github.com/hashicorp/terraform-provider-google/issues/22214

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
