### PR TITLE
Switched TestAccContainerCluster_withFlexStart to use engine versions datasource

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -7163,7 +7163,7 @@ data "google_container_engine_versions" "uscentral1a" {
 }
 
 resource "google_container_cluster" "flex_start" {
-  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
+  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["RAPID"]
 
   name                = "%s"
   location            = "us-central1-a"

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -7158,8 +7158,12 @@ resource "google_container_cluster" "max_run_duration" {
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_withFlexStart(clusterName, npName, networkName, subnetworkName string) string {
 	return fmt.Sprintf(`
+data "google_container_engine_versions" "uscentral1a" {
+  location = "us-central1-a"
+}
+
 resource "google_container_cluster" "flex_start" {
-  min_master_version = "1.32.3-gke.1717000"
+  min_master_version = data.google_container_engine_versions.uscentral1a.release_channel_latest_version["STABLE"]
 
   name                = "%s"
   location            = "us-central1-a"


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/22652
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
