### PR TITLE
Improve documentation for `google_compute_backend_bucket.cdn_policy`

### DIFF
--- a/mmv1/products/compute/BackendBucket.yaml
+++ b/mmv1/products/compute/BackendBucket.yaml
@@ -157,18 +157,21 @@ properties:
         type: Integer
         description: |
           Specifies the default TTL for cached content served by this origin for responses
-          that do not have an existing valid TTL (max-age or s-max-age).
+          that do not have an existing valid TTL (max-age or s-max-age). When the `cache_mode`
+          is set to "USE_ORIGIN_HEADERS", you must omit this field.
         default_from_api: true
         send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
-          Specifies the maximum allowed TTL for cached content served by this origin.
+          Specifies the maximum allowed TTL for cached content served by this origin. When the
+          `cache_mode` is set to "USE_ORIGIN_HEADERS", you must omit this field.
         default_from_api: true
       - name: 'clientTtl'
         type: Integer
         description: |
-          Specifies the maximum allowed TTL for cached content served by this origin.
+          Specifies the maximum allowed TTL for cached content served by this origin. When the
+          `cache_mode` is set to "USE_ORIGIN_HEADERS", you must omit this field.
         default_from_api: true
         send_empty_value: true
       - name: 'negativeCaching'


### PR DESCRIPTION
State that `default_ttl`, `client_ttl`, `max_ttl` should be omitted when `cache_mode` is set to `USE_ORIGIN_HEADERS`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22496

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: Improve documentation for `google_compute_backend_bucket.cdn_policy`
```
