### PR TITLE
Fix the bug when validating subnetwork project for compute instance

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -143,8 +143,9 @@ func ValidateSubnetworkProjectFunc(d tpgresource.TerraformResourceDiff) error {
 			return nil
 		}
 
-		if tpgresource.GetProjectFromRegionalSelfLink(subnetwork.(string)) != subnetworkProject.(string) {
-			return fmt.Errorf("project in subnetwork's self_link %q must match subnetwork_project %q", subnetwork, subnetworkProject)
+		project := tpgresource.GetProjectFromRegionalSelfLink(subnetwork.(string))
+		if  project != subnetworkProject.(string) {
+			return fmt.Errorf("project %s in subnetwork's self_link %q must match subnetwork_project %q", project, subnetwork, subnetworkProject)
 		}
 	}
 	return nil

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -189,7 +189,7 @@ func GetRegionFromRegionalSelfLink(selfLink string) string {
 }
 
 func GetProjectFromRegionalSelfLink(selfLink string) string {
-	re := regexp.MustCompile("projects/([a-zA-Z0-9-:]*)/(?:locations|regions)/[a-zA-Z0-9-:]*")
+	re := regexp.MustCompile("projects/([a-zA-Z0-9-:.]*)/(?:locations|regions)/[a-zA-Z0-9-:]*")
 	switch {
 	case re.MatchString(selfLink):
 		if res := re.FindStringSubmatch(selfLink); len(res) == 2 && res[1] != "" {

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers_test.go
@@ -189,9 +189,10 @@ func TestGetRegionFromRegionalSelfLink(t *testing.T) {
 
 func TestGetProjectFromRegionalSelfLink(t *testing.T) {
 	cases := map[string]string{
-		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar":            "foo",
-		"projects/REDACTED/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8":     "REDACTED",
-		"projects/REDA:CT-ED09/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8": "REDA:CT-ED09",
+		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar":                "foo",
+		"projects/REDACTED/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8":         "REDACTED",
+		"projects/REDA:CT-ED09/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8":     "REDA:CT-ED09",
+		"projects/REDA.com:CT-ED09/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8": "REDA.com:CT-ED09",
 	}
 	for input, expected := range cases {
 		if result := GetProjectFromRegionalSelfLink(input); result != expected {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes b/399906241

When validate the subnetwork project, the validation always fails for the project `xxx.com:xxxx`. In the function `GetProjectFromRegionalSelfLink`, the project `xxx.com:xxxx` cannot be extracted.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed the bug when validating the subnetwork project in `google_compute_instance` resource
```
