### PR TITLE
Switched to only one bootstrapped code repository index to reduce quota issues

### DIFF
--- a/mmv1/products/gemini/RepositoryGroup.yaml
+++ b/mmv1/products/gemini/RepositoryGroup.yaml
@@ -28,18 +28,12 @@ mutex: 'projects/{{project}}/locations/{{location}}/codeRepositoryIndexes/{{code
 examples:
   - name: "gemini_repository_group_basic"
     primary_resource_id: "example"
-    primary_resource_name: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e_do_not_delete"}), fmt.Sprintf("tf-test-gen-repository-group-%s", context["random_suffix"])'
     vars:
       repository_group_id: "example-repository-group"
       git_repository_link_id: 'example-git-repository-link-id'
       cri_id: "cri-example"
       repository_resource: "projects/example-project/locations/us-central1/connections/example-connection/gitRepositoryLinks/example-repo"
       connection_id: "example-connection-id"
-    test_vars_overrides:
-      git_repository_link_id: 'acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
-      cri_id: 'acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-gen-example", "us-central1", "", map[string]string{"ccfe_debug_note":"terraform_e2e_do_not_delete"})'
-      repository_resource: '"projects/"+envvar.GetTestProjectFromEnv()+"/locations/us-central1/connections/"+acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)+"/gitRepositoryLinks/"+acctest.BootstrapGitRepository(t, "basic", "us-central1", "https://github.com/CC-R-github-robot/tf-test.git", acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648))'
-      connection_id: 'acctest.BootstrapDeveloperConnection(t, "basic", "us-central1", "projects/502367051001/secrets/tf-test-cloudaicompanion-github-oauthtoken-c42e5c/versions/1", 54180648)'
     exclude_test: true
 timeouts:
   insert_minutes: 30

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_repository_group_test.go.tmpl
@@ -13,7 +13,7 @@ import (
 // More details: https://cloud.google.com/developer-connect/docs/connect-github-repo#before_you_begin
 
 func TestAccGeminiRepositoryGroup_update(t *testing.T) {
-	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic-rg-test", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
+	codeRepositoryIndexId := acctest.BootstrapSharedCodeRepositoryIndex(t, "basic", "us-central1", "", map[string]string{"ccfe_debug_note": "terraform_e2e_do_not_delete"})
 	context := map[string]interface{}{
 		"random_suffix":         acctest.RandString(t, 10),
 		"project_id":            os.Getenv("GOOGLE_PROJECT"),


### PR DESCRIPTION
I don't see a specific reason that this test needs to be using a separate bootstrapped instance, so I think we can save our limited quota by only using one.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
