### PR TITLE
Add Onprem Migration fields to Volume and Replication

### DIFF
--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -555,7 +555,7 @@ properties:
         description: |
           Optional. Description of the replication.
       - name: 'labels'
-        type: KeyValueLabels
+        type: KeyValuePairs
         description: |
           Optional. Labels to be added to the replication as the key value pairs. 
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -557,5 +557,5 @@ properties:
       - name: 'labels'
         type: KeyValuePairs
         description: |
-          Optional. Labels to be added to the replication as the key value pairs. 
+          Optional. Labels to be added to the replication as the key value pairs.
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -521,3 +521,41 @@ properties:
         enum_values:
           - 'ENABLED'
           - 'PAUSED'
+  - name: 'hybridReplicationParameters'
+    type: NestedObject
+    description: |-
+      The Hybrid Replication parameters for the volume.
+    properties:
+      - name: 'replication'
+        type: String
+        description: |
+          Required. Desired name for the replication of this volume.
+      - name: 'peerVolumeName'
+        type: String
+        description: |
+          Required. Name of the user's local source volume to be peered with the destination volume.
+      - name: 'peerClusterName'
+        type: String
+        description: |
+          Required. Name of the user's local source cluster to be peered with the destination cluster.
+      - name: 'peerSvmName'
+        type: String
+        description: |
+          Required. Name of the user's local source vserver svm to be peered with the destination vserver svm.
+      - name: 'peerIpAddresses'
+        type: String
+        description: |
+          Required. List of node ip addresses to be peered with.
+      - name: 'clusterLocation'
+        type: String
+        description: |
+          Optional. Name of source cluster location associated with the Hybrid replication. This is a free-form field for the display purpose only.
+      - name: 'description'
+        type: String
+        description: |
+          Optional. Description of the replication.
+      - name: 'labels'
+        type: KeyValueLabels
+        description: |
+          Optional. Labels to be added to the replication as the key value pairs. 
+          An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.

--- a/mmv1/products/netapp/VolumeReplication.yaml
+++ b/mmv1/products/netapp/VolumeReplication.yaml
@@ -318,11 +318,6 @@ properties:
         description: |
           Optional. Copy-paste-able commands to be used on user's ONTAP to accept peering requests.
         output: true
-      - name: 'command'
-        type: String
-        description: |
-          Cumulative time taken across all transfers for the replication relationship.
-        output: true
       - name: 'commandExpiryTime'
         type: String
         description: |

--- a/mmv1/products/netapp/VolumeReplication.yaml
+++ b/mmv1/products/netapp/VolumeReplication.yaml
@@ -297,3 +297,55 @@ properties:
     type: String
     description: |
       An description of this resource.
+  - name: 'hybridReplicationType'
+    type: String
+    description: |
+      Hybrid replication type.
+    output: true
+  - name: 'hybridPeeringDetails'
+    type: NestedObject
+    description: |-
+      HybridPeeringDetails contains details about the hybrid peering.
+    output: true
+    properties:
+      - name: 'subnetIp'
+        type: String
+        description: |
+          Optional. IP address of the subnet.
+        output: true
+      - name: 'command'
+        type: String
+        description: |
+          Optional. Copy-paste-able commands to be used on user's ONTAP to accept peering requests.
+        output: true
+      - name: 'command'
+        type: String
+        description: |
+          Cumulative time taken across all transfers for the replication relationship.
+        output: true
+      - name: 'commandExpiryTime'
+        type: String
+        description: |
+          Optional. Expiration time for the peering command to be executed on user's ONTAP.
+          Uses RFC 3339, where generated output will always be Z-normalized and uses 0, 3, 6 or 9 fractional digits. Offsets other than "Z" are also accepted.
+        output: true
+      - name: 'passphrase'
+        type: String
+        description: |
+          Optional. Temporary passphrase generated to accept cluster peering command.
+        output: true
+      - name: 'peerVolumeName'
+        type: String
+        description: |
+          Optional. Name of the user's local source volume to be peered with the destination volume.
+        output: true
+      - name: 'peerClusterName'
+        type: String
+        description: |
+          Optional. Name of the user's local source cluster to be peered with the destination cluster.
+        output: true
+      - name: 'peerSvmName'
+        type: String
+        description: |
+          Optional. Name of the user's local source vserver svm to be peered with the destination vserver svm.
+        output: true


### PR DESCRIPTION
```release-note:enhancement
netapp: added `hybridReplicationParameters` fields to `google_netapp_volume` resource
```
```release-note:enhancement
netapp: added `hybridPeeringDetails` and `hybridReplicationType` fields to `google_netapp_volume_replication` resource
```