### PR TITLE
Fix TTL zero value handling in compute backend service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -683,16 +683,19 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'clientTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -445,6 +445,29 @@ func TestAccComputeBackendService_withCdnPolicy(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_withCdnPolicyTtlZero(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withCdnPolicyTtlZero(serviceName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_withSecurityPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -1847,6 +1870,36 @@ resource "google_compute_backend_service" "foobar" {
       include_protocol       = true
       include_host           = true
       include_query_string   = true
+    }
+  }
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeBackendService_withCdnPolicyTtlZero(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+  enable_cdn    = true
+
+  cdn_policy {
+    cache_mode   = "CACHE_ALL_STATIC"
+    default_ttl  = 0
+    client_ttl   = 0
+    max_ttl      = 60
+    negative_caching = false
+    cache_key_policy {
+      include_protocol     = true
+      include_host         = true
+      include_query_string = true
     }
   }
 }


### PR DESCRIPTION
Add send_empty_value: true to TTL fields (defaultTtl, maxTtl, clientTtl) to ensure zero values are included in API requests rather than being treated as empty and omitted.

This resolves the issue where setting client_ttl=0 would cause the API to apply its default value of 3600, leading to validation errors when combined with lower max_ttl values.

Also adds test case to verify TTL zero value behavior works correctly.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/21632

```release-note:bug
compute: fixed `client_ttl`, `default_ttl`, and `max_ttl` fields in `google_compute_backend_service` and `google_compute_region_backend_service` not being sent to API when set to 0, which caused the API to apply default values and potentially trigger validation errors```