### PR TITLE
Remove extra permission required for doing a destory in resource_storage_bucket

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -1086,7 +1086,9 @@ func resourceStorageBucketDelete(d *schema.ResourceData, meta interface{}) error
 
 		cacheList, cacheListErr := getAnywhereCacheListResult(config, bucket)
 		if cacheListErr != nil {
-			return cacheListErr
+			// If we get any error, try deleting the bucket anyway in case it's empty
+			// This would help our customers to avoid requiring extra storage.anywhereCaches.list permission.
+			break
 		}
 
 		if len(res.Items) == 0 && len(cacheList) == 0 {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22359

```release-note: bug
storage: removed extra permission (storage.anywhereCaches.list) required for doing a destroy in `resource_storage_bucket`
```
