### PR TITLE
Add private_registry_config to VMware user and admin cluster resources.

### DIFF
--- a/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/VmwareAdminCluster.yaml
@@ -691,3 +691,13 @@ properties:
     name: enableAdvancedCluster
     description: If set, the advanced cluster feature is enabled.
     output: true
+  - type: NestedObject
+    name: privateRegistryConfig
+    description: Configuration for private registry.
+    properties:
+      - type: String
+        name: 'address'
+        description: The registry address.
+      - type: String
+        name: 'caCert'
+        description: Contains the CA certificate public key for private registry.

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_cluster_manuallb.tf.tmpl
@@ -88,4 +88,8 @@ resource "google_gkeonprem_vmware_cluster" "{{$.PrimaryResourceId}}" {
   auto_repair_config {
     enabled = true
   }
+  private_registry_config {
+    address: "test-adddress"
+    caCert: "test-ca-cert"
+  }
 }

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_cluster_test.go
@@ -479,6 +479,10 @@ func testAccGkeonpremVmwareCluster_vmwareClusterUpdateManualLb(context map[strin
     auto_repair_config {
       enabled = true
     }
+    private_registry_config {
+      address: "test-adddress"
+      caCert: "test-ca-cert"
+    }
   }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:
gkeonprem: added `private_registry_config` field to `google_gkeonprem_vmware_admin_cluster` resource
```
