### PR TITLE
fix TestAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigOrgFolderPausedExample

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -62,6 +62,7 @@ examples:
     test_env_vars:
       project: 'PROJECT_NAME'
       organization: 'ORG_ID'
+      location: 'REGION'
   - name: 'dlp_discovery_config_conditions_cadence'
     primary_resource_id: 'conditions_cadence'
     test_env_vars:

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_org_folder_paused.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_org_folder_paused.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_data_loss_prevention_discovery_config" "{{$.PrimaryResourceId}}" {
-	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/us"
-    location = "us"
+	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/{{index $.TestEnvVars "location"}}"
+    location = "{{index $.TestEnvVars "location"}}"
 
     targets {
         big_query_target {

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_org_running.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_org_running.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_data_loss_prevention_discovery_config" "{{$.PrimaryResourceId}}" {
-	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/us"
-    location = "us"
+	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/{{index $.TestEnvVars "location"}}"
+    location = "{{index $.TestEnvVars "location"}}"
 
     targets {
         big_query_target {

--- a/mmv1/templates/terraform/examples/dlp_discovery_config_org_running.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dlp_discovery_config_org_running.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_data_loss_prevention_discovery_config" "{{$.PrimaryResourceId}}" {
-	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/{{index $.TestEnvVars "location"}}"
-    location = "{{index $.TestEnvVars "location"}}"
+	parent = "organizations/{{index $.TestEnvVars "organization"}}/locations/us"
+    location = "us"
 
     targets {
         big_query_target {


### PR DESCRIPTION
All discovery configs must be in the same location. Change the location in TestAccDataLossPreventionDiscoveryConfig_dlpDiscoveryConfigOrgFolderPausedExample to align with other discovery config tests.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21744

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```