### PR TITLE
Add suspended field to dataplex data scan rules

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -369,6 +369,7 @@ properties:
               type: Boolean
               description: |
                 Whether the Rule is active or suspended. Default = false.
+              default_value: false
             - name: 'description'
               type: String
               description: |

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -365,6 +365,10 @@ properties:
                 The maximum length is 63 characters.
                 Must start with a letter.
                 Must end with a number or a letter.
+            - name: 'suspended'
+              type: Boolean
+              description: |
+                Whether the Rule is active or suspended. Default = false.
             - name: 'description'
               type: String
               description: |

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_datascan_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_datascan_test.go
@@ -222,6 +222,7 @@ resource "google_dataplex_datascan" "full_quality" {
         strict_min_enabled = true
         strict_max_enabled = false
       }
+      suspended = true
     }
   }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23123
```release-note:enhancement
dataplex: added `suspended` field to `google_dataplex_datascan` resource
```
