### PR TITLE
EdgeCacheService: Fixed `defaultTtl/maxTtl` Config validation failed error when switching `cache_mode`

### DIFF
--- a/mmv1/products/networkservices/EdgeCacheService.yaml
+++ b/mmv1/products/networkservices/EdgeCacheService.yaml
@@ -492,7 +492,6 @@ properties:
                               When the cache mode is set to "USE_ORIGIN_HEADERS" or "BYPASS_CACHE", you must omit this field.
 
                               A duration in seconds terminated by 's'. Example: "3s".
-                            default_from_api: true
  # defalt from api
                           - name: 'maxTtl'
                             type: String
@@ -511,7 +510,6 @@ properties:
                               When the cache mode is set to "USE_ORIGIN_HEADERS", "FORCE_CACHE_ALL", or "BYPASS_CACHE", you must omit this field.
 
                               A duration in seconds terminated by 's'. Example: "3s".
-                            default_from_api: true
                           - name: 'cacheKeyPolicy'
                             type: NestedObject
                             description: |

--- a/mmv1/products/networkservices/EdgeCacheService.yaml
+++ b/mmv1/products/networkservices/EdgeCacheService.yaml
@@ -42,6 +42,7 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+  encoder: 'templates/terraform/encoders/network_services_edge_cache_service.go.tmpl'
 examples:
   - name: 'network_services_edge_cache_service_basic'
     primary_resource_id: 'instance'
@@ -492,6 +493,7 @@ properties:
                               When the cache mode is set to "USE_ORIGIN_HEADERS" or "BYPASS_CACHE", you must omit this field.
 
                               A duration in seconds terminated by 's'. Example: "3s".
+                            default_from_api: true
  # defalt from api
                           - name: 'maxTtl'
                             type: String
@@ -510,6 +512,7 @@ properties:
                               When the cache mode is set to "USE_ORIGIN_HEADERS", "FORCE_CACHE_ALL", or "BYPASS_CACHE", you must omit this field.
 
                               A duration in seconds terminated by 's'. Example: "3s".
+                            default_from_api: true
                           - name: 'cacheKeyPolicy'
                             type: NestedObject
                             description: |

--- a/mmv1/templates/terraform/encoders/network_services_edge_cache_service.go.tmpl
+++ b/mmv1/templates/terraform/encoders/network_services_edge_cache_service.go.tmpl
@@ -1,0 +1,53 @@
+// This encoder ensures TTL fields are handled correctly based on cache mode
+routing, ok := obj["routing"].(map[string]interface{})
+if !ok {
+	return obj, nil
+}
+
+pathMatchers, ok := routing["pathMatchers"].([]interface{})
+if !ok || len(pathMatchers) == 0 {
+	return obj, nil
+}
+
+for _, pm := range pathMatchers {
+	pathMatcher, ok := pm.(map[string]interface{})
+	if !ok {
+		continue
+	}
+
+	routeRules, ok := pathMatcher["routeRules"].([]interface{})
+	if !ok {
+		continue
+	}
+
+	for _, rr := range routeRules {
+		routeRule, ok := rr.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		routeAction, ok := routeRule["routeAction"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		cdnPolicy, ok := routeAction["cdnPolicy"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		// Handle TTL fields based on cache mode
+		if cacheMode, ok := cdnPolicy["cacheMode"].(string); ok {
+			switch cacheMode {
+			case "USE_ORIGIN_HEADERS", "BYPASS_CACHE":
+				delete(cdnPolicy, "clientTtl")
+				delete(cdnPolicy, "defaultTtl")
+				delete(cdnPolicy, "maxTtl")
+			case "FORCE_CACHE_ALL":
+				delete(cdnPolicy, "maxTtl")
+			}
+		}
+	}
+}
+
+return obj, nil 

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
@@ -174,6 +174,14 @@ func TestAccNetworkServicesEdgeCacheService_cacheModeAndTtl(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_2(namebkt, nameorigin, nameservice),
+			},
+			{
+				ResourceName:      "google_network_services_edge_cache_service.served",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -272,6 +280,60 @@ resource "google_network_services_edge_cache_service" "served" {
         route_action {
           cdn_policy {
             cache_mode  = "FORCE_CACHE_ALL"
+            default_ttl = "1100s"
+          }
+        }
+        header_action {
+          response_header_to_add {
+            header_name  = "x-cache-status"
+            header_value = "{cdn_cache_status}"
+          }
+        }
+      }
+    }
+  }
+}
+`, bktName, originName, serviceName)
+}
+
+func testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_2(bktName, originName, serviceName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "dest" {
+  name                        = "%s"
+  location                    = "US"
+  force_destroy              = true
+  uniform_bucket_level_access = true
+}
+resource "google_network_services_edge_cache_origin" "instance" {
+  name           = "%s"
+  origin_address = google_storage_bucket.dest.url
+  description    = "The default bucket for media edge test"
+  max_attempts   = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+}
+resource "google_network_services_edge_cache_service" "served" {
+  name        = "%s"
+  description = "some description"
+  routing {
+    host_rule {
+      description  = "host rule description"
+      hosts        = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against"
+        priority    = 1
+        match_rule {
+          prefix_match = "/"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+            cache_mode = "BYPASS_CACHE"
           }
         }
         header_action {

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_edge_cache_service_test.go
@@ -147,3 +147,142 @@ resource "google_network_services_edge_cache_service" "served" {
 }
 `, bktName, originName, serviceName)
 }
+
+func TestAccNetworkServicesEdgeCacheService_cacheModeAndTtl(t *testing.T) {
+	t.Parallel()
+	namebkt := "tf-test-bucket-" + acctest.RandString(t, 10)
+	nameorigin := "tf-test-origin-" + acctest.RandString(t, 10)
+	nameservice := "tf-test-service-" + acctest.RandString(t, 10)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkServicesEdgeCacheServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_0(namebkt, nameorigin, nameservice),
+			},
+			{
+				ResourceName:      "google_network_services_edge_cache_service.served",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_1(namebkt, nameorigin, nameservice),
+			},
+			{
+				ResourceName:      "google_network_services_edge_cache_service.served",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_0(bktName, originName, serviceName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "dest" {
+  name                        = "%s"
+  location                    = "US"
+  force_destroy              = true
+  uniform_bucket_level_access = true
+}
+resource "google_network_services_edge_cache_origin" "instance" {
+  name           = "%s"
+  origin_address = google_storage_bucket.dest.url
+  description    = "The default bucket for media edge test"
+  max_attempts   = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+}
+resource "google_network_services_edge_cache_service" "served" {
+  name        = "%s"
+  description = "some description"
+  routing {
+    host_rule {
+      description  = "host rule description"
+      hosts        = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against"
+        priority    = 1
+        match_rule {
+          prefix_match = "/"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+            cache_mode  = "CACHE_ALL_STATIC"
+            default_ttl = "1000s"
+            max_ttl     = "2000s"
+          }
+          compression_mode = "AUTOMATIC"
+        }
+        header_action {
+          response_header_to_add {
+            header_name  = "x-cache-status"
+            header_value = "{cdn_cache_status}"
+          }
+        }
+      }
+    }
+  }
+}
+`, bktName, originName, serviceName)
+}
+
+func testAccNetworkServicesEdgeCacheService_cacheModeAndTtl_1(bktName, originName, serviceName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "dest" {
+  name                        = "%s"
+  location                    = "US"
+  force_destroy              = true
+  uniform_bucket_level_access = true
+}
+resource "google_network_services_edge_cache_origin" "instance" {
+  name           = "%s"
+  origin_address = google_storage_bucket.dest.url
+  description    = "The default bucket for media edge test"
+  max_attempts   = 2
+  timeout {
+    connect_timeout = "10s"
+  }
+}
+resource "google_network_services_edge_cache_service" "served" {
+  name        = "%s"
+  description = "some description"
+  routing {
+    host_rule {
+      description  = "host rule description"
+      hosts        = ["sslcert.tf-test.club"]
+      path_matcher = "routes"
+    }
+    path_matcher {
+      name = "routes"
+      route_rule {
+        description = "a route rule to match against"
+        priority    = 1
+        match_rule {
+          prefix_match = "/"
+        }
+        origin = google_network_services_edge_cache_origin.instance.name
+        route_action {
+          cdn_policy {
+            cache_mode  = "FORCE_CACHE_ALL"
+          }
+        }
+        header_action {
+          response_header_to_add {
+            header_name  = "x-cache-status"
+            header_value = "{cdn_cache_status}"
+          }
+        }
+      }
+    }
+  }
+}
+`, bktName, originName, serviceName)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
To align with [EdgeCacheService - CDNpolicy](https://cloud.google.com/media-cdn/docs/reference/rest/v1/projects.locations.edgeCacheServices#cdnpolicy) behavior, the `defaultTtl/maxTtl` must respect the client config instead of using the `default_from_api` which is actually the `last state` from api. By doing this, the omitted field will not be sent to the api.

Fixes: 
- https://github.com/hashicorp/terraform-provider-google/issues/16200
- https://github.com/hashicorp/terraform-provider-google/issues/14903
- https://github.com/hashicorp/terraform-provider-google/issues/20661


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
networkservices: fixed validation error when modifying the `cache_mode` field in `edge_cache_service`
```
