### PR TITLE
Update examples for mirroring and intercept security profiles to use google provider.

### DIFF
--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -58,7 +58,6 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
   - name: 'network_security_security_profile_mirroring'
-    min_version: 'beta'
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-security-profile'
@@ -68,7 +67,6 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
   - name: 'network_security_security_profile_intercept'
-    min_version: 'beta'
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-security-profile'

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -50,7 +50,6 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
   - name: 'network_security_security_profile_group_mirroring'
-    min_version: 'beta'
     primary_resource_id: 'default'
     vars:
       network_name: 'network'
@@ -61,7 +60,6 @@ examples:
     test_env_vars:
       org_id: 'ORG_ID'
   - name: 'network_security_security_profile_group_intercept'
-    min_version: 'beta'
     primary_resource_id: 'default'
     vars:
       network_name: 'network'

--- a/mmv1/templates/terraform/examples/network_security_security_profile_group_intercept.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_group_intercept.tf.tmpl
@@ -1,25 +1,21 @@
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "default" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "default" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.default.id
+  intercept_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.default.id
 }
 
 resource "google_network_security_security_profile" "default" {
-  provider    = google-beta
   name        = "{{index $.Vars "security_profile_name"}}"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   description = "my description"
@@ -31,7 +27,6 @@ resource "google_network_security_security_profile" "default" {
 }
 
 resource "google_network_security_security_profile_group" "{{$.PrimaryResourceId}}" {
-  provider                 = google-beta
   name                     = "{{index $.Vars "security_profile_group_name"}}"
   parent                   = "organizations/{{index $.TestEnvVars "org_id"}}"
   description              = "my description"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_group_mirroring.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_group_mirroring.tf.tmpl
@@ -1,25 +1,21 @@
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "default" {
-  provider                      = google-beta
   mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
   location                      = "global"
   mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
 }
 
 resource "google_network_security_security_profile" "default" {
-  provider    = google-beta
   name        = "{{index $.Vars "security_profile_name"}}"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   description = "my description"
@@ -31,7 +27,6 @@ resource "google_network_security_security_profile" "default" {
 }
 
 resource "google_network_security_security_profile_group" "{{$.PrimaryResourceId}}" {
-  provider                 = google-beta
   name                     = "{{index $.Vars "security_profile_group_name"}}"
   parent                   = "organizations/{{index $.TestEnvVars "org_id"}}"
   description              = "my description"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_intercept.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_intercept.tf.tmpl
@@ -1,25 +1,21 @@
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "default" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "default" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.default.id
+  intercept_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.default.id
 }
 
 resource "google_network_security_security_profile" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.Vars "resource_name"}}"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   description = "my description"

--- a/mmv1/templates/terraform/examples/network_security_security_profile_mirroring.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_security_profile_mirroring.tf.tmpl
@@ -1,25 +1,21 @@
 resource "google_compute_network" "default" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_mirroring_deployment_group" "default" {
-  provider                      = google-beta
   mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.default.id
 }
 
 resource "google_network_security_mirroring_endpoint_group" "default" {
-  provider                      = google-beta
-  mirroring_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
-  location                      = "global"
-  mirroring_deployment_group    = google_network_security_mirroring_deployment_group.default.id
+  mirroring_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  mirroring_deployment_group  = google_network_security_mirroring_deployment_group.default.id
 }
 
 resource "google_network_security_security_profile" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   name        = "{{index $.Vars "resource_name"}}"
   parent      = "organizations/{{index $.TestEnvVars "org_id"}}"
   description = "my description"


### PR DESCRIPTION
APIs have already been promoted to V1 and the resources in terraform have already been promoted to google provider.
This PR updates the examples which are still referencing the google-beta provider.

```release-note:none

```
