### PR TITLE
Don't render nested properties in top level required arguments section in dcl resources doc

### DIFF
--- a/tpgtools/property.go
+++ b/tpgtools/property.go
@@ -481,6 +481,10 @@ func (p Property) IsResourceAnnotations() bool {
 	return p.Name() == "annotations" && p.parent == nil
 }
 
+func (p Property) IsTopLevel() bool {
+	return p.parent == nil
+}
+
 func (p Property) ShouldShowUpInSamples() bool {
 	return (p.Settable && p.Name() != "effective_labels" && p.Name() != "effective_annotations") || p.IsResourceLabels() || p.IsResourceAnnotations()
 }

--- a/tpgtools/templates/resource.html.markdown.tmpl
+++ b/tpgtools/templates/resource.html.markdown.tmpl
@@ -70,7 +70,7 @@ The following arguments are supported:
 {{- end }}
 
 {{ range $v := $.Objects }}
-  {{- if and ($v.Required) ($v.ShouldGenerateNestedSchema) }}
+  {{- if and ($v.Required) ($v.IsTopLevel) ($v.ShouldGenerateNestedSchema) }}
 The `{{$v.Name}}` block supports:
     {{ range $p := $v.Properties }}
 * `{{$p.Name}}` -
@@ -100,7 +100,7 @@ The `{{$v.Name}}` block supports:
 {{- end }}
 
 {{ range $v := $.Objects }}
-  {{- if and ($v.Optional) ($v.ShouldGenerateNestedSchema) }}
+  {{- if and (or ($v.Optional) (and ($v.Required) (not $v.IsTopLevel))) ($v.ShouldGenerateNestedSchema) }}
 The `{{$v.Name}}` block supports:
     {{ range $p := $v.Properties }}
 * `{{$p.Name}}` -


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

A customer reported that `phase_configs` is a nested property inside `custom_canary_deployment` in the resource `google_clouddeploy_delivery_pipeline`. In the [doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/clouddeploy_delivery_pipeline#argument-reference), `phase_configs` is listed along with top level fields like `location` and `name`.



This change will remove the nested fields from the top level required arguments section in the doc for DCL resources.

In the new generated [doc](https://github.com/modular-magician/terraform-provider-google-beta/blob/fc006e34c4b2a99574dad1c6a6fdc05096612d7f/website/docs/r/clouddeploy_delivery_pipeline.html.markdown#argument-reference) for `google_clouddeploy_delivery_pipeline`, `phase_configs` is moved from the top level required arguments section.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
