### PR TITLE
Add kmskeyname to datastore

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -185,6 +185,16 @@ properties:
         type: Boolean
         description: If set true, automatic refresh is disabled for the DataStore.
         required: false
+  - name: 'kmsKeyName'
+    type: String
+    description: |
+      KMS key resource name which will be used to encrypt resources:
+      `/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{keyId}`
+      The KMS key to be used to protect this DataStore at creation time. Must be
+      set for requests that need to comply with CMEK Org Policy protections.
+      If this field is set and processed successfully, the DataStore will be
+      protected by the KMS key, as indicated in the cmek_config field.
+    required: false
   - name: 'documentProcessingConfig'
     type: NestedObject
     description: |

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -57,6 +57,13 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'
     vars:
       data_store_id: 'data-store-id'
+  - name: 'discoveryengine_datastore_kms_key_name'
+    primary_resource_id: 'kms_key_name'
+    vars:
+      data_store_id: 'data-store-id'
+      kms_key_name: 'kms-key'
+    test_vars_overrides:
+      kms_key_name: 'acctest.BootstrapKMSKeyInLocation(t, "eu").CryptoKey.Name'
   - name: 'discoveryengine_datastore_document_processing_config'
     primary_resource_id: 'document_processing_config'
     primary_resource_name: 'fmt.Sprintf("tf_test_data_store%s", context["random_suffix"])'

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_kms_key_name.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_kms_key_name.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_discovery_engine_data_store" "kms_key_name" {
+  location                     = "eu"
+  data_store_id                = "{{index $.Vars "data_store_id"}}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  kms_key_name                 = "{{index $.Vars "kms_key_name"}}"
+  create_advanced_site_search  = false
+  skip_default_schema_creation = false
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/19041

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
discoveryengine: added `kms_key_name` field to `google_discovery_engine_data_store` resource
```
