### PR TITLE
Magician vacation yaml

### DIFF
--- a/.ci/magician/cmd/data/reviewer_rotation.yaml
+++ b/.ci/magician/cmd/data/reviewer_rotation.yaml
@@ -1,0 +1,65 @@
+BBBmau:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/04/07
+          end: 2025/04/11
+NickElliot:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+ScottSuarez:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+SirGitsalot:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/01/18
+          end: 2025/01/25
+c2thorn:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/04/09
+          end: 2025/04/15
+hao-nan-li:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+melinath:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+rileykarson:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/02/25
+          end: 2025/03/10
+roaks3:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+shuyama1:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/05/23
+          end: 2025/05/30
+slevenick:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/05/22
+          end: 2025/06/07
+trodge:
+    timezone: US/Pacific
+    vacations:
+        - start: YYYY/MM/DD
+          end: YYYY/MM/DD
+zli82016:
+    timezone: US/Pacific
+    vacations:
+        - start: 2025/01/15
+          end: 2025/02/09

--- a/.ci/magician/cmd/reassign_reviewer.go
+++ b/.ci/magician/cmd/reassign_reviewer.go
@@ -60,6 +60,10 @@ var reassignReviewerCmd = &cobra.Command{
 		if len(args) > 2 {
 			newPrimaryReviewer = args[2]
 		}
+
+		if err := github.ReadReviewerRotation(reviewerRotationData); err != nil {
+			return err
+		}
 		return execReassignReviewer(prNumber, newPrimaryReviewer, gh)
 	},
 }

--- a/.ci/magician/cmd/request_reviewer.go
+++ b/.ci/magician/cmd/request_reviewer.go
@@ -21,6 +21,13 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	_ "embed"
+)
+
+var (
+	//go:embed data/reviewer_rotation.yaml
+	reviewerRotationData []byte
 )
 
 // requestReviewerCmd represents the requestReviewer command
@@ -48,6 +55,10 @@ var requestReviewerCmd = &cobra.Command{
 			return fmt.Errorf("did not provide GITHUB_TOKEN environment variable")
 		}
 		gh := github.NewClient(githubToken)
+
+		if err := github.ReadReviewerRotation(reviewerRotationData); err != nil {
+			return err
+		}
 		return execRequestReviewer(prNumber, gh)
 	},
 }

--- a/.ci/magician/github/membership_data.go
+++ b/.ci/magician/github/membership_data.go
@@ -1,66 +1,8 @@
 package github
 
-import "time"
-
-type date struct {
-	year  int
-	month int
-	day   int
-}
-
-func newDate(year, month, day int) date {
-	return date{
-		year:  year,
-		month: month,
-		day:   day,
-	}
-}
-
-type Vacation struct {
-	startDate, endDate date
-}
-
-// GetStart returns a time corresponding to the beginning of the start date in the given timezone.
-func (v Vacation) GetStart(timezone *time.Location) time.Time {
-	if timezone == nil {
-		timezone = usPacific
-	}
-	return time.Date(v.startDate.year, time.Month(v.startDate.month), v.startDate.day, 0, 0, 0, 0, timezone)
-}
-
-// GetEnd returns a time corresponding to the end of the end date in the given timezone
-func (v Vacation) GetEnd(timezone *time.Location) time.Time {
-	if timezone == nil {
-		timezone = usPacific
-	}
-	return time.Date(v.endDate.year, time.Month(v.endDate.month), v.endDate.day, 0, 0, 0, 0, timezone).AddDate(0, 0, 1).Add(-1 * time.Millisecond)
-}
-
-type ReviewerConfig struct {
-	// timezone controls the timezone for vacation start / end dates. Default: US/Pacific.
-	timezone *time.Location
-
-	// vacations allows specifying times when new reviews should not be requested of the reviewer.
-	// Existing PRs will still have reviews re-requested.
-	// Both startDate and endDate are inclusive.
-	// Example: taking vacation from 2024-03-28 to 2024-04-02.
-	// {
-	// 	 vacations:        []Vacation{
-	//     startDate: newDate(2024, 3, 28),
-	// 	   endDate:   newDate(2024, 4, 2),
-	//   },
-	// },
-	vacations []Vacation
-}
-
 var (
-	usPacific, _ = time.LoadLocation("US/Pacific")
-	usCentral, _ = time.LoadLocation("US/Central")
-	usEastern, _ = time.LoadLocation("US/Eastern")
-	london, _    = time.LoadLocation("Europe/London")
-
 	// This is for the random-assignee rotation.
-	reviewerRotation = map[string]ReviewerConfig{
+	reviewerRotation = ReviewerRotation{
 		"BBBmau": {
 			vacations: []Vacation{
 				{

--- a/.ci/magician/github/reviewer_assignment_test.go
+++ b/.ci/magician/github/reviewer_assignment_test.go
@@ -25,11 +25,12 @@ import (
 )
 
 func TestChooseCoreReviewers(t *testing.T) {
-	if len(AvailableReviewers(nil)) < 2 {
-		t.Fatalf("not enough available reviewers (%v) to test (need at least 2)", AvailableReviewers(nil))
+	available := AvailableReviewers(nil)
+	if len(available) < 2 {
+		t.Fatalf("not enough available reviewers (%v) to test (need at least 2)", available)
 	}
-	firstCoreReviewer := AvailableReviewers(nil)[0]
-	secondCoreReviewer := AvailableReviewers(nil)[1]
+	firstCoreReviewer := available[0]
+	secondCoreReviewer := available[1]
 	cases := map[string]struct {
 		RequestedReviewers                               []User
 		PreviousReviewers                                []User
@@ -39,7 +40,7 @@ func TestChooseCoreReviewers(t *testing.T) {
 		"no previous review requests assigns new reviewer from team": {
 			RequestedReviewers:      []User{},
 			PreviousReviewers:       []User{},
-			ExpectReviewersFromList: AvailableReviewers(nil),
+			ExpectReviewersFromList: available,
 			ExpectPrimaryReviewer:   true,
 		},
 		"requested reviewer from team means that primary reviewer was already selected": {
@@ -61,7 +62,7 @@ func TestChooseCoreReviewers(t *testing.T) {
 		"previously involved reviewers that are not team members are ignored": {
 			RequestedReviewers:      []User{},
 			PreviousReviewers:       []User{User{Login: "foobar"}},
-			ExpectReviewersFromList: AvailableReviewers(nil),
+			ExpectReviewersFromList: available,
 			ExpectPrimaryReviewer:   true,
 		},
 		"only previously involved team member reviewers will have review requested": {

--- a/.ci/magician/github/reviewer_config.go
+++ b/.ci/magician/github/reviewer_config.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ReviewerConfig struct {
+	// timezone controls the timezone for vacation start / end dates. Default: US/Pacific.
+	timezone *time.Location
+
+	// vacations allows specifying times when new reviews should not be requested of the reviewer.
+	// Existing PRs will still have reviews re-requested.
+	// Both startDate and endDate are inclusive.
+	vacations []Vacation
+}
+
+type reviewerConfigYAML struct {
+	Timezone  string
+	Vacations []vacationYAML
+}
+
+const defaultTimezone = "US/Pacific"
+
+func (rc ReviewerConfig) MarshalYAML() (any, error) {
+	yrc := reviewerConfigYAML{
+		Timezone:  rc.timezone.String(),
+		Vacations: make([]vacationYAML, len(rc.vacations)),
+	}
+	if rc.timezone == nil {
+		yrc.Timezone = defaultTimezone
+	}
+	if len(rc.vacations) == 0 {
+		yrc.Vacations = []vacationYAML{
+			vacationYAML{
+				Start: sampleDateStr,
+				End:   sampleDateStr,
+			},
+		}
+	}
+	for i, v := range rc.vacations {
+		marshalled, err := v.MarshalYAML()
+		if err != nil {
+			return nil, err
+		}
+		var ok bool
+		yrc.Vacations[i], ok = marshalled.(vacationYAML)
+		if !ok {
+			return nil, fmt.Errorf("non-vacationYAML returned from MarshalYAML: %v (%T)", marshalled, marshalled)
+		}
+	}
+	return yrc, nil
+}
+
+func (rc *ReviewerConfig) UnmarshalYAML(value *yaml.Node) error {
+	var yrc reviewerConfigYAML
+	if err := value.Decode(&yrc); err != nil {
+		return fmt.Errorf("failed to decode reviewer config: %w", err)
+	}
+
+	timezoneStr := yrc.Timezone
+	if timezoneStr == "" {
+		timezoneStr = defaultTimezone
+	}
+	loc, err := time.LoadLocation(timezoneStr)
+	if err != nil {
+		return fmt.Errorf("failed to load timezone %q: %w", timezoneStr, err)
+	}
+	rc.timezone = loc
+
+	for _, vYAML := range yrc.Vacations {
+		if vYAML.Start == sampleDateStr && vYAML.End == sampleDateStr {
+			continue // Skip sample placeholder vacations
+		}
+
+		parsedStartDate, err := time.Parse("2006/01/02", vYAML.Start)
+		if err != nil {
+			return fmt.Errorf("failed to parse start date %q: %w", vYAML.Start, err)
+		}
+		parsedEndDate, err := time.Parse("2006/01/02", vYAML.End)
+		if err != nil {
+			return fmt.Errorf("failed to parse end date %q: %w", vYAML.End, err)
+		}
+
+		vacation := Vacation{
+			// Date components are from parsed dates, time set to day boundaries in reviewer's timezone.
+			start: time.Date(parsedStartDate.Year(), parsedStartDate.Month(), parsedStartDate.Day(), 0, 0, 0, 0, rc.timezone),
+			end:   time.Date(parsedEndDate.Year(), parsedEndDate.Month(), parsedEndDate.Day(), 23, 59, 59, 0, rc.timezone),
+		}
+
+		rc.vacations = append(rc.vacations, vacation)
+	}
+
+	return nil
+}
+
+var usPacific, _ = time.LoadLocation("US/Pacific")
+
+// Set start and end for each vacation based on startDate and endDate.
+func (rc *ReviewerConfig) setStartEnd() {
+	for i := range rc.vacations {
+		v := &rc.vacations[i]
+		loc := usPacific
+		if rc.timezone != nil {
+			loc = rc.timezone
+		}
+		if v.start.IsZero() && v.end.IsZero() {
+			// Adjust vacation times to the reviewer's timezone
+			v.start = time.Date(v.startDate.year, time.Month(v.startDate.month), v.startDate.day, 0, 0, 0, 0, loc)
+			v.end = time.Date(v.endDate.year, time.Month(v.endDate.month), v.endDate.day, 23, 59, 59, 0, loc)
+		}
+	}
+}
+
+const (
+	vacationStartOffset = -8 * time.Hour // Vacations will effectively start at 4pm the previous day in the reviewer's timezone instead of midnight.
+	vacationEndOffset   = 9 * time.Hour  // Vacations will effectively end at 9am the next day in the reviewer's timezone instead of midnight.
+)
+
+func (rc *ReviewerConfig) onVacation(now time.Time) bool {
+	for _, v := range rc.vacations {
+		if v.start.Add(vacationStartOffset).Before(now) && v.end.Add(vacationEndOffset).After(now) {
+			return true
+		}
+	}
+	return false
+}

--- a/.ci/magician/github/reviewer_rotation.go
+++ b/.ci/magician/github/reviewer_rotation.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"fmt"
+	utils "magician/utility"
+	"math/rand"
+	"slices"
+	"time"
+
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
+)
+
+type ReviewerRotation map[string]*ReviewerConfig
+
+func (rr *ReviewerRotation) setStartEnd() {
+	for _, config := range *rr {
+		config.setStartEnd()
+	}
+}
+
+func (rr *ReviewerRotation) read(data []byte) error {
+	if err := yaml.Unmarshal(data, rr); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rr *ReviewerRotation) write() ([]byte, error) {
+	data, err := yaml.Marshal(rr)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (rr *ReviewerRotation) UnmarshalYAML(value *yaml.Node) error {
+	if len(value.Content)%2 != 0 {
+		return fmt.Errorf("reviewer rotation map content must be even, got %d", len(value.Content))
+	}
+	partial := make(map[string]*yaml.Node, len(value.Content)/2)
+	// Iterate through content of value.
+	for i := 0; i < len(value.Content); i += 2 {
+		keyNode := value.Content[i]
+		valueNode := value.Content[i+1]
+		partial[keyNode.Value] = valueNode
+	}
+
+	for reviewer, node := range partial {
+		if err := node.Decode((*rr)[reviewer]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isCoreReviewer returns true if the given user is a core reviewer
+func (rr ReviewerRotation) isCoreReviewer(user string) bool {
+	_, isCoreReviewer := rr[user]
+	return isCoreReviewer
+}
+
+// getRandomReviewer returns a random available reviewer (optionally excluding some people from the reviewer pool)
+func (rr ReviewerRotation) getRandomReviewer(excludedReviewers []string) string {
+	availableReviewers := rr.availableReviewers(excludedReviewers)
+	reviewer := availableReviewers[rand.Intn(len(availableReviewers))]
+	return reviewer
+}
+
+func (rr ReviewerRotation) availableReviewers(excludedReviewers []string) []string {
+	return rr.available(time.Now(), excludedReviewers)
+}
+
+func (rr ReviewerRotation) available(nowTime time.Time, excludedReviewers []string) []string {
+	excludedReviewers = append(excludedReviewers, rr.onVacation(nowTime)...)
+	ret := utils.Removes(maps.Keys(rr), excludedReviewers)
+	slices.Sort(ret)
+	return ret
+}
+
+// onVacation returns a list of reviewers who are on vacation at the given time
+func (rr ReviewerRotation) onVacation(now time.Time) []string {
+	var onVacationList []string
+	for reviewer, config := range rr {
+		if config.onVacation(now) {
+			onVacationList = append(onVacationList, reviewer)
+		}
+	}
+	return onVacationList
+}

--- a/.ci/magician/github/reviewer_rotation_test.go
+++ b/.ci/magician/github/reviewer_rotation_test.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRead(t *testing.T) {
+	start1 := time.Now().Add(-8 * 24 * time.Hour)
+	end1 := time.Now().Add(-4 * 24 * time.Hour)
+	rr := ReviewerRotation{
+		"id1": {
+			vacations: []Vacation{
+				{
+					start: start1,
+					end:   end1,
+				},
+			},
+		},
+		"id2": {
+			vacations: []Vacation{
+				{
+					start: start1,
+					end:   end1,
+				},
+			},
+		},
+	}
+	data := []byte(`id1:
+  vacations:
+  - start: YYYY/MM/DD
+    end: YYYY/MM/DD
+id2:
+  timezone: US/Eastern
+  vacations:
+  - start: 1969/07/16
+    end: 1969/07/24
+`)
+	if err := rr.read(data); err != nil {
+		t.Fatal(err)
+	}
+	if len(rr) != 2 {
+		t.Fatalf("expected 2 reviewers, got %d", len(rr))
+	}
+	if len(rr["id1"].vacations) != 1 {
+		// Confirm sample vacations are not loaded.
+		t.Fatalf("expected 1 vacation for id1, got %d", len(rr["id1"].vacations))
+	}
+	if !rr["id1"].vacations[0].start.Equal(start1) || !rr["id1"].vacations[0].end.Equal(end1) {
+		t.Fatalf("expected id1's vacation start %s and end1 %s, got %s and %s", start1, end1, rr["id1"].vacations[0].start, rr["id1"].vacations[0].end)
+	}
+	if len(rr["id2"].vacations) != 2 {
+		// Confirm vacations merge.
+		t.Fatalf("expected 2 vacations for id2, got %d", len(rr["id2"].vacations))
+	}
+	ny, _ := time.LoadLocation("America/New_York")
+	start2, _ := time.ParseInLocation("2006/01/02", "1969/07/16", ny)
+	if !rr["id2"].vacations[1].start.Equal(start2) {
+		t.Fatalf("expected id2's vacation start %s, got %s", start2, rr["id2"].vacations[1].start)
+	}
+}

--- a/.ci/magician/github/vacation.go
+++ b/.ci/magician/github/vacation.go
@@ -1,0 +1,67 @@
+package github
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Vacation struct {
+	start, end         time.Time
+	startDate, endDate date
+}
+
+type vacationYAML struct {
+	Start, End string
+}
+
+const sampleDateStr = "YYYY/MM/DD"
+
+type date struct {
+	year, month, day int
+}
+
+func newDate(year, month, day int) date {
+	return date{year: year, month: month, day: day}
+}
+
+func (v Vacation) MarshalYAML() (any, error) {
+	return vacationYAML{
+		Start: v.start.Format("2006/01/02"),
+		End:   v.end.Format("2006/01/02"),
+	}, nil
+}
+
+func (v *Vacation) UnmarshalYAML(value *yaml.Node) error {
+	var vacationMap map[string]string
+	if err := value.Decode(&vacationMap); err != nil {
+		return err
+	}
+
+	startDateStr, ok := vacationMap["start"]
+	if !ok {
+		return fmt.Errorf("vacation missing start date")
+	}
+	endDateStr, ok := vacationMap["end"]
+	if !ok {
+		return fmt.Errorf("vacation missing end date")
+	}
+
+	if startDateStr == sampleDateStr && endDateStr == sampleDateStr {
+		return nil
+	}
+
+	startDate, err := time.Parse("2006/01/02", startDateStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse start date %q: %w", startDateStr, err)
+	}
+	endDate, err := time.Parse("2006/01/02", endDateStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse end date %q: %w", endDateStr, err)
+	}
+
+	v.start = startDate
+	v.end = endDate
+	return nil
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The main purpose of this PR is to move the vacation data into yaml so that it is easier to update and to consume from the good build approver.

I have also attempted to simplify the logic for determining if reviewers are on vacation and prevent after-hours reviews from being assigned at the beginning of vacations.

The intention is to allow adding vacations the old way for now and at some later point switch to using yaml exclusively.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
