### PR TITLE
Add Network Firewall Policy "Policy Type" field

### DIFF
--- a/mmv1/products/compute/NetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicy.yaml
@@ -57,6 +57,16 @@ properties:
   - name: 'description'
     type: String
     description: An optional description of this resource. Provide this property when you create the resource.
+  - name: 'policyType'
+    type: Enum
+    immutable: true
+    description: |
+      Policy type is used to determine which resources (networks) the policy can be associated with.
+      A policy can be associated with a network only if the network has the matching policyType in its network profile.
+      Different policy types may support some of the Firewall Rules features.
+    min_version: 'beta'
+    enum_values:
+      - 'VPC_POLICY'
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.

--- a/mmv1/products/compute/NetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicy.yaml
@@ -65,6 +65,7 @@ properties:
       A policy can be associated with a network only if the network has the matching policyType in its network profile.
       Different policy types may support some of the Firewall Rules features.
     min_version: 'beta'
+    default_from_api: true
     enum_values:
       - 'VPC_POLICY'
   - name: 'fingerprint'

--- a/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
@@ -76,6 +76,16 @@ properties:
   - name: 'description'
     type: String
     description: An optional description of this resource.
+  - name: 'policyType'
+    type: Enum
+    immutable: true
+    description: |
+      Policy type is used to determine which resources (networks) the policy can be associated with.
+      A policy can be associated with a network only if the network has the matching policyType in its network profile.
+      Different policy types may support some of the Firewall Rules features.
+    min_version: 'beta'
+    enum_values:
+      - 'VPC_POLICY'
   - name: 'rule'
     type: Array
     description: A list of firewall policy rules.

--- a/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyWithRules.yaml
@@ -83,6 +83,7 @@ properties:
       Policy type is used to determine which resources (networks) the policy can be associated with.
       A policy can be associated with a network only if the network has the matching policyType in its network profile.
       Different policy types may support some of the Firewall Rules features.
+    default_from_api: true
     min_version: 'beta'
     enum_values:
       - 'VPC_POLICY'

--- a/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
@@ -38,6 +38,10 @@ examples:
     primary_resource_id: 'policy'
     vars:
       policy_name: 'tf-test-policy'
+  - name: 'region_network_firewall_policy_roce'
+    primary_resource_id: 'policy'
+    vars:
+      policy_name: 'tf-test-policy'
 parameters:
   - name: 'region'
     type: String
@@ -63,6 +67,18 @@ properties:
   - name: 'description'
     type: String
     description: An optional description of this resource. Provide this property when you create the resource.
+  - name: 'policyType'
+    type: Enum
+    immutable: true
+    description: |
+      Policy type is used to determine which resources (networks) the policy can be associated with.
+      A policy can be associated with a network only if the network has the matching policyType in its network profile.
+      Different policy types may support some of the Firewall Rules features.
+    min_version: 'beta'
+    default_from_api: true
+    enum_values:
+      - 'VPC_POLICY'
+      - 'RDMA_ROCE_POLICY'
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.

--- a/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
@@ -40,8 +40,9 @@ examples:
       policy_name: 'tf-test-policy'
   - name: 'region_network_firewall_policy_roce'
     primary_resource_id: 'policy'
+    min_version: beta
     vars:
-      policy_name: 'tf-test-policy'
+      policy_name: 'rnf-policy'
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
@@ -90,6 +90,7 @@ properties:
       Policy type is used to determine which resources (networks) the policy can be associated with.
       A policy can be associated with a network only if the network has the matching policyType in its network profile.
       Different policy types may support some of the Firewall Rules features.
+    default_from_api: true
     min_version: 'beta'
     enum_values:
       - 'VPC_POLICY'

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
@@ -83,6 +83,17 @@ properties:
   - name: 'description'
     type: String
     description: An optional description of this resource.
+  - name: 'policyType'
+    type: Enum
+    immutable: true
+    description: |
+      Policy type is used to determine which resources (networks) the policy can be associated with.
+      A policy can be associated with a network only if the network has the matching policyType in its network profile.
+      Different policy types may support some of the Firewall Rules features.
+    min_version: 'beta'
+    enum_values:
+      - 'VPC_POLICY'
+      - 'RDMA_ROCE_POLICY'
   - name: 'rule'
     type: Array
     description: A list of firewall policy rules.

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
@@ -52,6 +52,11 @@ examples:
       tag_value: 'tag-value'
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'compute_region_network_firewall_policy_with_rules_roce'
+    primary_resource_id: 'policy'
+    min_version: beta
+    vars:
+      policy_name: 'rnf-policy'
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_roce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_roce.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_compute_region_network_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "policy_name"}}"
+  description = "Terraform test"
+  policy_type = "RDMA_ROCE_POLICY"
+
+  rule {
+    description    = "deny all rule"
+    priority       = 1000
+    enable_logging = true
+    action         = "deny"
+    direction      = "INGRESS"
+
+    match {
+      src_ip_ranges            = ["0.0.0.0/0"]
+
+      layer4_config {
+        ip_protocol = "all"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_roce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_roce.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_region_network_firewall_policy_with_rules" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
   name        = "{{index $.Vars "policy_name"}}"
   description = "Terraform test"
   policy_type = "RDMA_ROCE_POLICY"

--- a/mmv1/templates/terraform/examples/region_network_firewall_policy_roce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_firewall_policy_roce.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_region_network_firewall_policy" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
   name = "{{index $.Vars "policy_name"}}"
   description = "Terraform test"
   policy_type = "RDMA_ROCE_POLICY"

--- a/mmv1/templates/terraform/examples/region_network_firewall_policy_roce.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_firewall_policy_roce.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_compute_region_network_firewall_policy" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "policy_name"}}"
+  description = "Terraform test"
+  policy_type = "RDMA_ROCE_POLICY"
+}


### PR DESCRIPTION
The policy type field is a new field, set on policy creation and is then immutable.
Used to define which resources the policy can be associated with (depending on the VPC type), and imposes limitations and validations on the rules in the policy.

The default policy type is VPC_POLICY. RDMA_ROCE_POLICY can be used with RoCE networks.

https://github.com/GoogleCloudPlatform/magic-modules/pull/14249

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `policyType` to `google_compute_network_firewall_policy`, `google_compute_network_firewall_policy_with_rules`, `google_compute_region_network_firewall_policy`, `google_compute_region_network_firewall_policy_with_rules`.
```
