### PR TITLE
Revert "Removed cloud identity group membership set_computed_name post_create"

### DIFF
--- a/mmv1/products/cloudidentity/GroupMembership.yaml
+++ b/mmv1/products/cloudidentity/GroupMembership.yaml
@@ -37,6 +37,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_update: 'templates/terraform/custom_update/cloud_identity_group_membership.go.tmpl'
   post_import: 'templates/terraform/post_import/cloud_identity_group_membership.go.tmpl'
 exclude_sweeper: true


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#13628

```release-note:none
```