### PR TITLE
Removed unnecessary check for name in spanner database post_create

### DIFF
--- a/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
+++ b/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
@@ -3,12 +3,6 @@
 // `terraform apply` twice to get their desired outcome, the provider does not set
 // `extraStatements` in the call to the `create` endpoint and all DDL (other than
 //  <CREATE DATABASE>) is run post-create, by calling the `updateDdl` endpoint 
-
-_, ok := opRes["name"]
-if !ok {
-	return fmt.Errorf("Create response didn't contain critical fields. Create may not have succeeded.")
-}
-
 retention, retentionPeriodOk := d.GetOk("version_retention_period")
 retentionPeriod := retention.(string)
 ddl, ddlOk := d.GetOk("ddl")


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

spanner database. post_create relied specifically on accessing opRes, but name is actually a settable & required field on that resource so it's not necessary to pull it from the operation as far as I can tell.

This code will stop working as a consequence of changes for https://github.com/hashicorp/terraform-provider-google/issues/22214, because this resource will no longer be detected as requiring opRes to be set (because there are no computed fields that need to be set after create.)

This part of the post_create template was added in [this commit](https://github.com/GoogleCloudPlatform/magic-modules/pull/6141/commits/3b78b94cf46073a2491a6b30add63b7cc35e9880), after [this round of review](https://github.com/GoogleCloudPlatform/magic-modules/pull/6141#pullrequestreview-1014203786). I don't see anything indicating that this was added in response to a specific problem, and `name` should always be available anyway (because it's a required field) so I think this may have been a mistake.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
