### PR TITLE
Revert "Use commit shas instead of branch names in diff comment"

### DIFF
--- a/.ci/magician/cmd/generate_comment_test.go
+++ b/.ci/magician/cmd/generate_comment_test.go
@@ -16,7 +16,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -38,22 +37,6 @@ func TestExecGenerateComment(t *testing.T) {
 		"PATH":    os.Getenv("PATH"),
 		"GOPATH":  os.Getenv("GOPATH"),
 		"HOME":    os.Getenv("HOME"),
-	}
-	for _, repo := range []string{
-		"terraform-provider-google",
-		"terraform-provider-google-beta",
-		"terraform-google-conversion",
-	} {
-		variablePathOld := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s-old.txt", repo)
-		variablePath := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s.txt", repo)
-		err := mr.WriteFile(variablePathOld, "1a2a3a4a")
-		if err != nil {
-			t.Errorf("Error writing file: %s", err)
-		}
-		err = mr.WriteFile(variablePath, "1a2a3a4b")
-		if err != nil {
-			t.Errorf("Error writing file: %s", err)
-		}
 	}
 	execGenerateComment(
 		123456,
@@ -132,7 +115,7 @@ func TestExecGenerateComment(t *testing.T) {
 			{"123456", "terraform-provider-breaking-change-test", "success", "https://console.cloud.google.com/cloud-build/builds;region=global/build1;step=17?project=project1", "sha1"},
 			{"123456", "terraform-provider-missing-service-labels", "success", "https://console.cloud.google.com/cloud-build/builds;region=global/build1;step=17?project=project1", "sha1"},
 		},
-		"PostComment": {{"123456", "Hi there, I'm the Modular magician. I've detected the following information about your changes:\n\n## Diff report\n\nYour PR generated some diffs in downstreams - here they are.\n\n`google` provider: [Diff](https://github.com/modular-magician/terraform-provider-google/compare/1a2a3a4a..1a2a3a4b) ( 2 files changed, 40 insertions(+))\n`google-beta` provider: [Diff](https://github.com/modular-magician/terraform-provider-google-beta/compare/1a2a3a4a..1a2a3a4b) ( 2 files changed, 40 insertions(+))\n`terraform-google-conversion`: [Diff](https://github.com/modular-magician/terraform-google-conversion/compare/1a2a3a4a..1a2a3a4b) ( 1 file changed, 10 insertions(+))\n\n\n\n## Missing test report\nYour PR includes resource fields which are not covered by any test.\n\nResource: `google_folder_access_approval_settings` (3 total tests)\nPlease add an acceptance test which includes these fields. The test should include the following:\n\n```hcl\nresource \"google_folder_access_approval_settings\" \"primary\" {\n  uncovered_field = # value needed\n}\n\n```\n\n\n"}},
+		"PostComment": {{"123456", "Hi there, I'm the Modular magician. I've detected the following information about your changes:\n\n## Diff report\n\nYour PR generated some diffs in downstreams - here they are.\n\n`google` provider: [Diff](https://github.com/modular-magician/terraform-provider-google/compare/auto-pr-123456-old..auto-pr-123456) ( 2 files changed, 40 insertions(+))\n`google-beta` provider: [Diff](https://github.com/modular-magician/terraform-provider-google-beta/compare/auto-pr-123456-old..auto-pr-123456) ( 2 files changed, 40 insertions(+))\n`terraform-google-conversion`: [Diff](https://github.com/modular-magician/terraform-google-conversion/compare/auto-pr-123456-old..auto-pr-123456) ( 1 file changed, 10 insertions(+))\n\n\n\n## Missing test report\nYour PR includes resource fields which are not covered by any test.\n\nResource: `google_folder_access_approval_settings` (3 total tests)\nPlease add an acceptance test which includes these fields. The test should include the following:\n\n```hcl\nresource \"google_folder_access_approval_settings\" \"primary\" {\n  uncovered_field = # value needed\n}\n\n```\n\n\n"}},
 		"AddLabels":   {{"123456", []string{"service/alloydb"}}},
 	} {
 		if actualCalls, ok := gh.calledMethods[method]; !ok {
@@ -187,27 +170,24 @@ func TestFormatDiffComment(t *testing.T) {
 		},
 		"diffs are displayed": {
 			data: diffCommentData{
+				PrNumber: 1234567890,
 				Diffs: []Diff{
 					{
-						Title:        "Repo 1",
-						Repo:         "repo-1",
-						ShortStat:    "+1 added, -1 removed",
-						CommitSHA:    "1a2a3a4b",
-						OldCommitSHA: "1a2a3a4a",
+						Title:     "Repo 1",
+						Repo:      "repo-1",
+						ShortStat: "+1 added, -1 removed",
 					},
 					{
-						Title:        "Repo 2",
-						Repo:         "repo-2",
-						ShortStat:    "+2 added, -2 removed",
-						CommitSHA:    "1a2a3a4d",
-						OldCommitSHA: "1a2a3a4c",
+						Title:     "Repo 2",
+						Repo:      "repo-2",
+						ShortStat: "+2 added, -2 removed",
 					},
 				},
 			},
 			expectedStrings: []string{
 				"## Diff report",
 				"generated some diffs",
-				"Repo 1: [Diff](https://github.com/modular-magician/repo-1/compare/1a2a3a4a..1a2a3a4b) (+1 added, -1 removed)\nRepo 2: [Diff](https://github.com/modular-magician/repo-2/compare/1a2a3a4c..1a2a3a4d) (+2 added, -2 removed)",
+				"Repo 1: [Diff](https://github.com/modular-magician/repo-1/compare/auto-pr-1234567890-old..auto-pr-1234567890) (+1 added, -1 removed)\nRepo 2: [Diff](https://github.com/modular-magician/repo-2/compare/auto-pr-1234567890-old..auto-pr-1234567890) (+2 added, -2 removed)",
 			},
 			notExpectedStrings: []string{
 				"hasn't generated any diffs",

--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -339,9 +339,7 @@ func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner
 	}
 
 	if _, err := rnr.Run("git", []string{"commit", "--signoff", "-m", commitMessage}, nil); err != nil {
-		if !strings.Contains(err.Error(), "nothing to commit") {
-			return "", err
-		}
+		return "", err
 	}
 
 	commitSha, err := rnr.Run("git", []string{"rev-parse", "HEAD"}, nil)
@@ -354,13 +352,8 @@ func createCommit(scratchRepo *source.Repo, commitMessage string, rnr ExecRunner
 
 	// auto-pr's use commitSHA_modular-magician_<repo>_.txt file to communicate commmit hash
 	// across cloudbuild steps. Used in test-tpg to execute unit tests for the HEAD commit
-	if strings.HasPrefix(scratchRepo.Branch, "auto-pr-") {
-		var variablePath string
-		if strings.HasSuffix(scratchRepo.Branch, "-old") {
-			variablePath = fmt.Sprintf("/workspace/commitSHA_modular-magician_%s-old.txt", scratchRepo.Name)
-		} else {
-			variablePath = fmt.Sprintf("/workspace/commitSHA_modular-magician_%s.txt", scratchRepo.Name)
-		}
+	if strings.HasPrefix(scratchRepo.Branch, "auto-pr-") && !strings.HasSuffix(scratchRepo.Branch, "-old") {
+		variablePath := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s.txt", scratchRepo.Name)
 		fmt.Println("variablePath: ", variablePath)
 		err = rnr.WriteFile(variablePath, commitSha)
 		if err != nil {

--- a/.ci/magician/cmd/mock_runner_test.go
+++ b/.ci/magician/cmd/mock_runner_test.go
@@ -41,7 +41,6 @@ type mockRunner struct {
 	cwd           string
 	dirStack      *list.List
 	notifyError   bool
-	fileContents  map[string]string
 }
 
 func sortedEnvString(env map[string]string) string {
@@ -108,14 +107,10 @@ func (mr *mockRunner) Walk(root string, fn filepath.WalkFunc) error {
 }
 
 func (mr *mockRunner) ReadFile(name string) (string, error) {
-	return mr.fileContents[name], nil
+	return "", nil
 }
 
 func (mr *mockRunner) WriteFile(name, data string) error {
-	if mr.fileContents == nil {
-		mr.fileContents = make(map[string]string)
-	}
-	mr.fileContents[name] = data
 	return nil
 }
 

--- a/.ci/magician/cmd/templates/DIFF_COMMENT.md.tmpl
+++ b/.ci/magician/cmd/templates/DIFF_COMMENT.md.tmpl
@@ -7,7 +7,7 @@ Your PR hasn't generated any diffs, but I'll let you know if a future commit doe
 Your PR generated some diffs in downstreams - here they are.
 
 {{range .Diffs -}}
-{{.Title}}: [Diff](https://github.com/modular-magician/{{.Repo}}/compare/{{.OldCommitSHA}}..{{.CommitSHA}}) ({{.ShortStat}})
+{{.Title}}: [Diff](https://github.com/modular-magician/{{.Repo}}/compare/auto-pr-{{$.PrNumber}}-old..auto-pr-{{$.PrNumber}}) ({{.ShortStat}})
 {{end -}}
 {{end -}}
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#13732


```release-note:none

```