### PR TITLE
Allow serial-port-logging-enable in google_workbench_instance metadata

### DIFF
--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -68,7 +68,6 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "report-system-status",
     "resource-url",
     "restriction",
-    "serial-port-logging-enable",
     "service-account-mode",
     "shutdown-script",
     "title",

--- a/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/workbench/resource_workbench_instance_test.go.tmpl
@@ -377,6 +377,7 @@ resource "google_workbench_instance" "instance" {
 
   gce_setup {
     metadata = {
+      "serial-port-logging-enable" = "true",
       terraform = "true"
       "resource-url" = "new-fake-value",
     }
@@ -401,6 +402,7 @@ resource "google_workbench_instance" "instance" {
       terraform = "true",
       "idle-timeout-seconds" = "10800",
       "image-url" = "fake-value",
+      "serial-port-logging-enable" = "true",
     }
   }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Issue: https://github.com/hashicorp/terraform-provider-google/issues/22381

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
google_workbench_instance: `metadata` can now modify serial-port-logging-enable.
```
