### PR TITLE
fix(securitypolicy): add ja4 fingerprint

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicy.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicy.yaml
@@ -461,6 +461,7 @@ properties:
                 * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
                 * REGION_CODE: The country/region from which the request originates.
                 * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+                * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                 * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
               enum_values:
                 - 'ALL'
@@ -472,6 +473,7 @@ properties:
                 - 'SNI'
                 - 'REGION_CODE'
                 - 'TLS_JA3_FINGERPRINT'
+                - 'TLS_JA4_FINGERPRINT'
                 - 'USER_IP'
             - name: 'enforceOnKeyName'
               type: String
@@ -501,6 +503,7 @@ properties:
                       * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
                       * REGION_CODE: The country/region from which the request originates.
                       * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+                      * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                       * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
                     enum_values:
                       - 'ALL'
@@ -512,6 +515,7 @@ properties:
                       - 'SNI'
                       - 'REGION_CODE'
                       - 'TLS_JA3_FINGERPRINT'
+                      - 'TLS_JA4_FINGERPRINT'
                       - 'USER_IP'
                   - name: 'enforceOnKeyName'
                     type: String

--- a/mmv1/products/compute/RegionSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicyRule.yaml
@@ -354,6 +354,7 @@ properties:
           * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
           * REGION_CODE: The country/region from which the request originates.
           * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+          * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
           * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
         enum_values:
           - 'ALL'
@@ -365,6 +366,7 @@ properties:
           - 'SNI'
           - 'REGION_CODE'
           - 'TLS_JA3_FINGERPRINT'
+          - 'TLS_JA4_FINGERPRINT'
           - 'USER_IP'
       - name: 'enforceOnKeyName'
         type: String
@@ -394,6 +396,7 @@ properties:
                 * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
                 * REGION_CODE: The country/region from which the request originates.
                 * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+                * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                 * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
               enum_values:
                 - 'ALL'
@@ -405,6 +408,7 @@ properties:
                 - 'SNI'
                 - 'REGION_CODE'
                 - 'TLS_JA3_FINGERPRINT'
+                - 'TLS_JA4_FINGERPRINT'
                 - 'USER_IP'
             - name: 'enforceOnKeyName'
               type: String

--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -370,6 +370,7 @@ properties:
           * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
           * REGION_CODE: The country/region from which the request originates.
           * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+          * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
           * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
         enum_values:
           - 'ALL'
@@ -381,6 +382,7 @@ properties:
           - 'SNI'
           - 'REGION_CODE'
           - 'TLS_JA3_FINGERPRINT'
+          - 'TLS_JA4_FINGERPRINT'
           - 'USER_IP'
       - name: 'enforceOnKeyName'
         type: String
@@ -410,6 +412,7 @@ properties:
                 * SNI: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to ALL on a HTTP session.
                 * REGION_CODE: The country/region from which the request originates.
                 * TLS_JA3_FINGERPRINT: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+                * TLS_JA4_FINGERPRINT: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
                 * USER_IP: The IP address of the originating client, which is resolved based on "userIpRequestHeaders" configured with the security policy. If there is no "userIpRequestHeaders" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
               enum_values:
                 - 'ALL'
@@ -421,6 +424,7 @@ properties:
                 - 'SNI'
                 - 'REGION_CODE'
                 - 'TLS_JA3_FINGERPRINT'
+                - 'TLS_JA4_FINGERPRINT'
                 - 'USER_IP'
             - name: 'enforceOnKeyName'
               type: String

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -722,6 +722,63 @@ func testAccComputeRegionSecurityPolicy_withMultipleEnforceOnKeyConfigs_update(c
 	`, context)
 }
 
+func testAccComputeRegionSecurityPolicy_withMultipleEnforceOnKeyConfigs_ja4(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+		resource "google_compute_region_security_policy" "policy" {
+			name	= "tf-test%{random_suffix}"
+			type	= "CLOUD_ARMOR"
+			region  = "us-west2"
+
+			rules {
+				priority = "100"
+				action          = "throttle"
+				rate_limit_options {
+					conform_action = "allow"
+					exceed_action = "deny(429)"
+
+					rate_limit_threshold {
+						count = 10
+						interval_sec = 60
+					}
+
+					enforce_on_key_configs {
+						enforce_on_key_type = "USER_IP"
+					}
+
+					enforce_on_key_configs {
+						enforce_on_key_type = "TLS_JA4_FINGERPRINT"
+					}
+
+					enforce_on_key_configs {
+						enforce_on_key_type = "REGION_CODE"
+					}
+				}
+				match {
+					config {
+						src_ip_ranges = [
+							"*"
+						]
+					}
+					versioned_expr = "SRC_IPS_V1"
+				}
+			}
+
+			rules {
+				action   = "allow"
+				priority = "2147483647"
+				preview 	= false
+				match {
+					versioned_expr = "SRC_IPS_V1"
+					config {
+						src_ip_ranges = ["*"]
+					}
+				}
+				description = "default rule"
+			}
+		}
+	`, context)
+}
+
 func TestAccComputeRegionSecurityPolicy_regionSecurityPolicyRuleOrderingWithMultipleRules(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -338,7 +338,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Description:  `Determines the key to enforce the rateLimitThreshold on`,
-										ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "USER_IP", ""}, false),
+										ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "TLS_JA4_FINGERPRINT", "USER_IP", ""}, false),
 									},
 
 									"enforce_on_key_name": {
@@ -357,7 +357,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 													Type:         schema.TypeString,
 													Optional:     true,
 													Description:  `Determines the key to enforce the rate_limit_threshold on`,
-													ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "USER_IP"}, false),
+													ValidateFunc: validation.StringInSlice([]string{"ALL", "IP", "HTTP_HEADER", "XFF_IP", "HTTP_COOKIE", "HTTP_PATH", "SNI", "REGION_CODE", "TLS_JA3_FINGERPRINT", "TLS_JA4_FINGERPRINT", "USER_IP"}, false),
 												},
 												"enforce_on_key_name": {
 													Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_rule_test.go
@@ -237,6 +237,14 @@ func TestAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnK
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs3(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy_rule.policy_rule",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1011,6 +1019,54 @@ resource "google_compute_security_policy_rule" "policy_rule" {
 
     enforce_on_key_configs {
       enforce_on_key_type = "TLS_JA3_FINGERPRINT"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "USER_IP"
+    }
+  }
+}
+
+`, spName)
+}
+
+func testAccComputeSecurityPolicyRule_withRateLimitOption_withMultipleEnforceOnKeyConfigs3(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "basic policy base"
+}
+
+resource "google_compute_security_policy_rule" "policy_rule" {
+  security_policy = google_compute_security_policy.policy.name
+  description     = "throttle rule withMultipleEnforceOnKeyConfigs3"
+  action          = "throttle"
+  priority        = "100"
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["*"]
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action = "deny(429)"
+
+    rate_limit_threshold {
+      count = 10
+      interval_sec = 60
+    }
+
+    enforce_on_key = ""
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "REGION_CODE"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_type = "TLS_JA4_FINGERPRINT"
     }
 
     enforce_on_key_configs {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -523,6 +523,14 @@ func TestAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyCo
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyConfigs3(spName),
+			},
+			{
+				ResourceName:      "google_compute_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -1925,6 +1933,51 @@ resource "google_compute_security_policy" "policy" {
 
 			enforce_on_key_configs {
 				enforce_on_key_type = "TLS_JA3_FINGERPRINT"
+			}
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "USER_IP"
+			}
+		}
+	}
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_withRateLimitOption_withMultipleEnforceOnKeyConfigs3(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name        = "%s"
+	description = "throttle rule with enforce_on_key_configs"
+
+	rule {
+		action   = "throttle"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule withMultipleEnforceOnKeyConfigs3"
+
+		rate_limit_options {
+			conform_action = "allow"
+			exceed_action = "deny(429)"
+
+			rate_limit_threshold {
+				count = 10
+				interval_sec = 60
+			}
+
+			enforce_on_key = ""
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "REGION_CODE"
+			}
+
+			enforce_on_key_configs {
+				enforce_on_key_type = "TLS_JA4_FINGERPRINT"
 			}
 
 			enforce_on_key_configs {

--- a/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -351,6 +351,7 @@ The following arguments are supported:
   * `SNI`: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to `ALL` on a HTTP session.
   * `REGION_CODE`: The country/region from which the request originates.
   * `TLS_JA3_FINGERPRINT`: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+  * `TLS_JA4_FINGERPRINT`: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
   * `USER_IP`: The IP address of the originating client, which is resolved based on "user_ip_request_headers" configured with the securitypolicy. If there is no "user_ip_request_headers" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
 
 * `enforce_on_key_name` - (Optional) Rate limit key name applicable only for the following key types:
@@ -380,6 +381,7 @@ The following arguments are supported:
     * `SNI`: Server name indication in the TLS session of the HTTPS request. The key value is truncated to the first 128 bytes. The key type defaults to `ALL` on a HTTP session.
     * `REGION_CODE`: The country/region from which the request originates.
     * `TLS_JA3_FINGERPRINT`: JA3 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
+    * `TLS_JA4_FINGERPRINT`: JA4 TLS/SSL fingerprint if the client connects using HTTPS, HTTP/2 or HTTP/3. If not available, the key type defaults to ALL.
     * `USER_IP`: The IP address of the originating client, which is resolved based on "user_ip_request_headers" configured with the securitypolicy. If there is no "user_ip_request_headers" configuration or an IP address cannot be resolved from it, the key type defaults to IP.
 
 * `exceed_redirect_options` - (Optional) Parameters defining the redirect action that is used as the exceed action. Cannot be specified if the exceed action is not redirect. Structure is [documented below](#nested_exceed_redirect_options).


### PR DESCRIPTION
Attempts to fix https://github.com/hashicorp/terraform-provider-google/issues/22548. 

I took a stab at trying to add JA4 working off of the JA3. 

```release-note:enhancement
compute: added `TLS_JA4_FINGERPRINT` option to `enforce_on_key` field in `google_compute_region_security_policy`, `google_compute_security_policy`, and `google_compute_security_policy_rule` resources
```
