### PR TITLE
[AlloyDB] Support for PSA Allocated IP Range Override 

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -443,6 +443,12 @@ properties:
         type: Boolean
         description: |
           Enabling outbound public ip for the instance.
+      - name: 'allocatedIpRangeOverride'
+        type: String
+        description: |
+          Name of the allocated IP range for the private IP AlloyDB instance, for example: "google-managed-services-default".
+          If set, the instance IPs will be created from this allocated range and will override the IP range used by the parent cluster.
+          The range name must comply with RFC 1035. Specifically, the name must be 1-63 characters long and match the regular expression [a-z]([-a-z0-9]*[a-z0-9])?.
   - name: 'publicIpAddress'
     type: String
     description: |

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -445,6 +445,7 @@ properties:
           Enabling outbound public ip for the instance.
       - name: 'allocatedIpRangeOverride'
         type: String
+        immutable: true
         description: |
           Name of the allocated IP range for the private IP AlloyDB instance, for example: "google-managed-services-default".
           If set, the instance IPs will be created from this allocated range and will override the IP range used by the parent cluster.

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go
@@ -1082,3 +1082,66 @@ resource "google_alloydb_cluster" "default" {
 data "google_project" "project" {}
 `, context)
 }
+
+func TestAccAlloydbInstance_createPrimaryAndReadPoolInstanceWithAllocatedIpRangeOverride(t *testing.T) {
+	t.Parallel()
+
+	testId := "alloydb-1"
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"address_name":  acctest.BootstrapSharedTestGlobalAddress(t, testId),
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, testId),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAlloydbInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAlloydbInstance_createPrimaryAndReadPoolInstanceWithAllocatedIpRangeOverride(context),
+			},
+		},
+	})
+}
+
+func testAccAlloydbInstance_createPrimaryAndReadPoolInstanceWithAllocatedIpRangeOverride(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_alloydb_instance" "primary" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}"
+  instance_type = "PRIMARY"
+}
+
+resource "google_alloydb_instance" "read_pool" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "tf-test-alloydb-instance%{random_suffix}-read"
+  instance_type = "READ_POOL"
+  read_pool_config {
+    node_count = 4
+  }
+  network_config {
+	allocated_ip_range_override = data.google_compute_global_address.private_ip_alloc.name
+  }
+  depends_on = [google_alloydb_instance.primary]
+}
+
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "tf-test-alloydb-cluster%{random_suffix}"
+  location   = "us-central1"
+  network_config {
+    network = data.google_compute_network.default.id
+  }
+}
+
+data "google_project" "project" {}
+
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+data "google_compute_global_address" "private_ip_alloc" {
+  name =  "%{address_name}"
+}
+`, context)
+}


### PR DESCRIPTION
Description:
Supporting Private Services Access Allocated IP Range Override in Terraform.

Issue - https://b.corp.google.com/issues/424329465

```release-note:enhancement
alloydb: added `network_config.allocated_ip_range_override` field to `google_alloydb_instance` resource
```
