### PR TITLE
Enforce id validation for WorkloadIdentityPool Managed Identity

### DIFF
--- a/mmv1/products/iambeta/WorkloadIdentityPoolManagedIdentity.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPoolManagedIdentity.yaml
@@ -84,6 +84,8 @@ parameters:
 
 
       The prefix `gcp-` will be reserved for future uses.
+    validation:
+      function: 'ValidateWorkloadIdentityPoolManagedIdentityId'
 properties:
   - name: 'name'
     type: String

--- a/mmv1/products/iambeta/WorkloadIdentityPoolNamespace.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPoolNamespace.yaml
@@ -39,12 +39,12 @@ examples:
     primary_resource_id: 'example'
     vars:
       workload_identity_pool_id: 'example-pool'
-      workload_identity_pool_namespace_id: 'example-nmspc'
+      workload_identity_pool_namespace_id: 'example-namespace'
   - name: 'iam_workload_identity_pool_namespace_full'
     primary_resource_id: 'example'
     vars:
       workload_identity_pool_id: 'example-pool'
-      workload_identity_pool_namespace_id: 'example-nmspc'
+      workload_identity_pool_namespace_id: 'example-namespace'
 parameters:
   - name: 'workload_identity_pool_id'
     type: String

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_managed_identity_id_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_managed_identity_id_test.go.tmpl
@@ -1,0 +1,38 @@
+{{- if ne $.TargetVersionName "ga" -}}
+package iambeta_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/services/iambeta"
+	"github.com/hashicorp/terraform-provider-google/google/verify"
+)
+
+func TestValidateWorkloadIdentityPoolManagedIdentityId(t *testing.T) {
+	x := []verify.StringValidationTestCase{
+		// No errors
+		{TestName: "basic", Value: "foobar"},
+		{TestName: "with numbers", Value: "foobar123"},
+		{TestName: "short", Value: "foos"},
+		{TestName: "long", Value: "12345678901234567890123456789012"},
+		{TestName: "has a hyphen", Value: "foo-bar"},
+
+		// With errors
+		{TestName: "empty", Value: "", ExpectError: true},
+		{TestName: "starts with a gcp-", Value: "gcp-foobar", ExpectError: true},
+		{TestName: "with uppercase", Value: "fooBar", ExpectError: true},
+		{TestName: "has an slash", Value: "foo/bar", ExpectError: true},
+		{TestName: "has an backslash", Value: "foo\bar", ExpectError: true},
+		{TestName: "too short", Value: "f", ExpectError: true},
+		{TestName: "too long", Value: strings.Repeat("f", 64), ExpectError: true},
+        {TestName: "starts with non-alphanumeric", Value: "-foobar", ExpectError: true},
+        {TestName: "ends with non-alphanumeric", Value: "foobar-", ExpectError: true},
+	}
+
+	es := verify.TestStringValidationCases(x, iambeta.ValidateWorkloadIdentityPoolManagedIdentityId)
+	if len(es) > 0 {
+		t.Errorf("Failed to validate WorkloadIdentityPoolManagedIdentity names: %v", es)
+	}
+}
+{{- end -}}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_namespace_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_namespace_test.go.tmpl
@@ -101,7 +101,7 @@ resource "google_iam_workload_identity_pool_namespace" "example" {
   provider = google-beta
 
   workload_identity_pool_id           = google_iam_workload_identity_pool.pool.workload_identity_pool_id
-  workload_identity_pool_namespace_id = "tf-test-example-nmspc%{random_suffix}"
+  workload_identity_pool_namespace_id = "tf-test-example-namespace%{random_suffix}"
 }
 `, context)
 }
@@ -119,7 +119,7 @@ resource "google_iam_workload_identity_pool_namespace" "example" {
   provider = google-beta
 
   workload_identity_pool_id           = google_iam_workload_identity_pool.pool.workload_identity_pool_id
-  workload_identity_pool_namespace_id = "tf-test-example-nmspc%{random_suffix}"
+  workload_identity_pool_namespace_id = "tf-test-example-namespace%{random_suffix}"
   description                         = "Example Namespace in a Workload Identity Pool"
   disabled                            = true
 }
@@ -139,7 +139,7 @@ resource "google_iam_workload_identity_pool_namespace" "example" {
   provider = google-beta
 
   workload_identity_pool_id           = google_iam_workload_identity_pool.pool.workload_identity_pool_id
-  workload_identity_pool_namespace_id = "tf-test-example-nmspc%{random_suffix}"
+  workload_identity_pool_namespace_id = "tf-test-example-namespace%{random_suffix}"
   description                         = "Updated Namespace in a Workload Identity Pool"
   disabled                            = false
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
iambeta: enforced `workload_identity_pool_managed_identity_id` field validation per the documented specifications
```

Add back ID validation on WorkloadIdentityPool Managed Identity. Context: https://github.com/GoogleCloudPlatform/magic-modules/pull/14110#issuecomment-2917187493