### PR TITLE
Add independent scaling fields (hyperdisk) to GA

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -35,7 +35,6 @@ description: |
  the next apply. You can trigger a manual
  [zone switch](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/edit-or-delete-storage-pool#switch_active_and_replica_zones)
  via Terraform by swapping the value of the `zone` and `replica_zone` parameters in your HCL code.
- Note: Custom Performance FLEX storage pools are supported in beta provider currently.
 
 references:
   guides:
@@ -187,14 +186,11 @@ properties:
     description: |
       Optional. True if using Independent Scaling of capacity and performance (Hyperdisk). Default is false.
     immutable: true
-    min_version: 'beta'
   - name: 'totalThroughputMibps'
     type: String
     description: |
       Optional. Custom Performance Total Throughput of the pool (in MiB/s).
-    min_version: 'beta'
   - name: 'totalIops'
     type: String
     description: |
       Optional. Custom Performance Total IOPS of the pool If not provided, it will be calculated based on the totalThroughputMibps
-    min_version: 'beta'

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go.tmpl
@@ -318,7 +318,6 @@ data "google_compute_network" "default" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t *testing.T) {
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-2", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
@@ -327,7 +326,7 @@ func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckNetappStoragePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -355,7 +354,6 @@ func TestAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(t
 func testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east4-a"
   service_level = "FLEX"
@@ -368,7 +366,6 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
@@ -377,7 +374,6 @@ data "google_compute_network" "default" {
 func testAccNetappStoragePool_customPerformanceStoragePoolCreateExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-east4-a"
   service_level = "FLEX"
@@ -390,9 +386,7 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
 }
-{{ end }}


### PR DESCRIPTION
```release-note:enhancement
netapp: promoted `custom_performance_enabled`, `total_throughput_mibps`, and `total_iops` fields of `google_netapp_storage_pool` resource to GA
```
