### PR TITLE
Update resource_network_security_client_tls_policy_test.go.tmpl

### DIFF
--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_client_tls_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_client_tls_policy_test.go.tmpl
@@ -84,11 +84,6 @@ func testAccNetworkSecurityClientTlsPolicy_update(clientTlsPolicyName string) st
       	target_uri = "unix:mypath1"
       }
     }
-    server_validation_ca {
-    	grpc_endpoint {
-      	target_uri = "unix:mypath2"
-      }
-    }
   }
 `, clientTlsPolicyName)
 }


### PR DESCRIPTION
Test had started failing after new validation to allow only one server_validation_ca. Fixed the test


**Release Note Template for Downstream PRs (will be copied)**
NA test only change

```release-note:none

```