### PR TITLE
Compute disk write only attributes

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -37,7 +37,6 @@ references:
 docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/disks'
 has_self_link: true
-immutable: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -63,11 +62,17 @@ custom_code:
   update_encoder: 'templates/terraform/update_encoder/hyper_disk.go.tmpl'
   decoder: 'templates/terraform/decoders/disk.tmpl'
   pre_delete: 'templates/terraform/pre_delete/detach_disk.tmpl'
+  raw_resource_config_validation: 'templates/terraform/validation/compute_disk.go.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("size", IsDiskShrinkage)'
   - 'hyperDiskIopsUpdateDiffSuppress'
 examples:
   - name: 'disk_basic'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-test-disk%s", context["random_suffix"])'
+    vars:
+      disk_name: 'test-disk'
+  - name: 'disk_basic_wo'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-test-disk%s", context["random_suffix"])'
     vars:
@@ -189,7 +194,6 @@ properties:
       If you do not provide an encryption key when creating the disk, then
       the disk will be encrypted using an automatically generated key and
       you do not need to provide a key to use the disk later.
-    immutable: true
     properties:
       - name: 'rawKey'
         type: String
@@ -197,6 +201,34 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+      immutable: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_key_flatten.go.tmpl'
+        conflicts:
+          - 'disk_encryption_key.0.rawKeyWo'
+      - name: 'rawKeyWoVersion'
+        type: Integer
+        description: |
+          Triggers update of write-only rawKey
+        immutable: true
+        default_value: 0
+        ignore_read: true
+      - name: 'rawKeyWo'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        write_only: true
+        required_with:
+          - 'disk_encryption_key.0.rawKeyWoVersion'
+        conflicts:
+          - 'disk_encryption_key.0.rawKey'
+      - name: 'rsaEncryptedKeyWoVersion'
+        type: Integer
+        description: |
+          Triggers update of write-only rsaEncryptedKey
+        immutable: true
+        default_value: 0
+        ignore_read: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |
@@ -204,14 +236,29 @@ properties:
           customer-supplied encryption key to either encrypt or decrypt
           this resource. You can provide either the rawKey or the rsaEncryptedKey.
         sensitive: true
+        conflicts:
+          - 'disk_encryption_key.0.rsaEncryptedKeyWo'
+      - name: 'rsaEncryptedKeyWo'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        write_only: true
+        required_with:
+          - 'disk_encryption_key.0.rsaEncryptedKeyWoVersion'
+        conflicts:
+          - 'disk_encryption_key.0.rsaEncryptedKey'
       - name: 'sha256'
         type: String
+        immutable: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_rsa_key_flatten.go.tmpl'
         description: |
           The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
           encryption key that protects this resource.
         output: true
       - name: 'kmsKeySelfLink'
         type: String
+        immutable: true
         description: |
           The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
           in the cloud console. Your project's Compute Engine System service account
@@ -222,6 +269,7 @@ properties:
         diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
       - name: 'kmsKeyServiceAccount'
         type: String
+        immutable: true
         description: |
           The service account used for the encryption request for the given KMS key.
           If absent, the Compute Engine Service Agent service account is used.

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -37,6 +37,8 @@ references:
 docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/disks'
 has_self_link: true
+update_verb: 'PATCH'
+update_mask: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -238,6 +238,7 @@ properties:
           customer-supplied encryption key to either encrypt or decrypt
           this resource. You can provide either the rawKey or the rsaEncryptedKey.
         sensitive: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_rsa_key_flatten.go.tmpl'
         conflicts:
           - 'disk_encryption_key.0.rsaEncryptedKeyWo'
       - name: 'rsaEncryptedKeyWo'
@@ -253,7 +254,6 @@ properties:
       - name: 'sha256'
         type: String
         immutable: true
-        custom_flatten: 'templates/terraform/custom_flatten/compute_rsa_key_flatten.go.tmpl'
         description: |
           The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
           encryption key that protects this resource.
@@ -568,6 +568,7 @@ properties:
     description: |
       A list of features to enable on the guest operating system.
       Applicable only for bootable disks.
+    immutable: true
     is_set: true
     default_from_api: true
     item_type:

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -203,7 +203,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
-      immutable: true
+        immutable: true
         custom_flatten: 'templates/terraform/custom_flatten/compute_key_flatten.go.tmpl'
         conflicts:
           - 'disk_encryption_key.0.rawKeyWo'

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -62,11 +62,19 @@ custom_code:
   encoder: 'templates/terraform/encoders/disk.tmpl'
   decoder: 'templates/terraform/decoders/disk.tmpl'
   pre_delete: 'templates/terraform/pre_delete/detach_disk.tmpl'
+  raw_resource_config_validation: 'templates/terraform/validation/compute_region_disk.go.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("size", IsDiskShrinkage)'
   - 'hyperDiskIopsUpdateDiffSuppress'
 examples:
   - name: 'region_disk_basic'
+    primary_resource_id: 'regiondisk'
+    primary_resource_name: 'fmt.Sprintf("tf-test-my-region-disk%s", context["random_suffix"])'
+    vars:
+      region_disk_name: 'my-region-disk'
+      disk_name: 'my-disk'
+      snapshot_name: 'my-snapshot'
+  - name: 'region_disk_disk_encryption_key_wo'
     primary_resource_id: 'regiondisk'
     primary_resource_name: 'fmt.Sprintf("tf-test-my-region-disk%s", context["random_suffix"])'
     vars:
@@ -125,7 +133,6 @@ properties:
       If you do not provide an encryption key when creating the disk, then
       the disk will be encrypted using an automatically generated key and
       you do not need to provide a key to use the disk later.
-    immutable: true
     properties:
       - name: 'rawKey'
         type: String
@@ -133,6 +140,27 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        immutable: true
+        custom_flatten: 'templates/terraform/custom_flatten/compute_key_flatten.go.tmpl'
+        conflicts:
+          - 'disk_encryption_key.0.rawKeyWo'
+      - name: 'rawKeyWo'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+        write_only: true
+        required_with:
+          - 'disk_encryption_key.0.rawKeyWoVersion'
+        conflicts:
+          - 'disk_encryption_key.0.rawKey'
+      - name: 'rawKeyWoVersion'
+        type: Integer
+        description: |
+          Triggers update of write-only rawKey
+        ignore_read: true
+        default_value: 0
+        immutable: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |
@@ -149,6 +177,7 @@ properties:
         # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
       - name: 'kmsKeyName'
         type: String
+        immutable: true
         description: |
           The name of the encryption key that is stored in Google Cloud KMS.
   - name: 'sourceSnapshotEncryptionKey'

--- a/mmv1/templates/terraform/custom_flatten/compute_key_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/compute_key_flatten.go.tmpl
@@ -1,0 +1,6 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+  if d.Get("disk_encryption_key.0.raw_key").(string) == "" {
+    return nil
+  }
+  return v
+}

--- a/mmv1/templates/terraform/custom_flatten/compute_rsa_key_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/compute_rsa_key_flatten.go.tmpl
@@ -1,0 +1,6 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+  if d.Get("disk_encryption_key.0.rsa_encrypted_key").(string) == "" {
+    return nil
+  }
+  return v
+}

--- a/mmv1/templates/terraform/encoders/disk.tmpl
+++ b/mmv1/templates/terraform/encoders/disk.tmpl
@@ -50,5 +50,17 @@ if v, ok := d.GetOk("image"); ok {
 	obj["sourceImage"] = imageUrl
 	log.Printf("[DEBUG] Image name resolved to: %s", imageUrl)
 }
+{{- if ne $.Compiler "terraformgoogleconversion-codegen" }}
+if rawKey, diags := d.GetRawConfigAt(cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("raw_key_wo")); !diags.HasError() && rawKey.IsKnown() && !rawKey.IsNull() {
+	obj["diskEncryptionKey"] = map[string]interface{}{
+		"rawKey": rawKey.AsString(),
+	}
+}
 
+if rsaEncryptedKey, diags := d.GetRawConfigAt(cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("rsa_encrypted_key_wo")); !diags.HasError() && rsaEncryptedKey.IsKnown() && !rsaEncryptedKey.IsNull() {
+	obj["diskEncryptionKey"] = map[string]interface{}{
+		"rsaEncryptedKey": rsaEncryptedKey.AsString(),
+	}
+}
+{{- end }}
 return obj, nil

--- a/mmv1/templates/terraform/examples/disk_basic_wo.tf.tmpl
+++ b/mmv1/templates/terraform/examples/disk_basic_wo.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_compute_disk" "default" {
+  name  = "{{index $.Vars "disk_name"}}"
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = "debian-11-bullseye-v20220719"
+  labels = {
+    environment = "dev"
+  }
+  disk_encryption_key {
+    raw_key_wo = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+    raw_key_wo_version = 1
+  }
+  physical_block_size_bytes = 4096
+}

--- a/mmv1/templates/terraform/examples/region_disk_disk_encryption_key_wo.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_disk_disk_encryption_key_wo.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_region_disk" "regiondisk" {
+  name                      = "{{index $.Vars "region_disk_name"}}"
+  snapshot                  = google_compute_snapshot.snapdisk.id
+  type                      = "pd-ssd"
+  region                    = "us-central1"
+  physical_block_size_bytes = 4096
+  disk_encryption_key {
+    raw_key_wo = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+    raw_key_wo_version = 1
+  }
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "{{index $.Vars "disk_name"}}"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name        = "{{index $.Vars "snapshot_name"}}"
+  source_disk = google_compute_disk.disk.name
+  zone        = "us-central1-a"
+}

--- a/mmv1/templates/terraform/update_encoder/hyper_disk.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/hyper_disk.go.tmpl
@@ -5,4 +5,6 @@ if (d.HasChange("provisioned_iops") && strings.Contains(d.Get("type").(string), 
         obj["name"] = nameProp
     }
 }
+obj["name"]= d.Get("name").(string)
+
 return obj, nil

--- a/mmv1/templates/terraform/validation/compute_disk.go.tmpl
+++ b/mmv1/templates/terraform/validation/compute_disk.go.tmpl
@@ -1,0 +1,2 @@
+validation.PreferWriteOnlyAttribute(cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("raw_key"),cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("raw_key_wo")),
+validation.PreferWriteOnlyAttribute(cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("rsa_encrypted_key"),cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("rsa_encrypted_key_wo"))

--- a/mmv1/templates/terraform/validation/compute_region_disk.go.tmpl
+++ b/mmv1/templates/terraform/validation/compute_region_disk.go.tmpl
@@ -1,0 +1,1 @@
+validation.PreferWriteOnlyAttribute(cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("rawKey"),cty.GetAttrPath("disk_encryption_key").IndexInt(0).GetAttr("rawKeyWo"))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -850,6 +850,38 @@ func TestAccComputeDisk_multiWriter(t *testing.T) {
 }
 {{- end }}
 
+func TestAccComputeDisk_update_wo(t *testing.T) {
+	t.Parallel()
+
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	diskType := "pd-ssd"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_basic(diskName, diskType),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"disk_encryption_key.0.raw_key_wo_version", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeDisk_basic_updated_wo(diskName, diskType),
+			},
+			{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"disk_encryption_key.0.raw_key_wo_version", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *compute.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1151,6 +1183,30 @@ resource "google_compute_disk" "foobar" {
   size  = 50
   type  = "%s"
   zone  = "us-central1-a"
+  labels = {
+    my-label = "my-label-value"
+  }
+}
+`, diskName, diskType)
+}
+
+func testAccComputeDisk_basic_updated_wo(diskName string, diskType string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "foobar" {
+  name  = "%s"
+  image = data.google_compute_image.my_image.self_link
+  size  = 50
+  type  = "%s"
+  zone  = "us-central1-a"
+  disk_encryption_key {
+    raw_key_wo = "DWw8Owgk6uhjgXXuATTZ1d9v9OwXXT8/lMYoZsblkM8="
+    raw_key_wo_version = 1
+  }
   labels = {
     my-label = "my-label-value"
   }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -85,7 +85,7 @@ func TestAccComputeRegionDisk_basicUpdate(t *testing.T) {
 				ResourceName:      "google_compute_region_disk.regiondisk",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"raw_key_wo_version", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccComputeRegionDisk_basicUpdated(diskName, "self_link"),
@@ -102,7 +102,51 @@ func TestAccComputeRegionDisk_basicUpdate(t *testing.T) {
 				ResourceName:      "google_compute_region_disk.regiondisk",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"raw_key_wo_version", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionDisk_diskEncryptionKeyWoUpdated(t *testing.T) {
+	t.Parallel()
+
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	var disk compute.Disk
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionDisk_diskEncryptionKeyWo(diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.regiondisk", &disk),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_disk.regiondisk",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"disk_encryption_key.0.raw_key_wo_version", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccComputeRegionDisk_diskEncryptionKeyWoUpdated(diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.regiondisk", &disk),
+					testAccCheckRegionDiskEncryptionKey("google_compute_region_disk.regiondisk", &disk),
+					testAccCheckComputeRegionDiskHasLabelFingerprint(&disk, "google_compute_region_disk.regiondisk"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_disk.regiondisk",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"disk_encryption_key.0.raw_key_wo_version", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -456,6 +500,71 @@ resource "google_compute_region_disk" "regiondisk" {
 }
 `, diskName, diskName, diskName, refSelector)
 }
+
+func testAccComputeRegionDisk_diskEncryptionKeyWo(diskName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "disk" {
+  name  = "%s"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  source_disk = google_compute_disk.disk.name
+}
+
+resource "google_compute_region_disk" "regiondisk" {
+  name     = "%s"
+  snapshot = google_compute_snapshot.snapdisk.self_link
+  type     = "pd-ssd"
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+
+  disk_encryption_key {
+    raw_key_wo = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+	raw_key_wo_version = 1
+  }
+}
+`, diskName, diskName, diskName)
+}
+
+func testAccComputeRegionDisk_diskEncryptionKeyWoUpdated(diskName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "disk" {
+  name  = "%s"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  source_disk = google_compute_disk.disk.name
+}
+
+resource "google_compute_region_disk" "regiondisk" {
+  name     = "%s"
+  snapshot = google_compute_snapshot.snapdisk.self_link
+  type     = "pd-ssd"
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+
+  disk_encryption_key {
+    raw_key_wo = "ADFEFG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
+	raw_key_wo_version = 2
+  }
+}
+`, diskName, diskName, diskName)
+}
+
 
 func testAccComputeRegionDisk_encryption(diskName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!--

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

``compute: added `raw_key_wo`, `rsaEncryptedKeyWo`, `rawKeyWoVersion` and `rsaEncryptedKeyWoVersion` fields in `resource_google_compute_disk` resource``

``compute: added `raw_key_wo` and `rawKeyWoVersion` fields in `resource_google_region_compute_disk` resource``

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```

```




