### PR TITLE
Check for fields that are needed for the read URL explicitly

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1218,8 +1218,15 @@ func (r Resource) GetIdFormat() string {
 
 // Returns true if the Type is in the ID format and false otherwise.
 func (r Resource) InPostCreateComputed(prop Type) bool {
-	fields := r.ExtractIdentifiers(r.GetIdFormat())
-	return slices.Contains(fields, google.Underscore(prop.Name))
+	fields := map[string]struct{}{}
+	for _, f := range r.ExtractIdentifiers(r.GetIdFormat()) {
+		fields[f] = struct{}{}
+	}
+	for _, f := range r.ExtractIdentifiers(r.SelfLinkUri()) {
+		fields[f] = struct{}{}
+	}
+	_, ok := fields[google.Underscore(prop.Name)]
+	return ok
 }
 
 // Returns true if at least one of the fields in the ID format is computed

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1217,20 +1217,23 @@ func (r Resource) GetIdFormat() string {
 }
 
 // Returns true if the Type is in the ID format and false otherwise.
-func (r Resource) InIdFormat(prop Type) bool {
+func (r Resource) InPostCreateComputed(prop Type) bool {
 	fields := r.ExtractIdentifiers(r.GetIdFormat())
 	return slices.Contains(fields, google.Underscore(prop.Name))
 }
 
 // Returns true if at least one of the fields in the ID format is computed
-func (r Resource) HasComputedIdFormatFields() bool {
-	idFormatFields := map[string]struct{}{}
+func (r Resource) HasPostCreateComputedFields() bool {
+	fields := map[string]struct{}{}
 	for _, f := range r.ExtractIdentifiers(r.GetIdFormat()) {
-		idFormatFields[f] = struct{}{}
+		fields[f] = struct{}{}
+	}
+	for _, f := range r.ExtractIdentifiers(r.SelfLinkUri()) {
+		fields[f] = struct{}{}
 	}
 	for _, p := range r.GettableProperties() {
 		// Skip fields not in the id format
-		if _, ok := idFormatFields[google.Underscore(p.Name)]; !ok {
+		if _, ok := fields[google.Underscore(p.Name)]; !ok {
 			continue
 		}
 		if (p.Output || p.DefaultFromApi) && !p.IgnoreRead {

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -358,7 +358,7 @@ func TestMagicianLocation(t *testing.T) {
 	}
 }
 
-func TestHasComputedIdFormatFields(t *testing.T) {
+func TestHasPostCreateComputedFields(t *testing.T) {
 	cases := []struct {
 		name, description string
 		resource          Resource
@@ -476,15 +476,29 @@ func TestHasComputedIdFormatFields(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "includes fields in self link that aren't in id format",
+			resource: Resource{
+				IdFormat: "projects/{{project}}/resource/{{resource_id}}",
+				SelfLink: "{{name}}",
+				Properties: []*Type{
+					{
+						Name:   "name",
+						Output: true,
+					},
+				},
+			},
+			want: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := tc.resource.HasComputedIdFormatFields()
+			got := tc.resource.HasPostCreateComputedFields()
 			if got != tc.want {
-				t.Errorf("HasComputedIdFormatFields(%q) returned unexpected value. got %t; want %t.", tc.name, got, tc.want)
+				t.Errorf("HasPostCreateComputedFields(%q) returned unexpected value. got %t; want %t.", tc.name, got, tc.want)
 			}
 		})
 	}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -291,7 +291,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- /* Set computed resource properties required for building the ID from create API response (as long as Create doesn't use an async operation) */}}
 {{- /* This is necessary so that the ID is set correctly (and so that the following Read can succeed.) */}}
 {{- /* Technically this should possibly use the read URL explicitly, since id_format could differ - but that might need to be in addition to id_format anyway. */}}
-{{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
+{{- if and $.HasPostCreateComputedFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
     // Set computed resource properties from create API response so that they're available on the subsequent Read
     // call.
     err = resource{{ $.ResourceName }}PostCreateSetComputedFields(d, meta, res)
@@ -309,7 +309,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 
 {{if and $.GetAsync ($.GetAsync.Allow "Create") -}}
 {{  if ($.GetAsync.IsA "OpAsync") -}}
-{{    if and $.GetAsync.Result.ResourceInsideResponse $.HasComputedIdFormatFields -}}
+{{    if and $.GetAsync.Result.ResourceInsideResponse $.HasPostCreateComputedFields -}}
     // Use the resource in the operation response to populate
     // identity fields and d.Id() before read
     var opRes map[string]interface{}
@@ -352,11 +352,11 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     }
 {{- end}}
 {{- end}}
-    {{- if $.HasComputedIdFormatFields}}
+    {{- if $.HasPostCreateComputedFields}}
     {{- $renderedIdFromName := "false" }}
     {{- range $prop := $.GettableProperties }}
     {{- /* Check if prop is potentially computed */}}
-    {{-   if and ($.InIdFormat $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
+    {{-   if and ($.InPostCreateComputed $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
     {{-     if and (eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl") (eq $renderedIdFromName "false") }}
     // Setting `name` field so that `id_from_name` flattener will work properly.
     if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(opRes["name"], d, config)); err != nil {
@@ -1222,7 +1222,7 @@ func resource{{ $.ResourceName -}}PostCreateFailure(d *schema.ResourceData, meta
 
     {{ $.CustomTemplate $.StateMigrationFile false -}}
 {{- end }}
-{{- if and $.HasComputedIdFormatFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
+{{- if and $.HasPostCreateComputedFields (or (or (not $.GetAsync) (not ($.GetAsync.Allow "Create"))) (and $.GetAsync (and ($.GetAsync.IsA "PollAsync") ($.GetAsync.Allow "Create"))))}}
 func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.ResourceData, meta interface{}, res map[string]interface{}) error {
     config := meta.(*transport_tpg.Config)
     {{- /* Don't render decoder for PollAsync resources - their decoders are expected to return `nil` until the resource completion completes, but we need to set their computed fields in order to call PollRead - so there can never be a dependency on the decoder. */}}
@@ -1252,7 +1252,7 @@ func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.Resource
     {{- $renderedIdFromName := "false" }}
     {{- range $prop := $.GettableProperties }}
     {{- /* Check if prop is potentially computed */}}
-    {{-   if and ($.InIdFormat $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
+    {{-   if and ($.InPostCreateComputed $prop) (and (or $prop.Output $prop.DefaultFromApi) (not $prop.IgnoreRead)) }}
     {{-     if and (eq $prop.CustomFlatten "templates/terraform/custom_flatten/id_from_name.tmpl") (eq $renderedIdFromName "false") }}
     // Setting `name` field so that `id_from_name` flattener will work properly.
     if err := d.Set("name", flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}Name(res["name"], d, config)); err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/13836. It turns out that active directory peering has divergent id_format and read url. Even though that's the only case right now, I think we should just handle both to be safe.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
