### PR TITLE
Add PSC fields to Filestore instance in beta

### DIFF
--- a/mmv1/products/filestore/Instance.yaml
+++ b/mmv1/products/filestore/Instance.yaml
@@ -209,6 +209,12 @@ properties:
                   An integer representing the anonymous group id with a default value of 65534.
                   Anon_gid may only be set with squashMode of ROOT_SQUASH. An error will be returned
                   if this field is specified for other squashMode settings.
+              - name: 'network'
+                type: String
+                min_version: beta
+                description: |
+                  The source VPC network for `ip_ranges`.
+                  Required for instances using Private Service Connect, optional otherwise.
           max_size: 10
     max_size: 1
   - name: 'networks'
@@ -273,6 +279,22 @@ properties:
           enum_values:
             - 'DIRECT_PEERING'
             - 'PRIVATE_SERVICE_ACCESS'
+            - 'PRIVATE_SERVICE_CONNECT'
+        - name: 'pscConfig'
+          type: NestedObject
+          min_version: beta
+          description: |
+            Private Service Connect configuration.
+            Should only be set when connect_mode is PRIVATE_SERVICE_CONNECT.
+          properties:
+            - name: endpointProject
+              type: String
+              description: |
+                Consumer service project in which the Private Service Connect endpoint
+                would be set up. This is optional, and only relevant in case the network
+                is a shared VPC. If this is not specified, the endpoint would be set up
+                in the VPC host project.
+              immutable: true
     min_size: 1
   - name: 'etag'
     type: String

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -646,7 +646,7 @@ func executeTemplate(tmplString string, data any) (string, error) {
 
 const pscInstanceConfigTemplate = `
 data "google_client_config" "current" {
-  provider = "google-beta"	
+  provider = google-beta
 }
 
 resource "google_compute_network" "psc_network" {

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -705,6 +705,7 @@ func TestAccFilestoreInstance_nfsExportOptionsNetwork_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, ""),
+				Check:  resource.TestCheckResourceAttr("google_filestore_instance.instance", "file_shares.0.nfs_export_options.0.network", ""),
 			},
 			{
 				ResourceName:            "google_filestore_instance.instance",
@@ -714,6 +715,7 @@ func TestAccFilestoreInstance_nfsExportOptionsNetwork_update(t *testing.T) {
 			},
 			{
 				Config: testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, "default"),
+				Check:  resource.TestCheckResourceAttr("google_filestore_instance.instance", "file_shares.0.nfs_export_options.0.network", "default"),
 			},
 			{
 				ResourceName:            "google_filestore_instance.instance",

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -645,7 +645,9 @@ func executeTemplate(tmplString string, data any) (string, error) {
 }
 
 const pscInstanceConfigTemplate = `
-data "google_client_config" "current" {}
+data "google_client_config" "current" {
+  provider = "google-beta"	
+}
 
 resource "google_compute_network" "psc_network" {
   provider                = google-beta

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -632,18 +632,6 @@ func TestAccFilestoreInstance_psc(t *testing.T) {
 	})
 }
 
-func executeTemplate(tmplString string, data any) (string, error) {
-	tmpl, err := template.New("tmpl").Delims("[[", "]]").Parse(tmplString)
-	if err != nil {
-		return "", err
-	}
-	var b bytes.Buffer
-	if err := tmpl.Execute(&b, data); err != nil {
-		return "", err
-	}
-	return b.String(), nil
-}
-
 const pscInstanceConfigTemplate = `
 data "google_client_config" "current" {
   provider = google-beta
@@ -707,3 +695,15 @@ resource "google_filestore_instance" "instance" {
 `
 
 {{- end }}
+
+func executeTemplate(tmplString string, data any) (string, error) {
+	tmpl, err := template.New("tmpl").Delims("[[", "]]").Parse(tmplString)
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, data); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -687,6 +687,7 @@ resource "google_filestore_instance" "instance" {
     }
   }
 }
-`
+`, context)
+}
 
 {{- end }}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -1,11 +1,13 @@
 package filestore_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
+	"text/template"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -592,4 +594,114 @@ resource "google_filestore_instance" "instance" {
 }
 `, name, location, tier)
 }
+
+{{- end }}
+{{- if ne $.TargetVersionName "ga" }}
+
+func TestAccFilestoreInstance_psc(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]string{
+		"Name": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
+		"Location": "us-central1",
+		"Tier": "REGIONAL",
+	}
+	config, err := executeTemplate(pscInstanceConfigTemplate, data)
+	if err != nil {
+		t.Fatalf("Failed to execute config template: %v", err)
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_filestore_instance.instance", "networks.0.connect_mode", "PRIVATE_SERVICE_CONNECT"),
+				),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+		},
+	})
+}
+
+func executeTemplate(tmplString string, data any) (string, error) {
+	tmpl, err := template.New("tmpl").Delims("[[", "]]").Parse(tmplString)
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, data); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+const pscInstanceConfigTemplate = `
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "psc_network" {
+  provider                = google-beta
+  name                    = "[[.Name]]"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "psc_subnet" {
+  provider      = google-beta
+  name          = "[[.Name]]"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "[[.Location]]"
+  network       = google_compute_network.psc_network.id
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  provider      = google-beta
+  name          = "[[.Name]]"
+  location      = "[[.Location]]"
+  service_class = "google-cloud-filestore"
+  network       = google_compute_network.psc_network.id
+  psc_config {
+    subnetworks = [google_compute_subnetwork.psc_subnet.id]
+  }
+}
+
+resource "google_filestore_instance" "instance" {
+  provider = google-beta
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+  name        = "[[.Name]]"
+  location    = "[[.Location]]"
+  tier        = "[[.Tier]]"
+  description = "An instance created during testing."
+  protocol    = "NFS_V4_1"
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+
+    nfs_export_options {
+      ip_ranges = ["70.0.0.1/24"]
+      network   = google_compute_network.psc_network.name
+    }
+  }
+
+  networks {
+    network      = google_compute_network.psc_network.name
+    modes        = ["MODE_IPV4"]
+    connect_mode = "PRIVATE_SERVICE_CONNECT"
+    psc_config {
+      endpoint_project = data.google_client_config.current.project
+    }
+  }
+}
+`
+
 {{- end }}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -1,13 +1,11 @@
 package filestore_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"reflect"
 	"regexp"
 	"testing"
-	"text/template"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -601,14 +599,10 @@ resource "google_filestore_instance" "instance" {
 func TestAccFilestoreInstance_psc(t *testing.T) {
 	t.Parallel()
 
-	data := map[string]string{
-		"Name": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
-		"Location": "us-central1",
-		"Tier": "REGIONAL",
-	}
-	config, err := executeTemplate(pscInstanceConfigTemplate, data)
-	if err != nil {
-		t.Fatalf("Failed to execute config template: %v", err)
+	context := map[string]interface{}{
+		"name":     fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
+		"location": "us-central1",
+		"tier":     "REGIONAL",
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -617,8 +611,8 @@ func TestAccFilestoreInstance_psc(t *testing.T) {
 		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: config,
-				Check: resource.ComposeTestCheckFunc(
+				Config: testAccFilestoreInstance_psc(context),
+				Check:  resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_filestore_instance.instance", "networks.0.connect_mode", "PRIVATE_SERVICE_CONNECT"),
 				),
 			},
@@ -632,29 +626,30 @@ func TestAccFilestoreInstance_psc(t *testing.T) {
 	})
 }
 
-const pscInstanceConfigTemplate = `
+func testAccFilestoreInstance_psc(context map[string]interface{}) string {
+	return acctest.Nprintf(`
 data "google_client_config" "current" {
   provider = google-beta
 }
 
 resource "google_compute_network" "psc_network" {
   provider                = google-beta
-  name                    = "[[.Name]]"
+  name                    = "%{name}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "psc_subnet" {
   provider      = google-beta
-  name          = "[[.Name]]"
+  name          = "%{name}"
   ip_cidr_range = "10.2.0.0/16"
-  region        = "[[.Location]]"
+  region        = "%{location}"
   network       = google_compute_network.psc_network.id
 }
 
 resource "google_network_connectivity_service_connection_policy" "default" {
   provider      = google-beta
-  name          = "[[.Name]]"
-  location      = "[[.Location]]"
+  name          = "%{name}"
+  location      = "%{location}"
   service_class = "google-cloud-filestore"
   network       = google_compute_network.psc_network.id
   psc_config {
@@ -667,9 +662,9 @@ resource "google_filestore_instance" "instance" {
   depends_on = [
     google_network_connectivity_service_connection_policy.default
   ]
-  name        = "[[.Name]]"
-  location    = "[[.Location]]"
-  tier        = "[[.Tier]]"
+  name        = "%{name}"
+  location    = "%{location}"
+  tier        = "%{tier}"
   description = "An instance created during testing."
   protocol    = "NFS_V4_1"
 
@@ -695,15 +690,3 @@ resource "google_filestore_instance" "instance" {
 `
 
 {{- end }}
-
-func executeTemplate(tmplString string, data any) (string, error) {
-	tmpl, err := template.New("tmpl").Delims("[[", "]]").Parse(tmplString)
-	if err != nil {
-		return "", err
-	}
-	var b bytes.Buffer
-	if err := tmpl.Execute(&b, data); err != nil {
-		return "", err
-	}
-	return b.String(), nil
-}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -690,4 +690,65 @@ resource "google_filestore_instance" "instance" {
 `, context)
 }
 
+func TestAccFilestoreInstance_nfsExportOptionsNetwork_update(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	location := "us-central1-a"
+	tier := "ZONAL"
+
+	// Currently, we can only alternate between an empty network and the instance network of non-PSC instances.
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, ""),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+			{
+				Config: testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, "default"),
+			},
+			{
+				ResourceName:            "google_filestore_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"zone"},
+			},
+		},
+	})
+}
+
+func testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, network string) string {
+	return fmt.Sprintf(`
+resource "google_filestore_instance" "instance" {
+  name        = "%s"
+  zone        = "%s"
+  tier        = "%s"
+  description = "An instance created during testing."
+
+  file_shares {
+    capacity_gb = 1024
+    name        = "share"
+
+	nfs_export_options {
+      ip_ranges = ["70.0.0.1/24"]
+      network   = "%s"
+    }
+  }
+
+  networks {
+    network = "default"
+	modes   = ["MODE_IPV4"]
+  }
+}
+`, name, location, tier, network)
+}
+
 {{- end }}

--- a/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/filestore/resource_filestore_instance_test.go.tmpl
@@ -700,7 +700,7 @@ func TestAccFilestoreInstance_nfsExportOptionsNetwork_update(t *testing.T) {
 	// Currently, we can only alternate between an empty network and the instance network of non-PSC instances.
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckFilestoreInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -728,6 +728,7 @@ func TestAccFilestoreInstance_nfsExportOptionsNetwork_update(t *testing.T) {
 func testAccFilestoreInstance_nfsExportOptionsNetwork_update(name, location, tier, network string) string {
 	return fmt.Sprintf(`
 resource "google_filestore_instance" "instance" {
+  provider    = google-beta
   name        = "%s"
   zone        = "%s"
   tier        = "%s"


### PR DESCRIPTION
PSC configuration support for Filestore.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
filestore: added PSC fields to `google_filestore_instance` (beta)
```
