### PR TITLE
Added a sleep between the parent folder and workload creation to Assured Workloads tests

### DIFF
--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic.tf.tmpl
@@ -16,6 +16,12 @@ resource "google_assured_workloads_workload" "primary" {
     display_name = "folder-display-name"
   }
   violation_notifications_enabled = true
+  depends_on = [time_sleep.wait_120_seconds]
+}
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on = [google_folder.folder1]
 }
 
 resource "google_folder" "folder1" {

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic.yaml
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic.yaml
@@ -10,4 +10,5 @@ variables:
     type: "org_id"
   - name: "billing_account"
     type: "billing_account"
-
+external_providers:
+  - "time"

--- a/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/basic_update.tf.tmpl
@@ -13,6 +13,12 @@ resource "google_assured_workloads_workload" "primary" {
     display_name = "folder-display-name"
   }
   violation_notifications_enabled = true
+  depends_on = [time_sleep.wait_120_seconds]
+}
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on = [google_folder.folder1]
 }
 
 resource "google_folder" "folder1" {

--- a/tpgtools/overrides/assuredworkloads/samples/workload/full.tf.tmpl
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/full.tf.tmpl
@@ -9,7 +9,14 @@ resource "google_assured_workloads_workload" "primary" {
     rotation_period = "864000s"
   }
   provisioned_resources_parent = google_folder.folder1.name
+  depends_on = [time_sleep.wait_120_seconds]
 }
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on = [google_folder.folder1]
+}
+
 
 resource "google_folder" "folder1" {
   display_name = "{{name}}"

--- a/tpgtools/overrides/assuredworkloads/samples/workload/full.yaml
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/full.yaml
@@ -7,4 +7,5 @@ variables:
     type: "org_id"
   - name: "billing_account"
     type: "billing_account"
-
+external_providers:
+  - "time"

--- a/tpgtools/overrides/assuredworkloads/samples/workload/meta.yaml
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/meta.yaml
@@ -13,5 +13,3 @@ doc_hide:
   - full.tf.tmpl
 test_hide:
   - basic_workload.yaml
-external_providers:
-  - "time"

--- a/tpgtools/overrides/assuredworkloads/samples/workload/meta.yaml
+++ b/tpgtools/overrides/assuredworkloads/samples/workload/meta.yaml
@@ -13,3 +13,5 @@ doc_hide:
   - full.tf.tmpl
 test_hide:
   - basic_workload.yaml
+external_providers:
+  - "time"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21419, fixes https://github.com/hashicorp/terraform-provider-google/issues/21420

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
