### PR TITLE
Move enabling SecretManager versions out of the expand function

### DIFF
--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -50,6 +50,7 @@ custom_code:
   pre_delete: 'templates/terraform/pre_delete/secret_version_deletion_policy.go.tmpl'
   custom_import: 'templates/terraform/custom_import/secret_version.go.tmpl'
   raw_resource_config_validation: 'templates/terraform/validation/secret_version.go.tmpl'
+  constants: 'templates/terraform/constants/secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 examples:

--- a/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecretVersion.yaml
@@ -49,6 +49,7 @@ custom_code:
   custom_update: 'templates/terraform/custom_update/regional_secret_version.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/regional_secret_version_deletion_policy.go.tmpl'
   custom_import: 'templates/terraform/custom_import/regional_secret_version.go.tmpl'
+  constants: 'templates/terraform/constants/regional_secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true
 examples:

--- a/mmv1/templates/terraform/constants/regional_secret_version.go.tmpl
+++ b/mmv1/templates/terraform/constants/regional_secret_version.go.tmpl
@@ -1,0 +1,35 @@
+{{- if ne $.Compiler "terraformgoogleconversion-codegen" }}
+func setEnabled(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) error {
+	name := d.Get("name").(string)
+	if name == "" {
+		return nil
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}SecretManagerRegionalBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	if v == true {
+		url = fmt.Sprintf("%s:enable", url)
+	} else {
+		url = fmt.Sprintf("%s:disable", url)
+	}
+
+	parts := strings.Split(name, "/")
+	project := parts[1]
+
+	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config: config,
+		Method: "POST",
+		Project: project,
+		RawURL: url,
+		UserAgent: userAgent,
+	})
+	return err
+}
+{{- end }}

--- a/mmv1/templates/terraform/constants/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/constants/secret_version.go.tmpl
@@ -1,0 +1,35 @@
+{{- if ne $.Compiler "terraformgoogleconversion-codegen" }}
+func setEnabled(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) error {
+	name := d.Get("name").(string)
+	if name == "" {
+		return nil
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}SecretManagerBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	if v == true {
+		url = fmt.Sprintf("%s:enable", url)
+	} else {
+		url = fmt.Sprintf("%s:disable", url)
+	}
+
+	parts := strings.Split(name, "/")
+	project := parts[1]
+
+	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config: config,
+		Method: "POST",
+		Project: project,
+		RawURL: url,
+		UserAgent: userAgent,
+	})
+	return err
+}
+{{- end }}

--- a/mmv1/templates/terraform/custom_expand/regional_secret_version_enable.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/regional_secret_version_enable.go.tmpl
@@ -10,41 +10,6 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
-func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	name := d.Get("name").(string)
-	if name == "" {
-		return "", nil
-	}
-
-	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}SecretManagerRegionalBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
-	if err != nil {
-		return nil, err
-	}
-
-	if v == true {
-		url = fmt.Sprintf("%s:enable", url)
-	} else {
-		url = fmt.Sprintf("%s:disable", url)
-	}
-
-	parts := strings.Split(name, "/")
-	project := parts[1]
-
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config: config,
-		Method: "POST",
-		Project: project,
-		RawURL: url,
-		UserAgent: userAgent,
-	})
-	if err != nil {
-		return nil, err
-	}
-
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(_ interface{}, _ tpgresource.TerraformResourceData, _ *transport_tpg.Config) (interface{}, error) {
 	return nil, nil
 }

--- a/mmv1/templates/terraform/custom_expand/secret_version_enable.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/secret_version_enable.go.tmpl
@@ -10,41 +10,6 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
-func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	name := d.Get("name").(string)
-	if name == "" {
-		return "", nil
-	}
-	
-	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}SecretManagerBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
-	if err != nil {
-		return nil, err
-	}
-
-	if v == true {
-		url = fmt.Sprintf("%s:enable", url)
-	} else {
-		url = fmt.Sprintf("%s:disable", url)
-	}
-
-	parts := strings.Split(name, "/")
-	project := parts[1]
-
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config: config,
-		Method: "POST",
-		Project: project,
-		RawURL: url,
-		UserAgent: userAgent,
-	})
-	if err != nil {
-		return nil, err
-	}
-
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(_ interface{}, _ tpgresource.TerraformResourceData, _ *transport_tpg.Config) (interface{}, error) {
 	return nil, nil
 }

--- a/mmv1/templates/terraform/custom_update/regional_secret_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/regional_secret_version.go.tmpl
@@ -10,7 +10,7 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
-_, err := expandSecretManagerRegionalRegionalSecretVersionEnabled(d.Get("enabled"), d, config)
+err := setEnabled(d.Get("enabled"), d, config)
 if err != nil {
 	return err
 }

--- a/mmv1/templates/terraform/custom_update/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/secret_version.go.tmpl
@@ -10,7 +10,7 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */ -}}
-_, err := expandSecretManagerSecretVersionEnabled(d.Get("enabled"), d, config)
+err := setEnabled(d.Get("enabled"), d, config)
 if err != nil {
 	return err
 }

--- a/mmv1/templates/terraform/post_create/regional_secret_version.go.tmpl
+++ b/mmv1/templates/terraform/post_create/regional_secret_version.go.tmpl
@@ -20,7 +20,7 @@ if err := d.Set("name", name.(string)); err != nil {
 }
 d.SetId(name.(string))
 
-_, err = expandSecretManagerRegionalRegionalSecretVersionEnabled(d.Get("enabled"), d, config)
+err = setEnabled(d.Get("enabled"), d, config)
 if err != nil {
 	return err
 }

--- a/mmv1/templates/terraform/post_create/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/post_create/secret_version.go.tmpl
@@ -8,7 +8,7 @@ if err := d.Set("name", name.(string)); err != nil {
 }
 d.SetId(name.(string))
 
-_, err = expandSecretManagerSecretVersionEnabled(d.Get("enabled"), d, config)
+err = setEnabled(d.Get("enabled"), d, config)
 if err != nil {
 	return err
 }


### PR DESCRIPTION
Previously, tgc would panic when running in offline mode because the `http.Client` in tpg was nil and
the custom expand function called tpg.SendRequest regardless of whether or not the client was nil.

Context: b/420739836

```release-note: none

```
