### PR TITLE
Add knowledge_connector_settings to dialogflow_cx_flow/page

### DIFF
--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -656,17 +656,7 @@ properties:
             item_type:
               type: NestedObject
               properties:
-                - name: 'responseType'
-                  type: Enum
-                  description: |
-                    Represents different response types.
-                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                  enum_values:
-                    - 'ENTRY_PROMPT'
-                    - 'PARAMETER_PROMPT'
-                    - 'HANDLER_PROMPT'
+                # 'responseType' is ignored when creating/updating resources, so we skip this field. See https://github.com/GoogleCloudPlatform/magic-modules/pull/8757/commits/65ad64bd008c60498d9b27b767dc7bc664d42c0b.
                 - name: 'channel'
                   type: String
                   description: |
@@ -769,7 +759,6 @@ properties:
                     This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
                   output: true
                   allow_empty_object: true
-                  send_empty_value: true
                   properties: []  # Meant to be an empty object with no properties.
                 - name: 'playAudio'
                   type: NestedObject
@@ -838,7 +827,7 @@ properties:
                   allow_empty_object: true
                   send_empty_value: true
                   properties: []  # Meant to be an empty object with no properties.
-                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform. 
+                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform.
                 # See https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3beta1/ResponseMessage
           - name: 'webhook'
             type: String

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -634,3 +634,401 @@ properties:
             type: Boolean
             description: |
               Enables consent-based end-user input redaction, if true, a pre-defined session parameter **$session.params.conversation-redaction** will be used to determine if the utterance should be redacted.
+  - name: 'knowledgeConnectorSettings'
+    type: NestedObject
+    description: |
+      Knowledge connector configuration.
+    properties:
+      - name: 'enabled'
+        type: Boolean
+        description: |
+          Whether Knowledge Connector is enabled or not.
+      - name: 'triggerFulfillment'
+        type: NestedObject
+        description: |
+          The fulfillment to be triggered.
+          When the answers from the Knowledge Connector are selected by Dialogflow, you can utitlize the request scoped parameter $request.knowledge.answers (contains up to the 5 highest confidence answers) and $request.knowledge.questions (contains the corresponding questions) to construct the fulfillment.
+        properties:
+          - name: 'messages'
+            type: Array
+            description: |
+              The list of rich message responses to present to the user.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'responseType'
+                  type: Enum
+                  description: |
+                    Represents different response types.
+                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                  enum_values:
+                    - 'ENTRY_PROMPT'
+                    - 'PARAMETER_PROMPT'
+                    - 'HANDLER_PROMPT'
+                - name: 'channel'
+                  type: String
+                  description: |
+                    The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
+                - name: 'text'
+                  type: NestedObject
+                  description: |
+                    The text response message.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'text'
+                      type: Array
+                      description: |
+                        A collection of text response variants. If multiple variants are defined, only one text response variant is returned at runtime.
+                        required: true
+                      item_type:
+                        type: String
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                - name: 'payload'
+                  type: String
+                  description: |
+                    Returns a response containing a custom, platform-specific payload.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+                - name: 'conversationSuccess'
+                  type: NestedObject
+                  description: |
+                    Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                    Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                    You may set this, for example:
+                    * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                    * In a webhook response when you determine that you handled the customer issue.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                    - name: 'metadata'
+                      type: String
+                      description: |
+                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                      state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                      custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                      validation:
+                        function: 'validation.StringIsJSON'
+                - name: 'outputAudioText'
+                  type: NestedObject
+                  description: |
+                    A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                    - name: 'text'
+                      type: String
+                      description: |
+                        The raw text to be synthesized.
+                        This field is part of a union field `source`: Only one of `text` or `ssml` may be set.
+                    - name: 'ssml'
+                      type: String
+                      description: |
+                        The SSML text to be synthesized. For more information, see SSML.
+                        This field is part of a union field `source`: Only one of `text` or `ssml` may be set.
+                - name: 'liveAgentHandoff'
+                  type: NestedObject
+                  description: |
+                    Indicates that the conversation should be handed off to a live agent.
+                    Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                    You may set this, for example:
+                    * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                    * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                    - name: 'metadata'
+                      type: String
+                      description: |
+                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                      state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                      custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                      validation:
+                        function: 'validation.StringIsJSON'
+                - name: 'endInteraction'
+                  type: NestedObject
+                  description: |
+                    This type has no fields.
+                    Indicates that interaction with the Dialogflow agent has ended. This message is generated by Dialogflow only and not supposed to be defined by the user.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  output: true
+                  allow_empty_object: true
+                  send_empty_value: true
+                  properties: []  # Meant to be an empty object with no properties.
+                - name: 'playAudio'
+                  type: NestedObject
+                  description: |
+                    Specifies an audio clip to be played by the client as part of the response.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'audioUri'
+                      type: String
+                      description: |
+                        URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      required: true
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                - name: 'mixedAudio'
+                  type: NestedObject
+                  description: |
+                    Represents an audio message that is composed of both segments synthesized from the Dialogflow agent prompts and ones hosted externally at the specified URIs. The external URIs are specified via playAudio. This message is generated by Dialogflow only and not supposed to be defined by the user.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  output: true
+                  properties:
+                    - name: 'segments'
+                      type: Array
+                      description: |
+                        Segments this audio response is composed of.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'allowPlaybackInterruption'
+                            type: Boolean
+                            description: |
+                              Whether the playback of this segment can be interrupted by the end user's speech and the client should then start the next Dialogflow request.
+                            output: true
+                          - name: 'audio'
+                            type: String
+                            description: |
+                              Raw audio synthesized from the Dialogflow agent's response using the output config specified in the request.
+                              A base64-encoded string.
+                              This field is part of a union field `content`: Only one of `audio` or `uri` may be set.
+                          - name: 'uri'
+                            type: String
+                            description: |
+                              Client-specific URI that points to an audio clip accessible to the client. Dialogflow does not impose any validation on it.
+                              This field is part of a union field `content`: Only one of `audio` or `uri` may be set.
+                - name: 'telephonyTransferCall'
+                  type: NestedObject
+                  description: |
+                    Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'phoneNumber'
+                      type: String
+                      description: |
+                        Transfer the call to a phone number in E.164 format.
+                      required: true
+                - name: 'knowledgeInfoCard'
+                  type: NestedObject
+                  description: |
+                    This type has no fields.
+                    Represents info card response. If the response contains generative knowledge prediction, Dialogflow will return a payload with Infobot Messenger compatible info card.
+                    Otherwise, the info card response is skipped.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  allow_empty_object: true
+                  send_empty_value: true
+                  properties: []  # Meant to be an empty object with no properties.
+                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform. 
+                # See https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3beta1/ResponseMessage
+          - name: 'webhook'
+            type: String
+            description: |
+              The webhook to call. Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/webhooks/<Webhook ID>.
+          - name: 'returnPartialResponses'
+            type: Boolean
+            description: |
+              Whether Dialogflow should return currently queued fulfillment response messages in streaming APIs. If a webhook is specified, it happens before Dialogflow invokes webhook. Warning: 1) This flag only affects streaming API. Responses are still queued and returned once in non-streaming API. 2) The flag can be enabled in any fulfillment but only the first 3 partial responses will be returned. You may only want to apply it to fulfillments that have slow webhooks.
+          - name: 'tag'
+            type: String
+            description: |
+              The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+          - name: 'setParameterActions'
+            type: Array
+            description: |
+              Set parameter values before executing the webhook.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'parameter'
+                  type: String
+                  description: |
+                    Display name of the parameter.
+                - name: 'value'
+                  type: String
+                  description: |
+                    The new JSON-encoded value of the parameter. A null value clears the parameter.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+          - name: 'conditionalCases'
+            type: Array
+            description: |
+              Conditional cases for this fulfillment.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'cases'
+                  type: String
+                  description: |
+                    A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                    See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+          - name: 'advancedSettings'
+            type: NestedObject
+            description: |
+              Hierarchical advanced settings for agent/flow/page/fulfillment/parameter. Settings exposed at lower level overrides the settings exposed at higher level. Overriding occurs at the sub-setting level. For example, the playbackInterruptionSettings at fulfillment level only overrides the playbackInterruptionSettings at the agent level, leaving other settings at the agent level unchanged.
+              DTMF settings does not override each other. DTMF settings set at different levels define DTMF detections running in parallel.
+              Hierarchy: Agent->Flow->Page->Fulfillment/Parameter.
+            properties:
+              # This field currently can't be set. The API is not including the value in the API response, causing Acceptance Test to fail.
+              # - name: 'audioExportGcsDestination'
+              #   type: NestedObject
+              #   description: |
+              #     If present, incoming audio is exported by Dialogflow to the configured Google Cloud Storage destination. Exposed at the following levels:
+              #     * Agent level
+              #     * Flow level
+              #   properties:
+              #     - name: 'uri'
+              #       type: String
+              #       description: |
+              #         The Google Cloud Storage URI for the exported objects. A URI is of the form: gs://bucket/object-name-or-prefix Whether a full object name, or just a prefix, its usage depends on the Dialogflow operation.
+              #       required: true
+              - name: 'speechSettings'
+                type: NestedObject
+                description: |
+                  Settings for speech to text detection. Exposed at the following levels:
+                  * Agent level
+                  * Flow level
+                  * Page level
+                  * Parameter level
+                properties:
+                  - name: 'endpointerSensitivity'
+                    type: Integer
+                    description: |
+                      Sensitivity of the speech model that detects the end of speech. Scale from 0 to 100.
+                  - name: 'noSpeechTimeout'
+                    type: String
+                    description: |
+                      Timeout before detecting no speech.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+                  - name: 'useTimeoutBasedEndpointing'
+                    type: Boolean
+                    description: |
+                      Use timeout based endpointing, interpreting endpointer sensitivity as seconds of timeout value.
+                  - name: 'models'
+                    type: KeyValuePairs
+                    description: |
+                      Mapping from language to Speech-to-Text model. The mapped Speech-to-Text model will be selected for requests from its corresponding language. For more information, see [Speech models](https://cloud.google.com/dialogflow/cx/docs/concept/speech-models).
+                      An object containing a list of **"key": value** pairs. Example: **{ "name": "wrench", "mass": "1.3kg", "count": "3" }**.
+              - name: 'dtmfSettings'
+                type: NestedObject
+                description: |
+                  Define behaviors for DTMF (dual tone multi frequency). DTMF settings does not override each other. DTMF settings set at different levels define DTMF detections running in parallel. Exposed at the following levels:
+                  * Agent level
+                  * Flow level
+                  * Page level
+                  * Parameter level
+                properties:
+                  - name: 'enabled'
+                    type: Boolean
+                    description: |
+                      If true, incoming audio is processed for DTMF (dual tone multi frequtectency) events. For example, if the caller presses a button on their telephone keypad and DTMF processing is enabled, Dialogflow will de the event (e.g. a "3" was pressed) in the incoming audio and pass the event to the bot to drive business logic (e.g. when 3 is pressed, return the account balance).
+                  - name: 'maxDigits'
+                    type: Integer
+                    description: |
+                      Max length of DTMF digits.
+                  - name: 'finishDigit'
+                    type: String
+                    description: |
+                      The digit that terminates a DTMF digit sequence.
+                  - name: 'interdigitTimeoutDuration'
+                    type: String
+                    description: |
+                      Interdigit timeout setting for matching dtmf input to regex.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+                  - name: 'endpointingTimeoutDuration'
+                    type: String
+                    description: |
+                      Endpoint timeout setting for matching dtmf input to regex.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+              - name: 'loggingSettings'
+                type: NestedObject
+                # Due to inconsistent  API behaviour http://b/303056144, ignore read can be removed once fixed
+                ignore_read: true
+                description: |
+                  Settings for logging. Settings for Dialogflow History, Contact Center messages, StackDriver logs, and speech logging. Exposed at the following levels:
+                  * Agent level
+                properties:
+                  - name: 'enableStackdriverLogging'
+                    type: Boolean
+                    description: |
+                      Enables Google Cloud Logging.
+                  - name: 'enableInteractionLogging'
+                    type: Boolean
+                    description: |
+                      Enables DF Interaction logging.
+                  - name: 'enableConsentBasedRedaction'
+                    type: Boolean
+                    description: |
+                      Enables consent-based end-user input redaction, if true, a pre-defined session parameter **$session.params.conversation-redaction** will be used to determine if the utterance should be redacted.
+          - name: 'enableGenerativeFallback'
+            type: Boolean
+            description: |
+              If the flag is true, the agent will utilize LLM to generate a text response. If LLM generation fails, the defined responses in the fulfillment will be respected. This flag is only useful for fulfillments associated with no-match event handlers.
+      - name: 'dataStoreConnections'
+        type: Array
+        description: |
+          Optional. List of related data store connections.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'dataStoreType'
+              type: Enum
+              description: |
+                The type of the connected data store.
+                * PUBLIC_WEB: A data store that contains public web content.
+                * UNSTRUCTURED: A data store that contains unstructured private data.
+                * STRUCTURED: A data store that contains structured data (for example FAQ).
+              enum_values:
+                - 'PUBLIC_WEB'
+                - 'UNSTRUCTURED'
+                - 'STRUCTURED'
+            - name: 'dataStore'
+              type: String
+              description: |
+                The full name of the referenced data store. Formats: projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore} projects/{project}/locations/{location}/dataStores/{dataStore}
+            - name: 'documentProcessingMode'
+              type: Enum
+              description: |
+                The document processing mode for the data store connection. Should only be set for PUBLIC_WEB and UNSTRUCTURED data stores. If not set it is considered as DOCUMENTS, as this is the legacy mode.
+                * DOCUMENTS: Documents are processed as documents.
+                * CHUNKS: Documents are converted to chunks.
+              enum_values:
+                - 'DOCUMENTS'
+                - 'CHUNKS'
+      - name: 'targetPage'
+        type: String
+        description: |
+          The target page to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>/pages/<PageID>.
+          This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.
+      - name: 'targetFlow'
+        type: String
+        description: |
+          The target flow to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>.
+          This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.

--- a/mmv1/products/dialogflowcx/Flow.yaml
+++ b/mmv1/products/dialogflowcx/Flow.yaml
@@ -1015,6 +1015,7 @@ properties:
         type: String
         description: |
           The target page to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>/pages/<PageID>.
+          The page must be in the same host flow (the flow that owns this `KnowledgeConnectorSettings`).
           This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.
       - name: 'targetFlow'
         type: String

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -1179,17 +1179,7 @@ properties:
             item_type:
               type: NestedObject
               properties:
-                - name: 'responseType'
-                  type: Enum
-                  description: |
-                    Represents different response types.
-                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
-                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
-                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
-                  enum_values:
-                    - 'ENTRY_PROMPT'
-                    - 'PARAMETER_PROMPT'
-                    - 'HANDLER_PROMPT'
+                # 'responseType' is ignored when creating/updating resources, so we skip this field. See https://github.com/GoogleCloudPlatform/magic-modules/pull/8757/commits/65ad64bd008c60498d9b27b767dc7bc664d42c0b.
                 - name: 'channel'
                   type: String
                   description: |
@@ -1292,7 +1282,6 @@ properties:
                     This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
                   output: true
                   allow_empty_object: true
-                  send_empty_value: true
                   properties: []  # Meant to be an empty object with no properties.
                 - name: 'playAudio'
                   type: NestedObject
@@ -1361,7 +1350,7 @@ properties:
                   allow_empty_object: true
                   send_empty_value: true
                   properties: []  # Meant to be an empty object with no properties.
-                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform. 
+                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform.
                 # See https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3beta1/ResponseMessage
           - name: 'webhook'
             type: String

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -1157,3 +1157,401 @@ properties:
             type: String
             description: |
               The digit that terminates a DTMF digit sequence.
+  - name: 'knowledgeConnectorSettings'
+    type: NestedObject
+    description: |
+      Knowledge connector configuration.
+    properties:
+      - name: 'enabled'
+        type: Boolean
+        description: |
+          Whether Knowledge Connector is enabled or not.
+      - name: 'triggerFulfillment'
+        type: NestedObject
+        description: |
+          The fulfillment to be triggered.
+          When the answers from the Knowledge Connector are selected by Dialogflow, you can utitlize the request scoped parameter $request.knowledge.answers (contains up to the 5 highest confidence answers) and $request.knowledge.questions (contains the corresponding questions) to construct the fulfillment.
+        properties:
+          - name: 'messages'
+            type: Array
+            description: |
+              The list of rich message responses to present to the user.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'responseType'
+                  type: Enum
+                  description: |
+                    Represents different response types.
+                    * ENTRY_PROMPT: The response is from an entry prompt in the page.
+                    * PARAMETER_PROMPT: The response is from form-filling prompt in the page.
+                    * HANDLER_PROMPT: The response is from a transition route or an [event handler][EventHandler] in the page or flow or transition route group.
+                  enum_values:
+                    - 'ENTRY_PROMPT'
+                    - 'PARAMETER_PROMPT'
+                    - 'HANDLER_PROMPT'
+                - name: 'channel'
+                  type: String
+                  description: |
+                    The channel which the response is associated with. Clients can specify the channel via QueryParameters.channel, and only associated channel response will be returned.
+                - name: 'text'
+                  type: NestedObject
+                  description: |
+                    The text response message.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'text'
+                      type: Array
+                      description: |
+                        A collection of text response variants. If multiple variants are defined, only one text response variant is returned at runtime.
+                        required: true
+                      item_type:
+                        type: String
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                - name: 'payload'
+                  type: String
+                  description: |
+                    Returns a response containing a custom, platform-specific payload.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+                - name: 'conversationSuccess'
+                  type: NestedObject
+                  description: |
+                    Indicates that the conversation succeeded, i.e., the bot handled the issue that the customer talked to it about.
+                    Dialogflow only uses this to determine which conversations should be counted as successful and doesn't process the metadata in this message in any way. Note that Dialogflow also considers conversations that get to the conversation end page as successful even if they don't return ConversationSuccess.
+                    You may set this, for example:
+                    * In the entryFulfillment of a Page if entering the page indicates that the conversation succeeded.
+                    * In a webhook response when you determine that you handled the customer issue.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                    - name: 'metadata'
+                      type: String
+                      description: |
+                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                      state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                      custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                      validation:
+                        function: 'validation.StringIsJSON'
+                - name: 'outputAudioText'
+                  type: NestedObject
+                  description: |
+                    A text or ssml response that is preferentially used for TTS output audio synthesis, as described in the comment on the ResponseMessage message.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                    - name: 'text'
+                      type: String
+                      description: |
+                        The raw text to be synthesized.
+                        This field is part of a union field `source`: Only one of `text` or `ssml` may be set.
+                    - name: 'ssml'
+                      type: String
+                      description: |
+                        The SSML text to be synthesized. For more information, see SSML.
+                        This field is part of a union field `source`: Only one of `text` or `ssml` may be set.
+                - name: 'liveAgentHandoff'
+                  type: NestedObject
+                  description: |
+                    Indicates that the conversation should be handed off to a live agent.
+                    Dialogflow only uses this to determine which conversations were handed off to a human agent for measurement purposes. What else to do with this signal is up to you and your handoff procedures.
+                    You may set this, for example:
+                    * In the entryFulfillment of a Page if entering the page indicates something went extremely wrong in the conversation.
+                    * In a webhook response when you determine that the customer issue can only be handled by a human.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    # This can be an arbitrary json blob, so we use a string instead of a NestedObject.
+                    - name: 'metadata'
+                      type: String
+                      description: |
+                        Custom metadata. Dialogflow doesn't impose any structure on this.
+                      state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                      custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                      custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                      validation:
+                        function: 'validation.StringIsJSON'
+                - name: 'endInteraction'
+                  type: NestedObject
+                  description: |
+                    This type has no fields.
+                    Indicates that interaction with the Dialogflow agent has ended. This message is generated by Dialogflow only and not supposed to be defined by the user.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  output: true
+                  allow_empty_object: true
+                  send_empty_value: true
+                  properties: []  # Meant to be an empty object with no properties.
+                - name: 'playAudio'
+                  type: NestedObject
+                  description: |
+                    Specifies an audio clip to be played by the client as part of the response.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'audioUri'
+                      type: String
+                      description: |
+                        URI of the audio clip. Dialogflow does not impose any validation on this value. It is specific to the client that reads it.
+                      required: true
+                    - name: 'allowPlaybackInterruption'
+                      type: Boolean
+                      description: |
+                        Whether the playback of this message can be interrupted by the end user's speech and the client can then starts the next Dialogflow request.
+                      output: true
+                - name: 'mixedAudio'
+                  type: NestedObject
+                  description: |
+                    Represents an audio message that is composed of both segments synthesized from the Dialogflow agent prompts and ones hosted externally at the specified URIs. The external URIs are specified via playAudio. This message is generated by Dialogflow only and not supposed to be defined by the user.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  output: true
+                  properties:
+                    - name: 'segments'
+                      type: Array
+                      description: |
+                        Segments this audio response is composed of.
+                      item_type:
+                        type: NestedObject
+                        properties:
+                          - name: 'allowPlaybackInterruption'
+                            type: Boolean
+                            description: |
+                              Whether the playback of this segment can be interrupted by the end user's speech and the client should then start the next Dialogflow request.
+                            output: true
+                          - name: 'audio'
+                            type: String
+                            description: |
+                              Raw audio synthesized from the Dialogflow agent's response using the output config specified in the request.
+                              A base64-encoded string.
+                              This field is part of a union field `content`: Only one of `audio` or `uri` may be set.
+                          - name: 'uri'
+                            type: String
+                            description: |
+                              Client-specific URI that points to an audio clip accessible to the client. Dialogflow does not impose any validation on it.
+                              This field is part of a union field `content`: Only one of `audio` or `uri` may be set.
+                - name: 'telephonyTransferCall'
+                  type: NestedObject
+                  description: |
+                    Represents the signal that telles the client to transfer the phone call connected to the agent to a third-party endpoint.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  properties:
+                    - name: 'phoneNumber'
+                      type: String
+                      description: |
+                        Transfer the call to a phone number in E.164 format.
+                      required: true
+                - name: 'knowledgeInfoCard'
+                  type: NestedObject
+                  description: |
+                    This type has no fields.
+                    Represents info card response. If the response contains generative knowledge prediction, Dialogflow will return a payload with Infobot Messenger compatible info card.
+                    Otherwise, the info card response is skipped.
+                    This field is part of a union field `message`: Only one of `text`, `payload`, `conversationSuccess`, `outputAudioText`, `liveAgentHandoff`, `endInteraction`, `playAudio`, `mixedAudio`, `telephonyTransferCall`, or `knowledgeInfoCard` may be set.
+                  allow_empty_object: true
+                  send_empty_value: true
+                  properties: []  # Meant to be an empty object with no properties.
+                # Although ResponseMessage has a field named "toolCall", we can't include it here because it references the Tool resource, which hasn't been available on Terraform. 
+                # See https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3beta1/ResponseMessage
+          - name: 'webhook'
+            type: String
+            description: |
+              The webhook to call. Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/webhooks/<Webhook ID>.
+          - name: 'returnPartialResponses'
+            type: Boolean
+            description: |
+              Whether Dialogflow should return currently queued fulfillment response messages in streaming APIs. If a webhook is specified, it happens before Dialogflow invokes webhook. Warning: 1) This flag only affects streaming API. Responses are still queued and returned once in non-streaming API. 2) The flag can be enabled in any fulfillment but only the first 3 partial responses will be returned. You may only want to apply it to fulfillments that have slow webhooks.
+          - name: 'tag'
+            type: String
+            description: |
+              The tag used by the webhook to identify which fulfillment is being called. This field is required if webhook is specified.
+          - name: 'setParameterActions'
+            type: Array
+            description: |
+              Set parameter values before executing the webhook.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'parameter'
+                  type: String
+                  description: |
+                    Display name of the parameter.
+                - name: 'value'
+                  type: String
+                  description: |
+                    The new JSON-encoded value of the parameter. A null value clears the parameter.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+          - name: 'conditionalCases'
+            type: Array
+            description: |
+              Conditional cases for this fulfillment.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'cases'
+                  type: String
+                  description: |
+                    A JSON encoded list of cascading if-else conditions. Cases are mutually exclusive. The first one with a matching condition is selected, all the rest ignored.
+                    See [Case](https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/Fulfillment#case) for the schema.
+                  state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                  custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                  custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                  validation:
+                    function: 'validation.StringIsJSON'
+          - name: 'advancedSettings'
+            type: NestedObject
+            description: |
+              Hierarchical advanced settings for agent/flow/page/fulfillment/parameter. Settings exposed at lower level overrides the settings exposed at higher level. Overriding occurs at the sub-setting level. For example, the playbackInterruptionSettings at fulfillment level only overrides the playbackInterruptionSettings at the agent level, leaving other settings at the agent level unchanged.
+              DTMF settings does not override each other. DTMF settings set at different levels define DTMF detections running in parallel.
+              Hierarchy: Agent->Flow->Page->Fulfillment/Parameter.
+            properties:
+              # This field currently can't be set. The API is not including the value in the API response, causing Acceptance Test to fail.
+              # - name: 'audioExportGcsDestination'
+              #   type: NestedObject
+              #   description: |
+              #     If present, incoming audio is exported by Dialogflow to the configured Google Cloud Storage destination. Exposed at the following levels:
+              #     * Agent level
+              #     * Flow level
+              #   properties:
+              #     - name: 'uri'
+              #       type: String
+              #       description: |
+              #         The Google Cloud Storage URI for the exported objects. A URI is of the form: gs://bucket/object-name-or-prefix Whether a full object name, or just a prefix, its usage depends on the Dialogflow operation.
+              #       required: true
+              - name: 'speechSettings'
+                type: NestedObject
+                description: |
+                  Settings for speech to text detection. Exposed at the following levels:
+                  * Agent level
+                  * Flow level
+                  * Page level
+                  * Parameter level
+                properties:
+                  - name: 'endpointerSensitivity'
+                    type: Integer
+                    description: |
+                      Sensitivity of the speech model that detects the end of speech. Scale from 0 to 100.
+                  - name: 'noSpeechTimeout'
+                    type: String
+                    description: |
+                      Timeout before detecting no speech.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+                  - name: 'useTimeoutBasedEndpointing'
+                    type: Boolean
+                    description: |
+                      Use timeout based endpointing, interpreting endpointer sensitivity as seconds of timeout value.
+                  - name: 'models'
+                    type: KeyValuePairs
+                    description: |
+                      Mapping from language to Speech-to-Text model. The mapped Speech-to-Text model will be selected for requests from its corresponding language. For more information, see [Speech models](https://cloud.google.com/dialogflow/cx/docs/concept/speech-models).
+                      An object containing a list of **"key": value** pairs. Example: **{ "name": "wrench", "mass": "1.3kg", "count": "3" }**.
+              - name: 'dtmfSettings'
+                type: NestedObject
+                description: |
+                  Define behaviors for DTMF (dual tone multi frequency). DTMF settings does not override each other. DTMF settings set at different levels define DTMF detections running in parallel. Exposed at the following levels:
+                  * Agent level
+                  * Flow level
+                  * Page level
+                  * Parameter level
+                properties:
+                  - name: 'enabled'
+                    type: Boolean
+                    description: |
+                      If true, incoming audio is processed for DTMF (dual tone multi frequtectency) events. For example, if the caller presses a button on their telephone keypad and DTMF processing is enabled, Dialogflow will de the event (e.g. a "3" was pressed) in the incoming audio and pass the event to the bot to drive business logic (e.g. when 3 is pressed, return the account balance).
+                  - name: 'maxDigits'
+                    type: Integer
+                    description: |
+                      Max length of DTMF digits.
+                  - name: 'finishDigit'
+                    type: String
+                    description: |
+                      The digit that terminates a DTMF digit sequence.
+                  - name: 'interdigitTimeoutDuration'
+                    type: String
+                    description: |
+                      Interdigit timeout setting for matching dtmf input to regex.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+                  - name: 'endpointingTimeoutDuration'
+                    type: String
+                    description: |
+                      Endpoint timeout setting for matching dtmf input to regex.
+                      A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.500s".
+              - name: 'loggingSettings'
+                type: NestedObject
+                # Due to inconsistent  API behaviour http://b/303056144, ignore read can be removed once fixed
+                ignore_read: true
+                description: |
+                  Settings for logging. Settings for Dialogflow History, Contact Center messages, StackDriver logs, and speech logging. Exposed at the following levels:
+                  * Agent level
+                properties:
+                  - name: 'enableStackdriverLogging'
+                    type: Boolean
+                    description: |
+                      Enables Google Cloud Logging.
+                  - name: 'enableInteractionLogging'
+                    type: Boolean
+                    description: |
+                      Enables DF Interaction logging.
+                  - name: 'enableConsentBasedRedaction'
+                    type: Boolean
+                    description: |
+                      Enables consent-based end-user input redaction, if true, a pre-defined session parameter **$session.params.conversation-redaction** will be used to determine if the utterance should be redacted.
+          - name: 'enableGenerativeFallback'
+            type: Boolean
+            description: |
+              If the flag is true, the agent will utilize LLM to generate a text response. If LLM generation fails, the defined responses in the fulfillment will be respected. This flag is only useful for fulfillments associated with no-match event handlers.
+      - name: 'dataStoreConnections'
+        type: Array
+        description: |
+          Optional. List of related data store connections.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'dataStoreType'
+              type: Enum
+              description: |
+                The type of the connected data store.
+                * PUBLIC_WEB: A data store that contains public web content.
+                * UNSTRUCTURED: A data store that contains unstructured private data.
+                * STRUCTURED: A data store that contains structured data (for example FAQ).
+              enum_values:
+                - 'PUBLIC_WEB'
+                - 'UNSTRUCTURED'
+                - 'STRUCTURED'
+            - name: 'dataStore'
+              type: String
+              description: |
+                The full name of the referenced data store. Formats: projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore} projects/{project}/locations/{location}/dataStores/{dataStore}
+            - name: 'documentProcessingMode'
+              type: Enum
+              description: |
+                The document processing mode for the data store connection. Should only be set for PUBLIC_WEB and UNSTRUCTURED data stores. If not set it is considered as DOCUMENTS, as this is the legacy mode.
+                * DOCUMENTS: Documents are processed as documents.
+                * CHUNKS: Documents are converted to chunks.
+              enum_values:
+                - 'DOCUMENTS'
+                - 'CHUNKS'
+      - name: 'targetPage'
+        type: String
+        description: |
+          The target page to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>/pages/<PageID>.
+          This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.
+      - name: 'targetFlow'
+        type: String
+        description: |
+          The target flow to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>.
+          This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.

--- a/mmv1/products/dialogflowcx/Page.yaml
+++ b/mmv1/products/dialogflowcx/Page.yaml
@@ -1538,6 +1538,7 @@ properties:
         type: String
         description: |
           The target page to transition to. Format: projects/<ProjectID>/locations/<LocationID>/agents/<AgentID>/flows/<FlowID>/pages/<PageID>.
+          The page must be in the same host flow (the flow that owns this `KnowledgeConnectorSettings`).
           This field is part of a union field `target`: Only one of `targetPage` or `targetFlow` may be set.
       - name: 'targetFlow'
         type: String

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
@@ -412,6 +412,7 @@ resource "google_discovery_engine_data_store" "my_datastore" {
   display_name      = "datastore-flow-full"
   industry_vertical = "GENERIC"
   content_config    = "NO_CONTENT"
+  solution_types    = ["SOLUTION_TYPE_CHAT"]
 }
 
 resource "google_dialogflow_cx_webhook" "my_webhook" {

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
@@ -399,7 +399,7 @@ resource "google_dialogflow_cx_flow" "{{$.PrimaryResourceId}}" {
     }
     data_store_connections {
       data_store_type = "UNSTRUCTURED"
-      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/some-datastore"
+      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/datastore-flow-full"
       document_processing_mode = "DOCUMENTS"
     }
     target_flow = google_dialogflow_cx_agent.agent.start_flow
@@ -408,8 +408,8 @@ resource "google_dialogflow_cx_flow" "{{$.PrimaryResourceId}}" {
 
 resource "google_discovery_engine_data_store" "my_datastore" {
   location          = "global"
-  data_store_id     = "some-datastore-id"
-  display_name      = "some-datastore"
+  data_store_id     = "datastore-flow-full"
+  display_name      = "datastore-flow-full"
   industry_vertical = "GENERIC"
   content_config    = "NO_CONTENT"
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
@@ -294,4 +294,125 @@ resource "google_dialogflow_cx_flow" "{{$.PrimaryResourceId}}" {
       enable_consent_based_redaction = true
     }
   }
-} 
+
+  knowledge_connector_settings {
+    enabled = true
+    trigger_fulfillment {
+      messages {
+        channel = "some-channel"
+        text {
+          text = ["information completed, navigating to page 2"]
+        }
+      }
+      messages {
+        payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8902"
+        }
+      }
+      webhook = google_dialogflow_cx_webhook.my_webhook.id
+      return_partial_responses = true
+      tag = "some-tag"
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      conditional_cases {
+        cases = jsonencode([
+          {
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = { text = ["First case"] } }
+              }
+            ]
+          },
+          {
+            caseContent = [
+              {
+                message = { text = { text = ["Final case"] } }
+              }
+            ]
+          },
+        ])
+      }
+      advanced_settings {
+        speech_settings {
+          endpointer_sensitivity        = 30
+          no_speech_timeout             = "3.500s"
+          use_timeout_based_endpointing = true
+          models = {
+            name : "wrench"
+            mass : "1.3kg"
+            count : "3"
+          }
+        }
+        dtmf_settings {
+          enabled      = true
+          max_digits   = 1
+          finish_digit = "#"
+          interdigit_timeout_duration = "3.500s"
+          endpointing_timeout_duration = "3.500s"
+        }
+        logging_settings {
+          enable_stackdriver_logging     = true
+          enable_interaction_logging     = true
+          enable_consent_based_redaction = true
+        }
+      }
+      enable_generative_fallback = true
+    }
+    data_store_connections {
+      data_store_type = "UNSTRUCTURED"
+      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/some-datastore"
+      document_processing_mode = "DOCUMENTS"
+    }
+    target_flow = google_dialogflow_cx_agent.agent.start_flow
+  }
+}
+
+resource "google_dialogflow_cx_webhook" "my_webhook" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  display_name = "MyWebhook"
+  generic_web_service {
+    uri = "https://example.com"
+  }
+}
+
+data "google_project" "project" {
+}

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
@@ -406,6 +406,14 @@ resource "google_dialogflow_cx_flow" "{{$.PrimaryResourceId}}" {
   }
 }
 
+resource "google_discovery_engine_data_store" "my_datastore" {
+  location          = "global"
+  data_store_id     = "some-datastore-id"
+  display_name      = "some-datastore"
+  industry_vertical = "GENERIC"
+  content_config    = "NO_CONTENT"
+}
+
 resource "google_dialogflow_cx_webhook" "my_webhook" {
   parent       = google_dialogflow_cx_agent.agent.id
   display_name = "MyWebhook"

--- a/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_flow_full.tf.tmpl
@@ -399,7 +399,7 @@ resource "google_dialogflow_cx_flow" "{{$.PrimaryResourceId}}" {
     }
     data_store_connections {
       data_store_type = "UNSTRUCTURED"
-      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/datastore-flow-full"
+      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/${google_discovery_engine_data_store.my_datastore.data_store_id}"
       document_processing_mode = "DOCUMENTS"
     }
     target_flow = google_dialogflow_cx_agent.agent.start_flow

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
@@ -558,6 +558,12 @@ resource "google_dialogflow_cx_page" "{{$.PrimaryResourceId}}" {
         knowledge_info_card {}
       }
       messages {
+        channel = "some-channel"
+        text {
+          text = ["information completed, navigating to page 2"]
+        }
+      }
+      messages {
         payload = <<EOF
           {"some-key": "some-value", "other-key": ["other-value"]}
         EOF

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
@@ -658,7 +658,7 @@ resource "google_dialogflow_cx_page" "{{$.PrimaryResourceId}}" {
     }
     data_store_connections {
       data_store_type = "PUBLIC_WEB"
-      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/some-datastore"
+      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/datastore-page-full"
       document_processing_mode = "CHUNKS"
     }
     target_page = google_dialogflow_cx_page.my_page2.id
@@ -672,8 +672,8 @@ resource "google_dialogflow_cx_page" "my_page2" {
 
 resource "google_discovery_engine_data_store" "my_datastore" {
   location          = "global"
-  data_store_id     = "some-datastore"
-  display_name      = "some-datastore"
+  data_store_id     = "datastore-page-full"
+  display_name      = "datastore-page-full"
   industry_vertical = "GENERIC"
   content_config    = "NO_CONTENT"
 }

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
@@ -670,6 +670,14 @@ resource "google_dialogflow_cx_page" "my_page2" {
   display_name = "MyPage2"
 }
 
+resource "google_discovery_engine_data_store" "my_datastore" {
+  location          = "global"
+  data_store_id     = "some-datastore"
+  display_name      = "some-datastore"
+  industry_vertical = "GENERIC"
+  content_config    = "NO_CONTENT"
+}
+
 resource "google_dialogflow_cx_webhook" "my_webhook" {
   parent       = google_dialogflow_cx_agent.agent.id
   display_name = "MyWebhook"

--- a/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflowcx_page_full.tf.tmpl
@@ -550,6 +550,113 @@ resource "google_dialogflow_cx_page" "{{$.PrimaryResourceId}}" {
       finish_digit = "#"
     }
   }
+  knowledge_connector_settings {
+    enabled = true
+    trigger_fulfillment {
+      messages {
+        channel = "some-channel"
+        knowledge_info_card {}
+      }
+      messages {
+        payload = <<EOF
+          {"some-key": "some-value", "other-key": ["other-value"]}
+        EOF
+      }
+      messages {
+        conversation_success {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        output_audio_text {
+          text = "some output text"
+        }
+      }
+      messages {
+        output_audio_text {
+          ssml = <<EOF
+            <speak>Some example <say-as interpret-as="characters">SSML XML</say-as></speak>
+          EOF
+        }
+      }
+      messages {
+        live_agent_handoff {
+          metadata = <<EOF
+            {"some-metadata-key": "some-value", "other-metadata-key": 1234}
+          EOF
+        }
+      }
+      messages {
+        play_audio {
+          audio_uri = "http://example.com/some-audio-file.mp3"
+        }
+      }
+      messages {
+        telephony_transfer_call {
+          phone_number = "1-234-567-8902"
+        }
+      }
+      webhook = google_dialogflow_cx_webhook.my_webhook.id
+      return_partial_responses = true
+      tag = "some-tag"
+      set_parameter_actions {
+        parameter = "some-param"
+        value     = "123.45"
+      }
+      conditional_cases {
+        cases = jsonencode([
+          {
+            condition = "$sys.func.RAND() < 0.5",
+            caseContent = [
+              {
+                message = { text = { text = ["First case"] } }
+              }
+            ]
+          },
+          {
+            caseContent = [
+              {
+                message = { text = { text = ["Final case"] } }
+              }
+            ]
+          },
+        ])
+      }
+      advanced_settings {
+        speech_settings {
+          endpointer_sensitivity        = 30
+          no_speech_timeout             = "3.500s"
+          use_timeout_based_endpointing = true
+          models = {
+            name : "wrench"
+            mass : "1.3kg"
+            count : "3"
+          }
+        }
+        dtmf_settings {
+          enabled      = true
+          max_digits   = 1
+          finish_digit = "#"
+          interdigit_timeout_duration = "3.500s"
+          endpointing_timeout_duration = "3.500s"
+        }
+        logging_settings {
+          enable_stackdriver_logging     = true
+          enable_interaction_logging     = true
+          enable_consent_based_redaction = true
+        }
+      }
+      enable_generative_fallback = true
+    }
+    data_store_connections {
+      data_store_type = "PUBLIC_WEB"
+      data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent.location}/collections/default_collection/dataStores/some-datastore"
+      document_processing_mode = "CHUNKS"
+    }
+    target_page = google_dialogflow_cx_page.my_page2.id
+  }
 }
 
 resource "google_dialogflow_cx_page" "my_page2" {
@@ -563,4 +670,7 @@ resource "google_dialogflow_cx_webhook" "my_webhook" {
   generic_web_service {
     uri = "https://example.com"
   }
+}
+
+data "google_project" "project" {
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -375,25 +375,8 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
           }
         }
       }
-      data_store_connections {
-        data_store_type = "UNSTRUCTURED"
-        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/${google_discovery_engine_data_store.my_datastore.data_store_id}"
-        document_processing_mode = "DOCUMENTS"
-      }
       target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
     }
-  }
-
-  resource "google_discovery_engine_data_store" "my_datastore" {
-    location          = "global"
-    data_store_id     = "datastore-flow-update%{random_suffix}"
-    display_name      = "datastore-flow-update"
-    industry_vertical = "GENERIC"
-    content_config    = "NO_CONTENT"
-    solution_types    = ["SOLUTION_TYPE_CHAT"]
-  }
-
-  data "google_project" "project" {
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -370,7 +370,9 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
       trigger_fulfillment {
         messages {
           channel = "some-channel"
-          end_interaction {}
+          output_audio_text {
+            text = "some output text"
+          }
         }
       }
       data_store_connections {
@@ -383,7 +385,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
   }
 
   resource "google_dialogflow_cx_page" "my_page" {
-    parent       = google_dialogflow_cx_agent.agent_page.start_flow
+    parent       = google_dialogflow_cx_agent.agent_entity.start_flow
     display_name = "MyPage"
   }
 

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -377,7 +377,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
       }
       data_store_connections {
         data_store_type = "UNSTRUCTURED"
-        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/some-datastore"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/datastore-flow-update"
         document_processing_mode = "DOCUMENTS"
       }
       target_page = google_dialogflow_cx_page.my_page.id
@@ -391,8 +391,8 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 
   resource "google_discovery_engine_data_store" "my_datastore" {
     location          = "global"
-    data_store_id     = "some-datastore"
-    display_name      = "some-datastore"
+    data_store_id     = "datastore-flow-update"
+    display_name      = "datastore-flow-update"
     industry_vertical = "GENERIC"
     content_config    = "NO_CONTENT"
   }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -364,6 +364,30 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
         enable_consent_based_redaction = true
       }
     }
+
+    knowledge_connector_settings {
+      enabled = true
+      trigger_fulfillment {
+        messages {
+          channel = "some-channel"
+          end_interaction {}
+        }
+      }
+      data_store_connections {
+        data_store_type = "UNSTRUCTURED"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/some-datastore"
+        document_processing_mode = "DOCUMENTS"
+      }
+      target_page = google_dialogflow_cx_page.my_page.id
+    }
+  }
+
+  resource "google_dialogflow_cx_page" "my_page" {
+    parent       = google_dialogflow_cx_agent.agent_page.start_flow
+    display_name = "MyPage"
+  }
+
+  data "google_project" "project" {
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -389,6 +389,14 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
     display_name = "MyPage"
   }
 
+  resource "google_discovery_engine_data_store" "my_datastore" {
+    location          = "global"
+    data_store_id     = "some-datastore"
+    display_name      = "some-datastore"
+    industry_vertical = "GENERIC"
+    content_config    = "NO_CONTENT"
+  }
+
   data "google_project" "project" {
   }
 `, context)

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -377,7 +377,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
       }
       data_store_connections {
         data_store_type = "UNSTRUCTURED"
-        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/datastore-flow-update"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/${google_discovery_engine_data_store.my_datastore.data_store_id}"
         document_processing_mode = "DOCUMENTS"
       }
       target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
@@ -386,7 +386,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
 
   resource "google_discovery_engine_data_store" "my_datastore" {
     location          = "global"
-    data_store_id     = "datastore-flow-update"
+    data_store_id     = "datastore-flow-update%{random_suffix}"
     display_name      = "datastore-flow-update"
     industry_vertical = "GENERIC"
     content_config    = "NO_CONTENT"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -548,7 +548,7 @@ resource "google_dialogflow_cx_intent" "default_welcome_intent" {
 }
 
 resource "google_dialogflow_cx_page" "my_page" {
-  parent       = google_dialogflow_cx_agent.agent.default_start_flow
+  parent       = google_dialogflow_cx_agent.agent.start_flow
   display_name = "MyPage"
 }
 

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -380,13 +380,8 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
         data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_entity.location}/collections/default_collection/dataStores/datastore-flow-update"
         document_processing_mode = "DOCUMENTS"
       }
-      target_page = google_dialogflow_cx_page.my_page.id
+      target_flow = google_dialogflow_cx_agent.agent_entity.start_flow
     }
-  }
-
-  resource "google_dialogflow_cx_page" "my_page" {
-    parent       = google_dialogflow_cx_agent.agent_entity.my_flow
-    display_name = "MyPage"
   }
 
   resource "google_discovery_engine_data_store" "my_datastore" {
@@ -552,6 +547,10 @@ resource "google_dialogflow_cx_intent" "default_welcome_intent" {
   }
 }
 
+resource "google_dialogflow_cx_page" "my_page" {
+  parent       = google_dialogflow_cx_agent.agent.default_start_flow
+  display_name = "MyPage"
+}
 
 resource "google_dialogflow_cx_flow" "default_start_flow" {
   parent                = google_dialogflow_cx_agent.agent.id
@@ -597,6 +596,18 @@ resource "google_dialogflow_cx_flow" "default_start_flow" {
         }
       }
     }
+  }
+
+  knowledge_connector_settings {
+    enabled = false
+    trigger_fulfillment {
+      messages {
+        output_audio_text {
+          text = "We can update the knowledge_connector_settings in this flow!"
+        }
+      }
+    }
+    target_page = google_dialogflow_cx_page.my_page.id
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -390,6 +390,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
     display_name      = "datastore-flow-update"
     industry_vertical = "GENERIC"
     content_config    = "NO_CONTENT"
+    solution_types    = ["SOLUTION_TYPE_CHAT"]
   }
 
   data "google_project" "project" {

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_flow_test.go
@@ -385,7 +385,7 @@ func testAccDialogflowCXFlow_full(context map[string]interface{}) string {
   }
 
   resource "google_dialogflow_cx_page" "my_page" {
-    parent       = google_dialogflow_cx_agent.agent_entity.start_flow
+    parent       = google_dialogflow_cx_agent.agent_entity.my_flow
     display_name = "MyPage"
   }
 

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -626,7 +626,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
       }
       data_store_connections {
         data_store_type = "UNSTRUCTURED"
-        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_page.location}/collections/default_collection/dataStores/some-datastore"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_page.location}/collections/default_collection/dataStores/datastore"
         document_processing_mode = "DOCUMENTS"
       }
       target_page = google_dialogflow_cx_page.my_page2.id
@@ -640,8 +640,8 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
 
   resource "google_discovery_engine_data_store" "my_datastore" {
     location          = "global"
-    data_store_id     = "some-datastore"
-    display_name      = "some-datastore"
+    data_store_id     = "datastore-page-update"
+    display_name      = "datastore-page-update"
     industry_vertical = "GENERIC"
     content_config    = "NO_CONTENT"
   }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -626,7 +626,7 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
       }
       data_store_connections {
         data_store_type = "UNSTRUCTURED"
-        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_page.location}/collections/default_collection/dataStores/datastore"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_page.location}/collections/default_collection/dataStores/datastore-page-update"
         document_processing_mode = "DOCUMENTS"
       }
       target_page = google_dialogflow_cx_page.my_page2.id

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -638,6 +638,14 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
     display_name = "MyPage2"
   }
 
+  resource "google_discovery_engine_data_store" "my_datastore" {
+    location          = "global"
+    data_store_id     = "some-datastore"
+    display_name      = "some-datastore"
+    industry_vertical = "GENERIC"
+    content_config    = "NO_CONTENT"
+  }
+
   resource "google_dialogflow_cx_webhook" "my_webhook" {
     parent       = google_dialogflow_cx_agent.agent_page.id
     display_name = "MyWebhook"

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -613,6 +613,27 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
         finish_digit = "#"
       }
     }
+
+    knowledge_connector_settings {
+      enabled = true
+      trigger_fulfillment {
+        messages {
+          responseType = "HANDLER_PROMPT"
+          channel = "some-channel"
+          messages {
+            output_audio_text {
+              text = "some output text"
+            }
+          }
+        }
+      }
+      data_store_connections {
+        data_store_type = "UNSTRUCTURED"
+        data_store = "projects/${data.google_project.project.number}/locations/${google_dialogflow_cx_agent.agent_page.location}/collections/default_collection/dataStores/some-datastore"
+        document_processing_mode = "DOCUMENTS"
+      }
+      target_page = google_dialogflow_cx_page.my_page2.id
+    }
   }
 
   resource "google_dialogflow_cx_page" "my_page2" {
@@ -626,6 +647,9 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
     generic_web_service {
       uri = "https://example.com"
     }
+  }
+
+  data "google_project" "project" {
   }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_page_test.go
@@ -618,12 +618,9 @@ func testAccDialogflowCXPage_full(context map[string]interface{}) string {
       enabled = true
       trigger_fulfillment {
         messages {
-          responseType = "HANDLER_PROMPT"
           channel = "some-channel"
-          messages {
-            output_audio_text {
-              text = "some output text"
-            }
+          output_audio_text {
+            text = "some output text"
           }
         }
       }


### PR DESCRIPTION
Add `knowledge_connector_settings` to `dialogflow_cx_flow` and `dialogflow_cx_page` resources.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dialogflowcx: added `knowledge_connector_settings` field to `google_dialogflow_cx_flow` and `google_dialogflow_cx_page` resources
```
