### PR TITLE
test: added test case that fails to reproduce `disabled` FW rule issu…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_rule_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_firewall_policy_rule_test.go
@@ -173,6 +173,43 @@ func TestAccComputeFirewallPolicyRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewallPolicyRule_disabled_enabled(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org_name":      fmt.Sprintf("organizations/%s", envvar.GetTestOrgFromEnv(t)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFirewallPolicyRule_disabled(context),
+			},
+			{
+				ResourceName:            "google_compute_firewall_policy_rule.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
+			},
+			{
+				Config: testAccComputeFirewallPolicyRule_enabled(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_firewall_policy_rule.default", "disabled", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_compute_firewall_policy_rule.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy"},
+			},
+		},
+	})
+}
+
 func testAccComputeFirewallPolicyRule_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_folder" "folder" {
@@ -774,6 +811,76 @@ resource "google_compute_firewall_policy_rule" "fw_policy_rule3" {
     src_fqdns                = ["google.com"]
     src_region_codes         = ["US"]
     src_threat_intelligences = ["iplist-known-malicious-ips"]
+  }
+}
+`, context)
+}
+
+func testAccComputeFirewallPolicyRule_disabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_folder" "default" {
+  display_name = "tf-test-folder-%{random_suffix}"
+  parent       = "%{org_name}"
+  deletion_protection = false
+}
+
+resource "google_compute_firewall_policy" "default" {
+  parent      = google_folder.default.name
+  short_name  = "tf-test-policy-%{random_suffix}"
+  description = "Resource created for Terraform acceptance testing"
+}
+
+resource "google_compute_firewall_policy_rule" "default" {
+  firewall_policy         = google_compute_firewall_policy.default.name
+  description             = "Resource created for Terraform acceptance testing"
+  priority                = 9000
+  enable_logging          = true
+  action                  = "allow"
+  direction               = "EGRESS"
+  disabled                = true
+
+  match {
+    dest_ip_ranges = ["35.235.240.0/20"]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = [22]
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeFirewallPolicyRule_enabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_folder" "default" {
+  display_name = "tf-test-folder-%{random_suffix}"
+  parent       = "%{org_name}"
+  deletion_protection = false
+}
+
+resource "google_compute_firewall_policy" "default" {
+  parent      = google_folder.default.name
+  short_name  = "tf-test-policy-%{random_suffix}"
+  description = "Resource created for Terraform acceptance testing"
+}
+
+resource "google_compute_firewall_policy_rule" "default" {
+  firewall_policy         = google_compute_firewall_policy.default.name
+  description             = "Resource created for Terraform acceptance testing"
+  priority                = 9000
+  enable_logging          = true
+  action                  = "allow"
+  direction               = "EGRESS"
+  disabled                = false
+
+  match {
+    dest_ip_ranges = ["35.235.240.0/20"]
+
+    layer4_configs {
+      ip_protocol = "tcp"
+      ports       = [22]
+    }
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
@@ -119,6 +119,12 @@ func resourceGoogleFolderCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
+	// if I do not add this locally, I get an error because config.ResourceManagerBasePath is not set:
+	// Error: Error creating folder 'tf-test-folder-a91bg4jvmy' in 'organizations/XXXXXXX':
+	// Error waiting for creating folder: error while retrieving operation: Get "operations/cf.6116480530026876052?alt=json": unsupported protocol scheme ""
+	// Will remove this in the actual PR, but want to discuss this because I face the error `unsupported protocol scheme ""` locally quite often when running acceptance tests
+	config.ResourceManagerBasePath = "https://cloudresourcemanager.googleapis.com/v3/"
+
 	err = ResourceManagerOperationWaitTime(config, opAsMap, "creating folder", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("Error creating folder '%s' in '%s': %s", displayName, parent, err)


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23135

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed `google_compute_firewall_policy_rule` staying disabled after apply with `disabled = false`
```
