### PR TITLE
Handle diffs correctly for the profile field in the Network resource.

### DIFF
--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -244,3 +244,4 @@ properties:
       following are valid URLs:
       * https://www.googleapis.com/compute/v1/projects/{projectId}/global/networkProfiles/{network_profile_name}
       * projects/{projectId}/global/networkProfiles/{network_profile_name}
+    diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -281,6 +281,49 @@ func TestAccComputeNetwork_networkProfile(t *testing.T) {
    })
 }
 
+func TestComputeNetworkProfileDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"old: no previous profile, new: partial profile URL": {
+			Old: "",
+			New: "projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			ExpectDiffSuppress: false,
+		},
+		"old: no previous profile, new: full profile URL": {
+			Old: "",
+			New: "https://www.googleapis.com/compute/v1/projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			ExpectDiffSuppress: false,
+		},
+		"old: beta profile URL, new: partial profile URL": {
+			Old: "https://www.googleapis.com/compute/beta/projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			New: "projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			ExpectDiffSuppress: true,
+		},
+		"old: v1 profile URL, new: partial profile URL": {
+			Old: "https://www.googleapis.com/compute/v1/projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			New: "projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			ExpectDiffSuppress: true,
+		},
+		"old: beta profile URL, new: v1 profile URL": {
+			Old: "https://www.googleapis.com/compute/beta/projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			New: "https://www.googleapis.com/compute/v1/projects/dummy-project/global/networkProfiles/europe-west1-b-vpc-roce",
+			ExpectDiffSuppress: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		tc := tc
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+			if tpgresource.CompareSelfLinkRelativePaths("", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+				t.Errorf("%q => %q expected DiffSuppress to return %t", tc.Old, tc.New, tc.ExpectDiffSuppress)
+			}
+		})
+	}
+}
+
 func TestAccComputeNetwork_numericId(t *testing.T) {
 	t.Parallel()
 	suffixName := acctest.RandString(t, 10)


### PR DESCRIPTION
Given the network_profile field in the Network resource is a URL reference, and can be specified using a few different forms (eg. different API versions, just relative path, etc.), it should be compared as merely a relative path to avoid diffs when the value is not changing.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23160

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed VPC Network's profile to not report diffs when it's not changing.
```
