### PR TITLE
Feature gap: Add missed fields for Reservation resource

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -182,7 +182,7 @@ properties:
       - name: 'projects'
         type: Array
         description: |
-          List of project IDs with which the reservation is shared. Only available in beta.
+          List of project IDs with which the reservation is shared.
         item_type:
           type: String
         min_version: 'beta'
@@ -283,7 +283,7 @@ properties:
           - name: 'maintenanceInterval'
             type: Enum
             description: |
-              Specifies the frequency of planned maintenance events. The accepted values are: PERIODIC.
+              Specifies the frequency of planned maintenance events.
             enum_values:
               - 'AS_NEEDED'
               - 'PERIODIC'
@@ -338,7 +338,6 @@ properties:
         type: Enum
         description: |
           Sharing config for all Google Cloud services.
-          Possible values: ["ALLOW_ALL", "DISALLOW_ALL", "SERVICE_SHARE_TYPE_UNSPECIFIED"].
         enum_values:
           - 'ALLOW_ALL'
           - 'DISALLOW_ALL'

--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -341,7 +341,6 @@ properties:
         enum_values:
           - 'ALLOW_ALL'
           - 'DISALLOW_ALL'
-          - 'SERVICE_SHARE_TYPE_UNSPECIFIED'
         default_from_api: true
         immutable: true
   - name: 'enableEmergentMaintenance'

--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -58,6 +58,19 @@ examples:
     primary_resource_id: 'gce_reservation'
     vars:
       reservation_name: 'gce-reservation'
+  - name: 'reservation_basic_beta'
+    primary_resource_id: 'gce_reservation'
+    vars:
+      reservation_name: 'gce-reservation'
+    min_version: 'beta'
+  - name: 'reservation_source_instance_template'
+    primary_resource_id: 'gce_reservation_source_instance_template'
+    vars:
+      reservation_name: 'gce-reservation-source-instance-template'
+  - name: 'reservation_sharing_policy'
+    primary_resource_id: 'gce_reservation_sharing_policy'
+    vars:
+      reservation_name: 'gce-reservation-sharing-policy'
   - name: 'shared_reservation_basic'
     primary_resource_id: 'gce_reservation'
     vars:
@@ -69,6 +82,18 @@ examples:
     exclude_docs: true
       # Resource creation race
     skip_vcr: true
+  - name: 'shared_reservation_beta'
+    primary_resource_id: 'gce_reservation'
+    vars:
+      reservation_name: 'gce-shared-reservation-beta'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+      # Resource creation race
+    skip_vcr: true
+    min_version: 'beta'
 parameters:
   - name: 'zone'
     type: ResourceRef
@@ -154,6 +179,13 @@ properties:
               type: String
               description: |
                 The project id/number, should be same as the key of this project config in the project map.
+      - name: 'projects'
+        type: Array
+        description: |
+          List of project IDs with which the reservation is shared. Only available in beta.
+        item_type:
+          type: String
+        min_version: 'beta'
   - name: 'specificReservation'
     type: NestedObject
     description: |
@@ -178,8 +210,11 @@ properties:
         type: NestedObject
         description: |
           The instance properties for the reservation.
-        required: true
         immutable: true
+        default_from_api: true
+        exactly_one_of:
+          - 'specific_reservation.0.instance_properties'
+          - 'specific_reservation.0.source_instance_template'
         properties:
           - name: 'machineType'
             type: String
@@ -245,3 +280,75 @@ properties:
                     The size of the disk in base-2 GB.
                   required: true
                   immutable: true
+          - name: 'maintenanceInterval'
+            type: Enum
+            description: |
+              Specifies the frequency of planned maintenance events. The accepted values are: PERIODIC.
+            enum_values:
+              - 'AS_NEEDED'
+              - 'PERIODIC'
+              - 'RECURRENT'
+            min_version: 'beta'
+            immutable: true
+      - name: 'sourceInstanceTemplate'
+        type: String
+        description: |
+          Specifies the instance template to create the reservation. If you use this field, you must exclude the
+          instanceProperties field.
+        exactly_one_of:
+          - 'specific_reservation.0.instance_properties'
+          - 'specific_reservation.0.source_instance_template'
+  - name: 'deleteAtTime'
+    type: String
+    description: |
+      Absolute time in future when the reservation will be auto-deleted by Compute Engine. Timestamp is represented in RFC3339 text format.
+      Cannot be used with delete_after_duration.
+    immutable: true
+    default_from_api: true
+    conflicts:
+      - 'delete_after_duration.0.seconds'
+      - 'delete_after_duration.0.nanos'
+  - name: 'deleteAfterDuration'
+    type: NestedObject
+    description: |
+      Duration after which the reservation will be auto-deleted by Compute Engine. Cannot be used with delete_at_time.
+    ignore_read: true
+    properties:
+      - name: 'seconds'
+        type: String
+        description: |
+          Number of seconds for the auto-delete duration.
+        immutable: true
+        conflicts:
+          - 'delete_at_time'
+      - name: 'nanos'
+        type: Integer
+        description: |
+          Number of nanoseconds for the auto-delete duration.
+        immutable: true
+        conflicts:
+          - 'delete_at_time'
+  - name: 'reservationSharingPolicy'
+    type: NestedObject
+    description: |
+      Sharing policy for reservations with Google Cloud managed services.
+    default_from_api: true
+    properties:
+      - name: 'serviceShareType'
+        type: Enum
+        description: |
+          Sharing config for all Google Cloud services.
+          Possible values: ["ALLOW_ALL", "DISALLOW_ALL", "SERVICE_SHARE_TYPE_UNSPECIFIED"].
+        enum_values:
+          - 'ALLOW_ALL'
+          - 'DISALLOW_ALL'
+          - 'SERVICE_SHARE_TYPE_UNSPECIFIED'
+        default_from_api: true
+        immutable: true
+  - name: 'enableEmergentMaintenance'
+    type: Boolean
+    description: |
+      Indicates if this group of VMs have emergent maintenance enabled.
+    immutable: true
+    ignore_read: true
+    min_version: 'beta'

--- a/mmv1/templates/terraform/examples/reservation_basic_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/reservation_basic_beta.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_compute_reservation" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.Vars "reservation_name"}}"
+  zone     = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      min_cpu_platform     = "Intel Cascade Lake"
+      machine_type         = "n2-standard-2"
+      maintenance_interval = "PERIODIC"
+    }
+  }
+
+  enable_emergent_maintenance = true
+}

--- a/mmv1/templates/terraform/examples/reservation_sharing_policy.tf.tmpl
+++ b/mmv1/templates/terraform/examples/reservation_sharing_policy.tf.tmpl
@@ -1,0 +1,50 @@
+data "google_compute_image" "my_image" {
+  family = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name = "tf-test-instance-template"
+  machine_type = "g2-standard-4"
+  can_ip_forward = false
+  tags = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete = true
+    boot = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+  labels = {
+    my_label = "foobar"
+  }
+}
+
+resource "google_compute_reservation" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "reservation_name"}}"
+  zone = "us-central1-b"
+
+  specific_reservation {
+    count = 2
+    source_instance_template = google_compute_instance_template.foobar.self_link
+  }
+
+  reservation_sharing_policy {
+    service_share_type = "ALLOW_ALL"
+  }
+}

--- a/mmv1/templates/terraform/examples/reservation_source_instance_template.tf.tmpl
+++ b/mmv1/templates/terraform/examples/reservation_source_instance_template.tf.tmpl
@@ -1,0 +1,48 @@
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "tf-test-instance-template"
+  machine_type   = "n2-standard-2"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible       = false
+    automatic_restart = true
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+
+resource "google_compute_reservation" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "reservation_name"}}"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    source_instance_template = google_compute_instance_template.foobar.self_link
+  }
+}

--- a/mmv1/templates/terraform/examples/shared_reservation_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/shared_reservation_beta.tf.tmpl
@@ -49,10 +49,6 @@ resource "google_compute_reservation" "{{$.PrimaryResourceId}}" {
   }
   share_settings {
     share_type = "SPECIFIC_PROJECTS"
-    project_map {
-      id = google_project.guest_project.project_id
-      project_id = google_project.guest_project.project_id
-    }
     projects = [google_project.guest_project.name]
   }
   depends_on = [google_organization_policy.shared_reservation_org_policy,google_project_service.compute]

--- a/mmv1/templates/terraform/examples/shared_reservation_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/shared_reservation_beta.tf.tmpl
@@ -1,0 +1,59 @@
+resource "google_project" "owner_project" {
+  provider        = google-beta
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+
+resource "google_project_service" "compute" {
+  provider = google-beta
+  project  = google_project.owner_project.project_id
+  service  = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project" "guest_project" {
+  provider        = google-beta
+  project_id      = "tf-test-2%{random_suffix}"
+  name            = "tf-test-2%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_organization_policy" "shared_reservation_org_policy" {
+  provider   = google-beta
+  org_id     = "{{index $.TestEnvVars "org_id"}}"
+  constraint = "constraints/compute.sharedReservationsOwnerProjects"
+  list_policy {
+    allow {
+      values = ["projects/${google_project.owner_project.number}"]
+    }
+  }
+}
+
+resource "google_compute_reservation" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  project  = google_project.owner_project.project_id
+  name = "{{index $.Vars "reservation_name"}}"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+  share_settings {
+    share_type = "SPECIFIC_PROJECTS"
+    project_map {
+      id = google_project.guest_project.project_id
+      project_id = google_project.guest_project.project_id
+    }
+    projects = [google_project.guest_project.name]
+  }
+  depends_on = [google_organization_policy.shared_reservation_org_policy,google_project_service.compute]
+}

--- a/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
@@ -15,8 +15,36 @@
 	maskId := ""
 	firstProject := true
 	urlUpdateMask := ""
+{{- if ne $.TargetVersionName "ga" }}
+
+	if d.HasChange("share_settings.0.projects") {
+		// Get name.
+		nameProp, err := expandComputeReservationName(d.Get("name"), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid value for name: %s", err)
+		} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+			newObj["name"] = nameProp
+		}
+		// 	Get zone.
+		zoneProp, err := expandComputeReservationZone(d.Get("zone"), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid value for zone: %s", err)
+		} else if v, ok := d.GetOkExists("zone"); !tpgresource.IsEmptyValue(reflect.ValueOf(zoneProp)) && (ok || !reflect.DeepEqual(v, zoneProp)) {
+			newObj["zone"] = zoneProp
+		}
+		transformed := make(map[string]interface{})
+		// Set shareType and projects.
+		transformed["shareType"] = "SPECIFIC_PROJECTS"
+		transformed["projects"] = obj["shareSettings"].(map[string]interface{})["projects"]
+		urlUpdateMask = "?paths=shareSettings.projects"
+		newObj["shareSettings"] = transformed
+		newObj["urlUpdateMask"] = urlUpdateMask
+
+	} else if d.HasChange("share_settings") {
+{{- else }}
 
 	if d.HasChange("share_settings") {
+{{- end }}
 		// Get name.
 		nameProp, err := expandComputeReservationName(d.Get("name"), d, config)
 		if err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
@@ -2,7 +2,9 @@ package compute_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -38,6 +40,65 @@ func TestAccComputeReservation_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeReservation_deleteAtTime(t *testing.T) {
+	acctest.SkipIfVcr(t) // timestamp
+	t.Parallel()
+
+	reservationName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	deleteTime := time.Now().UTC().Add(24 * time.Hour) // Set delete_at_time to 24 hours in the future
+	deleteAtTimeRFC3339 := deleteTime.Format(time.RFC3339)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeReservationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeReservation_deleteAtTime_deleteAfterDuration(reservationName, deleteAtTimeRFC3339, deleteTime.Unix()),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+			{
+				Config: testAccComputeReservation_deleteAtTime(reservationName, deleteAtTimeRFC3339),
+			},
+			{
+				ResourceName:      "google_compute_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeReservation_deleteAfterDuration(t *testing.T) {
+	acctest.SkipIfVcr(t) // timestamp
+	t.Parallel()
+
+	reservationName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	deleteTime := time.Now().UTC().Add(24 * time.Hour) // Set delete_at_time to 24 hours in the future
+	deleteAtTimeRFC3339 := deleteTime.Format(time.RFC3339)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeReservationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeReservation_deleteAtTime_deleteAfterDuration(reservationName, deleteAtTimeRFC3339, deleteTime.Unix()),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+			{
+				Config: testAccComputeReservation_deleteAfterDuration(reservationName, deleteTime.Unix()),
+			},
+			{
+				ResourceName:            "google_compute_reservation.reservation",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_after_duration"},
+			},
+		},
+	})
+}
+
 func testAccComputeReservation_basic(reservationName, count string) string {
 	return fmt.Sprintf(`
 resource "google_compute_reservation" "reservation" {
@@ -53,4 +114,63 @@ resource "google_compute_reservation" "reservation" {
   }
 }
 `, reservationName, count)
+}
+
+func testAccComputeReservation_deleteAtTime(reservationName, time string) string {
+	return fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+  delete_at_time = "%s"
+
+  specific_reservation {
+    count = 2
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+}
+`, reservationName, time)
+}
+
+func testAccComputeReservation_deleteAfterDuration(reservationName string, duration int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+  delete_after_duration {
+	seconds = %d
+  }
+
+  specific_reservation {
+    count = 2
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+}
+`, reservationName, duration)
+}
+
+func testAccComputeReservation_deleteAtTime_deleteAfterDuration(reservationName, time string, duration int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+  delete_at_time = "%s"
+  delete_after_duration {
+	seconds = %d
+  }
+
+  specific_reservation {
+    count = 2
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+}
+`, reservationName, time, duration)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR provides below fields to providers:
- specificReservation.instanceProperties.maintenanceInterval - beta
- specificReservation.sourceInstanceTemplate - ga
- deleteAtTime - ga
- deleteAfterDuration.seconds - ga
- deleteAfterDuration.nanos - ga
- shareSettings.projects - beta
- reservationSharingPolicy.serviceShareType - ga
- enableEmergentMaintenance - beta

Additional information:
* `deleteAfterDuration` is `ignore_read` field, because it's used to set `deleteAtTime` field. `deleteAfterDuration` is not returned by API.
* `enableEmergentMaintenance` is `ignore_read` field, because it's not returned by API

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `specific_reservation.0.instance_properties.0.maintenance_interval`, `share_settings.0.projects` and `enable_emergent_maintenance` fields to `google_compute_reservation` resource (beta)
```

```release-note:enhancement
compute: added `specific_reservation.0.source_instance_template`, `delete_at_time`, `delete_after_duration.0.seconds`, `delete_after_duration.0.nanos` and `reservation_sharing_policy.0.service_share_type` fields to `google_compute_reservation` resource (ga)
```
