### PR TITLE
remove TestAccComputeHealthCheck_tcpAndSsl_shouldFail

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_health_check_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_health_check_test.go.tmpl
@@ -192,26 +192,6 @@ func TestAccComputeHealthCheck_typeTransition(t *testing.T) {
 	})
 }
 
-func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
-	// No HTTP interactions, is a unit test
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeHealthCheckDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccComputeHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,grpc_tls_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
-			},
-		},
-	})
-}
-
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeHealthCheck_logConfigDisabled(t *testing.T) {
 	t.Parallel()
@@ -430,26 +410,6 @@ resource "google_compute_health_check" "foobar" {
   unhealthy_threshold = 3
   http2_health_check {
     port = "443"
-  }
-}
-`, hckName)
-}
-
-func testAccComputeHealthCheck_tcpAndSsl_shouldFail(hckName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_health_check" "foobar" {
-  check_interval_sec  = 3
-  description         = "Resource created for Terraform acceptance testing"
-  healthy_threshold   = 3
-  name                = "health-test-%s"
-  timeout_sec         = 2
-  unhealthy_threshold = 3
-
-  tcp_health_check {
-    port = 443
-  }
-  ssl_health_check {
-    port = 443
   }
 }
 `, hckName)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_health_check_test.go.tmpl
@@ -209,27 +209,6 @@ func TestAccComputeRegionHealthCheck_typeTransition(t *testing.T) {
 	})
 }
 
-func TestAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
-	// This is essentially a unit test, no interactions
-	acctest.SkipIfVcr(t)
-	t.Parallel()
-
-	hckName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckComputeRegionHealthCheckDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of\n`grpc_health_check,grpc_tls_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check`\ncan be specified, but `ssl_health_check,tcp_health_check` were specified"),
-
-			},
-		},
-	})
-}
-
 func TestAccComputeRegionHealthCheck_logConfigDisabled(t *testing.T) {
 	t.Parallel()
 
@@ -464,26 +443,6 @@ resource "google_compute_region_health_check" "foobar" {
   unhealthy_threshold = 3
   http2_health_check {
     port = "443"
-  }
-}
-`, hckName)
-}
-
-func testAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(hckName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_region_health_check" "foobar" {
-  check_interval_sec  = 3
-  description         = "Resource created for Terraform acceptance testing"
-  healthy_threshold   = 3
-  name                = "health-test-%s"
-  timeout_sec         = 2
-  unhealthy_threshold = 3
-
-  tcp_health_check {
-    port = 443
-  }
-  ssl_health_check {
-    port = 443
   }
 }
 `, hckName)


### PR DESCRIPTION
The test started failing in beta after a conflicting field was introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/13608. While https://github.com/GoogleCloudPlatform/magic-modules/pull/13901 addressed these beta failures by updating the expected error message to include the new field, it caused the tests to fail in GA because the field is beta-only

Instead of fixing the tests in GA, I propose removing them for the following reasons:
1. Limited value of the tests. The tests are narrowly focused on verifying that the provider errors out when two specific conflicting fields are set. It's basically testing the conflict_with behavior for only this particular pair of fields, while we don't apply the same validation to other conflicting field.
2. High Maintenance Cost. These tests require updates whenever a new conflicting field is added

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22812

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
