### PR TITLE
Modifies AnywhereCache Deletion logic in `google_storage_bucket` resource

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -590,9 +590,12 @@ func labelKeyValidator(val interface{}, key string) (warns []string, errs []erro
 	return
 }
 
-func getAnywhereCacheListResult(config *transport_tpg.Config, bucket string) ([]interface{}, error) {
+func getAnywhereCacheListResult(d *schema.ResourceData, config *transport_tpg.Config) ([]interface{}, error) {
 	// Define the cache list URL
-	cacheListUrl := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/anywhereCaches/", bucket)
+	cacheListUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{StorageBasePath}}b/{{name}}/anywhereCaches/"}}")
+	if err != nil {
+		return nil, err
+	}
 
 	// Send request to get resource list
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -619,9 +622,9 @@ func getAnywhereCacheListResult(config *transport_tpg.Config, bucket string) ([]
 	return rl, nil
 }
 
-func deleteAnywhereCacheIfAny(config *transport_tpg.Config, bucket string) error {
+func deleteAnywhereCacheIfAny(d *schema.ResourceData, config *transport_tpg.Config) error {
 	// Get the initial list of Anywhere Caches
-	cacheList, err := getAnywhereCacheListResult(config, bucket)
+	cacheList, err := getAnywhereCacheListResult(d, config)
 	if err != nil {
 		return err
 	}
@@ -653,8 +656,13 @@ func deleteAnywhereCacheIfAny(config *transport_tpg.Config, bucket string) error
 		if !ok {
 			return fmt.Errorf("missing or invalid anywhereCacheId: %v", obj)
 		}
-		disableUrl := fmt.Sprintf("https://storage.googleapis.com/storage/v1/b/%s/anywhereCaches/%s/disable", bucket, anywhereCacheId)
-		_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		anywhereCacheUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{StorageBasePath}}b/{{name}}/anywhereCaches/"}}")
+		if err != nil {
+			return err
+		}
+		disableUrl := anywhereCacheUrl + fmt.Sprintf("%s/disable", anywhereCacheId)
+
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
 			Project:   config.Project,
@@ -669,7 +677,7 @@ func deleteAnywhereCacheIfAny(config *transport_tpg.Config, bucket string) error
 
 	// Post this time, we check again!
 	// Get the list of Anywhere Caches after the sleep
-	cacheList, err = getAnywhereCacheListResult(config, bucket)
+	cacheList, err = getAnywhereCacheListResult(d, config)
 	if err != nil {
 		return err
 	}
@@ -1084,7 +1092,7 @@ func resourceStorageBucketDelete(d *schema.ResourceData, meta interface{}) error
 			break
 		}
 
-		cacheList, cacheListErr := getAnywhereCacheListResult(config, bucket)
+		cacheList, cacheListErr := getAnywhereCacheListResult(d, config)
 		if cacheListErr != nil {
 			return cacheListErr
 		}
@@ -1130,7 +1138,7 @@ func resourceStorageBucketDelete(d *schema.ResourceData, meta interface{}) error
 		wp := workerpool.New(runtime.NumCPU() - 1)
 
 		wp.Submit(func() {
-			err = deleteAnywhereCacheIfAny(config, bucket)
+			err = deleteAnywhereCacheIfAny(d, config)
 			if err != nil {
 				deleteObjectError = fmt.Errorf("error deleting the caches on the bucket %s : %w", bucket, err)
 			}


### PR DESCRIPTION
This PR Modifies AnywhereCache deletion logic to respect `StorageBasePath` value rather than using static API endpoint for fetching and deleting AnywhereCaches.

This will allow Bucket deletion in other environments as well which can be configured by user with `storage_custom_endpoint` field in the provider block. Currently it's throwing an error while deleting bucket when using different storage endpoint.


```release-note:none

```
