### PR TITLE
Add in performance_monitoring_unit for advanced_machine_features in node_config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
+	"github.com/hashicorp/terraform-provider-google/google/verify"
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/container/v1"
 {{- else }}
@@ -756,6 +757,12 @@ func schemaNodeConfig() *schema.Schema {
 								ForceNew: true,
 								Description: `Whether the node should have nested virtualization enabled.`,
 							},
+							"performance_monitoring_unit": {
+								Type: schema.TypeString,
+								Optional: true,
+								ValidateFunc: verify.ValidateEnum([]string{"ARCHITECTURAL", "STANDARD", "ENHANCED"}),
+								Description: `Level of Performance Monitoring Unit (PMU) requested. If unset, no access to the PMU is assumed.`,
+							},
 						},
 					},
 				},
@@ -1257,6 +1264,7 @@ func expandNodeConfig(v interface{}) *container.NodeConfig {
 		nc.AdvancedMachineFeatures = &container.AdvancedMachineFeatures{
 			ThreadsPerCore: int64(advanced_machine_features["threads_per_core"].(int)),
 			EnableNestedVirtualization: advanced_machine_features["enable_nested_virtualization"].(bool),
+			PerformanceMonitoringUnit: advanced_machine_features["performance_monitoring_unit"].(string),
 		}
 	}
 
@@ -1750,6 +1758,7 @@ func flattenAdvancedMachineFeaturesConfig(c *container.AdvancedMachineFeatures) 
 		result = append(result, map[string]interface{}{
 			"threads_per_core": c.ThreadsPerCore,
 			"enable_nested_virtualization": c.EnableNestedVirtualization,
+			"performance_monitoring_unit": c.PerformanceMonitoringUnit,
 		})
 	}
 	return result

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -2471,6 +2471,67 @@ resource "google_container_node_pool" "np" {
 `, cluster, networkName, subnetworkName, enableNV, np, enableNV)
 }
 
+func TestAccContainerNodePool_performanceMonitoringUnit(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	np := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_performanceMonitoringUnit(cluster, np, networkName, subnetworkName, "ARCHITECTURAL"),
+			},
+			{
+				ResourceName:            "google_container_cluster.cluster",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_performanceMonitoringUnit(cluster, np, networkName, subnetworkName, pmuLevel string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  deletion_protection = false
+  network    = "%s"
+  subnetwork    = "%s"
+
+  node_config {
+    machine_type = "c4-standard-4"
+	advanced_machine_features {
+		threads_per_core = 2
+		performance_monitoring_unit = "%s"
+	}
+  }
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 2
+
+  node_config {
+    machine_type = "c4-standard-4"
+	advanced_machine_features {
+		threads_per_core = 2
+		performance_monitoring_unit = "%s"
+	}
+  }
+}
+`, cluster, networkName, subnetworkName, pmuLevel, np, pmuLevel)
+}
 
 func testAccCheckContainerNodePoolDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1064,6 +1064,8 @@ sole_tenant_config {
 
 * `enable_nested_virtualization`- (Optional) Defines whether the instance should have nested virtualization enabled. Defaults to false.
 
+* `performance_monitoring_unit` - (Optional) Defines the performance monitoring unit [PMU](https://cloud.google.com/compute/docs/pmu-overview) level. Defaults to off.
+
 <a name="nested_ephemeral_storage_config"></a>The `ephemeral_storage_config` block supports:
 
 * `local_ssd_count` (Required) - Number of local SSDs to use to back ephemeral storage. Uses NVMe interfaces. Each local SSD is 375 GB in size. If zero, it means to disable using local SSDs as ephemeral storage.


### PR DESCRIPTION
Add support for performance_monitoring_unit in advanced_machine_features in node_config

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22266

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added 'performance_monitoring_unit' in node_config/advanced_machine_features to 'google_container_cluster' resource

```
