### PR TITLE
Promote network security intercept resources to GA.

### DIFF
--- a/mmv1/products/networksecurity/InterceptDeployment.yaml
+++ b/mmv1/products/networksecurity/InterceptDeployment.yaml
@@ -18,7 +18,6 @@ description: |-
   GENEVE-encapsulated traffic, e.g. a zonal instance group fronted by an
   internal passthrough load balancer. Deployments are always part of a
   global deployment group which represents a global intercept service.
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/interceptDeployments/{{intercept_deployment_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/interceptDeployments'
@@ -61,7 +60,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the deployment, e.g. `us-central1-a` or `asia-south1-b`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -70,7 +68,6 @@ parameters:
     description: |-
       The ID to use for the new deployment, which will become the final
       component of the deployment's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -81,34 +78,29 @@ properties:
       The resource name of this deployment, for example:
       `projects/123456789/locations/us-central1-a/interceptDeployments/my-dep`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'forwardingRule'
     type: String
     description: |-
       The regional forwarding rule that fronts the interceptors, for example:
       `projects/123456789/regions/us-central1/forwardingRules/my-rule`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'interceptDeploymentGroup'
@@ -117,7 +109,6 @@ properties:
       The deployment group that this deployment is a part of, for example:
       `projects/123456789/locations/global/interceptDeploymentGroups/my-dg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'state'
@@ -132,7 +123,6 @@ properties:
       DELETING
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -141,11 +131,9 @@ properties:
       and the system is working to reconcile them. This part of the normal
       operation (e.g. linking a new association to the parent group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: 'description'
     type: String
     description: |-
       User-provided description of the deployment.
       Used as additional context for the deployment.
-    min_version: 'beta'

--- a/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptDeploymentGroup.yaml
@@ -17,7 +17,6 @@ description: |-
   A deployment group aggregates many zonal intercept backends (deployments)
   into a single global intercept service. Consumers can connect this service
   using an endpoint group.
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups/{{intercept_deployment_group_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/interceptDeploymentGroups'
@@ -58,7 +57,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the deployment group, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -67,7 +65,6 @@ parameters:
     description: |-
       The ID to use for the new deployment group, which will become the final
       component of the deployment group's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -78,39 +75,33 @@ properties:
       The resource name of this deployment group, for example:
       `projects/123456789/locations/global/interceptDeploymentGroups/my-dg`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'network'
     type: String
     description: |-
       The network that will be used for all child deployments, for example:
       `projects/{project}/global/networks/{network}`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'connectedEndpointGroups'
     type: Array
-    min_version: 'beta'
     description: |-
       The list of endpoint groups that are connected to this resource.
     output: true
@@ -123,7 +114,6 @@ properties:
             The connected endpoint group's resource name, for example:
             `projects/123456789/locations/global/interceptEndpointGroups/my-eg`.
             See https://google.aip.dev/124.
-          min_version: 'beta'
           output: true
   - name: 'state'
     type: String
@@ -135,7 +125,6 @@ properties:
       ACTIVE
       CREATING
       DELETING
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -144,20 +133,17 @@ properties:
       and the system is working to reconcile them. This is part of the normal
       operation (e.g. adding a new deployment to the group)
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: 'description'
     type: String
     description: |-
       User-provided description of the deployment group.
       Used as additional context for the deployment group.
-    min_version: 'beta'
   - name: 'locations'
     type: Array
     is_set: true
     description: |-
       The list of locations where the deployment group is present.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -170,11 +156,9 @@ properties:
             STATE_UNSPECIFIED
             ACTIVE
             OUT_OF_SYNC
-          min_version: 'beta'
           output: true
         - name: 'location'
           type: String
           description: |-
             The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
-          min_version: 'beta'
           output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroup.yaml
@@ -19,7 +19,6 @@ description: |-
   - An association between their network and the endpoint group.
   - A security profile that points to the endpoint group.
   - A firewall rule that references the security profile (group).
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups/{{intercept_endpoint_group_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroups'
@@ -60,7 +59,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the endpoint group, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -69,7 +67,6 @@ parameters:
     description: |-
       The ID to use for the endpoint group, which will become the final component
       of the endpoint group's resource name.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -80,34 +77,29 @@ properties:
       The resource name of this endpoint group, for example:
       `projects/123456789/locations/global/interceptEndpointGroups/my-eg`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'interceptDeploymentGroup'
     type: String
     description: |-
       The deployment group that this endpoint group is connected to, for example:
       `projects/123456789/locations/global/interceptDeploymentGroups/my-dg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'state'
@@ -123,7 +115,6 @@ properties:
       DELETING
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -132,20 +123,17 @@ properties:
       and the system is working to reconcile them. This is part of the normal
       operation (e.g. adding a new association to the group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: description
     type: String
     description: |-
       User-provided description of the endpoint group.
       Used as additional context for the endpoint group.
-    min_version: 'beta'
   - name: associations
     type: Array
     is_set: true
     description: |-
       List of associations to this endpoint group.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -156,7 +144,6 @@ properties:
             The connected association's resource name, for example:
             `projects/123456789/locations/global/interceptEndpointGroupAssociations/my-ega`.
             See https://google.aip.dev/124.
-          min_version: 'beta'
           output: true
         - name: network
           type: String
@@ -164,7 +151,6 @@ properties:
             The associated network, for example:
             projects/123456789/global/networks/my-network.
             See https://google.aip.dev/124.
-          min_version: 'beta'
           output: true
         - name: state
           type: String
@@ -178,13 +164,11 @@ properties:
             CLOSED
             OUT_OF_SYNC
             DELETE_FAILED
-          min_version: 'beta'
           output: true
   - name: connectedDeploymentGroup
     type: NestedObject
     description: |-
       The endpoint group's view of a connected deployment group.
-    min_version: 'beta'
     output: true
     properties:
       - name: name
@@ -193,14 +177,12 @@ properties:
           The connected deployment group's resource name, for example:
           `projects/123456789/locations/global/interceptDeploymentGroups/my-dg`.
           See https://google.aip.dev/124.
-        min_version: 'beta'
         output: true
       - name: locations
         type: Array
         is_set: true
         description: |-
           The list of locations where the deployment group is present.
-        min_version: 'beta'
         output: true
         item_type:
           type: NestedObject
@@ -218,5 +200,4 @@ properties:
                 STATE_UNSPECIFIED
                 ACTIVE
                 OUT_OF_SYNC
-              min_version: 'beta'
               output: true

--- a/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
+++ b/mmv1/products/networksecurity/InterceptEndpointGroupAssociation.yaml
@@ -21,7 +21,6 @@ description: |-
   network to the endpoint group, but does not enable intercept by itself.
   To enable intercept, the user must also create a network firewall policy
   containing intercept rules and associate it with the network.
-min_version: 'beta'
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations/{{intercept_endpoint_group_association_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/interceptEndpointGroupAssociations'
@@ -62,7 +61,6 @@ parameters:
     type: String
     description: |-
       The cloud location of the association, currently restricted to `global`.
-    min_version: 'beta'
     url_param_only: true
     required: true
     immutable: true
@@ -72,7 +70,6 @@ parameters:
       The ID to use for the new association, which will become the final
       component of the endpoint group's resource name. If not provided, the
       server will generate a unique ID.
-    min_version: 'beta'
     url_param_only: true
     immutable: true
 properties:
@@ -82,34 +79,29 @@ properties:
       The resource name of this endpoint group association, for example:
       `projects/123456789/locations/global/interceptEndpointGroupAssociations/my-eg-association`.
       See https://google.aip.dev/122 for more details.
-    min_version: 'beta'
     output: true
   - name: 'createTime'
     type: String
     description: |-
       The timestamp when the resource was created.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'updateTime'
     type: String
     description: |-
       The timestamp when the resource was most recently updated.
       See https://google.aip.dev/148#timestamps.
-    min_version: 'beta'
     output: true
   - name: 'labels'
     type: KeyValueLabels
     description: |-
       Labels are key/value pairs that help to organize and filter resources.
-    min_version: 'beta'
   - name: 'interceptEndpointGroup'
     type: String
     description: |-
       The endpoint group that this association is connected to, for example:
       `projects/123456789/locations/global/interceptEndpointGroups/my-eg`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'network'
@@ -118,7 +110,6 @@ properties:
       The VPC network that is associated. for example:
       `projects/123456789/global/networks/my-network`.
       See https://google.aip.dev/124.
-    min_version: 'beta'
     required: true
     immutable: true
   - name: 'locationsDetails'
@@ -129,14 +120,12 @@ properties:
       of the association itself.
     deprecation_message: |-
       `locationsDetails` is deprecated and will be removed in a future major release. Use `locations` instead.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
       properties:
         - name: 'location'
           type: String
-          min_version: 'beta'
           description: |-
             The cloud location, e.g. `us-central1-a` or `asia-south1`.
           output: true
@@ -148,7 +137,6 @@ properties:
             STATE_UNSPECIFIED
             ACTIVE
             OUT_OF_SYNC
-          min_version: 'beta'
           output: true
   - name: 'state'
     type: String
@@ -162,7 +150,6 @@ properties:
       CLOSED
       OUT_OF_SYNC
       DELETE_FAILED
-    min_version: 'beta'
     output: true
   - name: 'reconciling'
     type: Boolean
@@ -171,7 +158,6 @@ properties:
       and the system is working to reconcile them. This part of the normal
       operation (e.g. adding a new location to the target deployment group).
       See https://google.aip.dev/128.
-    min_version: 'beta'
     output: true
   - name: locations
     type: Array
@@ -179,7 +165,6 @@ properties:
     description: |-
       The list of locations where the association is configured. This information
       is retrieved from the linked endpoint group.
-    min_version: 'beta'
     output: true
     item_type:
       type: NestedObject
@@ -188,7 +173,6 @@ properties:
           type: String
           description: |-
             The cloud location, e.g. `us-central1-a` or `asia-south1-b`.
-          min_version: 'beta'
           output: true
         - name: state
           type: String
@@ -198,5 +182,4 @@ properties:
             STATE_UNSPECIFIED
             ACTIVE
             OUT_OF_SYNC
-          min_version: 'beta'
           output: true

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_basic.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "{{index $.Vars "subnetwork_name"}}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -13,16 +11,14 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
-  name     = "{{index $.Vars "health_check_name"}}"
-  region   = "us-central1"
+  name   = "{{index $.Vars "health_check_name"}}"
+  region = "us-central1"
   http_health_check {
     port = 80
   }
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "{{index $.Vars "backend_service_name"}}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -31,26 +27,23 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
-  name                   = "{{index $.Vars "forwarding_rule_name"}}"
-  region                 = "us-central1"
-  network                = google_compute_network.network.name
-  subnetwork             = google_compute_subnetwork.subnetwork.name
-  backend_service        = google_compute_region_backend_service.backend_service.id
-  load_balancing_scheme  = "INTERNAL"
-  ports                  = [6081]
-  ip_protocol            = "UDP"
+  name                  = "{{index $.Vars "forwarding_rule_name"}}"
+  region                = "us-central1"
+  network               = google_compute_network.network.name
+  subnetwork            = google_compute_subnetwork.subnetwork.name
+  backend_service       = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme = "INTERNAL"
+  ports                 = [6081]
+  ip_protocol           = "UDP"
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_deployment" "{{$.PrimaryResourceId}}" {
-  provider                   = google-beta
   intercept_deployment_id    = "{{index $.Vars "deployment_id"}}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id

--- a/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_deployment_group_basic.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "{{$.PrimaryResourceId}}" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_association_basic.tf.tmpl
@@ -1,31 +1,26 @@
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "producer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "consumer_network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  intercept_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_intercept_endpoint_group_association" "{{$.PrimaryResourceId}}" {
-  provider                                = google-beta
   intercept_endpoint_group_association_id = "{{index $.Vars "endpoint_group_association_id"}}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id

--- a/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_intercept_endpoint_group_basic.tf.tmpl
@@ -1,22 +1,19 @@
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "{{$.PrimaryResourceId}}" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "{{index $.Vars "endpoint_group_id"}}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
-  description                   = "some description"
+  intercept_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
+  description                 = "some description"
   labels = {
     foo = "bar"
   }

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_group_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityInterceptDeploymentGroup_basic(context),
@@ -51,13 +50,11 @@ func TestAccNetworkSecurityInterceptDeploymentGroup_update(t *testing.T) {
 func testAccNetworkSecurityInterceptDeploymentGroup_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "default" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
@@ -72,13 +69,11 @@ resource "google_network_security_intercept_deployment_group" "default" {
 func testAccNetworkSecurityInterceptDeploymentGroup_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "default" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
@@ -89,5 +84,3 @@ resource "google_network_security_intercept_deployment_group" "default" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_deployment_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityInterceptDeployment_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityInterceptDeployment_basic(context),
@@ -51,13 +50,11 @@ func TestAccNetworkSecurityInterceptDeployment_update(t *testing.T) {
 func testAccNetworkSecurityInterceptDeployment_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "tf-test-example-subnet%{random_suffix}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -65,16 +62,14 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
-  name     = "tf-test-example-hc%{random_suffix}"
-  region   = "us-central1"
+  name   = "tf-test-example-hc%{random_suffix}"
+  region = "us-central1"
   http_health_check {
     port = 80
   }
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "tf-test-example-bs%{random_suffix}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -83,26 +78,23 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
-  name                   = "tf-test-example-fwr%{random_suffix}"
-  region                 = "us-central1"
-  network                = google_compute_network.network.name
-  subnetwork             = google_compute_subnetwork.subnetwork.name
-  backend_service        = google_compute_region_backend_service.backend_service.id
-  load_balancing_scheme  = "INTERNAL"
-  ports                  = [6081]
-  ip_protocol            = "UDP"
+  name                  = "tf-test-example-fwr%{random_suffix}"
+  region                = "us-central1"
+  network               = google_compute_network.network.name
+  subnetwork            = google_compute_subnetwork.subnetwork.name
+  backend_service       = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme = "INTERNAL"
+  ports                 = [6081]
+  ip_protocol           = "UDP"
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_deployment" "default" {
-  provider                   = google-beta
   intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
@@ -118,13 +110,11 @@ resource "google_network_security_intercept_deployment" "default" {
 func testAccNetworkSecurityInterceptDeployment_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  provider      = google-beta
   name          = "tf-test-example-subnet%{random_suffix}"
   region        = "us-central1"
   ip_cidr_range = "10.1.0.0/16"
@@ -132,16 +122,14 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider = google-beta
-  name     = "tf-test-example-hc%{random_suffix}"
-  region   = "us-central1"
+  name   = "tf-test-example-hc%{random_suffix}"
+  region = "us-central1"
   http_health_check {
     port = 80
   }
 }
 
 resource "google_compute_region_backend_service" "backend_service" {
-  provider              = google-beta
   name                  = "tf-test-example-bs%{random_suffix}"
   region                = "us-central1"
   health_checks         = [google_compute_region_health_check.health_check.id]
@@ -150,26 +138,23 @@ resource "google_compute_region_backend_service" "backend_service" {
 }
 
 resource "google_compute_forwarding_rule" "forwarding_rule" {
-  provider               = google-beta
-  name                   = "tf-test-example-fwr%{random_suffix}"
-  region                 = "us-central1"
-  network                = google_compute_network.network.name
-  subnetwork             = google_compute_subnetwork.subnetwork.name
-  backend_service        = google_compute_region_backend_service.backend_service.id
-  load_balancing_scheme  = "INTERNAL"
-  ports                  = [6081]
-  ip_protocol            = "UDP"
+  name                  = "tf-test-example-fwr%{random_suffix}"
+  region                = "us-central1"
+  network               = google_compute_network.network.name
+  subnetwork            = google_compute_subnetwork.subnetwork.name
+  backend_service       = google_compute_region_backend_service.backend_service.id
+  load_balancing_scheme = "INTERNAL"
+  ports                 = [6081]
+  ip_protocol           = "UDP"
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_deployment" "default" {
-  provider                   = google-beta
   intercept_deployment_id    = "tf-test-example-deployment%{random_suffix}"
   location                   = "us-central1-a"
   forwarding_rule            = google_compute_forwarding_rule.forwarding_rule.id
@@ -181,5 +166,3 @@ resource "google_network_security_intercept_deployment" "default" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_association_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context),
@@ -51,33 +50,28 @@ func TestAccNetworkSecurityInterceptEndpointGroupAssociation_update(t *testing.T
 func testAccNetworkSecurityInterceptEndpointGroupAssociation_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-prod-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-cons-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  intercept_endpoint_group_id = "tf-test-example-eg%{random_suffix}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_intercept_endpoint_group_association" "default" {
-  provider                                = google-beta
   intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
@@ -92,33 +86,28 @@ resource "google_network_security_intercept_endpoint_group_association" "default
 func testAccNetworkSecurityInterceptEndpointGroupAssociation_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "producer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-prod-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "consumer_network" {
-  provider                = google-beta
   name                    = "tf-test-example-cons-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.producer_network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "endpoint_group" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
+  intercept_endpoint_group_id = "tf-test-example-eg%{random_suffix}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
 }
 
 resource "google_network_security_intercept_endpoint_group_association" "default" {
-  provider                                = google-beta
   intercept_endpoint_group_association_id = "tf-test-example-ega%{random_suffix}"
   location                                = "global"
   network                                 = google_compute_network.consumer_network.id
@@ -129,5 +118,3 @@ resource "google_network_security_intercept_endpoint_group_association" "default
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_intercept_endpoint_group_test.go
@@ -1,5 +1,4 @@
 package networksecurity_test
-{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
@@ -19,7 +18,7 @@ func TestAccNetworkSecurityInterceptEndpointGroup_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNetworkSecurityInterceptEndpointGroup_basic(context),
@@ -51,24 +50,21 @@ func TestAccNetworkSecurityInterceptEndpointGroup_update(t *testing.T) {
 func testAccNetworkSecurityInterceptEndpointGroup_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "default" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
-  description                   = "initial description"
+  intercept_endpoint_group_id = "tf-test-example-eg%{random_suffix}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
+  description                 = "initial description"
   labels = {
     foo = "bar"
   }
@@ -79,29 +75,24 @@ resource "google_network_security_intercept_endpoint_group" "default" {
 func testAccNetworkSecurityInterceptEndpointGroup_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_network" "network" {
-  provider                = google-beta
   name                    = "tf-test-example-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_network_security_intercept_deployment_group" "deployment_group" {
-  provider                      = google-beta
   intercept_deployment_group_id = "tf-test-example-dg%{random_suffix}"
   location                      = "global"
   network                       = google_compute_network.network.id
 }
 
 resource "google_network_security_intercept_endpoint_group" "default" {
-  provider                      = google-beta
-  intercept_endpoint_group_id   = "tf-test-example-eg%{random_suffix}"
-  location                      = "global"
-  intercept_deployment_group    = google_network_security_intercept_deployment_group.deployment_group.id
-  description                   = "updated description"
+  intercept_endpoint_group_id = "tf-test-example-eg%{random_suffix}"
+  location                    = "global"
+  intercept_deployment_group  = google_network_security_intercept_deployment_group.deployment_group.id
+  description                 = "updated description"
   labels = {
     foo = "goo"
   }
 }
 `, context)
 }
-
-{{ end }}


### PR DESCRIPTION
Promoting the Network Security Intercept resources to GA:
* `google_network_security_intercept_deployment`
* `google_network_security_intercept_deployment_group`
* `google_network_security_intercept_endpoint_group`
* `google_network_security_intercept_endpoint_group_association`

APIs have already been promoted to v1.

```release-note:note
networksecurity: promoted `google_network_security_intercept_deployment`, `google_network_security_intercept_deployment_group`, `google_network_security_intercept_endpoint_group_association`, `google_network_security_intercept_endpoint_group` resources from Beta to GA
```
