### PR TITLE
Change description of destination_project field in backup and restore channel resources.

### DIFF
--- a/mmv1/products/gkebackup/BackupChannel.yaml
+++ b/mmv1/products/gkebackup/BackupChannel.yaml
@@ -78,7 +78,7 @@ properties:
     description: |
       The project where Backups are allowed to be stored.
       The format is `projects/{project}`.
-      {project} can only be a project number.
+      {project} can be project number or project id.
     required: true
     immutable: true
   - name: 'description'

--- a/mmv1/products/gkebackup/RestoreChannel.yaml
+++ b/mmv1/products/gkebackup/RestoreChannel.yaml
@@ -78,7 +78,7 @@ properties:
     description: |
       The project where Backups will be restored.
       The format is `projects/{project}`.
-      {project} can only be a project number.
+      {project} can be project number or project id.
     required: true
     immutable: true
   - name: 'description'


### PR DESCRIPTION
This PR updates comments for `destination_project` field for backup and restore channel.
Fixes b/417086441

#### Release Note Template for Downstream PRs (will be copied)

```release-note:none
```