### PR TITLE
add IAP IAM resources for Cloud Run

### DIFF
--- a/mmv1/products/iap/WebCloudRunService.yaml
+++ b/mmv1/products/iap/WebCloudRunService.yaml
@@ -1,0 +1,57 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'WebCloudRunService'
+description: |
+  Only used to generate IAM resources
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+id_format: 'projects/{{project}}/iap_web/cloud_run-{{location}}/services/{{name}}'
+base_url: 'projects/{{project}}/iap_web/cloud_run-{{location}}/services/{{name}}'
+self_link: 'projects/{{project}}/iap_web/cloud_run-{{location}}/services/{{name}}'
+import_format:
+  - 'projects/{{project}}/iap_web/cloud_run-{{location}}/services/{{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: 'google_cloud_run_v2_service'
+  fetch_iam_policy_verb: 'POST'
+  allowed_iam_role: 'roles/iap.httpsResourceAccessor'
+  parent_resource_attribute: 'name'
+  iam_conditions_request_type: 'REQUEST_BODY'
+  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
+  import_format:
+    - 'projects/{{project}}/iap_web/cloud_run-{{location}}/services/{{name}}'
+    - '{{name}}'
+  min_version: beta
+custom_code:
+exclude_tgc: true
+examples:
+  - name: 'cloudrunv2_service_iap'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-cloud-run-service%s", context["random_suffix"])'
+    vars:
+      cloud_run_service_name: 'cloud-run-service'
+parameters:
+properties:
+  - name: 'name'
+    type: String
+    description: Name of a Cloud Run service.
+    required: true
+min_version: beta

--- a/mmv1/products/iap/product.yaml
+++ b/mmv1/products/iap/product.yaml
@@ -17,5 +17,7 @@ display_name: 'Identity-Aware Proxy'
 versions:
   - name: 'ga'
     base_url: 'https://iap.googleapis.com/v1/'
+  - name: 'beta'
+    base_url: 'https://iap.googleapis.com/v1/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22280

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_iap_web_cloud_run_service_iam_*`
```
