### PR TITLE
Terraform should ignore "prodcurrent" and "prodprevious" when diff image subminor version for Dataproc clusters

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -262,7 +263,7 @@ func ResourceDataprocCluster() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Description: `The list of the labels (key/value pairs) configured on the resource and to be applied to instances in the cluster.
-				
+
 				**Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
 				Please refer to the field 'effective_labels' for all of the labels present on the resource.`,
 			},
@@ -3442,8 +3443,10 @@ func dataprocImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 	if newV.minor != oldV.minor {
 		return false
 	}
-	// Only compare subminor version if set in config version.
-	if newV.subminor != "" && newV.subminor != oldV.subminor {
+
+	ignoreSubminor := []string{"", "prodcurrent", "prodprevious"}
+	// Only compare subminor version if set to a numeric value in config version.
+	if !slices.Contains(ignoreSubminor, newV.subminor) && newV.subminor != oldV.subminor {
 		return false
 	}
 	// Only compare os if it is set in config version.

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_internal_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_internal_test.go
@@ -93,6 +93,8 @@ func TestDataprocDiffSuppress(t *testing.T) {
 		{"1.3.10-debian9", "1.3-debian9"},
 		{"1.3.10", "1.3"},
 		{"1.3-debian9", "1.3"},
+		{"1.3.10-debian9", "1.3.prodprevious-debian9"},
+		{"1.3.10-debian9", "1.3.prodcurrent-debian9"},
 	}
 
 	noSuppress := [][]string{
@@ -106,6 +108,9 @@ func TestDataprocDiffSuppress(t *testing.T) {
 		{"1.3", "1.3.10"},
 		{"1.3", "1.3.10-debian9"},
 		{"1.3", "1.3-debian9"},
+		{"1.3.prodprevious-debian9", "1.3.10-debian9"},
+		{"1.3.prodcurrent-debian9", "1.3.10-debian9"},
+		{"1.3.10-debian9", "1.3.randomstring-debian9"},
 	}
 
 	for _, tup := range doSuppress {


### PR DESCRIPTION
```release-note:bug
dataproc: Terraform should ignore "prodcurrent" and "prodprevious" when diff image subminor version for Dataproc clusters
```
