### PR TITLE
Fix permadiff on `dataflow_flex_template_job`

### DIFF
--- a/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataflow/resource_dataflow_flex_template_job.go.tmpl
@@ -465,11 +465,20 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 	}
 	optionsMap := sdkPipelineOptions["options"].(map[string]interface{})
 
+	// sdkPipelineOptions is not always populated with these values, hence the fallback
+	if _, ok := d.GetOk("num_workers"); !ok && optionsMap["numWorkers"] == nil || optionsMap["numWorkers"] == 0 {
+		optionsMap["numWorkers"] = job.Environment.WorkerPools[0].NumWorkers
+	}
+	if _, ok := d.GetOk("max_num_workers"); !ok && optionsMap["maxNumWorkers"] == nil || optionsMap["maxNumWorkers"] == 0 {
+		optionsMap["maxNumWorkers"] = job.Environment.WorkerPools[0].AutoscalingSettings.MaxNumWorkers
+	}
+	if _, ok := d.GetOk("machite_type"); !ok && optionsMap["workerMachineType"] == nil || optionsMap["workerMachineType"] == "" {
+		optionsMap["workerMachineType"] = job.Environment.WorkerPools[0].MachineType
+	}
+
+
 	if err := d.Set("temp_location", optionsMap["tempLocation"]); err != nil {
 		return fmt.Errorf("Error setting temp_gcs_location: %s", err)
-	}
-	if err := d.Set("network", optionsMap["network"]); err != nil {
-		return fmt.Errorf("Error setting network: %s", err)
 	}
 	if err := d.Set("num_workers", optionsMap["numWorkers"]); err != nil {
 		return fmt.Errorf("Error setting num_workers: %s", err)
@@ -483,10 +492,10 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 	if err := d.Set("sdk_container_image", optionsMap["sdkContainerImage"]); err != nil {
 		return fmt.Errorf("Error setting sdk_container_image: %s", err)
 	}
-	if err := d.Set("network", optionsMap["network"]); err != nil {
+	if err := d.Set("network",  job.Environment.WorkerPools[0].Network); err != nil {
 		return fmt.Errorf("Error setting network: %s", err)
 	}
-	if err := d.Set("subnetwork", optionsMap["subnetwork"]); err != nil {
+	if err := d.Set("subnetwork", job.Environment.WorkerPools[0].Subnetwork); err != nil {
 		return fmt.Errorf("Error setting subnetwork: %s", err)
 	}
 	if err := d.Set("machine_type", optionsMap["workerMachineType"]); err != nil {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/21322

The `sdkPipelineOptions` object isn't the same depending on the template causing these values to default to 0 or nil

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
Fields `network`, `subnetwork`, `numWorkers`, `maxNumWorkers` and `machineType` will no longer cause permadiff on `dataflow_flex_template_job`
```
