### PR TITLE
Use the correct form of `sha256.Sum256`.

### DIFF
--- a/mmv1/templates/terraform/constants/compute_certificate.go.tmpl
+++ b/mmv1/templates/terraform/constants/compute_certificate.go.tmpl
@@ -1,5 +1,6 @@
 // sha256DiffSuppress
 // if old is the hex-encoded sha256 sum of new, treat them as equal
 func sha256DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return hex.EncodeToString(sha256.New().Sum([]byte(old))) == new
+	h := sha256.Sum256([]byte(old))
+	return hex.EncodeToString(h[:]) == new
 }

--- a/mmv1/templates/terraform/custom_flatten/sha256.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/sha256.tmpl
@@ -1,3 +1,4 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return hex.EncodeToString(sha256.New().Sum([]byte(v.(string))))
+	h := sha256.Sum256([]byte(v.(string)))
+	return hex.EncodeToString(h[:])
 }


### PR DESCRIPTION
`sha256.New().Sum(foo)` appends the SHA-256 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk

Adapted from hashicorp/terraform-provider-google#22428

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed improper SHA256 calculations on `google_compute_ssl_certificate` when suppressing diff
```
