### PR TITLE
Add a new `recompute_message_storage_policy` option which allows an empty message storage policy to be sent. 

### DIFF
--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -52,6 +52,10 @@ iam_policy:
 custom_code:
   encoder: 'templates/terraform/encoders/no_send_name.go.tmpl'
   update_encoder: 'templates/terraform/update_encoder/pubsub_topic.tmpl'
+  constants: 'templates/terraform/constants/pubsub_topic.tmpl'
+  post_update: 'templates/terraform/post_update/pubsub_topic.go.tmpl'
+custom_diff:
+  - 'recomputeMessageStoragePolicy'
 error_retry_predicates:
 
   - 'transport_tpg.PubsubTopicProjectNotReady'
@@ -438,3 +442,14 @@ properties:
               The GCP service account to be used for Federated Identity authentication
               with Confluent Cloud.
             required: true
+virtual_fields:
+  - name: 'recompute_message_storage_policy'
+    type: Boolean
+    default_value: false
+    description: |
+      Controls the removal behavior of the message_storage_policy.
+      When false, removing the MessageStoragePolicy from config will not produce a diff as the
+      provider will default to the API's value.
+      When true, the provider will treat removing MessageStoragePolicy as requesting the
+      MessageStoragePolicy to be recomputed.
+      Defaults to false.

--- a/mmv1/templates/terraform/constants/pubsub_topic.tmpl
+++ b/mmv1/templates/terraform/constants/pubsub_topic.tmpl
@@ -3,26 +3,18 @@ func recomputeMessageStoragePolicy(_ context.Context, diff *schema.ResourceDiff,
 	if diff.Id() == "" {
 		return nil
 	}
-
-	sendZero := diff.Get("recompute_message_storage_policy").(bool)
-	if !sendZero {
+  // If recompute_message_storage_policy is not being changed from false to true, return immediately.
+	old, new := diff.GetChange("recompute_message_storage_policy")
+	if old != false || new != true {
 		return nil
 	}
-
 	configMessageStoragePolicy := diff.GetRawConfig().GetAttr("message_storage_policy")
 	if !configMessageStoragePolicy.IsKnown() {
 		return nil
 	}
 	configValueIsEmpty := configMessageStoragePolicy.IsNull() || configMessageStoragePolicy.LengthInt() == 0
-
-	stateMessageStoragePolicy := diff.GetRawState().GetAttr("message_storage_policy")
-	if !stateMessageStoragePolicy.IsKnown() {
-		return nil
-	}
-	stateValueIsEmpty := stateMessageStoragePolicy.IsNull() || stateMessageStoragePolicy.LengthInt() == 0
-
-	if configValueIsEmpty && !stateValueIsEmpty {
-		log.Printf("[DEBUG] setting message_storage_policy to newly empty")
+	if configValueIsEmpty {
+		log.Printf("[DEBUG] recalculating message storage policy as recompute_message_storage_policy is newly set to true and message_storage_policy is empty")
 		diff.SetNew("message_storage_policy", make([]interface{}, 0))
 	}
 

--- a/mmv1/templates/terraform/constants/pubsub_topic.tmpl
+++ b/mmv1/templates/terraform/constants/pubsub_topic.tmpl
@@ -1,4 +1,4 @@
-func sendMessageStoragePolicyIfEmptyDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func recomputeMessageStoragePolicy(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	// on create, return immediately as we don't need to determine if the value is empty or not
 	if diff.Id() == "" {
 		return nil

--- a/mmv1/templates/terraform/constants/pubsub_topic.tmpl
+++ b/mmv1/templates/terraform/constants/pubsub_topic.tmpl
@@ -1,0 +1,30 @@
+func sendMessageStoragePolicyIfEmptyDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	// on create, return immediately as we don't need to determine if the value is empty or not
+	if diff.Id() == "" {
+		return nil
+	}
+
+	sendZero := diff.Get("recompute_message_storage_policy").(bool)
+	if !sendZero {
+		return nil
+	}
+
+	configMessageStoragePolicy := diff.GetRawConfig().GetAttr("message_storage_policy")
+	if !configMessageStoragePolicy.IsKnown() {
+		return nil
+	}
+	configValueIsEmpty := configMessageStoragePolicy.IsNull() || configMessageStoragePolicy.LengthInt() == 0
+
+	stateMessageStoragePolicy := diff.GetRawState().GetAttr("message_storage_policy")
+	if !stateMessageStoragePolicy.IsKnown() {
+		return nil
+	}
+	stateValueIsEmpty := stateMessageStoragePolicy.IsNull() || stateMessageStoragePolicy.LengthInt() == 0
+
+	if configValueIsEmpty && !stateValueIsEmpty {
+		log.Printf("[DEBUG] setting message_storage_policy to newly empty")
+		diff.SetNew("message_storage_policy", make([]interface{}, 0))
+	}
+
+	return nil
+}

--- a/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
+++ b/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
@@ -2,90 +2,90 @@ if v, ok := d.GetOk("recompute_message_storage_policy"); ok && v.(bool) {
    // if message_storage_policy was dropped, but existed in state, send an empty object
   if rawCfg := d.GetRawConfig().GetAttr("message_storage_policy"); rawCfg.LengthInt() == 0 {
     log.Printf("[DEBUG] Sending empty message_storage_policy in update")
+    updateMask := []string{}
 		obj := make(map[string]interface{})
-		obj["messageStoragePolicy"] = make([]interface{}, 0)
+    updateMask = append(updateMask, "messageStoragePolicy")
 
-		// The rest is the same as the secondary_ip_range generated update code
-		// without the messageStoragePolicyProp logic
+		// The rest is the same as the generated update code in
+    // google/services/pubsub/resource_pubsub_topic.go without the
+    // messageStoragePolicyProp logic
     config := meta.(*transport_tpg.Config)
     userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
-            return err
+      return err
     }
 
     billingProject := ""
 
     project, err := tpgresource.GetProject(d, config)
     if err != nil {
-            return fmt.Errorf("Error fetching project for Topic: %s", err)
+      return fmt.Errorf("Error fetching project for Topic: %s", err)
     }
     billingProject = project
 
     kmsKeyNameProp, err := expandPubsubTopicKmsKeyName(d.Get("kms_key_name"), d, config)
     if err != nil {
-            return err
+      return err
     } else if v, ok := d.GetOkExists("kms_key_name"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, kmsKeyNameProp)) {
-            obj["kmsKeyName"] = kmsKeyNameProp
+      obj["kmsKeyName"] = kmsKeyNameProp
     }
     schemaSettingsProp, err := expandPubsubTopicSchemaSettings(d.Get("schema_settings"), d, config)
     if err != nil {
-            return err
+      return err
     } else if v, ok := d.GetOkExists("schema_settings"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, schemaSettingsProp)) {
-            obj["schemaSettings"] = schemaSettingsProp
+      obj["schemaSettings"] = schemaSettingsProp
     }
     messageRetentionDurationProp, err := expandPubsubTopicMessageRetentionDuration(d.Get("message_retention_duration"), d, config)
     if err != nil {
-            return err
+      return err
     } else if v, ok := d.GetOkExists("message_retention_duration"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, messageRetentionDurationProp)) {
-            obj["messageRetentionDuration"] = messageRetentionDurationProp
+      obj["messageRetentionDuration"] = messageRetentionDurationProp
     }
     ingestionDataSourceSettingsProp, err := expandPubsubTopicIngestionDataSourceSettings(d.Get("ingestion_data_source_settings"), d, config)
     if err != nil {
-            return err
+      return err
     } else if v, ok := d.GetOkExists("ingestion_data_source_settings"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, ingestionDataSourceSettingsProp)) {
-            obj["ingestionDataSourceSettings"] = ingestionDataSourceSettingsProp
+      obj["ingestionDataSourceSettings"] = ingestionDataSourceSettingsProp
     }
     labelsProp, err := expandPubsubTopicEffectiveLabels(d.Get("effective_labels"), d, config)
     if err != nil {
-            return err
+      return err
     } else if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
-            obj["labels"] = labelsProp
+      obj["labels"] = labelsProp
     }
 
     obj, err = resourcePubsubTopicUpdateEncoder(d, meta, obj)
     if err != nil {
-            return err
+      return err
     }
     url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}PubsubBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/topics/{{"{{"}}name{{"}}"}}")
     if err != nil {
-            return err
+      return err
     }
 
     log.Printf("[DEBUG] Updating Topic %q: %#v", d.Id(), obj)
     headers := make(http.Header)
-    updateMask := []string{}
-
     if d.HasChange("kms_key_name") {
-            updateMask = append(updateMask, "kmsKeyName")
+      updateMask = append(updateMask, "kmsKeyName")
     }
 
     if d.HasChange("message_storage_policy") {
-            updateMask = append(updateMask, "messageStoragePolicy")
+      updateMask = append(updateMask, "messageStoragePolicy")
     }
 
     if d.HasChange("schema_settings") {
-            updateMask = append(updateMask, "schemaSettings")
+      updateMask = append(updateMask, "schemaSettings")
     }
 
     if d.HasChange("message_retention_duration") {
-            updateMask = append(updateMask, "messageRetentionDuration")
+      updateMask = append(updateMask, "messageRetentionDuration")
     }
 
     if d.HasChange("ingestion_data_source_settings") {
-            updateMask = append(updateMask, "ingestionDataSourceSettings")
+      updateMask = append(updateMask, "ingestionDataSourceSettings")
     }
     if d.HasChange("effective_labels") {
-            updateMask = append(updateMask, "labels")
+      updateMask = append(updateMask, "labels")
     }
     // updateMask is a URL parameter but not present in the schema, so ReplaceVars
     // won't set it
@@ -96,28 +96,31 @@ if v, ok := d.GetOk("recompute_message_storage_policy"); ok && v.(bool) {
 
     // err == nil indicates that the billing_project value was found
     if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
-            billingProject = bp
+      billingProject = bp
     }
 
     // if updateMask is empty we are not updating anything so skip the post
     if len(updateMask) > 0 {
       res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-              Config:               config,
-              Method:               "PATCH",
-              Project:              billingProject,
-              RawURL:               url,
-              UserAgent:            userAgent,
-              Body:                 obj,
-              Timeout:              d.Timeout(schema.TimeoutUpdate),
-              Headers:              headers,
-              ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.PubsubTopicProjectNotReady},
+        Config:               config,
+        Method:               "PATCH",
+        Project:              billingProject,
+        RawURL:               url,
+        UserAgent:            userAgent,
+        Body:                 obj,
+        Timeout:              d.Timeout(schema.TimeoutUpdate),
+        Headers:              headers,
+        ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.PubsubTopicProjectNotReady},
       })
 
       if err != nil {
-              return fmt.Errorf("Error updating Topic %q: %s", d.Id(), err)
+        return fmt.Errorf("Error updating Topic %q: %s", d.Id(), err)
       } else {
-              log.Printf("[DEBUG] Finished updating Topic %q: %#v", d.Id(), res)
+        log.Printf("[DEBUG] Finished updating Topic %q: %#v", d.Id(), res)
       }
-    }                                                                                 
+    } else {
+      log.Printf("[DEBUG] Not sending update request for updating Topic %q", d.Id())
+    }
+    return resourcePubsubTopicRead(d, meta)                                                                                 
   }
 }

--- a/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
+++ b/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
@@ -1,0 +1,61 @@
+if v, ok := d.GetOk("recompute_message_storage_policy"); ok && v.(bool) {
+   // if message_storage_policy was dropped, but existed in state, send an empty object
+  if rawCfg := d.GetRawConfig().GetAttr("message_storage_policy"); rawCfg.LengthInt() == 0 {
+    log.Printf("[DEBUG] Sending empty message_storage_policy in update")
+		obj := make(map[string]interface{})
+		obj["messageStoragePolicy"] = make([]interface{}, 0)
+
+		// The rest is the same as the secondary_ip_range generated update code
+		// without the messageStoragePolicyProp logic
+
+   labelsProp, err := expandPubsubTopicLabels(d.Get("labels"), d, config)
+    if err != nil {
+      return err
+    } else if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
+      obj["labels"] = labelsProp
+    }
+
+    obj, err = resourcePubsubTopicUpdateEncoder(d, meta, obj)
+    if err != nil {
+      return err
+    }
+
+    url, err := replaceVars(d, config, "{{PubsubBasePath}}projects/{{project}}/topics/{{name}}")
+    if err != nil {
+      return err
+    }
+
+    log.Printf("[DEBUG] Updating Topic %q: %#v", d.Id(), obj)
+    updateMask := []string{}
+
+    if d.HasChange("labels") {
+      updateMask = append(updateMask, "labels")
+    }
+
+    if d.HasChange("message_storage_policy") {
+      updateMask = append(updateMask, "messageStoragePolicy")
+    }
+    // updateMask is a URL parameter but not present in the schema, so replaceVars
+    // won't set it
+    url, err = addQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+    
+    if err != nil {
+      return err
+    }
+
+    // err == nil indicates that the billing_project value was found
+    if bp, err := getBillingProject(d, config); err == nil {
+      billingProject = bp
+    }
+
+    res, err := sendRequestWithTimeout(config, "PATCH", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutUpdate), pubsubTopicProjectNotReady)
+
+    if err != nil {
+      return fmt.Errorf("Error updating Topic %q: %s", d.Id(), err)
+    } else {
+      log.Printf("[DEBUG] Finished updating Topic %q: %#v", d.Id(), res)
+    }
+
+    return resourcePubsubTopicRead(d, meta)
+  }
+}

--- a/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
+++ b/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
@@ -1,12 +1,13 @@
-if v, ok := d.GetOk("recompute_message_storage_policy"); ok && v.(bool) {
-   // if message_storage_policy was dropped, but existed in state, send an empty object
+
+old, new := d.GetChange("recompute_message_storage_policy")
+if (old == false && new == true) {
   if rawCfg := d.GetRawConfig().GetAttr("message_storage_policy"); rawCfg.LengthInt() == 0 {
     log.Printf("[DEBUG] Sending empty message_storage_policy in update")
     updateMask := []string{}
-		obj := make(map[string]interface{})
+    obj := make(map[string]interface{})
     updateMask = append(updateMask, "messageStoragePolicy")
 
-		// The rest is the same as the generated update code in
+    // The rest is the same as the generated update code in
     // google/services/pubsub/resource_pubsub_topic.go without the
     // messageStoragePolicyProp logic
     config := meta.(*transport_tpg.Config)

--- a/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
+++ b/mmv1/templates/terraform/post_update/pubsub_topic.go.tmpl
@@ -7,55 +7,117 @@ if v, ok := d.GetOk("recompute_message_storage_policy"); ok && v.(bool) {
 
 		// The rest is the same as the secondary_ip_range generated update code
 		// without the messageStoragePolicyProp logic
-
-   labelsProp, err := expandPubsubTopicLabels(d.Get("labels"), d, config)
+    config := meta.(*transport_tpg.Config)
+    userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
     if err != nil {
-      return err
-    } else if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
-      obj["labels"] = labelsProp
+            return err
+    }
+
+    billingProject := ""
+
+    project, err := tpgresource.GetProject(d, config)
+    if err != nil {
+            return fmt.Errorf("Error fetching project for Topic: %s", err)
+    }
+    billingProject = project
+
+    kmsKeyNameProp, err := expandPubsubTopicKmsKeyName(d.Get("kms_key_name"), d, config)
+    if err != nil {
+            return err
+    } else if v, ok := d.GetOkExists("kms_key_name"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, kmsKeyNameProp)) {
+            obj["kmsKeyName"] = kmsKeyNameProp
+    }
+    schemaSettingsProp, err := expandPubsubTopicSchemaSettings(d.Get("schema_settings"), d, config)
+    if err != nil {
+            return err
+    } else if v, ok := d.GetOkExists("schema_settings"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, schemaSettingsProp)) {
+            obj["schemaSettings"] = schemaSettingsProp
+    }
+    messageRetentionDurationProp, err := expandPubsubTopicMessageRetentionDuration(d.Get("message_retention_duration"), d, config)
+    if err != nil {
+            return err
+    } else if v, ok := d.GetOkExists("message_retention_duration"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, messageRetentionDurationProp)) {
+            obj["messageRetentionDuration"] = messageRetentionDurationProp
+    }
+    ingestionDataSourceSettingsProp, err := expandPubsubTopicIngestionDataSourceSettings(d.Get("ingestion_data_source_settings"), d, config)
+    if err != nil {
+            return err
+    } else if v, ok := d.GetOkExists("ingestion_data_source_settings"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, ingestionDataSourceSettingsProp)) {
+            obj["ingestionDataSourceSettings"] = ingestionDataSourceSettingsProp
+    }
+    labelsProp, err := expandPubsubTopicEffectiveLabels(d.Get("effective_labels"), d, config)
+    if err != nil {
+            return err
+    } else if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
+            obj["labels"] = labelsProp
     }
 
     obj, err = resourcePubsubTopicUpdateEncoder(d, meta, obj)
     if err != nil {
-      return err
+            return err
     }
-
-    url, err := replaceVars(d, config, "{{PubsubBasePath}}projects/{{project}}/topics/{{name}}")
+    url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}PubsubBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/topics/{{"{{"}}name{{"}}"}}")
     if err != nil {
-      return err
+            return err
     }
 
     log.Printf("[DEBUG] Updating Topic %q: %#v", d.Id(), obj)
+    headers := make(http.Header)
     updateMask := []string{}
 
-    if d.HasChange("labels") {
-      updateMask = append(updateMask, "labels")
+    if d.HasChange("kms_key_name") {
+            updateMask = append(updateMask, "kmsKeyName")
     }
 
     if d.HasChange("message_storage_policy") {
-      updateMask = append(updateMask, "messageStoragePolicy")
+            updateMask = append(updateMask, "messageStoragePolicy")
     }
-    // updateMask is a URL parameter but not present in the schema, so replaceVars
+
+    if d.HasChange("schema_settings") {
+            updateMask = append(updateMask, "schemaSettings")
+    }
+
+    if d.HasChange("message_retention_duration") {
+            updateMask = append(updateMask, "messageRetentionDuration")
+    }
+
+    if d.HasChange("ingestion_data_source_settings") {
+            updateMask = append(updateMask, "ingestionDataSourceSettings")
+    }
+    if d.HasChange("effective_labels") {
+            updateMask = append(updateMask, "labels")
+    }
+    // updateMask is a URL parameter but not present in the schema, so ReplaceVars
     // won't set it
-    url, err = addQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
-    
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
     if err != nil {
-      return err
+            return err
     }
 
     // err == nil indicates that the billing_project value was found
-    if bp, err := getBillingProject(d, config); err == nil {
-      billingProject = bp
+    if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+            billingProject = bp
     }
 
-    res, err := sendRequestWithTimeout(config, "PATCH", billingProject, url, userAgent, obj, d.Timeout(schema.TimeoutUpdate), pubsubTopicProjectNotReady)
+    // if updateMask is empty we are not updating anything so skip the post
+    if len(updateMask) > 0 {
+      res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+              Config:               config,
+              Method:               "PATCH",
+              Project:              billingProject,
+              RawURL:               url,
+              UserAgent:            userAgent,
+              Body:                 obj,
+              Timeout:              d.Timeout(schema.TimeoutUpdate),
+              Headers:              headers,
+              ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.PubsubTopicProjectNotReady},
+      })
 
-    if err != nil {
-      return fmt.Errorf("Error updating Topic %q: %s", d.Id(), err)
-    } else {
-      log.Printf("[DEBUG] Finished updating Topic %q: %#v", d.Id(), res)
-    }
-
-    return resourcePubsubTopicRead(d, meta)
+      if err != nil {
+              return fmt.Errorf("Error updating Topic %q: %s", d.Id(), err)
+      } else {
+              log.Printf("[DEBUG] Finished updating Topic %q: %#v", d.Id(), res)
+      }
+    }                                                                                 
   }
 }

--- a/mmv1/third_party/terraform/services/pubsub/BUILD
+++ b/mmv1/third_party/terraform/services/pubsub/BUILD
@@ -1,0 +1,25 @@
+load("//tools/build_defs/go:go_library.bzl", "go_library")
+load("//tools/build_defs/go:go_test.bzl", "go_test")
+
+go_library(
+    name = "pubsub",
+    srcs = [
+        "data_source_pubsub_subscription.go",
+        "data_source_pubsub_topic.go",
+        "iam_pubsub_subscription.go",
+        "pubsub_utils.go",
+    ],
+)
+
+go_test(
+    name = "pubsub_test",
+    srcs = [
+        "data_source_pubsub_subscription_test.go",
+        "data_source_pubsub_topic_test.go",
+        "iam_pubsub_subscription_test.go",
+        "iam_pubsub_topic_test.go",
+        "resource_pubsub_schema_test.go",
+        "resource_pubsub_subscription_test.go",
+        "resource_pubsub_topic_test.go",
+    ],
+)

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -239,6 +239,18 @@ resource "google_pubsub_topic" "foo" {
 `, topic, key, value, region)
 }
 
+func testAccPubsubTopic_removeMessageStoragePolicy(topic, key, value string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "foo" {
+  name = "%s"
+  labels = {
+    %s = "%s"
+  }
+	recompute_message_storage_policy = true
+}
+`, topic, key, value)
+}
+
 func testAccPubsubTopic_cmek(topicName, kmsKey string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "topic" {
@@ -582,4 +594,38 @@ resource "google_pubsub_topic" "foo" {
   }
 }
 `, topic)
+}
+
+func TestAccPubsubTopic_removeMessageStoragePolicy(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubTopic_updateWithRegion(topic, "wibble", "wobble", "us-central1"),
+			},
+			{
+				ResourceName:            "google_pubsub_topic.foo",
+				ImportStateId:           topic,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccPubsubTopic_removeMessageStoragePolicy(topic, "wibble", "wobble"),
+			},
+			{
+				ResourceName:            "google_pubsub_topic.foo",
+				ImportStateId:           topic,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
 }

--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -624,7 +624,57 @@ func TestAccPubsubTopic_removeMessageStoragePolicy(t *testing.T) {
 				ImportStateId:           topic,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "recompute_message_storage_policy"},
+			},
+		},
+	})
+}
+
+func TestAccPubsubTopic_noRemoveMessageStoragePolicy(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubTopic_updateWithRegion(topic, "wibble", "wobble", "us-central1"),
+			},
+			{
+				ResourceName:            "google_pubsub_topic.foo",
+				ImportStateId:           topic,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "recompute_message_storage_policy"},
+			},
+			{
+				// This step is to test that the recompute_message_storage_policy has no affect when there
+				// is a non-empty message_storage_policy.
+				Config: fmt.Sprintf(`
+					resource "google_pubsub_topic" "foo" {
+						name = "%s"
+						labels = {
+							wibble = "wobble"
+						}
+						message_storage_policy {
+							allowed_persistence_regions = [
+								"us-central1",
+							]
+							enforce_in_transit = false
+						}
+						recompute_message_storage_policy = true
+					}
+				`, topic),
+			},
+			{
+				ResourceName:            "google_pubsub_topic.foo",
+				ImportStateId:           topic,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "recompute_message_storage_policy"},
 			},
 		},
 	})


### PR DESCRIPTION
Add a new `recompute_message_storage_policy` option which allows an empty message storage policy to be sent. 
