### PR TITLE
Documentation changes to include "disk" resource type in backup_dr

### DIFF
--- a/mmv1/products/backupdr/BackupPlan.yaml
+++ b/mmv1/products/backupdr/BackupPlan.yaml
@@ -35,6 +35,13 @@ examples:
       backup_plan_id: 'backup-plan-simple-test'
     test_env_vars:
       project: :PROJECT_NAME
+  - name: 'backup_dr_backup_plan_for_disk_resource'
+    primary_resource_id: 'my-disk-backup-plan-1'
+    vars:
+      backup_vault_id: 'backup-vault-disk-test'
+      backup_plan_id: 'backup-plan-disk-test'
+    test_env_vars:
+      project: :PROJECT_NAME
 parameters:
   - name: 'location'
     type: String
@@ -74,7 +81,8 @@ properties:
   - name: 'resourceType'
     type: String
     description: |
-      The resource type to which the `BackupPlan` will be applied. Examples include, "compute.googleapis.com/Instance" and "storage.googleapis.com/Bucket".
+      The resource type to which the `BackupPlan` will be applied.
+      Examples include, "compute.googleapis.com/Instance", "compute.googleapis.com/Disk", and "storage.googleapis.com/Bucket".
     required: true
   - name: 'createTime'
     type: String

--- a/mmv1/products/backupdr/BackupPlanAssociation.yaml
+++ b/mmv1/products/backupdr/BackupPlanAssociation.yaml
@@ -73,7 +73,8 @@ properties:
   - name: 'resourceType'
     type: String
     description: |
-      The resource type of workload on which backupplan is applied
+      The resource type of workload on which backupplan is applied.
+      Examples include, "compute.googleapis.com/Instance", "compute.googleapis.com/Disk", and "compute.googleapis.com/RegionDisk"
     required: true
   - name: 'createTime'
     type: String

--- a/mmv1/templates/terraform/examples/backup_dr_backup_plan_for_disks_resource.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backup_dr_backup_plan_for_disks_resource.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_backup_dr_backup_vault" "my_backup_vault" {
+  location                                      = "us-central1"
+  backup_vault_id                               = "{{index $.Vars "backup_vault_id"}}"
+  backup_minimum_enforced_retention_duration    = "100000s"
+}
+
+resource "google_backup_dr_backup_plan" "{{$.PrimaryResourceId}}" {
+  location       = "us-central1"
+  backup_plan_id = "{{index $.Vars "backup_plan_id"}}"
+  resource_type  = "compute.googleapis.com/Disk"
+  backup_vault   = google_backup_dr_backup_vault.my_backup_vault.id
+
+  backup_rules {
+    rule_id                = "rule-1"
+    backup_retention_days  = 5
+
+    standard_schedule {
+      recurrence_type     = "HOURLY"
+      hourly_frequency    = 6
+      time_zone           = "UTC"
+
+      backup_window {
+        start_hour_of_day = 0
+        end_hour_of_day   = 6
+      }
+    }
+  }
+}
+


### PR DESCRIPTION

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
backup_dr: Added example usage in the documentation for `creating backup plan resources for disk type resource.
Made description changes for the `resource_type` field for BP and BPA to include `disk` resources.
```
