### PR TITLE
Add unknown changelog entries for changelog generation

### DIFF
--- a/.ci/magician/cmd/generate_downstream.go
+++ b/.ci/magician/cmd/generate_downstream.go
@@ -375,6 +375,12 @@ func addChangelogEntry(downstreamRepo *source.Repo, pullRequest *github.PullRequ
 			return err
 		}
 	}
+	// If changelog entry is missing, add an entry "unknown: <PR title>".
+	if matches == nil {
+		if err := rnr.WriteFile(filepath.Join(".changelog", fmt.Sprintf("%d.txt", pullRequest.Number)), "unknown: "+pullRequest.Title); err != nil {
+			return err
+		}
+	}
 	return rnr.PopDir()
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Part of https://github.com/hashicorp/terraform-provider-google/issues/16376

Our old changelog generation tool was querying PRs directly, so it could gather the titles for PRs without valid release notes, and add them to an `UNKNOWN CHANGELOG TYPE` section. With go-changelog, we would be relying solely on the provider txt files, so we need to add the titles during provider generation to get the same changelog output.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
