### PR TITLE
Added Fingerprint to TargetHttpProxy and TartgetHttpsProxy

### DIFF
--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -58,6 +58,13 @@ examples:
     vars:
       target_http_proxy_name: 'test-https-redirect-proxy'
       url_map_name: 'url-map'
+  - name: 'target_http_proxy_fingerprint'
+    primary_resource_id: 'default'
+    vars:
+      target_http_proxy_name: 'test-fingerprint-proxy'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
 parameters:
 properties:
   - name: 'creationTimestamp'
@@ -112,3 +119,13 @@ properties:
       value is 600 seconds, the minimum allowed value is 5 seconds, and the
       maximum allowed value is 600 seconds. For Global external HTTP(S) load
       balancer (classic), this option is not available publicly.
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking.
+      This field will be ignored when inserting a TargetHttpProxy. An up-to-date fingerprint must be provided in order to
+      patch/update the TargetHttpProxy; otherwise, the request will fail with error 412 conditionNotMet.
+      To see the latest fingerprint, make a get() request to retrieve the TargetHttpProxy.
+      
+      A base64-encoded string.
+    output: true

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -126,6 +126,5 @@ properties:
       This field will be ignored when inserting a TargetHttpProxy. An up-to-date fingerprint must be provided in order to
       patch/update the TargetHttpProxy; otherwise, the request will fail with error 412 conditionNotMet.
       To see the latest fingerprint, make a get() request to retrieve the TargetHttpProxy.
-      
       A base64-encoded string.
     output: true

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -253,6 +253,5 @@ properties:
       This field will be ignored when inserting a TargetHttpsProxy. An up-to-date fingerprint must be provided in order to
       patch the TargetHttpsProxy; otherwise, the request will fail with error 412 conditionNotMet.
       To see the latest fingerprint, make a get() request to retrieve the TargetHttpsProxy.
-      
       A base64-encoded string.
     output: true

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -79,6 +79,14 @@ examples:
       certificate_manager_certificate_name: 'my-certificate'
       url_map_name: 'url-map'
       backend_service_name: 'backend-service'
+  - name: 'target_https_proxy_fingerprint'
+    primary_resource_id: 'default'
+    vars:
+      target_https_proxy_name: 'test-fingerprint-proxy'
+      ssl_certificate_name: 'my-certificate'
+      url_map_name: 'url-map'
+      backend_service_name: 'backend-service'
+      http_health_check_name: 'http-health-check'
 parameters:
 properties:
   - name: 'creationTimestamp'
@@ -238,3 +246,13 @@ properties:
     fingerprint_name: 'fingerprint'
     resource: 'ServerTlsPolicy'
     imports: 'selfLink'
+  - name: 'fingerprint'
+    type: Fingerprint
+    description: |
+      Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking.
+      This field will be ignored when inserting a TargetHttpsProxy. An up-to-date fingerprint must be provided in order to
+      patch the TargetHttpsProxy; otherwise, the request will fail with error 412 conditionNotMet.
+      To see the latest fingerprint, make a get() request to retrieve the TargetHttpsProxy.
+      
+      A base64-encoded string.
+    output: true

--- a/mmv1/templates/terraform/examples/target_http_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/target_http_proxy_fingerprint.tf.tmpl
@@ -42,4 +42,4 @@ resource "google_compute_http_health_check" "default" {
 output "target_http_proxy_fingerprint" {
   value       = google_compute_target_http_proxy.{{$.PrimaryResourceId}}.fingerprint
   description = "The fingerprint of the target HTTP proxy for optimistic locking"
-} 
+}

--- a/mmv1/templates/terraform/examples/target_http_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/target_http_proxy_fingerprint.tf.tmpl
@@ -1,0 +1,45 @@
+resource "google_compute_target_http_proxy" "{{$.PrimaryResourceId}}" {
+  name    = "{{index $.Vars "target_http_proxy_name"}}"
+  url_map = google_compute_url_map.default.id
+}
+
+resource "google_compute_url_map" "default" {
+  name            = "{{index $.Vars "url_map_name"}}"
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "{{index $.Vars "backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.Vars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+output "target_http_proxy_fingerprint" {
+  value       = google_compute_target_http_proxy.{{$.PrimaryResourceId}}.fingerprint
+  description = "The fingerprint of the target HTTP proxy for optimistic locking"
+} 

--- a/mmv1/templates/terraform/examples/target_https_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/target_https_proxy_fingerprint.tf.tmpl
@@ -1,0 +1,54 @@
+resource "google_compute_target_https_proxy" "{{$.PrimaryResourceId}}" {
+  name             = "{{index $.Vars "target_https_proxy_name"}}"
+  url_map          = google_compute_url_map.default.id
+  ssl_certificates = [google_compute_ssl_certificate.default.id]
+}
+
+resource "google_compute_ssl_certificate" "default" {
+  name        = "{{index $.Vars "ssl_certificate_name"}}"
+  private_key = file("path/to/private.key")
+  certificate = file("path/to/certificate.crt")
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "{{index $.Vars "url_map_name"}}"
+  description = "a description"
+
+  default_service = google_compute_backend_service.default.id
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_backend_service.default.id
+
+    path_rule {
+      paths   = ["/*"]
+      service = google_compute_backend_service.default.id
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "{{index $.Vars "backend_service_name"}}"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_http_health_check.default.id]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.Vars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+output "target_https_proxy_fingerprint" {
+  value       = google_compute_target_https_proxy.{{$.PrimaryResourceId}}.fingerprint
+  description = "The fingerprint of the target HTTPS proxy for optimistic locking"
+} 

--- a/mmv1/templates/terraform/examples/target_https_proxy_fingerprint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/target_https_proxy_fingerprint.tf.tmpl
@@ -51,4 +51,4 @@ resource "google_compute_http_health_check" "default" {
 output "target_https_proxy_fingerprint" {
   value       = google_compute_target_https_proxy.{{$.PrimaryResourceId}}.fingerprint
   description = "The fingerprint of the target HTTPS proxy for optimistic locking"
-} 
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds fingerprint fields to TargetHttpProxy and TargetHttpsProxy

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `fingerprint` field in `google_compute_target_http_proxy` and `google_compute_target_https_proxy` resources.
```
