### PR TITLE
remove ignoredPorjectServices in google_project_service

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -810,16 +810,13 @@ func ListCurrentlyEnabledServices(project, billingProject, userAgent string, con
 						// services are returned as "projects/{{project}}/services/{{name}}"
 						name := tpgresource.GetResourceNameFromSelfLink(v.Name)
 
-						// if name not in ignoredProjectServicesSet
-						if _, ok := ignoredProjectServicesSet[name]; !ok {
-							apiServices[name] = struct{}{}
+						apiServices[name] = struct{}{}
 
-							// if a service has been renamed, set both. We'll deal
-							// with setting the right values later.
-							if v, ok := renamedServicesByOldAndNewServiceNames[name]; ok {
-								log.Printf("[DEBUG] Adding service alias for %s to enabled services: %s", name, v)
-								apiServices[v] = struct{}{}
-							}
+						// if a service has been renamed, set both. We'll deal
+						// with setting the right values later.
+						if v, ok := renamedServicesByOldAndNewServiceNames[name]; ok {
+							log.Printf("[DEBUG] Adding service alias for %s to enabled services: %s", name, v)
+							apiServices[v] = struct{}{}
 						}
 					}
 					return nil

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -21,11 +21,6 @@ import (
     "google.golang.org/api/serviceusage/v1"
 )
 
-// These services can only be enabled as a side-effect of enabling other services,
-// so don't bother storing them in the config or using them for diffing.
-var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com"}
-var ignoredProjectServicesSet = tpgresource.GolangSetFromStringSlice(ignoredProjectServices)
-
 // Services that can't be user-specified but are otherwise valid. Renamed
 // services should be added to this set during major releases.
 var bannedProjectServices = []string{"bigquery-json.googleapis.com"}
@@ -65,7 +60,7 @@ var renamedServicesByOldAndNewServiceNames = tpgresource.MergeStringMaps(Renamed
 const maxServiceUsageBatchSize = 20
 
 func validateProjectServiceService(val interface{}, key string) (warns []string, errs []error) {
-	bannedServicesFunc := verify.StringNotInSlice(append(ignoredProjectServices, bannedProjectServices...), false)
+	bannedServicesFunc := verify.StringNotInSlice(bannedProjectServices, false)
 	warns, errs = bannedServicesFunc(val, key)
 	if len(errs) > 0 {
 		return

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_internal_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_internal_test.go
@@ -9,10 +9,6 @@ func TestProjectServiceServiceValidateFunc(t *testing.T) {
 		val                   interface{}
 		ExpectValidationError bool
 	}{
-		"ignoredProjectService": {
-			val:                   "dataproc-control.googleapis.com",
-			ExpectValidationError: true,
-		},
 		"bannedProjectService": {
 			val:                   "bigquery-json.googleapis.com",
 			ExpectValidationError: true,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
b/422413011

Remove the `ignoredPorjectServices`  validation 
1. `dataproc-control.googleapis.com` is enabled automatically when `dataproc.googleapis.com` is enabled, and need to be disabled separately.
2. `source.googleapis.com` has been deprecated
3. `stackdriverprovisioning.googleapis.com` can be enabled and disabled separately.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
resourcemanager: allowed `dataproc-control.googleapis.com` and `stackdriverprovisioning.googleapis.com` services in `google_project_service` resource 
```
