### PR TITLE
Add fields for custom ranges for interconnect attachment

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -365,27 +365,27 @@ properties:
     type: String
     description: |
       Single IPv4 address + prefix length to be configured on the cloud router interface for this
-      interconnect attachment. Example: 192.0.2.0/24
+      interconnect attachment. Example: 203.0.113.1/29
     immutable: true
     min_version: beta
   - name: 'candidateCustomerRouterIpAddress'
     type: String
     description: |
       Single IPv4 address + prefix length to be configured on the customer router interface for this
-      interconnect attachment. Example: 192.0.2.0/24
+      interconnect attachment. Example: 203.0.113.2/29
     immutable: true
     min_version: beta
   - name: 'candidateCloudRouterIpv6Address'
     type: String
     description: |
       Single IPv6 address + prefix length to be configured on the cloud router interface for this
-      interconnect attachment. Example: 2001:db8::/32
+      interconnect attachment. Example: 2001:db8::1/125
     immutable: true
     min_version: beta
   - name: 'candidateCustomerRouterIpv6Address'
     type: String
     description: |
       Single IPv6 address + prefix length to be configured on the customer router interface for this
-      interconnect attachment. Example: 2001:db8::/32
+      interconnect attachment. Example: 2001:db8::2/125
     immutable: true
     min_version: beta

--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -63,6 +63,13 @@ examples:
       address_name: 'test-address'
       router_name: 'test-router'
       network_name: 'test-network'
+  - name: 'compute_interconnect_attachment_custom_ranges'
+    primary_resource_id: 'custom-ranges-interconnect-attachment'
+    vars:
+      interconnect_attachment_name: 'test-custom-ranges-interconnect-attachment'
+      router_name: 'test-router'
+      network_name: 'test-network'
+    min_version: beta
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -354,3 +361,31 @@ properties:
       You must always provide an up-to-date fingerprint hash in order to update or change labels,
       otherwise the request will fail with error 412 conditionNotMet.
     output: true
+  - name: 'candidateCloudRouterIpAddress'
+    type: String
+    description: |
+      Single IPv4 address + prefix length to be configured on the cloud router interface for this
+      interconnect attachment. Example: 192.0.2.0/24
+    immutable: true
+    min_version: beta
+  - name: 'candidateCustomerRouterIpAddress'
+    type: String
+    description: |
+      Single IPv4 address + prefix length to be configured on the customer router interface for this
+      interconnect attachment. Example: 192.0.2.0/24
+    immutable: true
+    min_version: beta
+  - name: 'candidateCloudRouterIpv6Address'
+    type: String
+    description: |
+      Single IPv6 address + prefix length to be configured on the cloud router interface for this
+      interconnect attachment. Example: 2001:db8::/32
+    immutable: true
+    min_version: beta
+  - name: 'candidateCustomerRouterIpv6Address'
+    type: String
+    description: |
+      Single IPv6 address + prefix length to be configured on the customer router interface for this
+      interconnect attachment. Example: 2001:db8::/32
+    immutable: true
+    min_version: beta

--- a/mmv1/templates/terraform/examples/compute_interconnect_attachment_custom_ranges.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_interconnect_attachment_custom_ranges.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_compute_interconnect_attachment" "{{$.PrimaryResourceId}}" {
+  name                                   = "{{index $.Vars "interconnect_attachment_name"}}"
+  edge_availability_domain               = "AVAILABILITY_DOMAIN_1"
+  type                                   = "PARTNER"
+  router                                 = google_compute_router.foobar.id
+  mtu                                    = 1500
+  stack_type                             = "IPV4_IPV6"
+  labels                                 = { mykey = "myvalue" }
+  candidate_cloud_router_ip_address      = "192.169.0.1/29"
+  candidate_customer_router_ip_address   = "192.169.0.2/29"
+  candidate_cloud_router_ipv6_address    = "748d:2f23:6651:9455:828b:ca81:6fe0:fed1/125"
+  candidate_customer_router_ipv6_address = "748d:2f23:6651:9455:828b:ca81:6fe0:fed2/125"
+  provider                               = google-beta
+}
+
+resource "google_compute_router" "foobar" {
+  name     = "{{index $.Vars "router_name"}}"
+  network  = google_compute_network.foobar.name
+  bgp {
+    asn = 16550
+  }
+  provider = google-beta
+}
+
+resource "google_compute_network" "foobar" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+  provider                = google-beta
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes [b/409091257](b/409091257) - Added support for custom ranges for interconnect attachment

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `candidateCloudRouterIpAddress`, `candidateCustomerRouterIpAddress`, `candidateCloudRouterIpv6Address`, and `candidateCustomerRouterIpv6Address` fields to `InterconnectAttachment` resource
```
