### PR TITLE
H2C protocol added to backend_service and region_backend_service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -923,7 +923,7 @@ properties:
 
       locality_lb_policy is applicable to either:
 
-      * A regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2,
+      * A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C,
         and loadBalancingScheme set to INTERNAL_MANAGED.
       * A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
       * A regional backend service with loadBalancingScheme set to EXTERNAL (External Network
@@ -1326,11 +1326,10 @@ properties:
     type: Enum
     description: |
       The protocol this BackendService uses to communicate with backends.
-      The default is HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
-      types and may result in errors if used with the GA API. **NOTE**: With protocol “UNSPECIFIED”,
-      the backend service can be used by Layer 4 Internal Load Balancing or Network Load Balancing
-      with TCP/UDP/L3_DEFAULT Forwarding Rule protocol.
-    # TODO: make a ResourceRef to Security Policy
+      The default is HTTP. Possible values are HTTP, HTTPS, HTTP2, H2C, TCP, SSL, UDP
+      or GRPC. Refer to the documentation for the load balancers or for Traffic Director
+      for more information. Must be set to GRPC when the backend service is referenced
+      by a URL map that is bound to target gRPC proxy.
     default_from_api: true
     enum_values:
       - 'HTTP'
@@ -1338,9 +1337,12 @@ properties:
       - 'HTTP2'
       - 'TCP'
       - 'SSL'
+      - 'UDP'
       - 'GRPC'
       - 'UNSPECIFIED'
+      - 'H2C'
   - name: 'securityPolicy'
+    # TODO: make a ResourceRef to Security Policy
     type: String
     description: |
       The security policy associated with this backend service.
@@ -1354,7 +1356,7 @@ properties:
     type: NestedObject
     description: |
       The security settings that apply to this backend service. This field is applicable to either
-      a regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2, and
+      a regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C, and
       load_balancing_scheme set to INTERNAL_MANAGED; or a global backend service with the
       load_balancing_scheme set to INTERNAL_SELF_MANAGED.
     properties:

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -336,7 +336,7 @@ properties:
     description: |
       Settings controlling the volume of connections to a backend service. This field
       is applicable only when the `load_balancing_scheme` is set to INTERNAL_MANAGED
-      and the `protocol` is set to HTTP, HTTPS, or HTTP2.
+      and the `protocol` is set to HTTP, HTTPS, HTTP2 or H2C.
     properties:
       - name: 'connectTimeout'
         type: NestedObject
@@ -441,7 +441,7 @@ properties:
       hashing.
       This field only applies when all of the following are true -
         * `load_balancing_scheme` is set to INTERNAL_MANAGED
-        * `protocol` is set to HTTP, HTTPS, or HTTP2
+        * `protocol` is set to HTTP, HTTPS, HTTP2 or H2C
         * `locality_lb_policy` is set to MAGLEV or RING_HASH
     properties:
       - name: 'httpCookie'
@@ -911,7 +911,7 @@ properties:
 
       locality_lb_policy is applicable to either:
 
-      * A regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2,
+      * A regional backend service with the service_protocol set to HTTP, HTTPS, HTTP2 or H2C,
         and loadBalancingScheme set to INTERNAL_MANAGED.
       * A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
       * A regional backend service with loadBalancingScheme set to EXTERNAL (External Network
@@ -975,7 +975,7 @@ properties:
     description: |
       Settings controlling eviction of unhealthy hosts from the load balancing pool.
       This field is applicable only when the `load_balancing_scheme` is set
-      to INTERNAL_MANAGED and the `protocol` is set to HTTP, HTTPS, or HTTP2.
+      to INTERNAL_MANAGED and the `protocol` is set to HTTP, HTTPS, HTTP2 or H2C.
     properties:
       - name: 'baseEjectionTime'
         type: NestedObject
@@ -1219,22 +1219,21 @@ properties:
   - name: 'protocol'
     type: Enum
     description: |
-      The protocol this RegionBackendService uses to communicate with backends.
-      The default is HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
-      types and may result in errors if used with the GA API.
+      The protocol this BackendService uses to communicate with backends.
+      The default is HTTP. Possible values are HTTP, HTTPS, HTTP2, H2C, TCP, SSL, UDP
+      or GRPC. Refer to the documentation for the load balancers or for Traffic Director
+      for more information.
     default_from_api: true
-    # This is removed to avoid breaking terraform, as default values cannot be
-    # unspecified. Providers should include this as needed via overrides
-    # default_value: :TCP
     enum_values:
       - 'HTTP'
       - 'HTTPS'
       - 'HTTP2'
-      - 'SSL'
       - 'TCP'
+      - 'SSL'
       - 'UDP'
       - 'GRPC'
       - 'UNSPECIFIED'
+      - 'H2C'
   - name: 'securityPolicy'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/backend_service_external_managed.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_external_managed.tf.tmpl
@@ -2,6 +2,7 @@ resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.Vars "backend_service_name"}}"
   health_checks = [google_compute_health_check.default.id]
   load_balancing_scheme = "EXTERNAL_MANAGED"
+  protocol              = "H2C"
 }
 
 resource "google_compute_health_check" "default" {

--- a/mmv1/templates/terraform/examples/region_backend_service_balancing_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_balancing_mode.tf.tmpl
@@ -9,7 +9,7 @@ resource "google_compute_region_backend_service" "default" {
 
   region      = "us-central1"
   name        = "{{index $.Vars "region_backend_service_name"}}"
-  protocol    = "HTTP"
+  protocol    = "H2C"
   timeout_sec = 10
 
   health_checks = [google_compute_region_health_check.default.id]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added 'H2C' as a supported value for `protocol` in `google_compute_backend_service` and `google_compute_region_backend_service`
```
