### PR TITLE
Removing folder policy orchestrator tests from ga provider

### DIFF
--- a/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_folder_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_for_folder_test.go.tmpl
@@ -1,3 +1,4 @@
+{{- if ne $.TargetVersionName "ga" -}}
 package osconfigv2_test
 
 import (
@@ -288,3 +289,4 @@ resource "google_os_config_v2_policy_orchestrator_for_folder" "policy_orchestrat
 }
 `, context)
 }
+{{- end }}


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/22518

```release-note:none
```