### PR TITLE
feat: (storage) added time_created and updated  timestamps for storage bucket

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -568,15 +568,13 @@ func ResourceStorageBucket() *schema.Resource {
 			},
 			"time_created": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
-				Required: false,
+				Description: `The creation time of the bucket in RFC 3339 format.`
 			},
 			"updated": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
-				Required: false,
+				Description: `The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.`
 			},
 		},
 		UseJSONNumber: true,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -569,12 +569,12 @@ func ResourceStorageBucket() *schema.Resource {
 			"time_created": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: `The creation time of the bucket in RFC 3339 format.`
+				Description: `The creation time of the bucket in RFC 3339 format.`,
 			},
 			"updated": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: `The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.`
+				Description: `The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.`,
 			},
 		},
 		UseJSONNumber: true,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -566,6 +566,16 @@ func ResourceStorageBucket() *schema.Resource {
 					},
 				},
 			},
+			"time_created": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"updated": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -1306,6 +1316,14 @@ func flattenBucketCustomPlacementConfig(cfc *storage.BucketCustomPlacementConfig
 	return customPlacementConfig
 }
 
+func flattenTimeCreated(v interface{}) interface{} {
+	return v
+}
+
+func flattenUpdated(v interface{}) interface{} {
+	return v
+}
+
 func expandBucketDataLocations(configured interface{}) []string {
 	l := configured.(*schema.Set).List()
 
@@ -2031,6 +2049,12 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 	}
 	if err := d.Set("custom_placement_config", flattenBucketCustomPlacementConfig(res.CustomPlacementConfig)); err != nil {
 		return fmt.Errorf("Error setting custom_placement_config: %s", err)
+	}
+	if err := d.Set("time_created", flattenTimeCreated(res.TimeCreated)); err != nil {
+		return fmt.Errorf("Error setting time_created: %s", err)
+	}
+	if err := d.Set("updated", flattenUpdated(res.Updated)); err != nil {
+		return fmt.Errorf("Error setting updated: %s", err)
 	}
 	// Needs to hide rpo field for single-region buckets.
 	// Check the Rpo field from API response to determine whether bucket is in single region config or not.

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -570,11 +570,13 @@ func ResourceStorageBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				Required: false,
 			},
 			"updated": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				Required: false,
 			},
 		},
 		UseJSONNumber: true,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go.tmpl
@@ -40,6 +40,10 @@ func TestAccStorageBucket_basic(t *testing.T) {
 						"google_storage_bucket.bucket", "project_number"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "rpo", "DEFAULT"),
+					resource.TestCheckResourceAttrSet(
+						"google_storage_bucket.bucket", "time_created"),
+					resource.TestCheckResourceAttrSet(
+						"google_storage_bucket.bucket", "updated"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -173,6 +173,10 @@ The following arguments are supported:
 
 * `hierarchical_namespace` -  (Optional, ForceNew) The bucket's hierarchical namespace policy, which defines the bucket capability to handle folders in logical structure. Structure is [documented below](#nested_hierarchical_namespace). To use this configuration, `uniform_bucket_level_access` must be enabled on bucket.
 
+* `time_created` -  (Computed) The creation time of the bucket in RFC 3339 format.
+
+* `updated` -  (Computed) The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.
+
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:
 
 * `action` - (Required) The Lifecycle Rule's action configuration. A single block of this type is supported. Structure is [documented below](#nested_action).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17106
```release-note:enhancement
storage: added new fields `time_created` and `updated` in `google_storage_bucket`
```
