### PR TITLE
tags: fixed permadiff for `parent` argument on `google_tags_location_tag_binding`

### DIFF
--- a/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_binding.go.tmpl
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_location_tag_binding.go.tmpl
@@ -35,6 +35,7 @@ func ResourceTagsLocationTagBinding() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
+				DiffSuppressFunc: tpgresource.ProjectNumberDiffSuppress,
 				Description: `The full resource name of the resource the TagValue is bound to. E.g. //cloudresourcemanager.googleapis.com/projects/123`,
 			},
 			"tag_value": {

--- a/mmv1/third_party/terraform/services/tags/resource_tags_test.go
+++ b/mmv1/third_party/terraform/services/tags/resource_tags_test.go
@@ -877,8 +877,6 @@ func TestAccTagsLocationTagBinding_locationTagBindingBasicWithProjectId(t *testi
 	t.Parallel()
 
 	context := map[string]interface{}{
-		// "org_id":        envvar.GetTestOrgFromEnv(t),
-		// "project_id":    "tf-test-" + acctest.RandString(t, 10),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23146

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
tags: fixed perma-diff for `parent` field in `google_tags_location_tag_binding` resource
```
