### PR TITLE
Update `google_alloydb_instance.network_config` to be O+C

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -363,6 +363,7 @@ properties:
                 The network attachment must be in the same region as the instance.
   - name: 'networkConfig'
     type: NestedObject
+    default_from_api: true
     description: |
       Instance level network configuration.
     properties:


### PR DESCRIPTION
Tests last 2 nights:

```
              - network_config {
                  - enable_outbound_public_ip = false -> null
                  - enable_public_ip          = false -> null
                }
```


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
alloydb: stopped diffs when `google_alloydb_instance.network_config` is not specified as the API newly returns a value. Removing the field from config will no longer create a diff and will preserve the current value
```
