### PR TITLE
Revert "Support for Tags in google_dataproc_metastore_service resource"

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -520,11 +520,3 @@ properties:
         enum_values:
           - 'LEGACY'
           - 'JSON'
-  - name: 'tags'
-    type: KeyValuePairs
-    description: |
-      A map of resource manager tags.
-      Resource manager tag keys and values have the same definition as resource manager tags.
-      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
-    immutable: true
-    ignore_read: true

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go.tmpl
@@ -2,9 +2,8 @@ package dataprocmetastore_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"testing"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -165,61 +164,6 @@ resource "google_dataproc_metastore_service" "backup" {
 resource "google_storage_bucket" "bucket" {
   name     = "tf-test-backup%{random_suffix}"
   location = "us-central1"
-}
-`, context)
-}
-
-func TestAccMetastoreService_tags(t *testing.T) {
-	t.Parallel()
-	tagKey := acctest.BootstrapSharedTestTagKey(t, "metastore-service-tagkey")
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
-		"org":           envvar.GetTestOrgFromEnv(t),
-		"tagKey":        tagKey,
-		"tagValue":      acctest.BootstrapSharedTestTagValue(t, "metastore-service-tagvalue", tagKey),
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataprocMetastoreServiceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccMetastoreServiceTags(context),
-			},
-			{
-				ResourceName:            "google_dataproc_metastore_service.default",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"service_id", "location", "labels", "terraform_labels", "tags"},
-			},
-		},
-	})
-}
-
-func testAccMetastoreServiceTags(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_dataproc_metastore_service" "default" {
-  service_id   = "tf-test-my-service-%{random_suffix}"
-  location   = "us-central1"
-  port       = 9080
-  tier       = "DEVELOPER"
-
-  maintenance_window {
-    hour_of_day = 2
-    day_of_week = "SUNDAY"
-   }
-
-  hive_metastore_config {
-    version = "2.3.6"
-  }
-
-  labels = {
-    env = "test"
-  }
-  tags = {
-	"%{org}/%{tagKey}" = "%{tagValue}"
-  }
 }
 `, context)
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#13440

As discussed with Ryan Offline, creating the Revert PR

```release-note:bug
metastore: remove non-functioning `tags` field from `google_dataproc_metastore_service`. It was introduced in v6.31.0 but the feature was not yet GA.
```