### PR TITLE
Remove hard-coded GKE version for flexStart test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4580,13 +4580,20 @@ func TestAccContainerNodePool_withFlexStart(t *testing.T) {
 
 func testAccContainerNodePool_withFlexStart(clusterName, np, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
 resource "google_container_cluster" "cluster" {
-  min_master_version = "1.32.3-gke.1717000"
-  
   name                = "%s"
   location            = "us-central1-a"
   initial_node_count  = 1
   deletion_protection = false
+
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_latest_version["RAPID"]
+  release_channel {
+    channel = "RAPID"
+  }
   network             = "%s"
   subnetwork          = "%s"
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22577
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22580

The errors in these tests are:

```
Master version "1.32.3-gke.1717000" is unsupported.
```

At the time the tests were written, that _was_ a supported master version, but it no longer is.

[This link](https://cloud.google.com/kubernetes-engine/docs/release-notes#April_28_2025) (which itself might eventually rot) shows that 1.32.3-gke.1717000 used to be a valid version in the Rapid channel, but now 1.32.3-gke.1785000 is. Rather than hardcoding that newer version, the test now looks similar to others in the same file: it uses whatever the minimum Rapid channel version is.

Testing these changes locally on the Hashicorp Google Terraform beta repo (i.e., the repo whose code is generated from the template files in the Magic Modules repo), the selected master version _is_ indeed 1.32.3-gke.1785000. Once _that_ version is no longer valid, the test _will_ continue to choose a valid version.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

<!--
According to the guidance link, release note type "none" is used for "Changes where there is no user impact, like test fixes, website updates and CI changes. Release notes of this type should be empty." Because these are test fixes, I've used type "none", and left the release notes as empty.
-->
```release-note:none
```
