### PR TITLE
Fix for the google_compute_router_route_policy - unable to create route policy with priority 0.

### DIFF
--- a/mmv1/products/compute/RouterRoutePolicy.yaml
+++ b/mmv1/products/compute/RouterRoutePolicy.yaml
@@ -158,6 +158,7 @@ properties:
                 description: |
                   String indicating the location of the expression for error
                   reporting, e.g. a file name and a position in the file
+    custom_expand: 'templates/terraform/custom_expand/expand_route_policy_terms.go.tmpl'
   - name: 'fingerprint'
     type: Fingerprint
     description: |

--- a/mmv1/templates/terraform/custom_expand/expand_route_policy_terms.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/expand_route_policy_terms.go.tmpl
@@ -1,0 +1,181 @@
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   l := v.([]interface{})
+   req := make([]interface{}, 0, len(l))
+   for _, raw := range l {
+       if raw == nil {
+           continue
+       }
+       original := raw.(map[string]interface{})
+       transformed := make(map[string]interface{})
+
+
+       transformedPriority, err := expandComputeRouterRoutePolicyTermsPriority(original["priority"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedPriority); val.IsValid() {
+           transformed["priority"] = transformedPriority
+       }
+
+
+       transformedMatch, err := expandComputeRouterRoutePolicyTermsMatch(original["match"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedMatch); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["match"] = transformedMatch
+       }
+
+
+       transformedActions, err := expandComputeRouterRoutePolicyTermsActions(original["actions"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedActions); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["actions"] = transformedActions
+       }
+
+
+       req = append(req, transformed)
+   }
+   return req, nil
+}
+
+
+
+
+func expandComputeRouterRoutePolicyTermsPriority(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsMatch(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   l := v.([]interface{})
+   if len(l) == 0 || l[0] == nil {
+       return nil, nil
+   }
+   raw := l[0]
+   original := raw.(map[string]interface{})
+   transformed := make(map[string]interface{})
+
+
+   transformedExpression, err := expandComputeRouterRoutePolicyTermsMatchExpression(original["expression"], d, config)
+   if err != nil {
+       return nil, err
+   } else if val := reflect.ValueOf(transformedExpression); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+       transformed["expression"] = transformedExpression
+   }
+
+
+   transformedTitle, err := expandComputeRouterRoutePolicyTermsMatchTitle(original["title"], d, config)
+   if err != nil {
+       return nil, err
+   } else if val := reflect.ValueOf(transformedTitle); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+       transformed["title"] = transformedTitle
+   }
+
+
+   transformedDescription, err := expandComputeRouterRoutePolicyTermsMatchDescription(original["description"], d, config)
+   if err != nil {
+       return nil, err
+   } else if val := reflect.ValueOf(transformedDescription); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+       transformed["description"] = transformedDescription
+   }
+
+
+   transformedLocation, err := expandComputeRouterRoutePolicyTermsMatchLocation(original["location"], d, config)
+   if err != nil {
+       return nil, err
+   } else if val := reflect.ValueOf(transformedLocation); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+       transformed["location"] = transformedLocation
+   }
+
+
+   return transformed, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsMatchExpression(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsMatchTitle(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsMatchDescription(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsMatchLocation(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsActions(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   l := v.([]interface{})
+   req := make([]interface{}, 0, len(l))
+   for _, raw := range l {
+       if raw == nil {
+           continue
+       }
+       original := raw.(map[string]interface{})
+       transformed := make(map[string]interface{})
+
+
+       transformedExpression, err := expandComputeRouterRoutePolicyTermsActionsExpression(original["expression"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedExpression); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["expression"] = transformedExpression
+       }
+
+
+       transformedTitle, err := expandComputeRouterRoutePolicyTermsActionsTitle(original["title"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedTitle); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["title"] = transformedTitle
+       }
+
+
+       transformedDescription, err := expandComputeRouterRoutePolicyTermsActionsDescription(original["description"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedDescription); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["description"] = transformedDescription
+       }
+
+
+       transformedLocation, err := expandComputeRouterRoutePolicyTermsActionsLocation(original["location"], d, config)
+       if err != nil {
+           return nil, err
+       } else if val := reflect.ValueOf(transformedLocation); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+           transformed["location"] = transformedLocation
+       }
+
+
+       req = append(req, transformed)
+   }
+   return req, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsActionsExpression(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsActionsTitle(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsActionsDescription(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}
+
+
+func expandComputeRouterRoutePolicyTermsActionsLocation(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+   return v, nil
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_route_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_route_policy_test.go.tmpl
@@ -1,0 +1,77 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccComputeRouterRoutePolicy_PriorityZero(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", acctest.RandString(t, 10))
+	routePolicyName := fmt.Sprintf("route-policy-%s", acctest.RandString(t, 5))
+	resourceName := "google_compute_router_route_policy.route_policy"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRouterRoutePolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterRoutePolicyPriorityZero(routerName, routePolicyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "terms.0.priority", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeRouterRoutePolicyPriorityZero(routerName, routePolicyName string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  project = "vpn-test-project-422614"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+
+resource "google_compute_network" "vpc" {
+  name                    = "vpc-%[1]s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_router" "router" {
+  name    = "%[1]s"
+  region  = "us-central1"
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_route_policy" "route_policy" {
+  name    = "%[2]s"
+  router  = google_compute_router.router.name
+  region  = "us-central1"
+  type    = "ROUTE_POLICY_TYPE_IMPORT"
+
+  terms {
+    priority = 0
+
+    match {
+      expression  = "destination == '192.168.0.0/24'"
+      title       = "match-title"
+      description = "test match description"
+      location    = "us-central1"
+    }
+
+    actions {
+      expression  = "accept()"
+      title       = "actions-title"
+      description = "test actions description"
+      location    = "us-central1"
+    }
+  }
+}
+`, routerName, routePolicyName)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_route_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_route_policy_test.go.tmpl
@@ -32,12 +32,6 @@ func TestAccComputeRouterRoutePolicy_PriorityZero(t *testing.T) {
 
 func testAccComputeRouterRoutePolicyPriorityZero(routerName, routePolicyName string) string {
 	return fmt.Sprintf(`
-provider "google" {
-  project = "vpn-test-project-422614"
-  region  = "us-central1"
-  zone    = "us-central1-c"
-}
-
 resource "google_compute_network" "vpc" {
   name                    = "vpc-%[1]s"
   auto_create_subnetworks = false


### PR DESCRIPTION
b/408043807
Issue: [google_compute_router_route_policy - unable to create route policy with priority 0](https://github.com/hashicorp/terraform-provider-google/issues/22184)

**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
compute: fixed an issue preventing `terms.priority` from being set to priority value 0 in `google_compute_router_route_policy` resource
```