### PR TITLE
Add httpFilterConfigs and httpFilterMetadata fields to route rules in URL maps.

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -156,6 +156,7 @@ examples:
       error_backend_bucket_name: 'error-backend-bucket'
   - name: 'url_map_http_filter_configs'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       default_backend_service_name: 'default-backend'
@@ -163,6 +164,7 @@ examples:
       health_check_name: 'health-check'
   - name: 'url_map_http_filter_metadata'
     primary_resource_id: 'urlmap'
+    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       default_backend_service_name: 'default-backend'
@@ -1848,6 +1850,7 @@ properties:
                     imports: 'selfLink'
               - name: 'httpFilterConfigs'
                 type: Array
+                min_version: 'beta'
                 description: |
                   Outbound route specific configuration for networkservices.HttpFilter resources enabled by Traffic Director.
                   httpFilterConfigs only applies for load balancers with loadBalancingScheme set to INTERNAL_SELF_MANAGED.
@@ -1874,6 +1877,7 @@ properties:
                         The configuration must be YAML formatted and only contain fields defined in the protobuf identified in configTypeUrl
               - name: 'httpFilterMetadata'
                 type: Array
+                min_version: 'beta'
                 description: |
                   Outbound route specific metadata supplied to networkservices.HttpFilter resources enabled by Traffic Director.
                   httpFilterMetadata only applies for load balancers with loadBalancingScheme set to INTERNAL_SELF_MANAGED.

--- a/mmv1/templates/terraform/examples/url_map_http_filter_configs.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_http_filter_configs.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for httpFilterConfigs in route rules"
   default_service = google_compute_backend_service.default.id
@@ -47,6 +48,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider    = google-beta
   name        = "{{index $.Vars "default_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -57,6 +59,7 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_backend_service" "service-a" {
+  provider    = google-beta
   name        = "{{index $.Vars "service_a_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -67,6 +70,7 @@ resource "google_compute_backend_service" "service-a" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_http_filter_metadata.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_http_filter_metadata.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "{{index $.Vars "url_map_name"}}"
   description = "Test for httpFilterMetadata in route rules"
   default_service = google_compute_backend_service.default.id
@@ -69,6 +70,7 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider    = google-beta
   name        = "{{index $.Vars "default_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -79,6 +81,7 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_backend_service" "service-a" {
+  provider    = google-beta
   name        = "{{index $.Vars "service_a_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -89,6 +92,7 @@ resource "google_compute_backend_service" "service-a" {
 }
 
 resource "google_compute_backend_service" "service-b" {
+  provider    = google-beta
   name        = "{{index $.Vars "service_b_backend_service_name"}}"
   port_name   = "http"
   protocol    = "HTTP"
@@ -99,6 +103,7 @@ resource "google_compute_backend_service" "service-b" {
 }
 
 resource "google_compute_health_check" "default" {
+  provider = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds httpFilterConfigs and httpFilterMetadata fields to route rules in URL maps.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `httpFilterConfigs` and `httpFilterMetadata` fields to `pathMatchers[].routeRules[]` in `google_compute_url_map` resource (beta)
```