### PR TITLE
Print original resource address for tgc testing

### DIFF
--- a/mmv1/third_party/terraform/acctest/tgc_utils.go
+++ b/mmv1/third_party/terraform/acctest/tgc_utils.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
 // Hardcode the Terraform resource name -> API service name mapping temporarily.
@@ -55,19 +54,10 @@ func GetTestMetadataForTgc(service, address, rawConfig string) resource.TestChec
 		// The acceptance tests names will be also used for the tgc tests.
 		// "service" is logged and will be used to put the tgc tests into specific service packages.
 		log.Printf("[DEBUG]TGC Terraform service: %s", service)
+		log.Printf("[DEBUG]TGC Terraform resource: %s", address)
 
 		re := regexp.MustCompile(`\"(tf[-_]?test[-_]?.*?)([a-z0-9]+)\"`)
 		rawConfig = re.ReplaceAllString(rawConfig, `"${1}tgc"`)
-
-		// Replace resource name with the resource's real name,
-		// which is used to get the main resource object by checking the address after parsing raw config.
-		// For example, replace `"google_compute_instance" "foobar"` with `"google_compute_instance" "tf-test-mi3fqaucf8"`
-		n := tpgresource.GetResourceNameFromSelfLink(rState.Primary.ID)
-		log.Printf("[DEBUG]TGC Terraform resource: %s.%s", resourceType, n)
-
-		old := fmt.Sprintf(`"%s" "%s"`, resourceType, resourceName)
-		new := fmt.Sprintf(`"%s" "%s"`, resourceType, n)
-		rawConfig = strings.Replace(rawConfig, old, new, 1)
 		log.Printf("[DEBUG]TGC raw_config starts %sEnd of TGC raw_config", rawConfig)
 		return nil
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
`raw_config` will be used to check if the config changes or not compared to the previous day's config. Only fetch cai assets for the resources with changed configs. 

This PR will keep the original resource name, e.g. `foobar`, instead of the resource id, e.g. `tf-test-random-string`. The resource id has a random string, which causes the config always changing.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
