### PR TITLE
docs: fix(dataproc): Add notes on private APIs, new API guide

### DIFF
--- a/mmv1/products/dataproc/AutoscalingPolicy.yaml
+++ b/mmv1/products/dataproc/AutoscalingPolicy.yaml
@@ -19,6 +19,8 @@ description: |
   Describes an autoscaling policy for Dataproc cluster autoscaler.
 docs:
 id_format: 'projects/{{project}}/locations/{{location}}/autoscalingPolicies/{{policy_id}}'
+  note: |
+    Dataproc Autoscaling Policies are an integral part of the Dataproc service and, like other Dataproc components, may rely on internal or private Google Cloud APIs for their underlying operations. These internal APIs are not intended for direct customer management or enablement via Terraform. You do not need to explicitly manage or import any such internal APIs when using this resource; their functionality is handled automatically by Google Cloud. For a comprehensive explanation of how Terraform interacts with different types of Google Cloud APIs (public vs. private), please refer to the [Understanding Google Cloud APIs and Terraform Guide](../guides/understanding-apis-and-terraform.md).
 base_url: 'projects/{{project}}/locations/{{location}}/autoscalingPolicies'
 self_link: 'projects/{{project}}/locations/{{location}}/autoscalingPolicies/{{policy_id}}'
 import_format:

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -20,6 +20,8 @@ references:
     'Official Documentation': 'https://cloud.google.com/dataproc-metastore/docs/overview'
   api: 'https://cloud.google.com/dataproc-metastore/docs/reference/rest/v1/projects.locations.services'
 docs:
+  note: |
+    The Dataproc Metastore service, as a fully managed Google Cloud service, relies on internal or private APIs for its operational functionalities. These APIs are essential for the service's underlying mechanisms but are not intended for direct customer interaction, enablement, or management via Terraform. You do not need to explicitly manage or import any such internal APIs when using this resource; their functionality is handled automatically by Google Cloud. For a comprehensive explanation of how Terraform interacts with different types of Google Cloud APIs (public vs. private), please refer to the [Understanding Google Cloud APIs and Terraform Guide](../guides/understanding-apis-and-terraform.md).
 base_url: 'projects/{{project}}/locations/{{location}}/services'
 self_link: 'projects/{{project}}/locations/{{location}}/services/{{service_id}}'
 create_url: 'projects/{{project}}/locations/{{location}}/services?serviceId={{service_id}}'

--- a/mmv1/third_party/terraform/website/docs/guides/understanding-apis-and-terraform.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/understanding-apis-and-terraform.html.markdown
@@ -1,0 +1,148 @@
+---
+page_title: "Understanding Google Cloud APIs and Terraform"
+description: |-
+  A guide to understanding public and private Google Cloud APIs and their interaction with Terraform.
+---
+
+# Understanding Google Cloud APIs and Terraform
+
+This guide aims to clarify how Terraform interacts with Google Cloud APIs,
+differentiating between public and private APIs, and explaining key concepts
+like API enablement and resource import. This understanding is crucial for
+effectively managing your Google Cloud resources with Terraform and avoiding
+common pitfalls.
+
+## Public vs. Private Google Cloud APIs
+
+Google Cloud services expose various APIs that allow applications and tools
+(like Terraform) to interact with and manage resources. These APIs broadly fall
+into two categories:
+
+### Public APIs
+
+* **Purpose:** These are the primary interfaces for customers and tools to
+  create, configure, and manage Google Cloud resources (e.g., Compute Engine
+  instances, Cloud Storage buckets, BigQuery datasets).
+
+* **Exposure:** Public APIs are well-documented, have defined REST endpoints,
+  and are intended for external consumption. They are the APIs that the `google`
+  Terraform provider is built to interact with.
+
+* **Examples:** `compute.googleapis.com`, `storage.googleapis.com`,
+  `bigquery.googleapis.com`.
+
+### Private (Internal) APIs
+
+* **Purpose:** These APIs are internal to Google Cloud services, used by Google
+  itself for the internal operation, orchestration, and provisioning of its
+  managed services. They expose functionalities that are not meant for direct
+  customer interaction or management.
+
+* **Exposure:** Private APIs are generally not publicly documented, do not have
+  stable external endpoints, and are not designed for direct access by
+  third-party tools like Terraform. They are an implementation detail of the
+  service.
+
+* **Example:** `dataproc-control.googleapis.com` (as seen in Case 59936942) is
+  an internal API that Dataproc uses for its operational control
+  plane. Customers do not directly interact with or manage this API.
+
+## API Enablement vs. Resource Import in Terraform
+
+Understanding the distinction between "enabling an API" and "importing a resource" is fundamental to using Terraform effectively with Google Cloud.
+
+### Enabling an API
+
+* **What it means:** When you "enable an API" in Google Cloud, you are
+  activating a specific Google Cloud service for your project. This grants your
+  project the necessary permissions and access to use the functionalities of
+  that service and create resources managed by it.
+
+* **Terraform context:** In Terraform, this is typically done using the
+  `google_project_service` resource. This resource ensures that a specified
+  public API (e.g., `compute.googleapis.com`) is enabled for your Google Cloud
+  project.
+
+* **Purpose:** Enabling an API is a **prerequisite** for creating or managing
+  resources that belong to that service. For instance, you must enable
+  `compute.googleapis.com` before you can create `google_compute_instance`
+  resources.
+
+* **Example (Terraform):**
+    ```hcl
+    resource "google_project_service" "compute_api" {
+      project = "your-gcp-project-id"
+      service = "compute.googleapis.com"
+      disable_on_destroy = false
+    }
+    ```
+
+* **Important Note:** The `google_project_service` resource is designed
+  exclusively for managing the enablement state of **publicly accessible Google
+  Cloud APIs**. It is not intended for, and will not work with, internal or
+  private APIs. Attempting to use it for private APIs will result in errors, as
+  those APIs are not exposed through the public API surface for such management.
+
+### Importing a Resource
+
+* **What it means:** In Terraform, "importing" refers to bringing an **existing
+  cloud resource** (one that was created manually or by another process outside
+  of Terraform) under Terraform's management. When you import a resource,
+  Terraform generates a state entry for it, allowing you to manage its lifecycle
+  (updates, deletion) using your Terraform configuration.
+
+* **Terraform context:** This is achieved using the `terraform import` command,
+  or by utilizing `import` blocks introduced in Terraform 1.5+.
+
+* **Purpose:** To gain control over resources that were not initially
+  provisioned by Terraform.
+
+* **Example (Terraform CLI):**
+    ```bash
+    terraform import google_compute_instance.my_instance projects/your-gcp-project-id/zones/us-central1-a/instances/my-vm
+    ```
+
+* **Important Note:** You "import" *resources* (like a
+  `google_compute_instance`, `google_storage_bucket`,
+  `google_sql_database_instance`), not generally "APIs" themselves. While an
+  API's enablement is a state managed by `google_project_service`, the API
+  itself is not a resource that can be separately "imported" in the same manner
+  as a VM or a bucket. If a public API is enabled for your project, its
+  enablement state can be managed by the `google_project_service` resource and
+  brought into state by importing the `google_project_service` resource (e.g.,
+  `terraform import google_project_service.my_api
+  projects/your-gcp-project-id/services/compute.googleapis.com`), but this is
+  distinct from importing a product-specific resource.
+
+## Addressing Concerns about Private APIs (e.g., `dataproc-control.googleapis.com`)
+
+Customers sometimes encounter references to private APIs (like
+`dataproc-control.googleapis.com` for Dataproc) in logs or documentation and
+wonder if they need to enable or import them with Terraform.
+
+* **No Customer Action Required:** If an API is identified as a private or
+  internal Google Cloud API, you **do not** need to explicitly enable it using
+  `google_project_service` or attempt to import it with Terraform.
+
+* **Internal Management:** These APIs are crucial for the internal operation of
+  Google Cloud services. They are automatically managed by Google and are not
+  designed for direct customer interaction or management through public tools.
+
+* **No Impact on Service Usage:** Your inability to "import" or explicitly
+  manage such a private API via Terraform will **not** impact your ability to
+  use the associated Google Cloud service (e.g., Dataproc will function
+  correctly without you managing `dataproc-control.googleapis.com`). The
+  necessary internal API interactions are handled by Google.
+
+* **Focus on Public APIs:** When managing Google Cloud resources with Terraform,
+  your focus should solely be on enabling and configuring the **public APIs**
+  that correspond to the services and resources you intend to provision.
+
+## Conclusion
+
+By understanding the clear distinction between public and private Google Cloud
+APIs, and the specific roles of "enabling" APIs versus "importing" resources in
+Terraform, you can effectively manage your Google Cloud infrastructure. Do not
+attempt to explicitly manage or import private Google Cloud APIs; they are
+internal components handled by Google. Focus your Terraform configurations on
+the publicly exposed APIs and their corresponding resources.

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -12,6 +12,30 @@ Manages a Cloud Dataproc cluster resource within GCP.
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/dataproc/docs)
 
+## Important Considerations for Dataproc APIs
+
+Dataproc, like many Google Cloud managed services, utilizes internal or private
+APIs for its core operational control and orchestration. These APIs are
+essential for the service's functionality but are **not intended for direct
+customer management or enablement via Terraform**.
+
+* **Example:** The `dataproc-control.googleapis.com` API is a private API used
+  by Dataproc internally. You **do not** need to explicitly enable this API
+  using `google_project_service` or attempt to import it into your Terraform
+  state.
+
+* **No Customer Action Required:** Your Dataproc clusters and jobs will function
+  correctly without any explicit Terraform configuration for these internal
+  APIs. Google Cloud automatically handles their necessary interactions.
+
+* **Focus on Public APIs:** When managing Dataproc resources with Terraform,
+  your configurations should focus on the publicly exposed Dataproc APIs (e.g.,
+  those related to `dataproc.googleapis.com`) and the resources documented here.
+
+For a broader understanding of how Terraform interacts with different types of
+Google Cloud APIs (public vs. private), please refer to the [Understanding
+Google Cloud APIs and Terraform
+Guide](../guides/understanding-apis-and-terraform.md).
 
 !> **Warning:** Due to limitations of the API, all arguments except
 `labels`,`cluster_config.worker_config.num_instances` and `cluster_config.preemptible_worker_config.num_instances` are non-updatable. Changing `cluster_config.worker_config.min_num_instances` will be ignored. Changing others will cause recreation of the

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -9,6 +9,27 @@ description: |-
 Manages a job resource within a Dataproc cluster within GCE. For more information see
 [the official dataproc documentation](https://cloud.google.com/dataproc/).
 
+## Important Considerations for Dataproc Job APIs
+
+Dataproc jobs, as part of the Google Cloud Dataproc service, leverage internal
+or private APIs for their underlying execution and cluster interaction. These
+APIs are essential for the service's functionality but are **not intended for
+direct customer management or enablement via Terraform**.
+
+* **No Customer Action Required:** You do not need to explicitly enable or
+  attempt to import any internal Dataproc APIs (such as
+  `dataproc-control.googleapis.com`) when submitting jobs with Terraform. Their
+  necessary interactions are handled automatically by Google Cloud.
+
+* **Focus on Public APIs:** When configuring `google_dataproc_job` resources
+  with Terraform, your focus should remain on the publicly documented Dataproc
+  APIs and the configurations available within this resource.
+
+For a comprehensive explanation of how Terraform interacts with different types
+of Google Cloud APIs (public versus private), please refer to the [Understanding
+Google Cloud APIs and Terraform
+Guide](../guides/understanding-apis-and-terraform.md).
+
 !> **Note:** This resource does not support 'update' and changing any attributes will cause the resource to be recreated.
 
 ## Example usage

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown
@@ -6,7 +6,30 @@ description: |-
 
 # google_dataproc_workflow_template
 
-A Workflow Template is a reusable workflow configuration. It defines a graph of jobs with information on where to run those jobs.
+A Workflow Template is a reusable workflow configuration. It defines a graph of
+jobs with information on where to run those jobs.
+
+## Important Considerations for Dataproc Workflow Template APIs
+
+Dataproc Workflow Templates, as a component of Google Cloud Dataproc, leverage
+internal or private APIs for their underlying operations and
+orchestration. These APIs are essential for the service's functionality but are
+**not intended for direct customer management or enablement via Terraform**.
+
+* **No Customer Action Required:** You do not need to explicitly enable or
+  attempt to import any internal Dataproc APIs (such as
+  `dataproc-control.googleapis.com`) when using Workflow Templates with
+  Terraform. Their necessary interactions are handled automatically by Google
+  Cloud.
+
+* **Focus on Public APIs:** When configuring `google_dataproc_workflow_template`
+  resources with Terraform, your focus should remain on the publicly documented
+  Dataproc APIs and the configurations available within this resource.
+
+For a comprehensive explanation of how Terraform interacts with different types
+of Google Cloud APIs (public versus private), please refer to the [Understanding
+Google Cloud APIs and Terraform
+Guide](../guides/understanding-apis-and-terraform.md).
 
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -22,6 +22,47 @@ To get more information about `google_project_service`, see:
 * Terraform guidance
     * [User Guide - google_project_service](/docs/providers/google/guides/google_project_service.html)
 
+## Understanding API Types and Usage
+
+This `google_project_service` resource is specifically designed to manage the
+**enabled state of publicly documented and accessible Google Cloud APIs** for
+your project. It serves to ensure that the services you intend to use are
+activated and available.
+
+**Important Considerations for API Services:**
+
+* **Public vs. Private APIs:** Google Cloud services often rely on internal,
+  **private APIs** for their operational backbone. These APIs are not exposed
+  for direct customer management via `google_project_service` and are not
+  intended for external interaction. Attempting to manage such private APIs with
+  this resource will result in errors.
+
+    * **Example:** The `dataproc-control.googleapis.com` API is an internal
+      Google Cloud API used by Dataproc for its internal operations. You **do
+      not** need to enable or manage this API with `google_project_service`; its
+      functionality is handled automatically by Google Cloud.
+
+* **Purpose of `google_project_service`:** This resource *enables* a service for
+  your project, making its functionalities available. This is a prerequisite for
+  creating resources that depend on that service.
+
+* **Enabling vs. Importing:** It's critical to distinguish between *enabling* an
+  API and *importing a resource*.
+
+    * **Enabling an API** (using `google_project_service`): Activates a Google
+      Cloud service for your project.
+
+    * **Importing a Resource** (using `terraform import` or `import` blocks):
+      Brings an *existing, deployed cloud resource* (e.g., a Compute Engine
+      instance, a Cloud Storage bucket) under Terraform's management. You
+      typically import *resources*, not APIs themselves. While you can import
+      the `google_project_service` resource to manage an already-enabled public
+      API, you cannot "import" the underlying API's internal functionality.
+
+For a comprehensive explanation of public and private Google Cloud APIs and
+their interaction with Terraform, please refer to the [Understanding Google
+Cloud APIs and Terraform Guide](./understanding-apis-and-terraform.md).
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION

This commit addresses customer confusion encountered in support case go/sf/59936942 and customer issue 422413011, related to understanding and managing Google Cloud private APIs with Terraform.

The changes aim to:

- **Clarify the distinction between public and private APIs.** Customers frequently attempt to manage or "import" internal Google Cloud APIs (like `dataproc-control.googleapis.com`) using Terraform, leading to errors and misunderstanding.

- **Differentiate between API enablement and resource import.** The nuances of `google_project_service` versus `terraform import` are clarified to prevent misapplication.

- **Reassure customers that private APIs do not require explicit management** and their non-management does not impact service functionality.

This is achieved through the following modifications in the Magic Modules repository, which will then generate the updated documentation for the `terraform-provider-google` repository:

- **New File: `mmv1/third_party/terraform/website/docs/guides/understanding-apis-and-terraform.html.markdown`**

    - This new comprehensive guide provides foundational knowledge on Google Cloud API types, their interaction with Terraform, and clarifies the purpose of `google_project_service` and `terraform import`. It serves as a central reference point for these concepts.

- **Modify `mmv1/products/dataproc/AutoscalingPolicy.yaml`**

    - Adds a `note` to the `docs` block, explaining that Dataproc Autoscaling Policies, like other Dataproc components, rely on internal APIs not managed by Terraform.

- **Modify `mmv1/products/metastore/Service.yaml`**

    - Adds a `note` to the `docs` block, clarifying that Dataproc Metastore services use internal APIs that do not require explicit Terraform management.

- **Modify `mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown`**

    - Inserts a new "Understanding API Types and Usage" section, prominently warning users that this resource is only for public APIs and detailing the differences between enabling and importing, linking to the new conceptual guide.

- **Modify `mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown`**

    - Adds an "Important Considerations for Dataproc APIs" section, explicitly stating that `dataproc-control.googleapis.com` and similar internal APIs do not require customer management via Terraform, linking to the new guide.

- **Modify `mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown`**

    - Adds an "Important Considerations for Dataproc Job APIs" section, similar to the cluster documentation, clarifying the non-requirement for explicit management of internal APIs.

- **Modify `mmv1/third_party/terraform/website/docs/r/dataproc_workflow_template.html.markdown`**

    - Adds an "Important Considerations for Dataproc Workflow Template APIs" section, consistent with other Dataproc resource documentation, advising on internal API management.

These documentation enhancements are expected to significantly improve customer self-service capabilities by providing clear, consistent, and easily discoverable information, thereby reducing the volume of support cases related to these common misunderstandings.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
