### PR TITLE
Disable siteverification domain test

### DIFF
--- a/mmv1/third_party/terraform/services/siteverification/resource_site_verification_web_resource_test.go
+++ b/mmv1/third_party/terraform/services/siteverification/resource_site_verification_web_resource_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestAccSiteVerificationWebResource_siteVerificationDomain(t *testing.T) {
 	// This test requires manual project configuration.
-	acctest.SkipIfVcr(t)
+	t.Skip()
 
 	// This test needs to be able to create DNS records that are publicly
 	// resolvable. To run, you'll need a registered domain with a GCP managed zone


### PR DESCRIPTION
This is probably what I meant to do when I first wrote the test, since one of the prerequisites is effectively "register a new, real domain that has properly configured DNS that has propagated globally". The storage bucket test is still there during all test runs, and the API hasn't changed in like 15 years so we should be safe.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19533

```release-note: none

```
