### PR TITLE
Add numeric_id to compute_instance_region_template

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -650,6 +650,13 @@ Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key m
 				},
 			},
 
+			"numeric_id": {
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Computed:    true,
+				Description: `The ID of the template in numeric format.`,
+			},
+
 			"project": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1419,6 +1426,10 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 		if err = d.Set("metadata", _md); err != nil {
 			return fmt.Errorf("Error setting metadata: %s", err)
 		}
+	}
+
+	if err = d.Set("numeric_id", instanceTemplate["id"]); err != nil {
+		return fmt.Errorf("Error setting numeric_id: %s", err)
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -757,6 +757,8 @@ exported:
 
 * `metadata_fingerprint` - The unique fingerprint of the metadata.
 
+* `numeric_id` - numeric identifier of the resource.
+
 * `self_link` - The URI of the created resource.
 
 * `tags_fingerprint` - The unique fingerprint of the tags.


### PR DESCRIPTION
Add `numeric_id` to `google_compute_region_instance_template` to improve interoperability with resource tags / conditions.

See: #13584 for similar change for `google_compute_instance_template`
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `numeric_id` to `google_compute_region_instance_template` resource
```

CC: @ludoo 