### PR TITLE
Fixed TestAccComputeHealthCheck_tcpAndSsl_shouldFail

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_health_check_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_health_check_test.go.tmpl
@@ -206,7 +206,7 @@ func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
+				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,grpc_tls_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
@@ -223,7 +223,7 @@ func TestAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
+				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,grpc_tls_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
 
 			},
 		},


### PR DESCRIPTION
This was broken by https://github.com/GoogleCloudPlatform/magic-modules/pull/13608 and is a result of https://github.com/hashicorp/terraform-provider-google/issues/19079 plus https://github.com/hashicorp/terraform-provider-google/issues/15427

Fixed https://github.com/hashicorp/terraform-provider-google/issues/22651
Fixed https://github.com/hashicorp/terraform-provider-google/issues/22659

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
