### PR TITLE
Allow in-place update for producer accept/reject lists

### DIFF
--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -22,7 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networkAttachments'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/networkAttachments'
-immutable: true
+update_verb: 'PATCH'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -62,6 +62,7 @@ parameters:
     description: |
       Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])? which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
     required: true
+    immutable: true
   - name: 'region'
     type: ResourceRef
     description: |
@@ -102,6 +103,7 @@ properties:
     type: Enum
     description: |
       The connection preference of service attachment. The value can be set to ACCEPT_AUTOMATIC. An ACCEPT_AUTOMATIC service attachment is one that always accepts the connection from consumer forwarding rules.
+    immutable: true
     required: true
     enum_values:
       - 'ACCEPT_AUTOMATIC'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_attachment_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_attachment_test.go.tmpl
@@ -1,0 +1,204 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeNetworkAttachment_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeNetworkAttachmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetworkAttachment_full(context),
+			},
+			{
+				ResourceName:            "google_compute_network_attachment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+			{
+				Config: testAccComputeNetworkAttachment_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_network_attachment.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_compute_network_attachment.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}
+
+func testAccComputeNetworkAttachment_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network_attachment" "default" {
+    name = "tf-test-basic-network-attachment%{random_suffix}"
+    region = "us-central1"
+    description = "basic network attachment description"
+    connection_preference = "ACCEPT_MANUAL"
+
+    subnetworks = [
+        google_compute_subnetwork.net1.self_link
+    ]
+
+    producer_accept_lists = [
+        google_project.accepted_producer_project1.project_id
+    ]
+
+    producer_reject_lists = [
+        google_project.rejected_producer_project1.project_id
+    ]
+}
+
+resource "google_compute_network" "default" {
+    name = "tf-test-basic-network%{random_suffix}"
+    auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "net1" {
+    name = "tf-test-basic-subnetwork1-%{random_suffix}"
+    region = "us-central1"
+
+    network = google_compute_network.default.id
+    ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "net2" {
+    name = "tf-test-basic-subnetwork2-%{random_suffix}"
+    region = "us-central1"
+
+    network = google_compute_network.default.id
+    ip_cidr_range = "10.1.0.0/16"
+}
+
+resource "google_project" "rejected_producer_project1" {
+    project_id      = "tf-test-prj-reject1-%{random_suffix}"
+    name            = "tf-test-prj-reject1-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "rejected_producer_project2" {
+    project_id      = "tf-test-prj-reject2-%{random_suffix}"
+    name            = "tf-test-prj-reject2-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "accepted_producer_project1" {
+    project_id      = "tf-test-prj-accept1-%{random_suffix}"
+    name            = "tf-test-prj-accept1-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "accepted_producer_project2" {
+    project_id      = "tf-test-prj-accept2-%{random_suffix}"
+    name            = "tf-test-prj-accept2-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+`, context)
+}
+
+func testAccComputeNetworkAttachment_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network_attachment" "default" {
+    name = "tf-test-basic-network-attachment%{random_suffix}"
+    region = "us-central1"
+    description = "basic network attachment description"
+    connection_preference = "ACCEPT_MANUAL"
+
+    subnetworks = [
+        google_compute_subnetwork.net2.self_link
+    ]
+
+    producer_accept_lists = [
+        google_project.accepted_producer_project2.project_id
+    ]
+
+    producer_reject_lists = [
+        google_project.rejected_producer_project2.project_id
+    ]
+}
+
+resource "google_compute_network" "default" {
+    name = "tf-test-basic-network%{random_suffix}"
+    auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "net1" {
+    name = "tf-test-basic-subnetwork1-%{random_suffix}"
+    region = "us-central1"
+
+    network = google_compute_network.default.id
+    ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "net2" {
+    name = "tf-test-basic-subnetwork2-%{random_suffix}"
+    region = "us-central1"
+
+    network = google_compute_network.default.id
+    ip_cidr_range = "10.1.0.0/16"
+}
+
+resource "google_project" "rejected_producer_project1" {
+    project_id      = "tf-test-prj-reject1-%{random_suffix}"
+    name            = "tf-test-prj-reject1-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "rejected_producer_project2" {
+    project_id      = "tf-test-prj-reject2-%{random_suffix}"
+    name            = "tf-test-prj-reject2-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "accepted_producer_project1" {
+    project_id      = "tf-test-prj-accept1-%{random_suffix}"
+    name            = "tf-test-prj-accept1-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+
+resource "google_project" "accepted_producer_project2" {
+    project_id      = "tf-test-prj-accept2-%{random_suffix}"
+    name            = "tf-test-prj-accept2-%{random_suffix}"
+    org_id          = "%{org_id}"
+    billing_account = "%{billing_account}"
+    deletion_policy = "DELETE"
+}
+`, context)
+}


### PR DESCRIPTION
Allow in-place update for producer accept/reject lists, as this operation is allowed, and removing existing attachment is not possible, when it is in use.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: allow in-place updates for producer accept/reject lists for `google_compute_network_attachment`
```

Closes: [terraform-provider-google#22569](https://github.com/hashicorp/terraform-provider-google/issues/22569)
