### PR TITLE
support external providers for DCL tests

### DIFF
--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -76,6 +76,9 @@ type Sample struct {
 	// ExtraDependencies are the additional golang dependencies the injected code may require
 	ExtraDependencies []string `yaml:"extra_dependencies"`
 
+	// ExternalProviders are the external providers needed for tests
+	ExternalProviders []string `yaml:"external_providers"`
+
 	// Type is the resource type.
 	Type string `yaml:"type"`
 

--- a/tpgtools/templates/test_file.go.tmpl
+++ b/tpgtools/templates/test_file.go.tmpl
@@ -68,6 +68,11 @@ func TestAcc{{$.PathType}}_{{$s.TestSlug}}(t *testing.T) {
 	{{- else }}
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 	{{- end }}
+	{{- range $external_p := $s.ExternalProviders }}
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"{{ $external_p }}": {},
+		},
+	{{- end }}
 	{{ if true -}}
 		CheckDestroy: testAccCheck{{$.PathType}}DestroyProducer(t),
 	{{- end }}


### PR DESCRIPTION
This adds support for configuring external providers in DCL-based tests, allowing for capabilities such as adding delays in tests

Example usage: https://github.com/GoogleCloudPlatform/magic-modules/pull/13777

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
