### PR TITLE
Improve Node Pool Reconciliation time by listing and caching node pools instead of getting them separately

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -5,7 +5,7 @@ import (
 	"log"
 	"regexp"
 	"strings"
-{{ if ne $.TargetVersionName `ga` }}
+{{- if ne $.TargetVersionName `ga` }}
 	"sync"
 {{- end }}
 	"time"
@@ -951,7 +951,7 @@ func resourceContainerNodePoolExists(d *schema.ResourceData, meta interface{}) (
 	}
 
 	name := getNodePoolName(d.Id())
-{{ if eq $.TargetVersionName `ga` }}
+{{- if eq $.TargetVersionName `ga` }}
 	clusterNodePoolsGetCall := config.NewContainerClient(userAgent).Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name))
 	if config.UserProjectOverride {
 		clusterNodePoolsGetCall.Header().Add("X-Goog-User-Project", nodePoolInfo.project)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23128

```release-note:none
```
