### PR TITLE
Switched force destroy to use a URL param instead of request body

### DIFF
--- a/mmv1/products/gemini/CodeRepositoryIndex.yaml
+++ b/mmv1/products/gemini/CodeRepositoryIndex.yaml
@@ -21,6 +21,7 @@ references:
 base_url: projects/{{project}}/locations/{{location}}/codeRepositoryIndexes
 self_link: projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code_repository_index_id}}
 create_url: projects/{{project}}/locations/{{location}}/codeRepositoryIndexes?codeRepositoryIndexId={{code_repository_index_id}}
+delete_url: projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code_repository_index_id}}?force={{force_destroy}}
 update_verb: 'PATCH'
 update_mask: true
 id_format: projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code_repository_index_id}}
@@ -53,11 +54,12 @@ async:
   result:
     resource_inside_response: true
   include_project: false
-custom_code:
-  pre_delete: templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
 error_retry_predicates:
   - 'transport_tpg.IsCodeRepositoryIndexUnreadyError'
   - 'transport_tpg.IsRepositoryGroupQueueError'
+sweeper:
+  url_substitutions:
+    - force_destroy: true
 virtual_fields:
   - name: 'force_destroy'
     description:

--- a/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/code_repository_index_force_delete.go.tmpl
@@ -1,6 +1,0 @@
-obj = make(map[string]interface{})
-if v, ok := d.GetOk("force_destroy"); ok {
-	if v == true {
-		obj["force"] = true
-	}
-}


### PR DESCRIPTION
This aligns correctly with https://cloud.google.com/gemini/docs/api/reference/rest/v1/projects.locations.codeRepositoryIndexes/delete and also enables sweeper generation

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
gemini: fixed bug on `google_gemini_code_repository_index` where `force_destroy` field did nothing.
```
