### PR TITLE
`appengine` add `oauth2_client_secret` write-only field to `resource_google_app_engine_application`

### DIFF
--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -145,10 +146,24 @@ func ResourceAppEngineApplication() *schema.Resource {
 							Description: `OAuth2 client ID to use for the authentication flow.`,
 						},
 						"oauth2_client_secret": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Sensitive:   true,
-							Description: `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+							Type:          schema.TypeString,
+							Required:      true,
+							Sensitive:     true,
+							ConflictsWith: []string{"oauth_client_secret_wo"},
+							Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth_client_secret_wo": {
+							Type:          schema.TypeString,
+							Required:      true,
+							WriteOnly:     true,
+							ConflictsWith: []string{"oauth2_client_secret"},
+							RequiredWith:  []string{"oauth_client_secret_wo_version"},
+							Description:   `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth_client_secret_wo_version": {
+							Type:         schema.TypeString,
+							RequiredWith: []string{"oauth_client_secret_wo"},
+							Description:  `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
 						},
 						"oauth2_client_secret_sha256": {
 							Type:        schema.TypeString,
@@ -395,10 +410,16 @@ func expandAppEngineApplicationIap(d *schema.ResourceData) (*appengine.IdentityA
 	if len(blocks) < 1 {
 		return nil, nil
 	}
+	var clientSecret string
+	if clientSecretWo, _ := d.GetRawConfigAt(cty.GetAttrPath("iap").IndexInt(0).GetAttr("oauth2_client_secret_wo")); !clientSecretWo.IsNull() {
+		clientSecret = clientSecretWo.AsString()
+	} else {
+		clientSecret = d.Get("iap.0.oauth2_client_secret").(string)
+	}
 	return &appengine.IdentityAwareProxy{
 		Enabled:                  d.Get("iap.0.enabled").(bool),
 		Oauth2ClientId:           d.Get("iap.0.oauth2_client_id").(string),
-		Oauth2ClientSecret:       d.Get("iap.0.oauth2_client_secret").(string),
+		Oauth2ClientSecret:       clientSecret,
 		Oauth2ClientSecretSha256: d.Get("iap.0.oauth2_client_secret_sha256").(string),
 	}, nil
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -157,10 +158,24 @@ func ResourceAppEngineApplication() *schema.Resource {
 							Description: `OAuth2 client ID to use for the authentication flow.`,
 						},
 						"oauth2_client_secret": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Sensitive:   true,
-							Description: `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+							Type:          schema.TypeString,
+							Required:      true,
+							Sensitive:     true,
+							ConflictsWith: []string{"oauth_client_secret_wo"},
+							Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth_client_secret_wo": {
+							Type:          schema.TypeString,
+							Required:      true,
+							WriteOnly:     true,
+							ConflictsWith: []string{"oauth2_client_secret"},
+							RequiredWith:  []string{"oauth_client_secret_wo_version"},
+							Description:   `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth_client_secret_wo_version": {
+							Type:         schema.TypeString,
+							RequiredWith: []string{"oauth_client_secret_wo"},
+							Description:  `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
 						},
 						"oauth2_client_secret_sha256": {
 							Type:        schema.TypeString,
@@ -411,10 +426,16 @@ func expandAppEngineApplicationIap(d *schema.ResourceData) (*appengine.IdentityA
 	if len(blocks) < 1 {
 		return nil, nil
 	}
+	var clientSecret string
+	if clientSecretWo, _ := d.GetRawConfigAt(cty.GetAttrPath("iap").IndexInt(0).GetAttr("oauth2_client_secret_wo")); !clientSecretWo.IsNull() {
+		clientSecret = clientSecretWo.AsString()
+	} else {
+		clientSecret = d.Get("iap.0.oauth2_client_secret").(string)
+	}
 	return &appengine.IdentityAwareProxy{
 		Enabled:                  d.Get("iap.0.enabled").(bool),
 		Oauth2ClientId:           d.Get("iap.0.oauth2_client_id").(string),
-		Oauth2ClientSecret:       d.Get("iap.0.oauth2_client_secret").(string),
+		Oauth2ClientSecret:       clientSecret,
 		Oauth2ClientSecretSha256: d.Get("iap.0.oauth2_client_secret_sha256").(string),
 	}, nil
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,6 +36,7 @@ func ResourceAppEngineApplication() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			appEngineApplicationLocationIDCustomizeDiff,
+			appEngineApplicationIapSecretCustomizeDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -138,10 +140,10 @@ func ResourceAppEngineApplication() *schema.Resource {
 				Description: `The GCR domain used for storing managed Docker images for this app.`,
 			},
 			"iap": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				// Not Computed: Terraform SDK forbids WriteOnly attributes in Computed blocks.
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
 				Description: `Settings for enabling Cloud Identity Aware Proxy`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -157,25 +159,11 @@ func ResourceAppEngineApplication() *schema.Resource {
 							Description: `OAuth2 client ID to use for the authentication flow.`,
 						},
 						"oauth2_client_secret": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Sensitive:    true,
-							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
-							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
-						},
-						"oauth2_client_secret_wo": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							WriteOnly:    true,
-							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
-							RequiredWith: []string{"iap.0.oauth2_client_secret_wo_version"},
-							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
-						},
-						"oauth2_client_secret_wo_version": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							RequiredWith: []string{"iap.0.oauth2_client_secret_wo"},
-							Description:  "Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)",
+							Type:          schema.TypeString,
+							Optional:      true,
+							Sensitive:     true,
+							ConflictsWith: []string{"oauth2_client_secret_wo"},
+							Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
 						},
 						"oauth2_client_secret_sha256": {
 							Type:        schema.TypeString,
@@ -185,6 +173,24 @@ func ResourceAppEngineApplication() *schema.Resource {
 						},
 					},
 				},
+			},
+			// Handwritten equivalent of flatten_object: true on the write-only
+			// fields. The SDK forbids WriteOnly inside a Computed block, and iap
+			// must stay Computed. Same pattern as SecretVersion payload.secretData
+			// → top-level secret_data_wo. Expand still sends iap.oauth2ClientSecret.
+			"oauth2_client_secret_wo": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"iap.0.oauth2_client_secret"},
+				RequiredWith:  []string{"oauth2_client_secret_wo_version", "iap"},
+				Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field. Write-only alternative to iap.oauth2_client_secret; expand maps this value into the IAP API body.`,
+			},
+			"oauth2_client_secret_wo_version": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"oauth2_client_secret_wo"},
+				Description:  "Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)",
 			},
 		},
 		UseJSONNumber: true,
@@ -225,6 +231,21 @@ func appEngineApplicationLocationIDCustomizeDiff(_ context.Context, d *schema.Re
 	old, new := d.GetChange("location_id")
 	if old != "" && old != new {
 		return fmt.Errorf("Cannot change location_id once the resource is created.")
+	}
+	return nil
+}
+
+func appEngineApplicationIapSecretCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	iapCfg, diags := d.GetRawConfigAt(cty.GetAttrPath("iap"))
+	if len(diags) > 0 || iapCfg.IsNull() || !iapCfg.IsKnown() || iapCfg.LengthInt() == 0 {
+		return nil
+	}
+
+	secret, _ := d.Get("iap.0.oauth2_client_secret").(string)
+	woCfg, woDiags := d.GetRawConfigAt(cty.GetAttrPath("oauth2_client_secret_wo"))
+	woSet := len(woDiags) == 0 && !woCfg.IsNull() && woCfg.IsKnown() && woCfg.AsString() != ""
+	if secret == "" && !woSet {
+		return fmt.Errorf("one of iap.0.oauth2_client_secret or oauth2_client_secret_wo must be set when iap is configured")
 	}
 	return nil
 }
@@ -426,16 +447,22 @@ func expandAppEngineApplicationIap(d *schema.ResourceData) (*appengine.IdentityA
 	if len(blocks) < 1 {
 		return nil, nil
 	}
-	clientSecret := tpgresource.GetRawConfigAttributeAsString(d, "iap.0.oauth2_client_secret_wo")
-	if clientSecret == "" {
-		clientSecret = d.Get("iap.0.oauth2_client_secret").(string)
-	}
 	return &appengine.IdentityAwareProxy{
 		Enabled:                  d.Get("iap.0.enabled").(bool),
 		Oauth2ClientId:           d.Get("iap.0.oauth2_client_id").(string),
-		Oauth2ClientSecret:       clientSecret,
+		Oauth2ClientSecret:       expandAppEngineApplicationIapOauth2ClientSecret(d),
 		Oauth2ClientSecretSha256: d.Get("iap.0.oauth2_client_secret_sha256").(string),
 	}, nil
+}
+
+// expandAppEngineApplicationIapOauth2ClientSecret maps the top-level write-only
+// secret into iap.oauth2ClientSecret on the API request. oauth2_client_secret_wo
+// cannot live in the Computed iap schema block.
+func expandAppEngineApplicationIapOauth2ClientSecret(d *schema.ResourceData) string {
+	if wo := tpgresource.GetRawConfigAttributeAsString(d, "oauth2_client_secret_wo"); wo != "" {
+		return wo
+	}
+	return d.Get("iap.0.oauth2_client_secret").(string)
 }
 
 func flattenAppEngineApplicationFeatureSettings(settings *appengine.FeatureSettings) ([]map[string]interface{}, error) {
@@ -452,18 +479,11 @@ func flattenAppEngineApplicationIap(d *schema.ResourceData, iap *appengine.Ident
 	if iap == nil {
 		return []map[string]interface{}{}, nil
 	}
-	_, configured := d.GetOk("iap")
-	// iap cannot be Computed (it contains write-only attributes), so omit
-	// API-default IAP from state when the user did not configure the block.
-	if !configured && !iap.Enabled && iap.Oauth2ClientId == "" {
-		return []map[string]interface{}{}, nil
-	}
 	result := map[string]interface{}{
-		"enabled":                         iap.Enabled,
-		"oauth2_client_id":                iap.Oauth2ClientId,
-		"oauth2_client_secret":            d.Get("iap.0.oauth2_client_secret"),
-		"oauth2_client_secret_wo_version": d.Get("iap.0.oauth2_client_secret_wo_version"),
-		"oauth2_client_secret_sha256":     iap.Oauth2ClientSecretSha256,
+		"enabled":                     iap.Enabled,
+		"oauth2_client_id":            iap.Oauth2ClientId,
+		"oauth2_client_secret":        d.Get("iap.0.oauth2_client_secret"),
+		"oauth2_client_secret_sha256": iap.Oauth2ClientSecretSha256,
 	}
 	return []map[string]interface{}{result}, nil
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -36,7 +35,6 @@ func ResourceAppEngineApplication() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			appEngineApplicationLocationIDCustomizeDiff,
-			appEngineApplicationIapSecretCustomizeDiff,
 		),
 
 		Schema: map[string]*schema.Schema{
@@ -140,11 +138,11 @@ func ResourceAppEngineApplication() *schema.Resource {
 				Description: `The GCR domain used for storing managed Docker images for this app.`,
 			},
 			"iap": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Computed:    true,
-				MaxItems:    1,
-				Description: `Settings for enabling Cloud Identity Aware Proxy`,
+				Type:             schema.TypeList,
+				Optional:         true,
+				MaxItems:         1,
+				DiffSuppressFunc: suppressAppEngineApplicationIapDiffWhenUnset,
+				Description:      `Settings for enabling Cloud Identity Aware Proxy`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -159,11 +157,25 @@ func ResourceAppEngineApplication() *schema.Resource {
 							Description: `OAuth2 client ID to use for the authentication flow.`,
 						},
 						"oauth2_client_secret": {
-							Type:          schema.TypeString,
-							Optional:      true,
-							Sensitive:     true,
-							ConflictsWith: []string{"oauth2_client_secret_wo"},
-							Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
+							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth2_client_secret_wo": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							WriteOnly:    true,
+							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
+							RequiredWith: []string{"iap.0.oauth2_client_secret_wo_version"},
+							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth2_client_secret_wo_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"iap.0.oauth2_client_secret_wo"},
+							Description:  "Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)",
 						},
 						"oauth2_client_secret_sha256": {
 							Type:        schema.TypeString,
@@ -173,24 +185,6 @@ func ResourceAppEngineApplication() *schema.Resource {
 						},
 					},
 				},
-			},
-			// Handwritten equivalent of flatten_object: true on the write-only
-			// fields. The SDK forbids WriteOnly inside a Computed block, and iap
-			// must stay Computed. Same pattern as SecretVersion payload.secretData
-			// → top-level secret_data_wo. Expand still sends iap.oauth2ClientSecret.
-			"oauth2_client_secret_wo": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				WriteOnly:     true,
-				ConflictsWith: []string{"iap.0.oauth2_client_secret"},
-				RequiredWith:  []string{"oauth2_client_secret_wo_version", "iap"},
-				Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field. Write-only alternative to iap.oauth2_client_secret; expand maps this value into the IAP API body.`,
-			},
-			"oauth2_client_secret_wo_version": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				RequiredWith: []string{"oauth2_client_secret_wo"},
-				Description:  "Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)",
 			},
 		},
 		UseJSONNumber: true,
@@ -235,19 +229,13 @@ func appEngineApplicationLocationIDCustomizeDiff(_ context.Context, d *schema.Re
 	return nil
 }
 
-func appEngineApplicationIapSecretCustomizeDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
-	iapCfg, diags := d.GetRawConfigAt(cty.GetAttrPath("iap"))
-	if len(diags) > 0 || iapCfg.IsNull() || !iapCfg.IsKnown() || iapCfg.LengthInt() == 0 {
-		return nil
+// Suppress API-returned IAP values when the iap block is omitted from configuration.
+func suppressAppEngineApplicationIapDiffWhenUnset(_ string, _, _ string, d *schema.ResourceData) bool {
+	iap := d.GetRawConfig().GetAttr("iap")
+	if iap.IsNull() {
+		return true
 	}
-
-	secret, _ := d.Get("iap.0.oauth2_client_secret").(string)
-	woCfg, woDiags := d.GetRawConfigAt(cty.GetAttrPath("oauth2_client_secret_wo"))
-	woSet := len(woDiags) == 0 && !woCfg.IsNull() && woCfg.IsKnown() && woCfg.AsString() != ""
-	if secret == "" && !woSet {
-		return fmt.Errorf("one of iap.0.oauth2_client_secret or oauth2_client_secret_wo must be set when iap is configured")
-	}
-	return nil
+	return iap.IsKnown() && iap.LengthInt() == 0
 }
 
 func resourceAppEngineApplicationCreate(d *schema.ResourceData, meta interface{}) error {
@@ -447,22 +435,16 @@ func expandAppEngineApplicationIap(d *schema.ResourceData) (*appengine.IdentityA
 	if len(blocks) < 1 {
 		return nil, nil
 	}
+	clientSecret := tpgresource.GetRawConfigAttributeAsString(d, "iap.0.oauth2_client_secret_wo")
+	if clientSecret == "" {
+		clientSecret = d.Get("iap.0.oauth2_client_secret").(string)
+	}
 	return &appengine.IdentityAwareProxy{
 		Enabled:                  d.Get("iap.0.enabled").(bool),
 		Oauth2ClientId:           d.Get("iap.0.oauth2_client_id").(string),
-		Oauth2ClientSecret:       expandAppEngineApplicationIapOauth2ClientSecret(d),
+		Oauth2ClientSecret:       clientSecret,
 		Oauth2ClientSecretSha256: d.Get("iap.0.oauth2_client_secret_sha256").(string),
 	}, nil
-}
-
-// expandAppEngineApplicationIapOauth2ClientSecret maps the top-level write-only
-// secret into iap.oauth2ClientSecret on the API request. oauth2_client_secret_wo
-// cannot live in the Computed iap schema block.
-func expandAppEngineApplicationIapOauth2ClientSecret(d *schema.ResourceData) string {
-	if wo := tpgresource.GetRawConfigAttributeAsString(d, "oauth2_client_secret_wo"); wo != "" {
-		return wo
-	}
-	return d.Get("iap.0.oauth2_client_secret").(string)
 }
 
 func flattenAppEngineApplicationFeatureSettings(settings *appengine.FeatureSettings) ([]map[string]interface{}, error) {
@@ -480,10 +462,11 @@ func flattenAppEngineApplicationIap(d *schema.ResourceData, iap *appengine.Ident
 		return []map[string]interface{}{}, nil
 	}
 	result := map[string]interface{}{
-		"enabled":                     iap.Enabled,
-		"oauth2_client_id":            iap.Oauth2ClientId,
-		"oauth2_client_secret":        d.Get("iap.0.oauth2_client_secret"),
-		"oauth2_client_secret_sha256": iap.Oauth2ClientSecretSha256,
+		"enabled":                         iap.Enabled,
+		"oauth2_client_id":                iap.Oauth2ClientId,
+		"oauth2_client_secret":            d.Get("iap.0.oauth2_client_secret"),
+		"oauth2_client_secret_wo_version": d.Get("iap.0.oauth2_client_secret_wo_version"),
+		"oauth2_client_secret_sha256":     iap.Oauth2ClientSecretSha256,
 	}
 	return []map[string]interface{}{result}, nil
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -158,24 +157,25 @@ func ResourceAppEngineApplication() *schema.Resource {
 							Description: `OAuth2 client ID to use for the authentication flow.`,
 						},
 						"oauth2_client_secret": {
-							Type:          schema.TypeString,
-							Required:      true,
-							Sensitive:     true,
-							ConflictsWith: []string{"oauth_client_secret_wo"},
-							Description:   `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
-						},
-						"oauth_client_secret_wo": {
-							Type:          schema.TypeString,
-							Required:      true,
-							WriteOnly:     true,
-							ConflictsWith: []string{"oauth2_client_secret"},
-							RequiredWith:  []string{"oauth_client_secret_wo_version"},
-							Description:   `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
-						},
-						"oauth_client_secret_wo_version": {
 							Type:         schema.TypeString,
-							RequiredWith: []string{"oauth_client_secret_wo"},
-							Description:  `The Write-Only OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+							Optional:     true,
+							Sensitive:    true,
+							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
+							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth2_client_secret_wo": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							WriteOnly:    true,
+							ExactlyOneOf: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo"},
+							RequiredWith: []string{"iap.0.oauth2_client_secret_wo_version"},
+							Description:  `OAuth2 client secret to use for the authentication flow. The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.`,
+						},
+						"oauth2_client_secret_wo_version": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"iap.0.oauth2_client_secret_wo"},
+							Description:  "Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)",
 						},
 						"oauth2_client_secret_sha256": {
 							Type:        schema.TypeString,
@@ -426,10 +426,8 @@ func expandAppEngineApplicationIap(d *schema.ResourceData) (*appengine.IdentityA
 	if len(blocks) < 1 {
 		return nil, nil
 	}
-	var clientSecret string
-	if clientSecretWo, _ := d.GetRawConfigAt(cty.GetAttrPath("iap").IndexInt(0).GetAttr("oauth2_client_secret_wo")); !clientSecretWo.IsNull() {
-		clientSecret = clientSecretWo.AsString()
-	} else {
+	clientSecret := tpgresource.GetRawConfigAttributeAsString(d, "iap.0.oauth2_client_secret_wo")
+	if clientSecret == "" {
 		clientSecret = d.Get("iap.0.oauth2_client_secret").(string)
 	}
 	return &appengine.IdentityAwareProxy{
@@ -455,10 +453,11 @@ func flattenAppEngineApplicationIap(d *schema.ResourceData, iap *appengine.Ident
 		return []map[string]interface{}{}, nil
 	}
 	result := map[string]interface{}{
-		"enabled":                     iap.Enabled,
-		"oauth2_client_id":            iap.Oauth2ClientId,
-		"oauth2_client_secret":        d.Get("iap.0.oauth2_client_secret"),
-		"oauth2_client_secret_sha256": iap.Oauth2ClientSecretSha256,
+		"enabled":                         iap.Enabled,
+		"oauth2_client_id":                iap.Oauth2ClientId,
+		"oauth2_client_secret":            d.Get("iap.0.oauth2_client_secret"),
+		"oauth2_client_secret_wo_version": d.Get("iap.0.oauth2_client_secret_wo_version"),
+		"oauth2_client_secret_sha256":     iap.Oauth2ClientSecretSha256,
 	}
 	return []map[string]interface{}{result}, nil
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application.go
@@ -138,10 +138,10 @@ func ResourceAppEngineApplication() *schema.Resource {
 				Description: `The GCR domain used for storing managed Docker images for this app.`,
 			},
 			"iap": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Computed:    true,
-				MaxItems:    1,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				// Not Computed: Terraform SDK forbids WriteOnly attributes in Computed blocks.
 				Description: `Settings for enabling Cloud Identity Aware Proxy`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -450,6 +450,12 @@ func flattenAppEngineApplicationFeatureSettings(settings *appengine.FeatureSetti
 
 func flattenAppEngineApplicationIap(d *schema.ResourceData, iap *appengine.IdentityAwareProxy) ([]map[string]interface{}, error) {
 	if iap == nil {
+		return []map[string]interface{}{}, nil
+	}
+	_, configured := d.GetOk("iap")
+	// iap cannot be Computed (it contains write-only attributes), so omit
+	// API-default IAP from state when the user did not configure the block.
+	if !configured && !iap.Enabled && iap.Oauth2ClientId == "" {
 		return []map[string]interface{}{}, nil
 	}
 	result := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
@@ -21,8 +21,8 @@ fields:
   - api_field: 'iap.oauth2ClientId'
   - api_field: 'iap.oauth2ClientSecret'
   - api_field: 'iap.oauth2ClientSecret'
-    field: 'iap.oauth2_client_secret_wo'
-  - field: 'iap.oauth2_client_secret_wo_version'
+    field: 'oauth2_client_secret_wo'
+  - field: 'oauth2_client_secret_wo_version'
     provider_only: true
   - api_field: 'iap.oauth2ClientSecretSha256'
   - api_field: 'locationId'

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
@@ -20,6 +20,10 @@ fields:
   - api_field: 'iap.enabled'
   - api_field: 'iap.oauth2ClientId'
   - api_field: 'iap.oauth2ClientSecret'
+  - api_field: 'iap.oauth2ClientSecret'
+    field: 'iap.oauth2_client_secret_wo'
+  - field: 'iap.oauth2_client_secret_wo_version'
+    provider_only: true
   - api_field: 'iap.oauth2ClientSecretSha256'
   - api_field: 'locationId'
   - api_field: 'name'

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_meta.yaml.tmpl
@@ -21,8 +21,8 @@ fields:
   - api_field: 'iap.oauth2ClientId'
   - api_field: 'iap.oauth2ClientSecret'
   - api_field: 'iap.oauth2ClientSecret'
-    field: 'oauth2_client_secret_wo'
-  - field: 'oauth2_client_secret_wo_version'
+    field: 'iap.oauth2_client_secret_wo'
+  - field: 'iap.oauth2_client_secret_wo_version'
     provider_only: true
   - api_field: 'iap.oauth2ClientSecretSha256'
   - api_field: 'locationId'

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -47,6 +47,44 @@ func TestAccAppEngineApplication_basic(t *testing.T) {
 	})
 }
 
+func TestAccAppEngineApplication_IAP_wo_basic(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	pid := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "url_dispatch_rule.#"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "name"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "code_bucket"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_hostname"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_bucket"),
+				),
+			},
+			{
+				ResourceName:      "google_app_engine_application.acceptance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount),
+			},
+			{
+				ResourceName:      "google_app_engine_application.acceptance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAppEngineApplication_withIAP(t *testing.T) {
 	t.Parallel()
 
@@ -112,6 +150,60 @@ resource "google_app_engine_application" "acceptance" {
   location_id    = "us-central"
   database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
   serving_status = "SERVING"
+}
+`, pid, pid, org, billingAccount)
+}
+
+func testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "acceptance" {
+  project        = google_project.acceptance.project_id
+  auth_domain    = "hashicorptest.com"
+  location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
+  serving_status = "SERVING"
+
+  iap {
+    enabled              = false
+    oauth2_client_id     = "test"
+    oauth2_client_secret = "test"
+	oauth_2_client_secret_version = 1
+  }
+}
+`, pid, pid, org, billingAccount)
+}
+
+func testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "acceptance" {
+  project        = google_project.acceptance.project_id
+  auth_domain    = "tf-test.club"
+  location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
+  serving_status = "USER_DISABLED"
+
+  iap {
+    enabled              = false
+    oauth2_client_id     = "test"
+    oauth2_client_secret_wo = "test_2"
+	oauth_2_client_secret_wo_version = 2
+  }
 }
 `, pid, pid, org, billingAccount)
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -49,6 +49,44 @@ func TestAccAppEngineApplication_basic(t *testing.T) {
 	})
 }
 
+func TestAccAppEngineApplication_IAP_wo_basic(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	pid := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	billingAccount := envvar.GetTestBillingAccountFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "url_dispatch_rule.#"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "name"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "code_bucket"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_hostname"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_bucket"),
+				),
+			},
+			{
+				ResourceName:      "google_app_engine_application.acceptance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount),
+			},
+			{
+				ResourceName:      "google_app_engine_application.acceptance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAppEngineApplication_withIAP(t *testing.T) {
 	t.Parallel()
 
@@ -141,6 +179,60 @@ resource "google_app_engine_application" "acceptance" {
   location_id    = "us-central"
   database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
   serving_status = "SERVING"
+}
+`, pid, pid, org, billingAccount)
+}
+
+func testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "acceptance" {
+  project        = google_project.acceptance.project_id
+  auth_domain    = "hashicorptest.com"
+  location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
+  serving_status = "SERVING"
+
+  iap {
+    enabled              = false
+    oauth2_client_id     = "test"
+    oauth2_client_secret = "test"
+	oauth_2_client_secret_version = 1
+  }
+}
+`, pid, pid, org, billingAccount)
+}
+
+func testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "acceptance" {
+  project        = google_project.acceptance.project_id
+  auth_domain    = "tf-test.club"
+  location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
+  serving_status = "USER_DISABLED"
+
+  iap {
+    enabled              = false
+    oauth2_client_id     = "test"
+    oauth2_client_secret_wo = "test_2"
+	oauth_2_client_secret_wo_version = 2
+  }
 }
 `, pid, pid, org, billingAccount)
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -63,8 +63,8 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 			{
 				Config: testAccAppEngineApplication_withIAPWriteOnly(pid, org, billingAccount),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo"),
-					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "1"),
 					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
 				),
 			},
@@ -74,13 +74,13 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 				ImportStateVerify: true,
 				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
 				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
-				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "oauth2_client_secret_wo_version"},
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
 			},
 			{
 				Config: testAccAppEngineApplication_withIAPWriteOnlyUpdate(pid, org, billingAccount),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo"),
-					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "2"),
 					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
 				),
 			},
@@ -90,7 +90,7 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 				ImportStateVerify: true,
 				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
 				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
-				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "oauth2_client_secret_wo_version"},
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
 			},
 		},
 	})
@@ -204,16 +204,16 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_app_engine_application" "acceptance" {
-  project                         = google_project.acceptance.project_id
-  auth_domain                     = "hashicorptest.com"
-  location_id                     = "us-central"
-  serving_status                  = "SERVING"
-  oauth2_client_secret_wo         = "test"
-  oauth2_client_secret_wo_version = "1"
+  project        = google_project.acceptance.project_id
+  auth_domain    = "hashicorptest.com"
+  location_id    = "us-central"
+  serving_status = "SERVING"
 
   iap {
-    enabled          = false
-    oauth2_client_id = "test"
+    enabled                         = false
+    oauth2_client_id                = "test"
+    oauth2_client_secret_wo         = "test"
+    oauth2_client_secret_wo_version = "1"
   }
 }
 `, pid, pid, org, billingAccount)
@@ -230,16 +230,16 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_app_engine_application" "acceptance" {
-  project                         = google_project.acceptance.project_id
-  auth_domain                     = "hashicorptest.com"
-  location_id                     = "us-central"
-  serving_status                  = "SERVING"
-  oauth2_client_secret_wo         = "test_2"
-  oauth2_client_secret_wo_version = "2"
+  project        = google_project.acceptance.project_id
+  auth_domain    = "hashicorptest.com"
+  location_id    = "us-central"
+  serving_status = "SERVING"
 
   iap {
-    enabled          = false
-    oauth2_client_id = "test"
+    enabled                         = false
+    oauth2_client_id                = "test"
+    oauth2_client_secret_wo         = "test_2"
+    oauth2_client_secret_wo_version = "2"
   }
 }
 `, pid, pid, org, billingAccount)

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -49,7 +49,7 @@ func TestAccAppEngineApplication_basic(t *testing.T) {
 	})
 }
 
-func TestAccAppEngineApplication_IAP_wo_basic(t *testing.T) {
+func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 	t.Parallel()
 
 	org := envvar.GetTestOrgFromEnv(t)
@@ -61,27 +61,36 @@ func TestAccAppEngineApplication_IAP_wo_basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount),
+				Config: testAccAppEngineApplication_withIAPWriteOnly(pid, org, billingAccount),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "url_dispatch_rule.#"),
-					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "name"),
-					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "code_bucket"),
-					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_hostname"),
-					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "default_bucket"),
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "1"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
 				),
 			},
 			{
 				ResourceName:      "google_app_engine_application.acceptance",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
+				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
 			},
 			{
-				Config: testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount),
+				Config: testAccAppEngineApplication_withIAPWriteOnlyUpdate(pid, org, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "2"),
+					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
+				),
 			},
 			{
 				ResourceName:      "google_app_engine_application.acceptance",
 				ImportState:       true,
 				ImportStateVerify: true,
+				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
+				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
 			},
 		},
 	})
@@ -102,9 +111,10 @@ func TestAccAppEngineApplication_withIAP(t *testing.T) {
 				Config: testAccAppEngineApplication_withIAP(pid, org, billingAccount),
 			},
 			{
-				ResourceName:            "google_app_engine_application.acceptance",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "google_app_engine_application.acceptance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
 				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
 			},
 		},
@@ -183,12 +193,12 @@ resource "google_app_engine_application" "acceptance" {
 `, pid, pid, org, billingAccount)
 }
 
-func testAccAppEngineApplication_IAP_wo_basic(pid, org, billingAccount string) string {
+func testAccAppEngineApplication_withIAPWriteOnly(pid, org, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-  project_id = "%s"
-  name       = "%s"
-  org_id     = "%s"
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
   billing_account = "%s"
   deletion_policy = "DELETE"
 }
@@ -197,41 +207,39 @@ resource "google_app_engine_application" "acceptance" {
   project        = google_project.acceptance.project_id
   auth_domain    = "hashicorptest.com"
   location_id    = "us-central"
-  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
   serving_status = "SERVING"
 
   iap {
-    enabled              = false
-    oauth2_client_id     = "test"
-    oauth2_client_secret = "test"
-	oauth_2_client_secret_version = 1
+    enabled                         = false
+    oauth2_client_id                = "test"
+    oauth2_client_secret_wo         = "test"
+    oauth2_client_secret_wo_version = "1"
   }
 }
 `, pid, pid, org, billingAccount)
 }
 
-func testAccAppEngineApplication_IAP_wo_basic_update(pid, org, billingAccount string) string {
+func testAccAppEngineApplication_withIAPWriteOnlyUpdate(pid, org, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-  project_id = "%s"
-  name       = "%s"
-  org_id     = "%s"
+  project_id      = "%s"
+  name            = "%s"
+  org_id          = "%s"
   billing_account = "%s"
   deletion_policy = "DELETE"
 }
 
 resource "google_app_engine_application" "acceptance" {
   project        = google_project.acceptance.project_id
-  auth_domain    = "tf-test.club"
+  auth_domain    = "hashicorptest.com"
   location_id    = "us-central"
-  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
-  serving_status = "USER_DISABLED"
+  serving_status = "SERVING"
 
   iap {
-    enabled              = false
-    oauth2_client_id     = "test"
-    oauth2_client_secret_wo = "test_2"
-	oauth_2_client_secret_wo_version = 2
+    enabled                         = false
+    oauth2_client_id                = "test"
+    oauth2_client_secret_wo         = "test_2"
+    oauth2_client_secret_wo_version = "2"
   }
 }
 `, pid, pid, org, billingAccount)

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_application_test.go
@@ -63,8 +63,8 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 			{
 				Config: testAccAppEngineApplication_withIAPWriteOnly(pid, org, billingAccount),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
-					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo_version", "1"),
 					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
 				),
 			},
@@ -74,13 +74,13 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 				ImportStateVerify: true,
 				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
 				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
-				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "oauth2_client_secret_wo_version"},
 			},
 			{
 				Config: testAccAppEngineApplication_withIAPWriteOnlyUpdate(pid, org, billingAccount),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo"),
-					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo"),
+					resource.TestCheckResourceAttr("google_app_engine_application.acceptance", "oauth2_client_secret_wo_version", "2"),
 					resource.TestCheckResourceAttrSet("google_app_engine_application.acceptance", "iap.0.oauth2_client_secret_sha256"),
 				),
 			},
@@ -90,7 +90,7 @@ func TestAccAppEngineApplication_withIAPWriteOnly(t *testing.T) {
 				ImportStateVerify: true,
 				// oauth2_client_secret is never returned by the API (only the SHA-256 hash is).
 				// oauth2_client_secret_wo_version is client-side and is not returned by the API.
-				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "iap.0.oauth2_client_secret_wo_version"},
+				ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret", "oauth2_client_secret_wo_version"},
 			},
 		},
 	})
@@ -204,16 +204,16 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_app_engine_application" "acceptance" {
-  project        = google_project.acceptance.project_id
-  auth_domain    = "hashicorptest.com"
-  location_id    = "us-central"
-  serving_status = "SERVING"
+  project                         = google_project.acceptance.project_id
+  auth_domain                     = "hashicorptest.com"
+  location_id                     = "us-central"
+  serving_status                  = "SERVING"
+  oauth2_client_secret_wo         = "test"
+  oauth2_client_secret_wo_version = "1"
 
   iap {
-    enabled                         = false
-    oauth2_client_id                = "test"
-    oauth2_client_secret_wo         = "test"
-    oauth2_client_secret_wo_version = "1"
+    enabled          = false
+    oauth2_client_id = "test"
   }
 }
 `, pid, pid, org, billingAccount)
@@ -230,16 +230,16 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_app_engine_application" "acceptance" {
-  project        = google_project.acceptance.project_id
-  auth_domain    = "hashicorptest.com"
-  location_id    = "us-central"
-  serving_status = "SERVING"
+  project                         = google_project.acceptance.project_id
+  auth_domain                     = "hashicorptest.com"
+  location_id                     = "us-central"
+  serving_status                  = "SERVING"
+  oauth2_client_secret_wo         = "test_2"
+  oauth2_client_secret_wo_version = "2"
 
   iap {
-    enabled                         = false
-    oauth2_client_id                = "test"
-    oauth2_client_secret_wo         = "test_2"
-    oauth2_client_secret_wo_version = "2"
+    enabled          = false
+    oauth2_client_id = "test"
   }
 }
 `, pid, pid, org, billingAccount)

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -67,6 +67,15 @@ The following arguments are supported:
   * `oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
 
+  * `oauth2_client_secret_wo_version` - (Optional) The version of the oauth2_client_secret. For more info see [updating   write-only attributes](/docs/providers/google/guides/using_write_only_attributes.  html#updating-write-only-attributes).
+
+## Ephemeral Attributes Reference
+
+The following write-only attributes are supported:
+
+* `iap.oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
+    The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -65,6 +65,15 @@ The following arguments are supported:
   * `oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
 
+  * `oauth2_client_secret_wo_version` - (Optional) The version of the oauth2_client_secret. For more info see [updating   write-only attributes](/docs/providers/google/guides/using_write_only_attributes.  html#updating-write-only-attributes).
+
+## Ephemeral Attributes Reference
+
+The following write-only attributes are supported:
+
+* `iap.oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
+    The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -16,7 +16,7 @@ Allows creation and management of an App Engine application.
 ~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
 state as plain-text. [Read more about sensitive data in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
-~> **Note:** All arguments marked as write-only values will not be stored in the state: `iap.oauth2_client_secret_wo`.
+~> **Note:** All arguments marked as write-only values will not be stored in the state: `oauth2_client_secret_wo`.
 [Read more about Write-only Arguments](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments).
 
 ## Example Usage
@@ -69,15 +69,16 @@ The following arguments are supported:
 
   * `oauth2_client_secret` - (Optional) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
-    Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
+    Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` must be set when `iap` is configured.
 
-  * `oauth2_client_secret_wo` - (Optional, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OAuth2 client secret to use for the authentication flow.
-    The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
-    **Note**: This property is write-only and will not be read from the API.
+* `oauth2_client_secret_wo` - (Optional, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OAuth2 client secret to use for the authentication flow.
+  The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+  This is a top-level write-only alternative to `iap.oauth2_client_secret` (`iap` is a Computed block, which cannot contain write-only attributes).
+  **Note**: This property is write-only and will not be read from the API.
 
-    ~> **Note:** Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
+  ~> **Note:** Exactly one of `iap.oauth2_client_secret` or `oauth2_client_secret_wo` must be set when `iap` is configured.
 
-  * `oauth2_client_secret_wo_version` - (Optional) Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
+* `oauth2_client_secret_wo_version` - (Optional) Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -16,6 +16,9 @@ Allows creation and management of an App Engine application.
 ~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
 state as plain-text. [Read more about sensitive data in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
+~> **Note:** All arguments marked as write-only values will not be stored in the state: `iap.oauth2_client_secret_wo`.
+[Read more about Write-only Arguments](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments).
+
 ## Example Usage
 
 ```hcl
@@ -62,19 +65,22 @@ The following arguments are supported:
 
 * `iap` - (Optional) Settings for enabling Cloud Identity Aware Proxy
 
+  * `enabled` - (Optional) Whether the serving infrastructure will authenticate and authorize all incoming requests.
+    (default is false)
+
   * `oauth2_client_id` - (Required) OAuth2 client ID to use for the authentication flow.
 
-  * `oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
+  * `oauth2_client_secret` - (Optional) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+    Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
 
-  * `oauth2_client_secret_wo_version` - (Optional) The version of the oauth2_client_secret. For more info see [updating   write-only attributes](/docs/providers/google/guides/using_write_only_attributes.  html#updating-write-only-attributes).
-
-## Ephemeral Attributes Reference
-
-The following write-only attributes are supported:
-
-* `iap.oauth2_client_secret` - (Required) OAuth2 client secret to use for the authentication flow.
+  * `oauth2_client_secret_wo` - (Optional, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+    **Note**: This property is write-only and will not be read from the API.
+
+    ~> **Note:** Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
+
+  * `oauth2_client_secret_wo_version` - (Optional) Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
 
 ## Attributes Reference
 
@@ -98,9 +104,6 @@ exported:
 * `gcr_domain` - The GCR domain used for storing managed Docker images for this app.
 
 * `iap` - Settings for enabling Cloud Identity Aware Proxy
-
-  * `enabled` - (Optional) Whether the serving infrastructure will authenticate and authorize all incoming requests. 
-  (default is false)
 
   * `oauth2_client_secret_sha256` - Hex-encoded SHA-256 hash of the client secret.
 

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -65,9 +65,6 @@ The following arguments are supported:
 
 * `iap` - (Optional) Settings for enabling Cloud Identity Aware Proxy
 
-  * `enabled` - (Optional) Whether the serving infrastructure will authenticate and authorize all incoming requests.
-    (default is false)
-
   * `oauth2_client_id` - (Required) OAuth2 client ID to use for the authentication flow.
 
   * `oauth2_client_secret` - (Optional) OAuth2 client secret to use for the authentication flow.
@@ -104,6 +101,9 @@ exported:
 * `gcr_domain` - The GCR domain used for storing managed Docker images for this app.
 
 * `iap` - Settings for enabling Cloud Identity Aware Proxy
+
+  * `enabled` - (Optional) Whether the serving infrastructure will authenticate and authorize all incoming requests. 
+  (default is false)
 
   * `oauth2_client_secret_sha256` - Hex-encoded SHA-256 hash of the client secret.
 

--- a/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -16,7 +16,7 @@ Allows creation and management of an App Engine application.
 ~> **Warning:** All arguments including `iap.oauth2_client_secret` will be stored in the raw
 state as plain-text. [Read more about sensitive data in state](https://developer.hashicorp.com/terraform/language/manage-sensitive-data).
 
-~> **Note:** All arguments marked as write-only values will not be stored in the state: `oauth2_client_secret_wo`.
+~> **Note:** All arguments marked as write-only values will not be stored in the state: `iap.oauth2_client_secret_wo`.
 [Read more about Write-only Arguments](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments).
 
 ## Example Usage
@@ -69,16 +69,15 @@ The following arguments are supported:
 
   * `oauth2_client_secret` - (Optional) OAuth2 client secret to use for the authentication flow.
     The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
-    Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` must be set when `iap` is configured.
+    Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
 
-* `oauth2_client_secret_wo` - (Optional, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OAuth2 client secret to use for the authentication flow.
-  The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
-  This is a top-level write-only alternative to `iap.oauth2_client_secret` (`iap` is a Computed block, which cannot contain write-only attributes).
-  **Note**: This property is write-only and will not be read from the API.
+  * `iap.oauth2_client_secret_wo` - (Optional, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) OAuth2 client secret to use for the authentication flow.
+    The SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
+    **Note**: This property is write-only and will not be read from the API.
 
-  ~> **Note:** Exactly one of `iap.oauth2_client_secret` or `oauth2_client_secret_wo` must be set when `iap` is configured.
+    ~> **Note:** Exactly one of `oauth2_client_secret` or `oauth2_client_secret_wo` can be set.
 
-* `oauth2_client_secret_wo_version` - (Optional) Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
+  * `iap.oauth2_client_secret_wo_version` - (Optional) Triggers update of `oauth2_client_secret_wo` write-only. Increment this value when an update to `oauth2_client_secret_wo` is needed. For more info see [updating write-only arguments](/docs/providers/google/guides/using_write_only_arguments.html#updating-write-only-arguments)
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```hcl
󰀵 mau  …/terraform-provider-google   main $!⇣   v1.24.2   14:00   envchain GCLOUD make test TEST=./google/services/appengine TESTARGS='--run TestAccAppEngineApplication_IAP_wo_basic'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
go test --run TestAccAppEngineApplication_IAP_wo_basic -timeout=30s ./google/services/appengine
ok      github.com/hashicorp/terraform-provider-google/google/services/appengine        1.486s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
appengine: added `oauth2_client_secret` write-only field and `oauth2_client_secret_wo_version` field in `google_app_engine_application` resource
```
