### PR TITLE
Give appropriate permissions to App Engine service account 

### DIFF
--- a/mmv1/products/appengine/FlexibleAppVersion.yaml
+++ b/mmv1/products/appengine/FlexibleAppVersion.yaml
@@ -69,8 +69,6 @@ examples:
     ignore_read_extra:
       - 'noop_on_destroy'
       - 'deployment.0.zip'
-    # https://github.com/hashicorp/terraform-provider-google/issues/19040
-    exclude_test: true
 virtual_fields:
   - name: 'noop_on_destroy'
     description: |

--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.tmpl
@@ -42,6 +42,12 @@ resource "google_project_iam_member" "storage_viewer" {
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
 
+resource "google_project_iam_member" "artifact_registry_admin {
+  project = google_project_service.service.project
+  role = "roles/artifactregistry.admin"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
+}
+
 resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
   version_id = "v1"
   project    = google_project_iam_member.gae_api.project

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
-	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
+	// t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -79,14 +79,14 @@ resource "google_project_service" "appengineflex" {
 
 resource "google_service_account" "custom_service_account" {
   provider = google-beta
-  project      = google_project_service.service.project
-  account_id   = "{{index $.Vars "account_id"}}"
+  project      = google_project_service.appengineflex.project
+  account_id   = "my-account"
   display_name = "Custom Service Account"
 }
 
 resource "google_project_iam_member" "editor" {
   provider = google-beta
-  project = google_project_service.service.project
+  project = google_project_service.appengineflex.project
   role    = "roles/editor"
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
@@ -284,14 +284,14 @@ resource "google_project_service" "appengineflex" {
 
 resource "google_service_account" "custom_service_account" {
   provider = google-beta
-  project      = google_project_service.service.project
-  account_id   = "{{index $.Vars "account_id"}}"
+  project      = google_project_service.appengineflex.project
+  account_id   = "my-account"
   display_name = "Custom Service Account"
 }
 
 resource "google_project_iam_member" "editor" {
   provider = google-beta
-  project = google_project_service.service.project
+  project = google_project_service.appengineflex.project
   role    = "roles/editor"
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -78,12 +78,14 @@ resource "google_project_service" "appengineflex" {
 }
 
 resource "google_service_account" "custom_service_account" {
+  provider = google-beta
   project      = google_project_service.service.project
   account_id   = "{{index $.Vars "account_id"}}"
   display_name = "Custom Service Account"
 }
 
 resource "google_project_iam_member" "editor" {
+  provider = google-beta
   project = google_project_service.service.project
   role    = "roles/editor"
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -3,12 +3,9 @@ package appengine_test
 {{ if ne $.TargetVersionName `ga` -}}
 
 import (
-  "log"
-  "strings"
   "testing"
 
   "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-  "github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -459,22 +459,4 @@ resource "google_storage_bucket_object" "main" {
 }`, context)
 }
 
-// Remove when generated test is enabled
-func testAccCheckAppEngineFlexibleAppVersionDestroyProducer(t *testing.T) func(s *terraform.State) error {
-  return func(s *terraform.State) error {
-    for name, rs := range s.RootModule().Resources {
-      if rs.Type != "google_app_engine_flexible_app_version" {
-        continue
-      }
-      if strings.HasPrefix(name, "data.") {
-        continue
-      }
-
-      log.Printf("[DEBUG] Ignoring destroy during test")
-    }
-
-    return nil
-  }
-}
-
 {{ end }}

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -14,7 +14,6 @@ import (
 )
 
 func TestAccAppEngineFlexibleAppVersion_update(t *testing.T) {
-	// t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18239")
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -78,6 +77,18 @@ resource "google_project_service" "appengineflex" {
   depends_on = [google_project_service.compute]
 }
 
+resource "google_service_account" "custom_service_account" {
+  project      = google_project_service.service.project
+  account_id   = "{{index $.Vars "account_id"}}"
+  display_name = "Custom Service Account"
+}
+
+resource "google_project_iam_member" "editor" {
+  project = google_project_service.service.project
+  role    = "roles/editor"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
+}
+
 resource "google_compute_network" "network" {
   provider = google-beta
   project                 = google_project_service.compute.project
@@ -136,6 +147,8 @@ resource "google_app_engine_standard_app_version" "foo" {
   }
 
   noop_on_destroy = true
+
+  service_account = google_service_account.custom_service_account.email
 }
 
 resource "google_app_engine_flexible_app_version" "foo" {
@@ -206,6 +219,8 @@ resource "google_app_engine_flexible_app_version" "foo" {
   noop_on_destroy = true
 
   depends_on = [google_app_engine_standard_app_version.foo]
+
+  service_account = google_service_account.custom_service_account.email
 }
 
 resource "google_storage_bucket" "bucket" {
@@ -263,6 +278,18 @@ resource "google_project_service" "appengineflex" {
 
   disable_dependent_services = false
   depends_on = [google_project_service.compute]
+}
+
+resource "google_service_account" "custom_service_account" {
+  project      = google_project_service.service.project
+  account_id   = "{{index $.Vars "account_id"}}"
+  display_name = "Custom Service Account"
+}
+
+resource "google_project_iam_member" "editor" {
+  project = google_project_service.service.project
+  role    = "roles/editor"
+  member  = "serviceAccount:${google_service_account.custom_service_account.email}"
 }
 
 resource "google_compute_network" "network" {
@@ -323,6 +350,8 @@ resource "google_app_engine_standard_app_version" "foo" {
   }
 
   noop_on_destroy = true
+
+  service_account = google_service_account.custom_service_account.email
 }
 
 resource "google_app_engine_flexible_app_version" "foo" {
@@ -393,6 +422,8 @@ resource "google_app_engine_flexible_app_version" "foo" {
   delete_service_on_destroy = true
   
   depends_on = [google_app_engine_standard_app_version.foo]
+
+  service_account = google_service_account.custom_service_account.email
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_flexible_app_version_test.go.tmpl
@@ -283,12 +283,14 @@ resource "google_project_service" "appengineflex" {
 }
 
 resource "google_service_account" "custom_service_account" {
+  provider = google-beta
   project      = google_project_service.service.project
   account_id   = "{{index $.Vars "account_id"}}"
   display_name = "Custom Service Account"
 }
 
 resource "google_project_iam_member" "editor" {
+  provider = google-beta
   project = google_project_service.service.project
   role    = "roles/editor"
   member  = "serviceAccount:${google_service_account.custom_service_account.email}"

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
@@ -21,7 +21,7 @@ func TestAccProjectService_basic(t *testing.T) {
 	acctest.SkipIfVcr(t)
 
 	org := envvar.GetTestOrgFromEnv(t)
-	pid := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	pid := fmt.Sprintf("tf-ftest-%d", acctest.RandInt(t))
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
@@ -21,7 +21,7 @@ func TestAccProjectService_basic(t *testing.T) {
 	acctest.SkipIfVcr(t)
 
 	org := envvar.GetTestOrgFromEnv(t)
-	pid := fmt.Sprintf("tf-ftest-%d", acctest.RandInt(t))
+	pid := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
The new org policy changes no longer grant the App Engine default service account the editor role. In the update test, the service account was missing the Cloud Build Service Account role. Additionally, the service account used in the example test lacked sufficient permissions to pull images from Artifact Registry.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19040, https://github.com/hashicorp/terraform

```release-note:none
```
