### PR TITLE
Add Mirror Percent to request_mirror_policy in URLMAP

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -86,6 +86,34 @@ examples:
       service_a_backend_service_name: 'service-a'
       service_b_backend_service_name: 'service-b'
       health_check_name: 'health-check'
+  - name: 'url_map_default_mirror_percent'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+  - name: 'url_map_path_matcher_default_mirror_percent'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+  - name: 'url_map_path_rule_mirror_percent'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
+  - name: 'url_map_route_rule_mirror_percent'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      home_backend_service_name: 'home'
+      mirror_backend_service_name: 'mirror'
+      health_check_name: 'health-check'
   - name: 'external_http_lb_mig_backend'
     primary_resource_id: 'default'
     vars:
@@ -681,6 +709,13 @@ properties:
                         custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
                         resource: 'BackendService'
                         imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
                   - name: 'retryPolicy'
                     type: NestedObject
                     description: |
@@ -1433,6 +1468,13 @@ properties:
                         custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
                         resource: 'BackendService'
                         imports: 'selfLink'
+                      - name: 'mirrorPercent'
+                        type: Double
+                        description: |
+                          The percentage of requests to be mirrored to backendService.
+                          The value must be between 0.0 and 100.0 inclusive.
+                        validation:
+                          function: 'validation.FloatBetween(0, 100)'
                   - name: 'retryPolicy'
                     type: NestedObject
                     description: |
@@ -2101,6 +2143,13 @@ properties:
                   custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
                   resource: 'BackendService'
                   imports: 'selfLink'
+                - name: 'mirrorPercent'
+                  type: Double
+                  description: |
+                    The percentage of requests to be mirrored to backendService.
+                    The value must be between 0.0 and 100.0 inclusive.
+                  validation:
+                    function: 'validation.FloatBetween(0, 100)'
             - name: 'corsPolicy'
               type: NestedObject
               description: |
@@ -2692,6 +2741,13 @@ properties:
             custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
             resource: 'BackendService'
             imports: 'selfLink'
+          - name: 'mirrorPercent'
+            type: Double
+            description: |
+              The percentage of requests to be mirrored to backendService.
+              The value must be between 0.0 and 100.0 inclusive.
+            validation:
+              function: 'validation.FloatBetween(0, 100)'
       - name: 'corsPolicy'
         type: NestedObject
         description: |

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -714,7 +714,7 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta 
+                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -1474,7 +1474,7 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
-                        min_version: beta 
+                        min_version: beta
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -2150,7 +2150,7 @@ properties:
                   resource: 'BackendService'
                   imports: 'selfLink'
                 - name: 'mirrorPercent'
-                  min_version: beta 
+                  min_version: beta
                   type: Double
                   description: |
                     The percentage of requests to be mirrored to backendService.
@@ -2749,7 +2749,7 @@ properties:
             resource: 'BackendService'
             imports: 'selfLink'
           - name: 'mirrorPercent'
-            min_version: beta 
+            min_version: beta
             type: Double
             description: |
               The percentage of requests to be mirrored to backendService.

--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -88,6 +88,7 @@ examples:
       health_check_name: 'health-check'
   - name: 'url_map_default_mirror_percent'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       home_backend_service_name: 'home'
@@ -95,6 +96,7 @@ examples:
       health_check_name: 'health-check'
   - name: 'url_map_path_matcher_default_mirror_percent'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       home_backend_service_name: 'home'
@@ -102,6 +104,7 @@ examples:
       health_check_name: 'health-check'
   - name: 'url_map_path_rule_mirror_percent'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       home_backend_service_name: 'home'
@@ -109,6 +112,7 @@ examples:
       health_check_name: 'health-check'
   - name: 'url_map_route_rule_mirror_percent'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       home_backend_service_name: 'home'
@@ -710,6 +714,7 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
+                        min_version: beta 
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -1469,6 +1474,7 @@ properties:
                         resource: 'BackendService'
                         imports: 'selfLink'
                       - name: 'mirrorPercent'
+                        min_version: beta 
                         type: Double
                         description: |
                           The percentage of requests to be mirrored to backendService.
@@ -2144,6 +2150,7 @@ properties:
                   resource: 'BackendService'
                   imports: 'selfLink'
                 - name: 'mirrorPercent'
+                  min_version: beta 
                   type: Double
                   description: |
                     The percentage of requests to be mirrored to backendService.
@@ -2742,6 +2749,7 @@ properties:
             resource: 'BackendService'
             imports: 'selfLink'
           - name: 'mirrorPercent'
+            min_version: beta 
             type: Double
             description: |
               The percentage of requests to be mirrored to backendService.

--- a/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
@@ -1,0 +1,55 @@
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "url_map_name"}}"
+  description = "a description"
+  default_service = google_compute_backend_service.home.id
+
+  default_route_action {
+    request_mirror_policy {
+      backend_service = google_compute_backend_service.mirror.id
+      mirror_percent = 50.0
+    }
+  }
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+    default_service = google_compute_backend_service.home.id
+  }
+
+  test {
+    service = google_compute_backend_service.home.id
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "{{index $.Vars "home_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_backend_service" "mirror" {
+  name        = "{{index $.Vars "mirror_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+} 

--- a/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "url_map_name"}}"
-  description = "a description"
+  description = "Test for default route action mirror percent"
+  
   default_service = google_compute_backend_service.home.id
 
   default_route_action {
@@ -16,14 +17,8 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   }
 
   path_matcher {
-    name = "allpaths"
+    name            = "allpaths"
     default_service = google_compute_backend_service.home.id
-  }
-
-  test {
-    service = google_compute_backend_service.home.id
-    host    = "hi.com"
-    path    = "/home"
   }
 }
 
@@ -32,9 +27,9 @@ resource "google_compute_backend_service" "home" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_backend_service" "mirror" {
@@ -42,9 +37,9 @@ resource "google_compute_backend_service" "mirror" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_health_check" "default" {
@@ -52,4 +47,4 @@ resource "google_compute_health_check" "default" {
   http_health_check {
     port = 80
   }
-} 
+}

--- a/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_default_mirror_percent.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for default route action mirror percent"
   
@@ -23,6 +24,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
+  provider    = google-beta
   name        = "{{index $.Vars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -33,6 +35,7 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
+  provider    = google-beta
   name        = "{{index $.Vars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -43,6 +46,7 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider    = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
@@ -1,7 +1,15 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "url_map_name"}}"
-  description = "a description"
+  description = "Test for default route action mirror percent"
+  
   default_service = google_compute_backend_service.home.id
+
+  default_route_action {
+    request_mirror_policy {
+      backend_service = google_compute_backend_service.mirror.id
+      mirror_percent = 50.0
+    }
+  }
 
   host_rule {
     hosts        = ["mysite.com"]
@@ -9,21 +17,8 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   }
 
   path_matcher {
-    name = "allpaths"
+    name            = "allpaths"
     default_service = google_compute_backend_service.home.id
-
-    default_route_action {
-      request_mirror_policy {
-        backend_service = google_compute_backend_service.mirror.id
-        mirror_percent = 75.0
-      }
-    }
-  }
-
-  test {
-    service = google_compute_backend_service.home.id
-    host    = "hi.com"
-    path    = "/home"
   }
 }
 
@@ -32,9 +27,9 @@ resource "google_compute_backend_service" "home" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_backend_service" "mirror" {
@@ -42,9 +37,9 @@ resource "google_compute_backend_service" "mirror" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_health_check" "default" {
@@ -52,4 +47,4 @@ resource "google_compute_health_check" "default" {
   http_health_check {
     port = 80
   }
-} 
+}

--- a/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for default route action mirror percent"
   
@@ -23,6 +24,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
+  provider    = google-beta
   name        = "{{index $.Vars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -33,6 +35,7 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
+  provider    = google-beta
   name        = "{{index $.Vars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -43,6 +46,7 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_matcher_default_mirror_percent.tf.tmpl
@@ -1,0 +1,55 @@
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "url_map_name"}}"
+  description = "a description"
+  default_service = google_compute_backend_service.home.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+    default_service = google_compute_backend_service.home.id
+
+    default_route_action {
+      request_mirror_policy {
+        backend_service = google_compute_backend_service.mirror.id
+        mirror_percent = 75.0
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.id
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "{{index $.Vars "home_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_backend_service" "mirror" {
+  name        = "{{index $.Vars "mirror_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+} 

--- a/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for path matcher default route action mirror percent"
   
@@ -23,6 +24,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
+  provider    = google-beta
   name        = "{{index $.Vars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -33,6 +35,7 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
+  provider    = google-beta
   name        = "{{index $.Vars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -43,6 +46,7 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider    = google-beta 
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
@@ -1,0 +1,59 @@
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "url_map_name"}}"
+  description = "a description"
+  default_service = google_compute_backend_service.home.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+    default_service = google_compute_backend_service.home.id
+
+    path_rule {
+      paths   = ["/home"]
+      service = google_compute_backend_service.home.id
+      route_action {
+        request_mirror_policy {
+          backend_service = google_compute_backend_service.mirror.id
+          mirror_percent = 25.0
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.id
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "{{index $.Vars "home_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_backend_service" "mirror" {
+  name        = "{{index $.Vars "mirror_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+} 

--- a/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_path_rule_mirror_percent.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "url_map_name"}}"
-  description = "a description"
+  description = "Test for path matcher default route action mirror percent"
+  
   default_service = google_compute_backend_service.home.id
 
   host_rule {
@@ -9,25 +10,15 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   }
 
   path_matcher {
-    name = "allpaths"
+    name            = "allpaths"
     default_service = google_compute_backend_service.home.id
 
-    path_rule {
-      paths   = ["/home"]
-      service = google_compute_backend_service.home.id
-      route_action {
-        request_mirror_policy {
-          backend_service = google_compute_backend_service.mirror.id
-          mirror_percent = 25.0
-        }
+    default_route_action {
+      request_mirror_policy {
+        backend_service = google_compute_backend_service.mirror.id
+        mirror_percent = 75.0
       }
     }
-  }
-
-  test {
-    service = google_compute_backend_service.home.id
-    host    = "hi.com"
-    path    = "/home"
   }
 }
 
@@ -36,9 +27,9 @@ resource "google_compute_backend_service" "home" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_backend_service" "mirror" {
@@ -46,9 +37,9 @@ resource "google_compute_backend_service" "mirror" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_health_check" "default" {
@@ -56,4 +47,4 @@ resource "google_compute_health_check" "default" {
   http_health_check {
     port = 80
   }
-} 
+}

--- a/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
@@ -1,6 +1,7 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "url_map_name"}}"
-  description = "a description"
+  description = "Test for path rule route action mirror percent"
+
   default_service = google_compute_backend_service.home.id
 
   host_rule {
@@ -9,28 +10,19 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
   }
 
   path_matcher {
-    name = "allpaths"
+    name            = "allpaths"
     default_service = google_compute_backend_service.home.id
 
-    route_rules {
-      priority = 1
+    path_rule {
+      paths   = ["/home"]
       service = google_compute_backend_service.home.id
-      match_rules {
-        prefix_match = "/home"
-      }
       route_action {
         request_mirror_policy {
           backend_service = google_compute_backend_service.mirror.id
-          mirror_percent = 100.0
+          mirror_percent = 25.0
         }
       }
     }
-  }
-
-  test {
-    service = google_compute_backend_service.home.id
-    host    = "hi.com"
-    path    = "/home"
   }
 }
 
@@ -39,9 +31,9 @@ resource "google_compute_backend_service" "home" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_backend_service" "mirror" {
@@ -49,9 +41,9 @@ resource "google_compute_backend_service" "mirror" {
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
+  load_balancing_scheme = "EXTERNAL_MANAGED"
 
   health_checks = [google_compute_health_check.default.id]
-  load_balancing_scheme = "EXTERNAL_MANAGED"
 }
 
 resource "google_compute_health_check" "default" {
@@ -59,4 +51,4 @@ resource "google_compute_health_check" "default" {
   http_health_check {
     port = 80
   }
-} 
+}

--- a/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for path rule route action mirror percent"
 
@@ -27,6 +28,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "home" {
+  provider    = google-beta
   name        = "{{index $.Vars "home_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -37,6 +39,7 @@ resource "google_compute_backend_service" "home" {
 }
 
 resource "google_compute_backend_service" "mirror" {
+  provider    = google-beta
   name        = "{{index $.Vars "mirror_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -47,6 +50,7 @@ resource "google_compute_backend_service" "mirror" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_route_rule_mirror_percent.tf.tmpl
@@ -1,0 +1,62 @@
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "url_map_name"}}"
+  description = "a description"
+  default_service = google_compute_backend_service.home.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+    default_service = google_compute_backend_service.home.id
+
+    route_rules {
+      priority = 1
+      service = google_compute_backend_service.home.id
+      match_rules {
+        prefix_match = "/home"
+      }
+      route_action {
+        request_mirror_policy {
+          backend_service = google_compute_backend_service.mirror.id
+          mirror_percent = 100.0
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.id
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "{{index $.Vars "home_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_backend_service" "mirror" {
+  name        = "{{index $.Vars "mirror_backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.id]
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  http_health_check {
+    port = 80
+  }
+} 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR Adds missing Mirror Percent to request_mirror_policy in URLMAP

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `mirrorPercent` field to `requestMirrorPolicy` in `defaultRouteAction`, `pathMatchers[].defaultRouteAction`, `pathMatchers[].pathRules[].routeAction`, and `pathMatchers[].routeRules[].routeAction` to `google_compute_url_map` resource (beta)
```
