### PR TITLE
removing `required_with` tag from `min`/`max_instances` fields in vpcaccess connector

### DIFF
--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -136,7 +136,7 @@ properties:
   - name: 'maxInstances'
     type: Integer
     description: |
-      Required. Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
+      Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
       higher than the value specified by min_instances. Required alongside `min_instances` if not using `min_throughput`/`max_throughput`.
     default_from_api: true
     conflicts:

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -128,8 +128,8 @@ properties:
   - name: 'minInstances'
     type: Integer
     description: |
-      Required. Minimum value of instances in autoscaling group underlying the connector. Value must be between 2 and 9, inclusive. Must be
-      lower than the value specified by max_instances.
+      Minimum value of instances in autoscaling group underlying the connector. Value must be between 2 and 9, inclusive. Must be
+      lower than the value specified by max_instances. Required alongside `max_instances` if not using `min_throughput`/`max_throughput`.
     default_from_api: true
     conflicts:
       - min_throughput
@@ -137,7 +137,7 @@ properties:
     type: Integer
     description: |
       Required. Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
-      higher than the value specified by min_instances.
+      higher than the value specified by min_instances. Required alongside `min_instances` if not using `min_throughput`/`max_throughput`.
     default_from_api: true
     conflicts:
       - max_throughput

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -128,23 +128,19 @@ properties:
   - name: 'minInstances'
     type: Integer
     description: |
-      Minimum value of instances in autoscaling group underlying the connector. Value must be between 2 and 9, inclusive. Must be
+      Required. Minimum value of instances in autoscaling group underlying the connector. Value must be between 2 and 9, inclusive. Must be
       lower than the value specified by max_instances.
     default_from_api: true
     conflicts:
       - min_throughput
-    required_with:
-      - max_instances
   - name: 'maxInstances'
     type: Integer
     description: |
-      Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
+      Required. Maximum value of instances in autoscaling group underlying the connector. Value must be between 3 and 10, inclusive. Must be
       higher than the value specified by min_instances.
     default_from_api: true
     conflicts:
       - max_throughput
-    required_with:
-      - min_instances
   - name: 'maxThroughput'
     type: Integer
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
when resource mutability was introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/12830, a `required_with` tag was added to these fields.

presently API error handling/defaults cover these situations, where creating a connector without `max` will result in a "max needs to be greater than min" error, and creating without `min` will result in "min must be greater than or equal to 2". Creating without either says you need to have one declared.

Thus, the `required_with` is theoretically accurate, but also in theory could have been introducing a breaking change to existing users if those values formerly had different default behavior. Because API validation covers invalid situations, allowing it to reject those requests is a more stable option.

given these fields are required for creating new resources, updated the field descriptions accordingly (even if it does not reflect the validation we perform)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
vpcaccess: fixed an issue where Terraform config validation conditions could have erroneously invalidated existing `google_vpc_access_connector` resources
```
