### PR TITLE
fix: string based ordering for `google_compute_region_security_policy` causes recreate after apply

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicy.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicy.yaml
@@ -39,6 +39,7 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+  constants: 'templates/terraform/constants/region_security_policy.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us-south1"
@@ -188,6 +189,7 @@ properties:
     description: |
       The set of rules that belong to this policy. There must always be a default rule (rule with priority 2147483647 and match "*"). If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
     default_from_api: true
+    diff_suppress_func: 'resourceComputeRegionSecurityPolicySpecRulesDiffSuppress'
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/templates/terraform/constants/region_security_policy.go.tmpl
+++ b/mmv1/templates/terraform/constants/region_security_policy.go.tmpl
@@ -1,0 +1,31 @@
+{{- if ne $.Compiler "terraformgoogleconversion-codegen" }}
+func resourceComputeRegionSecurityPolicySpecRulesDiffSuppress(k, o, n string, d *schema.ResourceData) bool {
+    oldCount, newCount := d.GetChange("rules.#")
+    var count int
+    // There could be duplicates - worth continuing even if the counts are unequal.
+    if oldCount.(int) < newCount.(int) {
+        count = newCount.(int)
+    } else {
+        count = oldCount.(int)
+    }
+
+    old := make([]interface{}, 0, count)
+    new := make([]interface{}, 0, count)
+    for i := 0; i < count; i++ {
+        o, n := d.GetChange(fmt.Sprintf("rules.%d", i))
+
+        if o != nil {
+            old = append(old, o)
+        }
+        if n != nil {
+            new = append(new, n)
+        }
+    }
+
+    oldSet := schema.NewSet(schema.HashResource(ResourceComputeRegionSecurityPolicy().Schema["rules"].Elem.(*schema.Resource)), old)
+    newSet := schema.NewSet(schema.HashResource(ResourceComputeRegionSecurityPolicy().Schema["rules"].Elem.(*schema.Resource)), new)
+
+    return oldSet.Equal(newSet)
+}
+
+{{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -750,7 +750,7 @@ func TestAccComputeRegionSecurityPolicy_regionSecurityPolicyRuleOrderingWithMult
 func testAccComputeRegionSecurityPolicy_ruleOrderingWithMultipleRules_create(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 
-resource "google_compute_region_security_policy" "region_sec_policy_with_rules" {
+resource "google_compute_region_security_policy" "policy" {
 	name	    = "tf-test-ordering%{random_suffix}"
 	description = "basic region security policy with multiple rules"
 	type        = "CLOUD_ARMOR"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -722,6 +722,67 @@ func testAccComputeRegionSecurityPolicy_withMultipleEnforceOnKeyConfigs_update(c
 	`, context)
 }
 
+func TestAccComputeRegionSecurityPolicy_regionSecurityPolicyRuleOrderingWithMultipleRules(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionSecurityPolicy_ruleOrderingWithMultipleRules_create(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+
+func testAccComputeRegionSecurityPolicy_ruleOrderingWithMultipleRules_create(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_compute_region_security_policy" "region_sec_policy_with_rules" {
+	name	    = "tf-test-ordering%{random_suffix}"
+	description = "basic region security policy with multiple rules"
+	type        = "CLOUD_ARMOR"
+	region      = "us-central1"
+
+	rules {
+		action   = "deny"
+		priority = "3000"
+		match {
+			expr {
+			expression = "request.path.matches(\"/login.html\") && token.recaptcha_session.score < 0.2"
+			}
+		}
+	}
+
+	rules {
+		action   = "deny"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+}
+
+	`, context)
+}
+
+
 {{- if ne $.TargetVersionName "ga" }}
 func TestAccComputeRegionSecurityPolicy_regionSecurityPolicyWithRulesNetworkMatch(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -742,6 +742,14 @@ func TestAccComputeRegionSecurityPolicy_regionSecurityPolicyRuleOrderingWithMult
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeRegionSecurityPolicy_ruleOrderingWithMultipleRules_update(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -779,6 +787,52 @@ resource "google_compute_region_security_policy" "policy" {
 	}
 }
 
+	`, context)
+}
+
+
+func testAccComputeRegionSecurityPolicy_ruleOrderingWithMultipleRules_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+resource "google_compute_region_security_policy" "policy" {
+	name	    = "tf-test-ordering%{random_suffix}"
+	description = "basic region security policy with multiple rules, updated"
+	type        = "CLOUD_ARMOR"
+	region      = "us-central1"
+
+	rules {
+		action   = "allow"
+		priority = "4000"
+		match {
+			expr {
+				expression = "request.path.matches(\"/login.html\") && token.recaptcha_session.score < 0.2"
+			}
+		}
+	}
+
+	rules {
+		action   = "allow"
+		priority = "5000"
+		match {
+			expr {
+				expression = "request.path.matches(\"/404.html\") && token.recaptcha_session.score > 0.4"
+			}
+		}
+		description = "new rule"
+	}
+
+	rules {
+		action   = "deny"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+}
 	`, context)
 }
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/22995

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed an issue where rules ordering in `google_compute_region_security_policy` caused a diff after apply
```
