### PR TITLE
transition functions to go-github

### DIFF
--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -424,12 +424,12 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 	ticketLabels = append(ticketLabels, labels...)
 
 	issueRquest := &github.IssueRequest{
-		Title:  github.String(issueTitle),
-		Body:   github.String(issueBody),
+		Title:  github.Ptr(issueTitle),
+		Body:   github.Ptr(issueBody),
 		Labels: &ticketLabels,
 		// Milestone: Near-Term Goals
 		// https://github.com/hashicorp/terraform-provider-google/milestone/11
-		Milestone: github.Int(11),
+		Milestone: github.Ptr(11),
 	}
 
 	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)

--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -397,7 +397,7 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 		// short-circuit if service labels have already been added to the PR
 		hasServiceLabels := false
 		for _, label := range pullRequest.Labels {
-			if strings.HasPrefix(label.Name, "service/") {
+			if strings.HasPrefix(label.GetName(), "service/") {
 				hasServiceLabels = true
 			}
 		}
@@ -414,14 +414,13 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 			}
 		}
 	}
-
 	// Update breaking changes status on PR
 	breakingState := "success"
 	if len(uniqueBreakingChanges) > 0 {
 		breakingState = "failure"
 		// If fetching the PR failed, Labels will be empty
 		for _, label := range pullRequest.Labels {
-			if label.Name == allowBreakingChangesLabel {
+			if label.GetName() == allowBreakingChangesLabel {
 				breakingState = "success"
 				break
 			}
@@ -452,7 +451,7 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 		if len(missingServiceLabels) > 0 {
 			missingServiceLabelsState = "failure"
 			for _, label := range pullRequest.Labels {
-				if label.Name == allowMissingServiceLabelsLabel {
+				if label.GetName() == allowMissingServiceLabelsLabel {
 					missingServiceLabelsState = "success"
 					break
 				}

--- a/.ci/magician/cmd/generate_comment_test.go
+++ b/.ci/magician/cmd/generate_comment_test.go
@@ -23,12 +23,16 @@ import (
 
 	"magician/source"
 
+	ghi "github.com/google/go-github/v68/github"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExecGenerateComment(t *testing.T) {
 	mr := NewMockRunner()
 	gh := &mockGithub{
+		pullRequest: &ghi.PullRequest{
+			Number: ghi.Ptr(123456),
+		},
 		calledMethods: make(map[string][][]any),
 	}
 	ctlr := source.NewController("/mock/dir/go", "modular-magician", "*******", mr)

--- a/.ci/magician/cmd/interfaces.go
+++ b/.ci/magician/cmd/interfaces.go
@@ -18,17 +18,19 @@ package cmd
 import (
 	"magician/github"
 	"magician/teamcity"
+
+	ghi "github.com/google/go-github/v68/github"
 )
 
 type GithubClient interface {
-	GetPullRequest(prNumber string) (github.PullRequest, error)
-	GetPullRequests(state, base, sort, direction string) ([]github.PullRequest, error)
-	GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error)
-	GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error)
-	GetPullRequestComments(prNumber string) ([]github.PullRequestComment, error)
+	GetPullRequest(prNumber string) (*ghi.PullRequest, error)
+	GetPullRequests(state, base, sort, direction string) ([]*ghi.PullRequest, error)
+	GetPullRequestRequestedReviewers(prNumber string) ([]*ghi.User, error)
+	GetPullRequestPreviousReviewers(prNumber string) ([]*ghi.User, error)
+	GetPullRequestComments(prNumber string) ([]*ghi.IssueComment, error)
 	GetCommitMessage(owner, repo, sha string) (string, error)
 	GetUserType(user string) github.UserType
-	GetTeamMembers(organization, team string) ([]github.User, error)
+	GetTeamMembers(organization, team string) ([]*ghi.User, error)
 	MergePullRequest(owner, repo, prNumber, commitSha string) error
 	PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error
 	PostComment(prNumber, comment string) error

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -142,14 +142,14 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 	for _, ticketNumber := range shouldCloseTickets {
 		fmt.Println("Closing ticket ", ticketNumber)
 		issueComment := &github.IssueComment{
-			Body: github.String(comment),
+			Body: github.Ptr(comment),
 		}
 		_, _, err = gh.Issues.CreateComment(ctx, GithubOwner, GithubRepo, ticketNumber, issueComment)
 		if err != nil {
 			return fmt.Errorf("error posting comment to issue %d: %w", ticketNumber, err)
 		}
 		issueRquest := &github.IssueRequest{
-			State: github.String("closed"),
+			State: github.Ptr("closed"),
 		}
 		_, _, err = gh.Issues.Edit(ctx, GithubOwner, GithubRepo, ticketNumber, issueRquest)
 		if err != nil {

--- a/.ci/magician/cmd/membership_checker.go
+++ b/.ci/magician/cmd/membership_checker.go
@@ -67,7 +67,7 @@ func execMembershipChecker(prNumber, commitSha string, gh GithubClient, cb Cloud
 		return err
 	}
 
-	author := pullRequest.User.Login
+	author := pullRequest.User.GetLogin()
 	authorUserType := gh.GetUserType(author)
 	trusted := authorUserType == github.CoreContributorUserType || authorUserType == github.GooglerUserType
 

--- a/.ci/magician/cmd/mock_github_test.go
+++ b/.ci/magician/cmd/mock_github_test.go
@@ -19,27 +19,29 @@ import (
 	"errors"
 
 	"magician/github"
+
+	ghi "github.com/google/go-github/v68/github"
 )
 
 type mockGithub struct {
-	pullRequest         github.PullRequest
+	pullRequest         *ghi.PullRequest
 	userType            github.UserType
-	requestedReviewers  []github.User
-	previousReviewers   []github.User
-	pullRequestComments []github.PullRequestComment
-	teamMembers         map[string][]github.User
+	requestedReviewers  []*ghi.User
+	previousReviewers   []*ghi.User
+	pullRequestComments []*ghi.IssueComment
+	teamMembers         map[string][]*ghi.User
 	calledMethods       map[string][][]any
 	commitMessage       string
 }
 
-func (m *mockGithub) GetPullRequest(prNumber string) (github.PullRequest, error) {
+func (m *mockGithub) GetPullRequest(prNumber string) (*ghi.PullRequest, error) {
 	m.calledMethods["GetPullRequest"] = append(m.calledMethods["GetPullRequest"], []any{prNumber})
 	return m.pullRequest, nil
 }
 
-func (m *mockGithub) GetPullRequests(state, base, sort, direction string) ([]github.PullRequest, error) {
+func (m *mockGithub) GetPullRequests(state, base, sort, direction string) ([]*ghi.PullRequest, error) {
 	m.calledMethods["GetPullRequests"] = append(m.calledMethods["GetPullRequests"], []any{state, base, sort, direction})
-	return []github.PullRequest{m.pullRequest}, nil
+	return []*ghi.PullRequest{m.pullRequest}, nil
 }
 
 func (m *mockGithub) GetUserType(user string) github.UserType {
@@ -47,17 +49,17 @@ func (m *mockGithub) GetUserType(user string) github.UserType {
 	return m.userType
 }
 
-func (m *mockGithub) GetPullRequestRequestedReviewers(prNumber string) ([]github.User, error) {
+func (m *mockGithub) GetPullRequestRequestedReviewers(prNumber string) ([]*ghi.User, error) {
 	m.calledMethods["GetPullRequestRequestedReviewers"] = append(m.calledMethods["GetPullRequestRequestedReviewers"], []any{prNumber})
 	return m.requestedReviewers, nil
 }
 
-func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]github.User, error) {
+func (m *mockGithub) GetPullRequestPreviousReviewers(prNumber string) ([]*ghi.User, error) {
 	m.calledMethods["GetPullRequestPreviousReviewers"] = append(m.calledMethods["GetPullRequestPreviousReviewers"], []any{prNumber})
 	return m.previousReviewers, nil
 }
 
-func (m *mockGithub) GetPullRequestComments(prNumber string) ([]github.PullRequestComment, error) {
+func (m *mockGithub) GetPullRequestComments(prNumber string) ([]*ghi.IssueComment, error) {
 	m.calledMethods["GetPullRequestComments"] = append(m.calledMethods["GetPullRequestComments"], []any{prNumber})
 	return m.pullRequestComments, nil
 }
@@ -67,7 +69,7 @@ func (m *mockGithub) GetCommitMessage(owner, repo, sha string) (string, error) {
 	return m.commitMessage, nil
 }
 
-func (m *mockGithub) GetTeamMembers(organization, team string) ([]github.User, error) {
+func (m *mockGithub) GetTeamMembers(organization, team string) ([]*ghi.User, error) {
 	m.calledMethods["GetTeamMembers"] = append(m.calledMethods["GetTeamMembers"], []any{organization, team})
 	if team == "" {
 		return nil, errors.New("No team members set")

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -76,7 +76,8 @@ func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) 
 
 	reviewerComment, currentReviewer := github.FindReviewerComment(comments)
 	if newPrimaryReviewer == "" {
-		newPrimaryReviewer = github.GetRandomReviewer([]string{currentReviewer, pullRequest.User.Login})
+		userLogin := pullRequest.User.GetLogin()
+		newPrimaryReviewer = github.GetRandomReviewer([]string{currentReviewer, userLogin})
 	}
 
 	if newPrimaryReviewer == "" {
@@ -100,7 +101,8 @@ func execReassignReviewer(prNumber, newPrimaryReviewer string, gh GithubClient) 
 			fmt.Printf("Failed to remove reviewer %s from pull request: %s\n", currentReviewer, err)
 		}
 		fmt.Println("Updating reviewer comment")
-		err := gh.UpdateComment(prNumber, comment, reviewerComment.ID)
+		reviewerComment := int(reviewerComment.GetID())
+		err := gh.UpdateComment(prNumber, comment, reviewerComment)
 		if err != nil {
 			return err
 		}

--- a/.ci/magician/cmd/remove_label_test.go
+++ b/.ci/magician/cmd/remove_label_test.go
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*     http://www.apache.org/licenses/LICENSE-2.0
+* http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,27 +19,29 @@ import (
 	"magician/github"
 	"reflect"
 	"testing"
+
+	ghi "github.com/google/go-github/v68/github"
 )
 
 func TestExecRemoveAwaitingApproval(t *testing.T) {
-	gh := &mockGithub{
-		pullRequest: github.PullRequest{
-			User: github.User{
-				Login: "core_author",
+	mockGH := &mockGithub{
+		pullRequest: &ghi.PullRequest{
+			User: &ghi.User{
+				Login: ghi.String("core_author"),
 			},
 		},
 		userType:      github.CoreContributorUserType,
 		calledMethods: make(map[string][][]any),
 	}
 
-	execRemoveLabel("pr1", gh, "awaiting-approval")
+	execRemoveLabel("pr1", mockGH, "awaiting-approval")
 
 	method := "RemoveLabel"
 	expected := [][]any{{"pr1", "awaiting-approval"}}
-	if calls, ok := gh.calledMethods[method]; !ok {
+
+	if calls, ok := mockGH.calledMethods[method]; !ok {
 		t.Fatal("awaiting-approval label not removed for PR ")
 	} else if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("Wrong calls for %s, got %v, expected %v", method, calls, expected)
 	}
-
 }

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -58,7 +58,7 @@ func execRequestReviewer(prNumber string, gh GithubClient) error {
 		return err
 	}
 
-	author := pullRequest.User.Login
+	author := pullRequest.User.GetLogin()
 	if !github.IsCoreContributor(author) {
 		fmt.Println("Not core contributor - assigning reviewer")
 

--- a/.ci/magician/cmd/request_reviewer_test.go
+++ b/.ci/magician/cmd/request_reviewer_test.go
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*     http://www.apache.org/licenses/LICENSE-2.0
+* http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,13 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
  */
-
 package cmd
 
 import (
 	"magician/github"
 	"testing"
 
+	ghi "github.com/google/go-github/v68/github"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,8 +28,9 @@ func TestExecRequestReviewer(t *testing.T) {
 	if len(availableReviewers) < 3 {
 		t.Fatalf("not enough available reviewers (%v) to run TestExecRequestReviewer (need at least 3)", availableReviewers)
 	}
+
 	cases := map[string]struct {
-		pullRequest             github.PullRequest
+		pullRequest             *ghi.PullRequest
 		requestedReviewers      []string
 		previousReviewers       []string
 		teamMembers             map[string][]string
@@ -37,69 +38,73 @@ func TestExecRequestReviewer(t *testing.T) {
 		expectReviewersFromList []string
 	}{
 		"core contributor author doesn't get a new reviewer, re-request, or comment with no previous reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: availableReviewers[0]},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String(availableReviewers[0])},
 			},
 			expectSpecificReviewers: []string{},
 		},
 		"core contributor author doesn't get a new reviewer, re-request, or comment with previous reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: availableReviewers[0]},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String(availableReviewers[0])},
 			},
 			previousReviewers:       []string{availableReviewers[1]},
 			expectSpecificReviewers: []string{},
 		},
 		"non-core-contributor author gets a new reviewer with no previous reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: "author"},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String("author")},
 			},
 			expectReviewersFromList: availableReviewers,
 		},
 		"non-core-contributor author doesn't get a new reviewer (but does get re-request) with previous reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: "author"},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String("author")},
 			},
 			previousReviewers:       []string{availableReviewers[1], "author2", availableReviewers[2]},
 			expectSpecificReviewers: []string{availableReviewers[1], availableReviewers[2]},
 		},
 		"non-core-contributor author doesn't get a new reviewer or a re-request with already-requested reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: "author"},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String("author")},
 			},
 			requestedReviewers:      []string{availableReviewers[1], "author2", availableReviewers[2]},
 			expectSpecificReviewers: []string{},
 		},
 	}
+
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			requestedReviewers := []github.User{}
+			requestedReviewers := []*ghi.User{}
 			for _, login := range tc.requestedReviewers {
-				requestedReviewers = append(requestedReviewers, github.User{Login: login})
+				requestedReviewers = append(requestedReviewers, &ghi.User{Login: ghi.String(login)})
 			}
-			previousReviewers := []github.User{}
+
+			previousReviewers := []*ghi.User{}
 			for _, login := range tc.previousReviewers {
-				previousReviewers = append(previousReviewers, github.User{Login: login})
+				previousReviewers = append(previousReviewers, &ghi.User{Login: ghi.String(login)})
 			}
-			gh := &mockGithub{
+
+			mockGH := &mockGithub{
 				pullRequest:        tc.pullRequest,
 				requestedReviewers: requestedReviewers,
 				previousReviewers:  previousReviewers,
 				calledMethods:      make(map[string][][]any),
 			}
 
-			execRequestReviewer("1", gh)
+			execRequestReviewer("1", mockGH)
 
 			actualReviewers := []string{}
-			for _, args := range gh.calledMethods["RequestPullRequestReviewers"] {
+			for _, args := range mockGH.calledMethods["RequestPullRequestReviewers"] {
 				actualReviewers = append(actualReviewers, args[1].([]string)...)
 			}
 
 			if tc.expectSpecificReviewers != nil {
 				assert.ElementsMatch(t, tc.expectSpecificReviewers, actualReviewers)
 				if len(tc.expectSpecificReviewers) == 0 {
-					assert.Len(t, gh.calledMethods["RequestPullRequestReviewers"], 0)
+					assert.Len(t, mockGH.calledMethods["RequestPullRequestReviewers"], 0)
 				}
 			}
+
 			if tc.expectReviewersFromList != nil {
 				for _, reviewer := range actualReviewers {
 					assert.Contains(t, tc.expectReviewersFromList, reviewer)

--- a/.ci/magician/cmd/request_service_reviewers.go
+++ b/.ci/magician/cmd/request_service_reviewers.go
@@ -79,11 +79,12 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 	githubTeamsSet := make(map[string]struct{})
 	teamCount := 0
 	for _, label := range pullRequest.Labels {
-		if !strings.HasPrefix(label.Name, "service/") || label.Name == "service/terraform" {
+		labelName := label.GetName()
+		if !strings.HasPrefix(labelName, "service/") || labelName == "service/terraform" {
 			continue
 		}
 		teamCount += 1
-		if labelData, ok := enrolledTeams[label.Name]; ok && labelData.Team != "" {
+		if labelData, ok := enrolledTeams[labelName]; ok && labelData.Team != "" {
 			githubTeamsSet[labelData.Team] = struct{}{}
 		}
 	}
@@ -98,12 +99,12 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 	reviewersToRequest := []string{}
 	requestedReviewersSet := make(map[string]struct{})
 	for _, reviewer := range requestedReviewers {
-		requestedReviewersSet[reviewer.Login] = struct{}{}
+		requestedReviewersSet[reviewer.GetLogin()] = struct{}{}
 	}
 
 	previousReviewersSet := make(map[string]struct{})
 	for _, reviewer := range previousReviewers {
-		previousReviewersSet[reviewer.Login] = struct{}{}
+		previousReviewersSet[reviewer.GetLogin()] = struct{}{}
 	}
 
 	exitCode := 0
@@ -118,18 +119,18 @@ func execRequestServiceReviewers(prNumber string, gh GithubClient, enrolledTeams
 		reviewerPool := []string{}
 		for _, member := range members {
 			// Skip PR author
-			if member.Login == pullRequest.User.Login {
+			if member.GetLogin() == pullRequest.User.GetLogin() {
 				continue
 			}
 
-			reviewerPool = append(reviewerPool, member.Login)
+			reviewerPool = append(reviewerPool, member.GetLogin())
 			// Don't re-request review if there's an active review request
-			if _, ok := requestedReviewersSet[member.Login]; ok {
+			if _, ok := requestedReviewersSet[member.GetLogin()]; ok {
 				hasReviewer = true
 			}
-			if _, ok := previousReviewersSet[member.Login]; ok {
+			if _, ok := previousReviewersSet[member.GetLogin()]; ok {
 				hasReviewer = true
-				reviewersToRequest = append(reviewersToRequest, member.Login)
+				reviewersToRequest = append(reviewersToRequest, member.GetLogin())
 			}
 		}
 

--- a/.ci/magician/cmd/request_service_reviewers_test.go
+++ b/.ci/magician/cmd/request_service_reviewers_test.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
-	"github.com/stretchr/testify/assert"
-	"magician/github"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ghi "github.com/google/go-github/v68/github"
 )
 
 var enrolledTeamsYaml = []byte(`
@@ -22,118 +24,122 @@ service/google-z:
 
 func TestExecRequestServiceReviewersMembershipChecker(t *testing.T) {
 	cases := map[string]struct {
-		pullRequest             github.PullRequest
+		pullRequest             *ghi.PullRequest
 		requestedReviewers      []string
 		previousReviewers       []string
 		teamMembers             map[string][]string
 		expectSpecificReviewers []string
 	}{
 		"no service labels means no service team reviewers": {
-			pullRequest: github.PullRequest{
-				User: github.User{Login: "googler_author"},
+			pullRequest: &ghi.PullRequest{
+				User: &ghi.User{Login: ghi.String("googler_author")},
 			},
 			expectSpecificReviewers: []string{},
 		},
 		"unregistered service labels will not trigger review": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-a"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-a")}},
 			},
 			expectSpecificReviewers: []string{},
 		},
 		"no configured team means no reviewers": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-z"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-z")}},
 			},
 			expectSpecificReviewers: []string{},
 		},
 		"no previous reviewers means all reviews will be requested": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}},
 			expectSpecificReviewers: []string{"googler_team_member"},
 		},
 		"previous reviewers will be re-requested": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
 			previousReviewers:       []string{"googler_team_member"},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member", "googler_team_member_2", "googler_team_member_3", "googler_team_member_4", "googler_team_member_5"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member", "googler_team_member_2", "googler_team_member_3", "googler_team_member_4", "googler_team_member_5"}},
 			expectSpecificReviewers: []string{"googler_team_member"},
 		},
 		"active reviewers will not be re-requested": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
 			requestedReviewers:      []string{"googler_team_member"},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}},
 			expectSpecificReviewers: []string{},
 		},
 		"authors will not be requested on their own PRs": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_team_member"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_team_member")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}},
 			expectSpecificReviewers: []string{},
 		},
 		"authors will not be requested on their own PRs even if they left comments on it previously": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_team_member"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_team_member")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}},
 			previousReviewers:       []string{"googler_team_member"},
 			expectSpecificReviewers: []string{},
 		},
 		"other team members be requested even if the author is excluded": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_team_member"},
-				Labels: []github.Label{{Name: "service/google-x"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_team_member")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member", "googler_team_member_2"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member", "googler_team_member_2"}},
 			expectSpecificReviewers: []string{"googler_team_member_2"},
 		},
 		"multiple teams can be requested at once": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-x"}, {Name: "service/google-y"}, {Name: "service/google-z"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}, {Name: ghi.String("service/google-y")}, {Name: ghi.String("service/google-z")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}, "google-y": []string{"googler_y_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}, "google-y": {"googler_y_team_member"}},
 			expectSpecificReviewers: []string{"googler_team_member", "googler_y_team_member"},
 		},
 		">3 service teams will not be requested": {
-			pullRequest: github.PullRequest{
-				User:   github.User{Login: "googler_author"},
-				Labels: []github.Label{{Name: "service/google-x"}, {Name: "service/google-y"}, {Name: "service/google-z"}, {Name: "service/google-a"}},
+			pullRequest: &ghi.PullRequest{
+				User:   &ghi.User{Login: ghi.String("googler_author")},
+				Labels: []*ghi.Label{{Name: ghi.String("service/google-x")}, {Name: ghi.String("service/google-y")}, {Name: ghi.String("service/google-z")}, {Name: ghi.String("service/google-a")}},
 			},
-			teamMembers:             map[string][]string{"google-x": []string{"googler_team_member"}, "google-y": []string{"googler_y_team_member"}},
+			teamMembers:             map[string][]string{"google-x": {"googler_team_member"}, "google-y": {"googler_y_team_member"}},
 			expectSpecificReviewers: []string{},
 		},
 	}
+
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			requestedReviewers := []github.User{}
+			requestedReviewers := []*ghi.User{}
 			for _, login := range tc.requestedReviewers {
-				requestedReviewers = append(requestedReviewers, github.User{Login: login})
+				requestedReviewers = append(requestedReviewers, &ghi.User{Login: ghi.String(login)})
 			}
-			previousReviewers := []github.User{}
+
+			previousReviewers := []*ghi.User{}
 			for _, login := range tc.previousReviewers {
-				previousReviewers = append(previousReviewers, github.User{Login: login})
+				previousReviewers = append(previousReviewers, &ghi.User{Login: ghi.String(login)})
 			}
-			teamMembers := map[string][]github.User{}
+
+			teamMembers := map[string][]*ghi.User{}
 			for team, logins := range tc.teamMembers {
-				teamMembers[team] = []github.User{}
+				teamMembers[team] = []*ghi.User{}
 				for _, login := range logins {
-					teamMembers[team] = append(teamMembers[team], github.User{Login: login})
+					teamMembers[team] = append(teamMembers[team], &ghi.User{Login: ghi.String(login)})
 				}
 			}
-			gh := &mockGithub{
+
+			mockGH := &mockGithub{
 				pullRequest:        tc.pullRequest,
 				requestedReviewers: requestedReviewers,
 				previousReviewers:  previousReviewers,
@@ -141,10 +147,10 @@ func TestExecRequestServiceReviewersMembershipChecker(t *testing.T) {
 				calledMethods:      make(map[string][][]any),
 			}
 
-			execRequestServiceReviewers("1", gh, enrolledTeamsYaml)
+			execRequestServiceReviewers("1", mockGH, enrolledTeamsYaml)
 
 			actualReviewers := []string{}
-			for _, args := range gh.calledMethods["RequestPullRequestReviewers"] {
+			for _, args := range mockGH.calledMethods["RequestPullRequestReviewers"] {
 				actualReviewers = append(actualReviewers, args[1].([]string)...)
 			}
 

--- a/.ci/magician/cmd/scheduled_pr_reminders_test.go
+++ b/.ci/magician/cmd/scheduled_pr_reminders_test.go
@@ -6,7 +6,7 @@ import (
 
 	membership "magician/github"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +24,7 @@ func TestNotificationState(t *testing.T) {
 		// expectState: waitingForReviewerAssignment
 		"no review requests, and no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			expectState: waitingForReviewerAssignment,
@@ -32,17 +32,17 @@ func TestNotificationState(t *testing.T) {
 		},
 		"request for non-core reviewer, and no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String("reviewer")},
+					&github.User{Login: github.Ptr("reviewer")},
 				},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String("reviewer")},
+					RequestedReviewer: &github.User{Login: github.Ptr("reviewer")},
 				},
 			},
 			expectState: waitingForReviewerAssignment,
@@ -50,17 +50,17 @@ func TestNotificationState(t *testing.T) {
 		},
 		"request for team reviewer, and no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 				RequestedTeams: []*github.Team{
-					&github.Team{Name: github.String("terraform-team")},
+					&github.Team{Name: github.Ptr("terraform-team")},
 				},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:         github.String("review_requested"),
+					Event:         github.Ptr("review_requested"),
 					CreatedAt:     &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedTeam: &github.Team{Name: github.String("terraform-team")},
+					RequestedTeam: &github.Team{Name: github.Ptr("terraform-team")},
 				},
 			},
 			expectState: waitingForReviewerAssignment,
@@ -68,22 +68,22 @@ func TestNotificationState(t *testing.T) {
 		},
 		"request for team reviewer which was later removed, and no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 				RequestedTeams: []*github.Team{
-					&github.Team{Name: github.String("terraform-team")},
+					&github.Team{Name: github.Ptr("terraform-team")},
 				},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_request_removed"),
+					Event:             github.Ptr("review_request_removed"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			expectState: waitingForReviewerAssignment,
@@ -93,14 +93,14 @@ func TestNotificationState(t *testing.T) {
 		// expectState: waitingForReview
 		"no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			expectState: waitingForReview,
@@ -108,24 +108,24 @@ func TestNotificationState(t *testing.T) {
 		},
 		"review requested, removed, and rerequested, with no reviews": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_request_removed"),
+					Event:             github.Ptr("review_request_removed"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			expectState: waitingForReview,
@@ -133,45 +133,45 @@ func TestNotificationState(t *testing.T) {
 		},
 		"no reviews since latest review request": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("DISMISSED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("DISMISSED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 6, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -180,20 +180,20 @@ func TestNotificationState(t *testing.T) {
 		},
 		"ignore reviews from deleted accounts": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
 					User:        nil,
-					State:       github.String("APPROVED"),
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -204,35 +204,35 @@ func TestNotificationState(t *testing.T) {
 		// waitingForContributor
 		"change request followed by comment review from same reviewer": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -241,30 +241,30 @@ func TestNotificationState(t *testing.T) {
 		},
 		"approved review with a change request review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -273,30 +273,30 @@ func TestNotificationState(t *testing.T) {
 		},
 		"approved review followed by change request review from same user": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -307,35 +307,35 @@ func TestNotificationState(t *testing.T) {
 		// expectState: waitingForMerge
 		"approved review on its own": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 3, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -344,30 +344,30 @@ func TestNotificationState(t *testing.T) {
 		},
 		"approved review with a comment review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -376,30 +376,30 @@ func TestNotificationState(t *testing.T) {
 		},
 		"approved review followed by comment review from same user": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -408,35 +408,35 @@ func TestNotificationState(t *testing.T) {
 		},
 		"approved review followed by dismissed review from same user": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(secondCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(secondCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("DISMISSED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("DISMISSED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(secondCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(secondCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 2, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -445,17 +445,17 @@ func TestNotificationState(t *testing.T) {
 		},
 		"ready_for_review event after creation": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -465,18 +465,18 @@ func TestNotificationState(t *testing.T) {
 
 		"ready_for_review event before review request": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			expectState: waitingForReview,
@@ -485,24 +485,24 @@ func TestNotificationState(t *testing.T) {
 
 		"review after ready_for_review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("APPROVED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("APPROVED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -511,24 +511,24 @@ func TestNotificationState(t *testing.T) {
 		},
 		"changes_requested after ready_for_review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)}, // Earlier request
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)}, // Early changes requested
 				},
 			},
@@ -538,24 +538,24 @@ func TestNotificationState(t *testing.T) {
 
 		"changes_requested before ready_for_review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)}, // Earlier ready
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -565,24 +565,24 @@ func TestNotificationState(t *testing.T) {
 
 		"comment review after ready_for_review": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -592,28 +592,28 @@ func TestNotificationState(t *testing.T) {
 
 		"multiple ready_for_review events": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
 				},
 				&github.IssueEvent{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 				&github.IssueEvent{
-					Event:     github.String("ready_for_review"),
+					Event:     github.Ptr("ready_for_review"),
 					CreatedAt: &github.Timestamp{time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)}, // Later ready_for_review
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				&github.PullRequestReview{
-					User:        &github.User{Login: github.String(firstCoreReviewer)},
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)},
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -622,25 +622,25 @@ func TestNotificationState(t *testing.T) {
 		},
 		"ignore reviews from PR author": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				{
-					User:        &github.User{Login: github.String("author")}, // PR author's review
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr("author")}, // PR author's review
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 				{
-					User:        &github.User{Login: github.String("author")}, // PR author's review
-					State:       github.String("CHANGES_REQUESTED"),
+					User:        &github.User{Login: github.Ptr("author")}, // PR author's review
+					State:       github.Ptr("CHANGES_REQUESTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -651,25 +651,25 @@ func TestNotificationState(t *testing.T) {
 		// Add case where both author and reviewer comment
 		"reviews from both author and reviewer": {
 			pullRequest: &github.PullRequest{
-				User:      &github.User{Login: github.String("author")},
+				User:      &github.User{Login: github.Ptr("author")},
 				CreatedAt: &github.Timestamp{time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)},
 			},
 			issueEvents: []*github.IssueEvent{
 				{
-					Event:             github.String("review_requested"),
+					Event:             github.Ptr("review_requested"),
 					CreatedAt:         &github.Timestamp{time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)},
-					RequestedReviewer: &github.User{Login: github.String(firstCoreReviewer)},
+					RequestedReviewer: &github.User{Login: github.Ptr(firstCoreReviewer)},
 				},
 			},
 			reviews: []*github.PullRequestReview{
 				{
-					User:        &github.User{Login: github.String("author")}, // PR author's review
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr("author")}, // PR author's review
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)},
 				},
 				{
-					User:        &github.User{Login: github.String(firstCoreReviewer)}, // Reviewer's comment
-					State:       github.String("COMMENTED"),
+					User:        &github.User{Login: github.Ptr(firstCoreReviewer)}, // Reviewer's comment
+					State:       github.Ptr("COMMENTED"),
 					SubmittedAt: &github.Timestamp{time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)},
 				},
 			},
@@ -881,7 +881,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForMerge skip with label": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-review-reminders")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-review-reminders")}},
 			},
 			state:     waitingForMerge,
 			sinceDays: 5,
@@ -889,7 +889,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForMerge ignore disable-automatic-closure": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-automatic-closure")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-automatic-closure")}},
 			},
 			state:     waitingForMerge,
 			sinceDays: 10,
@@ -935,7 +935,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForReview skip with label": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-review-reminders")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-review-reminders")}},
 			},
 			state:     waitingForReview,
 			sinceDays: 5,
@@ -943,7 +943,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForReview ignore disable-automatic-closure": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-automatic-closure")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-automatic-closure")}},
 			},
 			state:     waitingForReview,
 			sinceDays: 10,
@@ -995,7 +995,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForContributor skip with label": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-automatic-closure")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-automatic-closure")}},
 			},
 			state:     waitingForContributor,
 			sinceDays: 10,
@@ -1003,7 +1003,7 @@ func TestShouldNotify(t *testing.T) {
 		},
 		"waitingForContributor ignore disable-review-reminders": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-review-reminders")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-review-reminders")}},
 			},
 			state:     waitingForContributor,
 			sinceDays: 10,
@@ -1034,11 +1034,11 @@ func TestFormatReminderComment(t *testing.T) {
 		// waitingForMerge
 		"waitingForMerge one week": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForMerge,
@@ -1056,11 +1056,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForMerge two weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForMerge,
@@ -1078,11 +1078,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForMerge many weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForMerge,
@@ -1102,11 +1102,11 @@ func TestFormatReminderComment(t *testing.T) {
 		// waitingForReview
 		"waitingForReview three days": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForReview,
@@ -1125,11 +1125,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForReview one week": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForReview,
@@ -1148,11 +1148,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForReview two weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForReview,
@@ -1171,11 +1171,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForReview three days with current reviewer": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForReview,
@@ -1197,11 +1197,11 @@ func TestFormatReminderComment(t *testing.T) {
 		// waitingForContributor
 		"waitingForContributor two weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForContributor,
@@ -1219,11 +1219,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForContributor four weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForContributor,
@@ -1241,11 +1241,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForContributor 28 days": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:     waitingForContributor,
@@ -1263,11 +1263,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForContributor six weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:           waitingForContributor,
@@ -1283,11 +1283,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForContributor seven weeks": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String("pr-author")},
+				User: &github.User{Login: github.Ptr("pr-author")},
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},
-					&github.User{Login: github.String(secondCoreReviewer)},
-					&github.User{Login: github.String("other-reviewer")},
+					&github.User{Login: github.Ptr(firstCoreReviewer)},
+					&github.User{Login: github.Ptr(secondCoreReviewer)},
+					&github.User{Login: github.Ptr("other-reviewer")},
 				},
 			},
 			state:           waitingForContributor,
@@ -1303,11 +1303,11 @@ func TestFormatReminderComment(t *testing.T) {
 		},
 		"waitingForReview with author as core reviewer": {
 			pullRequest: &github.PullRequest{
-				User: &github.User{Login: github.String(firstCoreReviewer)}, // PR author is a core reviewer
+				User: &github.User{Login: github.Ptr(firstCoreReviewer)}, // PR author is a core reviewer
 				RequestedReviewers: []*github.User{
-					&github.User{Login: github.String(firstCoreReviewer)},  // Review requested from author
-					&github.User{Login: github.String(secondCoreReviewer)}, // Review requested from another core reviewer
-					&github.User{Login: github.String("other-reviewer")},   // Non-core reviewer
+					&github.User{Login: github.Ptr(firstCoreReviewer)},  // Review requested from author
+					&github.User{Login: github.Ptr(secondCoreReviewer)}, // Review requested from another core reviewer
+					&github.User{Login: github.Ptr("other-reviewer")},   // Non-core reviewer
 				},
 			},
 			state:     waitingForReview,
@@ -1396,7 +1396,7 @@ func TestShouldClose(t *testing.T) {
 		},
 		"waitingForContributor skip with label": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-automatic-closure")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-automatic-closure")}},
 			},
 			state:     waitingForContributor,
 			sinceDays: 30,
@@ -1404,7 +1404,7 @@ func TestShouldClose(t *testing.T) {
 		},
 		"waitingForContributor ignore disable-review-reminders": {
 			pullRequest: &github.PullRequest{
-				Labels: []*github.Label{{Name: github.String("disable-review-reminders")}},
+				Labels: []*github.Label{{Name: github.Ptr("disable-review-reminders")}},
 			},
 			state:     waitingForContributor,
 			sinceDays: 30,

--- a/.ci/magician/cmd/vcr_merge.go
+++ b/.ci/magician/cmd/vcr_merge.go
@@ -7,6 +7,7 @@ import (
 	"magician/source"
 	"os"
 
+	ghi "github.com/google/go-github/v68/github"
 	"github.com/spf13/cobra"
 )
 
@@ -58,8 +59,8 @@ func execVCRMerge(gh GithubClient, sha string, baseBranch string, runner source.
 		return nil
 	}
 
-	mergeCassettes("gs://ci-vcr-cassettes", baseBranch, fmt.Sprintf("refs/heads/auto-pr-%d", pr.Number), runner)
-	mergeCassettes("gs://ci-vcr-cassettes/beta", baseBranch, fmt.Sprintf("refs/heads/auto-pr-%d", pr.Number), runner)
+	mergeCassettes("gs://ci-vcr-cassettes", baseBranch, fmt.Sprintf("refs/heads/auto-pr-%d", pr.GetNumber()), runner)
+	mergeCassettes("gs://ci-vcr-cassettes/beta", baseBranch, fmt.Sprintf("refs/heads/auto-pr-%d", pr.GetNumber()), runner)
 	return nil
 }
 
@@ -126,10 +127,10 @@ func rmCassettes(dest string, runner source.Runner) {
 	}
 }
 
-func findPRBySHA(sha string, arr []github.PullRequest) *github.PullRequest {
+func findPRBySHA(sha string, arr []*ghi.PullRequest) *ghi.PullRequest {
 	for _, pr := range arr {
-		if pr.MergeCommitSha == sha {
-			return &pr
+		if pr.GetMergeCommitSHA() == sha {
+			return pr
 		}
 	}
 	return nil

--- a/.ci/magician/cmd/vcr_merge_test.go
+++ b/.ci/magician/cmd/vcr_merge_test.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
-	"magician/github"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	ghi "github.com/google/go-github/v68/github"
 )
 
 func TestExecVCRMerge(t *testing.T) {
@@ -61,12 +61,13 @@ func TestExecVCRMerge(t *testing.T) {
 	}
 
 	githubClient := &mockGithub{
-		pullRequest: github.PullRequest{
-			Number:         123,
-			MergeCommitSha: "sha",
+		pullRequest: &ghi.PullRequest{
+			Number:         ghi.Ptr(123),
+			MergeCommitSHA: ghi.Ptr("sha"),
 		},
 		calledMethods: make(map[string][][]any),
 	}
+
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			runner := &mockRunner{

--- a/.ci/magician/github/init.go
+++ b/.ci/magician/github/init.go
@@ -15,13 +15,76 @@
  */
 package github
 
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	utils "magician/utility" // Your utility package
+
+	gh "github.com/google/go-github/v68/github"
+)
+
 // Client for GitHub interactions.
 type Client struct {
 	token string
+	gh    *gh.Client
+	ctx   context.Context
+}
+
+// retryTransport is a custom RoundTripper that adds retry and logging
+type retryTransport struct {
+	underlyingTransport http.RoundTripper
+	token               string
 }
 
 func NewClient(token string) *Client {
-	return &Client{
-		token: token,
+	ctx := context.Background()
+
+	// Create a custom transport with retry logic
+	rt := &retryTransport{
+		underlyingTransport: http.DefaultTransport,
+		token:               token,
 	}
+
+	// Use this custom transport with OAuth2
+	tc := &http.Client{Transport: rt}
+
+	// Create the GitHub client with our custom transport
+	ghClient := gh.NewClient(tc)
+
+	return &Client{
+		gh:    ghClient,
+		token: token,
+		ctx:   ctx,
+	}
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Extract information from the request
+	method := req.Method
+	urlStr := req.URL.String()
+
+	// Read and log the request body if present
+	var bodyBytes []byte
+	if req.Body != nil {
+		bodyBytes, _ = io.ReadAll(req.Body)
+		req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	}
+
+	// Use our utility function with retry logic
+	resp, respBody, err := utils.RequestCallWithRetryRaw(urlStr, method, rt.token, bodyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the response body with our captured body
+	resp.Body.Close() // Close the original body
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+	resp.ContentLength = int64(len(respBody))
+
+	return resp, nil
 }

--- a/.ci/magician/github/set.go
+++ b/.ci/magician/github/set.go
@@ -17,120 +17,116 @@ package github
 
 import (
 	"fmt"
-	utils "magician/utility"
 	"strings"
 	"time"
+
+	utils "magician/utility"
+
+	gh "github.com/google/go-github/v68/github"
 )
 
-func (gh *Client) PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/%s", commitSha)
-
-	postBody := map[string]string{
-		"context":    title,
-		"state":      state,
-		"target_url": targetURL,
+// PostBuildStatus creates a commit status for a specific SHA
+func (c *Client) PostBuildStatus(prNumber, title, state, targetURL, commitSha string) error {
+	repoStatus := &gh.RepoStatus{
+		Context:   gh.Ptr(title),
+		State:     gh.Ptr(state),
+		TargetURL: gh.Ptr(targetURL),
 	}
 
-	err := utils.RequestCallWithRetry(url, "POST", gh.token, nil, postBody)
+	_, _, err := c.gh.Repositories.CreateStatus(c.ctx, defaultOwner, defaultRepo, commitSha, repoStatus)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully posted build status to pull request %s\n", prNumber)
-
 	return nil
 }
 
-func (gh *Client) PostComment(prNumber, comment string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/comments", prNumber)
-
-	body := map[string]string{
-		"body": comment,
+// PostComment adds a comment to a pull request
+func (c *Client) PostComment(prNumber, comment string) error {
+	num := utils.ParseInt(prNumber)
+	issueComment := &gh.IssueComment{
+		Body: gh.Ptr(comment),
 	}
 
-	err := utils.RequestCallWithRetry(url, "POST", gh.token, nil, body)
+	_, _, err := c.gh.Issues.CreateComment(c.ctx, defaultOwner, defaultRepo, num, issueComment)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully posted comment to pull request %s\n", prNumber)
-
 	return nil
 }
 
-func (gh *Client) UpdateComment(prNumber, comment string, id int) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/comments/%d", id)
-
-	body := map[string]string{
-		"body": comment,
+// UpdateComment updates an existing comment
+func (c *Client) UpdateComment(prNumber, comment string, id int) error {
+	issueComment := &gh.IssueComment{
+		Body: gh.Ptr(comment),
 	}
 
-	err := utils.RequestCallWithRetry(url, "PATCH", gh.token, nil, body)
+	_, _, err := c.gh.Issues.EditComment(c.ctx, defaultOwner, defaultRepo, int64(id), issueComment)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully updated comment %d in pull request %s\n", id, prNumber)
-
 	return nil
 }
 
-func (gh *Client) RequestPullRequestReviewers(prNumber string, reviewers []string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
+// RequestPullRequestReviewers adds reviewers to a pull request
+func (c *Client) RequestPullRequestReviewers(prNumber string, reviewers []string) error {
+	num := utils.ParseInt(prNumber)
 
-	body := map[string][]string{
-		"reviewers":      reviewers,
-		"team_reviewers": {},
+	// Create the reviewers request
+	reviewersRequest := gh.ReviewersRequest{
+		Reviewers:     reviewers,
+		TeamReviewers: nil,
 	}
 
-	err := utils.RequestCallWithRetry(url, "POST", gh.token, nil, body)
+	_, _, err := c.gh.PullRequests.RequestReviewers(c.ctx, defaultOwner, defaultRepo, num, reviewersRequest)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully added reviewers %v to pull request %s\n", reviewers, prNumber)
-
 	return nil
 }
 
-func (gh *Client) RemovePullRequestReviewers(prNumber string, reviewers []string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/%s/requested_reviewers", prNumber)
+// RemovePullRequestReviewers removes reviewers from a pull request
+func (c *Client) RemovePullRequestReviewers(prNumber string, reviewers []string) error {
+	num := utils.ParseInt(prNumber)
 
-	body := map[string][]string{
-		"reviewers":      reviewers,
-		"team_reviewers": {},
+	reviewersRequest := gh.ReviewersRequest{
+		Reviewers:     reviewers,
+		TeamReviewers: nil,
 	}
 
-	err := utils.RequestCall(url, "DELETE", gh.token, nil, body)
+	_, err := c.gh.PullRequests.RemoveReviewers(c.ctx, defaultOwner, defaultRepo, num, reviewersRequest)
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully removed reviewers %v to pull request %s\n", reviewers, prNumber)
-
 	return nil
 }
 
-func (gh *Client) AddLabels(prNumber string, labels []string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/labels", prNumber)
+// AddLabels adds labels to an issue or pull request
+func (c *Client) AddLabels(prNumber string, labels []string) error {
+	num := utils.ParseInt(prNumber)
 
-	body := map[string][]string{
-		"labels": labels,
-	}
-	err := utils.RequestCallWithRetry(url, "POST", gh.token, nil, body)
-
+	_, _, err := c.gh.Issues.AddLabelsToIssue(c.ctx, defaultOwner, defaultRepo, num, labels)
 	if err != nil {
 		return fmt.Errorf("failed to add %q labels: %s", labels, err)
 	}
 
 	return nil
-
 }
 
-func (gh *Client) RemoveLabel(prNumber, label string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/%s/labels/%s", prNumber, label)
-	err := utils.RequestCallWithRetry(url, "DELETE", gh.token, nil, nil)
+// RemoveLabel removes a label from an issue or pull request
+func (c *Client) RemoveLabel(prNumber, label string) error {
+	num := utils.ParseInt(prNumber)
 
+	_, err := c.gh.Issues.RemoveLabelForIssue(c.ctx, defaultOwner, defaultRepo, num, label)
 	if err != nil {
 		return fmt.Errorf("failed to remove %s label: %s", label, err)
 	}
@@ -138,19 +134,24 @@ func (gh *Client) RemoveLabel(prNumber, label string) error {
 	return nil
 }
 
-func (gh *Client) CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/magic-modules/actions/workflows/%s/dispatches", workflowFileName)
-	err := utils.RequestCallWithRetry(url, "POST", gh.token, nil, map[string]any{
-		"ref":    "main",
-		"inputs": inputs,
-	})
+// CreateWorkflowDispatchEvent triggers a workflow run
+func (c *Client) CreateWorkflowDispatchEvent(workflowFileName string, inputs map[string]any) error {
+	stringInputs := make(map[string]interface{})
+	for k, v := range inputs {
+		stringInputs[k] = v
+	}
 
+	event := gh.CreateWorkflowDispatchEventRequest{
+		Ref:    "main",
+		Inputs: stringInputs,
+	}
+
+	_, err := c.gh.Actions.CreateWorkflowDispatchEventByFileName(c.ctx, defaultOwner, defaultRepo, workflowFileName, event)
 	if err != nil {
 		return fmt.Errorf("failed to create workflow dispatch event: %s", err)
 	}
 
 	fmt.Printf("Successfully created workflow dispatch event for %s with inputs %v\n", workflowFileName, inputs)
-
 	return nil
 }
 
@@ -178,7 +179,7 @@ func (gh *Client) MergePullRequest(owner, repo, prNumber, commitSha string) erro
 			if err != nil {
 				return fmt.Errorf("failed to check if PR was already merged: %w", err)
 			}
-			if pr.Merged {
+			if pr.GetMerged() {
 				fmt.Printf("Pull request %s was already merged\n", prNumber)
 				return nil
 			}

--- a/.ci/magician/go.mod
+++ b/.ci/magician/go.mod
@@ -16,7 +16,6 @@ require (
 require (
 	cloud.google.com/go/storage v1.50.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-github/v61 v61.0.0
 	github.com/google/go-github/v68 v68.0.0
 	github.com/otiai10/copy v1.12.0
 	github.com/stretchr/testify v1.10.0

--- a/.ci/magician/go.sum
+++ b/.ci/magician/go.sum
@@ -85,8 +85,6 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
-github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
 github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/.ci/magician/utility/utils.go
+++ b/.ci/magician/utility/utils.go
@@ -143,9 +143,11 @@ func calculateBackoff(attempt int, config retryConfig) time.Duration {
 	return backoff
 }
 
-// RequestCallWithRetry makes an HTTP request with retry capability
-func requestCallWithRetry(url, method, credentials string, result any, body any, config retryConfig) error {
+// RequestCallWithRetryRaw raw version of the retry function that returns the response and body bytes
+func requestCallWithRetryRaw(url, method, credentials string, body any, config retryConfig) (*http.Response, []byte, error) {
 	var lastErr error
+	var lastResp *http.Response
+	var lastBodyBytes []byte
 
 	for attempt := 0; attempt <= config.MaxRetries; attempt++ {
 		// If this is a retry attempt, wait before trying again
@@ -161,27 +163,36 @@ func requestCallWithRetry(url, method, credentials string, result any, body any,
 			continue // Network error, retry
 		}
 
-		// Process the response
-		err = processResponse(resp, respBodyBytes, result)
-		if err != nil {
-			lastErr = err
+		lastResp = resp
+		lastBodyBytes = respBodyBytes
 
-			// Check if we should retry based on status code
+		// Check if we should retry based on status code
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			if shouldRetry(resp.StatusCode, config) {
 				continue
 			}
 		}
 
-		// If we got here with no error, return success
-		return err
+		return lastResp, lastBodyBytes, nil
 	}
 
-	return fmt.Errorf("max retries exceeded: %w", lastErr)
+	return lastResp, lastBodyBytes, lastErr
+}
+
+// RequestCallWithRetryRaw is a convenience function that uses default retry settings
+func RequestCallWithRetryRaw(url, method, credentials string, body any) (*http.Response, []byte, error) {
+	return requestCallWithRetryRaw(url, method, credentials, body, defaultRetryConfig())
 }
 
 // RequestCallWithRetry is a convenience function that uses default retry settings
+// and unmarshals the response into the result
 func RequestCallWithRetry(url, method, credentials string, result any, body any) error {
-	return requestCallWithRetry(url, method, credentials, result, body, defaultRetryConfig())
+	resp, respBodyBytes, err := requestCallWithRetryRaw(url, method, credentials, body, defaultRetryConfig())
+	if err != nil {
+		return err
+	}
+
+	return processResponse(resp, respBodyBytes, result)
 }
 
 func Removes(s1 []string, s2 []string) []string {
@@ -218,4 +229,10 @@ func ReadFromJson(data interface{}, path string) error {
 		return fmt.Errorf("failed to unmarshal data: %w", err)
 	}
 	return nil
+}
+
+func ParseInt(s string) int {
+	var num int
+	fmt.Sscanf(s, "%d", &num)
+	return num
 }

--- a/tools/issue-labeler/go.mod
+++ b/tools/issue-labeler/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/golang/glog v1.1.1
-	github.com/google/go-github/v61 v61.0.0
+	github.com/google/go-github/v68 v68.0.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/exp v0.0.0-20230810033253-352e893a4cad
 	golang.org/x/oauth2 v0.24.0

--- a/tools/issue-labeler/go.sum
+++ b/tools/issue-labeler/go.sum
@@ -4,8 +4,8 @@ github.com/golang/glog v1.1.1/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
-github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
+github.com/google/go-github/v68 v68.0.0 h1:ZW57zeNZiXTdQ16qrDiZ0k6XucrxZ2CGmoTvcCyQG6s=
+github.com/google/go-github/v68 v68.0.0/go.mod h1:K9HAUBovM2sLwM408A18h+wd9vqdLOEqTUCbnRIcx68=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/tools/issue-labeler/labeler/backfill.go
+++ b/tools/issue-labeler/labeler/backfill.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 )
 
 type Label struct {

--- a/tools/issue-labeler/labeler/backfill_test.go
+++ b/tools/issue-labeler/labeler/backfill_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 )
 
 func testIssueBodyWithResources(resources []string) *string {
-	return github.String(fmt.Sprintf(`
+	return github.Ptr(fmt.Sprintf(`
 ### New or Affected Resource(s):
 
 %s
@@ -54,7 +54,7 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "gracefully handle a nil issue body",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 				},
 			},
 			regexpLabels:         defaultRegexpLabels,
@@ -75,8 +75,8 @@ func TestComputeIssueUpdates(t *testing.T) {
 			name: "no listed resources",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
-					Body:   github.String("Body with unusual structure"),
+					Number: github.Ptr(1),
+					Body:   github.Ptr("Body with unusual structure"),
 				},
 			},
 			regexpLabels:         defaultRegexpLabels,
@@ -87,14 +87,14 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "issues with service/terraform shouldn't get new labels",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("service/terraform")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/terraform")}},
 				},
 				{
-					Number: github.Int(2),
+					Number: github.Ptr(2),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("forward/exempt")}},
+					Labels: []*github.Label{{Name: github.Ptr("forward/exempt")}},
 				},
 			},
 			regexpLabels:         defaultRegexpLabels,
@@ -105,11 +105,11 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "issues with affected resources should normally get new labels added",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
 				},
 				{
-					Number: github.Int(2),
+					Number: github.Ptr(2),
 					Body:   testIssueBodyWithResources([]string{"google_service2_resource1"}),
 				},
 			},
@@ -130,14 +130,14 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "don't update issues if all expected service labels are already present",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("service/service1")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/service1")}},
 				},
 				{
-					Number: github.Int(2),
+					Number: github.Ptr(2),
 					Body:   testIssueBodyWithResources([]string{"google_service2_resource1"}),
-					Labels: []*github.Label{{Name: github.String("service/service2-subteam1")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/service2-subteam1")}},
 				},
 			},
 			regexpLabels:         defaultRegexpLabels,
@@ -148,14 +148,14 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "add missing service labels",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("service/service2-subteam1")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/service2-subteam1")}},
 				},
 				{
-					Number: github.Int(2),
+					Number: github.Ptr(2),
 					Body:   testIssueBodyWithResources([]string{"google_service2_resource2"}),
-					Labels: []*github.Label{{Name: github.String("service/service1")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/service1")}},
 				},
 			},
 			regexpLabels: defaultRegexpLabels,
@@ -177,9 +177,9 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "don't add missing service labels if already linked",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("service/service2-subteam1")}, {Name: github.String("forward/linked")}},
+					Labels: []*github.Label{{Name: github.Ptr("service/service2-subteam1")}, {Name: github.Ptr("forward/linked")}},
 				},
 			},
 			regexpLabels:         defaultRegexpLabels,
@@ -190,14 +190,14 @@ func TestComputeIssueUpdates(t *testing.T) {
 			description: "add service labels if missed but don't add forward/review label for test failure ticket",
 			issues: []*github.Issue{
 				{
-					Number: github.Int(1),
+					Number: github.Ptr(1),
 					Body:   testIssueBodyWithResources([]string{"google_service1_resource1"}),
-					Labels: []*github.Label{{Name: github.String("test-failure")}, {Name: github.String("test-failure-100")}},
+					Labels: []*github.Label{{Name: github.Ptr("test-failure")}, {Name: github.Ptr("test-failure-100")}},
 				},
 				{
-					Number: github.Int(2),
+					Number: github.Ptr(2),
 					Body:   testIssueBodyWithResources([]string{"google_service2_resource1"}),
-					Labels: []*github.Label{{Name: github.String("test-failure")}, {Name: github.String("test-failure-50")}, {Name: github.String("service/service2-subteam1")}},
+					Labels: []*github.Label{{Name: github.Ptr("test-failure")}, {Name: github.Ptr("test-failure-50")}, {Name: github.Ptr("service/service2-subteam1")}},
 				},
 			},
 			regexpLabels: defaultRegexpLabels,

--- a/tools/issue-labeler/labeler/github.go
+++ b/tools/issue-labeler/labeler/github.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 	"golang.org/x/oauth2"
 )
 

--- a/tools/issue-labeler/labeler/labels.go
+++ b/tools/issue-labeler/labeler/labels.go
@@ -10,7 +10,7 @@ import (
 	_ "embed"
 
 	"github.com/golang/glog"
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 	"gopkg.in/yaml.v2"
 )
 

--- a/tools/issue-labeler/labeler/labels_test.go
+++ b/tools/issue-labeler/labeler/labels_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/google/go-github/v61/github"
+	"github.com/google/go-github/v68/github"
 	"golang.org/x/exp/slices"
 )
 
@@ -225,9 +225,9 @@ func TestComputeLabelChanges(t *testing.T) {
 		{
 			name: "existing labels with correct color",
 			existingLabels: []*github.Label{
-				{Name: github.String("xyz"), Color: github.String("FF0000")},
-				{Name: github.String("bug"), Color: github.String("FF0000")},
-				{Name: github.String("enhancement"), Color: github.String("FF0000")},
+				{Name: github.Ptr("xyz"), Color: github.Ptr("FF0000")},
+				{Name: github.Ptr("bug"), Color: github.Ptr("FF0000")},
+				{Name: github.Ptr("enhancement"), Color: github.Ptr("FF0000")},
 			},
 			desiredLabels: []string{"bug", "enhancement"},
 			desiredColor:  "FF0000",
@@ -239,8 +239,8 @@ func TestComputeLabelChanges(t *testing.T) {
 		{
 			name: "existing labels with wrong color",
 			existingLabels: []*github.Label{
-				{Name: github.String("bug"), Color: github.String("00FF00")},
-				{Name: github.String("enhancement"), Color: github.String("00FF00")},
+				{Name: github.Ptr("bug"), Color: github.Ptr("00FF00")},
+				{Name: github.Ptr("enhancement"), Color: github.Ptr("00FF00")},
 			},
 			desiredLabels: []string{"bug", "enhancement"},
 			desiredColor:  "FF0000",
@@ -252,7 +252,7 @@ func TestComputeLabelChanges(t *testing.T) {
 		{
 			name: "mixed existing and new labels",
 			existingLabels: []*github.Label{
-				{Name: github.String("bug"), Color: github.String("FF0000")},
+				{Name: github.Ptr("bug"), Color: github.Ptr("FF0000")},
 			},
 			desiredLabels: []string{"bug", "enhancement"},
 			desiredColor:  "FF0000",
@@ -264,7 +264,7 @@ func TestComputeLabelChanges(t *testing.T) {
 		{
 			name: "case insensitive color comparison",
 			existingLabels: []*github.Label{
-				{Name: github.String("bug"), Color: github.String("ff0000")},
+				{Name: github.Ptr("bug"), Color: github.Ptr("ff0000")},
 			},
 			desiredLabels: []string{"bug"},
 			desiredColor:  "FF0000",


### PR DESCRIPTION
I've transitioned all functions in .ci/magician to use go-github except for the merge function. We have special retry logic based on very specific errors. This will break if we bring it over to the new system.

I also changed all interfaces to go-github natives for consistency and eliminated one unneeded version of go-github
closes https://github.com/hashicorp/terraform-provider-google/issues/17191
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
