### PR TITLE
networkconnectivity: add `producer_instance_location` and `allowed_google_producers_resource_hierarchy_level` to `psc_config` for `google_network_connectivity_service_connection_policy`

### DIFF
--- a/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
+++ b/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
@@ -123,7 +123,7 @@ properties:
         description: |
           ProducerInstanceLocation is used to specify which authorization mechanism to use to determine which projects
           the Producer instance can be within.
-        required: true
+        default_from_api: true
         enum_values:
           - 'PRODUCER_INSTANCE_LOCATION_UNSPECIFIED'
           - 'CUSTOM_RESOURCE_HIERARCHY_LEVELS'

--- a/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
+++ b/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
@@ -118,6 +118,29 @@ properties:
         required: true
         item_type:
           type: String
+      - name: 'producerInstanceLocation'
+        type: Enum
+        description: |
+          ProducerInstanceLocation is used to specify which authorization mechanism to use to determine which projects
+          the Producer instance can be within.
+        required: true
+        enum_values:
+          - 'PRODUCER_INSTANCE_LOCATION_UNSPECIFIED'
+          - 'CUSTOM_RESOURCE_HIERARCHY_LEVELS'
+      - name: 'allowedGoogleProducersResourceHierarchyLevel'
+        type: Array
+        description: |
+          List of Projects, Folders, or Organizations from where the Producer instance can be within. For example,
+          a network administrator can provide both 'organizations/foo' and 'projects/bar' as
+          allowed_google_producers_resource_hierarchy_levels. This allowlists this network to connect with any Producer
+          instance within the 'foo' organization or the 'bar' project. By default,
+          allowedGoogleProducersResourceHierarchyLevel is empty. The format for each
+          allowedGoogleProducersResourceHierarchyLevel is / where is one of 'projects', 'folders', or 'organizations'
+          and is either the ID or the number of the resource type. Format for each
+          allowedGoogleProducersResourceHierarchyLevel value: 'projects/' or 'folders/' or 'organizations/' Eg.
+          [projects/my-project-id, projects/567, folders/891, organizations/123]
+        item_type:
+          String
       - name: 'limit'
         type: String
         description: |

--- a/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
+++ b/mmv1/products/networkconnectivity/ServiceConnectionPolicy.yaml
@@ -140,7 +140,7 @@ properties:
           allowedGoogleProducersResourceHierarchyLevel value: 'projects/' or 'folders/' or 'organizations/' Eg.
           [projects/my-project-id, projects/567, folders/891, organizations/123]
         item_type:
-          String
+          type: String
       - name: 'limit'
         type: String
         description: |

--- a/mmv1/templates/terraform/examples/network_connectivity_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_policy_basic.tf.tmpl
@@ -17,8 +17,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   description   = "my basic service connection policy"
   network = google_compute_network.producer_net.id
   psc_config {
-    subnetworks                = [google_compute_subnetwork.producer_subnet.id]
-    producer_instance_location = "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
-    limit                      = 2
+    subnetworks = [google_compute_subnetwork.producer_subnet.id]
+    limit = 2
   }
 }

--- a/mmv1/templates/terraform/examples/network_connectivity_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_policy_basic.tf.tmpl
@@ -17,7 +17,8 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   description   = "my basic service connection policy"
   network = google_compute_network.producer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.producer_subnet.id]
-    limit = 2
+    subnetworks                = [google_compute_subnetwork.producer_subnet.id]
+    producer_instance_location = "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
+    limit                      = 2
   }
 }

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccNetworkConnectivityServiceConnectionPolicy_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+		"org_id":                      envvar.GetTestOrgFromEnv(t),
 		"networkProducerName":         fmt.Sprintf("tf-test-network-%s", acctest.RandString(t, 10)),
 		"subnetworkProducerName1":     fmt.Sprintf("tf-test-subnet-producer-%s", acctest.RandString(t, 10)),
 		"subnetworkProducerName2":     fmt.Sprintf("tf-test-subnet-producer-%s", acctest.RandString(t, 10)),
@@ -74,9 +76,8 @@ func testAccNetworkConnectivityServiceConnectionPolicy_basic(context map[string]
     service_class = "gcp-memorystore-redis"
     network = google_compute_network.producer_net.id
     psc_config {
-      producer_instance_location = "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
-      subnetworks 				 = [google_compute_subnetwork.producer_subnet.id]
-      limit 					 = 2
+      subnetworks = [google_compute_subnetwork.producer_subnet.id]
+      limit = 2
     }
   }
 `, context)
@@ -106,8 +107,7 @@ resource "google_network_connectivity_service_connection_policy" "default" {
     subnetworks                                       = [google_compute_subnetwork.producer_subnet1.id]
     limit                                             = 4
     allowed_google_producers_resource_hierarchy_level = [
-        "projects/foo-bar",
-        "organizations/baz-qux",
+		"organizations/%{org_id}",
     ]
   }
   labels      = {

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
@@ -74,13 +74,9 @@ func testAccNetworkConnectivityServiceConnectionPolicy_basic(context map[string]
     service_class = "gcp-memorystore-redis"
     network = google_compute_network.producer_net.id
     psc_config {
-      producer_instance_location 						= "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
-      allowed_google_producers_resource_hierarchy_level = [
-          "projects/foo-bar",
-          "organizations/baz-qux",
-      ]
-      subnetworks 				 						= [google_compute_subnetwork.producer_subnet.id]
-      limit 					 						= 2
+      producer_instance_location = "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
+      subnetworks 				 = [google_compute_subnetwork.producer_subnet.id]
+      limit 					 = 2
     }
   }
 `, context)
@@ -106,9 +102,13 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   service_class = "gcp-memorystore-redis"
   network = google_compute_network.producer_net.id
   psc_config {
-    producer_instance_location = "CUSTOM_RESOURCE_HIERARCHY_LEVELS"
-    subnetworks                = [google_compute_subnetwork.producer_subnet1.id]
-    limit                      = 4
+    producer_instance_location                        = "CUSTOM_RESOURCE_HIERARCHY_LEVELS"
+    subnetworks                                       = [google_compute_subnetwork.producer_subnet1.id]
+    limit                                             = 4
+    allowed_google_producers_resource_hierarchy_level = [
+        "projects/foo-bar",
+        "organizations/baz-qux",
+    ]
   }
   labels      = {
     foo = "bar"

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
@@ -74,8 +74,13 @@ func testAccNetworkConnectivityServiceConnectionPolicy_basic(context map[string]
     service_class = "gcp-memorystore-redis"
     network = google_compute_network.producer_net.id
     psc_config {
-      subnetworks = [google_compute_subnetwork.producer_subnet.id]
-      limit = 2
+      producer_instance_location 						= "PRODUCER_INSTANCE_LOCATION_UNSPECIFIED"
+      allowed_google_producers_resource_hierarchy_level = [
+          "projects/foo-bar",
+          "organizations/baz-qux",
+      ]
+      subnetworks 				 						= [google_compute_subnetwork.producer_subnet.id]
+      limit 					 						= 2
     }
   }
 `, context)
@@ -101,8 +106,9 @@ resource "google_network_connectivity_service_connection_policy" "default" {
   service_class = "gcp-memorystore-redis"
   network = google_compute_network.producer_net.id
   psc_config {
-    subnetworks = [google_compute_subnetwork.producer_subnet1.id]
-    limit = 4
+    producer_instance_location = "CUSTOM_RESOURCE_HIERARCHY_LEVELS"
+    subnetworks                = [google_compute_subnetwork.producer_subnet1.id]
+    limit                      = 4
   }
   labels      = {
     foo = "bar"


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23077

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
* ~producerInstanceLocation [seems to be a required argument](https://cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest/v1/projects.locations.serviceConnectionPolicies#PscConfig) in the API~
* ~might introduce breaking change, because `producer_instance_location` is now required within `psc_config`~

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkconnectivity: add `psc_config.producer_instance_location` and `psc_config.allowed_google_producers_resource_hierarchy_level` fields to `google_network_connectivity_service_connection_policy`
```
