### PR TITLE
Add default_time_zone to Spanner database resource

### DIFF
--- a/mmv1/products/spanner/Database.yaml
+++ b/mmv1/products/spanner/Database.yaml
@@ -81,6 +81,11 @@ virtual_fields:
       When the field is set to false, deleting the database is allowed.
     type: Boolean
     default_value: true
+  - name: 'default_time_zone'
+    description: |
+      The default time zone for the database. The default time zone must be a valid name
+      from the tz database. Default value is "America/Los_angeles".
+    type: String
 parameters:
   - name: 'instance'
     type: ResourceRef

--- a/mmv1/templates/terraform/examples/spanner_database_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/spanner_database_basic.tf.tmpl
@@ -8,6 +8,7 @@ resource "google_spanner_database" "database" {
   instance = google_spanner_instance.main.name
   name     = "{{index $.Vars "database_name"}}"
   version_retention_period = "3d"
+  default_time_zone = "UTC"
   ddl = [
     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
     "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",

--- a/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
+++ b/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
@@ -3,15 +3,28 @@
 // `terraform apply` twice to get their desired outcome, the provider does not set
 // `extraStatements` in the call to the `create` endpoint and all DDL (other than
 //  <CREATE DATABASE>) is run post-create, by calling the `updateDdl` endpoint 
+defaultTimeZoneObj, defaultTimeZoneOk := d.GetOk("version_retention_period")
+defaultTimeZone := defaultTimeZoneObj.(string)
 retention, retentionPeriodOk := d.GetOk("version_retention_period")
 retentionPeriod := retention.(string)
 ddl, ddlOk := d.GetOk("ddl")
 ddlStatements := ddl.([]interface{})
 
-if retentionPeriodOk || ddlOk {
+if defaultTimeZoneOk || retentionPeriodOk || ddlOk {
 
 	obj := make(map[string]interface{})
 	updateDdls := []string{}
+
+	// We need to put setting default time zone as first because it requires an empty
+	// database where tables do not exist.
+	if defaultTimeZoneOk {
+		dbName := d.Get("name")
+		timeZoneDdl := fmt.Sprintf("ALTER DATABASE `%s` SET OPTIONS (default_time_zone=\"%s\")", dbName, defaultTimeZone)
+		if dialect, ok := d.GetOk("database_dialect"); ok && dialect == "POSTGRESQL" {
+			timeZoneDdl = fmt.Sprintf("ALTER DATABASE \"%s\" SET spanner.default_time_zone TO \"%s\"", dbName, defaultTimeZone)
+		}
+		updateDdls = append(updateDdls, timeZoneDdl)
+	}
 
 	if ddlOk {
 		for i := 0; i < len(ddlStatements); i++ {

--- a/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
+++ b/mmv1/templates/terraform/post_create/spanner_database.go.tmpl
@@ -3,7 +3,7 @@
 // `terraform apply` twice to get their desired outcome, the provider does not set
 // `extraStatements` in the call to the `create` endpoint and all DDL (other than
 //  <CREATE DATABASE>) is run post-create, by calling the `updateDdl` endpoint 
-defaultTimeZoneObj, defaultTimeZoneOk := d.GetOk("version_retention_period")
+defaultTimeZoneObj, defaultTimeZoneOk := d.GetOk("default_time_zone")
 defaultTimeZone := defaultTimeZoneObj.(string)
 retention, retentionPeriodOk := d.GetOk("version_retention_period")
 retentionPeriod := retention.(string)

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
@@ -388,6 +388,108 @@ resource "google_spanner_database" "basic" {
 `, instanceName, instanceName, databaseName, databaseName, databaseName)
 }
 
+func TestAccSpannerDatabase_defaultTimeZone(t *testing.T) {
+	t.Parallel()
+
+	rnd := acctest.RandString(t, 10)
+	instanceName := fmt.Sprintf("tf-test-%s", rnd)
+	databaseName := fmt.Sprintf("tfgen_%s", rnd)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerDatabaseDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Test creating a database with `default_time_zone` set
+				Config: testAccSpannerDatabase_defaultTimeZone(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "default_time_zone", "UTC"),
+				),
+			},
+			{
+				// Test removing `default_time_zone` and setting default time zone to a new value with a DDL statement in `ddl`
+				Config: testAccSpannerDatabase_defaultTimeZoneUpdate1(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "default_time_zone", "UTC"),
+				),
+			},
+			{
+				// Test that adding `default_time_zone`, regardless of any previous statements in `ddl`
+				Config: testAccSpannerDatabase_defaultTimeZoneUpdate2(instanceName, databaseName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_database.basic", "state"),
+					resource.TestCheckResourceAttr("google_spanner_database.basic", "default_time_zone", "Australia/Sydney"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSpannerDatabase_defaultTimeZone(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  default_time_zone = "UTC"
+  ddl = [
+     "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName)
+}
+
+func testAccSpannerDatabase_defaultTimeZoneUpdate1(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  default_time_zone = "UTC"
+  // Change : remove the table.
+  ddl = []
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
+}
+
+func testAccSpannerDatabase_defaultTimeZoneUpdate2(instanceName, databaseName string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-display"
+  num_nodes    = 1
+}
+
+resource "google_spanner_database" "basic" {
+  instance = google_spanner_instance.basic.name
+  name     = "%s"
+  default_time_zone = "Australia/Sydney" // Change : updated default_time_zone argument
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+  ]
+  deletion_protection = false
+}
+`, instanceName, instanceName, databaseName, databaseName)
+}
+
 func TestAccSpannerDatabase_enableDropProtection(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_database_test.go.tmpl
@@ -466,7 +466,7 @@ resource "google_spanner_database" "basic" {
   ddl = []
   deletion_protection = false
 }
-`, instanceName, instanceName, databaseName, databaseName)
+`, instanceName, instanceName, databaseName)
 }
 
 func testAccSpannerDatabase_defaultTimeZoneUpdate2(instanceName, databaseName string) string {
@@ -487,7 +487,7 @@ resource "google_spanner_database" "basic" {
   ]
   deletion_protection = false
 }
-`, instanceName, instanceName, databaseName, databaseName)
+`, instanceName, instanceName, databaseName)
 }
 
 func TestAccSpannerDatabase_enableDropProtection(t *testing.T) {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
spanner: Added field `default_time_zone` to `google_spanner_database` resource
```
