### PR TITLE
feat: expose the numeric `id` attribute as `generated_id` for the `google_compute_network_endpoint_group`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 # IDEA files
 .idea/*
 *.iml
-**/.idea/*
 
 # OS generated files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 # IDEA files
 .idea/*
 *.iml
+**/.idea/*
 
 # OS generated files
 .DS_Store

--- a/mmv1/products/compute/NetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/NetworkEndpointGroup.yaml
@@ -143,3 +143,9 @@ properties:
     description: |
       The default port used if the port number is not specified in the
       network endpoint.
+  - name: 'identifier'
+    type: Integer
+    api_name: 'id'
+    output: true
+    description: |
+      The unique identifier for the resource. This identifier is defined by the server.

--- a/mmv1/products/compute/NetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/NetworkEndpointGroup.yaml
@@ -143,9 +143,9 @@ properties:
     description: |
       The default port used if the port number is not specified in the
       network endpoint.
-  - name: 'identifier'
+  - name: 'generated_id'
     type: Integer
     api_name: 'id'
     output: true
     description: |
-      The unique identifier for the resource. This identifier is defined by the server.
+      The uniquely generated identifier for the resource. This identifier is defined by the server.

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
@@ -63,7 +63,7 @@ func testAccDataSourceComputeNetworkEndpointGroupCheck(data_source_name string, 
 		}
 
 		if v, ok := ds_attr["identifier"]; !ok || v == "" {
-			return fmt.Errorf("identifier is not set, this is likely a bug in the provider")
+			return fmt.Errorf("identifier is not set")
 		}
 
 		return nil

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
@@ -61,6 +61,11 @@ func testAccDataSourceComputeNetworkEndpointGroupCheck(data_source_name string, 
 				)
 			}
 		}
+
+		if v, ok := ds_attr["identifier"]; !ok || v == "" {
+			return fmt.Errorf("identifier is not set, this is likely a bug in the provider")
+		}
+
 		return nil
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
@@ -62,7 +62,7 @@ func testAccDataSourceComputeNetworkEndpointGroupCheck(data_source_name string, 
 			}
 		}
 
-		if v, ok := ds_attr["identifier"]; !ok || v == "" {
+		if v, ok := ds_attr["generated_id"]; !ok || v == "" {
 			return fmt.Errorf("identifier is not set")
 		}
 

--- a/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_compute_network_endpoint_group_test.go
@@ -63,7 +63,7 @@ func testAccDataSourceComputeNetworkEndpointGroupCheck(data_source_name string, 
 		}
 
 		if v, ok := ds_attr["generated_id"]; !ok || v == "" {
-			return fmt.Errorf("identifier is not set")
+			return fmt.Errorf("generated_id is not set")
 		}
 
 		return nil


### PR DESCRIPTION
Solves https://github.com/hashicorp/terraform-provider-google/issues/22745

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added the numeric id as `generated_id` attribute to the `google_compute_network_endpoint_group`
```
