### PR TITLE
Remove invalid attributes on expirationPolicy.ttl

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -397,8 +397,6 @@ properties:
       resource never expires.  The minimum allowed value for expirationPolicy.ttl
       is 1 day.
     default_from_api: true
-    send_empty_value: true
-    allow_empty_object: true
     properties:
       - name: 'ttl'
         type: String


### PR DESCRIPTION
part of https://github.com/hashicorp/terraform-provider-google/issues/22257

see https://github.com/hashicorp/terraform-provider-google/issues/22257#issuecomment-2885060663

`google_pubsub_subscription.expiration_policy` has a required field, and thus cannot be set to empty. This [was set from a time](https://github.com/hashicorp/terraform-provider-google/pull/3742) when `expiration_policy.ttl` [was optional](https://github.com/modular-magician/terraform-provider-google/blob/792e9cdad00bf4c1e59fb677772bc0ac230c682d/google/resource_pubsub_subscription.go#L85C1-L86C1).

this should have no impact on users. Unsetting the field during create still results in an API value:
```
"expirationPolicy": {
   "ttl": "2678400s"
},
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
