### PR TITLE
Revert "Removed cloud identity group set_computed_name post_create"

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -45,6 +45,7 @@ async:
   target_occurrences: 10
   actions: ['create', 'update', 'delete']
 custom_code:
+  post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_import: 'templates/terraform/custom_import/cloud_identity_group_import.go.tmpl'
 exclude_sweeper: true
 examples:


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#13627.

It looks like this does cause real failures (due to introducing a bug).


```release-note:none
```