### PR TITLE
Fix copy-paste errors in `google_storage_bucket` docs examples.

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -94,7 +94,7 @@ resource "google_storage_bucket" "no-age-enabled" {
 ## Example Usage - Enabling public access prevention
 
 ```hcl
-resource "google_storage_bucket" "auto-expire" {
+resource "google_storage_bucket" "no-public-access" {
   name          = "no-public-access-bucket"
   location      = "US"
   force_destroy = true
@@ -106,7 +106,7 @@ resource "google_storage_bucket" "auto-expire" {
 ## Example Usage - Enabling hierarchical namespace
 
 ```hcl
-resource "google_storage_bucket" "auto-expire" {
+resource "google_storage_bucket" "hns-enabled" {
   name          = "hns-enabled-bucket"
   location      = "US"
   force_destroy = true


### PR DESCRIPTION
For the public access prevention and hierarchical namespace examples, the resource name `auto-expire` was used. This seems to be a copy-paste issue from the Life cycle settings example.

This makes the resource names better reflect the purpose of the example.

```release-note:none
storage: Change resource names for examples in storage_bucket docs.
```
