### PR TITLE
Netapp immutable backups

### DIFF
--- a/mmv1/products/netapp/BackupVault.yaml
+++ b/mmv1/products/netapp/BackupVault.yaml
@@ -119,7 +119,7 @@ properties:
   - name: 'backupRetentionPolicy'
     type: NestedObject
     description: |
-      Backup retention policy defining the retention of backups.
+      Backup retention policy defining the retention of the backups.
     properties:
       - name: 'backupMinimumEnforcedRetentionDays'
         type: Integer

--- a/mmv1/products/netapp/BackupVault.yaml
+++ b/mmv1/products/netapp/BackupVault.yaml
@@ -116,3 +116,33 @@ properties:
     description: |
       Name of the Backup vault created in backup region.
     output: true
+  - name: 'backupRetentionPolicy'
+    type: NestedObject
+    description: |
+      Backup retention policy defining the retention of backups.
+    properties:
+      - name: 'backupMinimumEnforcedRetentionDays'
+        type: Integer
+        description: |
+          Minimum retention duration in days for backups in the backup vault.
+        required: true
+      - name: 'dailyBackupImmutable'
+        type: Boolean
+        description: |
+          Indicates if the daily backups are immutable. At least one of daily_backup_immutable, weekly_backup_immutable, monthly_backup_immutable and manual_backup_immutable must be true.
+        required: false
+      - name: 'weeklyBackupImmutable'
+        type: Boolean
+        description: |
+          Indicates if the weekly backups are immutable. At least one of daily_backup_immutable, weekly_backup_immutable, monthly_backup_immutable and manual_backup_immutable must be true.
+        required: false
+      - name: 'monthlyBackupImmutable'
+        type: Boolean
+        description: |
+           Indicates if the monthly backups are immutable. At least one of daily_backup_immutable, weekly_backup_immutable, monthly_backup_immutable and manual_backup_immutable must be true.
+        required: false
+      - name: 'manualBackupImmutable'
+        type: Boolean
+        description: |
+          Indicates if the manual backups are immutable. At least one of daily_backup_immutable, weekly_backup_immutable, monthly_backup_immutable and manual_backup_immutable must be true.
+        required: false

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -407,7 +407,7 @@ resource "google_netapp_volume_snapshot" "default" {
   }
 resource "google_netapp_backup" "test_backup" {
   name = "tf-test-test-backup%{random_suffix}"
-  description = "This is a test integrated backup"
+  description = "This is a test immutable backup"
   source_volume = google_netapp_volume.default.id
   location = google_netapp_backup_vault.default.location
   vault_name = google_netapp_backup_vault.default.name
@@ -468,7 +468,7 @@ resource "google_netapp_volume_snapshot" "default" {
   }
 resource "google_netapp_backup" "test_backup" {
   name = "tf-test-test-backup%{random_suffix}"
-  description = "This is a test integrated backup"
+  description = "This is a test immutable backup"
   source_volume = google_netapp_volume.default.id
   location = google_netapp_backup_vault.default.location
   vault_name = google_netapp_backup_vault.default.name

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -325,3 +325,158 @@ resource "google_netapp_backup" "test_backup" {
 }
 `, context)
 }
+
+func TestAccNetappBackup_NetappImmutableBackup(t *testing.T) {
+	context := map[string]interface{}{
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-2", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetappBackupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetappBackup_ImmutableBackup(context),
+			},
+			{
+				ResourceName:            "google_netapp_backup.test_backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+			},
+      {
+				Config: testAccNetappBackup_ImmutableBackup_update(context),
+			},
+			{
+				ResourceName:            "google_netapp_backup.test_backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+			},
+		},
+	})
+}
+
+func testAccNetappBackup_ImmutableBackup(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+resource "google_netapp_storage_pool" "default" {
+  name = "tf-test-backup-pool%{random_suffix}"
+  location = "us-east4"
+  service_level = "PREMIUM"
+  capacity_gib = "2048"
+  network = data.google_compute_network.default.id
+}
+resource "google_netapp_volume" "default" {
+  name = "tf-test-backup-volume%{random_suffix}"
+  location = google_netapp_storage_pool.default.location
+  capacity_gib = "100"
+  share_name = "tf-test-backup-volume%{random_suffix}"
+  storage_pool = google_netapp_storage_pool.default.name
+  protocols = ["NFSV3"]
+  deletion_policy = "FORCE"
+  backup_config {
+    backup_vault = google_netapp_backup_vault.default.id
+  }
+}
+resource "google_netapp_backup_vault" "default" {
+  name = "tf-test-backup-vault%{random_suffix}"
+  location = google_netapp_storage_pool.default.location
+  backup_retention_policy {
+	backup_minimum_enforced_retention_days = 2
+  daily_backup_immutable = true
+	weekly_backup_immutable = false
+	monthly_backup_immutable = false
+	manual_backup_immutable = false
+  }
+}
+resource "google_netapp_volume_snapshot" "default" {
+  depends_on = [google_netapp_volume.default]
+  location = google_netapp_volume.default.location
+  volume_name = google_netapp_volume.default.name
+  description = "This is a test description"
+  name = "testvolumesnap%{random_suffix}"
+  labels = {
+    key= "test"
+    value= "snapshot"
+  }
+  }
+resource "google_netapp_backup" "test_backup" {
+  name = "tf-test-test-backup%{random_suffix}"
+  description = "This is a test integrated backup"
+  source_volume = google_netapp_volume.default.id
+  location = google_netapp_backup_vault.default.location
+  vault_name = google_netapp_backup_vault.default.name
+  source_snapshot = google_netapp_volume_snapshot.default.id
+  labels = {
+  key= "test"
+  value= "backup"
+  }
+}
+`, context)
+}
+
+func testAccNetappBackup_ImmutableBackup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+resource "google_netapp_storage_pool" "default" {
+  name = "tf-test-backup-pool%{random_suffix}"
+  location = "us-east4"
+  service_level = "PREMIUM"
+  capacity_gib = "2048"
+  network = data.google_compute_network.default.id
+}
+resource "google_netapp_volume" "default" {
+  name = "tf-test-backup-volume%{random_suffix}"
+  location = google_netapp_storage_pool.default.location
+  capacity_gib = "100"
+  share_name = "tf-test-backup-volume%{random_suffix}"
+  storage_pool = google_netapp_storage_pool.default.name
+  protocols = ["NFSV3"]
+  deletion_policy = "FORCE"
+  backup_config {
+    backup_vault = google_netapp_backup_vault.default.id
+  }
+}
+resource "google_netapp_backup_vault" "default" {
+  name = "tf-test-backup-vault%{random_suffix}"
+  location = google_netapp_storage_pool.default.location
+  backup_retention_policy {
+	backup_minimum_enforced_retention_days = 10
+	daily_backup_immutable = false
+	weekly_backup_immutable = true
+	monthly_backup_immutable = false
+	manual_backup_immutable = false
+  }
+}
+resource "google_netapp_volume_snapshot" "default" {
+  depends_on = [google_netapp_volume.default]
+  location = google_netapp_volume.default.location
+  volume_name = google_netapp_volume.default.name
+  description = "This is a test description"
+  name = "testvolumesnap%{random_suffix}"
+  labels = {
+    key= "test"
+    value= "snapshot"
+  }
+  }
+resource "google_netapp_backup" "test_backup" {
+  name = "tf-test-test-backup%{random_suffix}"
+  description = "This is a test integrated backup"
+  source_volume = google_netapp_volume.default.id
+  location = google_netapp_backup_vault.default.location
+  vault_name = google_netapp_backup_vault.default.name
+  source_snapshot = google_netapp_volume_snapshot.default.id
+  labels = {
+  key= "test"
+  value= "backup"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
```release-note:none
Add immutable backup retention policy support
```
This commit adds support for the `backupRetentionPolicy` field to the `google_netapp_backup_vault` resource. This includes:

*   Adding the `backupRetentionPolicy` nested object with fields for:
    *   `backupMinimumEnforcedRetentionDays`
    *   `dailyBackupImmutable`
    *   `weeklyBackupImmutable`
    *   `monthlyBackupImmutable`
    *   `manualBackupImmutable`
*   Updating the `backupVault.yaml` file to include the new fields.
* Adding acceptance tests for create and update scenarios, to validate the new functionality.

These fields allow users to define the retention policy and immutability settings for their backup vaults.

