### PR TITLE
Add deletion_protection field to Memcache Instance

### DIFF
--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -37,7 +37,8 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
-custom_code:
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: 'templates/terraform/pre_delete/memcache_instance.go.tmpl'
 examples:
   - name: 'memcache_instance_basic'
     primary_resource_id: 'instance'
@@ -46,6 +47,8 @@ examples:
       network_name: 'test-network'
       address_name: 'address'
     exclude_test: true
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'memcache_instance_basic_test'
     primary_resource_id: 'instance'
     vars:
@@ -330,3 +333,14 @@ properties:
     ignore_read: true
     item_type:
       type: String
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the instance. Defaults to true.
+      When a`terraform destroy` or `terraform apply` would delete the instance,
+      the command will fail if this field is not set to false in Terraform state.
+      When the field is set to true or unset in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the instance will fail.
+      When the field is set to false, deleting the instance is allowed.
+    type: Boolean
+    default_value: true

--- a/mmv1/templates/terraform/examples/memcache_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memcache_instance_basic.tf.tmpl
@@ -27,7 +27,8 @@ resource "google_service_networking_connection" "private_service_connection" {
 resource "google_memcache_instance" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "instance_name"}}"
   authorized_network = google_service_networking_connection.private_service_connection.network
-
+  deletion_protection = false
+  
   labels = {
     env = "test"
   }

--- a/mmv1/templates/terraform/pre_delete/memcache_instance.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/memcache_instance.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+  return fmt.Errorf("cannot destroy memcache instance without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -2,6 +2,7 @@ package memcache_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -96,4 +97,62 @@ data "google_compute_network" "memcache_network" {
   name = "%s"
 }
 `, name, network)
+}
+
+func TestAccMemcacheInstance_deletionprotection(t *testing.T) {
+	t.Parallel()
+
+	prefix := fmt.Sprintf("%d", acctest.RandInt(t))
+	name := fmt.Sprintf("tf-test-%s", prefix)
+	network := acctest.BootstrapSharedServiceNetworkingConnection(t, "memcache-instance-update-1")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemcacheInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemcacheInstance_deletionprotection(prefix, name, network, "us-central1"),
+			},
+			{
+				ResourceName:            "google_memcache_instance.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"reserved_ip_range_id", "deletion_protection"},
+			},
+			{
+				Config:      testAccMemcacheInstance_deletionprotection(prefix, name, network, "us-west2"),
+				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
+			{
+				Config: testAccMemcacheInstance_update(prefix, name, network),
+			},
+		},
+	})
+}
+
+func testAccMemcacheInstance_deletionprotection(prefix, name, network, region string) string {
+	return fmt.Sprintf(`
+resource "google_memcache_instance" "test" {
+  name = "%s"
+  region = "%s"
+  authorized_network = data.google_compute_network.memcache_network.id
+  deletion_protection = true
+  node_config {
+    cpu_count      = 1
+    memory_size_mb = 1024
+  }
+  node_count = 1
+  memcache_parameters {
+    params = {
+      "listen-backlog" = "2048"
+      "max-item-size" = "8388608"
+    }
+  }
+  reserved_ip_range_id = ["tf-bootstrap-addr-memcache-instance-update-1"]
+}
+data "google_compute_network" "memcache_network" {
+  name = "%s"
+}
+`, name, region, network)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/368232860
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
memcache: added `deletion_protection` field to `memcache_instance` to make deleting them require an explicit intent. `memcache_instance` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```
