### PR TITLE
Terraform integration for adding multi party approval step id field to Entitlement

### DIFF
--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -145,7 +145,7 @@ properties:
           - name: 'steps'
             type: Array
             description: |
-              List of approval steps in this workflow. These steps would be followed in the specified order sequentially.  1 step is supported for now.
+              List of approval steps in this workflow. These steps would be followed in the specified order sequentially.
             required: true
             item_type:
               type: NestedObject
@@ -185,6 +185,12 @@ properties:
                   is_set: true
                   item_type:
                     type: String
+                - name: 'id'
+                  type: String
+                  description: |
+                    Output Only. The ID of the approval step.
+                  min_version: beta
+                  output: true
   - name: 'privilegedAccess'
     type: NestedObject
     description: |


### PR DESCRIPTION
This Pull Request enhances the Entitlement Terraform resource by introducing a new `id` field. This is an OUTPUT ONLY field, meaning it will display the step id for each approval steps, providing more visibility into the approval process. 

Important Note: This Pull Request is being submitted for early review and feedback. However, it should only be merged into the main codebase once the backend API supporting multi-party approval has been fully promoted to beta. This dependency ensures that the new id field functions correctly and as intended with the corresponding API changes.

```release-note:enhancement
privilegedaccessmanager: added `id` field to `google_privileged_access_manager_entitlement` resource
``` 
