### PR TITLE
Add Terraform Support for WireGroups.

### DIFF
--- a/mmv1/products/compute/WireGroup.yaml
+++ b/mmv1/products/compute/WireGroup.yaml
@@ -1,0 +1,183 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'WireGroup'
+kind: 'compute#wireGroup'
+description: |
+  The WireGroup resource represents a group of redundant wires between interconnects in two different metros. Each WireGroup belongs to a CrossSiteNetwork. A wire group defines endpoints and the wires which exist between them.
+
+references:
+  guides:
+    'Create a WireGroup': 'https://cloud.google.com/network-connectivity/docs/interconnect/how-to/cross-site/modify-network#add-wire-group'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/wireGroups'
+min_version: beta
+docs:
+id_format: 'projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}'
+base_url: 'projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups'
+self_link: 'projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}'
+update_verb: 'PATCH'
+import_format:
+  - 'projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+examples:
+  - name: 'compute_wire_group_basic'
+    primary_resource_id: 'example-test-wire-group'
+    vars:
+      name: 'test-wire-group'
+      description: 'Example Wire Group'
+      cross_site_network: 'test-cross-site-network'
+    min_version: 'beta'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+parameters:
+  - name: 'crossSiteNetwork'
+    type: ResourceRef
+    description: Required cross site network to which wire group belongs.
+    required: true
+    immutable: true
+    resource: 'CrossSiteNetwork'
+    imports: 'name'
+    diff_suppress_func: 'tpgresource.CompareResourceNames'
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+properties:
+  - name: 'description'
+    type: String
+    description: |
+      An optional description of this resource. Provide this property when you create the resource.
+  - name: 'creationTimestamp'
+    type: Time
+    description: |
+      Creation timestamp in RFC3339 text format.
+    output: true
+  - name: 'name'
+    type: String
+    description: |
+      Name of the resource. Provided by the client when the resource is created. The name must be
+      1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters
+      long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
+      character must be a lowercase letter, and all following characters must be a dash,
+      lowercase letter, or digit, except the last character, which cannot be a dash.
+    required: true
+    immutable:
+    validation:
+      regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
+  - name: endpoints
+    type: KeyValuePairs
+    description: |
+      Endpoints grouped by location, each mapping to interconnect configurations.
+    properties:
+      - name: interconnects
+        type: KeyValuePairs
+        description: |
+          Map of interconnect details.
+        properties:
+          - name: interconnect
+            type: string
+          - name: vlan_tags
+            type: Array
+            description: |
+              VLAN tags for the interconnect.
+            item_type:
+              type: integer
+  - name: admin_enabled
+    type: boolean
+    description: |
+      Indicates whether the wire group is administratively enabled.
+  - name: wire_group_properties
+    type: NestedObject
+    description: |
+      Properties specific to the wire group.
+    properties:
+      - name: type
+        type: enum
+        description: |
+          Type of wire group (enum).
+          WIRE: a single pseudowire over two Interconnect connections   with no redundancy.
+          REDUNDANT: two pseudowires over four Interconnect connections, with two connections in one metro and two connections in another metro.
+          BOX_AND_CROSS: four pseudowires over four Interconnect connections, with two connections in one metro and two connections in another metro.
+        enum_values:
+          - 'WIRE'
+          - 'REDUNDANT'
+          - 'BOX_AND_CROSS'
+  - name: wire_properties
+    type: NestedObject
+    description: |
+      Default properties for wires within the group.
+    properties:
+      - name: bandwidth_unmetered
+        type: Integer
+        description: |
+          The unmetered bandwidth setting.
+      - name: fault_response
+        type: enum
+        description: |
+          Response when a fault is detected in a pseudowire:
+          NONE: default.
+          DISABLE_PORT: set the port line protocol down when inline probes detect a fault. This setting is only permitted on port mode pseudowires.
+        enum_values:
+          - 'NONE'
+          - 'DISABLE_PORT'
+  - name: wires
+    type: NestedObject
+    description: |
+      The single/redundant wire(s) managed by the wire group.
+    output: true
+    properties:
+      - name: label
+        type: string
+      - name: endpoints
+        type: NestedObject
+        description: |
+          'Wire endpoints are specific Interconnect connections.'
+        properties:
+          - name: interconnect
+            type: string
+          - name: vlan_tag
+            type: integer
+      - name: wire_properties
+        type: NestedObject
+        output: true
+        properties:
+          - name: bandwidth_unmetered
+            type: Integer
+          - name: fault_response
+            type: enum
+            enum_values:
+              - 'NONE'
+              - 'DISABLE_PORT'
+      - name: admin_enabled
+        type: boolean
+  - name: topology
+    type: NestedObject
+    description: |
+      Topology details for the wire group configuration.
+    output: true
+    properties:
+      - name: endpoints
+        type: NestedObject
+        properties:
+          - name: label
+            type: string
+          - name: city
+            type: string

--- a/mmv1/templates/terraform/examples/compute_wire_group_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_wire_group_basic.tf.tmpl
@@ -1,0 +1,25 @@
+data "google_project" "project" {
+provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "example-cross-site-network" {
+  name        = "{{index $.Vars "cross_site_network"}}"
+  description = "Example cross site network"
+  provider    = google-beta
+}
+
+resource "google_compute_wire_group" "{{$.PrimaryResourceId}}" {
+  name               = "{{index $.Vars "name"}}"
+  description        = "{{index $.Vars "description"}}"
+  cross_site_network = "{{index $.Vars "cross_site_network"}}"
+  provider           = google-beta
+  depends_on = [
+    google_compute_cross_site_network.example-cross-site-network
+  ]
+  wire_properties {
+    bandwidth_unmetered = 10
+  }
+  wire_group_properties {
+    type = "WIRE"
+  }
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_wire_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_wire_group_test.go.tmpl
@@ -1,0 +1,109 @@
+package compute_test
+{{ if ne $.TargetVersionName `ga` -}}
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeWireGroup_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckComputeWireGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeWireGroup_basic(context),
+			},
+			{
+				ResourceName:            "google_compute_wire_group.example-test-wire-group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cross_site_network"},
+			},
+			{
+				Config: testAccComputeWireGroup_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_wire_group.example-test-wire-group", "description", "Example Wire Group Updated"+context["random_suffix"].(string)),
+				),
+			},
+			{
+				ResourceName:            "google_compute_wire_group.example-test-wire-group",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cross_site_network"},
+			},
+		},
+	})
+}
+
+func testAccComputeWireGroup_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "example-cross-site-network" {
+  name        = "tf-test-cross-site-network%{random_suffix}"
+  description = "Example cross site network"
+  provider    = google-beta
+}
+
+resource "google_compute_wire_group" "example-test-wire-group" {
+  name               = "tf-test-test-wire-group%{random_suffix}"
+  description        = "Example Wire Group%{random_suffix}"
+  cross_site_network = google_compute_cross_site_network.example-cross-site-network.name
+  provider           = google-beta
+  depends_on = [
+    google_compute_cross_site_network.example-cross-site-network
+  ]
+  wire_properties {
+    bandwidth_unmetered = 1000
+  }
+  wire_group_properties {
+    type = "REDUNDANT"
+  }
+}
+`, context)
+}
+
+func testAccComputeWireGroup_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+provider = google-beta
+}
+
+resource "google_compute_cross_site_network" "example-cross-site-network" {
+  name        = "tf-test-cross-site-network%{random_suffix}"
+  description = "Example cross site network"
+  provider    = google-beta
+}
+
+resource "google_compute_wire_group" "example-test-wire-group" {
+  name               = "tf-test-test-wire-group%{random_suffix}"
+  description        = "Example Wire Group Updated%{random_suffix}"
+  cross_site_network = google_compute_cross_site_network.example-cross-site-network.name
+  provider           = google-beta
+  depends_on = [
+    google_compute_cross_site_network.example-cross-site-network
+  ]
+  wire_properties {
+    bandwidth_unmetered = 1000
+  }
+  wire_group_properties {
+    type = "REDUNDANT"
+  }
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
```release-note: new-resource 
`google_compute_wire_group`
```
The WireGroup resource represents a group of redundant wires between interconnects in two different metros.
---

# google_compute_wire_group

The WireGroup resource represents a group of redundant wires between interconnects in two different metros. Each WireGroup belongs to a CrossSiteNetwork. A wire group defines endpoints and the wires which exist between them.

~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
See [Provider Versions](https://terraform.io/docs/providers/google/guides/provider_versions.html) for more details on beta resources.

To get more information about WireGroup, see:

* [API documentation](https://cloud.google.com/compute/docs/reference/rest/beta/wireGroups)
* How-to Guides
    * [Create a WireGroup](https://cloud.google.com/network-connectivity/docs/interconnect/how-to/cross-site/modify-network#add-wire-group)

## Example Usage - Compute Wire Group Basic


```hcl
data "google_project" "project" {
provider = google-beta
}

resource "google_compute_cross_site_network" "example-cross-site-network" {
  name        = "tf-test-cross-site-network"
  description = "Example cross site network"
  provider    = google-beta
}

resource "google_compute_wire_group" "example-test-wire-group" {
  name               = "test-wire-group"
  description        = "Example Wire Group"
  cross_site_network = "test-cross-site-network"
  provider           = google-beta
  depends_on = [
    google_compute_cross_site_network.example-cross-site-network
  ]
  wire_properties {
    bandwidth_unmetered = 10
  }
  wire_group_properties {
    type = "WIRE"
  }
}
```

## Argument Reference

The following arguments are supported:


* `name` -
  (Required)
  Name of the resource. Provided by the client when the resource is created. The name must be
  1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters
  long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first
  character must be a lowercase letter, and all following characters must be a dash,
  lowercase letter, or digit, except the last character, which cannot be a dash.

* `cross_site_network` -
  (Required)
  Required cross site network to which wire group belongs.


- - -


* `description` -
  (Optional)
  An optional description of this resource. Provide this property when you create the resource.

* `endpoints` -
  (Optional)
  Endpoints grouped by location, each mapping to interconnect configurations.

* `admin_enabled` -
  (Optional)
  Indicates whether the wire group is administratively enabled.

* `wire_group_properties` -
  (Optional)
  Properties specific to the wire group.
  Structure is [documented below](#nested_wire_group_properties).

* `wire_properties` -
  (Optional)
  Default properties for wires within the group.
  Structure is [documented below](#nested_wire_properties).

* `project` - (Optional) The ID of the project in which the resource belongs.
    If it is not provided, the provider project is used.


<a name="nested_wire_group_properties"></a>The `wire_group_properties` block supports:

* `type` -
  (Optional)
  Type of wire group (enum).
  WIRE: a single pseudowire over two Interconnect connections   with no redundancy.
  REDUNDANT: two pseudowires over four Interconnect connections, with two connections in one metro and two connections in another metro.
  BOX_AND_CROSS: four pseudowires over four Interconnect connections, with two connections in one metro and two connections in another metro.

<a name="nested_wire_properties"></a>The `wire_properties` block supports:

* `bandwidth_unmetered` -
  (Optional)
  The unmetered bandwidth setting.

* `fault_response` -
  (Optional)
  Response when a fault is detected in a pseudowire:
  NONE: default.
  DISABLE_PORT: set the port line protocol down when inline probes detect a fault. This setting is only permitted on port mode pseudowires.

## Attributes Reference

In addition to the arguments listed above, the following computed attributes are exported:

* `id` - an identifier for the resource with format `projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}`

* `creation_timestamp` -
  Creation timestamp in RFC3339 text format.

* `wires` -
  The single/redundant wire(s) managed by the wire group.
  Structure is [documented below](#nested_wires).

* `topology` -
  Topology details for the wire group configuration.
  Structure is [documented below](#nested_topology).


<a name="nested_wires"></a>The `wires` block contains:

* `label` -
  (Optional)

* `endpoints` -
  (Optional)
  'Wire endpoints are specific Interconnect connections.'
  Structure is [documented below](#nested_wires_endpoints).

* `wire_properties` -
  (Output)
  A nested object resource.
  Structure is [documented below](#nested_wires_wire_properties).

* `admin_enabled` -
  (Optional)


<a name="nested_wires_endpoints"></a>The `endpoints` block supports:

* `interconnect` -
  (Optional)

* `vlan_tag` -
  (Optional)

<a name="nested_wires_wire_properties"></a>The `wire_properties` block contains:

* `bandwidth_unmetered` -
  (Optional)

* `fault_response` -
  (Optional)

<a name="nested_topology"></a>The `topology` block contains:

* `endpoints` -
  (Optional)
  A nested object resource.
  Structure is [documented below](#nested_topology_endpoints).


<a name="nested_topology_endpoints"></a>The `endpoints` block supports:

* `label` -
  (Optional)

* `city` -
  (Optional)

## Timeouts

This resource provides the following
[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:

- `create` - Default is 20 minutes.
- `update` - Default is 20 minutes.
- `delete` - Default is 20 minutes.

## Import


WireGroup can be imported using any of these accepted formats:

* `projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}`
* `{{project}}/{{cross_site_network}}/{{name}}`
* `{{cross_site_network}}/{{name}}`


In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import WireGroup using one of the formats above. For example:

```tf
import {
  id = "projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}"
  to = google_compute_wire_group.default
}
```

When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), WireGroup can be imported using one of the formats above. For example:

```
$ terraform import google_compute_wire_group.default projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}
$ terraform import google_compute_wire_group.default {{project}}/{{cross_site_network}}/{{name}}
$ terraform import google_compute_wire_group.default {{cross_site_network}}/{{name}}
```

## User Project Overrides

This resource supports [User Project Overrides](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#user_project_override).

