### PR TITLE
Remove bad ExpectError from data. google_kms_crypto_key_latest_versio…

### DIFF
--- a/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_latest_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/data_source_google_kms_crypto_key_latest_version_test.go
@@ -40,7 +40,6 @@ func TestAccDataSourceGoogleKmsCryptoKeyLatestVersion_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.google_kms_crypto_key_latest_version.latest_version", "crypto_key", asymSignKey.CryptoKey.Name),
 					resource.TestMatchResourceAttr("data.google_kms_crypto_key_latest_version.latest_version", "version", regexp.MustCompile("[1-9]+[0-9]*")),
 				),
-				ExpectError: regexp.MustCompile("Error: googleapi: Error 400:"),
 			},
 			{
 				Config: testAccDataSourceGoogleKmsCryptoKeyLatestVersion_basic(context, fmt.Sprintf("filter = \"%s\"", filterNameFindEnabledLatestCryptoKeyVersion)),


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/20110

I think the contributor misunderstood when to use ExpectError? We're referencing a bootstrapped key that has a version in it.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
