### PR TITLE
added sweepable prefixes for compute disk

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
@@ -66,7 +66,7 @@ func testSweepDisk(region string) error {
 			id := obj["name"].(string)
 			// Increment count and skip if resource is not sweepable.
 			prefixes := []string{
-				"pvc-", // https://github.com/kubernetes/kubernetes/issues/109328
+				"pvc-", // b/291168201
 			}
 			if !sweeper.IsSweepableTestResource(id) && !sweeper.HasAnyPrefix(id, prefixes) {
 				nonPrefixCount++

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
@@ -68,7 +68,7 @@ func testSweepDisk(region string) error {
 			prefixes := []string{
 				"pvc-", // https://github.com/kubernetes/kubernetes/issues/109328
 			}
-			if !sweeper.IsSweepableTestResource(id) && !sweeper.HasAnyPrefix(id, prefixes){
+			if !sweeper.IsSweepableTestResource(id) && !sweeper.HasAnyPrefix(id, prefixes) {
 				nonPrefixCount++
 				continue
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_sweeper.go
@@ -65,7 +65,10 @@ func testSweepDisk(region string) error {
 
 			id := obj["name"].(string)
 			// Increment count and skip if resource is not sweepable.
-			if !sweeper.IsSweepableTestResource(id) {
+			prefixes := []string{
+				"pvc-", // https://github.com/kubernetes/kubernetes/issues/109328
+			}
+			if !sweeper.IsSweepableTestResource(id) && !sweeper.HasAnyPrefix(id, prefixes){
 				nonPrefixCount++
 				continue
 			}


### PR DESCRIPTION
Added sweepable prefix for auto-generated disk.
context: b/291168201#comment10

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
