### PR TITLE
chore: Clean up logic in MMV1 binary

### DIFF
--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -140,38 +140,19 @@ func main() {
 	log.Printf("Building %s version", *version)
 	log.Printf("Building %s provider", providerName)
 
-	// Building compute takes a long time and can't be parallelized within the product
-	// so lets build it first
-	sort.Slice(allProductFiles, func(i int, j int) bool {
-		if allProductFiles[i] == "products/compute" {
-			return true
-		}
-		return false
-	})
-
-	var providerToGenerate provider.Provider
-
-	productFileChannel := make(chan string, len(allProductFiles))
 	productsForVersionChannel := make(chan *api.Product, len(allProductFiles))
-	for _, pf := range allProductFiles {
-		productFileChannel <- pf
-	}
-
-	for i := 0; i < len(allProductFiles); i++ {
+	for _, productFile := range allProductFiles {
 		wg.Add(1)
-		go GenerateProduct(productFileChannel, providerToGenerate, productsForVersionChannel, startTime, productsToGenerate, *resourceToGenerate, *overrideDirectory, generateCode, generateDocs)
+		go GenerateProduct(productFile, productsForVersionChannel, startTime, productsToGenerate, *resourceToGenerate, *overrideDirectory, generateCode, generateDocs)
 	}
 	wg.Wait()
 
-	close(productFileChannel)
 	close(productsForVersionChannel)
 
 	var productsForVersion []*api.Product
-
 	for p := range productsForVersionChannel {
 		productsForVersion = append(productsForVersion, p)
 	}
-
 	slices.SortFunc(productsForVersion, func(p1, p2 *api.Product) int {
 		return strings.Compare(strings.ToLower(p1.Name), strings.ToLower(p2.Name))
 	})
@@ -179,7 +160,7 @@ func main() {
 	// In order to only copy/compile files once per provider this must be called outside
 	// of the products loop. This will get called with the provider from the final iteration
 	// of the loop
-	providerToGenerate = setProvider(*forceProvider, *version, productsForVersion[0], startTime)
+	providerToGenerate := newProvider(*forceProvider, *version, productsForVersion[0], startTime)
 	providerToGenerate.CopyCommonFiles(*outputPath, generateCode, generateDocs)
 
 	if generateCode {
@@ -189,10 +170,8 @@ func main() {
 	provider.FixImports(*outputPath, *showImportDiffs)
 }
 
-func GenerateProduct(productChannel chan string, providerToGenerate provider.Provider, productsForVersionChannel chan *api.Product, startTime time.Time, productsToGenerate []string, resourceToGenerate, overrideDirectory string, generateCode, generateDocs bool) {
-
+func GenerateProduct(productName string, productsForVersionChannel chan *api.Product, startTime time.Time, productsToGenerate []string, resourceToGenerate, overrideDirectory string, generateCode, generateDocs bool) {
 	defer wg.Done()
-	productName := <-productChannel
 
 	productYamlPath := path.Join(productName, "product.yaml")
 
@@ -308,8 +287,6 @@ func GenerateProduct(productChannel chan string, providerToGenerate provider.Pro
 	productApi.Objects = resources
 	productApi.Validate()
 
-	providerToGenerate = setProvider(*forceProvider, *version, productApi, startTime)
-
 	productsForVersionChannel <- productApi
 
 	if !slices.Contains(productsToGenerate, productName) {
@@ -318,12 +295,13 @@ func GenerateProduct(productChannel chan string, providerToGenerate provider.Pro
 	}
 
 	log.Printf("%s: Generating files", productName)
+
+	providerToGenerate := newProvider(*forceProvider, *version, productApi, startTime)
 	providerToGenerate.Generate(*outputPath, productName, resourceToGenerate, generateCode, generateDocs)
 }
 
-// Sets provider via flag
-func setProvider(forceProvider, version string, productApi *api.Product, startTime time.Time) provider.Provider {
-	switch forceProvider {
+func newProvider(name, version string, productApi *api.Product, startTime time.Time) provider.Provider {
+	switch name {
 	case "tgc":
 		return provider.NewTerraformGoogleConversion(productApi, version, startTime)
 	case "tgc_cai2hcl":

--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -158,8 +158,7 @@ func main() {
 	})
 
 	// In order to only copy/compile files once per provider this must be called outside
-	// of the products loop. This will get called with the provider from the final iteration
-	// of the loop
+	// of the products loop. Create an MMv1 provider with an arbitrary product (the first loaded).
 	providerToGenerate := newProvider(*forceProvider, *version, productsForVersion[0], startTime)
 	providerToGenerate.CopyCommonFiles(*outputPath, generateCode, generateDocs)
 
@@ -300,8 +299,8 @@ func GenerateProduct(productName string, productsForVersionChannel chan *api.Pro
 	providerToGenerate.Generate(*outputPath, productName, resourceToGenerate, generateCode, generateDocs)
 }
 
-func newProvider(name, version string, productApi *api.Product, startTime time.Time) provider.Provider {
-	switch name {
+func newProvider(providerName, version string, productApi *api.Product, startTime time.Time) provider.Provider {
+	switch providerName {
 	case "tgc":
 		return provider.NewTerraformGoogleConversion(productApi, version, startTime)
 	case "tgc_cai2hcl":

--- a/mmv1/provider/terraform_tgc_cai2hcl.go
+++ b/mmv1/provider/terraform_tgc_cai2hcl.go
@@ -62,7 +62,7 @@ func (cai2hcl CaiToTerraformConversion) CopyCommonFiles(outputFolder string, gen
 	if !generateCode {
 		return
 	}
-	log.Printf("Coping cai2hcl common files")
+	log.Print("Copying cai2hcl common files")
 
 	if err := os.MkdirAll(outputFolder, os.ModePerm); err != nil {
 		log.Println(fmt.Errorf("error creating output directory %v: %v", outputFolder, err))


### PR DESCRIPTION
* Remove unnecessary passing of provider in GenerateProduct
* Remove unnecessary usage of a channel to pass product file to GenerateProduct
* Remove slice sorting that placed the compute product first
* Rename `setProvider` to `newProvider` to more accurately describe functionality
* Fix typo in tgc cai2hcl log

```release-note:none
```