### PR TITLE
fix: do not enforce recreate for `node_scaling_factor` on bigtable instances when using default value

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -155,7 +155,7 @@ func ResourceBigtableInstance() *schema.Resource {
 						"node_scaling_factor": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     false,
+							ForceNew:     true,
 							Default:      "NodeScalingFactor1X",
 							ValidateFunc: validation.StringInSlice([]string{"NodeScalingFactor1X", "NodeScalingFactor2X"}, false),
 							Description:  `The node scaling factor of this cluster. One of "NodeScalingFactor1X" or "NodeScalingFactor2X". Defaults to "NodeScalingFactor1X".`,
@@ -739,6 +739,7 @@ func resourceBigtableInstanceClusterReorderTypeListFunc(diff tpgresource.Terrafo
 		_, newId := diff.GetChange(fmt.Sprintf("cluster.%d.cluster_id", i))
 		_, c := diff.GetChange(fmt.Sprintf("cluster.%d", i))
 		typedCluster := c.(map[string]interface{})
+		log.Printf("[DEBUG] typedCluster: %#v", typedCluster)
 		typedCluster["state"] = "READY"
 		clusters[newId.(string)] = typedCluster
 	}
@@ -824,6 +825,14 @@ func resourceBigtableInstanceClusterReorderTypeListFunc(diff tpgresource.Terrafo
 	return nil
 }
 
+func resourceBigtableInstanceClusterDefaultNodeScalingFactor(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return resourceBigtableInstanceCLusterDefaultNodeScalingFactorFunc(diff, func(nodeScalingFactor string) error {
+		return diff.SetNew("node_scaling_factor", nodeScalingFactor)
+	})
+}
+func resourceBigtableInstanceCLusterDefaultNodeScalingFactorFunc(diff tpgresource.TerraformResourceDiff, setNew func([]interface{}) error) error {
+	// todo implementation
+}
 func resourceBigtableInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -825,14 +825,6 @@ func resourceBigtableInstanceClusterReorderTypeListFunc(diff tpgresource.Terrafo
 	return nil
 }
 
-func resourceBigtableInstanceClusterDefaultNodeScalingFactor(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
-	return resourceBigtableInstanceCLusterDefaultNodeScalingFactorFunc(diff, func(nodeScalingFactor string) error {
-		return diff.SetNew("node_scaling_factor", nodeScalingFactor)
-	})
-}
-func resourceBigtableInstanceCLusterDefaultNodeScalingFactorFunc(diff tpgresource.TerraformResourceDiff, setNew func([]interface{}) error) error {
-	// todo implementation
-}
 func resourceBigtableInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -155,7 +155,7 @@ func ResourceBigtableInstance() *schema.Resource {
 						"node_scaling_factor": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ForceNew:     true,
+							ForceNew:     false,
 							Default:      "NodeScalingFactor1X",
 							ValidateFunc: validation.StringInSlice([]string{"NodeScalingFactor1X", "NodeScalingFactor2X"}, false),
 							Description:  `The node scaling factor of this cluster. One of "NodeScalingFactor1X" or "NodeScalingFactor2X". Defaults to "NodeScalingFactor1X".`,

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -3,6 +3,7 @@ package bigtable_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"regexp"
 	"testing"
 
@@ -621,6 +622,55 @@ func TestAccBigtableInstance_createWithNodeScalingFactorThenUpdateViaForceNew(t 
 	})
 }
 
+func TestAccBigtableInstance_updateWithDefaultNodeScalingFactorShouldNotReplace(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-nsf-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigtableInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Create config with node scaling factor as 2x.
+				Config: testAccBigtableInstance_ClusterDefaultNodeScalingFactorShouldNotReplace_create(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigtable_instance.instance", "cluster.0.num_nodes", "1"),
+					resource.TestCheckResourceAttr("google_bigtable_instance.instance", "cluster.0.node_scaling_factor", "NodeScalingFactor1X"),
+				),
+			},
+			{
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
+			},
+			{
+				// Updating the node scaling factor to default value should not cause a recreate
+				Config: testAccBigtableInstance_ClusterDefaultNodeScalingFactorShouldNotReplace_update(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigtable_instance.instance", "cluster.0.num_nodes", "1"),
+					resource.TestCheckResourceAttr("google_bigtable_instance.instance", "cluster.0.node_scaling_factor", "NodeScalingFactor1X"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_bigtable_instance.instance", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
+			},
+		},
+	})
+}
+
 func testAccBigtableInstance_nodeScalingFactor_allowDestroy(instanceName string, numNodes int, nodeScalingFactor string) string {
 	nodeScalingFactorAttribute := ""
 	if nodeScalingFactor != "" {
@@ -1120,6 +1170,41 @@ provider "google" {
 }
 resource "time_offset" "week-in-future" {
   offset_days = 7
+}
+`
+}
+
+func testAccBigtableInstance_ClusterDefaultNodeScalingFactorShouldNotReplace_create() string {
+	return `
+resource "google_bigtable_instance" "instance" {
+  name                = "name"
+  deletion_protection = true
+
+  cluster {
+        cluster_id   = "cluster_id"
+        num_nodes    = 2
+        state        = "READY"
+        storage_type = "SSD"
+        zone         = "us-central1-c"
+    }
+}
+`
+}
+
+func testAccBigtableInstance_ClusterDefaultNodeScalingFactorShouldNotReplace_update() string {
+	return `
+resource "google_bigtable_instance" "instance" {
+  name                = "name"
+  deletion_protection = true
+
+  cluster {
+        cluster_id          = "cluster_id"
+        num_nodes           = 2
+        state               = "READY"
+        storage_type        = "SSD"
+        zone                = "us-central1-c"
+		node_scaling_factor = "NodeScalingFactor1X" # should not enforce recreate on default value
+    }
 }
 `
 }


### PR DESCRIPTION
Solves https://github.com/hashicorp/terraform-provider-google/issues/22617

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigtable: fixed an issue where setting the default value for `node_scaling_factor` in `google_bigtable_instance` would cause the resource to be recreated
```
