### PR TITLE
Adding documentation and examples for Apigee data residency

### DIFF
--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -76,6 +76,20 @@ examples:
     exclude_docs: true
     # Resource creation race
     skip_vcr: true
+  - name: 'apigee_organization_cloud_basic_data_residency'
+    exclude_test: true
+  # This is a more verbose version of the above that creates all
+  # the resources needed for the acceptance test.
+  - name: 'apigee_organization_cloud_basic_data_residency_test'
+    primary_resource_id: 'org'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    ignore_read_extra:
+      - 'properties'
+    exclude_docs: true
+    # Resource creation race
+    skip_vcr: true
   - name: 'apigee_organization_cloud_full'
     exclude_test: true
   # This is a more verbose version of the above that creates all

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -18,6 +18,7 @@ description: |
 references:
   guides:
     'Creating an API organization': 'https://cloud.google.com/apigee/docs/api-platform/get-started/create-org'
+    'Setting a custom endpoint (required for data residency)': 'https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#advanced-settings-configuration'
   api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations'
 docs:
 base_url: 'organizations'

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency.tf.tmpl
@@ -1,0 +1,12 @@
+provider "google" {
+  apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
+}
+
+data "google_client_config" "current" {}
+
+resource "google_apigee_organization" "org" {
+  description         = "Terraform-provisioned basic Apigee Org under European Union hosting jurisdiction."
+  project_id          = data.google_client_config.current.project
+  disable_vpc_peering = true
+}
+

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -1,0 +1,25 @@
+provider "google" {
+  apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
+}
+
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
+  description         = "Terraform-provisioned basic Apigee Org under European Union hosting jurisdiction."
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+  depends_on          = [
+    google_project_service.apigee,
+  ]
+}


### PR DESCRIPTION
The only previous and public mentions of this feature can be found [here](https://www.googlecloudcommunity.com/gc/Apigee/Apigee-X-Organization-Provisioning-with-Google-Terraform-Modules/m-p/527135) and [here](https://www.googlecloudcommunity.com/gc/Apigee/Unable-to-setup-Apigee-X-via-Terraform/m-p/817667).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```