### PR TITLE
tgc-revival: Modify the return type of cai2hcl

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/convert.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/convert.go
@@ -16,7 +16,7 @@ type Options struct {
 }
 
 // Converts CAI Assets into HCL string.
-func Convert(assets []*caiasset.Asset, options *Options) ([]byte, error) {
+func Convert(assets []caiasset.Asset, options *Options) ([]byte, error) {
 	if options == nil || options.ErrorLogger == nil {
 		return nil, fmt.Errorf("logger is not initialized")
 	}

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/convert_resource.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/convert_resource.go
@@ -5,7 +5,7 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
 )
 
-func ConvertResource(asset *caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
+func ConvertResource(asset caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
 	converter, ok := ConverterMap[asset.Type]
 	if !ok {
 		return nil, nil

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/services/compute/compute_instance.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/services/compute/compute_instance.go
@@ -36,10 +36,7 @@ func NewComputeInstanceConverter(provider *schema.Provider) models.Converter {
 }
 
 // Convert converts asset to HCL resource blocks.
-func (c *ComputeInstanceConverter) Convert(asset *caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
-	if asset == nil || asset.Resource == nil && asset.Resource.Data == nil {
-		return nil, nil
-	}
+func (c *ComputeInstanceConverter) Convert(asset caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
 	var blocks []*models.TerraformResourceBlock
 	block, err := c.convertResourceData(asset)
 	if err != nil {
@@ -49,8 +46,8 @@ func (c *ComputeInstanceConverter) Convert(asset *caiasset.Asset) ([]*models.Ter
 	return blocks, nil
 }
 
-func (c *ComputeInstanceConverter) convertResourceData(asset *caiasset.Asset) (*models.TerraformResourceBlock, error) {
-	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+func (c *ComputeInstanceConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
 

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/services/resourcemanager/project.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/converters/services/resourcemanager/project.go
@@ -34,11 +34,7 @@ func NewProjectConverter(provider *tfschema.Provider) models.Converter {
 }
 
 // Convert converts asset resource data.
-func (c *ProjectConverter) Convert(asset *caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
-	if asset == nil || asset.Resource == nil && asset.Resource.Data == nil {
-		return nil, nil
-	}
-
+func (c *ProjectConverter) Convert(asset caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
 	var blocks []*models.TerraformResourceBlock
 	block, err := c.convertResourceData(asset)
 	if err != nil {
@@ -48,8 +44,8 @@ func (c *ProjectConverter) Convert(asset *caiasset.Asset) ([]*models.TerraformRe
 	return blocks, nil
 }
 
-func (c *ProjectConverter) convertResourceData(asset *caiasset.Asset) (*models.TerraformResourceBlock, error) {
-	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+func (c *ProjectConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
 

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/models/converter.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/models/converter.go
@@ -7,5 +7,5 @@ import (
 // Converter interface for resources.
 type Converter interface {
 	// Convert turns asset into hcl blocks.
-	Convert(asset *caiasset.Asset) ([]*TerraformResourceBlock, error)
+	Convert(asset caiasset.Asset) ([]*TerraformResourceBlock, error)
 }

--- a/mmv1/third_party/tgc_next/pkg/caiasset/asset.go
+++ b/mmv1/third_party/tgc_next/pkg/caiasset/asset.go
@@ -11,13 +11,13 @@ type Asset struct {
 	// The name, in a peculiar format: `\\<api>.googleapis.com/<self_link>`
 	Name string `json:"name"`
 	// The type name in `google.<api>.<resourcename>` format.
-	Type          string           `json:"assetType"`
+	Type          string           `json:"asset_type"`
 	Resource      *AssetResource   `json:"resource,omitempty"`
-	IAMPolicy     *IAMPolicy       `json:"iamPolicy,omitempty"`
-	OrgPolicy     []*OrgPolicy     `json:"orgPolicy,omitempty"`
+	IAMPolicy     *IAMPolicy       `json:"iam_policy,omitempty"`
+	OrgPolicy     []*OrgPolicy     `json:"org_policy,omitempty"`
 	V2OrgPolicies []*V2OrgPolicies `json:"v2_org_policies,omitempty"`
 	Ancestors     []string         `json:"ancestors"`
-	TfplanAddress []string         `json:"tfplanAddress,omitempty"`
+	TfplanAddress []string         `json:"tfplan_address,omitempty"`
 }
 
 // IAMPolicy is the representation of a Cloud IAM policy set on a cloud resource.
@@ -34,8 +34,8 @@ type IAMBinding struct {
 // AssetResource is nested within the Asset type.
 type AssetResource struct {
 	Version              string                 `json:"version"`
-	DiscoveryDocumentURI string                 `json:"discoveryDocumentUri"`
-	DiscoveryName        string                 `json:"discoveryName"`
+	DiscoveryDocumentURI string                 `json:"discovery_document_uri"`
+	DiscoveryName        string                 `json:"discovery_name"`
 	Parent               string                 `json:"parent"`
 	Data                 map[string]interface{} `json:"data"`
 	Location             string                 `json:"location,omitempty"`

--- a/mmv1/third_party/tgc_next/pkg/tfplan2cai/converters/convert_resource.go
+++ b/mmv1/third_party/tgc_next/pkg/tfplan2cai/converters/convert_resource.go
@@ -33,6 +33,7 @@ func ConvertResource(rdList []*models.FakeResourceDataWithMeta, cfg *transport_t
 				if errors.Cause(err) == cai.ErrNoConversion {
 					continue
 				}
+				return assets, err
 			}
 
 			// TODO: combine assets and fetch full policy for IAM bindings/members


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

In the roundtrip testing, cai2hcl -> tfplan2cai -> cai2hcl -> tfplan2cai, the output of tfplan2cai will be the input of cai2hcl.
Currently, tfplan2cai returns `[]caiasset.Asset`, but the input of cai2hcl is `[]*caiasset.Asset`. To make the roundtrip testing work smoothly, change the input of cai2hcl to `[]caiasset.Asset`.

This PR needs to be merged together with PR https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/3788 to make the tests pass.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
