### PR TITLE
Update RegionalEndpoints examples to use the public hostname

### DIFF
--- a/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
+++ b/mmv1/products/networkconnectivity/RegionalEndpoint.yaml
@@ -89,7 +89,7 @@ properties:
   - name: 'targetGoogleApi'
     type: String
     description: |
-      The service endpoint this private regional endpoint connects to. Format: `{apiname}.{region}.p.rep.googleapis.com` Example: \"cloudkms.us-central1.p.rep.googleapis.com\".
+      The service endpoint this private regional endpoint connects to. Format: `{apiname}.{region}.rep.googleapis.com` Example: \"cloudkms.us-central1.rep.googleapis.com\".
     required: true
   - name: 'network'
     type: String

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_global_access.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "{{$.PrimaryResourceId}}" {
   name              = "{{index $.Vars "rep_name"}}"
   location          = "us-central1"
-  target_google_api = "storage.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.rep.googleapis.com"
   access_type       = "GLOBAL"
   address           = "192.168.0.4"
   network           = google_compute_network.my_network.id

--- a/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_regional_endpoint_regional_access.tf.tmpl
@@ -13,11 +13,11 @@ resource "google_compute_subnetwork" "my_subnetwork" {
 resource "google_network_connectivity_regional_endpoint" "{{$.PrimaryResourceId}}" {
   name              = "{{index $.Vars "rep_name"}}"
   location          = "us-central1"
-  target_google_api = "storage.us-central1.p.rep.googleapis.com"
+  target_google_api = "storage.us-central1.rep.googleapis.com"
   access_type       = "REGIONAL"
   address           = "192.168.0.5"
   network           = google_compute_network.my_network.id
   subnetwork        = google_compute_subnetwork.my_subnetwork.id
-  description       = "My RegionalEndpoint targeting Google API storage.us-central1.p.rep.googleapis.com"
+  description       = "My RegionalEndpoint targeting Google API storage.us-central1.rep.googleapis.com"
   labels            = {env = "default"}
 }


### PR DESCRIPTION
RegionalEndpoint can now be used with the regular hostname rather than the version with an extra ".p." following b/366290435 implementation.
We want to encourage this and therefore update the examples in the terraform documentation

```release-note:none
```
