### PR TITLE
Add headers, expectedOutputUrl, and expectedRedirectResponseCode fields to URL map

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -118,6 +118,24 @@ examples:
       home_backend_service_name: 'home'
       mirror_backend_service_name: 'mirror'
       health_check_name: 'health-check'
+  - name: 'url_map_test_headers'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
+  - name: 'url_map_test_expected_output_url'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
+  - name: 'url_map_test_redirect_response_code'
+    primary_resource_id: 'urlmap'
+    vars:
+      url_map_name: 'urlmap'
+      backend_service_name: 'backend'
+      health_check_name: 'health-check'
   - name: 'external_http_lb_mig_backend'
     primary_resource_id: 'default'
     vars:
@@ -2356,13 +2374,45 @@ properties:
           description: |
             Path portion of the URL.
           required: true
+        - name: 'headers'
+          type: Array
+          description: |
+            HTTP headers for this request.
+          item_type:
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |
+                  Header name.
+                required: true
+              - name: 'value'
+                type: String
+                description: |
+                  Header value.
+                required: true
         - name: 'service'
           type: ResourceRef
           description: The backend service or backend bucket link that should be matched by this test.
-          required: true
           custom_expand: 'templates/terraform/custom_expand/reference_to_backend.tmpl'
           resource: 'BackendService'
           imports: 'selfLink'
+        - name: 'expectedOutputUrl'
+          type: String
+          description: |
+            The expected output URL evaluated by the load balancer containing the scheme, host, path and query parameters.
+
+            For rules that forward requests to backends, the test passes only when expectedOutputUrl matches the request forwarded by the load balancer to backends. For rules with urlRewrite, the test verifies that the forwarded request matches hostRewrite and pathPrefixRewrite in the urlRewrite action. When service is specified, expectedOutputUrl`s scheme is ignored.
+
+            For rules with urlRedirect, the test passes only if expectedOutputUrl matches the URL in the load balancer's redirect response. If urlRedirect specifies httpsRedirect, the test passes only if the scheme in expectedOutputUrl is also set to HTTPS. If urlRedirect specifies stripQuery, the test passes only if expectedOutputUrl does not contain any query parameters.
+
+            expectedOutputUrl is optional when service is specified.
+        - name: 'expectedRedirectResponseCode'
+          type: Integer
+          description: |
+            For rules with urlRedirect, the test passes only if expectedRedirectResponseCode matches the HTTP status code in load balancer's redirect response.
+
+            expectedRedirectResponseCode cannot be set when service is set.
   - name: 'defaultUrlRedirect'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/url_map_test_expected_output_url.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_test_expected_output_url.tf.tmpl
@@ -1,0 +1,52 @@
+resource "google_compute_health_check" "{{$.Vars.health_check_name}}" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "{{$.Vars.backend_service_name}}" {
+  name        = "{{index $.Vars "backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.{{$.Vars.health_check_name}}.id]
+}
+
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name            = "{{index $.Vars "url_map_name"}}"
+  description     = "URL map with expected output URL tests"
+  default_service = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+
+  test {
+    description = "Test with expected output URL"
+    host        = "example.com"
+    path        = "/"
+    service     = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+    
+    headers {
+      name  = "User-Agent"
+      value = "TestBot/1.0"
+    }
+    
+    expected_output_url = "http://example.com/"
+  }
+
+  test {
+    description = "Test API routing with expected output URL"
+    host        = "api.example.com"
+    path        = "/v1/users"
+    service     = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+    
+    headers {
+      name  = "Authorization"
+      value = "Bearer token123"
+    }
+    
+    expected_output_url = "http://api.example.com/v1/users"
+  }
+} 

--- a/mmv1/templates/terraform/examples/url_map_test_headers.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_test_headers.tf.tmpl
@@ -1,0 +1,58 @@
+resource "google_compute_health_check" "{{$.Vars.health_check_name}}" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "{{$.Vars.backend_service_name}}" {
+  name        = "{{index $.Vars "backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.{{$.Vars.health_check_name}}.id]
+}
+
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name            = "{{index $.Vars "url_map_name"}}"
+  description     = "URL map with test headers"
+  default_service = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+
+  test {
+    description = "Test with custom headers"
+    host        = "example.com"
+    path        = "/"
+    service     = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+    
+    headers {
+      name  = "User-Agent"
+      value = "TestBot/1.0"
+    }
+    
+    headers {
+      name  = "X-Custom-Header"
+      value = "test-value"
+    }
+  }
+
+  test {
+    description = "Test with authorization headers"
+    host        = "api.example.com"
+    path        = "/v1/test"
+    service     = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+    
+    headers {
+      name  = "Authorization"
+      value = "Bearer token123"
+    }
+    
+    headers {
+      name  = "Content-Type"
+      value = "application/json"
+    }
+  }
+} 

--- a/mmv1/templates/terraform/examples/url_map_test_redirect_response_code.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_test_redirect_response_code.tf.tmpl
@@ -1,0 +1,73 @@
+resource "google_compute_health_check" "{{$.Vars.health_check_name}}" {
+  name               = "{{index $.Vars "health_check_name"}}"
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "{{$.Vars.backend_service_name}}" {
+  name        = "{{index $.Vars "backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.{{$.Vars.health_check_name}}.id]
+}
+
+resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
+  name            = "{{index $.Vars "url_map_name"}}"
+  description     = "URL map with redirect response code tests"
+  default_service = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+
+  host_rule {
+    hosts        = ["example.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.{{$.Vars.backend_service_name}}.id
+
+    path_rule {
+      paths = ["/redirect/*"]
+      url_redirect {
+        host_redirect          = "newsite.com"
+        path_redirect          = "/new-path/"
+        https_redirect         = true
+        redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+        strip_query           = false
+      }
+    }
+  }
+
+  test {
+    description = "Test redirect with expected response code"
+    host        = "example.com"
+    path        = "/redirect/old-page"
+    
+    headers {
+      name  = "Referer"
+      value = "https://oldsite.com"
+    }
+    
+    expected_output_url              = "https://newsite.com/new-path/"
+    expected_redirect_response_code  = 301
+  }
+
+  test {
+    description = "Test another redirect scenario"
+    host        = "example.com"
+    path        = "/redirect/another-page"
+    
+    headers {
+      name  = "User-Agent"
+      value = "TestBot/1.0"
+    }
+    
+    expected_output_url              = "https://newsite.com/new-path/"
+    expected_redirect_response_code  = 301
+  }
+} 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds headers, expectedOutputUrl, and expectedRedirectResponseCode fields to URL map tests, and makes the service field optional to support redirect testing scenarios.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `headers`, `expected_output_url`, and `expected_redirect_response_code` fields to `test[]` in `google_compute_url_map` resource and made `service` field optional
```