### PR TITLE
Adding desired_auto_created_endpoints Virtual field to Memorystore instance

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -104,6 +104,8 @@ virtual_fields:
     description: "Please use desired_auto_created_endpoints "
     type: Array
     immutable: true
+    conflicts:
+      - desired_auto_created_endpoints
     item_type:
       type: NestedObject
       properties:
@@ -124,6 +126,8 @@ virtual_fields:
       endpoints connections. "
     type: Array
     immutable: true
+    conflicts:
+      - desired_psc_auto_connections
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -102,7 +102,7 @@ examples:
 virtual_fields:
   - name: 'desired_psc_auto_connections'
     description: "Immutable. User inputs for the auto-created PSC connections. "
-    deprecation_message: '`desired_psc_auto_connections` is deprecated and will be removed in a future major release. Use `desired_auto_created_endpoints` instead.'
+    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead.'
     type: Array
     immutable: true
     conflicts:
@@ -282,6 +282,7 @@ properties:
     description:
       "Output only. Endpoints clients can connect to the instance through.
       Currently only one\ndiscovery endpoint is supported. "
+    deprecation_message: '`discovery_endpoints` is deprecated  Use `endpoints` instead.'
     output: true
     item_type:
       type: NestedObject
@@ -700,6 +701,7 @@ properties:
     description:
       "Output only. User inputs and resource details of the auto-created
       PSC connections. "
+    deprecation_message: '`psc_auto_connections` is deprecated  Use `endpoints.connections.pscAutoConnections` instead.'
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -101,8 +101,7 @@ examples:
       'secondary_instance_prevent_destroy': 'false'
 virtual_fields:
   - name: 'desired_psc_auto_connections'
-    description: "Immutable. User inputs for the auto-created
-      PSC connections. "
+    description: "Please use desired_auto_created_endpoints "
     type: Array
     immutable: true
     item_type:
@@ -141,7 +140,6 @@ virtual_fields:
             the form of\nprojects/{project_id}/global/networks/{network_id}. "
           required: true
 parameters:
-  
   - name: 'location'
     type: String
     description:
@@ -507,7 +505,7 @@ properties:
   - name: 'endpoints'
     type: Array
     description: "Endpoints for the instance."
-    # output: true
+    output: true
     item_type:
       type: NestedObject
       properties:
@@ -542,13 +540,13 @@ properties:
                     description:
                       "Output only. The consumer project_id where the forwarding rule is
                       created from. "
-                    # output: true
+                    output: true
                   - name: 'network'
                     type: String
                     description:
                       "Output only. The consumer network where the IP address resides, in
                       the form of\nprojects/{project_id}/global/networks/{network_id}. "
-                    # output: true
+                    output: true
                   - name: 'serviceAttachment'
                     type: String
                     description:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -101,11 +101,12 @@ examples:
       'secondary_instance_prevent_destroy': 'false'
 virtual_fields:
   - name: 'desired_psc_auto_connections'
-    description: "Please use desired_auto_created_endpoints "
+    description: "Immutable. User inputs for the auto-created PSC connections. "
+    deprecation_message: '`desired_psc_auto_connections` is deprecated and will be removed in a future major release. Use `desired_auto_created_endpoints` instead.'
     type: Array
     immutable: true
     conflicts:
-      - desired_auto_created_endpoints
+      - desiredAutoCreatedEndpoints
     item_type:
       type: NestedObject
       properties:
@@ -125,9 +126,10 @@ virtual_fields:
     description: "Immutable. User inputs for the auto-created
       endpoints connections. "
     type: Array
+    # is_set: true
     immutable: true
     conflicts:
-      - desired_psc_auto_connections
+      - desiredPscAutoConnections
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -120,7 +120,28 @@ virtual_fields:
             "Required. The consumer network where the IP address resides, in
             the form of\nprojects/{project_id}/global/networks/{network_id}. "
           required: true
+  - name: 'desired_auto_created_endpoints'
+    description: "Immutable. User inputs for the auto-created
+      endpoints connections. "
+    type: Array
+    immutable: true
+    item_type:
+      type: NestedObject
+      properties:
+        - type: String
+          name: project_id
+          description:
+            "Required. The consumer project_id where the forwarding rule is
+            created from. "
+          required: true
+        - type: String
+          name: network
+          description:
+            "Required. The consumer network where the IP address resides, in
+            the form of\nprojects/{project_id}/global/networks/{network_id}. "
+          required: true
 parameters:
+  
   - name: 'location'
     type: String
     description:
@@ -486,7 +507,7 @@ properties:
   - name: 'endpoints'
     type: Array
     description: "Endpoints for the instance."
-    output: true
+    # output: true
     item_type:
       type: NestedObject
       properties:
@@ -521,13 +542,13 @@ properties:
                     description:
                       "Output only. The consumer project_id where the forwarding rule is
                       created from. "
-                    output: true
+                    # output: true
                   - name: 'network'
                     type: String
                     description:
                       "Output only. The consumer network where the IP address resides, in
                       the form of\nprojects/{project_id}/global/networks/{network_id}. "
-                    output: true
+                    # output: true
                   - name: 'serviceAttachment'
                     type: String
                     description:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -101,7 +101,7 @@ examples:
       'secondary_instance_prevent_destroy': 'false'
 virtual_fields:
   - name: 'desired_psc_auto_connections'
-    description: "Immutable. User inputs for the auto-created PSC connections. "
+    description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead."
     deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead.'
     type: Array
     immutable: true

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -42,4 +42,58 @@ for _, raw := range connections {
 }
 
 d.Set("desired_psc_auto_connections", transformed)
+
+// Retrieve endpoints.connections.pscAutoConnection from API response
+endpoints, ok := res["endpoints"]
+if ok {
+	endpointsArray, ok := endpoints.([]interface{})
+	if !ok || len(endpointsArray) == 0 {
+		// No endpoints or empty array, nothing to process
+	} else {
+		transformed := make([]interface{}, 0)
+		uniqueEndpoints := make(map[string]bool) // Track unique project+network combos
+		
+		for _, endpoint := range endpointsArray {
+			endpointData, ok := endpoint.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			
+			connections, ok := endpointData["connections"].([]interface{})
+			if !ok {
+				continue
+			}
+			
+			for _, connection := range connections {
+				connectionData, ok := connection.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				
+				pscAutoConnection, ok := connectionData["pscAutoConnection"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				
+				projectID, projectOk := pscAutoConnection["projectId"].(string)
+				networkID, networkOk := pscAutoConnection["network"].(string)
+				
+				if projectOk && networkOk {
+					uniqueKey := projectID + networkID
+					if !uniqueEndpoints[uniqueKey] { // Check for uniqueness
+						uniqueEndpoints[uniqueKey] = true
+						transformed = append(transformed, map[string]interface{}{
+							"project_id": projectID,
+							"network":    networkID,
+						})
+					}
+				}
+			}
+		}
+		
+		if len(transformed) > 0 {
+			d.Set("desired_auto_created_endpoints", transformed)
+		}
+	}
+}
 return res, nil

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -4,44 +4,44 @@ if !ok {
 	if _, endpointsFound := res["endpoints"]; endpointsFound {
 		return res, nil // For Cluster Disabled instances, we would have 'endpoints' instead of 'pscAutoConnections'
 	}
-	return res, nil
 }
-
-connections, ok := v.([]interface{})
-if !ok {
-	return nil, fmt.Errorf("pscAutoConnections is not an array")
-}
-
-transformed := make([]interface{}, 0, len(connections))
-uniqueConnections := make(map[string]bool) // Track unique project+network combos
-
-for _, raw := range connections {
-	connectionData, ok := raw.(map[string]interface{})
-	if !ok || len(connectionData) < 1 {
-		return nil, fmt.Errorf("Invalid or empty psc connection data: %v", raw)
-	}
-
-	projectID, ok := connectionData["projectId"].(string)
+if ok {
+	connections, ok := v.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("invalid project ID in psc connection: %v", connectionData)
+		return nil, fmt.Errorf("pscAutoConnections is not an array")
 	}
 
-	networkID, ok := connectionData["network"].(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid network ID in psc connection: %v", connectionData)
+	transformed := make([]interface{}, 0, len(connections))
+	uniqueConnections := make(map[string]bool) // Track unique project+network combos
+
+	for _, raw := range connections {
+		connectionData, ok := raw.(map[string]interface{})
+		if !ok || len(connectionData) < 1 {
+			return nil, fmt.Errorf("Invalid or empty psc connection data: %v", raw)
+		}
+
+		projectID, ok := connectionData["projectId"].(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid project ID in psc connection: %v", connectionData)
+		}
+
+		networkID, ok := connectionData["network"].(string)
+		if !ok {
+			return nil, fmt.Errorf("invalid network ID in psc connection: %v", connectionData)
+		}
+
+		uniqueKey := projectID + networkID
+		if !uniqueConnections[uniqueKey] { // Check for uniqueness
+			uniqueConnections[uniqueKey] = true
+			transformed = append(transformed, map[string]interface{}{
+				"project_id": projectID,
+				"network":    networkID,
+			})
+		}
 	}
 
-	uniqueKey := projectID + networkID
-	if !uniqueConnections[uniqueKey] { // Check for uniqueness
-		uniqueConnections[uniqueKey] = true
-		transformed = append(transformed, map[string]interface{}{
-			"project_id": projectID,
-			"network":    networkID,
-		})
-	}
+	d.Set("desired_psc_auto_connections", transformed)
 }
-
-d.Set("desired_psc_auto_connections", transformed)
 
 // Retrieve endpoints.connections.pscAutoConnection from API response
 endpoints, ok := res["endpoints"]

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -1,10 +1,5 @@
 // Retrieve pscAutoConnections from API response
 v, ok := res["pscAutoConnections"]
-if !ok {
-	if _, endpointsFound := res["endpoints"]; endpointsFound {
-		return res, nil // For Cluster Disabled instances, we would have 'endpoints' instead of 'pscAutoConnections'
-	}
-}
 if ok {
 	connections, ok := v.([]interface{})
 	if !ok {
@@ -90,8 +85,8 @@ if ok {
 				}
 			}
 		}
-		log.Printf("[DEBUG] FYou are in Decode and printing this for transformed %#v", transformed)
 		if len(transformed) > 0 {
+			log.Printf("[DEBUG] Setting desired_auto_created_endpoints for %#v", transformed)
 			d.Set("desired_auto_created_endpoints", transformed)
 		}
 	}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -90,7 +90,7 @@ if ok {
 				}
 			}
 		}
-		
+		log.Printf("[DEBUG] FYou are in Decode and printing this for transformed %#v", transformed)
 		if len(transformed) > 0 {
 			d.Set("desired_auto_created_endpoints", transformed)
 		}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -1,94 +1,97 @@
-// Retrieve pscAutoConnections from API response
-v, ok := res["pscAutoConnections"]
-if ok {
-	connections, ok := v.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("pscAutoConnections is not an array")
-	}
+    // Retrieve endpoints.connections.pscAutoConnection from API response
+	v, ok := res["pscAutoConnections"]
+	if ok {
 
-	transformed := make([]interface{}, 0, len(connections))
-	uniqueConnections := make(map[string]bool) // Track unique project+network combos
-
-	for _, raw := range connections {
-		connectionData, ok := raw.(map[string]interface{})
-		if !ok || len(connectionData) < 1 {
-			return nil, fmt.Errorf("Invalid or empty psc connection data: %v", raw)
-		}
-
-		projectID, ok := connectionData["projectId"].(string)
+		connections, ok := v.([]interface{})
 		if !ok {
-			return nil, fmt.Errorf("invalid project ID in psc connection: %v", connectionData)
+			return nil, fmt.Errorf("pscAutoConnections is not an array")
 		}
 
-		networkID, ok := connectionData["network"].(string)
-		if !ok {
-			return nil, fmt.Errorf("invalid network ID in psc connection: %v", connectionData)
-		}
+		transformed := make([]interface{}, 0, len(connections))
+		uniqueConnections := make(map[string]bool) // Track unique project+network combos
 
-		uniqueKey := projectID + networkID
-		if !uniqueConnections[uniqueKey] { // Check for uniqueness
-			uniqueConnections[uniqueKey] = true
-			transformed = append(transformed, map[string]interface{}{
-				"project_id": projectID,
-				"network":    networkID,
-			})
-		}
-	}
-
-	d.Set("desired_psc_auto_connections", transformed)
-}
-
-// Retrieve endpoints.connections.pscAutoConnection from API response
-endpoints, ok := res["endpoints"]
-if ok {
-	endpointsArray, ok := endpoints.([]interface{})
-	if !ok || len(endpointsArray) == 0 {
-		// No endpoints or empty array, nothing to process
-	} else {
-		transformed := make([]interface{}, 0)
-		uniqueEndpoints := make(map[string]bool) // Track unique project+network combos
-		
-		for _, endpoint := range endpointsArray {
-			endpointData, ok := endpoint.(map[string]interface{})
-			if !ok {
-				continue
+		for _, raw := range connections {
+			connectionData, ok := raw.(map[string]interface{})
+			if !ok || len(connectionData) < 1 {
+				return nil, fmt.Errorf("Invalid or empty psc connection data: %v", raw)
 			}
-			
-			connections, ok := endpointData["connections"].([]interface{})
+
+			projectID, ok := connectionData["projectId"].(string)
 			if !ok {
-				continue
+				return nil, fmt.Errorf("invalid project ID in psc connection: %v", connectionData)
 			}
-			
-			for _, connection := range connections {
-				connectionData, ok := connection.(map[string]interface{})
+
+			networkID, ok := connectionData["network"].(string)
+			if !ok {
+				return nil, fmt.Errorf("invalid network ID in psc connection: %v", connectionData)
+			}
+
+			uniqueKey := projectID + networkID
+			if !uniqueConnections[uniqueKey] { // Check for uniqueness
+				uniqueConnections[uniqueKey] = true
+				transformed = append(transformed, map[string]interface{}{
+					"project_id": projectID,
+					"network":    networkID,
+				})
+			}
+		}
+		d.Set("desired_psc_auto_connections", transformed)
+		log.Printf("[DEBUG] You are setting desired_psc_auto_connections in decoder %#v", transformed)
+
+	// Retrieve pscAutoConnections from API response
+	} else if v, ok := res["endpoints"]; ok {
+
+		endpointsArray, ok := v.([]interface{})
+		if !ok || len(endpointsArray) == 0 {
+			// No endpoints or empty array, nothing to process
+		} else {
+			transformed := make([]interface{}, 0)
+			uniqueEndpoints := make(map[string]bool) // Track unique project+network combos
+
+			for _, endpoint := range endpointsArray {
+				endpointData, ok := endpoint.(map[string]interface{})
 				if !ok {
 					continue
 				}
-				
-				pscAutoConnection, ok := connectionData["pscAutoConnection"].(map[string]interface{})
+
+				connections, ok := endpointData["connections"].([]interface{})
 				if !ok {
 					continue
 				}
-				
-				projectID, projectOk := pscAutoConnection["projectId"].(string)
-				networkID, networkOk := pscAutoConnection["network"].(string)
-				
-				if projectOk && networkOk {
-					uniqueKey := projectID + networkID
-					if !uniqueEndpoints[uniqueKey] { // Check for uniqueness
-						uniqueEndpoints[uniqueKey] = true
-						transformed = append(transformed, map[string]interface{}{
-							"project_id": projectID,
-							"network":    networkID,
-						})
+
+				for _, connection := range connections {
+					connectionData, ok := connection.(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					pscAutoConnection, ok := connectionData["pscAutoConnection"].(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					projectID, projectOk := pscAutoConnection["projectId"].(string)
+					networkID, networkOk := pscAutoConnection["network"].(string)
+
+					if projectOk && networkOk {
+						uniqueKey := projectID + networkID
+						if !uniqueEndpoints[uniqueKey] { // Check for uniqueness
+							uniqueEndpoints[uniqueKey] = true
+							transformed = append(transformed, map[string]interface{}{
+								"project_id": projectID,
+								"network":    networkID,
+							})
+						}
 					}
 				}
 			}
+			if len(transformed) > 0 {
+				d.Set("desired_auto_created_endpoints", transformed)
+				log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder for %#v", transformed)
+
+			}
 		}
-		if len(transformed) > 0 {
-			log.Printf("[DEBUG] Setting desired_auto_created_endpoints for %#v", transformed)
-			d.Set("desired_auto_created_endpoints", transformed)
-		}
+
 	}
-}
-return res, nil
+
+	return res, nil

--- a/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
@@ -1,72 +1,73 @@
-v, ok := d.GetOk("desired_psc_auto_connections")
+	// Handles desired_auto_created_endpoints virtual field
+	v, ok := d.GetOk("desired_auto_created_endpoints")
+	if ok {
+		l := v.([]interface{})
+		if len(l) > 0 {
+			endpoints := make([]interface{}, 1)
+			endpointObj := make(map[string]interface{})
+			connections := make([]interface{}, 0, len(l))
 
-if ok {
-    l := v.([]interface{})
-    req := make([]interface{}, 0, len(l))
-    for _, raw := range l {
-        if raw == nil {
-            continue
-        }
-        desiredConnection := raw.(map[string]interface{})
-        connectionReq := make(map[string]interface{})
+			for _, raw := range l {
+				if raw == nil {
+					continue
+				}
+				desiredEndpoint := raw.(map[string]interface{})
+				connectionObj := make(map[string]interface{})
+				pscAutoConnection := make(map[string]interface{})
 
-        projectId := desiredConnection["project_id"]
-        if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-            connectionReq["projectId"] = projectId
-        }
+				projectId := desiredEndpoint["project_id"]
+				if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+					pscAutoConnection["projectId"] = projectId
+				}
 
-        network := desiredConnection["network"]
-        if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-            connectionReq["network"] = network
-        }
+				network := desiredEndpoint["network"]
+				if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+					pscAutoConnection["network"] = network
+				}
 
-        req = append(req, connectionReq)
-    }
+				connectionObj["pscAutoConnection"] = pscAutoConnection
+				connections = append(connections, connectionObj)
+			}
 
-    obj["pscAutoConnections"] = req
-}
+			endpointObj["connections"] = connections
+			endpoints[0] = endpointObj
+			obj["endpoints"] = endpoints
+			log.Printf("[DEBUG] You are setting desired_auto_created_endpoints in encoder %#v", endpoints)
 
-// Handle desired_auto_created_endpoints virtual field
-v, ok = d.GetOk("desired_auto_created_endpoints")
-if ok {
-    l := v.([]interface{})
-    if len(l) > 0 {
-        endpoints := make([]interface{}, 1)
-        endpointObj := make(map[string]interface{})
-        connections := make([]interface{}, 0, len(l))
-        
-        for _, raw := range l {
-            if raw == nil {
-                continue
-            }
-            desiredEndpoint := raw.(map[string]interface{})
-            connectionObj := make(map[string]interface{})
-            pscAutoConnection := make(map[string]interface{})
-            
-            projectId := desiredEndpoint["project_id"]
-            if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-                pscAutoConnection["projectId"] = projectId
-            }
-            
-            network := desiredEndpoint["network"]
-            if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-                pscAutoConnection["network"] = network
-            }
-            
-            connectionObj["pscAutoConnection"] = pscAutoConnection
-            connections = append(connections, connectionObj)
-        }
-        
-        endpointObj["connections"] = connections
-        endpoints[0] = endpointObj
-        obj["endpoints"] = endpoints
-    }
-}
-//  If the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
-if obj["automatedBackupConfig"] == nil {
-    config := meta.(*transport_tpg.Config)
-    automatedBackupConfigProp, _ := expandMemorystoreInstanceAutomatedBackupConfig(d.Get("automated_backup_config"), d, config)
-    obj["automatedBackupConfig"] = automatedBackupConfigProp
-}
-return obj, nil
+		}
+	// Handles desired_auto_created_endpoints virtual field 
+	} else if v, ok := d.GetOk("desired_psc_auto_connections"); ok {
+		l := v.([]interface{})
+		req := make([]interface{}, 0, len(l))
+		for _, raw := range l {
+			if raw == nil {
+				continue
+			}
+			desiredConnection := raw.(map[string]interface{})
+			connectionReq := make(map[string]interface{})
 
+			projectId := desiredConnection["project_id"]
+			if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+				connectionReq["projectId"] = projectId
+			}
+
+			network := desiredConnection["network"]
+			if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+				connectionReq["network"] = network
+			}
+
+			req = append(req, connectionReq)
+		}
+
+		obj["pscAutoConnections"] = req
+		log.Printf("[DEBUG] You are setting desired_psc_auto_connections in encoder  %#v", req)
+
+	}
+
+	// If the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
+	if obj["automatedBackupConfig"] == nil {
+		config := meta.(*transport_tpg.Config)
+		automatedBackupConfigProp, _ := expandMemorystoreInstanceAutomatedBackupConfig(d.Get("automated_backup_config"), d, config)
+		obj["automatedBackupConfig"] = automatedBackupConfigProp
+	}
+    return obj, nil

--- a/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
@@ -1,30 +1,30 @@
 v, ok := d.GetOk("desired_psc_auto_connections")
-if !ok {
-    return obj, nil // No desired connections, nothing to update
+
+if ok {
+    l := v.([]interface{})
+    req := make([]interface{}, 0, len(l))
+    for _, raw := range l {
+        if raw == nil {
+            continue
+        }
+        desiredConnection := raw.(map[string]interface{})
+        connectionReq := make(map[string]interface{})
+
+        projectId := desiredConnection["project_id"]
+        if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+            connectionReq["projectId"] = projectId
+        }
+
+        network := desiredConnection["network"]
+        if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+            connectionReq["network"] = network
+        }
+
+        req = append(req, connectionReq)
+    }
+
+    obj["pscAutoConnections"] = req
 }
-l := v.([]interface{})
-req := make([]interface{}, 0, len(l))
-for _, raw := range l {
-    if raw == nil {
-        continue
-    }
-    desiredConnection := raw.(map[string]interface{})
-    connectionReq := make(map[string]interface{})
-
-    projectId := desiredConnection["project_id"]
-    if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-        connectionReq["projectId"] = projectId
-    }
-
-    network := desiredConnection["network"]
-    if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-        connectionReq["network"] = network
-    }
-
-    req = append(req, connectionReq)
-}
-
-obj["pscAutoConnections"] = req
 
 // Handle desired_auto_created_endpoints virtual field
 v, ok = d.GetOk("desired_auto_created_endpoints")
@@ -62,7 +62,6 @@ if ok {
         obj["endpoints"] = endpoints
     }
 }
-
 //  If the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
 if obj["automatedBackupConfig"] == nil {
     config := meta.(*transport_tpg.Config)
@@ -70,3 +69,4 @@ if obj["automatedBackupConfig"] == nil {
     obj["automatedBackupConfig"] = automatedBackupConfigProp
 }
 return obj, nil
+

--- a/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
@@ -26,190 +26,47 @@ for _, raw := range l {
 
 obj["pscAutoConnections"] = req
 
-//  if the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
+// Handle desired_auto_created_endpoints virtual field
+v, ok = d.GetOk("desired_auto_created_endpoints")
+if ok {
+    l := v.([]interface{})
+    if len(l) > 0 {
+        endpoints := make([]interface{}, 1)
+        endpointObj := make(map[string]interface{})
+        connections := make([]interface{}, 0, len(l))
+        
+        for _, raw := range l {
+            if raw == nil {
+                continue
+            }
+            desiredEndpoint := raw.(map[string]interface{})
+            connectionObj := make(map[string]interface{})
+            pscAutoConnection := make(map[string]interface{})
+            
+            projectId := desiredEndpoint["project_id"]
+            if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+                pscAutoConnection["projectId"] = projectId
+            }
+            
+            network := desiredEndpoint["network"]
+            if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+                pscAutoConnection["network"] = network
+            }
+            
+            connectionObj["pscAutoConnection"] = pscAutoConnection
+            connections = append(connections, connectionObj)
+        }
+        
+        endpointObj["connections"] = connections
+        endpoints[0] = endpointObj
+        obj["endpoints"] = endpoints
+    }
+}
+
+//  If the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
 if obj["automatedBackupConfig"] == nil {
     config := meta.(*transport_tpg.Config)
     automatedBackupConfigProp, _ := expandMemorystoreInstanceAutomatedBackupConfig(d.Get("automated_backup_config"), d, config)
     obj["automatedBackupConfig"] = automatedBackupConfigProp
 }
 return obj, nil
-
-
-v, ok := d.GetOk("desired_auto_created_endpoints")
-if !ok {
-    return obj, nil // No desired connections, nothing to update
-}
-l := v.([]interface{})
-req := make([]interface{}, 0, len(l))
-for _, raw := range l {
-    if raw == nil {
-        continue
-    }
-    originalDesiredEndpoints := raw.(map[string]interface{})
-    transformedConnectionReq := make(map[string]interface{})
-
-    projectId := originalDesiredEndpoints["project_id"]
-    network := originalDesiredEndpoints["network"]
-
-
-
-
-    if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-        transformedConnectionReq["projectId"] = projectId
-    }
-
-    if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-        transformedConnectionReq["network"] = network
-    }
-
-    req = append(req, connectionReq)
-}
-
-
-
-
-func expandMemorystoreInstanceEndpoints(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	l := v.([]interface{})
-	req := make([]interface{}, 0, len(l))
-	for _, raw := range l {
-		if raw == nil {
-			continue
-		}
-		original := raw.(map[string]interface{})
-		transformed := make(map[string]interface{})
-
-		transformedConnections, err := expandMemorystoreInstanceEndpointsConnections(original["connections"], d, config)
-		if err != nil {
-			return nil, err
-		} else if val := reflect.ValueOf(transformedConnections); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-			transformed["connections"] = transformedConnections
-		}
-
-		req = append(req, transformed)
-	}
-	return req, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnections(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	l := v.([]interface{})
-	req := make([]interface{}, 0, len(l))
-	for _, raw := range l {
-		if raw == nil {
-			continue
-		}
-		original := raw.(map[string]interface{})
-		transformed := make(map[string]interface{})
-
-		transformedPscAutoConnection, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnection(original["psc_auto_connection"], d, config)
-		if err != nil {
-			return nil, err
-		} else if val := reflect.ValueOf(transformedPscAutoConnection); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-			transformed["pscAutoConnection"] = transformedPscAutoConnection
-		}
-
-		req = append(req, transformed)
-	}
-	return req, nil
-}
-
-
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnection(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	l := v.([]interface{})
-	if len(l) == 0 || l[0] == nil {
-		return nil, nil
-	}
-	raw := l[0]
-	original := raw.(map[string]interface{})
-	transformed := make(map[string]interface{})
-
-	transformedPscConnectionId, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPscConnectionId(original["psc_connection_id"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedPscConnectionId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["pscConnectionId"] = transformedPscConnectionId
-	}
-
-	transformedIpAddress, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionIpAddress(original["ip_address"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedIpAddress); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["ipAddress"] = transformedIpAddress
-	}
-
-	transformedForwardingRule, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionForwardingRule(original["forwarding_rule"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedForwardingRule); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["forwardingRule"] = transformedForwardingRule
-	}
-
-	transformedProjectId, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionProjectId(original["project_id"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedProjectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["projectId"] = transformedProjectId
-	}
-
-	transformedNetwork, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionNetwork(original["network"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedNetwork); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["network"] = transformedNetwork
-	}
-
-	transformedServiceAttachment, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionServiceAttachment(original["service_attachment"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedServiceAttachment); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["serviceAttachment"] = transformedServiceAttachment
-	}
-
-	transformedConnectionType, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionConnectionType(original["connection_type"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedConnectionType); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["connectionType"] = transformedConnectionType
-	}
-
-	transformedPort, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPort(original["port"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedPort); val.IsValid() && !tpgresource.IsEmptyValue(val) {
-		transformed["port"] = transformedPort
-	}
-
-	return transformed, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPscConnectionId(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionIpAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionForwardingRule(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionProjectId(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionNetwork(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionServiceAttachment(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionConnectionType(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPort(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	return v, nil
-}

--- a/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/memorystore_instance.go.tmpl
@@ -25,6 +25,7 @@ for _, raw := range l {
 }
 
 obj["pscAutoConnections"] = req
+
 //  if the automated_backup_config is not defined, automatedBackupMode needs to be passed and set to DISABLED in the expand
 if obj["automatedBackupConfig"] == nil {
     config := meta.(*transport_tpg.Config)
@@ -32,3 +33,183 @@ if obj["automatedBackupConfig"] == nil {
     obj["automatedBackupConfig"] = automatedBackupConfigProp
 }
 return obj, nil
+
+
+v, ok := d.GetOk("desired_auto_created_endpoints")
+if !ok {
+    return obj, nil // No desired connections, nothing to update
+}
+l := v.([]interface{})
+req := make([]interface{}, 0, len(l))
+for _, raw := range l {
+    if raw == nil {
+        continue
+    }
+    originalDesiredEndpoints := raw.(map[string]interface{})
+    transformedConnectionReq := make(map[string]interface{})
+
+    projectId := originalDesiredEndpoints["project_id"]
+    network := originalDesiredEndpoints["network"]
+
+
+
+
+    if val := reflect.ValueOf(projectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+        transformedConnectionReq["projectId"] = projectId
+    }
+
+    if val := reflect.ValueOf(network); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+        transformedConnectionReq["network"] = network
+    }
+
+    req = append(req, connectionReq)
+}
+
+
+
+
+func expandMemorystoreInstanceEndpoints(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		original := raw.(map[string]interface{})
+		transformed := make(map[string]interface{})
+
+		transformedConnections, err := expandMemorystoreInstanceEndpointsConnections(original["connections"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedConnections); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+			transformed["connections"] = transformedConnections
+		}
+
+		req = append(req, transformed)
+	}
+	return req, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnections(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		original := raw.(map[string]interface{})
+		transformed := make(map[string]interface{})
+
+		transformedPscAutoConnection, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnection(original["psc_auto_connection"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedPscAutoConnection); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+			transformed["pscAutoConnection"] = transformedPscAutoConnection
+		}
+
+		req = append(req, transformed)
+	}
+	return req, nil
+}
+
+
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnection(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedPscConnectionId, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPscConnectionId(original["psc_connection_id"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedPscConnectionId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["pscConnectionId"] = transformedPscConnectionId
+	}
+
+	transformedIpAddress, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionIpAddress(original["ip_address"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedIpAddress); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["ipAddress"] = transformedIpAddress
+	}
+
+	transformedForwardingRule, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionForwardingRule(original["forwarding_rule"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedForwardingRule); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["forwardingRule"] = transformedForwardingRule
+	}
+
+	transformedProjectId, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionProjectId(original["project_id"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedProjectId); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["projectId"] = transformedProjectId
+	}
+
+	transformedNetwork, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionNetwork(original["network"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedNetwork); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["network"] = transformedNetwork
+	}
+
+	transformedServiceAttachment, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionServiceAttachment(original["service_attachment"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedServiceAttachment); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["serviceAttachment"] = transformedServiceAttachment
+	}
+
+	transformedConnectionType, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionConnectionType(original["connection_type"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedConnectionType); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["connectionType"] = transformedConnectionType
+	}
+
+	transformedPort, err := expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPort(original["port"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedPort); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		transformed["port"] = transformedPort
+	}
+
+	return transformed, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPscConnectionId(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionIpAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionForwardingRule(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionProjectId(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionNetwork(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionServiceAttachment(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionConnectionType(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandMemorystoreInstanceEndpointsConnectionsPscAutoConnectionPort(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}

--- a/mmv1/templates/terraform/examples/memorystore_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_basic.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id = "{{index $.Vars "instance_name"}}"
   shard_count = 3
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }

--- a/mmv1/templates/terraform/examples/memorystore_instance_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_basic.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id = "{{index $.Vars "instance_name"}}"
-  shard_count = 3
+  shard_count = 1
   desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id

--- a/mmv1/templates/terraform/examples/memorystore_instance_desired_user_and_auto_created_endpoints.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_desired_user_and_auto_created_endpoints.tf.tmpl
@@ -73,7 +73,7 @@ resource "google_compute_network" "network2" {
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id                 = "{{index $.Vars "instance_name"}}"
   shard_count                 = 1
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                   = google_compute_network.network1.id
     project_id                = data.google_project.project.project_id
   }

--- a/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
@@ -1,12 +1,12 @@
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id = "{{index $.Vars "instance_name"}}"
-  shard_count = 3
-  desired_psc_auto_connections {
+  shard_count = 1
+  desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }
   location                = "us-central1"
-  replica_count           = 2
+  replica_count           = 1
   node_type               = "SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_DISABLED"
   authorization_mode      = "AUTH_DISABLED"

--- a/mmv1/templates/terraform/examples/memorystore_instance_persistence_aof.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_persistence_aof.tf.tmpl
@@ -1,7 +1,7 @@
 resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   instance_id = "{{index $.Vars "instance_name"}}"
-  shard_count = 3
-  desired_psc_auto_connections {
+  shard_count = 1
+  desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }

--- a/mmv1/templates/terraform/examples/memorystore_instance_secondary_instance.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_secondary_instance.tf.tmpl
@@ -2,7 +2,7 @@
 resource "google_memorystore_instance" "primary_instance" {
   instance_id                    = "{{index $.Vars "primary_instance_name"}}"
   shard_count                    = 1
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                      = google_compute_network.primary_producer_net.id
     project_id                   = data.google_project.project.project_id
   }
@@ -63,7 +63,7 @@ resource "google_compute_network" "primary_producer_net" {
 resource "google_memorystore_instance" "secondary_instance" {
   instance_id                    = "{{index $.Vars "secondary_instance_name"}}"
   shard_count                    = 1
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                      = google_compute_network.secondary_producer_net.id
     project_id                   = data.google_project.project.project_id
   }

--- a/mmv1/templates/terraform/examples/memorystore_instance_standalone_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_standalone_full.tf.tmpl
@@ -2,12 +2,12 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   provider    = google-beta
   instance_id = "{{index $.Vars "instance_name"}}"
   shard_count = 1
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network    = google_compute_network.producer_net.id
     project_id = data.google_project.project.project_id
   }
   location                = "us-central1"
-  replica_count           = 2
+  replica_count           = 1
   node_type               = "SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_DISABLED"
   authorization_mode      = "AUTH_DISABLED"

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
@@ -32,7 +32,7 @@ func testAccMemorystoreInstanceDatasourceConfig(context map[string]interface{}) 
 resource "google_memorystore_instance" "instance-basic" {
   instance_id                 = "tf-test-memorystore-instance%{random_suffix}"
   shard_count                 = 1
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                   = google_compute_network.producer_net.id
     project_id                = data.google_project.project.project_id
   }

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
@@ -31,7 +31,7 @@ func testAccMemorystoreInstanceDatasourceConfig(context map[string]interface{}) 
 	return acctest.Nprintf(`
 resource "google_memorystore_instance" "instance-basic" {
   instance_id                 = "tf-test-memorystore-instance%{random_suffix}"
-  shard_count                 = 3
+  shard_count                 = 1
   desired_psc_auto_connections {
     network                   = google_compute_network.producer_net.id
     project_id                = data.google_project.project.project_id
@@ -52,7 +52,6 @@ resource "google_network_connectivity_service_connection_policy" "default" {
     subnetworks               = [google_compute_subnetwork.producer_subnet.id]
   }
 }
-
 
 resource "google_compute_subnetwork" "producer_subnet" {
 	name                      = "%{network_name}-sn"

--- a/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/data_source_memorystore_instance_test.go
@@ -12,7 +12,6 @@ func TestAccMemorystoreInstanceDatasourceConfig(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "memorystore-instance-ds"),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -22,6 +21,9 @@ func TestAccMemorystoreInstanceDatasourceConfig(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMemorystoreInstanceDatasourceConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_memorystore_instance.default", "google_memorystore_instance.instance-basic"),
+				),
 			},
 		},
 	})
@@ -32,46 +34,13 @@ func testAccMemorystoreInstanceDatasourceConfig(context map[string]interface{}) 
 resource "google_memorystore_instance" "instance-basic" {
   instance_id                 = "tf-test-memorystore-instance%{random_suffix}"
   shard_count                 = 1
-  desired_auto_created_endpoints {
-    network                   = google_compute_network.producer_net.id
-    project_id                = data.google_project.project.project_id
-  }
   location                    = "us-central1"
   deletion_protection_enabled = false
-  depends_on                  = [google_network_connectivity_service_connection_policy.default]
-
 }
-
-resource "google_network_connectivity_service_connection_policy" "default" {
-  name                        = "%{network_name}-policy"
-  location                    = "us-central1"
-  service_class               = "gcp-memorystore"
-  description                 = "my basic service connection policy"
-  network                     = google_compute_network.producer_net.id
-  psc_config {
-    subnetworks               = [google_compute_subnetwork.producer_subnet.id]
-  }
-}
-
-resource "google_compute_subnetwork" "producer_subnet" {
-	name                      = "%{network_name}-sn"
-	ip_cidr_range             = "10.0.0.248/29"
-	region                    = "us-central1"
-	network                   = google_compute_network.producer_net.id
-}
-
-resource "google_compute_network" "producer_net" {
-  name                        = "%{network_name}-vpc"
-  auto_create_subnetworks     = false
-}
-
- data "google_project" "project" {
- }
 
 data "google_memorystore_instance" "default" {
   instance_id                 = google_memorystore_instance.instance-basic.instance_id
   location                    = "us-central1"
-
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -93,7 +93,7 @@ resource "google_memorystore_instance" "test_abc" {
   replica_count                  = 0
   node_type                      = "SHARED_CORE_NANO"
   deletion_protection_enabled    = false
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                      = google_compute_network.primary_producer_net.id
     project_id                   = data.google_project.project.project_id
   }
@@ -146,7 +146,7 @@ resource "google_memorystore_instance" "test_abc" {
   replica_count                  = 0
   node_type                      = "SHARED_CORE_NANO"
   deletion_protection_enabled    = false
-  desired_psc_auto_connections {
+  desired_auto_created_endpoints {
     network                      = google_compute_network.primary_producer_net.id
     project_id                   = data.google_project.project.project_id
   }
@@ -1033,7 +1033,7 @@ resource "google_memorystore_instance" "test_secondary" {
 	shard_count = %d
 	node_type = "%s"
 	location         = "us-west2"
-	desired_psc_auto_connections  {
+	desired_auto_created_endpoints  {
 			network = google_compute_network.producer_net.id
             project_id = data.google_project.project.project_id
 	}
@@ -1328,7 +1328,7 @@ resource "google_memorystore_instance" "test" {
 	shard_count = %d
 	node_type = "%s"
 	location         = "us-west2"
-	desired_psc_auto_connections  {
+	desired_auto_created_endpoints  {
 			network = google_compute_network.producer_net.id
             project_id = data.google_project.project.project_id
 	}

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -181,6 +181,75 @@ data "google_project" "project" {
 `, context)
 }
 
+func TestAccMemorystoreInstance_deprecatedDesiredPscAutoConnections(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemorystoreInstance_deprecatedDesiredPscAutoConnections(context),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.test_abc",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccMemorystoreInstance_deprecatedDesiredPscAutoConnections(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+// Primary instance
+resource "google_memorystore_instance" "test_abc" {
+  instance_id                    = "tf-test-instance-abc-%{random_suffix}"
+  shard_count                    = 1
+  location                       = "us-central1"
+  replica_count                  = 0
+  node_type                      = "SHARED_CORE_NANO"
+  deletion_protection_enabled    = false
+  desired_psc_auto_connections {
+    network                      = google_compute_network.primary_producer_net.id
+    project_id                   = data.google_project.project.project_id
+  }
+  depends_on  					 = [ google_network_connectivity_service_connection_policy.primary_policy ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "primary_policy" {
+  name                           = "tf-test-abc-policy-%{random_suffix}"
+  location                       = "us-central1"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.primary_producer_net.id
+  psc_config {                 
+    subnetworks                  = [google_compute_subnetwork.primary_producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "primary_producer_subnet" {
+  name                           = "tf-test-abc-%{random_suffix}"
+  ip_cidr_range                  = "10.0.4.0/29"
+  region                         = "us-central1"
+  network                        = google_compute_network.primary_producer_net.id
+}
+
+resource "google_compute_network" "primary_producer_net" {
+  name                           = "tf-test-abc-net-%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}
+
 // Validate that shard count is updated for the cluster
 func TestAccMemorystoreInstance_updateShardCount(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
memorystore: added field `desired_auto_created_endpoints` for `google_memorystore_instance` resource
```
