### PR TITLE
address notebooks_instance flaky tests

### DIFF
--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -70,6 +70,8 @@ examples:
     region_override: 'us-west1-a'
     vars:
       instance_name: 'notebooks-instance'
+    ignore_read_extra:
+      - 'update_time'
   - name: 'notebook_instance_basic_stopped'
     primary_resource_id: 'instance'
     primary_resource_name: 'fmt.Sprintf("tf-test-notebooks-instance%s", context["random_suffix"])'
@@ -78,6 +80,7 @@ examples:
       instance_name: 'notebooks-instance'
     ignore_read_extra:
       - 'desired_state'
+    skip_test: https://github.com/hashicorp/terraform-provider-google/issues/17593#issuecomment-2888583933
   - name: 'notebook_instance_basic_container'
     primary_resource_id: 'instance'
     primary_resource_name: 'fmt.Sprintf("tf-test-notebooks-instance%s", context["random_suffix"])'


### PR DESCRIPTION
Skipping failing test `TestAccNotebooksInstance_notebookInstanceBasicStoppedExample`

Context: https://github.com/hashicorp/terraform-provider-google/issues/17593#issuecomment-2888583933

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
