### PR TITLE
fix flaky test TestAccComputeInstanceSettings_update

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_settings_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_settings_test.go
@@ -55,7 +55,7 @@ func testAccComputeInstanceSettings_basic(context map[string]interface{}) string
 	return acctest.Nprintf(`
 
 resource "google_compute_instance_settings" "gce_instance_settings" {
-  zone = "us-east7-b"
+  zone = "us-east5-c"
   metadata {
     items = {
       foo = "baz"
@@ -70,7 +70,7 @@ func testAccComputeInstanceSettings_update(context map[string]interface{}) strin
 	return acctest.Nprintf(`
 
 resource "google_compute_instance_settings" "gce_instance_settings" {
-  zone = "us-east7-b"
+  zone = "us-east5-c"
   metadata {
     items = {
       foo = "bar"
@@ -86,7 +86,7 @@ func testAccComputeInstanceSettings_delete(context map[string]interface{}) strin
 	return acctest.Nprintf(`
 
 resource "google_compute_instance_settings" "gce_instance_settings" {
-  zone = "us-east7-b"
+  zone = "us-east5-c"
   metadata {
     items = {
       baz = "qux"


### PR DESCRIPTION
Use a different zone than the one specified in `TestAccComputeInstanceSettings_instanceSettingsBasicExample` to avoid conflicts, as this is a singleton resource.

fixes https://github.com/hashicorp/terraform-provider-google/issues/16741

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
