### PR TITLE
remove MANAGEMENT_AUTOMATIC from ACM tests

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub/resource_gke_hub_feature_membership_test.go.tmpl
@@ -209,7 +209,6 @@ resource "google_gke_hub_feature_membership" "feature_member_1" {
         }
       }
     }
-    management = "MANAGEMENT_AUTOMATIC"
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/hashicorp/terraform-provider-google/issues/22740
