### PR TITLE
Add terraform support for CrossSiteNetwork.

### DIFF
--- a/mmv1/products/compute/CrossSiteNetwork.yaml
+++ b/mmv1/products/compute/CrossSiteNetwork.yaml
@@ -1,0 +1,64 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'CrossSiteNetwork'
+description: |
+  Represents a cross-site-network resource.A CrossSiteNetwork is used to establish L2 connectivity between groups of Interconnects.
+min_version: beta
+references:
+  guides:
+    'Create a Cross-Site Interconnect': 'https://cloud.google.com/network-connectivity/docs/interconnect/how-to/cross-site/create-network'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/crossSiteNetworks'
+docs:
+base_url: 'projects/{{project}}/global/crossSiteNetworks'
+self_link: 'projects/{{project}}/global/crossSiteNetworks/{{name}}'
+update_verb: 'PATCH'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+examples:
+  - name: 'compute_cross_site_network_basic'
+    primary_resource_id: 'example-cross-site-network'
+    vars:
+      name: 'test-cross-site-network'
+      description: 'Example cross site network'
+    min_version: 'beta'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+parameters:
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is created. The name must be
+      1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters
+      long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
+      character must be a lowercase letter, and all following characters must be a dash,
+      lowercase letter, or digit, except the last character, which cannot be a dash.
+    required: true
+    immutable: true
+    validation:
+      regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when you create the resource.

--- a/mmv1/products/compute/CrossSiteNetwork.yaml
+++ b/mmv1/products/compute/CrossSiteNetwork.yaml
@@ -14,7 +14,7 @@
 ---
 name: 'CrossSiteNetwork'
 description: |
-  Represents a cross-site-network resource.A CrossSiteNetwork is used to establish L2 connectivity between groups of Interconnects.
+  Represents a cross-site-network resource. A CrossSiteNetwork is used to establish L2 connectivity between groups of Interconnects.
 min_version: beta
 references:
   guides:

--- a/mmv1/products/compute/CrossSiteNetwork.yaml
+++ b/mmv1/products/compute/CrossSiteNetwork.yaml
@@ -61,4 +61,4 @@ properties:
   - name: 'description'
     type: String
     description: |
-      An optional description of this resource. Provide this property when you create the resource.
+      An optional description of this resource.

--- a/mmv1/templates/terraform/examples/compute_cross_site_network_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_cross_site_network_basic.tf.tmpl
@@ -1,0 +1,9 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "{{$.PrimaryResourceId}}" {
+  name                 = "{{index $.Vars "name"}}"
+  description         = "{{index $.Vars "description"}}"
+  provider = google-beta
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_cross_site_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_cross_site_network_test.go.tmpl
@@ -1,0 +1,75 @@
+package compute_test
+{{ if ne $.TargetVersionName `ga` -}}
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeCrossSiteNetwork_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeCrossSiteNetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeCrossSiteNetwork_basic(context),
+			},
+			{
+				ResourceName:      "google_compute_cross_site_network.example-cross-site-network",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeCrossSiteNetwork_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_cross_site_network.example-cross-site-network", "description", "Example cross site network updated"+context["random_suffix"].(string)),
+				),
+			},
+			{
+				ResourceName:      "google_compute_cross_site_network.example-cross-site-network",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeCrossSiteNetwork_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "example-cross-site-network" {
+  name       = "tf-test-test-cross-site-network%{random_suffix}"
+  description         = "Example cross site network%{random_suffix}"
+  provider = google-beta
+}
+`, context)
+}
+
+func testAccComputeCrossSiteNetwork_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "example-cross-site-network" {
+name       = "tf-test-test-cross-site-network%{random_suffix}"
+description         = "Example cross site network updated%{random_suffix}"
+  provider = google-beta
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
```release-note: new-resource 
`google_compute_cross_site_network`
```

Represents a cross-site-network resource.A CrossSiteNetwork is used to establish L2 connectivity between groups of Interconnects.

~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.

To get more information about CrossSiteNetwork, see:

* [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/crossSiteNetworks)
* How-to Guides
    * [Create a Cross-Site Interconnect](https://cloud.google.com/network-connectivity/docs/interconnect/how-to/cross-site/create-network)

## Example Usage - Compute Cross Site Network Basic


```hcl
data "google_project" "project" {
  provider = google-beta
}

resource "google_compute_cross_site_network" "example-cross-site-network" {
  name                 = "test-cross-site-network"
  description         = "Example cross site network"
  provider = google-beta
}
```

## Argument Reference

The following arguments are supported:


* `name` -
  (Required)
  Name of the resource. Provided by the client when the resource is created. The name must be
  1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters
  long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
  character must be a lowercase letter, and all following characters must be a dash,
  lowercase letter, or digit, except the last character, which cannot be a dash.


- - -


* `description` -
  (Optional)
  An optional description of this resource. Provide this property when you create the resource.

* `project` - (Optional) The ID of the project in which the resource belongs.
    If it is not provided, the provider project is used.


## Attributes Reference

In addition to the arguments listed above, the following computed attributes are exported:

* `id` - an identifier for the resource with format `projects/{{project}}/global/crossSiteNetworks/{{name}}`


## Timeouts

This resource provides the following
[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:

- `create` - Default is 20 minutes.
- `update` - Default is 20 minutes.
- `delete` - Default is 20 minutes.

## Import


CrossSiteNetwork can be imported using any of these accepted formats:

* `projects/{{project}}/global/crossSiteNetworks/{{name}}`
* `{{project}}/{{name}}`
* `{{name}}`


In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CrossSiteNetwork using one of the formats above. For example:

```tf
import {
  id = "projects/{{project}}/global/crossSiteNetworks/{{name}}"
  to = google_compute_cross_site_network.default
}
```

When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), CrossSiteNetwork can be imported using one of the formats above. For example:

```
$ terraform import google_compute_cross_site_network.default projects/{{project}}/global/crossSiteNetworks/{{name}}
$ terraform import google_compute_cross_site_network.default {{project}}/{{name}}
$ terraform import google_compute_cross_site_network.default {{name}}
```

## User Project Overrides

This resource supports [User Project Overrides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override).