### PR TITLE
use bootstrapped network for gke cluster tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -659,7 +659,7 @@ func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAdditiveVPC(clusterName. networkName, subnetworkName),
+				Config: testAccContainerCluster_withAdditiveVPC(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.cluster",
@@ -6078,6 +6078,8 @@ func TestAccContainerCluster_autopilot_minimal(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -6153,13 +6155,16 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 
 	domain := "additive.autopilot.example"
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6171,7 +6176,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, true, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6183,7 +6188,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, true, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, true, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6195,7 +6200,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPC(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, true, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, true, true, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6291,13 +6296,16 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 
 	domain := "additive-mutating.autopilot.example"
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
 				),
@@ -6309,7 +6317,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, domain),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, false, domain),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", domain),
 				),
@@ -6322,7 +6330,7 @@ func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, false, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "dns_config.0.additive_vpc_scope_dns_domain", ""),
 				),
@@ -13425,13 +13433,16 @@ func TestAccContainerCluster_withCgroupMode(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withCgroupMode(clusterName, "CGROUP_MODE_V2"),
+				Config: testAccContainerCluster_withCgroupMode(clusterName, networkName, subnetworkName, "CGROUP_MODE_V2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "node_pool_auto_config.0.linux_node_config.0.cgroup_mode"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool_auto_config.0.linux_node_config.0.cgroup_mode", "CGROUP_MODE_V2"),

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -650,6 +650,8 @@ func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -657,7 +659,7 @@ func TestAccContainerCluster_withAdditiveVPC(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAdditiveVPC(clusterName),
+				Config: testAccContainerCluster_withAdditiveVPC(clusterName. networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.cluster",
@@ -913,12 +915,15 @@ resource "google_container_cluster" "cluster" {
 `, clusterName, clusterName)
 }
 
-func testAccContainerCluster_withAdditiveVPC(clusterName string) string {
+func testAccContainerCluster_withAdditiveVPC(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
 
   dns_config {
     cluster_dns = "CLOUD_DNS"
@@ -927,7 +932,7 @@ resource "google_container_cluster" "cluster" {
   }
   deletion_protection = false
 }
-`, clusterName)
+`, clusterName, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withFQDNNetworkPolicy(clusterName string, enabled bool) string {
@@ -1237,6 +1242,8 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -1244,7 +1251,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{}, ""),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName, []string{}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
 						"master_authorized_networks_config.#", "1"),
@@ -1253,7 +1260,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"8.8.8.8/32"}, ""),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName, []string{"8.8.8.8/32"}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
 						"master_authorized_networks_config.0.cidr_blocks.#", "1"),
@@ -1266,7 +1273,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{"10.0.0.0/8", "8.8.8.8/32"}, ""),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName, []string{"10.0.0.0/8", "8.8.8.8/32"}, ""),
 			},
 			{
 				ResourceName:		     "google_container_cluster.with_master_authorized_networks",
@@ -1275,7 +1282,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, []string{}, ""),
+				Config: testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName, []string{}, ""),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_master_authorized_networks",
 						"master_authorized_networks_config.0.cidr_blocks.#", "0"),
@@ -1288,7 +1295,7 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName),
+				Config: testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:		     "google_container_cluster.with_master_authorized_networks",
@@ -1398,6 +1405,8 @@ func TestAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(t *te
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -1405,7 +1414,7 @@ func TestAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(t *te
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, false),
+				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, networkName, subnetworkName, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary",
 						"master_authorized_networks_config.0.private_endpoint_enforcement_enabled", "false"),
@@ -1418,7 +1427,7 @@ func TestAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(t *te
 				ImportStateVerifyIgnore:	[]string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, true),
+				Config: testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, networkName, subnetworkName, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary",
 						"master_authorized_networks_config.0.private_endpoint_enforcement_enabled", "true"),
@@ -1434,7 +1443,7 @@ func TestAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(t *te
 	})
 }
 
-func testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName string, enabled bool) string {
+func testAccContainerCluster_withAuthorizedNetworkPrivateEnforcementToggle(clusterName, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -1442,11 +1451,14 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   deletion_protection = false
 
+  network    = "%s"
+  subnetwork = "%s"
+
   master_authorized_networks_config {
     private_endpoint_enforcement_enabled = %t
   }
 }
-`, clusterName, enabled)
+`, clusterName, networkName, subnetworkName, enabled)
 }
 
 func TestAccContainerCluster_regional(t *testing.T) {
@@ -2874,6 +2886,8 @@ func TestAccContainerCluster_withNodePoolConflictingNameFields(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	npPrefix := "tf-test-np"
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
@@ -2881,7 +2895,7 @@ func TestAccContainerCluster_withNodePoolConflictingNameFields(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:		 testAccContainerCluster_withNodePoolConflictingNameFields(clusterName, npPrefix),
+				Config:		 testAccContainerCluster_withNodePoolConflictingNameFields(clusterName, networkName, subnetworkName, npPrefix),
 				ExpectError: regexp.MustCompile("Cannot specify both name and name_prefix for a node_pool"),
 			},
 		},
@@ -3702,6 +3716,8 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3712,7 +3728,7 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAutopilotKubeletConfigBaseline(clusterName),
+				Config: testAccContainerCluster_withAutopilotKubeletConfigBaseline(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
@@ -3721,7 +3737,7 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, "FALSE"),
+				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, networkName, subnetworkName, "FALSE"),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
@@ -3730,7 +3746,7 @@ func TestAccContainerCluster_withAutopilotKubeletConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, "TRUE"),
+				Config: testAccContainerCluster_withAutopilotKubeletConfigUpdates(clusterName, networkName, subnetworkName, "TRUE"),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_autopilot_kubelet_config",
@@ -3910,6 +3926,8 @@ func TestAccContainerCluster_withWorkloadIdentityConfigAutopilot(t *testing.T) {
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	pid := envvar.GetTestProjectFromEnv()
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -3917,7 +3935,7 @@ func TestAccContainerCluster_withWorkloadIdentityConfigAutopilot(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withWorkloadIdentityConfigEnabledAutopilot(pid, clusterName),
+				Config: testAccContainerCluster_withWorkloadIdentityConfigEnabledAutopilot(pid, clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_workload_identity_config",
@@ -5257,6 +5275,8 @@ func TestAccContainerCluster_withIncompatibleMasterVersionNodeVersion(t *testing
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck: func(){acctest.AccTestPreCheck(t)},
@@ -5264,7 +5284,7 @@ func TestAccContainerCluster_withIncompatibleMasterVersionNodeVersion(t *testing
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(clusterName),
+				Config: testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(clusterName, networkName, subnetworkName),
 				PlanOnly: true,
 				ExpectError: regexp.MustCompile(`Resource argument node_version`),
 			},
@@ -5555,6 +5575,8 @@ func TestAccContainerCluster_withWorkloadALTSConfigAutopilot(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 	pid := envvar.GetTestProjectFromEnv()
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -5562,7 +5584,7 @@ func TestAccContainerCluster_withWorkloadALTSConfigAutopilot(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withWorkloadALTSConfigAutopilot(pid, clusterName, true),
+				Config: testAccContainerCluster_withWorkloadALTSConfigAutopilot(pid, clusterName, networkName, subnetworkName, true),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_workload_alts_config",
@@ -5632,17 +5654,20 @@ resource "google_container_cluster" "primary" {
 `, resource_name, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name string) string {
+func testAccContainerCluster_withIncompatibleMasterVersionNodeVersion(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "gke_cluster" {
   name     = "%s"
   location = "us-central1"
 
+  network    = "%s"
+  subnetwork = "%s"
+
   min_master_version = "1.10.9-gke.5"
   node_version       = "1.10.6-gke.11"
   initial_node_count = 1
 }
-	`, name)
+	`, name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_SetSecurityPostureToStandard(resource_name, networkName, subnetworkName string) string {
@@ -6059,7 +6084,7 @@ func TestAccContainerCluster_autopilot_minimal(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_minimal(clusterName),
+				Config: testAccContainerCluster_autopilot_minimal(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.primary",
@@ -6075,13 +6100,16 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, false, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6090,7 +6118,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, false, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, true, false, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6099,7 +6127,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, false, true, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, false, true, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6108,7 +6136,7 @@ func TestAccContainerCluster_autopilot_withDNSConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, true, true, true, true, ""),
+				Config: testAccContainerCluster_withAdvancedDNSConfig(clusterName, networkName, subnetworkName, true, true, true, true, ""),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6186,13 +6214,16 @@ func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withDNSConfigWithoutScope(clusterName),
+				Config: testAccContainerCluster_withDNSConfigWithoutScope(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -6201,7 +6232,7 @@ func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withDNSConfigWithUnspecifiedScope(clusterName),
+				Config: testAccContainerCluster_withDNSConfigWithUnspecifiedScope(clusterName, networkName, subnetworkName),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionNoop),
@@ -6218,7 +6249,7 @@ func TestAccContainerCluster_cloudDns_nil_scope(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withDNSConfigWithoutScope(clusterName string) string {
+func testAccContainerCluster_withDNSConfigWithoutScope(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -6228,12 +6259,15 @@ resource "google_container_cluster" "primary" {
     cluster_dns      = "CLOUD_DNS"
   }
 
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
 }
-`, clusterName)
+`, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withDNSConfigWithUnspecifiedScope(clusterName string) string {
+func testAccContainerCluster_withDNSConfigWithUnspecifiedScope(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
@@ -6244,9 +6278,12 @@ resource "google_container_cluster" "primary" {
     cluster_dns_scope = "DNS_SCOPE_UNSPECIFIED"
   }
 
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
 }
-`, clusterName)
+`, clusterName, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_autopilot_withAdditiveVPCMutation(t *testing.T) {
@@ -7380,7 +7417,7 @@ resource "google_container_cluster" "primary" {
 }
 
 
-func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName string, cidrs []string, emptyValue string) string {
+func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName string, cidrs []string, emptyValue string) string {
 
 	cidrBlocks := emptyValue
 	if len(cidrs) > 0 {
@@ -7404,20 +7441,28 @@ resource "google_container_cluster" "with_master_authorized_networks" {
   master_authorized_networks_config {
     %s
   }
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
 }
-`, clusterName, cidrBlocks)
+`, clusterName, cidrBlocks, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName string) string {
+func testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_authorized_networks" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
   deletion_protection = false
 }
-`, clusterName)
+`, clusterName, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_regional(clusterName, networkName, subnetworkName string) string {
@@ -9515,11 +9560,14 @@ resource "google_container_cluster" "with_node_pool_multiple" {
 `, cluster, npPrefix, npPrefix, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withNodePoolConflictingNameFields(cluster, npPrefix string) string {
+func testAccContainerCluster_withNodePoolConflictingNameFields(cluster, networkName, subnetworkName, npPrefix string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_multiple" {
   name     = "%s"
   location = "us-central1-a"
+
+  network    = "%s"
+  subnetwork = "%s"
 
   node_pool {
     # ERROR: name and name_prefix cannot be both specified
@@ -9529,7 +9577,7 @@ resource "google_container_cluster" "with_node_pool_multiple" {
   }
   deletion_protection = false
 }
-`, cluster, npPrefix, npPrefix)
+`, cluster, networkName, subnetworkName, npPrefix, npPrefix)
 }
 
 func testAccContainerCluster_withNodePoolNodeConfig(cluster, np, networkName, subnetworkName string) string {
@@ -10255,7 +10303,7 @@ resource "google_container_cluster" "with_workload_identity_config" {
 `, projectID, clusterName, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withWorkloadIdentityConfigEnabledAutopilot(projectID string, clusterName string) string {
+func testAccContainerCluster_withWorkloadIdentityConfigEnabledAutopilot(projectID string, clusterName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
@@ -10271,8 +10319,11 @@ resource "google_container_cluster" "with_workload_identity_config" {
   }
   enable_autopilot    = true
   deletion_protection = false
+
+  network    = "%s"
+  subnetwork = "%s"
 }
-`, projectID, clusterName)
+`, projectID, clusterName, networkName, subnetworkName)
 }
 
 
@@ -11693,23 +11744,27 @@ resource "google_container_cluster" "primary" {
 {{- end }}
 
 
-func testAccContainerCluster_autopilot_minimal(name string) string {
+func testAccContainerCluster_autopilot_minimal(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
   location            = "us-central1"
   enable_autopilot    = true
   deletion_protection = false
-}`, name)
+  network    = "%s"
+  subnetwork = "%s"
+}`, name, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withAdvancedDNSConfig(name string, autopilot, dnsConfigSectionPresent, clusterDnsPresent, clusterDnsScopePresent bool, additiveVpcDnsDomain string) string {
+func testAccContainerCluster_withAdvancedDNSConfig(name, networkName, subnetworkName string, autopilot, dnsConfigSectionPresent, clusterDnsPresent, clusterDnsScopePresent bool, additiveVpcDnsDomain string) string {
 	config := fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
   location            = "us-central1"
+  network    = "%s"
+  subnetwork = "%s"
   deletion_protection = false
-`, name)
+`, name, networkName, subnetworkName)
 	if autopilot {
 		config += `
   enable_autopilot    = true
@@ -12135,32 +12190,34 @@ resource "google_container_cluster" "with_workload_alts_config" {
 `, projectID, networkName, subnetworkName, name, enable)
 }
 
-func testAccContainerCluster_withWorkloadALTSConfigAutopilot(projectID, name string, enable bool) string {
+func testAccContainerCluster_withWorkloadALTSConfigAutopilot(projectID, name, networkName, subnetworkName string, enable bool) string {
   return fmt.Sprintf(`
-  data "google_project" "project" {
-    provider = google-beta
-    project_id = "%s"
+data "google_project" "project" {
+  provider = google-beta
+  project_id = "%s"
+}
+resource "google_container_cluster" "with_workload_alts_config" {
+  provider = google-beta
+  name               = "%s"
+  location           = "us-central1"
+  initial_node_count = 1
+  workload_alts_config {
+    enable_alts = %v
   }
-  resource "google_container_cluster" "with_workload_alts_config" {
-    provider = google-beta
-    name               = "%s"
-    location           = "us-central1"
-    initial_node_count = 1
-    workload_alts_config {
-      enable_alts = %v
-    }
-    workload_identity_config {
-      workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
-    }
-    enable_autopilot = true
-    deletion_protection = false
+  workload_identity_config {
+    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
   }
-`, projectID, name, enable)
+  enable_autopilot = true
+  deletion_protection = false
+  network    = "%s"
+  subnetwork = "%s"
+}
+`, projectID, name, enable, networkName, subnetworkName)
 }
 
 {{ end }}
 
-func testAccContainerCluster_withAutopilotKubeletConfigBaseline(name string) string {
+func testAccContainerCluster_withAutopilotKubeletConfigBaseline(name, networkName, subnetworkName string) string {
   return fmt.Sprintf(`
 resource "google_container_cluster" "with_autopilot_kubelet_config" {
   name                = "%s"
@@ -12168,16 +12225,21 @@ resource "google_container_cluster" "with_autopilot_kubelet_config" {
   initial_node_count  = 1
   enable_autopilot    = true
   deletion_protection = false
+  network    = "%s"
+  subnetwork = "%s"
 }
-`, name)
+`, name, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, insecureKubeletReadonlyPortEnabled string) string {
+func testAccContainerCluster_withAutopilotKubeletConfigUpdates(name, networkName, subnetworkName, insecureKubeletReadonlyPortEnabled string) string {
   return fmt.Sprintf(`
 resource "google_container_cluster" "with_autopilot_kubelet_config" {
   name               = "%s"
   location           = "us-central1"
   initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
 
   node_pool_auto_config {
     node_kubelet_config {
@@ -12188,7 +12250,7 @@ resource "google_container_cluster" "with_autopilot_kubelet_config" {
   enable_autopilot    = true
   deletion_protection = false
 }
-`, name, insecureKubeletReadonlyPortEnabled)
+`, name, networkName, subnetworkName, insecureKubeletReadonlyPortEnabled)
 }
 
 func testAccContainerCluster_withAutopilot_withNodePoolDefaults(name, networkName, subnetworkName string) string {
@@ -13229,6 +13291,8 @@ func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {
 
 	randomSuffix := acctest.RandString(t, 10)
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randomSuffix)
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -13239,7 +13303,7 @@ func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(clusterName),
+				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(clusterName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_autopilot_gcp_filestore", "addons_config.0.gcp_filestore_csi_driver_config.0.enabled", "true"),
 				),
@@ -13251,7 +13315,7 @@ func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(clusterName),
+				Config: testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_autopilot_gcp_filestore",
@@ -13263,18 +13327,21 @@ func TestAccContainerCluster_withAutopilotGcpFilestoreCsiDriver(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(name string) string {
+func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverDefault(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_autopilot_gcp_filestore" {
   name                = "%s"
   location            = "us-central1"
   enable_autopilot    = true
   deletion_protection = false
+
+  network    = "%s"
+  subnetwork = "%s"
 }
-`, name)
+`, name, networkName, subnetworkName)
 }
 
-func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(name string) string {
+func testAccContainerCluster_withAutopilotGcpFilestoreCsiDriverUpdated(name, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_autopilot_gcp_filestore" {
   name                = "%s"
@@ -13287,21 +13354,27 @@ resource "google_container_cluster" "with_autopilot_gcp_filestore" {
       enabled = false
     }
   }
+
+  network    = "%s"
+  subnetwork = "%s"
 }
-`, name)
+`, name, networkName, subnetworkName)
 }
 
 func TestAccContainerCluster_withDnsEndpoint(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withDnsEndpoint(clusterName, false),
+				Config: testAccContainerCluster_withDnsEndpoint(clusterName, networkName, subnetworkName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// The DNS endpoint should always be set, even if allow_external_traffic is false.
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
@@ -13315,7 +13388,7 @@ func TestAccContainerCluster_withDnsEndpoint(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withDnsEndpoint(clusterName, true),
+				Config: testAccContainerCluster_withDnsEndpoint(clusterName, networkName, subnetworkName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.endpoint"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "control_plane_endpoints_config.0.dns_endpoint_config.0.allow_external_traffic", "true"),
@@ -13331,19 +13404,21 @@ func TestAccContainerCluster_withDnsEndpoint(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withDnsEndpoint(name string, enabled bool) string {
+func testAccContainerCluster_withDnsEndpoint(name, networkName, subnetworkName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
   location            = "us-central1-a"
   initial_node_count  = 1
+  network    = "%s"
+  subnetwork = "%s"
   deletion_protection = false
   control_plane_endpoints_config {
     dns_endpoint_config {
       allow_external_traffic = %t
     }
   }
-}`, name, enabled)
+}`, name, networkName, subnetworkName, enabled)
 }
 
 func TestAccContainerCluster_withCgroupMode(t *testing.T) {
@@ -13376,13 +13451,16 @@ func TestAccContainerCluster_withCgroupModeUpdate(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+  networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_autopilot_minimal(clusterName),
+				Config: testAccContainerCluster_autopilot_minimal(clusterName, networkName, subnetworkName),
 			},
 			{
 				ResourceName:            "google_container_cluster.primary",
@@ -13391,7 +13469,7 @@ func TestAccContainerCluster_withCgroupModeUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withCgroupMode(clusterName, "CGROUP_MODE_V2"),
+				Config: testAccContainerCluster_withCgroupMode(clusterName, networkName, subnetworkName, "CGROUP_MODE_V2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "node_pool_auto_config.0.linux_node_config.0.cgroup_mode"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool_auto_config.0.linux_node_config.0.cgroup_mode", "CGROUP_MODE_V2"),
@@ -13407,11 +13485,13 @@ func TestAccContainerCluster_withCgroupModeUpdate(t *testing.T) {
 	})
 }
 
-func testAccContainerCluster_withCgroupMode(name string, cgroupMode string) string {
+func testAccContainerCluster_withCgroupMode(name, networkName, subnetworkName string, cgroupMode string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
   name                = "%s"
   enable_autopilot    = true
+  network    = "%s"
+  subnetwork = "%s"
   deletion_protection = false
   node_pool_auto_config {
     linux_node_config {
@@ -13419,7 +13499,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 }
-  `, name, cgroupMode)
+  `, name, networkName, subnetworkName, cgroupMode)
 }
 
 func TestAccContainerCluster_withEnterpriseConfig(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4490,6 +4490,8 @@ func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster-1")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster-1", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 			PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -4497,7 +4499,7 @@ func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 			CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 			Steps: []resource.TestStep{
 					{
-							Config: testAccContainerNodePool_withHostMaintenancePolicy(cluster, np),
+							Config: testAccContainerNodePool_withHostMaintenancePolicy(cluster, networkName, subnetworkName, np),
 					},
 					{
 							ResourceName:      "google_container_node_pool.np",
@@ -4508,7 +4510,7 @@ func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_withHostMaintenancePolicy(cluster, np string) string {
+func testAccContainerNodePool_withHostMaintenancePolicy(cluster, networkName, subnetworkName, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name               = "%s"
@@ -4520,6 +4522,8 @@ resource "google_container_cluster" "cluster" {
     }
     machine_type = "n2-standard-2"
   }
+  network    = "%s"
+  subnetwork = "%s"
   deletion_protection = false
 }
 
@@ -4535,7 +4539,7 @@ resource "google_container_node_pool" "np" {
     machine_type = "n2-standard-2"
   }
 }
-`, cluster, np)
+`, cluster, networkName, subnetworkName, np)
 }
 {{- end }}
 
@@ -5127,6 +5131,8 @@ func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster-1")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluste1", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -5134,7 +5140,7 @@ func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_defaultDriverInstallation(cluster, np),
+				Config: testAccContainerNodePool_defaultDriverInstallation(cluster, networkName, subnetworkName, np),
 			},
 			{
 				ResourceName:      "google_container_node_pool.np",
@@ -5145,7 +5151,7 @@ func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_defaultDriverInstallation(cluster, np string) string {
+func testAccContainerNodePool_defaultDriverInstallation(cluster, networkName, subnetworkName, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -5161,6 +5167,8 @@ resource "google_container_cluster" "cluster" {
   release_channel {
     channel = "RAPID"
   }
+  network    = "%s"
+  subnetwork = "%s"
 }
 
 resource "google_container_node_pool" "np" {
@@ -5183,7 +5191,7 @@ resource "google_container_node_pool" "np" {
     }
   }
 }
-`, cluster, np)
+`, cluster, networkName, subnetworkName, np)
 }
 
 func TestAccContainerNodePool_storagePools(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4514,7 +4514,7 @@ func testAccContainerNodePool_withHostMaintenancePolicy(cluster, networkName, su
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
   name               = "%s"
-  location           = "asia-east1-c"
+  location           = "us-central1-a"
   initial_node_count = 1
   node_config {
     host_maintenance_policy {
@@ -4529,7 +4529,7 @@ resource "google_container_cluster" "cluster" {
 
 resource "google_container_node_pool" "np" {
   name               = "%s"
-  location           = "asia-east1-c"
+  location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4490,8 +4490,8 @@ func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
-	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster-1")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster-1", networkName)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 			PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -5131,8 +5131,8 @@ func TestAccContainerNodePool_defaultDriverInstallation(t *testing.T) {
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
-	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster-1")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluste1", networkName)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
Switched to use the bootstrapped network instead of default network for [vpc-native (default mode) GKE clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) to to avoid traffic to the default network. This follows the direction as https://github.com/GoogleCloudPlatform/magic-modules/pull/9265, https://github.com/GoogleCloudPlatform/magic-modules/pull/9348 and https://github.com/GoogleCloudPlatform/magic-modules/pull/9664

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
