### PR TITLE
remove -v from github go test runs

### DIFF
--- a/.github/workflows/unit-test-magician.yml
+++ b/.github/workflows/unit-test-magician.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run magician unit tests
         run: |
           cd .ci/magician
-          go test ./... -v
+          go test ./...
         env:
           GITHUB_TOKEN_CLASSIC: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/unit-test-mmv1.yml
+++ b/.github/workflows/unit-test-mmv1.yml
@@ -65,5 +65,5 @@ jobs:
       - name: Run mmv1 unit tests
         run: |
           cd mmv1
-          go test ./... -v
+          go test ./...
 

--- a/.github/workflows/unit-test-tools.yml
+++ b/.github/workflows/unit-test-tools.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Test diff-processor with TPG
         run: |
           cd tools/diff-processor
-          go test -v ./...
+          go test ./...
         env:
           SERVICES_DIR: tools/diff-processor/new/google/services
 
@@ -42,7 +42,7 @@ jobs:
       - name: Test diff-processor with TPGB
         run: |
           cd tools/diff-processor
-          go test -v ./...
+          go test ./...
         env:
           SERVICES_DIR: tools/diff-processor/new/google/services
 
@@ -64,7 +64,7 @@ jobs:
       - name: Test go-changelog
         run: |
           cd tools/go-changelog
-          go test -v ./...
+          go test ./...
 
   issue-labeler:
     runs-on: ubuntu-22.04
@@ -84,7 +84,7 @@ jobs:
       - name: Test issue-labeler
         run: |
           cd tools/issue-labeler
-          go test -v ./...
+          go test ./...
 
   template-check:
     runs-on: ubuntu-22.04
@@ -104,7 +104,7 @@ jobs:
       - name: Test template-check
         run: |
           cd tools/template-check
-          go test -v ./...
+          go test ./...
 
   test-reader:
     runs-on: ubuntu-22.04
@@ -124,4 +124,4 @@ jobs:
       - name: Test test-reader
         run: |
           cd tools/test-reader
-          go test -v ./...
+          go test ./...


### PR DESCRIPTION
-v makes the test logs difficult to parse since it shows all test logs not just the failures. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
