### PR TITLE
Adding API Docs for private ca Certificate

### DIFF
--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -21,8 +21,8 @@ description: |
   `tier = "ENTERPRISE"`
 references:
   guides:
-    'Official Documentation': 'https://cloud.google.com/certificate-authority-service'
-  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest'
+    'Certificate Authority Service Overview': 'https://cloud.google.com/certificate-authority-service/docs/overview'
+  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest/v1/projects.locations.caPools.certificates'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificates'
 create_url: 'projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificates?certificateId={{name}}'

--- a/mmv1/products/privateca/Certificate.yaml
+++ b/mmv1/products/privateca/Certificate.yaml
@@ -19,6 +19,10 @@ description: |
 
   ~> **Note:** The Certificate Authority that is referenced by this resource **must** be
   `tier = "ENTERPRISE"`
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/certificate-authority-service'
+  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificates'
 create_url: 'projects/{{project}}/locations/{{location}}/caPools/{{pool}}/certificates?certificateId={{name}}'


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
private:  Adding API Docs for google_privateca_certificate
```