### PR TITLE
allow sending propagatedConnectionLimit zero value for ServiceAttachment

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -38,6 +38,7 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/compute_service_attachment.go.tmpl'
   update_encoder: 'templates/terraform/update_encoder/compute_service_attachment.go.tmpl'
+  encoder: 'templates/terraform/encoders/compute_service_attachment.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us-west2"
@@ -264,5 +265,14 @@ properties:
       If the connection preference of the service attachment is ACCEPT_MANUAL, the limit applies to each project or network that is listed in the consumer accept list.
       If the connection preference of the service attachment is ACCEPT_AUTOMATIC, the limit applies to each project that contains a connected endpoint.
 
-      If unspecified, the default propagated connection limit is 250.
+      If unspecified, the default propagated connection limit is 250. To explicitly send a zero value, set `send_propagated_connection_limit_if_zero = true`.
     default_from_api: true
+virtual_fields:
+  - name: 'send_propagated_connection_limit_if_zero'
+    description: |
+      Controls the behavior of propagated_connection_limit.
+      When false, setting propagated_connection_limit to zero causes the provider to use to the API's default value.
+      When true, the provider will set propagated_connection_limit to zero.
+      Defaults to false.
+    type: Boolean
+    default_value: false

--- a/mmv1/templates/terraform/encoders/compute_service_attachment.go.tmpl
+++ b/mmv1/templates/terraform/encoders/compute_service_attachment.go.tmpl
@@ -1,0 +1,8 @@
+propagatedConnectionLimitProp := d.Get("propagated_connection_limit")
+if sv, ok := d.GetOk("send_propagated_connection_limit_if_zero"); ok && sv.(bool) {
+  if v, ok := d.GetOkExists("propagated_connection_limit"); ok || !reflect.DeepEqual(v, propagatedConnectionLimitProp) {
+    obj["propagatedConnectionLimit"] = propagatedConnectionLimitProp
+  }
+}
+
+return obj, nil

--- a/mmv1/templates/terraform/update_encoder/compute_service_attachment.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/compute_service_attachment.go.tmpl
@@ -23,4 +23,11 @@ if v, ok := d.GetOkExists("enable_proxy_protocol"); !tpgresource.IsEmptyValue(re
 	obj["enableProxyProtocol"] = enableProxyProtocolProp
 }
 
+propagatedConnectionLimitProp := d.Get("propagated_connection_limit")
+if sv, ok := d.GetOk("send_propagated_connection_limit_if_zero"); ok && sv.(bool) {
+  if v, ok := d.GetOkExists("propagated_connection_limit"); ok || !reflect.DeepEqual(v, propagatedConnectionLimitProp) {
+    obj["propagatedConnectionLimit"] = propagatedConnectionLimitProp
+  }
+}
+
 return obj, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
@@ -1,9 +1,11 @@
 package compute_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
@@ -29,7 +31,7 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 			{
-				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, true),
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, true, -1),
 			},
 			{
 				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
@@ -38,13 +40,21 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 			{
-				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false),
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, -1),
 			},
 			{
 				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
+			},
+			{
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, 0),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -179,13 +189,25 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
 `, context)
 }
 
-func testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context map[string]interface{}, preventDestroy bool) string {
+func testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context map[string]interface{}, preventDestroy bool, propagatedConnectionLimit int) string {
 	context["lifecycle_block"] = ""
 	if preventDestroy {
 		context["lifecycle_block"] = `
 		lifecycle {
 			prevent_destroy = true
 		}`
+	}
+
+	switch {
+	case propagatedConnectionLimit == 0:
+		context["propagated_connection_limit"] = `
+		propagated_connection_limit = 0
+		send_propagated_connection_limit_if_zero = true
+		`
+	case propagatedConnectionLimit > 0:
+		context["propagated_connection_limit"] = fmt.Sprintf("propagated_connection_limit = %d", propagatedConnectionLimit)
+	default:
+		context["propagated_connection_limit"] = ""
 	}
 
 	return acctest.Nprintf(`
@@ -206,6 +228,7 @@ resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
   }
   reconcile_connections = false
   %{lifecycle_block}
+  %{propagated_connection_limit}
 }
 
 resource "google_compute_address" "psc_ilb_consumer_address" {


### PR DESCRIPTION
When creating or modifying `google_compute_service_attachment`, the `propagated_connection_limit` cannot be set to `0` and the default is used instead. This adds a new `send_propagated_connection_limit_if_zero` flag that, when enabled, will send the zero value.

https://github.com/hashicorp/terraform-provider-google/issues/22939

```release-note:enhancement
compute: added `send_propagated_connection_limit_if_zero` to `google_compute_service_attachment` to resolve an issue where `propagated_connection_limit` were not working for 0 value previously. Now setting `send_propagated_connection_limit_if_zero = true` will send `propagated_connection_limit = 0` when it's unset or set to `0`.
```
