### PR TITLE
Terraform integration for adding output only RoleBinding ID to entitlement resource

### DIFF
--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -225,6 +225,12 @@ properties:
                   description: |
                     The expression field of the IAM condition to be associated with the role. If specified, a user with an active grant for this entitlement would be able to access the resource only if this condition evaluates to true for their request.
                     https://cloud.google.com/iam/docs/conditions-overview#attributes.
+                - name: 'id'
+                  type: String
+                  description: |
+                    Output Only. The ID corresponding to this role binding in the policy binding. This will be unique within an entitlement across time. Gets re-generated each time the entitlement is updated.
+                  min_version: beta
+                  output: true
   - name: 'maxRequestDuration'
     type: String
     description: |


### PR DESCRIPTION
This Pull Request enhances the Entitlement Terraform resource by introducing a new RoleBinding id field. This is an OUTPUT ONLY field, meaning it will display the id for each of the role bindings associated with the entitlement, providing more visibility into the assigned roles and enabling more granular scoped grant creation.

Important Note: This Pull Request is being submitted for early review and feedback. However, it should only be merged into the main codebase once the backend API supporting scope selection has been fully promoted to beta. This dependency ensures that the new id field functions correctly and as intended with the corresponding API changes.



```
privilegedaccessmanager: added  RoleBinding `id` field to `google_privileged_access_manager_entitlement` resource
```
