### PR TITLE
Fix issue on hubs in google_beyondcorp_security_gateway

### DIFF
--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -114,7 +114,6 @@ properties:
         - name: internetGateway
           type: NestedObject
           description: Internet Gateway configuration.
-          default_from_api: true
           properties:
             - name: assignedIps
               type: Array

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -54,6 +54,8 @@ async:
     resource_inside_response: true
   include_project: false
 autogen_status: U2VjdXJpdHlHYXRld2F5
+custom_code:
+  constants: 'templates/terraform/constants/beyondcorp_security_gateway.go.tmpl'
 parameters:
   - name: location
     type: String
@@ -104,6 +106,7 @@ properties:
       as a key.
     key_name: region
     key_description: The region to deploy the hub in.
+    set_hash_func: 'beyondcorpSecurityGatewayHubsHash'
     value_type:
       name: Hub
       type: NestedObject

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -111,6 +111,7 @@ properties:
         - name: internetGateway
           type: NestedObject
           description: Internet Gateway configuration.
+          default_from_api: true
           properties:
             - name: assignedIps
               type: Array

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -108,11 +108,11 @@ properties:
       name: Hub
       type: NestedObject
       properties:
-        - name: internet_gateway
+        - name: internetGateway
           type: NestedObject
           description: Internet Gateway configuration.
           properties:
-            - name: assigned_ips
+            - name: assignedIps
               type: Array
               description: Output only. List of IP addresses assigned to the Cloud NAT.
               output: true

--- a/mmv1/products/beyondcorp/SecurityGateway.yaml
+++ b/mmv1/products/beyondcorp/SecurityGateway.yaml
@@ -114,6 +114,7 @@ properties:
         - name: internetGateway
           type: NestedObject
           description: Internet Gateway configuration.
+          default_from_api: true
           properties:
             - name: assignedIps
               type: Array

--- a/mmv1/templates/terraform/constants/beyondcorp_security_gateway.go.tmpl
+++ b/mmv1/templates/terraform/constants/beyondcorp_security_gateway.go.tmpl
@@ -1,0 +1,24 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func beyondcorpSecurityGatewayHubsHash(v interface{}) int {
+        if v == nil {
+		return 0
+	}
+
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
+
+	return hashcode(buf.String())
+}

--- a/mmv1/templates/terraform/constants/beyondcorp_security_gateway.go.tmpl
+++ b/mmv1/templates/terraform/constants/beyondcorp_security_gateway.go.tmpl
@@ -11,7 +11,7 @@
 	limitations under the License.
 */ -}}
 func beyondcorpSecurityGatewayHubsHash(v interface{}) int {
-        if v == nil {
+	if v == nil {
 		return 0
 	}
 
@@ -20,5 +20,5 @@ func beyondcorpSecurityGatewayHubsHash(v interface{}) int {
 
 	buf.WriteString(fmt.Sprintf("%s-", m["region"].(string)))
 
-	return hashcode(buf.String())
+	return tpgresource.Hashcode(buf.String())
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
beyondcorp: fixed the issue where `hubs.internet_gateway.assigned_ips` was not populated correctly in the `google_beyondcorp_security_gateway` resource
```
