### PR TITLE
feat: implementation of spanner `instance_type` to be able to provision a `FREE_INSTANCE` via terraform

### DIFF
--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -112,6 +112,11 @@ properties:
       autoscaling_config must be present in terraform except when instance_type = FREE_INSTANCE.
     api_name: nodeCount
     default_from_api: true
+    at_least_one_of:
+      - 'num_nodes'
+      - 'processing_units'
+      - 'autoscaling_config'
+      - 'instance_type'
     conflicts:
       - 'processing_units'
       - 'autoscaling_config'
@@ -121,6 +126,11 @@ properties:
       The number of processing units allocated to this instance. Exactly one of either num_nodes,
       processing_units or autoscaling_config must be present in terraform except when instance_type = FREE_INSTANCE.
     default_from_api: true
+    at_least_one_of:
+      - 'num_nodes'
+      - 'processing_units'
+      - 'autoscaling_config'
+      - 'instance_type'
     conflicts:
       - 'num_nodes'
       - 'autoscaling_config'
@@ -146,6 +156,11 @@ properties:
       When autoscaling is enabled, num_nodes and processing_units are treated as,
       OUTPUT_ONLY fields and reflect the current compute capacity allocated to
       the instance.
+    at_least_one_of:
+      - 'num_nodes'
+      - 'processing_units'
+      - 'autoscaling_config'
+      - 'instance_type'
     conflicts:
       - 'num_nodes'
       - 'processing_units'
@@ -267,6 +282,11 @@ properties:
       usage restrictions, quotas and billing. Currently this is used to distinguish FREE_INSTANCE vs PROVISIONED instances.
       When configured as FREE_INSTANCE, the field `edition` should not be configured.
     default_from_api: true
+    at_least_one_of:
+      - 'num_nodes'
+      - 'processing_units'
+      - 'autoscaling_config'
+      - 'instance_type'
     enum_values:
       - 'PROVISIONED'
       - 'FREE_INSTANCE'

--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -112,8 +112,7 @@ properties:
       must be present in terraform.
     api_name: nodeCount
     default_from_api: true
-    exactly_one_of:
-      - 'num_nodes'
+    conflicts:
       - 'processing_units'
       - 'autoscaling_config'
   - name: 'processingUnits'
@@ -122,9 +121,8 @@ properties:
       The number of processing units allocated to this instance. Exactly one of processing_units
       or node_count must be present in terraform.
     default_from_api: true
-    exactly_one_of:
+    conflicts:
       - 'num_nodes'
-      - 'processing_units'
       - 'autoscaling_config'
   - name: 'labels'
     type: KeyValueLabels
@@ -146,10 +144,9 @@ properties:
       When autoscaling is enabled, num_nodes and processing_units are treated as,
       OUTPUT_ONLY fields and reflect the current compute capacity allocated to
       the instance.
-    exactly_one_of:
+    conflicts:
       - 'num_nodes'
       - 'processing_units'
-      - 'autoscaling_config'
     properties:
       - name: 'autoscalingLimits'
         type: NestedObject
@@ -261,6 +258,16 @@ properties:
       - 'STANDARD'
       - 'ENTERPRISE'
       - 'ENTERPRISE_PLUS'
+  - name: 'instanceType'
+    type: Enum
+    description: |
+      The type of this instance. The type can be used to distinguish product variants, that can affect aspects like:
+      usage restrictions, quotas and billing. Currently this is used to distinguish FREE_INSTANCE vs PROVISIONED instances.
+      When configured as FREE_INSTANCE, the field `edition` should not be configured.
+    default_from_api: true
+    enum_values:
+      - 'PROVISIONED'
+      - 'FREE_INSTANCE'
   - name: 'defaultBackupScheduleType'
     type: Enum
     description: |

--- a/mmv1/products/spanner/Instance.yaml
+++ b/mmv1/products/spanner/Instance.yaml
@@ -108,8 +108,8 @@ properties:
   - name: 'num_nodes'
     type: Integer
     description: |
-      The number of nodes allocated to this instance. Exactly one of either node_count or processing_units
-      must be present in terraform.
+      The number of nodes allocated to this instance. Exactly one of either num_nodes, processing_units or
+      autoscaling_config must be present in terraform except when instance_type = FREE_INSTANCE.
     api_name: nodeCount
     default_from_api: true
     conflicts:
@@ -118,8 +118,8 @@ properties:
   - name: 'processingUnits'
     type: Integer
     description: |
-      The number of processing units allocated to this instance. Exactly one of processing_units
-      or node_count must be present in terraform.
+      The number of processing units allocated to this instance. Exactly one of either num_nodes,
+      processing_units or autoscaling_config must be present in terraform except when instance_type = FREE_INSTANCE.
     default_from_api: true
     conflicts:
       - 'num_nodes'
@@ -141,6 +141,8 @@ properties:
     type: NestedObject
     description: |
       The autoscaling configuration. Autoscaling is enabled if this field is set.
+      Exactly one of either num_nodes, processing_units or autoscaling_config must be
+      present in terraform except when instance_type = FREE_INSTANCE.
       When autoscaling is enabled, num_nodes and processing_units are treated as,
       OUTPUT_ONLY fields and reflect the current compute capacity allocated to
       the instance.

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
@@ -1,26 +1,15 @@
-if obj["instanceType"] == nil ||  obj["instanceType"] == "PROVISIONED" {
-	// when provisioning a PROVISIONED instance, or instance_type is not set at all
-	// exactly one of the following fields must be specified (cannot use exactly_one_of because of the FREE_INSTANCE case):
-	count := 0
-	if obj["autoscalingConfig"] != nil {
-		count++
+if obj["instanceType"] == "FREE_INSTANCE" {
+	// when provisioning a FREE_INSTANCE, the following fields cannot be specified
+	if obj["nodeCount"] != nil || obj["processingUnits"] != nil || obj["autoscalingConfig"] != nil {
+		return nil, fmt.Errorf("`num_nodes`, `processing_units`, and `autoscaling_config` cannot be specified when instance_type is FREE_INSTANCE")
 	}
-	if obj["nodeCount"] != nil {
-		count++
-	}
-	if obj["processingUnits"] != nil {
-		count++
-	}
-
-	if count != 1 {
-		return nil, fmt.Errorf("Exactly one of `autoscaling_config`, `num_nodes`, or `processing_units` must be specified")
+} else {
+	// Temp Logic to accommodate autoscaling_config, processing_units and num_nodes
+	if obj["processingUnits"] == nil && obj["nodeCount"] == nil && obj["autoscalingConfig"] == nil && obj["instanceType"] != "FREE_INSTANCE" {
+		obj["nodeCount"] = 1
 	}
 }
 
-// Temp Logic to accommodate autoscaling_config, processing_units and num_nodes
-if obj["processingUnits"] == nil && obj["nodeCount"] == nil && obj["autoscalingConfig"] == nil {
-	obj["nodeCount"] = 1
-}
 newObj := make(map[string]interface{})
 newObj["instance"] = obj
 if obj["name"] == nil {
@@ -30,12 +19,6 @@ if obj["name"] == nil {
 	newObj["instanceId"] = d.Get("name").(string)
 } else {
 	newObj["instanceId"] = obj["name"]
-}
-if obj["instanceType"] != nil && obj["instanceType"] == "FREE_INSTANCE" {
-	// when provisioning a FREE_INSTANCE, the following fields cannot be specified
-	if obj["nodeCount"] != nil || obj["processingUnits"] != nil || obj["autoscalingConfig"] != nil {
-		return nil, fmt.Errorf("`num_nodes`, `processing_units`, and `autoscaling_config` cannot be specified when instance_type is FREE_INSTANCE")
-	}
 }
 delete(obj, "name")
 return newObj, nil

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
@@ -1,3 +1,22 @@
+if obj["instanceType"] == nil || obj["instanceType"] != nil && obj["instanceType"] == "PROVISIONED" {
+	// when provisioning a PROVISIONED instance, or instance_type is not set at all
+	// exactly one of the following fields must be specified (cannot use exatcly_one_of because of the FREE_INSTANCE case):
+	count := 0
+	if obj["autoscalingConfig"] != nil {
+		count++
+	}
+	if obj["nodeCount"] != nil {
+		count++
+	}
+	if obj["processingUnits"] != nil {
+		count++
+	}
+
+	if count != 1 {
+		return nil, fmt.Errorf("Exactly one of `autoscaling_config`, `num_nodes`, or `processing_units` must be specified")
+	}
+}
+
 // Temp Logic to accommodate autoscaling_config, processing_units and num_nodes
 if obj["processingUnits"] == nil && obj["nodeCount"] == nil && obj["autoscalingConfig"] == nil {
 	obj["nodeCount"] = 1
@@ -11,6 +30,12 @@ if obj["name"] == nil {
 	newObj["instanceId"] = d.Get("name").(string)
 } else {
 	newObj["instanceId"] = obj["name"]
+}
+if obj["instanceType"] != nil && obj["instanceType"] == "FREE_INSTANCE" {
+	// when provisioning a FREE_INSTANCE, the following fields cannot be specified
+	delete(obj, "nodeCount")
+	delete(obj, "processingUnits")
+	delete(obj, "autoscalingConfig")
 }
 delete(obj, "name")
 return newObj, nil

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
@@ -1,6 +1,6 @@
 if obj["instanceType"] == nil ||  obj["instanceType"] == "PROVISIONED" {
 	// when provisioning a PROVISIONED instance, or instance_type is not set at all
-	// exactly one of the following fields must be specified (cannot use exatcly_one_of because of the FREE_INSTANCE case):
+	// exactly one of the following fields must be specified (cannot use exactly_one_of because of the FREE_INSTANCE case):
 	count := 0
 	if obj["autoscalingConfig"] != nil {
 		count++
@@ -33,9 +33,9 @@ if obj["name"] == nil {
 }
 if obj["instanceType"] != nil && obj["instanceType"] == "FREE_INSTANCE" {
 	// when provisioning a FREE_INSTANCE, the following fields cannot be specified
-	delete(obj, "nodeCount")
-	delete(obj, "processingUnits")
-	delete(obj, "autoscalingConfig")
+	if obj["nodeCount"] != nil || obj["processingUnits"] != nil || obj["autoscalingConfig"] != nil {
+		return nil, fmt.Errorf("`num_nodes`, `processing_units`, and `autoscaling_config` cannot be specified when instance_type is FREE_INSTANCE")
+	}
 }
 delete(obj, "name")
 return newObj, nil

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.tmpl
@@ -1,4 +1,4 @@
-if obj["instanceType"] == nil || obj["instanceType"] != nil && obj["instanceType"] == "PROVISIONED" {
+if obj["instanceType"] == nil ||  obj["instanceType"] == "PROVISIONED" {
 	// when provisioning a PROVISIONED instance, or instance_type is not set at all
 	// exactly one of the following fields must be specified (cannot use exatcly_one_of because of the FREE_INSTANCE case):
 	count := 0

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -84,7 +84,7 @@ func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units,instance_type`\nmust be specified.*"),
+				ExpectError: regexp.MustCompile(".*one of\n`autoscaling_config,instance_type,num_nodes,processing_units` must be\nspecified.*"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -2,6 +2,7 @@ package spanner_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -67,6 +68,23 @@ func TestAccSpannerInstance_basicUpdateWithProviderDefaultLabels(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
+	t.Parallel()
+
+	idName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
+				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units,instance_type`\nmust be specified.*"),
 			},
 		},
 	})
@@ -582,6 +600,16 @@ resource "google_spanner_instance" "basic" {
   }
 }
 `, extraLabel, name, name)
+}
+
+func testAccSpannerInstance_noNodeCountSpecified(name string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-dname"
+}
+`, name, name)
 }
 
 func testAccSpannerInstance_basicWithAutogenName(name string) string {

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -84,7 +84,7 @@ func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile(".*one of `autoscaling_config,num_nodes,processing_units`\nmust be specified.*"),
+				ExpectError: regexp.MustCompile(".*one of `autoscaling_config`, `num_nodes`, or `processing_units` must be specified*"),
 			},
 		},
 	})
@@ -497,6 +497,41 @@ func TestAccSpannerInstance_spannerInstanceWithAutoscaling(t *testing.T) {
 	})
 }
 
+func TestAccSpannerInstance_freeInstanceBasicUpdate(t *testing.T) {
+	displayName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_freeInstanceBasic(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.main", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.main",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccSpannerInstance_freeInstanceBasicUpdate(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.main", "state"),
+				),
+			},
+			{
+				ResourceName:            "google_spanner_instance.main",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccSpannerInstance_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_spanner_instance" "basic" {
@@ -792,4 +827,28 @@ resource "google_spanner_instance" "example" {
   }
 }
 `, context)
+}
+
+func testAccSpannerInstance_freeInstanceBasic(name string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "main" {
+  name          = "%s"
+  config        = "regional-europe-west1"
+  display_name  = "%s"
+  instance_type = "FREE_INSTANCE"
+}
+`, name, name)
+}
+
+func testAccSpannerInstance_freeInstanceBasicUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "main" {
+  name          = "%s"
+  config        = "nam-eur-asia3"
+  display_name  = "%s"
+  edition       = "ENTERPRISE_PLUS"
+  instance_type = "PROVISIONED"
+  num_nodes     = 1
+}
+`, name, name)
 }

--- a/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/services/spanner/resource_spanner_instance_test.go
@@ -2,7 +2,6 @@ package spanner_test
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -68,23 +67,6 @@ func TestAccSpannerInstance_basicUpdateWithProviderDefaultLabels(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
-			},
-		},
-	})
-}
-
-func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
-	t.Parallel()
-
-	idName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckSpannerInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccSpannerInstance_noNodeCountSpecified(idName),
-				ExpectError: regexp.MustCompile(".*one of `autoscaling_config`, `num_nodes`, or `processing_units` must be specified*"),
 			},
 		},
 	})
@@ -600,16 +582,6 @@ resource "google_spanner_instance" "basic" {
   }
 }
 `, extraLabel, name, name)
-}
-
-func testAccSpannerInstance_noNodeCountSpecified(name string) string {
-	return fmt.Sprintf(`
-resource "google_spanner_instance" "basic" {
-  name         = "%s"
-  config       = "regional-us-central1"
-  display_name = "%s-dname"
-}
-`, name, name)
 }
 
 func testAccSpannerInstance_basicWithAutogenName(name string) string {


### PR DESCRIPTION
Solves https://github.com/hashicorp/terraform-provider-google/issues/22596

feat: implementation of spanner `instance_type` to be able to provision a `FREE_INSTANCE` via terraform
* had to implement a custom version of `exactly_one_of` because when provisioning a spanner instance with instance_type = `FREE_INSTANCE` neither one of `num_nodes` or `processing_units` or `autoscaling_config` is allowed to be configured.

**Added / direct affected tests pass locally:**

![image](https://github.com/user-attachments/assets/ca2db72f-8005-4615-afa7-99a87aeea24b)

Couldn't run all tests locally with `-run=TestAccSpannerInstance_` because I ran into some org / quota policies on my sandbox project.


**Another thing to keep in mind, that makes testing a bit harder:**

![image](https://github.com/user-attachments/assets/0296cb0f-ced7-4184-a3e7-caceb3a94b13)

E.g.: tests always have to run on a "new" GCP project, not sure if that is solved within the CI?

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
spanner: added field `instance_type` to the `google_spanner_instance` resource
```
