### PR TITLE
fix documentation of mtu field in interconnect attachments resource

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -108,8 +108,8 @@ properties:
   - name: 'mtu'
     type: String
     description: |
-      Maximum Transmission Unit (MTU), in bytes, of packets passing through
-      this interconnect attachment. Currently, only 1440 and 1500 are allowed. If not specified, the value will default to 1440.
+      Maximum Transmission Unit (MTU), in bytes, of packets passing through this interconnect attachment.
+      Valid values are 1440, 1460, 1500, and 8896. If not specified, the value will default to 1440.
     default_from_api: true
     custom_flatten: 'templates/terraform/custom_flatten/float64_to_int_to_string.go.tmpl'
   - name: 'bandwidth'


### PR DESCRIPTION
<!--
Updating the documentation of MTU field in Interconnect Attachments resource according to the public docs.
https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: none
```
