### PR TITLE
Fix `target_server` validation for service attachment

### DIFF
--- a/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
@@ -1,10 +1,11 @@
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	resource := strings.Split(v.(string), "/")
-    resourceKind := resource[len(resource)-2]
-    resourceBound := resource[len(resource)-4]
     if len(resource) < 4 {
 		return nil, fmt.Errorf("invalid value for target_service")
 	}
+
+	resourceKind := resource[len(resource)-2]
+	resourceBound := resource[len(resource)-4]
     
     _, err := tpgresource.ParseRegionalFieldValue(resourceKind, v.(string), "project", resourceBound, "zone", d, config, true)
 	if err != nil {

--- a/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
@@ -1,16 +1,16 @@
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	resource := strings.Split(v.(string), "/")
-    if len(resource) < 4 {
+	if len(resource) < 4 {
 		return nil, fmt.Errorf("invalid value for target_service")
 	}
 
 	resourceKind := resource[len(resource)-2]
 	resourceBound := resource[len(resource)-4]
-    
-    _, err := tpgresource.ParseRegionalFieldValue(resourceKind, v.(string), "project", resourceBound, "zone", d, config, true)
+
+	_, err := tpgresource.ParseRegionalFieldValue(resourceKind, v.(string), "project", resourceBound, "zone", d, config, true)
 	if err != nil {
 		return nil, fmt.Errorf("invalid value for target_service: %w", err)
 	}
-    
-    return v, nil
+
+	return v, nil
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Originally addressed in https://github.com/GoogleCloudPlatform/magic-modules/pull/12571 where validation was added back for the `target_service` argument.

Unfortunately if an invalid format of a target service is provided, it will results in an out of bound exception due to the order of error handling/validating.

```
Stack trace from the terraform-provider-google_v6.35.0_x5 plugin:

panic: runtime error: index out of range [-1]

goroutine 186 [running]:
github.com/hashicorp/terraform-provider-google/google/services/compute.expandComputeServiceAttachmentTargetService({0x4090440, 0xc001677eb0}, {0x52fbf00, 0xc001f46e80}, 0xc00060b408)
	github.com/hashicorp/terraform-provider-google/google/services/compute/resource_compute_service_attachment.go:894 +0x1b3
```


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed validation for `target_service`  in `google_compute_service_attachment`
```
