### PR TITLE
Bump disk size in tests to new 12 GB minimum

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -2951,7 +2951,7 @@ resource "google_container_node_pool" "np_with_management" {
 
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 10
+    disk_size_gb = 12
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
 }
@@ -2976,7 +2976,7 @@ resource "google_container_node_pool" "np_with_node_config" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 10
+    disk_size_gb = 12
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
@@ -3033,7 +3033,7 @@ resource "google_container_node_pool" "np_with_node_config" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 10
+    disk_size_gb = 12
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
@@ -3993,7 +3993,7 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 10
+    disk_size_gb = 12
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -2951,7 +2951,7 @@ resource "google_container_node_pool" "np_with_management" {
 
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 12
+    disk_size_gb = 15
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
 }
@@ -2976,7 +2976,7 @@ resource "google_container_node_pool" "np_with_node_config" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 12
+    disk_size_gb = 15
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
@@ -3033,7 +3033,7 @@ resource "google_container_node_pool" "np_with_node_config" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 12
+    disk_size_gb = 15
     oauth_scopes = [
       "https://www.googleapis.com/auth/compute",
       "https://www.googleapis.com/auth/devstorage.read_only",
@@ -3993,7 +3993,7 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
   initial_node_count = 1
   node_config {
     machine_type = "g1-small"
-    disk_size_gb = 12
+    disk_size_gb = 15
     oauth_scopes = ["compute-rw", "storage-ro", "logging-write", "monitoring"]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22490
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22491
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22493

Which get the error:

```
 "statusMessage": "Google Compute Engine: Invalid value for field 'resource.properties.disks[0].initializeParams.diskSizeGb': '10'. Disk cannot be smaller than the chosen image 'gke-1322-gke1182003-cos-117-18613-164-38-c-pre' (12.0 GB).",
```

**Didn't run the tests myself**, mostly to save time. Figured I'd leave it to the bot.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
container: fixed TestAccContainerNodePool_withNodeConfigScopeAlias, TestAccContainerNodePool_withNodeConfig, TestAccContainerNodePool_withManagement using an invalid disk size
```
