### PR TITLE
Replace a hardcoded Kubernetes version with a current stable one.

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -7735,7 +7735,7 @@ func TestAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(t *te
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(containerNetName, clusterName, "us-central1-a"),
+				Config: testAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(containerNetName, clusterName),
 			},
 			{
 				ResourceName:				"google_container_cluster.with_private_flexible_cluster",
@@ -7747,8 +7747,12 @@ func TestAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(t *te
 	})
 }
 
-func testAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(containerNetName, clusterName, location string) string {
+func testAccContainerCluster_withCidrBlockWithoutPrivateEndpointSubnetwork(containerNetName, clusterName string) string {
 	return fmt.Sprintf(`
+data "google_container_engine_versions" "uscentral1a" {
+  location = "us-central1-a"
+}
+
 resource "google_compute_network" "container_network" {
   name                    = "%s"
   auto_create_subnetworks = false
@@ -7762,8 +7766,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 
 resource "google_container_cluster" "with_private_flexible_cluster" {
   name               = "%s"
-  location           = "%s"
-  min_master_version = "1.29"
+  location           = "us-central1-a"
+  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
   initial_node_count = 1
 
   networking_mode = "VPC_NATIVE"
@@ -7776,7 +7780,7 @@ resource "google_container_cluster" "with_private_flexible_cluster" {
   }
   deletion_protection = false
 }
-`, containerNetName, clusterName, location)
+`, containerNetName, clusterName)
 }
 
 func TestAccContainerCluster_withEnablePrivateEndpointToggle(t *testing.T) {


### PR DESCRIPTION
The current approach is brittle: every time a version goes end-of-life, tests need to be updated. This change updates the test to retrive the currently available version from the STABLE release channel.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22576

```release-note: none
```