### PR TITLE
doc: state possible `total_egress_bandwidth_tier` values

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -470,7 +470,7 @@ var schemaNodePool = map[string]*schema.Schema{
 							"total_egress_bandwidth_tier": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: `Specifies the total network bandwidth tier for the NodePool. Valid values are: "TIER_1" and "TIER_UNSPECIFIED".`,
+								Description: `Specifies the total network bandwidth tier for the NodePool. [Valid values](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters.nodePools#NodePool.Tier) include: "TIER_1" and "TIER_UNSPECIFIED".`,
 							},
 						},
 					},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -470,7 +470,7 @@ var schemaNodePool = map[string]*schema.Schema{
 							"total_egress_bandwidth_tier": {
 								Type:        schema.TypeString,
 								Required:    true,
-								Description: `Specifies the total network bandwidth tier for the NodePool.`,
+								Description: `Specifies the total network bandwidth tier for the NodePool. Valid values are: "TIER_1" and "TIER_UNSPECIFIED".`,
 							},
 						},
 					},

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -240,7 +240,8 @@ cluster.
 
 <a name="network_performance_config"></a>The `network_performance_config` block supports:
 
-* `total_egress_bandwidth_tier` (Required) - Specifies the total network bandwidth tier for the NodePool. Valid values are: "TIER_1" and "TIER_UNSPECIFIED".
+* `total_egress_bandwidth_tier` (Required) - Specifies the total network bandwidth tier for the NodePool. [Valid values](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters.nodePools#NodePool.Tier) include: "TIER_1" and "TIER_UNSPECIFIED".
+* ```
 
 <a name="pod_cidr_overprovision_config"></a>The `pod_cidr_overprovision_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -240,7 +240,7 @@ cluster.
 
 <a name="network_performance_config"></a>The `network_performance_config` block supports:
 
-* `total_egress_bandwidth_tier` (Required) - Specifies the total network bandwidth tier for the NodePool.
+* `total_egress_bandwidth_tier` (Required) - Specifies the total network bandwidth tier for the NodePool. Valid values are: "TIER_1" and "TIER_UNSPECIFIED".
 
 <a name="pod_cidr_overprovision_config"></a>The `pod_cidr_overprovision_config` block supports:
 


### PR DESCRIPTION
Valid values seem to be "TIER_1" and "TIER_UNSPECIFIED" according to https://github.com/terraform-google-modules/terraform-google-kubernetes-engine?tab=readme-ov-file#node_pools-variable


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
