### PR TITLE
added IP address range for direct connectivity from GCE VM and IPv6

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_netblock_ip_ranges.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_netblock_ip_ranges.go
@@ -124,22 +124,62 @@ func dataSourceGoogleNetblockIpRangesRead(d *schema.ResourceData, meta interface
 	case "restricted-googleapis":
 		// https://cloud.google.com/vpc/docs/private-access-options#domain-vips
 		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.4/30")
-		CidrBlocks["cidr_blocks"] = CidrBlocks["cidr_blocks_ipv4"]
+		CidrBlocks["cidr_blocks_ipv6"] = append(CidrBlocks["cidr_blocks_ipv6"], "2600:2d00:0002:1000::/64")
+		CidrBlocks["cidr_blocks"] = append(CidrBlocks["cidr_blocks_ipv4"], CidrBlocks["cidr_blocks_ipv6"]...)
+
 		if err := d.Set("cidr_blocks", CidrBlocks["cidr_blocks"]); err != nil {
 			return fmt.Errorf("Error setting cidr_blocks: %s", err)
 		}
 		if err := d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"]); err != nil {
 			return fmt.Errorf("Error setting cidr_blocks_ipv4: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv6: %s", err)
+		}
+	case "restricted-googleapis-with-directconnectivity":
+		// https://cloud.google.com/vpc/docs/configure-private-google-access#config-options
+		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.4/30", "34.126.0.0/18")
+		CidrBlocks["cidr_blocks_ipv6"] = append(CidrBlocks["cidr_blocks_ipv6"], "2600:2d00:0002:1000::/64", "2001:4860:8040::/42")
+		CidrBlocks["cidr_blocks"] = append(CidrBlocks["cidr_blocks_ipv4"], CidrBlocks["cidr_blocks_ipv6"]...)
+
+		if err := d.Set("cidr_blocks", CidrBlocks["cidr_blocks"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv4: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv6: %s", err)
 		}
 	case "private-googleapis":
 		// https://cloud.google.com/vpc/docs/private-access-options#domain-vips
 		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.8/30")
-		CidrBlocks["cidr_blocks"] = CidrBlocks["cidr_blocks_ipv4"]
+		CidrBlocks["cidr_blocks_ipv6"] = append(CidrBlocks["cidr_blocks_ipv6"], "2600:2d00:0002:2000::/64")
+		CidrBlocks["cidr_blocks"] = append(CidrBlocks["cidr_blocks_ipv4"], CidrBlocks["cidr_blocks_ipv6"]...)
+
 		if err := d.Set("cidr_blocks", CidrBlocks["cidr_blocks"]); err != nil {
 			return fmt.Errorf("Error setting cidr_blocks: %s", err)
 		}
 		if err := d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"]); err != nil {
 			return fmt.Errorf("Error setting cidr_blocks_ipv4: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv6: %s", err)
+		}
+	case "private-googleapis-with-directconnectivity":
+		// https://cloud.google.com/vpc/docs/private-access-options#domain-vips
+		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.8/30", "34.126.0.0/18")
+		CidrBlocks["cidr_blocks_ipv6"] = append(CidrBlocks["cidr_blocks_ipv6"], "2600:2d00:0002:2000::/64", "2001:4860:8040::/42")
+		CidrBlocks["cidr_blocks"] = append(CidrBlocks["cidr_blocks_ipv4"], CidrBlocks["cidr_blocks_ipv6"]...)
+
+		if err := d.Set("cidr_blocks", CidrBlocks["cidr_blocks"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv4: %s", err)
+		}
+		if err := d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"]); err != nil {
+			return fmt.Errorf("Error setting cidr_blocks_ipv6: %s", err)
 		}
 	case "dns-forwarders":
 		// https://cloud.google.com/dns/zones/#creating-forwarding-zones

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_netblock_ip_ranges_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_netblock_ip_ranges_test.go
@@ -71,26 +71,60 @@ func TestAccDataSourceGoogleNetblockIpRanges_basic(t *testing.T) {
 				Config: testAccNetblockIpRangesConfig_restricted,
 				Check: resource.ComposeTestCheckFunc(
 					// Private Google Access Restricted VIP
-					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks.#", "2"),
 					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
 						"cidr_blocks.0", regexp.MustCompile("^(?:[0-9a-fA-F./:]{1,4}){1,2}.*/[0-9]{1,3}$")),
 					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks_ipv4.#", "1"),
 					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
 						"cidr_blocks_ipv4.0", regexp.MustCompile("^(?:[0-9]{1,3}.){3}[0-9]{1,3}/[0-9]{1,2}$")),
-					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks_ipv6.#", "0"),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks_ipv6.#", "1"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
+						"cidr_blocks_ipv6.0", regexp.MustCompile("^(?:[0-9a-fA-F]{1,4}:){1,2}.*/[0-9]{1,3}$")),
+				),
+			},
+			{
+				Config: testAccNetblockIpRangesConfig_restricted_with_directconnectivity,
+				Check: resource.ComposeTestCheckFunc(
+					// Private Google Access Restricted VIP
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks.#", "4"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
+						"cidr_blocks.0", regexp.MustCompile("^(?:[0-9a-fA-F./:]{1,4}){1,2}.*/[0-9]{1,3}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks_ipv4.#", "2"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
+						"cidr_blocks_ipv4.1", regexp.MustCompile("^(?:[0-9]{1,3}.){3}[0-9]{1,3}/[0-9]{1,2}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.restricted", "cidr_blocks_ipv6.#", "2"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.restricted",
+						"cidr_blocks_ipv6.1", regexp.MustCompile("^(?:[0-9a-fA-F]{1,4}:){1,2}.*/[0-9]{1,3}$")),
 				),
 			},
 			{
 				Config: testAccNetblockIpRangesConfig_private,
 				Check: resource.ComposeTestCheckFunc(
 					// Private Google Access Unrestricted VIP
-					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks.#", "1"),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks.#", "2"),
 					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
 						"cidr_blocks.0", regexp.MustCompile("^(?:[0-9a-fA-F./:]{1,4}){1,2}.*/[0-9]{1,3}$")),
 					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv4.#", "1"),
 					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
 						"cidr_blocks_ipv4.0", regexp.MustCompile("^(?:[0-9]{1,3}.){3}[0-9]{1,3}/[0-9]{1,2}$")),
-					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv6.#", "0"),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv6.#", "1"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks_ipv6.0", regexp.MustCompile("^(?:[0-9a-fA-F]{1,4}:){1,2}.*/[0-9]{1,3}$")),
+				),
+			},
+			{
+				Config: testAccNetblockIpRangesConfig_private_with_directconnectivity,
+				Check: resource.ComposeTestCheckFunc(
+					// Private Google Access Unrestricted VIP
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks.#", "4"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks.0", regexp.MustCompile("^(?:[0-9a-fA-F./:]{1,4}){1,2}.*/[0-9]{1,3}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv4.#", "2"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks_ipv4.1", regexp.MustCompile("^(?:[0-9]{1,3}.){3}[0-9]{1,3}/[0-9]{1,2}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv6.#", "2"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks_ipv6.1", regexp.MustCompile("^(?:[0-9a-fA-F]{1,4}:){1,2}.*/[0-9]{1,3}$")),
 				),
 			},
 			{
@@ -171,9 +205,21 @@ data "google_netblock_ip_ranges" "restricted" {
 }
 `
 
+const testAccNetblockIpRangesConfig_restricted_with_directconnectivity = `
+data "google_netblock_ip_ranges" "restricted" {
+  range_type = "restricted-googleapis-with-directconnectivity"
+}
+`
+
 const testAccNetblockIpRangesConfig_private = `
 data "google_netblock_ip_ranges" "private" {
   range_type = "private-googleapis"
+}
+`
+
+const testAccNetblockIpRangesConfig_private_with_directconnectivity = `
+data "google_netblock_ip_ranges" "private" {
+  range_type = "private-googleapis-with-directconnectivity"
 }
 `
 

--- a/mmv1/third_party/terraform/website/docs/d/netblock_ip_ranges.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/netblock_ip_ranges.html.markdown
@@ -63,9 +63,13 @@ The following arguments are supported:
 
   * `google-netblocks` - Corresponds to IP addresses used for Google services. [More details.](https://cloud.google.com/compute/docs/faq#where_can_i_find_product_name_short_ip_ranges)
 
-  * `restricted-googleapis` - Corresponds to the IP addresses used for Private Google Access only for services that support VPC Service Controls API access. [More details.](https://cloud.google.com/vpc/docs/private-access-options#domain-vips)
+  * `restricted-googleapis` - Corresponds to the IP addresses used for Private Google Access only for services that support VPC Service Controls API access. These ranges are for DNS configuration. [More details.](https://cloud.google.com/vpc/docs/configure-private-google-access#config-options)
 
-  * `private-googleapis` - Corresponds to the IP addresses used for Private Google Access for services that do not support VPC Service Controls. [More details.](https://cloud.google.com/vpc/docs/private-access-options#domain-vips)
+  * `restricted-googleapis-with-directconnectivity` - Corresponds to the IP addresses used for Private Google Access only for services that support VPC Service Controls API access. These ranges are for routing and firewall configurations. [More details.](https://cloud.google.com/vpc/docs/configure-private-google-access#config-options)
+
+  * `private-googleapis` - Corresponds to the IP addresses used for Private Google Access, including services that do not support VPC Service Controls. These ranges are for DNS configuration. [More details.](https://cloud.google.com/vpc/docs/configure-private-google-access#config-options)
+
+  * `private-googleapis-with-directconnectivity` - Corresponds to the IP addresses used for Private Google Access, including services that do not support VPC Service Controls. These ranges are for routing and firewall configurations. [More details.](https://cloud.google.com/vpc/docs/configure-private-google-access#config-options)
 
   * `dns-forwarders` - Corresponds to the IP addresses used to originate Cloud DNS outbound forwarding. [More details.](https://cloud.google.com/dns/zones/#creating-forwarding-zones)
 
@@ -73,7 +77,7 @@ The following arguments are supported:
 
   * `health-checkers` - Corresponds to the IP addresses used for health checking in Cloud Load Balancing. [More details.](https://cloud.google.com/load-balancing/docs/health-checks)
 
-  * `legacy-health-checkers` - Corresponds to the IP addresses used for legacy style health checkers (used by Network Load Balancing). [ More details.](https://cloud.google.com/load-balancing/docs/health-checks)
+  * `legacy-health-checkers` - Corresponds to the IP addresses used for legacy style health checkers (used by Network Load Balancing). [More details.](https://cloud.google.com/load-balancing/docs/health-checks)
 
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22459

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
netblock: added `restricted-googleapis-with-directconnectivity` and `private-googleapis-with-directconnectivity` range_types to `google_netblock_ip_ranges` data source 
```

```release-note:enhancement
netblock: added ipv6 ranges for `restricted-googleapis` and `private-googleapis` range_types to `google_netblock_ip_ranges` data source 
```
