### PR TITLE
[#23232] Add region url_parameter to google_vertex_ai_index_endpoint_…

### DIFF
--- a/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
@@ -108,6 +108,11 @@ parameters:
     immutable: true
     resource: 'IndexEndpoint'
     imports: 'name'
+  - name: 'region'
+    type: String
+    description: The region of the index endpoint deployment. eg us-central1
+    url_param_only: true
+    immutable: true
 properties:
   - name: 'name'
     type: String


### PR DESCRIPTION
Adds `region` url_parameter to `google_vertex_ai_index_endpoint_deployed_index`.

Reference [hashicorp/terraform-provider-google/issues/23232](https://github.com/hashicorp/terraform-provider-google/issues/23232)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
vertexai: added missing region url_param in `google_vertex_ai_index_endpoint_deployed_index`
```
