### PR TITLE
Add manual scaling for cloudrunv2 services

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -340,6 +340,17 @@ properties:
         type: Integer
         description: |
           Minimum number of instances for the service, to be divided among all revisions receiving traffic.
+      - name: 'scalingMode'
+        type: Enum
+        description: |
+          The [scaling mode](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services#scalingmode) for the service.
+        enum_values:
+          - 'AUTOMATIC'
+          - 'MANUAL'
+      - name: 'manualInstanceCount'
+        type: Integer
+        description: |
+          Total instance count for the service in manual scaling mode. This number of instances is divided among all revisions with specified traffic based on the percent of traffic they are receiving.
   - name: 'defaultUriDisabled'
     type: Boolean
     description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1558,6 +1558,88 @@ resource "google_project_iam_member" "logs_writer" {
 `, context)
 }
 
+func TestAccCloudRunV2Service_cloudrunv2ServiceWithManualScaling(t *testing.T) {
+  t.Parallel()
+  context := map[string]interface{} {
+    "random_suffix" : acctest.RandString(t, 10),
+  }
+  acctest.VcrTest(t, resource.TestCase {
+    PreCheck: func() { acctest.AccTestPreCheck(t)},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithManualScaling(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithManualScaling(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+    }, 
+  })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithManualScaling(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-manual-scaling-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  deletion_protection = false
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  launch_stage = "BETA"
+  scaling {
+    scaling_mode = "MANUAL"
+    manual_instance_count = 2
+  }
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithManualScaling(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-manual-scaling-service%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  deletion_protection = false
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  ingress = "INGRESS_TRAFFIC_ALL"
+  launch_stage = "BETA"
+  scaling {
+    scaling_mode = "MANUAL"
+    manual_instance_count = 10
+  }
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+`, context)
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccCloudRunV2Service_cloudrunv2ServiceIapUpdate(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `scaling_mode` and `manual_instance_count` fields to `google_cloud_run_v2_service` resource
```
