### PR TITLE
Add documentation for `md5hexhash `field.

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -6,11 +6,11 @@ description: |-
 
 # google_storage_bucket_object
 
-Creates a new object inside an existing bucket in Google cloud storage service (GCS). 
+Creates a new object inside an existing bucket in Google cloud storage service (GCS).
 [ACLs](https://cloud.google.com/storage/docs/access-control/lists) can be applied using the `google_storage_object_acl` resource.
- For more information see 
-[the official documentation](https://cloud.google.com/storage/docs/key-terms#objects) 
-and 
+ For more information see
+[the official documentation](https://cloud.google.com/storage/docs/key-terms#objects)
+and
 [API](https://cloud.google.com/storage/docs/json_api/v1/objects).
 
 A datasource can be used to retrieve the data of the stored object:
@@ -120,6 +120,8 @@ exported:
 `google_storage_object_acl` resources when your `google_storage_bucket_object` is recreated.
 
 * `media_link` - (Computed) A url reference to download this object.
+
+* `md5hexhash` - (Computed) Hex value of md5hash`
 
 ## Timeouts
 


### PR DESCRIPTION
Remaining work of the PR: https://github.com/GoogleCloudPlatform/magic-modules/commit/be65ab7653b147db2ca4c6ba5dd93a59e563e892 where documentation for the new field was missed. 

This PR adds documentation of the `md5hexhash` field in the `google_storage_bucket_object` resource.
```release-note:none

```
