### PR TITLE
Add fields to support for configuring Class ALB migration feature.

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -860,7 +860,6 @@ properties:
       external load balancing. A backend service created for one type of
       load balancing cannot be used with the other. For more information, refer to
       [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service).
-    immutable: true
     default_value: "EXTERNAL"
     # If you're modifying this value, it probably means Global ILB is now
     # an option. If that's the case, all of the documentation is based on
@@ -870,6 +869,38 @@ properties:
       - 'INTERNAL_SELF_MANAGED'
       - 'INTERNAL_MANAGED'
       - 'EXTERNAL_MANAGED'
+  - name: 'externalManagedMigrationState'
+    type: Enum
+    description: |
+      Specifies the canary migration state. Possible values are PREPARE, TEST_BY_PERCENTAGE, and
+      TEST_ALL_TRAFFIC.
+
+      To begin the migration from EXTERNAL to EXTERNAL_MANAGED, the state must be changed to
+      PREPARE. The state must be changed to TEST_ALL_TRAFFIC before the loadBalancingScheme can be
+      changed to EXTERNAL_MANAGED. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate
+      traffic by percentage using externalManagedMigrationTestingPercentage.
+
+      Rolling back a migration requires the states to be set in reverse order. So changing the
+      scheme from EXTERNAL_MANAGED to EXTERNAL requires the state to be set to TEST_ALL_TRAFFIC at
+      the same time. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate some traffic
+      back to EXTERNAL or PREPARE can be used to migrate all traffic back to EXTERNAL.
+    enum_values:
+      - 'PREPARE'
+      - 'TEST_BY_PERCENTAGE'
+      - 'TEST_ALL_TRAFFIC'
+  - name: 'externalManagedMigrationTestingPercentage'
+    type: Double
+    description: |
+      Determines the fraction of requests that should be processed by the Global external
+      Application Load Balancer.
+
+      The value of this field must be in the range [0, 100].
+
+      Session affinity options will slightly affect this routing behavior, for more details,
+      see: Session Affinity.
+
+      This value can only be set if the loadBalancingScheme in the backend service is set to
+      EXTERNAL (when using the Classic ALB) and the migration state is TEST_BY_PERCENTAGE.
   - name: 'localityLbPolicy'
     type: Enum
     description: |

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -318,6 +318,8 @@ properties:
       - 'EXTERNAL_MANAGED'
       - 'INTERNAL_MANAGED'
       - 'INTERNAL_SELF_MANAGED'
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
   - name: 'metadataFilters'
     type: Array
     description: |
@@ -500,6 +502,40 @@ properties:
     enum_values:
       - 'PREMIUM'
       - 'STANDARD'
+  - name: 'externalManagedBackendBucketMigrationState'
+    type: Enum
+    description: |
+      Specifies the canary migration state for the backend buckets attached to this forwarding rule.
+      Possible values are PREPARE, TEST_BY_PERCENTAGE, and TEST_ALL_TRAFFIC.
+
+      To begin the migration from EXTERNAL to EXTERNAL_MANAGED, the state must be changed to
+      PREPARE. The state must be changed to TEST_ALL_TRAFFIC before the loadBalancingScheme can be
+      changed to EXTERNAL_MANAGED. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate
+      traffic to backend buckets attached to this forwarding rule by percentage using
+      externalManagedBackendBucketMigrationTestingPercentage.
+
+      Rolling back a migration requires the states to be set in reverse order. So changing the
+      scheme from EXTERNAL_MANAGED to EXTERNAL requires the state to be set to TEST_ALL_TRAFFIC at
+      the same time. Optionally, the TEST_BY_PERCENTAGE state can be used to migrate some traffic
+      back to EXTERNAL or PREPARE can be used to migrate all traffic back to EXTERNAL.
+    enum_values:
+      - 'PREPARE'
+      - 'TEST_BY_PERCENTAGE'
+      - 'TEST_ALL_TRAFFIC'
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
+  - name: 'externalManagedBackendBucketMigrationTestingPercentage'
+    type: Double
+    description: |
+      Determines the fraction of requests to backend buckets that should be processed by the Global
+      external Application Load Balancer.
+
+      The value of this field must be in the range [0, 100].
+
+      This value can only be set if the loadBalancingScheme in the forwarding rule is set to
+      EXTERNAL (when using the Classic ALB) and the migration state is TEST_BY_PERCENTAGE.
+    update_url: 'projects/{{project}}/global/forwardingRules/{{name}}'
+    update_verb: 'PATCH'
   - name: 'serviceDirectoryRegistrations'
     type: Array
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -3,8 +3,8 @@ package compute_test
 import (
 	"fmt"
 	"testing"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -2685,4 +2685,101 @@ resource "google_compute_health_check" "health_check" {
   }
 }
 `, suffix, timeout, loadBalancingScheme, preference, suffix, suffix, suffix)
+}
+
+func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_basic(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+			Config: testAccComputeBackendService_withCanaryMigration(
+					serviceName, checkName, "updated-to-prepare", "PREPARE"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCanaryMigrationPercentage(
+					serviceName, checkName, "updated-to-percentage", 50),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCanaryMigration(
+					serviceName, checkName, "update-to-all", "TEST_ALL_TRAFFIC"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeBackendService_withCanaryMigration(serviceName, checkName, description, migrationState string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name             = "%s"
+  description      = "%s"
+  health_checks    = [google_compute_http_health_check.zero.self_link]
+  external_managed_migration_state = "%s"
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, description, migrationState, checkName)
+}
+
+func testAccComputeBackendService_withCanaryMigrationPercentage(serviceName, checkName, description string, percentage int64) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "six_minutes_delay" {
+  create_duration = "370s" # litte more than 6 minutes (360 seconds = 6 minutes)
+}
+
+resource "google_compute_backend_service" "foobar" {
+  name             = "%s"
+  description      = "%s"
+  health_checks    = [google_compute_http_health_check.zero.self_link]
+  external_managed_migration_state = "TEST_BY_PERCENTAGE"
+	external_managed_migration_testing_percentage = %d
+	depends_on = [
+		time_sleep.six_minutes_delay
+	]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, description, percentage, checkName)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccComputeBackendService_basic(t *testing.T) {
@@ -146,12 +147,10 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 	})
 }
 
-func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
+func TestAccComputeBackendService_withBackendAndPreferenceInternalManaged(t *testing.T) {
 	t.Parallel()
 
 	im_suffix := fmt.Sprintf("im-%s", acctest.RandString(t, 10))
-	ism_suffix := fmt.Sprintf("ism-%s", acctest.RandString(t, 10))
-	em_suffix := fmt.Sprintf("em-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -174,6 +173,20 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
+
+func TestAccComputeBackendService_withBackendAndPreferenceInternalSelfManaged(t *testing.T) {
+	t.Parallel()
+
+	ism_suffix := fmt.Sprintf("ism-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeBackendService_withBackendAndPreference(ism_suffix, "INTERNAL_SELF_MANAGED", "DEFAULT", 10),
 			},
@@ -190,7 +203,20 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
+		},
+	})
+}
+
+func TestAccComputeBackendService_withBackendAndPreferenceExternalManaged(t *testing.T) {
+	t.Parallel()
+	em_suffix := fmt.Sprintf("em-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+		{
 				Config: testAccComputeBackendService_withBackendAndPreference(em_suffix, "EXTERNAL_MANAGED", "DEFAULT", 10),
 			},
 			{
@@ -739,9 +765,6 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
-	serviceName2 := fmt.Sprintf("%s-2",serviceName)
-	checkName2 := fmt.Sprintf("%s-2", checkName)
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -795,8 +818,23 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
+
+func TestAccComputeBackendService_withLogConfigMode(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-lc-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-lc-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName2, checkName2, "INCLUDE_ALL_OPTIONAL", true),
+				Config: testAccComputeBackendService_withLogConfigMode(serviceName, checkName, "INCLUDE_ALL_OPTIONAL", true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -804,7 +842,7 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName2, checkName2, "EXCLUDE_ALL_OPTIONAL", true),
+				Config: testAccComputeBackendService_withLogConfigMode(serviceName, checkName, "EXCLUDE_ALL_OPTIONAL", true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -2238,7 +2276,7 @@ resource "google_compute_http_health_check" "zero" {
 `, serviceName, enabled, checkName)
 }
 
-func testAccComputeBackendService_withLogConfig3(serviceName, checkName, mode string, enabled bool) string {
+func testAccComputeBackendService_withLogConfigMode(serviceName, checkName, mode string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
   name          		= "%s"
@@ -2716,8 +2754,13 @@ func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-			Config: testAccComputeBackendService_withCanaryMigration(
+				Config: testAccComputeBackendService_withCanaryMigration(
 					serviceName, checkName, "updated-to-prepare", "PREPARE"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_backend_service.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -2727,6 +2770,11 @@ func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
 			{
 				Config: testAccComputeBackendService_withCanaryMigrationPercentage(
 					serviceName, checkName, "updated-to-percentage", 50),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_backend_service.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -2736,6 +2784,11 @@ func TestAccComputeBackendService_updateCanaryMigration(t *testing.T) {
 			{
 				Config: testAccComputeBackendService_withCanaryMigration(
 					serviceName, checkName, "update-to-all", "TEST_ALL_TRAFFIC"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_backend_service.foobar", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -2753,6 +2806,31 @@ resource "google_compute_backend_service" "foobar" {
   description      = "%s"
   health_checks    = [google_compute_http_health_check.zero.self_link]
   external_managed_migration_state = "%s"
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, description, migrationState, checkName)
+}
+
+func testAccComputeBackendService_withCanaryMigrationWithWait(serviceName, checkName, description, migrationState string) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "six_minutes_delay" {
+  create_duration = "370s" # litte more than 6 minutes (360 seconds = 6 minutes)
+}
+
+resource "google_compute_backend_service" "foobar" {
+  name             = "%s"
+  description      = "%s"
+  health_checks    = [google_compute_http_health_check.zero.self_link]
+  external_managed_migration_state = "%s"
+	depends_on = [
+		time_sleep.six_minutes_delay
+	]
 }
 
 resource "google_compute_http_health_check" "zero" {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -149,14 +149,17 @@ func TestAccComputeBackendService_withBackendAndIAP(t *testing.T) {
 func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 	t.Parallel()
 
-	randomSuffix := acctest.RandString(t, 10)
+	im_suffix := fmt.Sprintf("im-%s", acctest.RandString(t, 10))
+	ism_suffix := fmt.Sprintf("ism-%s", acctest.RandString(t, 10))
+	em_suffix := fmt.Sprintf("em-%s", acctest.RandString(t, 10))
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_MANAGED", "DEFAULT", 10),
+				Config: testAccComputeBackendService_withBackendAndPreference(im_suffix, "INTERNAL_MANAGED", "DEFAULT", 10),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -164,7 +167,7 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_MANAGED", "PREFERRED", 20),
+				Config: testAccComputeBackendService_withBackendAndPreference(im_suffix, "INTERNAL_MANAGED", "PREFERRED", 20),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -172,7 +175,7 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_SELF_MANAGED", "DEFAULT", 10),
+				Config: testAccComputeBackendService_withBackendAndPreference(ism_suffix, "INTERNAL_SELF_MANAGED", "DEFAULT", 10),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -180,7 +183,7 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "INTERNAL_SELF_MANAGED", "PREFERRED", 20),
+				Config: testAccComputeBackendService_withBackendAndPreference(ism_suffix, "INTERNAL_SELF_MANAGED", "PREFERRED", 20),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -188,7 +191,7 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "EXTERNAL_MANAGED", "DEFAULT", 10),
+				Config: testAccComputeBackendService_withBackendAndPreference(em_suffix, "EXTERNAL_MANAGED", "DEFAULT", 10),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -196,7 +199,7 @@ func TestAccComputeBackendService_withBackendAndPreference(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withBackendAndPreference(randomSuffix, "EXTERNAL_MANAGED", "PREFERRED", 20),
+				Config: testAccComputeBackendService_withBackendAndPreference(em_suffix, "EXTERNAL_MANAGED", "PREFERRED", 20),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.lipsum",
@@ -736,6 +739,9 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
+	serviceName2 := fmt.Sprintf("%s-2",serviceName)
+	checkName2 := fmt.Sprintf("%s-2", checkName)
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -790,7 +796,7 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "INCLUDE_ALL_OPTIONAL", true),
+				Config: testAccComputeBackendService_withLogConfig3(serviceName2, checkName2, "INCLUDE_ALL_OPTIONAL", true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",
@@ -798,7 +804,7 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeBackendService_withLogConfig3(serviceName, checkName, "EXCLUDE_ALL_OPTIONAL", true),
+				Config: testAccComputeBackendService_withLogConfig3(serviceName2, checkName2, "EXCLUDE_ALL_OPTIONAL", true),
 			},
 			{
 				ResourceName:      "google_compute_backend_service.foobar",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -367,6 +367,59 @@ func TestUnitComputeGlobalForwardingRule_InternalIpDiffSuppress(t *testing.T) {
 	}
 }
 
+func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
+	t.Parallel()
+
+  fr := fmt.Sprintf("fr-canary-mgiration-%s", acctest.RandString(t, 10))
+	proxy := fmt.Sprintf("pr-canary-mgiration-%s", acctest.RandString(t, 10))
+	urlmap := fmt.Sprintf("um-canary-mgiration-%s", acctest.RandString(t, 10))
+	backendservice := fmt.Sprintf("bs-canary-mgiration-%s", acctest.RandString(t, 10))
+	address := fmt.Sprintf("addr-canary-mgiration-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy:             testAccCheckComputeGlobalForwardingRuleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeGlobalForwardingRule_basic(fr, proxy, urlmap, backendservice, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeGlobalForwardingRule_withCanaryMigration(fr, "PREPARE", proxy, urlmap, backendservice, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+      {
+        Config: testAccComputeGlobalForwardingRule_withCanaryMigrationPercentage(fr, proxy, urlmap, backendservice, address, 50),
+      },
+      {
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+      {
+				Config: testAccComputeGlobalForwardingRule_withCanaryMigration(fr, "TEST_ALL_TRAFFIC", proxy, urlmap, backendservice, address),
+			},
+			{
+				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeGlobalForwardingRule_httpProxy(fr, targetProxy, proxy, proxy2, backend, hc, urlmap string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
@@ -912,3 +965,113 @@ resource "google_compute_instance_template" "instance_template" {
 `, fr, proxy, backend, hc, urlmap, igm, it)
 }
 {{- end }}
+
+
+
+func testAccComputeGlobalForwardingRule_basic(fr, proxy, urlmap, backendservice, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL"
+  target                = google_compute_target_http_proxy.my_target_http_proxy.id
+  ip_address            = google_compute_global_address.my_global_ip.address
+}
+
+resource "google_compute_target_http_proxy" "my_target_http_proxy" {
+  name    = "%s"
+  url_map = google_compute_url_map.my_url_map.id
+}
+
+resource "google_compute_url_map" "my_url_map" {
+  name            = "%s"
+  default_service = google_compute_backend_service.my_backend_service.id
+}
+
+resource "google_compute_backend_service" "my_backend_service" {
+  name                  = "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+}
+
+resource "google_compute_global_address" "my_global_ip" {
+  name = "%s"
+}
+`, fr, proxy, urlmap, backendservice, address)
+}
+
+func testAccComputeGlobalForwardingRule_withCanaryMigration(fr, bucket_migration_state, proxy, urlmap, backendservice, address string) string {
+	return fmt.Sprintf(`
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL"
+  target                = google_compute_target_http_proxy.my_target_http_proxy.id
+  ip_address            = google_compute_global_address.my_global_ip.address
+  external_managed_backend_bucket_migration_state = "%s"
+}
+
+resource "google_compute_target_http_proxy" "my_target_http_proxy" {
+  name    = "%s"
+  url_map = google_compute_url_map.my_url_map.id
+}
+
+resource "google_compute_url_map" "my_url_map" {
+  name            = "%s"
+  default_service = google_compute_backend_service.my_backend_service.id
+}
+
+resource "google_compute_backend_service" "my_backend_service" {
+  name                  = "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+}
+
+resource "google_compute_global_address" "my_global_ip" {
+  name = "%s"
+}
+`, fr, bucket_migration_state, proxy, urlmap, backendservice, address)
+}
+
+
+func testAccComputeGlobalForwardingRule_withCanaryMigrationPercentage(fr, proxy, urlmap, backendservice, address string, percentage int64) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "six_minutes_delay" {
+  create_duration = "370s" # litte more than 6 minutes (360 seconds = 6 minutes)
+}
+
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "%s"
+  ip_protocol           = "TCP"
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL"
+  target                = google_compute_target_http_proxy.my_target_http_proxy.id
+  ip_address            = google_compute_global_address.my_global_ip.address
+  external_managed_backend_bucket_migration_state = "TEST_BY_PERCENTAGE"
+  external_managed_backend_bucket_migration_testing_percentage = %d
+  depends_on = [time_sleep.six_minutes_delay]
+}
+
+resource "google_compute_target_http_proxy" "my_target_http_proxy" {
+  name    = "%s"
+  url_map = google_compute_url_map.my_url_map.id
+}
+
+resource "google_compute_url_map" "my_url_map" {
+  name            = "%s"
+  default_service = google_compute_backend_service.my_backend_service.id
+}
+
+resource "google_compute_backend_service" "my_backend_service" {
+  name                  = "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "EXTERNAL"
+}
+
+resource "google_compute_global_address" "my_global_ip" {
+  name = "%s"
+}
+`, fr, percentage, proxy, urlmap, backendservice, address)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -371,7 +371,7 @@ func TestUnitComputeGlobalForwardingRule_InternalIpDiffSuppress(t *testing.T) {
 func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
 	t.Parallel()
 
-  fr := fmt.Sprintf("fr-canary-mgiration-%s", acctest.RandString(t, 10))
+	fr := fmt.Sprintf("fr-canary-mgiration-%s", acctest.RandString(t, 10))
 	proxy := fmt.Sprintf("pr-canary-mgiration-%s", acctest.RandString(t, 10))
 	urlmap := fmt.Sprintf("um-canary-mgiration-%s", acctest.RandString(t, 10))
 	backendservice := fmt.Sprintf("bs-canary-mgiration-%s", acctest.RandString(t, 10))
@@ -419,7 +419,7 @@ func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      {
+			{
 				Config: testAccComputeGlobalForwardingRule_withCanaryMigration(fr, "TEST_ALL_TRAFFIC", proxy, urlmap, backendservice, address),
         ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_global_forwarding_rule_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  "github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
   "github.com/hashicorp/terraform-provider-google/google/services/compute"
 )
@@ -394,6 +395,11 @@ func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
 			},
 			{
 				Config: testAccComputeGlobalForwardingRule_withCanaryMigration(fr, "PREPARE", proxy, urlmap, backendservice, address),
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_global_forwarding_rule.forwarding_rule", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
@@ -402,6 +408,11 @@ func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
 			},
       {
         Config: testAccComputeGlobalForwardingRule_withCanaryMigrationPercentage(fr, proxy, urlmap, backendservice, address, 50),
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_global_forwarding_rule.forwarding_rule", plancheck.ResourceActionUpdate),
+					},
+				},
       },
       {
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
@@ -410,6 +421,11 @@ func TestAccComputeGlobalForwardingRule_updateCanaryMigration(t *testing.T) {
 			},
       {
 				Config: testAccComputeGlobalForwardingRule_withCanaryMigration(fr, "TEST_ALL_TRAFFIC", proxy, urlmap, backendservice, address),
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_global_forwarding_rule.forwarding_rule", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add Terraform support for configuring Classic ALB migration feature. The support is added for the global backend-service and global forwarding rule. This feature allows gradual and controlled migration to the External Managed LB from Classic LB. The global forwarding rule config changes applies to all the backend bucket attached to the forwarding rule.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/22760 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `external_managed_migration_state` and `external_managed_migration_testing_percentage` to `google_compute_backend_service` resource.
```

```release-note:enhancement
compute: added `external_managed_backend_bucket_migration_state` and `external_managed_backend_bucket_migration_testing_percentage` to `google_compute_global_forwarding_rule` resource.
```

```release-note:enhancement
compute: added update support for `load_balancing_scheme` in `google_compute_backend_service` and `google_compute_global_forwarding_rule` resources to allow migrating between classic and global external ALB
```