### PR TITLE
Removed unused required: true from two resources' name fields to make sure it's clear that these fields are not required

### DIFF
--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -77,7 +77,6 @@ properties:
       the instance is created. The name must be between 6 and 30 characters
       in length.
       If not provided, a random string starting with `tf-` will be selected.
-    required: true
     immutable: true
         # This resource supports a sort of odd autogenerate-if-not-set
         # system, which is done in the encoder.  Consequently we have

--- a/mmv1/products/spanner/InstanceConfig.yaml
+++ b/mmv1/products/spanner/InstanceConfig.yaml
@@ -63,7 +63,6 @@ properties:
     description: |
       A unique identifier for the instance configuration. Values are of the
       form projects/<project>/instanceConfigs/[a-z][-a-z0-9]*
-    required: true
     immutable: true
     default_from_api: true
   - name: 'displayName'


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-google/issues/18832. I ran across these while working on something and figured I might as well fix them.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
