### PR TITLE
tgc-revival: Only print compute instance asset name in logs

### DIFF
--- a/mmv1/third_party/terraform/acctest/tgc_utils.go
+++ b/mmv1/third_party/terraform/acctest/tgc_utils.go
@@ -41,7 +41,6 @@ func GetTestMetadataForTgc(service, address, rawConfig string) resource.TestChec
 		if apiServiceName, ok := ApiServiceNames[resourceType]; !ok {
 			return fmt.Errorf("The Cai product backend name for resource %s doesn't exist.", resourceType)
 		} else {
-			var assetNames string
 			var rName string
 			switch resourceType {
 			case "google_project":
@@ -50,17 +49,7 @@ func GetTestMetadataForTgc(service, address, rawConfig string) resource.TestChec
 				rName = rState.Primary.ID
 			}
 			caiAssetName := fmt.Sprintf("//%s/%s", apiServiceName, rName)
-
-			switch resourceType {
-			case "google_compute_instance":
-				// The disk asset name is to get the boot disk details,
-				// which are converted to boot_disk.initialize_params in google_compute_instance
-				diskAssetName := strings.Replace(caiAssetName, "/instances/", "/disks/", 1)
-				assetNames = fmt.Sprintf("%s\n%s", caiAssetName, diskAssetName)
-			default:
-				assetNames = caiAssetName
-			}
-			log.Printf("[DEBUG]TGC CAI asset names\n%s\nEnd of TGC CAI asset names", assetNames)
+			log.Printf("[DEBUG]TGC CAI asset names start\n%s\nEnd of TGC CAI asset names", caiAssetName)
 		}
 
 		// The acceptance tests names will be also used for the tgc tests.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Only print compute instance asset name in logs for now.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
