### PR TITLE
Feature gap: Add missed fields to `BackendService` and `RegionBackendService`

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -142,6 +142,11 @@ examples:
     vars:
       url_map_name: 'url_map'
     exclude_test: true
+  - name: 'backend_service_dynamic_forwarding'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service'
 parameters:
 properties:
   - name: 'affinityCookieTtlSec'
@@ -1618,3 +1623,52 @@ properties:
           Span of time that's a fraction of a second at nanosecond resolution.
           Durations less than one second are represented with a 0 seconds field and a positive nanos field.
           Must be from 0 to 999,999,999 inclusive.
+  - name: 'networkPassThroughLbTrafficPolicy'
+    type: NestedObject
+    description: |
+      Configures traffic steering properties of internal passthrough Network Load Balancers.
+    min_version: beta
+    properties:
+      - name: 'zonalAffinity'
+        type: NestedObject
+        description: |
+          When configured, new connections are load balanced across healthy backend endpoints in the local zone.
+        properties:
+          - name: 'spillover'
+            type: Enum
+            description: |
+              This field indicates whether zonal affinity is enabled or not.
+            enum_values:
+              - 'ZONAL_AFFINITY_DISABLED'
+              - 'ZONAL_AFFINITY_SPILL_CROSS_ZONE'
+              - 'ZONAL_AFFINITY_STAY_WITHIN_ZONE'
+            default_value: 'ZONAL_AFFINITY_DISABLED'
+            min_version: beta
+          - name: 'spilloverRatio'
+            type: Double
+            description: |
+              The value of the field must be in [0, 1]. When the ratio of the count of healthy backend endpoints in a zone
+              to the count of backend endpoints in that same zone is equal to or above this threshold, the load balancer
+              distributes new connections to all healthy endpoints in the local zone only. When the ratio of the count
+              of healthy backend endpoints in a zone to the count of backend endpoints in that same zone is below this
+              threshold, the load balancer distributes all new connections to all healthy endpoints across all zones.
+            min_version: beta
+  - name: 'dynamicForwarding'
+    type: NestedObject
+    description: |
+      Dynamic forwarding configuration. This field is used to configure the backend service with dynamic forwarding
+      feature which together with Service Extension allows customized and complex routing logic.
+    min_version: beta
+    properties:
+      - name: 'ipPortSelection'
+        type: NestedObject
+        description: |
+          IP:PORT based dynamic forwarding configuration.
+        min_version: beta
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            min_version: beta
+            description: |
+              A boolean flag enabling IP:PORT based dynamic forwarding.
+            immutable: true

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -139,6 +139,11 @@ examples:
       instance_group_name: 'instance_group'
       network_name: 'network'
     exclude_test: true
+  - name: 'region_backend_service_dynamic_forwarding'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      region_backend_service_name: 'region-service'
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -1438,3 +1443,32 @@ properties:
         required: true
         enum_values:
           - 'CONSISTENT_HASH_SUBSETTING'
+      - name: 'subsetSize'
+        type: Integer
+        description: |
+          The number of backends per backend group assigned to each proxy instance or each service mesh client.
+          An input parameter to the CONSISTENT_HASH_SUBSETTING algorithm. Can only be set if policy is set to
+          CONSISTENT_HASH_SUBSETTING. Can only be set if load balancing scheme is INTERNAL_MANAGED or INTERNAL_SELF_MANAGED.
+          subsetSize is optional for Internal HTTP(S) load balancing and required for Traffic Director.
+          If you do not provide this value, Cloud Load Balancing will calculate it dynamically to optimize the number
+          of proxies/clients visible to each backend and vice versa.
+          Must be greater than 0. If subsetSize is larger than the number of backends/endpoints, then subsetting is disabled.
+  - name: 'dynamicForwarding'
+    type: NestedObject
+    description: |
+      Dynamic forwarding configuration. This field is used to configure the backend service with dynamic forwarding
+      feature which together with Service Extension allows customized and complex routing logic.
+    min_version: beta
+    properties:
+      - name: 'ipPortSelection'
+        type: NestedObject
+        description: |
+          IP:PORT based dynamic forwarding configuration.
+        min_version: beta
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            min_version: beta
+            description: |
+              A boolean flag enabling IP:PORT based dynamic forwarding.
+            immutable: true

--- a/mmv1/templates/terraform/examples/backend_service_dynamic_forwarding.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_dynamic_forwarding.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  dynamic_forwarding {
+    ip_port_selection {
+      enabled = false
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/backend_service_dynamic_forwarding.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_dynamic_forwarding.tf.tmpl
@@ -1,9 +1,10 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
   load_balancing_scheme = "INTERNAL_MANAGED"
   dynamic_forwarding {
     ip_port_selection {
-      enabled = false
+      enabled = true
     }
   }
 }

--- a/mmv1/templates/terraform/examples/region_backend_service_dynamic_forwarding.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_dynamic_forwarding.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
+  name                            = "{{index $.Vars "region_backend_service_name"}}"
+  region                          = "us-central1"
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
+  dynamic_forwarding {
+    ip_port_selection {
+      enabled = true
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/region_backend_service_dynamic_forwarding.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_dynamic_forwarding.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
+  provider                        = google-beta
   name                            = "{{index $.Vars "region_backend_service_name"}}"
   region                          = "us-central1"
   load_balancing_scheme           = "EXTERNAL_MANAGED"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -2,6 +2,7 @@ package compute_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -1115,6 +1116,50 @@ func TestAccComputeBackendService_backendServiceMaxDuration(t *testing.T) {
 		},
 	})
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(t *testing.T) {
+	t.Parallel()
+
+	namePrefix := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(namePrefix, "ZONAL_AFFINITY_DISABLED", 0.5),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.nptlbtp",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(namePrefix, "ZONAL_AFFINITY_SPILL_CROSS_ZONE", 0.6),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.nptlbtp",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(namePrefix, "ZONAL_AFFINITY_STAY_WITHIN_ZONE", 0.2),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.nptlbtp",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      testAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(namePrefix, "ZONAL_AFFINITY_STAY_WITHIN_ZONE", 1.001),
+				ExpectError: regexp.MustCompile("Must be less than or equal to 1.0"),
+			},
+		},
+	})
+}
+{{- end }}
 
 func testAccComputeBackendService_trafficDirectorBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
@@ -2867,3 +2912,61 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, description, percentage, checkName)
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func testAccComputeBackendService_withNetworkPassThroughLbTrafficPolicy(namePrefix, spillover string, ratio float64) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "nptlbtp" {
+  provider      = google-beta
+  name          = "%s-backend"
+  description   = "Hello World 1234"
+  protocol      = "TCP"
+  health_checks = [google_compute_health_check.default.self_link]
+
+  backend {
+    group                        = google_compute_network_endpoint_group.lb-neg.self_link
+    balancing_mode               = "CONNECTION"
+	max_connections_per_endpoint = 1000
+  }
+
+  network_pass_through_lb_traffic_policy {
+	zonal_affinity {
+		spillover 	    = "%s"
+		spillover_ratio = %f
+	}
+  }
+}
+
+resource "google_compute_network_endpoint_group" "lb-neg" {
+  provider     = google-beta
+  name         = "%s-neg"
+  network      = google_compute_network.default.self_link
+  subnetwork   = google_compute_subnetwork.default.self_link
+  default_port = "90"
+  zone         = "us-central1-a"
+}
+
+resource "google_compute_network" "default" {
+  provider                = google-beta
+  name                    = "%s-network"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  provider      = google-beta
+  name          = "%s-subnetwork"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.self_link
+}
+
+resource "google_compute_health_check" "default" {
+  provider = google-beta
+  name     = "%s-health-check"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, namePrefix, spillover, ratio, namePrefix, namePrefix, namePrefix, namePrefix)
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -2,7 +2,9 @@ package compute_test
 
 import (
 	"fmt"
+{{ if ne $.TargetVersionName `ga` -}}
 	"regexp"
+{{- end }}
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -385,6 +385,18 @@ func TestAccComputeRegionBackendService_subsettingUpdate(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeRegionBackendService_imlbWithSubsettingSubsetSize(backendName, checkName, 3),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      testAccComputeRegionBackendService_imlbWithSubsettingSubsetSize(backendName, checkName, -1),
+				ExpectError: regexp.MustCompile("Must be greater than or equal to 1"),
+			},
 		},
 	})
 }
@@ -1310,7 +1322,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
   protocol              = "TCP"
-  load_balancing_scheme = "INTERNAL"  
+  load_balancing_scheme = "INTERNAL"
   subsetting {
 	  policy = "CONSISTENT_HASH_SUBSETTING"
   }
@@ -1331,7 +1343,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
   protocol              = "TCP"
-  load_balancing_scheme = "INTERNAL"  
+  load_balancing_scheme = "INTERNAL"
 }
 
 resource "google_compute_health_check" "health_check" {
@@ -1341,6 +1353,32 @@ resource "google_compute_health_check" "health_check" {
   }
 }
 `, serviceName, checkName)
+}
+
+func testAccComputeRegionBackendService_imlbWithSubsettingSubsetSize(serviceName, checkName string, subsetSize int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_region_health_check.zero.self_link]
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  subsetting {
+	  policy = "CONSISTENT_HASH_SUBSETTING"
+    subset_size = %d
+  }
+}
+
+resource "google_compute_region_health_check" "zero" {
+  name               = "%s"
+  region             = "us-central1"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, subsetSize, checkName)
 }
 {{- end }}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR contains changes within `BackendService` and `RegionBackendService`.

`dynamic_forwarding.0.ip_port_selection.0.enabled` is immutable, because of error:
```
Error: Error updating BackendService "projects/iac-poc-krakow4/global/backendServices/test-backend-service1": googleapi: Error 400: Invalid value for field 'resource.dynamicForwarding.ipPortSelection.enabled': 'false'. IpPort Selection Dynamic Forwarding cannot be unset., invalid 
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `network_pass_through_lb_traffic_policy.0.zonal_affinity.0.spillover`, `network_pass_through_lb_traffic_policy.0.zonal_affinity.0.spillover_ratio` and `dynamic_forwarding.0.ip_port_selection.0.enabled` to `google_compute_backend_service` resource (beta)
```

```release-note:enhancement
compute: added `subsetting.0.subset_size` and `dynamic_forwarding.0.ip_port_selection.0.enabled` to `google_compute_region_backend_service` resource (beta)
```