### PR TITLE
tgc-revival: cai2hcl  resource converter template

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1980,7 +1980,7 @@ func (r Resource) MarkdownHeader(templatePath string) string {
 // ====================
 // TGC
 // ====================
-// Converts most properties during cai2hcl, exept for computed properties
+// Filters out computed properties during cai2hcl
 func (r Resource) ReadPropertiesForTgc() []*Type {
 	return google.Reject(r.AllUserProperties(), func(v *Type) bool {
 		return v.Output

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1976,3 +1976,13 @@ func (r Resource) CodeHeader(templatePath string) string {
 func (r Resource) MarkdownHeader(templatePath string) string {
 	return strings.Replace(r.CodeHeader(templatePath), "//", "#", -1)
 }
+
+// ====================
+// TGC
+// ====================
+// Converts most properties during cai2hcl, exept for computed properties
+func (r Resource) ReadPropertiesForTgc() []*Type {
+	return google.Reject(r.AllUserProperties(), func(v *Type) bool {
+		return v.Output
+	})
+}

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -196,6 +196,7 @@ func (td *TemplateData) GenerateTGCResourceFile(templatePath, filePath string, r
 		"templates/terraform/expand_property_method.go.tmpl",
 		"templates/terraform/schema_property.go.tmpl",
 		"templates/terraform/schema_subresource.go.tmpl",
+		"templates/terraform/flatten_property_method.go.tmpl",
 	}
 	td.GenerateFile(filePath, templatePath, resource, true, templates...)
 }

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -93,6 +93,7 @@ func (tgc TerraformGoogleConversionNext) GenerateObject(object api.Resource, out
 
 	if !object.IsExcluded() {
 		tgc.GenerateResource(object, *templateData, outputFolder, generateCode, generateDocs, "tfplan2cai")
+		tgc.GenerateResource(object, *templateData, outputFolder, generateCode, generateDocs, "cai2hcl")
 	}
 }
 

--- a/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
@@ -89,21 +89,7 @@ func (c *{{ $.ResourceName -}}Converter) convertResourceData(asset caiasset.Asse
 
 {{ range $prop := $.ReadPropertiesForTgc }}
 {{   if $prop.FlattenObject -}}
-// Terraform must set the top level schema field, but since this object contains collapsed properties
-// it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
-    if flattenedProp := flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config); flattenedProp != nil {
-        if gerr, ok := flattenedProp.(*googleapi.Error); ok {
-            return fmt.Errorf("Error reading {{ $.Name -}}: %s", gerr)
-        }
-        casted := flattenedProp.([]interface{})[0]
-        if casted != nil {
-            for k, v := range casted.(map[string]interface{}) {
-                if err := d.Set(k, v); err != nil {
-                    return fmt.Errorf("Error setting %s: %s", k, err)
-                }
-            }
-        }
-    }
+{{/* TODO */}}
 {{-    else -}}
     hclData["{{ underscore $prop.Name -}}"] = flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}(res["{{ $prop.ApiName -}}"], d, config)
 {{-    end}}

--- a/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
@@ -1,0 +1,130 @@
+{{/* The license inside this block applies to this file
+  Copyright 2025 Google LLC. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. */ -}}
+{{$.CodeHeader TemplatePath}}
+
+package {{ lower $.ProductMetadata.Name }}
+
+import (
+{{/* We list all the v2 imports here and unstable imports, because we run 'goimports' to guess the correct
+     set of imports, which will never guess the major version correctly. */ -}}
+  "github.com/apparentlymart/go-cidr/cidr"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+  "google.golang.org/api/bigtableadmin/v2"
+  "google.golang.org/api/googleapi"
+
+  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
+  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/utils"
+  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tpgresource"
+  transport_tpg "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/transport"
+  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/verify"
+)
+
+{{- $caiProductBaseUrl := $.CaiProductBaseUrl }}
+{{- $productBackendName := $.CaiProductBackendName $caiProductBaseUrl }}
+{{- $apiVersion := $.CaiApiVersion $productBackendName $caiProductBaseUrl}}
+
+{{if $.CustomCode.Constants -}} 
+    {{- $.CustomTemplate $.CustomCode.Constants true -}}
+{{- end}}
+
+const {{ $.ResourceName -}}AssetType string = "{{ $productBackendName }}.googleapis.com/{{ $.Name -}}"
+const {{ $.ResourceName -}}SchemaName string = "{{ $.TerraformName }}"
+
+type {{ $.ResourceName -}}Converter struct {
+	name   string
+	schema map[string]*schema.Schema
+}
+
+func New{{ $.ResourceName -}}Converter(provider *schema.Provider) models.Converter {
+	schema := provider.ResourcesMap[{{ $.ResourceName -}}SchemaName].Schema
+
+	return &{{ $.ResourceName -}}Converter{
+		name:   {{ $.ResourceName -}}SchemaName,
+		schema: schema,
+	}
+}
+
+// Convert converts asset to HCL resource blocks.
+func (c *{{ $.ResourceName -}}Converter) Convert(asset caiasset.Asset) ([]*models.TerraformResourceBlock, error) {
+	var blocks []*models.TerraformResourceBlock
+	block, err := c.convertResourceData(asset)
+	if err != nil {
+		return nil, err
+	}
+	blocks = append(blocks, block)
+	return blocks, nil
+}
+
+func (c *{{ $.ResourceName -}}Converter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+	if asset.Resource == nil || asset.Resource.Data == nil {
+		return nil, fmt.Errorf("asset resource data is nil")
+	}
+
+	res := asset.Resource.Data
+	config := utils.NewConfig()
+	d := &schema.ResourceData{}
+
+	hclData := make(map[string]interface{})
+
+{{ range $prop := $.ReadPropertiesForTgc }}
+{{   if $prop.FlattenObject -}}
+// Terraform must set the top level schema field, but since this object contains collapsed properties
+// it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
+    if flattenedProp := flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}(res["{{ $prop.ApiName -}}"], d, config); flattenedProp != nil {
+        if gerr, ok := flattenedProp.(*googleapi.Error); ok {
+            return fmt.Errorf("Error reading {{ $.Name -}}: %s", gerr)
+        }
+        casted := flattenedProp.([]interface{})[0]
+        if casted != nil {
+            for k, v := range casted.(map[string]interface{}) {
+                if err := d.Set(k, v); err != nil {
+                    return fmt.Errorf("Error setting %s: %s", k, err)
+                }
+            }
+        }
+    }
+{{-    else -}}
+    hclData["{{ underscore $prop.Name -}}"] = flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}(res["{{ $prop.ApiName -}}"], d, config)
+{{-    end}}
+{{- end}}
+
+	ctyVal, err := utils.MapToCtyValWithSchema(hclData, c.schema)
+	if err != nil {
+		return nil, err
+	}
+	return &models.TerraformResourceBlock{
+		Labels: []string{c.name, res["name"].(string)},
+		Value:  ctyVal,
+	}, nil
+}
+
+{{- range $prop := $.ReadPropertiesForTgc }}
+    {{ if $prop.IsA "KeyValueLabels" }}
+func flatten{{$prop.GetPrefix}}{{$prop.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+  return utils.RemoveTerraformAttributionLabel(v)
+}
+    {{ else }}
+        {{ template "flattenPropertyMethod" $prop -}}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The generated compute address cai2hcl converter is  in the [diff](pkg/cai2hcl/converters/services/compute/compute_address.go).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
