### PR TITLE
Adding API Docs for CA Pool

### DIFF
--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -17,6 +17,10 @@ description: |
   A CaPool represents a group of CertificateAuthorities that form a trust anchor. A CaPool can be used to manage
   issuance policies for one or more CertificateAuthority resources and to rotate CA certificates in and out of the
   trust anchor.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/certificate-authority-service'
+  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/caPools'
 self_link: 'projects/{{project}}/locations/{{location}}/caPools/{{name}}'

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -19,8 +19,8 @@ description: |
   trust anchor.
 references:
   guides:
-    'Official Documentation': 'https://cloud.google.com/certificate-authority-service'
-  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest'
+    'Certificate Authority Service Overview': 'https://cloud.google.com/certificate-authority-service/docs/overview'
+  api: 'https://cloud.google.com/certificate-authority-service/docs/reference/rest/v1/projects.locations.caPools'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/caPools'
 self_link: 'projects/{{project}}/locations/{{location}}/caPools/{{name}}'


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
privateca:  Adding API Docs for google_privateca_ca_pool
```