### PR TITLE
Suppress the diff for false value of force_attach field

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -54,6 +54,10 @@ func IpCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 }
 
 func DisksForceAttachDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	if (new == "false" && old == "") || (new == "" && old == "false") {
+		return true
+	}
+
 	if new == old {
 		return true
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -126,6 +126,16 @@ func TestDisksForceAttachDiffSuppress(t *testing.T) {
 			New:                "false",
 			ExpectDiffSuppress: true,
 		},
+		"force_attach changed false from empty": {
+			Old:                "",
+			New:                "false",
+			ExpectDiffSuppress: true,
+		},
+		"force_attach changed empty from false": {
+			Old:                "false",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
fixes https://github.com/hashicorp/terraform-provider-google/issues/22950

The immutable `force_attach` is added to the `attached_disk` with the default value false.

This PR suppresses the permadiff between false and empty value for this field.

As this field is immutable, the resource recreation is expected when adding `force_attach = true` to the config.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed forced instance recreation when adding a `attached_disk` with `force_attach` being `false` to `google_compute_instance` 
```
