### PR TITLE
Prevent storagecontrol target project from being swept

### DIFF
--- a/mmv1/third_party/terraform/services/storagecontrol/data_source_storage_control_project_intelligence_config_test.go
+++ b/mmv1/third_party/terraform/services/storagecontrol/data_source_storage_control_project_intelligence_config_test.go
@@ -13,7 +13,7 @@ func TestAccDataSourceGoogleStorageControlProjectIntelligenceConfig_basic(t *tes
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
-		"project":       acctest.BootstrapProject(t, "tf-test-stor-int-", envvar.GetTestBillingAccountFromEnv(t), []string{"storage.googleapis.com"}).ProjectId,
+		"project":       acctest.BootstrapProject(t, "tf-boot-stor-int-", envvar.GetTestBillingAccountFromEnv(t), []string{"storage.googleapis.com"}).ProjectId,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/storagecontrol/resource_storage_control_project_intelligence_config_test.go
+++ b/mmv1/third_party/terraform/services/storagecontrol/resource_storage_control_project_intelligence_config_test.go
@@ -14,7 +14,7 @@ func TestAccStorageControlProjectIntelligenceConfig_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"project":       acctest.BootstrapProject(t, "tf-test-stor-int-", envvar.GetTestBillingAccountFromEnv(t), []string{"storage.googleapis.com"}).ProjectId,
+		"project":       acctest.BootstrapProject(t, "tf-boot-stor-int-", envvar.GetTestBillingAccountFromEnv(t), []string{"storage.googleapis.com"}).ProjectId,
 		"random_suffix": acctest.RandString(t, 10),
 	}
 


### PR DESCRIPTION
Update the bootstrapped project prefix from `tf-test` to `tf-boot` to prevent the project from being deleted by the sweeper. Though the bootstrap function will [restore](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go.tmpl#L995) the project during each run, [there might be a delay before a restored project can be linked to a billing account](https://cloud.google.com/resource-manager/docs/creating-managing-projects#restoring_a_project). This caused tests to fail when setting the billing account.

fixes https://github.com/hashicorp/terraform-provider-google/issues/22537, fixes https://github.com/hashicorp/terraform-provider-google/issues/22536
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
