### PR TITLE
Add attestation rule to workload identity pool managed identity.

### DIFF
--- a/mmv1/products/iambeta/WorkloadIdentityPoolManagedIdentity.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPoolManagedIdentity.yaml
@@ -32,6 +32,9 @@ autogen_async: true
 custom_code:
   constants: 'templates/terraform/constants/iam_workload_identity_pool_managed_identity.go.tmpl'
   decoder: 'templates/terraform/decoders/treat_deleted_state_as_gone.go.tmpl'
+  post_create: 'templates/terraform/post_create/iam_workload_identity_pool_managed_identity.go.tmpl'
+  post_read: 'templates/terraform/post_read/iam_workload_identity_pool_managed_identity.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/iam_workload_identity_pool_managed_identity.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/iam_workload_identity_pool_managed_identity.go.tmpl'
 examples:
   - name: 'iam_workload_identity_pool_managed_identity_basic'
@@ -46,6 +49,8 @@ examples:
       workload_identity_pool_id: 'example-pool'
       workload_identity_pool_namespace_id: 'example-namespace'
       workload_identity_pool_managed_identity_id: 'example-managed-identity'
+    test_env_vars:
+      project: 'PROJECT_NUMBER'
 parameters:
   - name: 'workload_identity_pool_id'
     type: String
@@ -115,3 +120,21 @@ properties:
     description: |
       Whether the managed identity is disabled. If disabled, credentials may no longer be issued for
       the identity, however existing credentials will still be accepted until they expire.
+  - name: 'attestationRules'
+    type: Array
+    description: |
+      Defines which workloads can receive an identity within a pool. When an AttestationRule is
+      defined under a managed identity, matching workloads may receive that identity. A maximum of
+      50 AttestationRules can be set.
+    update_url: 'projects/{{project}}/locations/global/workloadIdentityPools/{{workload_identity_pool_id}}/namespaces/{{workload_identity_pool_namespace_id}}/managedIdentities/{{workload_identity_pool_managed_identity_id}}:setAttestationRules'
+    update_verb: 'POST'
+    is_set: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'googleCloudResource'
+          type: String
+          description: |
+            A single workload operating on Google Cloud. For example:
+            `//compute.googleapis.com/projects/123/uid/zones/us-central1-a/instances/12345678`.
+          required: true

--- a/mmv1/templates/terraform/examples/iam_workload_identity_pool_managed_identity_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iam_workload_identity_pool_managed_identity_full.tf.tmpl
@@ -20,4 +20,10 @@ resource "google_iam_workload_identity_pool_managed_identity" "{{$.PrimaryResour
   workload_identity_pool_managed_identity_id = "{{index $.Vars "workload_identity_pool_managed_identity_id"}}"
   description                                = "Example Managed Identity in a Workload Identity Pool Namespace"
   disabled                                   = true
+  attestation_rules {
+    google_cloud_resource = "//compute.googleapis.com/projects/{{index $.TestEnvVars "project"}}/uid/zones/us-central1-a/instances/12345678"
+  }
+  attestation_rules {
+    google_cloud_resource = "//run.googleapis.com/projects/{{index $.TestEnvVars "project"}}/name/locations/us-east1/services/my-service"
+  }
 }

--- a/mmv1/templates/terraform/post_create/iam_workload_identity_pool_managed_identity.go.tmpl
+++ b/mmv1/templates/terraform/post_create/iam_workload_identity_pool_managed_identity.go.tmpl
@@ -1,0 +1,32 @@
+	// create attestation_rules
+	if hasRule {
+		qIdx := strings.Index(url, "?")
+		var basePath string
+		if qIdx != -1 {
+			basePath = url[:qIdx]
+		} else {
+			basePath = url
+		}
+		ruleUrl := basePath + "/" + d.Get("workload_identity_pool_managed_identity_id").(string) + ":setAttestationRules"
+
+		ruleRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   billingProject,
+			RawURL:    ruleUrl,
+			UserAgent: userAgent,
+			Body:      ruleObj,
+			Timeout:   d.Timeout(schema.TimeoutCreate),
+			Headers:   headers,
+		})
+		if err != nil {
+			return fmt.Errorf("Error creating WorkloadIdentityPoolManagedIdentity %q: %s", d.Id(), err)
+		}
+
+		err = IAMBetaOperationWaitTime(
+			config, ruleRes, project, "Creating WorkloadIdentityPoolManagedIdentity", userAgent,
+			d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return fmt.Errorf("Error waiting to create WorkloadIdentityPoolManagedIdentity: %s", err)
+		}
+	}

--- a/mmv1/templates/terraform/post_read/iam_workload_identity_pool_managed_identity.go.tmpl
+++ b/mmv1/templates/terraform/post_read/iam_workload_identity_pool_managed_identity.go.tmpl
@@ -1,0 +1,18 @@
+	// list attestation_rules
+	ruleUrl := url + ":listAttestationRules"
+
+	ruleRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    ruleUrl,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("IAMBetaWorkloadIdentityPoolManagedIdentity %q", d.Id()))
+	}
+
+	for k, v := range ruleRes {
+		res[k] = v
+	}

--- a/mmv1/templates/terraform/pre_create/iam_workload_identity_pool_managed_identity.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/iam_workload_identity_pool_managed_identity.go.tmpl
@@ -1,0 +1,7 @@
+	// see if we need to create attestation_rules
+	_, hasRule := d.GetOk("attestation_rules")
+	ruleObj := make(map[string]interface{})
+	if hasRule {
+		ruleObj["attestationRules"] = attestationRulesProp
+		delete(obj, "attestationRules")
+	}

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_managed_identity_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_managed_identity_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccIAMBetaWorkloadIdentityPoolManagedIdentity_minimal(t *testing.T) {
@@ -53,6 +54,7 @@ func TestAccIAMBetaWorkloadIdentityPoolManagedIdentity_full(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectNumberFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -138,6 +140,12 @@ resource "google_iam_workload_identity_pool_managed_identity" "example" {
   workload_identity_pool_managed_identity_id = "tf-test-example-managed-identity%{random_suffix}"
   description                                = "Example Managed Identity in a Workload Identity Pool Namespace"
   disabled                                   = true
+  attestation_rules {
+    google_cloud_resource = "//compute.googleapis.com/projects/%{project}/uid/zones/us-central1-a/instances/12345678"
+  }
+  attestation_rules {
+    google_cloud_resource = "//run.googleapis.com/projects/%{project}/name/locations/us-east1/services/my-service"
+  }
 }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
iam_beta: added `attestation_rules` field to `google_iam_workload_identity_pool_managed_identity` resource
```

`attestation_rules` is using a different set of API endpoints ([`listAttestationRules`](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.namespaces.managedIdentities/listAttestationRules), [`setAttestationRules`](https://cloud.google.com/iam/docs/reference/rest/v1/projects.locations.workloadIdentityPools.namespaces.managedIdentities/setAttestationRules)), hence injected code before & after `create`, and after `read` to support this. 