### PR TITLE
Update changes to BackupPlan with respect to disk and regional disk 

### DIFF
--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -75,6 +75,7 @@ properties:
     type: Array
     description: |
       The list of all resource types to which the `BackupPlan` can be applied.
+    min_version: beta
     item_type:
       type: String
     output: true

--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -77,6 +77,7 @@ properties:
       The list of all resource types to which the `BackupPlan` can be applied.
     item_type:
       type: String
+    min_version: 'beta'
     output: true
   - name: 'resourceType'
     type: String

--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -77,7 +77,6 @@ properties:
       The list of all resource types to which the `BackupPlan` can be applied.
     item_type:
       type: String
-    min_version: 'beta'
     output: true
   - name: 'resourceType'
     type: String

--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -71,6 +71,13 @@ properties:
     description: |
       The Google Cloud Platform Service Account to be used by the BackupVault for taking backups.
     output: true
+  - name: 'supportedResourceTypes'
+    type: Array
+    description: |
+      The list of all resource types to which the `BackupPlan` can be applied.
+    item_type:
+      type: String
+    output: true
   - name: 'resourceType'
     type: String
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
backupdr: added 'supported_resource_types' field to `google_backup_dr_backup_plan` resource (beta)
```
This field is added to support disk and regional disk resource type for backup plan creation.
