### PR TITLE
make datasource google_projects universe domain aware

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_projects.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_projects.go
@@ -75,7 +75,8 @@ func datasourceGoogleProjectsRead(d *schema.ResourceData, meta interface{}) erro
 
 	for {
 		params["filter"] = d.Get("filter").(string)
-		url := "https://cloudresourcemanager.googleapis.com/v1/projects"
+		domain := transport_tpg.GetUniverseDomainFromMeta(meta)
+		url := fmt.Sprintf("https://cloudresourcemanager.%s/v1/projects", domain)
 
 		url, err := transport_tpg.AddQueryParams(url, params)
 		if err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

tested with modified `TestAccDataSourceGoogleProjects_basic`: 
configuration: g/5973121842282496
resulting log: g/4880129941307392

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
resourcemanager: fixed an issue in `google_projects` data source where the provider `universe_domain` did not overwrite the list URL 
```
