### PR TITLE
Allow folder ancestor list only contains folder itself inside

### DIFF
--- a/mmv1/third_party/tgc/ancestrymanager/ancestryutil.go
+++ b/mmv1/third_party/tgc/ancestrymanager/ancestryutil.go
@@ -24,8 +24,8 @@ func assetParent(cai *resources.Asset, ancestors []string) (string, error) {
 				return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[1]), nil
 			}
 		}
-		if len(ancestors) == 1 && strings.HasPrefix(ancestors[0], "organizations/") {
-			// organizations/unknown
+		if len(ancestors) == 1 {
+			// organizations/unknown or folder itself
 			return fmt.Sprintf("//cloudresourcemanager.googleapis.com/%s", ancestors[0]), nil
 		}
 	case "cloudresourcemanager.googleapis.com/Organization":

--- a/mmv1/third_party/tgc/ancestrymanager/ancestryutil_test.go
+++ b/mmv1/third_party/tgc/ancestrymanager/ancestryutil_test.go
@@ -48,6 +48,12 @@ func TestAssetParent(t *testing.T) {
 			want:      "//cloudresourcemanager.googleapis.com/organizations/unknown",
 		},
 		{
+			name:      "new folder with only itself in ancestors",
+			ancestors: []string{"folders/123"},
+			cai:       &resources.Asset{Type: "cloudresourcemanager.googleapis.com/Folder"},
+			want:      "//cloudresourcemanager.googleapis.com/folders/123",
+		},
+		{
 			name:      "organization",
 			ancestors: []string{"organizations/789"},
 			cai:       &resources.Asset{Type: "cloudresourcemanager.googleapis.com/Organization"},
@@ -84,11 +90,6 @@ func TestAssetParent_Fail(t *testing.T) {
 			name:      "project",
 			ancestors: []string{},
 			cai:       &resources.Asset{Type: "cloudresourcemanager.googleapis.com/Project"},
-		},
-		{
-			name:      "folder",
-			ancestors: []string{"folders/456"},
-			cai:       &resources.Asset{Type: "cloudresourcemanager.googleapis.com/Folder"},
 		},
 		{
 			name:      "other resource",


### PR DESCRIPTION
Context: when offline mode is enabled, folder ancestor list only contains folder itself inside. But this should be accepted and doesn't return error. 

```release-note:note
fixed the `assertParent` function to support the situation that ancestors only contain folder resource itself
```