### PR TITLE
fix: bigtable - avoid instance recreation due to node_scaling_factor addition in 6.34.0 for existing clusters

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -535,6 +535,8 @@ func flattenBigtableCluster(c *bigtable.ClusterInfo) map[string]interface{} {
 		nodeScalingFactor = "NodeScalingFactor1X"
 	case bigtable.NodeScalingFactor2X:
 		nodeScalingFactor = "NodeScalingFactor2X"
+	default:
+		nodeScalingFactor = "NodeScalingFactor1X"
 	}
 
 	cluster := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_internal_test.go
@@ -167,8 +167,8 @@ func TestUnitBigtable_flattenBigtableCluster(t *testing.T) {
 						"storage_target": 60,
 					},
 				},
-				// unspecified node scaling factor in input will lead to an empty string here
-				"node_scaling_factor": "",
+				// unspecified node scaling factor in input will default to 1X
+				"node_scaling_factor": "NodeScalingFactor1X",
 			},
 		},
 		"HDD manual scaling": {


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigtable: fixed forced instance recreation due to addition of `cluster.node_scaling_factor` for `google_bigtable_instance` in 6.34.0
```

Compatibility testing was executed manually to verify successful upgrades for instances created in 6.33.0 and 6.34.0