### PR TITLE
Removed IAP client post_create

### DIFF
--- a/mmv1/products/iap/Client.yaml
+++ b/mmv1/products/iap/Client.yaml
@@ -36,7 +36,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  post_create: 'templates/terraform/post_create/iap_client.go.tmpl'
   custom_import: 'templates/terraform/custom_import/iap_client.go.tmpl'
 exclude_sweeper: true
 error_retry_predicates:

--- a/mmv1/templates/terraform/post_create/iap_client.go.tmpl
+++ b/mmv1/templates/terraform/post_create/iap_client.go.tmpl
@@ -1,7 +1,0 @@
-brand := d.Get("brand")
-clientId := flattenIapClientClientId(res["name"], d, config)
-
-if err := d.Set("client_id", clientId); err != nil {
-	return fmt.Errorf("Error setting client_id: %s", err)
-}
-d.SetId(fmt.Sprintf("%s/identityAwareProxyClients/%s", brand, clientId))


### PR DESCRIPTION
This is now duplicated code - we set the client id automatically based on name after create.

Part of https://github.com/hashicorp/terraform-provider-google/issues/22214

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
