### PR TITLE
Removed post-create setting of identity fields that aren't computed or in id_format

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -309,7 +309,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
 {{if and $.GetAsync ($.GetAsync.Allow "Create") -}}
 {{  if ($.GetAsync.IsA "OpAsync") -}}
-{{    if and $.GetAsync.Result.ResourceInsideResponse (or $.GetIdentity $.HasComputedIdFormatFields) -}}
+{{    if and $.GetAsync.Result.ResourceInsideResponse $.HasComputedIdFormatFields -}}
     // Use the resource in the operation response to populate
     // identity fields and d.Id() before read
     var opRes map[string]interface{}
@@ -378,17 +378,6 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     {{-     end }}
     {{-   end }}{{/* prop is potentially computed */}}
     {{- end }}{{/* range */}}
-    {{- else}}
-{{- /*
-    Temporarily keeping these resources the same - but setting properties here should be unnecessary because the impacted fields aren't expected to change as a result of the API request. Will remove in a separate step for clarity.
- */}}
-{{- range $prop := $.GettableProperties }}
-{{-  if $.IsInIdentity $prop }}
-    if err := d.Set("{{ underscore $prop.Name -}}", flatten{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(opRes["{{ $prop.ApiName -}}"], d, config)); err != nil {
-        return err
-    }
-{{- end}}
-{{- end}}
     {{- end}}
 
     // This may have caused the ID to update - update it if so.


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/13619 (and part of https://github.com/hashicorp/terraform-provider-google/issues/22214). It removes the logic to set "identity" fields on post-create _unless_ they're also in id_format and computed.

If a field is not in id_format, we do not consider it necessary to set on post-create even if it's computed.

If a field is not computed, it doesn't need to be set on post-create because it will already be set (or not set) on the config - the value will not change based on the API response. (Generally speaking, fields that are part of id_format and not computed should be required.)

The failure scenario if there were an issue with this code is that the read after create would fail.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
