### PR TITLE
Fix runner to surface generic errors

### DIFF
--- a/.ci/magician/exec/runner.go
+++ b/.ci/magician/exec/runner.go
@@ -131,6 +131,9 @@ func (ar *Runner) Run(name string, args []string, env map[string]string) (string
 		return "", fmt.Errorf("path error running %s: %v", name, typedErr)
 
 	}
+	if err != nil {
+		return "", fmt.Errorf("error running %q: %v", name, err)
+	}
 	return string(out), nil
 }
 

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -1,7 +1,5 @@
 package accesscontextmanager_test
 
-// Test change.
-
 import (
 	"fmt"
 	"testing"

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -1,5 +1,7 @@
 package accesscontextmanager_test
 
+// Test change.
+
 import (
 	"fmt"
 	"testing"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Note that this is not currently breaking or blocking anything I'm aware of, but when working through the EAP VCR setup, the runner appeared to be swallowing gsutil errors. I made this change directly in the CL, which seemed to work, so it seems like something we want upstream. My theory is that we can't assume all errors coming from CLI tools will be `ExitError` or `PathError`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
