### PR TITLE
Update Misleading Documentation in CloudSQL Data Cache Behaviour

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -359,7 +359,7 @@ The optional `settings.active_directory_config` subblock supports:
 
 The optional `settings.data_cache_config` subblock supports:
 
-* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true`. Can only be used with `ENTERPRISE_PLUS` only.
+* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true`. Can be used with `ENTERPRISE_PLUS` only.
 
 The optional `settings.deny_maintenance_period` subblock supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -359,7 +359,7 @@ The optional `settings.active_directory_config` subblock supports:
 
 The optional `settings.data_cache_config` subblock supports:
 
-* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true`. Can be used `ENTERPRISE_PLUS` only.
+* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true`. Can only be used with `ENTERPRISE_PLUS` only.
 
 The optional `settings.deny_maintenance_period` subblock supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -359,7 +359,7 @@ The optional `settings.active_directory_config` subblock supports:
 
 The optional `settings.data_cache_config` subblock supports:
 
-* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `false`. Can be used with MYSQL and PostgreSQL only.
+* `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true`. Can be used `ENTERPRISE_PLUS` only.
 
 The optional `settings.deny_maintenance_period` subblock supports:
 


### PR DESCRIPTION

This PR update the documentation of `google_sql_database_instance` where `data_cache` argument doesn't meet with the current api behavior where data_cache_config will defaults to `true` instead of `false`  

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/22427

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: note
cloudsql: update documentation of `google_sql_database_instance`
```

