### PR TITLE
tgc-revival: HclWriteBlocks function modification

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/models/hcl_block.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/models/hcl_block.go
@@ -3,7 +3,6 @@ package models
 import (
 	"fmt"
 
-	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -20,12 +19,15 @@ func HclWriteBlocks(blocks []*TerraformResourceBlock) ([]byte, error) {
 
 	for _, resourceBlock := range blocks {
 		hclBlock := rootBody.AppendNewBlock("resource", resourceBlock.Labels)
+		resourceBody := hclBlock.Body()
+		resourceBody.SetAttributeRaw("provider", hclwrite.TokensForIdentifier("google-beta"))
+
 		if err := hclWriteBlock(resourceBlock.Value, hclBlock.Body()); err != nil {
 			return nil, err
 		}
 	}
 
-	return printer.Format(f.Bytes())
+	return hclwrite.Format(f.Bytes()), nil
 }
 
 func hclWriteBlock(val cty.Value, body *hclwrite.Body) error {
@@ -49,7 +51,7 @@ func hclWriteBlock(val cty.Value, body *hclwrite.Body) error {
 				return err
 			}
 		case objValType.IsCollectionType():
-			if objVal.LengthInt() == 0 {
+			if objVal.LengthInt() == 0 && !objValType.IsSetType() {
 				continue
 			}
 			// Presumes map should not contain object type.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

1. Add `provider = google-beta` to all of the converted HCL, as we use the schema from TPGB. Also, the google-beta provider is used for testing in tgc.
2. Generate empty object if the type of the field is `TypeSet` to handle the case that the field is required. For example, [scopes](https://github.com/GoogleCloudPlatform/terraform-google-conversion/blob/main/pkg/tfplan2cai/converters/services/compute/compute_instance.go) is required and has the type `scopes`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
