### PR TITLE
feat: added `google_bigquery_table` data source

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -44,6 +44,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_beyondcorp_app_gateway":                    beyondcorp.DataSourceGoogleBeyondcorpAppGateway(),
 	"google_beyondcorp_security_gateway":               beyondcorp.DataSourceGoogleBeyondcorpSecurityGateway(),
 	"google_billing_account":                           billing.DataSourceGoogleBillingAccount(),
+	"google_bigquery_table":          								  bigquery.DataSourceGoogleBigQueryTable(),
 	"google_bigquery_tables":          								  bigquery.DataSourceGoogleBigQueryTables(),
 	"google_bigquery_dataset":          								bigquery.DataSourceGoogleBigqueryDataset(),
 	"google_bigquery_default_service_account":          bigquery.DataSourceGoogleBigqueryDefaultServiceAccount(),

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
@@ -1,121 +1,27 @@
 package bigquery
 
 import (
-	"context"
 	"fmt"
-	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// see https://cloud.google.com/bigquery/docs/nested-repeated#limitations
+const maxNestingLevel = 15
+
 func DataSourceGoogleBigQueryTable() *schema.Resource {
-	fieldSchema := map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 300 characters",
-		},
-		"type": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The field data type.",
-		},
-		"mode": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "The field mode (NULLABLE, REQUIRED, or REPEATED).",
-		},
-		"description": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Field description. The maximum length is 1,024 characters.",
-		},
-		"fields": {
-			Type:        schema.TypeList,
-			Computed:    true,
-			Optional:    true,
-			Description: "Describes the nested schema fields if the type property is set to RECORD.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{},
-			},
-		},
-		"policy_tags": {
-			Type:        schema.TypeList,
-			Computed:    true,
-			Optional:    true,
-			Description: "Policy tag list for this field.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"names": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Schema{
-							Type: schema.TypeString,
-						},
-					},
-				},
-			},
-		},
-		"max_length": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Maximum length of values of this field for STRINGS or BYTES.",
-		},
-		"precision": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Precision (maximum number of total digits) for NUMERIC or BIGNUMERIC.",
-		},
-		"scale": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Scale (maximum number of digits in the fractional part) for NUMERIC or BIGNUMERIC.",
-		},
-		"rounding_mode": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Rounding mode for NUMERIC or BIGNUMERIC.",
-		},
-		"collation": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Collation specification of the field.",
-		},
-		"default_value_expression": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Optional:    true,
-			Description: "Default value expression for this field.",
-		},
-		"range_element_type": {
-			Type:        schema.TypeList,
-			Computed:    true,
-			Optional:    true,
-			Description: "Element type for RANGE type fields.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
+	return &schema.Resource{
+		Read:   dataSourceBigQueryTableRead,
+		Schema: getDataSourceSchema(),
 	}
+}
 
-	// fieldSchema["fields"].Elem.(*schema.Resource).Schema = fieldSchema
+func getDataSourceSchema() map[string]*schema.Schema {
+	fieldSchema := buildFieldSchema(maxNestingLevel)
 
-	dsSchema := map[string]*schema.Schema{
+	return map[string]*schema.Schema{
 		"dataset_id": {
 			Type:        schema.TypeString,
 			Required:    true,
@@ -129,30 +35,103 @@ func DataSourceGoogleBigQueryTable() *schema.Resource {
 		"project": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "The ID of the project in which the table is located. If it is not provided, the provider project is used.",
+			Description: "The ID of the project in which the table is located.",
 		},
-		"table": {
+		"schema": {
 			Type:     schema.TypeList,
 			Computed: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
-					"schema": {
+					"fields": {
 						Type:     schema.TypeList,
 						Computed: true,
 						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"fields": {
-									Type:     schema.TypeList,
-									Computed: true,
-									Elem: &schema.Resource{
-										Schema: fieldSchema,
-									},
-								},
-							},
+							Schema: fieldSchema,
 						},
 					},
-					// TODO(ramon) add other properties
-					"table_id": {
+				},
+			},
+		},
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func buildFieldSchema(depth int) map[string]*schema.Schema {
+	baseSchema := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The field name.",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The field data type.",
+		},
+		"mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The field mode (NULLABLE, REQUIRED, or REPEATED).",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Field description.",
+		},
+		"policy_tags": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Policy tag list for this field.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"names": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
+		},
+		"max_length": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Maximum length of values of this field for STRINGS or BYTES.",
+		},
+		"precision": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Precision (maximum number of total digits) for NUMERIC or BIGNUMERIC.",
+		},
+		"scale": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Scale (maximum number of digits in the fractional part) for NUMERIC or BIGNUMERIC.",
+		},
+		"rounding_mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Rounding mode for NUMERIC or BIGNUMERIC.",
+		},
+		"collation": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Collation specification of the field.",
+		},
+		"default_value_expression": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Default value expression for this field.",
+		},
+		"range_element_type": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Element type for RANGE type fields.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
 						Type:     schema.TypeString,
 						Computed: true,
 					},
@@ -161,22 +140,43 @@ func DataSourceGoogleBigQueryTable() *schema.Resource {
 		},
 	}
 
-	return &schema.Resource{
-		ReadContext: dataSourceGoogleBigQueryTableRead,
-		Schema:      dsSchema,
+	if depth > 0 {
+		nestedSchema := make(map[string]*schema.Schema)
+		for k, v := range baseSchema {
+			nestedSchema[k] = v
+		}
+		nestedSchema["fields"] = &schema.Schema{
+			Type:        schema.TypeList,
+			Computed:    true,
+			Description: "Nested fields for RECORD type fields.",
+			Elem: &schema.Resource{
+				Schema: buildFieldSchema(depth - 1),
+			},
+		}
+		return nestedSchema
 	}
+
+	return baseSchema
 }
 
-func dataSourceGoogleBigQueryTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project: %s", err)
+	}
+
+	datasetID := d.Get("dataset_id").(string)
+	tableID := d.Get("table_id").(string)
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 	if err != nil {
-		return diag.FromErr(err)
+		return err
 	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
@@ -185,10 +185,67 @@ func dataSourceGoogleBigQueryTableRead(_ context.Context, d *schema.ResourceData
 		RawURL:    url,
 		UserAgent: userAgent,
 	})
-	log.Printf("[RAMON][DEBUG] BigQuery response: %s", res)
 	if err != nil {
-		return diag.FromErr(fmt.Errorf("Error retrieving table: %s", err))
+		return fmt.Errorf("Error retrieving table: %s", err)
 	}
 
+	if schemaData, ok := res["schema"].(map[string]interface{}); ok {
+		if fields, ok := schemaData["fields"].([]interface{}); ok {
+			if err := d.Set("schema", []map[string]interface{}{
+				{"fields": flattenSchemaFields(fields, 0)},
+			}); err != nil {
+				return fmt.Errorf("Error setting schema: %s", err)
+			}
+		}
+	}
+
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
 	return nil
+}
+
+func flattenSchemaFields(fields []interface{}, currentLevel int) []interface{} {
+	if currentLevel > maxNestingLevel {
+		return nil
+	}
+
+	var result []interface{}
+	for _, f := range fields {
+		field := f.(map[string]interface{})
+		flattened := map[string]interface{}{
+			"name":                     field["name"],
+			"type":                     field["type"],
+			"mode":                     field["mode"],
+			"description":              field["description"],
+			"max_length":               field["maxLength"],
+			"precision":                field["precision"],
+			"scale":                    field["scale"],
+			"rounding_mode":            field["roundingMode"],
+			"collation":                field["collation"],
+			"default_value_expression": field["defaultValueExpression"],
+		}
+
+		if policyTags, ok := field["policyTags"].(map[string]interface{}); ok {
+			if names, ok := policyTags["names"].([]interface{}); ok {
+				flattened["policy_tags"] = []interface{}{
+					map[string]interface{}{"names": names},
+				}
+			}
+		}
+
+		if rangeElementType, ok := field["rangeElementType"].(map[string]interface{}); ok {
+			flattened["range_element_type"] = []interface{}{
+				map[string]interface{}{"type": rangeElementType["type"]},
+			}
+		}
+
+		if field["type"] == "RECORD" {
+			if nestedFields, ok := field["fields"].([]interface{}); ok {
+				// a RECORD has nested fields, therefore recursion is applied here
+				flattened["fields"] = flattenSchemaFields(nestedFields, currentLevel+1)
+			}
+		}
+
+		result = append(result, flattened)
+	}
+	return result
 }

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
@@ -8,164 +8,21 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-// see https://cloud.google.com/bigquery/docs/nested-repeated#limitations
-const maxNestingLevel = 15
-
 func DataSourceGoogleBigQueryTable() *schema.Resource {
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceBigQueryTable().Schema)
+
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "dataset_id")
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "table_id")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+
 	return &schema.Resource{
 		Read:   dataSourceBigQueryTableRead,
-		Schema: getDataSourceSchema(),
+		Schema: dsSchema,
 	}
-}
-
-func getDataSourceSchema() map[string]*schema.Schema {
-	fieldSchema := buildFieldSchema(maxNestingLevel)
-
-	return map[string]*schema.Schema{
-		"dataset_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The ID of the dataset containing the table.",
-		},
-		"table_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "The ID of the table.",
-		},
-		"project": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "The ID of the project in which the table is located.",
-		},
-		"schema": {
-			Type:     schema.TypeList,
-			Computed: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"fields": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem: &schema.Resource{
-							Schema: fieldSchema,
-						},
-					},
-				},
-			},
-		},
-		"id": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-	}
-}
-
-func buildFieldSchema(depth int) map[string]*schema.Schema {
-	baseSchema := map[string]*schema.Schema{
-		"name": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The field name.",
-		},
-		"type": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The field data type.",
-		},
-		"mode": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The field mode (NULLABLE, REQUIRED, or REPEATED).",
-		},
-		"description": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Field description.",
-		},
-		"policy_tags": {
-			Type:        schema.TypeList,
-			Computed:    true,
-			Description: "Policy tag list for this field.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"names": {
-						Type:     schema.TypeList,
-						Computed: true,
-						Elem:     &schema.Schema{Type: schema.TypeString},
-					},
-				},
-			},
-		},
-		"max_length": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Maximum length of values of this field for STRINGS or BYTES.",
-		},
-		"precision": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Precision (maximum number of total digits) for NUMERIC or BIGNUMERIC.",
-		},
-		"scale": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Scale (maximum number of digits in the fractional part) for NUMERIC or BIGNUMERIC.",
-		},
-		"rounding_mode": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Rounding mode for NUMERIC or BIGNUMERIC.",
-		},
-		"collation": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Collation specification of the field.",
-		},
-		"default_value_expression": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "Default value expression for this field.",
-		},
-		"range_element_type": {
-			Type:        schema.TypeList,
-			Computed:    true,
-			Description: "Element type for RANGE type fields.",
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"type": {
-						Type:     schema.TypeString,
-						Computed: true,
-					},
-				},
-			},
-		},
-	}
-
-	if depth > 0 {
-		nestedSchema := make(map[string]*schema.Schema)
-		for k, v := range baseSchema {
-			nestedSchema[k] = v
-		}
-		nestedSchema["fields"] = &schema.Schema{
-			Type:        schema.TypeList,
-			Computed:    true,
-			Description: "Nested fields for RECORD type fields.",
-			Elem: &schema.Resource{
-				Schema: buildFieldSchema(depth - 1),
-			},
-		}
-		return nestedSchema
-	}
-
-	return baseSchema
 }
 
 func dataSourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return err
-	}
-
 	project, err := tpgresource.GetProject(d, config)
 	if err != nil {
 		return fmt.Errorf("Error fetching project: %s", err)
@@ -174,78 +31,21 @@ func dataSourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error
 	datasetID := d.Get("dataset_id").(string)
 	tableID := d.Get("table_id").(string)
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
-	if err != nil {
-		return err
-	}
+	id := fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID)
+	d.SetId(id)
 
-	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		RawURL:    url,
-		UserAgent: userAgent,
-	})
+	err = resourceBigQueryTableRead(d, meta)
 	if err != nil {
 		return fmt.Errorf("Error retrieving table: %s", err)
 	}
 
-	if schemaData, ok := res["schema"].(map[string]interface{}); ok {
-		if fields, ok := schemaData["fields"].([]interface{}); ok {
-			if err := d.Set("schema", []map[string]interface{}{
-				{"fields": flattenSchemaFields(fields, 0)},
-			}); err != nil {
-				return fmt.Errorf("Error setting schema: %s", err)
-			}
-		}
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
 	return nil
-}
-
-func flattenSchemaFields(fields []interface{}, currentLevel int) []interface{} {
-	if currentLevel > maxNestingLevel {
-		return nil
-	}
-
-	var result []interface{}
-	for _, f := range fields {
-		field := f.(map[string]interface{})
-		flattened := map[string]interface{}{
-			"name":                     field["name"],
-			"type":                     field["type"],
-			"mode":                     field["mode"],
-			"description":              field["description"],
-			"max_length":               field["maxLength"],
-			"precision":                field["precision"],
-			"scale":                    field["scale"],
-			"rounding_mode":            field["roundingMode"],
-			"collation":                field["collation"],
-			"default_value_expression": field["defaultValueExpression"],
-		}
-
-		if policyTags, ok := field["policyTags"].(map[string]interface{}); ok {
-			if names, ok := policyTags["names"].([]interface{}); ok {
-				flattened["policy_tags"] = []interface{}{
-					map[string]interface{}{"names": names},
-				}
-			}
-		}
-
-		if rangeElementType, ok := field["rangeElementType"].(map[string]interface{}); ok {
-			flattened["range_element_type"] = []interface{}{
-				map[string]interface{}{"type": rangeElementType["type"]},
-			}
-		}
-
-		if field["type"] == "RECORD" {
-			if nestedFields, ok := field["fields"].([]interface{}); ok {
-				// a RECORD has nested fields, therefore recursion is applied here
-				flattened["fields"] = flattenSchemaFields(nestedFields, currentLevel+1)
-			}
-		}
-
-		result = append(result, flattened)
-	}
-	return result
 }

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table.go
@@ -1,0 +1,194 @@
+package bigquery
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleBigQueryTable() *schema.Resource {
+	fieldSchema := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The field name. The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 300 characters",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The field data type.",
+		},
+		"mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "The field mode (NULLABLE, REQUIRED, or REPEATED).",
+		},
+		"description": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Field description. The maximum length is 1,024 characters.",
+		},
+		"fields": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Optional:    true,
+			Description: "Describes the nested schema fields if the type property is set to RECORD.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{},
+			},
+		},
+		"policy_tags": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Optional:    true,
+			Description: "Policy tag list for this field.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"names": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+					},
+				},
+			},
+		},
+		"max_length": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Maximum length of values of this field for STRINGS or BYTES.",
+		},
+		"precision": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Precision (maximum number of total digits) for NUMERIC or BIGNUMERIC.",
+		},
+		"scale": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Scale (maximum number of digits in the fractional part) for NUMERIC or BIGNUMERIC.",
+		},
+		"rounding_mode": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Rounding mode for NUMERIC or BIGNUMERIC.",
+		},
+		"collation": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Collation specification of the field.",
+		},
+		"default_value_expression": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Optional:    true,
+			Description: "Default value expression for this field.",
+		},
+		"range_element_type": {
+			Type:        schema.TypeList,
+			Computed:    true,
+			Optional:    true,
+			Description: "Element type for RANGE type fields.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+
+	// fieldSchema["fields"].Elem.(*schema.Resource).Schema = fieldSchema
+
+	dsSchema := map[string]*schema.Schema{
+		"dataset_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ID of the dataset containing the table.",
+		},
+		"table_id": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The ID of the table.",
+		},
+		"project": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The ID of the project in which the table is located. If it is not provided, the provider project is used.",
+		},
+		"table": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"schema": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"fields": {
+									Type:     schema.TypeList,
+									Computed: true,
+									Elem: &schema.Resource{
+										Schema: fieldSchema,
+									},
+								},
+							},
+						},
+					},
+					// TODO(ramon) add other properties
+					"table_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+	}
+
+	return &schema.Resource{
+		ReadContext: dataSourceGoogleBigQueryTableRead,
+		Schema:      dsSchema,
+	}
+}
+
+func dataSourceGoogleBigQueryTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	log.Printf("[RAMON][DEBUG] BigQuery response: %s", res)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Error retrieving table: %s", err))
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table_test.go
@@ -1,0 +1,75 @@
+package bigquery_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleBigqueryTable_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleBigqueryTable_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "table_id", fmt.Sprintf("tf_test_table_%s", context["random_suffix"])),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleBigqueryTable_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  
+  resource "google_bigquery_dataset" "test" {
+    dataset_id                  = "tf_test_ds_%{random_suffix}"
+    friendly_name               = "testing"
+    description                 = "This is a test description"
+    location                    = "US"
+    default_table_expiration_ms = 3600000
+  }
+
+  resource "google_bigquery_table" "test" {
+    dataset_id        = google_bigquery_dataset.test.dataset_id
+    table_id          = "tf_test_table_%{random_suffix}"
+    deletion_protection = false
+    schema     = <<EOF
+    [
+      {
+        "name": "name",
+        "type": "STRING",
+        "mode": "NULLABLE"
+      },
+	  {
+		"name": "age",
+		"type": "INTEGER",
+		"mode": "NULLABLE",
+		"description": "Age of the person",
+		"policy_tags": {
+			"names": [
+				"projects/my-project/locations/us/policyTags/1234567890"
+			]
+		}
+	  }
+    ]
+    EOF
+  }
+
+  data "google_bigquery_table" "example" {
+    dataset_id = google_bigquery_table.test.dataset_id
+	table_id   = google_bigquery_table.test.table_id
+  }
+`, context)
+}

--- a/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/data_source_google_bigquery_table_test.go
@@ -2,10 +2,12 @@ package bigquery_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccDataSourceGoogleBigqueryTable_basic(t *testing.T) {
@@ -14,6 +16,8 @@ func TestAccDataSourceGoogleBigqueryTable_basic(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 	}
+
+	expectedID := fmt.Sprintf("projects/%s/datasets/%s/tables/%s", envvar.GetTestProjectFromEnv(), fmt.Sprintf("tf_test_ds_%s", context["random_suffix"]), fmt.Sprintf("tf_test_table_%s", context["random_suffix"]))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -24,6 +28,16 @@ func TestAccDataSourceGoogleBigqueryTable_basic(t *testing.T) {
 				Config: testAccDataSourceGoogleBigqueryTable_basic(context),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "table_id", fmt.Sprintf("tf_test_table_%s", context["random_suffix"])),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "dataset_id", fmt.Sprintf("tf_test_ds_%s", context["random_suffix"])),
+					resource.TestCheckResourceAttrSet("data.google_bigquery_table.example", "schema.#"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.0.name", "name"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.0.type", "STRING"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.0.mode", "NULLABLE"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.2.name", "address"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.2.fields.1.name", "zip"),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "id", expectedID),
+					resource.TestCheckResourceAttr("data.google_bigquery_table.example", "schema.0.fields.4.name", "policy_tag_test"),
+					resource.TestMatchResourceAttr("data.google_bigquery_table.example", "schema.0.fields.4.policy_tags.0.names.0", regexp.MustCompile("^projects/[^/]+/locations/us-central1/taxonomies/[^/]+/policyTags/[^/]+$")),
 				),
 			},
 		},
@@ -32,20 +46,34 @@ func TestAccDataSourceGoogleBigqueryTable_basic(t *testing.T) {
 
 func testAccDataSourceGoogleBigqueryTable_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+
+  resource "google_data_catalog_policy_tag" "test" {
+    taxonomy     = google_data_catalog_taxonomy.test.id
+    display_name = "Low security"
+    description  = "A policy tag normally associated with low security items"
+  }
   
+  resource "google_data_catalog_taxonomy" "test" {
+    region                 = "us-central1"
+    display_name           = "taxonomy_%{random_suffix}"
+    description            = "A collection of policy tags"
+    activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]
+  }
+
   resource "google_bigquery_dataset" "test" {
     dataset_id                  = "tf_test_ds_%{random_suffix}"
     friendly_name               = "testing"
     description                 = "This is a test description"
-    location                    = "US"
+    location                    = "us-central1"
     default_table_expiration_ms = 3600000
   }
 
   resource "google_bigquery_table" "test" {
-    dataset_id        = google_bigquery_dataset.test.dataset_id
-    table_id          = "tf_test_table_%{random_suffix}"
+    dataset_id          = google_bigquery_dataset.test.dataset_id
+    table_id            = "tf_test_table_%{random_suffix}"
     deletion_protection = false
-    schema     = <<EOF
+    depends_on          = [google_data_catalog_policy_tag.test]
+    schema              = <<EOF
     [
       {
         "name": "name",
@@ -56,13 +84,60 @@ func testAccDataSourceGoogleBigqueryTable_basic(context map[string]interface{}) 
 		"name": "age",
 		"type": "INTEGER",
 		"mode": "NULLABLE",
-		"description": "Age of the person",
-		"policy_tags": {
-			"names": [
-				"projects/my-project/locations/us/policyTags/1234567890"
-			]
+		"description": "Age of the person"
+	  },
+	  {
+		"name": "address",
+		"type": "RECORD",
+		"mode": "NULLABLE",
+		"fields": [
+		  {
+			"name": "street",
+			"type": "STRING",
+			"mode": "NULLABLE"
+		  },
+		  {
+			"name": "zip",
+			"type": "STRING",
+			"mode": "NULLABLE"
+		  },
+		  {
+			"name": "city",
+			"type": "STRING",
+			"mode": "NULLABLE"
+		  }
+		],
+		"description": "Address of the person"
+      },
+	  {
+		"name": "phone_numbers",
+		"type": "RECORD",
+		"mode": "REPEATED",
+		"fields": [
+		  {
+			"name": "type",
+			"type": "STRING",
+			"mode": "NULLABLE"
+		  },
+		  {
+			"name": "number",
+			"type": "STRING",
+			"mode": "NULLABLE"
+		  }
+		],
+		"description": "Phone numbers of the person"
+	  },
+	  {
+		"name": "policy_tag_test",
+		"type": "STRING",
+		"mode": "NULLABLE",
+		"description": "A test field with policy tags",
+		"policyTags": {
+		  "names": [
+			"${google_data_catalog_policy_tag.test.id}"
+          ]
 		}
-	  }
+      }
     ]
     EOF
   }

--- a/mmv1/third_party/terraform/website/docs/d/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/bigquery_table.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "BigQuery"
+description: |-
+  A datasource to retrieve a specific table in a dataset.
+---
+
+# `google_bigquery_table`
+
+Get a specific table in a BigQuery dataset. For more information see
+the [official documentation](https://cloud.google.com/bigquery/docs)
+and [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/get).
+
+## Example Usage
+
+```hcl
+data "google_bigquery_table" "table" {
+  project    = "my-project"
+  dataset_id = "my-bq-dataset"
+  table_id   = "my-table"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `dataset_id` - (Required) The dataset ID.
+
+* `table_id` - (Required) The table ID.
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+  If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_bigquery_table](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#attributes-reference) resource for details of the available attributes.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Closes https://github.com/hashicorp/terraform-provider-google/issues/22834

- First time doing a data source implementation

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.


**Acceptance tests locally:**
```
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/bigquery -v -run=TestAccDataSourceGoogleBigqueryTable_basic -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceGoogleBigqueryTable_basic
=== PAUSE TestAccDataSourceGoogleBigqueryTable_basic
=== CONT  TestAccDataSourceGoogleBigqueryTable_basic
--- PASS: TestAccDataSourceGoogleBigqueryTable_basic (12.87s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/bigquery 13.550s
```

 ~Would like to get some thoughts on the `schema` property, since it has a reference to itself. E.g. when the type = `RECORD` it has a nested schema, following the google docs this has a max depth of 15.~

 ~https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#tableschema~
 ~https://cloud.google.com/bigquery/docs/nested-repeated#limitations~
 ~How are generally slightly more complex data structures like this implemented in data sources?~

Edit: Took a look at https://github.com/GoogleCloudPlatform/magic-modules/pull/13908 and implemented in a similar manner, handling `schema` just as the same type as in the original resource (in this case json as string).

Via 

```go
dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceBigQueryTable().Schema)
```

```release-note:new-datasource
`google_bigquery_table`
```