### PR TITLE
Don't suppress diff for Workbench Instance serial port logging metadata.

### DIFF
--- a/mmv1/products/colab/RuntimeTemplate.yaml
+++ b/mmv1/products/colab/RuntimeTemplate.yaml
@@ -207,6 +207,7 @@ properties:
       - name: 'postStartupScriptConfig'
         type: NestedObject
         description: 'Post startup script config.'
+        deprecation_message: 'The use of post-startup scripts is unavailable at this time. For feedback and questions about Preview features, contact Vertex AI.'
         properties:
           - name: 'postStartupScript'
             type: String

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -438,7 +438,7 @@ properties:
       - name: 'metadata'
         type: KeyValuePairs
         description: |
-          Optional. Custom metadata to apply to this instance. The `serial-port-logging-enable` is not updatable.
+          Optional. Custom metadata to apply to this instance. Note that the `serial-port-logging-enable` can be set but is not updatable.
         default_from_api: true
         diff_suppress_func: 'WorkbenchInstanceMetadataDiffSuppress'
       - name: 'enableIpForwarding'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -438,7 +438,7 @@ properties:
       - name: 'metadata'
         type: KeyValuePairs
         description: |
-          Optional. Custom metadata to apply to this instance.
+          Optional. Custom metadata to apply to this instance. The `serial-port-logging-enable` is not updatable.
         default_from_api: true
         diff_suppress_func: 'WorkbenchInstanceMetadataDiffSuppress'
       - name: 'enableIpForwarding'

--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -69,7 +69,6 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "report-system-status",
     "resource-url",
     "restriction",
-    "serial-port-logging-enable",
     "service-account-mode",
     "shutdown-script",
     "title",


### PR DESCRIPTION
<!--
Fixes a customer issue where serial port logging cannot be disabled via Terraform. Updates to this metadata are blocked at the API level, but we want to allow it to be set during resource creation.
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
workbench: fixed `metadata` serial-port-logging-enable diff on `google_workbench_instance`.
```
