### PR TITLE
Increase WorkstationCluster operations to 120m

### DIFF
--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -28,9 +28,9 @@ update_mask: true
 import_format:
   - 'projects/{{project}}/locations/{{location}}/workstationClusters/{{workstation_cluster_id}}'
 timeouts:
-  insert_minutes: 60
-  update_minutes: 60
-  delete_minutes: 60
+  insert_minutes: 120
+  update_minutes: 120
+  delete_minutes: 120
 autogen_async: true
 async:
   actions: ['create', 'delete', 'update']
@@ -38,9 +38,9 @@ async:
   operation:
     base_url: '{{op_id}}'
     timeouts:
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
+      insert_minutes: 120
+      update_minutes: 120
+      delete_minutes: 120
   result:
     resource_inside_response: false
 custom_code:


### PR DESCRIPTION
Tests last night:

```
    "@type": "type.googleapis.com/google.cloud.workstations.v1beta.OperationMetadata",
    "createTime": "2025-04-23T07:11:55.891117474Z",
    "endTime": "2025-04-23T08:24:28.056419333Z",
    "target": "projects/<snip>/locations/us-central1/workstationClusters/tf-test-workstation-clusterg9u8dhgcsr",
    "verb": "create",
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
workstations: increased default timeouts on `google_workstations_workstation_cluster` operations to 120m from 60m. Operations could take longer than an hour.
```
