### PR TITLE
eventarc: use tf-bootstrap prefix for bootstrapped resource names

### DIFF
--- a/mmv1/products/eventarc/Pipeline.yaml
+++ b/mmv1/products/eventarc/Pipeline.yaml
@@ -45,7 +45,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_http_destination
     primary_resource_id: primary
     vars:
@@ -54,7 +54,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_workflow_destination
     primary_resource_id: primary
     vars:
@@ -64,7 +64,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_oidc_and_json_format
     primary_resource_id: primary
     vars:
@@ -74,7 +74,7 @@ examples:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_oauth_and_protobuf_format
     primary_resource_id: primary
     vars:
@@ -84,7 +84,7 @@ examples:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_cmek_and_avro_format
     primary_resource_id: primary
     bootstrap_iam:
@@ -97,7 +97,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
       'key_name': 'acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-pipeline-key").CryptoKey.Name'
 parameters:
   - name: location

--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -50,7 +50,7 @@ examples:
       trigger_name: some-trigger
       network_attachment_name: network-attachment
     test_vars_overrides:
-      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-trigger-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-trigger-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-trigger-network")))'
+      'network_attachment_name': 'acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-trigger-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-trigger-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-trigger-network")))'
     test_env_vars:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_message_bus_test.go
@@ -416,7 +416,7 @@ func testAccEventarcMessageBus_pipeline(t *testing.T) {
 		"project_id":              envvar.GetTestProjectFromEnv(),
 		"region":                  envvar.GetTestRegionFromEnv(),
 		"random_suffix":           acctest.RandString(t, 10),
-		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-messagebus-network"))),
+		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-messagebus-network"))),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -464,7 +464,7 @@ func testAccEventarcMessageBus_enrollment(t *testing.T) {
 		"project_id":              envvar.GetTestProjectFromEnv(),
 		"region":                  envvar.GetTestRegionFromEnv(),
 		"random_suffix":           acctest.RandString(t, 10),
-		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-messagebus-network"))),
+		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-messagebus-network"))),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -531,7 +531,7 @@ func testAccEventarcMessageBus_updateEnrollment(t *testing.T) {
 		"project_id":              envvar.GetTestProjectFromEnv(),
 		"region":                  envvar.GetTestRegionFromEnv(),
 		"random_suffix":           acctest.RandString(t, 10),
-		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-messagebus-network"))),
+		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-messagebus-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-messagebus-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-messagebus-network"))),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/eventarc/resource_eventarc_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/resource_eventarc_pipeline_test.go
@@ -18,7 +18,7 @@ func TestAccEventarcPipeline_update(t *testing.T) {
 		"service_account":         envvar.GetTestServiceAccountFromEnv(t),
 		"key_name":                acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-pipeline-key").CryptoKey.Name,
 		"key2_name":               acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-pipeline-key2").CryptoKey.Name,
-		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-test-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-test-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-test-eventarc-pipeline-network"))),
+		"network_attachment_name": acctest.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", acctest.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", acctest.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network"))),
 		"random_suffix":           acctest.RandString(t, 10),
 	}
 	acctest.BootstrapIamMembers(t, []acctest.IamMember{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23018. Use the "tf-bootstrap" prefix for bootstrapped resources, instead of "tf-test", as mentioned in https://github.com/hashicorp/terraform-provider-google/issues/21795#issuecomment-2863655980.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
