### PR TITLE
Make Internal IPv6 Prefix configurable

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -463,7 +463,7 @@ properties:
     type: String
     description: |
       The internal IPv6 address range that is assigned to this subnetwork.
-    output: true
+    default_from_api: true
   - name: 'externalIpv6Prefix'
     type: String
     description: |


### PR DESCRIPTION
This change makes the `internal_ipv6_prefix` configurable to set it up.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Made Internal IPv6 Prefix in subnetwork configurable
```
