### PR TITLE
`mmv1/identity`: support `identities` schema generation in `tpgtools/templates/resource.go.tmpl`

### DIFF
--- a/tpgtools/id.go
+++ b/tpgtools/id.go
@@ -38,6 +38,24 @@ func idParts(id string) (parts []string) {
 	return parts
 }
 
+func createIdentityProperty(p Property) IdentityProperty {
+	if p.Name() == "project" || p.Name() == "location" || p.Name() == "zone" {
+		return IdentityProperty{
+			Title:       p.Name(),
+			Required:    true,
+			Optional:    false,
+			Description: p.Description,
+		}
+	} else {
+		return IdentityProperty{
+			Title:       p.Name(),
+			Required:    false,
+			Optional:    true,
+			Description: p.Description,
+		}
+	}
+}
+
 // PatternToRegex formats a pattern string into a Python-compatible regex.
 func PatternToRegex(s string, allowForwardSlash bool) string {
 	re := regexp.MustCompile(PatternPart)
@@ -48,17 +66,17 @@ func PatternToRegex(s string, allowForwardSlash bool) string {
 }
 
 // Finds the correct resource id based on the schema and any overrides. Returns whether a custom ID override was used.
-func findResourceID(schema *openapi.Schema, overrides Overrides, location string) (identities []Property, id string, customID bool, err error) {
+func findResourceID(schema *openapi.Schema, overrides Overrides, location string) (id string, customID bool, err error) {
 	id, ok := schema.Extension["x-dcl-id"].(string)
 	if !ok {
-		return nil, "", false, fmt.Errorf("Malformed or missing x-dcl-id: %v", schema.Extension["x-dcl-id"])
+		return "", false, fmt.Errorf("Malformed or missing x-dcl-id: %v", schema.Extension["x-dcl-id"])
 	}
 
 	// Resource Override: Custom ID
 	cid := CustomIDDetails{}
 	cidOk, err := overrides.ResourceOverrideWithDetails(CustomID, &cid, location)
 	if err != nil {
-		return nil, "", false, fmt.Errorf("failed to decode custom id details: %v", err)
+		return "", false, fmt.Errorf("failed to decode custom id details: %v", err)
 	}
 
 	if cidOk {
@@ -69,13 +87,10 @@ func findResourceID(schema *openapi.Schema, overrides Overrides, location string
 		if override.Type == CustomName {
 			if strings.Contains(id, fmt.Sprintf("{{%s}}", *override.Field)) {
 				id = strings.Replace(id, fmt.Sprintf("{{%s}}", *override.Field), fmt.Sprintf("{{%s}}", override.Details.(map[interface{}]interface{})["name"].(string)), 1)
-				identities = append(identities, Property{
-					PackageName: override.Details.(map[interface{}]interface{})["name"].(string),
-				})
 			}
 		}
 	}
-	return identities, id, cidOk, nil
+	return id, cidOk, nil
 }
 
 // Finds all import formats for a given id. This can include short forms and

--- a/tpgtools/resource.go
+++ b/tpgtools/resource.go
@@ -87,6 +87,9 @@ type Resource struct {
 	// Properties are the fields of a resource. Properties may be nested.
 	Properties []Property
 
+	// Identities is the list of resource properties that are used to identify the resource.
+	Identities []Property
+
 	// InsertTimeoutMinutes is the timeout value in minutes for the resource
 	// create operation
 	InsertTimeoutMinutes int
@@ -330,6 +333,11 @@ func (r Resource) SchemaProperties() (props []Property) {
 	return collapsedProperties(r.Properties)
 }
 
+// IdentityProperties is the list of resource properties that are used to identify the resource.
+func (r Resource) IdentityProperties() (props []Property) {
+	return r.Identities
+}
+
 // Enum arrays are not arrays of strings in the DCL and require special
 // conversion
 func (r Resource) EnumArrays() (props []Property) {
@@ -484,10 +492,11 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 		res.title = SnakeCaseTerraformResourceName(crname.Title)
 	}
 
-	id, customID, err := findResourceID(schema, overrides, location)
+	identities, id, customID, err := findResourceID(schema, overrides, location)
 	if err != nil {
 		return nil, err
 	}
+	res.Identities = identities
 	res.ID = id
 	res.UseTerraformID = customID
 
@@ -539,6 +548,7 @@ func createResource(schema *openapi.Schema, info *openapi.Info, typeFetcher *Typ
 	}
 
 	res.Properties = props
+	res.Identities = props
 
 	onlyLongFormFormat := shouldAllowForwardSlashInFormat(res.ID, res.Properties)
 	// Resource Override: Import formats

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -103,8 +103,15 @@ func Resource{{$.PathType}}() *schema.Resource {
 			SchemaFunc: func() map[string]*schema.Schema {
 			return map[string]*schema.Schema{
 {{- range $p := $.IdentityProperties }}
-					"{{$p.Name}}": {
+					"{{$p.Title}}": {
 						Type:     schema.TypeString,
+						{{- if $p.Required }}
+						RequiredForImport: true,
+						{{- end }}
+						{{- if $p.Optional }}
+						OptionalForImport: true,
+						{{- end }}
+						Description: "{{escapeDescription $p.Description}}",
 					},
 {{- end }}
 				}

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -98,6 +98,19 @@ func Resource{{$.PathType}}() *schema.Resource {
 		},
 {{- end }}
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+			return map[string]*schema.Schema{
+{{- range $p := $.IdentityProperties }}
+					"{{$p.Name}}": {
+						Type:     schema.TypeString,
+					},
+{{- end }}
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 {{- range $p := $.SchemaProperties }}
 			"{{$p.Name}}": {


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is opened on `mmv1/identity-generation`, serving as the first PR being opened to support ResourceIdentity in MMv1 with more PRs to follow. The `mmv1/identity-generation` branch is meant to be merged upon the merging of `FEATURE-BRANCH-resource-identity`

Only adds support for resources being generated from `tpgtools/templates/resource.go.tmpl`, below is the generation result on `ResourceApiKeysKey` as well as how the identity matches the regex import

![image](https://github.com/user-attachments/assets/6f781dcd-9762-46ea-84c6-5eccb04bd6fc)

![image](https://github.com/user-attachments/assets/ed52cb49-86d8-478c-bdb1-1958d76af1d3)

- [X] IdentitySchema Generated
- [ ] IdentitySchemaVersion

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
