### PR TITLE
Allow updates to the mtu property in the Network resource.

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -204,8 +204,11 @@ properties:
       Note that packets larger than 1500 bytes (standard Ethernet) can be subject to TCP-MSS clamping or dropped
       with an ICMP `Fragmentation-Needed` message if the packets are routed to the Internet or other VPCs
       with varying MTUs.
-    immutable: true
     default_from_api: true
+    update_url: 'projects/{{project}}/global/networks/{{name}}'
+    update_verb: 'PATCH'
+    update_id: 'mtu'
+    fingerprint_name: 'fingerprint'
   - name: 'enableUlaInternalIpv6'
     type: Boolean
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -78,6 +78,41 @@ func TestAccComputeNetwork_customSubnet(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetwork_mtuAndUpdate(t *testing.T) {
+	t.Parallel()
+
+	var network compute.Network
+	suffixName := acctest.RandString(t, 10)
+	networkName := fmt.Sprintf("tf-test-network-routing-mode-%s", suffixName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeNetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetwork_mtu(networkName, 1460),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_mtu", &network),
+					testAccCheckComputeNetworkHasMtu(
+						t, "google_compute_network.acc_network_mtu", &network, 1460),
+				),
+			},
+			// Test updating the mtu field from 1460 to 1500.
+			{
+				Config: testAccComputeNetwork_mtu(networkName, 1500),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeNetworkExists(
+						t, "google_compute_network.acc_network_mtu", &network),
+					testAccCheckComputeNetworkHasMtu(
+						t, "google_compute_network.acc_network_mtu", &network, 1500),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -530,6 +565,35 @@ func testAccCheckComputeNetworkIsCustomSubnet(t *testing.T, n string, network *c
 	}
 }
 
+func testAccCheckComputeNetworkHasMtu(t *testing.T, n string, network *compute.Network, mtu int32) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := acctest.GoogleProviderConfig(t)
+
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.Attributes["mtu"] == "" {
+			return fmt.Errorf("Routing mode not found on resource")
+		}
+
+		found, err := config.NewComputeClient(config.UserAgent).Networks.Get(
+			config.Project, network.Name).Do()
+		if err != nil {
+			return err
+		}
+
+		foundMtu := found.Mtu
+
+		if int64(mtu) != foundMtu {
+			return fmt.Errorf("Expected mtu %d to match actual routing mode %d", mtu, foundMtu)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *compute.Network, routingMode string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -644,6 +708,15 @@ resource "google_compute_network" "baz" {
 `, networkName)
 }
 
+func testAccComputeNetwork_mtu(networkName string, mtu int32) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "acc_network_mtu" {
+  name = "%s"
+  mtu  = %d
+}
+`, networkName, mtu)
+}
+
 func testAccComputeNetwork_routing_mode(networkName, routingMode string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_routing_mode" {
@@ -652,7 +725,6 @@ resource "google_compute_network" "acc_network_routing_mode" {
 }
 `, networkName, routingMode)
 }
-
 
 func testAccComputeNetwork_best_bgp_path_selection_mode(networkName, bgpBestPathSelection string) string {
    return fmt.Sprintf(`


### PR DESCRIPTION
Currently using terraform to update the mtu property of the Network results in forcing the replacement of the Network resource.

This change marks the mtu property as mutable, and instead uses the PATCH API on the Network resource to update the mtu property of the network.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22543

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
compute: fixed VPC Network's MTU to be updatable without forcing a replacement of the Network resource.
```
