### PR TITLE
Add volatile status fields from google_tpu_v2_vm to ISVI

### DIFF
--- a/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/tpuv2/resource_tpu_v2_vm_test.go.tmpl
@@ -29,7 +29,7 @@ func TestAccTpuV2Vm_update(t *testing.T) {
 				ResourceName:            "google_tpu_v2_vm.tpu",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone", "health", "health_description"},
 			},
 			{
 				Config: testAccTpuV2Vm_update(context, true),
@@ -38,7 +38,7 @@ func TestAccTpuV2Vm_update(t *testing.T) {
 				ResourceName:            "google_tpu_v2_vm.tpu",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone", "health", "health_description"},
 			},
 			{
 				Config: testAccTpuV2Vm_update(context, false),
@@ -47,7 +47,7 @@ func TestAccTpuV2Vm_update(t *testing.T) {
 				ResourceName:            "google_tpu_v2_vm.tpu",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "zone", "health", "health_description"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16957 (we should refile if we get a new one after)

```
    resource_tpu_v2_vm_test.go:21: Step 6/6 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
          map[string]string{
        -   "health":             "TIMEOUT",
        +   "health":             "UNHEALTHY_MAINTENANCE",
        -   "health_description": "",
        +   "health_description": "The TPU had a maintenance event at 2025-04-23T07:43:36.67877072Z",
          }
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
