### PR TITLE
Adds IP Filter feature support to google_storage_bucket resource. 

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -576,6 +576,83 @@ func ResourceStorageBucket() *schema.Resource {
 				Computed: true,
 				Description: `The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.`,
 			},
+			"ip_filter": {
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				Description:      `The bucket IP filtering configuration.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"mode": {
+							Type: schema.TypeString,
+							Required: true,
+							Description: `The mode of the IP filter. Valid values are 'Enabled' and 'Disabled'.`,
+							ValidateFunc: validation.StringInSlice([]string{"Enabled", "Disabled"}, false),
+						},
+						"public_network_source": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							Description: `The public network IP address ranges that can access the bucket and its data.`,
+							Elem:        &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allowed_ip_cidr_ranges": {
+										Type:        schema.TypeList,
+										Required:    true,
+										Description: "The list of public IPv4, IPv6 cidr ranges that are allowed to access the bucket.",
+										Elem:        &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.IsCIDR,
+										},
+									},
+								},
+							},
+						},
+						"vpc_network_sources": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `The list of VPC networks that can access the bucket.`,
+							Elem:        &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allowed_ip_cidr_ranges": {
+										Type:     schema.TypeList,
+										Required: true,
+										Description: "The list of public or private IPv4 and IPv6 CIDR ranges that can access the bucket.",
+										Elem:     &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.IsCIDR,
+										},
+									},
+									"network": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Name of the network. Format: projects/{PROJECT_ID}/global/networks/{NETWORK_NAME}",
+									},
+								},
+							},
+						},
+					},
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if k == "ip_filter.#" {
+						o, _ := d.GetChange("ip_filter")
+						l := o.([]interface{})
+						if len(l) == 0 {
+							return false
+						}
+
+						if contents, ok := l[0].(map[string]interface{}); !ok {
+							return false
+						} else if mode, ok := contents["mode"].(string); ok && mode == "Disabled" {
+							return true
+						}
+						return false
+					} else if k == "ip_filter.0.mode" {
+						return old == "Disabled" && new == ""
+					}
+					return false
+				},
+      },
 		},
 		UseJSONNumber: true,
 	}
@@ -827,6 +904,10 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 		sb.HierarchicalNamespace = expandBucketHierachicalNamespace(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("ip_filter"); ok {
+		sb.IpFilter = expandBucketIpFilter(v.([]interface{}))
+	}
+
 	var res *storage.Bucket
 
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
@@ -1008,6 +1089,12 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.HasChange("soft_delete_policy") {
 		if v, ok := d.GetOk("soft_delete_policy"); ok {
 			sb.SoftDeletePolicy = expandBucketSoftDeletePolicy(v.([]interface{}))
+		}
+	}
+
+	if d.HasChange("ip_filter") {
+		if v, ok := d.GetOk("ip_filter"); ok {
+			sb.IpFilter = expandBucketIpFilter(v.([]interface{}))
 		}
 	}
 
@@ -1945,6 +2032,107 @@ func lockRetentionPolicy(bucketsService *storage.BucketsService, bucketName stri
 	return nil
 }
 
+func flattenBucketIpFilter(ipFilter *storage.BucketIpFilter) []map[string]interface{} {
+	ipFilterList := make([]map[string]interface{}, 0, 1)
+
+	if ipFilter == nil {
+		return ipFilterList
+	}
+
+	filterItem := map[string]interface{}{
+		"mode": ipFilter.Mode,
+	}
+
+	if publicSrc := flattenBucketIpFilterPublicNetworkSource(ipFilter.PublicNetworkSource); publicSrc != nil {
+		filterItem["public_network_source"] = publicSrc
+	}
+	if vpcSrc := flattenBucketIpFilterVpcNetworkSources(ipFilter.VpcNetworkSources); vpcSrc != nil {
+		filterItem["vpc_network_sources"] = vpcSrc
+	}
+
+	return append(ipFilterList, filterItem)
+}
+
+func flattenBucketIpFilterPublicNetworkSource(publicNetworkSource *storage.BucketIpFilterPublicNetworkSource) []map[string]interface{} {
+	if publicNetworkSource == nil || len(publicNetworkSource.AllowedIpCidrRanges) == 0 {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"allowed_ip_cidr_ranges": publicNetworkSource.AllowedIpCidrRanges,
+		},
+	}
+}
+
+func flattenBucketIpFilterVpcNetworkSources(vpnNetworkSource []*storage.BucketIpFilterVpcNetworkSources) []map[string]interface{} {
+	if len(vpnNetworkSource) == 0 {
+		return nil
+	}
+
+	srcs := make([]map[string]interface{}, 0, len(vpnNetworkSource))
+
+	for i := range vpnNetworkSource {
+		srcs = append(srcs, map[string]interface{}{
+		"allowed_ip_cidr_ranges": vpnNetworkSource[i].AllowedIpCidrRanges,
+		"network":                vpnNetworkSource[i].Network,
+		})
+	}
+
+	return srcs
+}
+
+func expandBucketIpFilter(v interface{}) (*storage.BucketIpFilter) {
+	ipFilterList := v.([]interface{})
+	if len(ipFilterList) == 0 || ipFilterList[0] == nil {
+		return nil
+	}
+	ipFilter := ipFilterList[0].(map[string]interface{})
+	return &storage.BucketIpFilter{
+		Mode:                ipFilter["mode"].(string),
+		PublicNetworkSource: expandBucketIpFilterPublicNetworkSource(ipFilter["public_network_source"]),
+		VpcNetworkSources:   expandBucketIpFilterVpcNetworkSources(ipFilter["vpc_network_sources"]),
+		ForceSendFields:     []string{"PublicNetworkSource", "VpcNetworkSources"},
+	}
+}
+
+func expandBucketIpFilterPublicNetworkSource(v interface{}) (*storage.BucketIpFilterPublicNetworkSource) {
+	e := &storage.BucketIpFilterPublicNetworkSource{
+			ForceSendFields: []string{"AllowedIpCidrRanges"},
+		}
+
+	publicNetworkSources := v.([]interface{})
+	if len(publicNetworkSources) == 0 || publicNetworkSources[0] == nil {
+		return e
+	}
+	publicNetworkSource := publicNetworkSources[0].(map[string]interface{})
+	cidrs := publicNetworkSource["allowed_ip_cidr_ranges"].([]interface{})
+	if len(cidrs) == 0 {
+		return e
+	}
+
+	e.AllowedIpCidrRanges = tpgresource.ConvertStringArr(cidrs)
+	return e
+}
+
+func expandBucketIpFilterVpcNetworkSources(v interface{}) ([]*storage.BucketIpFilterVpcNetworkSources) {
+	vpcNetworkSources := v.([]interface{})
+	if len(vpcNetworkSources) == 0 || vpcNetworkSources[0] == nil {
+		return nil
+	}
+
+	transformedvpcNetworkSources := make([]*storage.BucketIpFilterVpcNetworkSources, 0, len(vpcNetworkSources))
+	for i := range vpcNetworkSources {
+		transformedvpcNetworkSource := vpcNetworkSources[i].(map[string]interface{})
+		transformedvpcNetworkSources = append(transformedvpcNetworkSources, &storage.BucketIpFilterVpcNetworkSources{
+			AllowedIpCidrRanges: tpgresource.ConvertStringArr(transformedvpcNetworkSource["allowed_ip_cidr_ranges"].([]interface{})),
+			Network:             transformedvpcNetworkSource["network"].(string),
+		})
+	}
+
+	return transformedvpcNetworkSources
+}
+
 // d.HasChange("lifecycle_rule") always returns true, giving false positives. This function detects changes
 // to the list size or the actions/conditions of rules directly.
 func detectLifecycleChange(d *schema.ResourceData) bool {
@@ -2093,6 +2281,10 @@ func setStorageBucket(d *schema.ResourceData, config *transport_tpg.Config, res 
 		if err := d.Set("requester_pays", res.Billing.RequesterPays); err != nil {
 			return fmt.Errorf("Error setting requester_pays: %s", err)
 		}
+	}
+
+	if err := d.Set("ip_filter", flattenBucketIpFilter(res.IpFilter)); err != nil {
+		return fmt.Errorf("Error setting ip_filter: %s", err)
 	}
 
 	d.SetId(res.Id)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -1551,6 +1551,82 @@ func TestAccStorageBucket_hns_force_destroy(t *testing.T) {
 	})
 }
 
+func TestAccStorageBucket_IPFilter(t *testing.T) {
+	t.Parallel()
+
+	var bucket storage.Bucket
+	var disabled storage.Bucket
+	var noIPfilter storage.Bucket
+	bucketName := fmt.Sprintf("tf-test-ip-filter-bucket-%d", acctest.RandInt(t))
+	nwSuffix := acctest.RandString(t, 8)
+	project := envvar.GetTestProjectFromEnv()
+	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageBucket_withoutIPFilter(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &noIPfilter),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_IPFilter(
+					bucketName, nwSuffix, project, serviceAccount,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_IPFilter_disable(bucketName, nwSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &disabled),
+					testAccCheckStorageBucketWasUpdated(&disabled, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
+				Config: testAccStorageBucket_withoutIPFilter(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &noIPfilter),
+					testAccCheckStorageBucketWasUpdated(&noIPfilter, &disabled),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}
+
 func testAccCheckStorageBucketPutFolderItem(t *testing.T, bucketName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
@@ -2699,6 +2775,112 @@ resource "google_storage_bucket" "bucket" {
   retention_policy {
     retention_period = 3600
   }
+}
+`, bucketName)
+}
+
+func testAccStorageBucket_IPFilter(bucketName string, nwSuffix string, project string, serviceAccount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "vpc_gcs_ipfilter1" {
+  name = "tf-test-storage-ipfilter1-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ipfilter_1" {
+  name          = "tf-test-storage-ipfilter1-%s"
+  ip_cidr_range = "10.201.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.vpc_gcs_ipfilter1.id
+}
+
+resource "google_project_iam_custom_role" "ipfilter_exempt_role" {
+  role_id     = "_%s"
+  title       = "IP Filter Exempt Role"
+  description = "A custom role to bypass IP Filtering on GCS bucket."
+  permissions = ["storage.buckets.exemptFromIpFilter"]
+}
+
+resource "google_project_iam_member" "primary" {
+  project = "%s"
+  role    = "projects/%s/roles/${google_project_iam_custom_role.ipfilter_exempt_role.role_id}"
+  member  = "serviceAccount:%s"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "us-central1"
+  uniform_bucket_level_access = true
+  force_destroy = true
+  ip_filter  {
+    mode = "Enabled"
+    public_network_source {
+      allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
+    }
+    vpc_network_sources {
+      network = google_compute_network.vpc_gcs_ipfilter1.id
+      allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
+    }
+  }
+}
+`, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)
+}
+
+func testAccStorageBucket_IPFilter_disable(bucketName string, nwSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "vpc_gcs_ipfilter1" {
+  name = "tf-test-storage-ipfilter1-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ipfilter_1" {
+  name          = "tf-test-storage-ipfilter1-%s"
+  ip_cidr_range = "10.201.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.vpc_gcs_ipfilter1.id
+}
+
+resource "google_compute_network" "vpc_gcs_ipfilter2" {
+  name = "tf-test-storage-ipfilter2-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ipfilter_2" {
+  name          = "tf-test-storage-ipfilter2-%s"
+  ip_cidr_range = "10.202.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.vpc_gcs_ipfilter2.id
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "us-central1"
+  uniform_bucket_level_access = true
+  force_destroy = true
+  ip_filter {
+    mode = "Disabled"
+    public_network_source {
+      allowed_ip_cidr_ranges = ["192.0.2.0/24", "2001:db8::/32"]
+    }
+    vpc_network_sources {
+      network = google_compute_network.vpc_gcs_ipfilter1.id
+      allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
+    }
+    vpc_network_sources {
+      network = google_compute_network.vpc_gcs_ipfilter2.id
+      allowed_ip_cidr_ranges = ["10.201.0.0/16", "10.202.0.0/16"]
+    }
+  }
+}
+`, nwSuffix, nwSuffix, nwSuffix, nwSuffix, bucketName)
+}
+
+func testAccStorageBucket_withoutIPFilter(bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "us-central1"
+  uniform_bucket_level_access = true
+  force_destroy = true
 }
 `, bucketName)
 }

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -177,6 +177,8 @@ The following arguments are supported:
 
 * `updated` -  (Computed) The time at which the bucket's metadata or IAM policy was last updated, in RFC 3339 format.
 
+* `ip_filter` -  (Optional) The bucket IP filtering configuration. Specifies the network sources that can access the bucket, as well as its underlying objects. Structure is [documented below](#nested_ip_filter).
+
 <a name="nested_lifecycle_rule"></a>The `lifecycle_rule` block supports:
 
 * `action` - (Required) The Lifecycle Rule's action configuration. A single block of this type is supported. Structure is [documented below](#nested_action).
@@ -293,6 +295,23 @@ The following arguments are supported:
 
 * `enabled` - (Required) Enables hierarchical namespace for the bucket.
 
+<a name="nested_ip_filter"></a>The `ip_filter` block supports:
+
+* `mode` - (Required) The state of the IP filter configuration. Valid values are `Enabled` and `Disabled`. When set to `Enabled`, IP filtering rules are applied to a bucket and all incoming requests to the bucket are evaluated against these rules. When set to `Disabled`, IP filtering rules are not applied to a bucket.
+
+* `public_network_source` - (Optional) The public network IP address ranges that can access the bucket and its data. Structure is [documented below](#nested_public_network_source).
+
+* `vpc_network_sources` - (Optional) The list of VPC networks that can access the bucket. Structure is [documented below](#nested_vpc_network_sources).
+
+<a name="nested_public_network_source"></a>The `public_network_source` block supports:
+
+* `allowed_ip_cidr_ranges` - The list of public IPv4 and IPv6 CIDR ranges that can access the bucket and its data.
+
+<a name="nested_vpc_network_sources"></a>The `vpc_network_sources` block supports:
+
+* `network` - Name of the network. Format: `projects/PROJECT_ID/global/networks/NETWORK_NAME`
+
+* `allowed_ip_cidr_ranges` - The list of public or private IPv4 and IPv6 CIDR ranges that can access the bucket.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR enables users to specify IP Filtering configuration within `google_storage_bucket` resource.  

Original PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/12576
Authors: @translucens, @kautikdk 

```release-note: enhancement
storage: added `ip_filter` to `google_storage_bucket` resource.
```
