### PR TITLE
Support Cloud SQL read pool

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -315,6 +315,7 @@ settings.backup_configuration.enabled is set to true.
 For MySQL instances, ensure that settings.backup_configuration.binary_log_enabled is set to true.
 For Postgres instances, ensure that settings.backup_configuration.point_in_time_recovery_enabled
 is set to true. Defaults to ZONAL.`,
+							DiffSuppressFunc: availabilityTypeDiffSuppress,
 						},
 						"backup_configuration": {
 							Type:     schema.TypeList,
@@ -874,7 +875,15 @@ is set to true. Defaults to ZONAL.`,
 				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    true,
-				Description: `The type of the instance. The valid values are:- 'SQL_INSTANCE_TYPE_UNSPECIFIED', 'CLOUD_SQL_INSTANCE', 'ON_PREMISES_INSTANCE' and 'READ_REPLICA_INSTANCE'.`,
+				Description: `The type of the instance. The valid values are:- 'SQL_INSTANCE_TYPE_UNSPECIFIED', 'CLOUD_SQL_INSTANCE', 'ON_PREMISES_INSTANCE', 'READ_REPLICA_INSTANCE', and 'READ_POOL_INSTANCE'.`,
+			},
+
+			"node_count": {
+				Type:             schema.TypeInt,
+				Computed:         true,
+				Optional:         true,
+				Description:      `For a read pool instance, the number of nodes in the read pool.`,
+				DiffSuppressFunc: nodeCountDiffSuppress,
 			},
 
 			"replica_configuration": {
@@ -1251,6 +1260,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	if _, ok := d.GetOk("instance_type"); ok {
 		instance.InstanceType = d.Get("instance_type").(string)
+	}
+
+	if _, ok := d.GetOk("node_count"); ok {
+		instance.NodeCount = int64(d.Get("node_count").(int))
 	}
 
 	instance.RootPassword = d.Get("root_password").(string)
@@ -1840,6 +1853,11 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("instance_type", instance.InstanceType); err != nil {
 		return fmt.Errorf("Error setting instance_type: %s", err)
 	}
+	if instance.NodeCount != 0 {
+		if err := d.Set("node_count", instance.NodeCount); err != nil {
+			return fmt.Errorf("Error setting node_count: %s", err)
+		}
+	}
 	if err := d.Set("settings", flattenSettings(instance.Settings, d)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Settings")
 	}
@@ -2191,6 +2209,10 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		instance.InstanceType = d.Get("instance_type").(string)
 	}
 
+	if _, ok := d.GetOk("node_count"); ok {
+		instance.NodeCount = int64(d.Get("node_count").(int))
+	}
+
 	// Database Version is required for all calls with Google ML integration enabled or it will be rejected by the API.
 	if d.Get("settings.0.enable_google_ml_integration").(bool) {
 		instance.DatabaseVersion = databaseVersion
@@ -2277,6 +2299,24 @@ func databaseVersionDiffSuppress(_, oldVersion, newVersion string, _ *schema.Res
 		}
 	}
 
+	return false
+}
+
+func availabilityTypeDiffSuppress(_, old, new string, d *schema.ResourceData) bool {
+	instance_type := d.Get("instance_type").(string)
+	if instance_type == "READ_POOL_INSTANCE" {
+		log.Printf("[DEBUG] Instance is a read pool. Suppressing diff for availability_type (%s => %s)", old, new)
+		return true
+	}
+	return false
+}
+
+func nodeCountDiffSuppress(_, old, new string, d *schema.ResourceData) bool {
+	instance_type := d.Get("instance_type").(string)
+	if instance_type != "READ_POOL_INSTANCE" {
+		log.Printf("[DEBUG] Instance is not a read pool. Suppressing diff for node_count (%s => %s)", old, new)
+		return true
+	}
 	return false
 }
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -2863,6 +2864,190 @@ func TestAccSqlDatabaseInstance_PostgresSwitchoverSuccess(t *testing.T) {
 	})
 }
 
+// Read pool for Postgres. Scale out (change node count)
+func TestAccSqlDatabaseInstance_PostgresReadPoolScaleOutSuccess(t *testing.T) {
+	t.Parallel()
+	primaryName := "tf-test-pg-readpool-primary-" + acctest.RandString(t, 10)
+	readPoolName := "tf-test-pg-readpool-" + acctest.RandString(t, 10)
+	project := envvar.GetTestProjectFromEnv()
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType: "POSTGRES_15",
+					ReplicaName:  readPoolName,
+					NodeCount:    1,
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType: "POSTGRES_15",
+					ReplicaName:  readPoolName,
+					NodeCount:    2,
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+// Read pool for Postgres. Scale up (change machine type)
+func TestAccSqlDatabaseInstance_PostgresReadPoolScaleUpSuccess(t *testing.T) {
+	t.Parallel()
+	primaryName := "tf-test-pg-readpool-mtc-primary-" + acctest.RandString(t, 10)
+	readPoolName := "tf-test-pg-readpool-mtc-" + acctest.RandString(t, 10)
+	project := envvar.GetTestProjectFromEnv()
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType:        "POSTGRES_15",
+					ReplicaName:         readPoolName,
+					NodeCount:           1,
+					ReplicaMachineType:  "db-perf-optimized-N-2",
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType:        "POSTGRES_15",
+					ReplicaName:         readPoolName,
+					NodeCount:           1,
+					ReplicaMachineType:  "db-perf-optimized-N-4",
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+// Read pool for MySQL. Enable and disable read pool
+func TestAccSqlDatabaseInstance_MysqlReadPoolEnableDisableSuccess(t *testing.T) {
+	t.Parallel()
+	primaryName := "tf-test-mysql-readpool-primary-" + acctest.RandString(t, 10)
+	readPoolName := "tf-test-mysql-readpool-" + acctest.RandString(t, 10)
+	project := envvar.GetTestProjectFromEnv()
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType: "MYSQL_8_0",
+					ReplicaName:  readPoolName,
+					InstanceType: "READ_REPLICA_INSTANCE",
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			// Enable read pool
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType: "MYSQL_8_0",
+					ReplicaName:  readPoolName,
+					InstanceType: "READ_POOL_INSTANCE",
+					NodeCount:    1,
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			// Disable read pool
+			{
+				Config: testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName, ReadPoolConfig{
+					DatabaseType: "MYSQL_8_0",
+					ReplicaName:  readPoolName,
+					InstanceType: "READ_REPLICA_INSTANCE",
+				}),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				ResourceName:            "google_sql_database_instance.original-read-pool",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				// node_count is no longer populated after disable pool
+				ImportStateVerifyIgnore: []string{"deletion_protection", "node_count"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_updateSslOptionsForPostgreSQL(t *testing.T) {
 	t.Parallel()
 
@@ -4560,6 +4745,81 @@ resource "google_sql_database_instance" "original-replica" {
   }
 }
 `, project, replicaName)
+}
+
+type ReadPoolConfig struct {
+	DatabaseType string
+	ReplicaName string
+	// InstanceType specifies the instance type of the replica,
+	// defaulting to READ_POOL_INSTANCE.
+	//
+	// Despite the naming of this struct, you can also set it to
+	// READ_REPLICA_INSTANCE to create an ordinary read replica in order
+	// to test enable/disable pool scenarios.
+	InstanceType string
+	NodeCount int64
+	// ReplicaMachineType gives the machine type of the read pool nodes
+	// or read replica. It defaults to db-perf-optimized-N-2.
+	ReplicaMachineType string
+}
+
+func testGoogleSqlDatabaseInstanceConfig_eplusWithReadPool(project, primaryName string, rpconfig ReadPoolConfig) string {
+  nodeCountStr := ""
+	if rpconfig.NodeCount > 0 {
+		nodeCountStr = fmt.Sprintf(`  node_count = %d
+`, rpconfig.NodeCount)
+	}
+
+	if rpconfig.InstanceType == "" {
+		rpconfig.InstanceType = "READ_POOL_INSTANCE"
+	}
+
+	if rpconfig.ReplicaMachineType == "" {
+		rpconfig.ReplicaMachineType = "db-perf-optimized-N-2"
+	}
+
+	primaryTxnLogs := ""
+	if strings.HasPrefix(rpconfig.DatabaseType, "MYSQL") {
+		primaryTxnLogs = "binary_log_enabled = true\n"
+	} else if strings.HasPrefix(rpconfig.DatabaseType, "POSTGRES") {
+		primaryTxnLogs = "point_in_time_recovery_enabled = true\n"
+	}
+	
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "original-primary" {
+  project             = "%s"
+  name                = "%s"
+  region              = "us-east1"
+  database_version    = "%s"
+  instance_type       = "CLOUD_SQL_INSTANCE"
+  deletion_protection = false
+
+  settings {
+    tier              = "db-perf-optimized-N-2"
+    edition           = "ENTERPRISE_PLUS"
+    backup_configuration {
+      enabled                        = true
+%s
+    }
+  }
+}
+
+resource "google_sql_database_instance" "original-read-pool" {
+  project              = "%s"
+  name                 = "%s"
+  region               = "us-east1"
+  database_version     = "%s"
+  instance_type        = "%s"
+%s
+  master_instance_name = google_sql_database_instance.original-primary.name
+  deletion_protection  = false
+
+  settings {
+    tier              = "%s"
+    edition           = "ENTERPRISE_PLUS"
+  }
+}
+`, project, primaryName, rpconfig.DatabaseType, primaryTxnLogs, project, rpconfig.ReplicaName, rpconfig.DatabaseType, rpconfig.InstanceType, nodeCountStr, rpconfig.ReplicaMachineType)
 }
 
 func testAccSqlDatabaseInstance_basicInstanceForPsc(instanceName string, projectId string, orgId string, billingAccount string) string {


### PR DESCRIPTION
Adds support for:
* instance_type=READ_POOL_INSTANCE
* new node_count field

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added `node_count` field to `sql_database_instance` resource
sql: added new value `READ_POOL_INSTANCE` to the `instance_type` field of `sql_database_instance` resource
```
