### PR TITLE
fix: differentiate between ga and beta Cloud SQL API endpoints

### DIFF
--- a/mmv1/products/sql/product.yaml
+++ b/mmv1/products/sql/product.yaml
@@ -17,6 +17,8 @@ display_name: 'Cloud SQL'
 client_name: 'SqlAdmin'
 versions:
   - name: 'ga'
+    base_url: 'https://sqladmin.googleapis.com/sql/v1/'
+  - name: 'beta'
     base_url: 'https://sqladmin.googleapis.com/sql/v1beta4/'
 scopes:
   - 'https://www.googleapis.com/auth/sqlservice.admin'


### PR DESCRIPTION
ga endpoint is currently set to the beta API. See other product.yaml files for comparison.

**Release Note Template for Downstream PRs**

```release-note:bug
cloudsql: fixed Cloud SQL API endpoint to point to v1 instead of v1beta4 when using hashicorp/google provider
```
