### PR TITLE
Make capacity immutable in google_network_security_address_group

### DIFF
--- a/mmv1/products/networksecurity/AddressGroup.yaml
+++ b/mmv1/products/networksecurity/AddressGroup.yaml
@@ -135,6 +135,7 @@ properties:
     description: |
       Capacity of the Address Group.
     required: true
+    immutable: true
   - name: 'purpose'
     type: Array
     description: |


### PR DESCRIPTION
Make `capacity` immutable for `google_network_security_address_group` since it cannot be updated in-place (in-place update says `googleapi: Error 400: capacity can't be changed: invalid argument`).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
networksecurity: marked google_network_security_address_group.capacity as immutable because it can't be updated in place.
```
