### PR TITLE
Fix the logs that are uploaded during EAP VCR to match OSS

### DIFF
--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -173,6 +173,15 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 			return fmt.Errorf("error uploading cassettes: %w", err)
 		}
 
+		if err := vt.UploadLogs(vcr.UploadLogsOptions{
+			Head:     head,
+			Parallel: true,
+			Mode:     vcr.Recording,
+			Version:  provider.Private,
+		}); err != nil {
+			return fmt.Errorf("error uploading recording logs: %w", err)
+		}
+
 		if hasPanics, err := handleEAPVCRPanics(head, kokoroArtifactsDir, modifiedFilePath, recordingResult, vcr.Recording, rnr); err != nil {
 			return fmt.Errorf("error handling panics: %w", err)
 		} else if hasPanics {
@@ -191,10 +200,10 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 				Head:           head,
 				Parallel:       true,
 				AfterRecording: true,
-				Mode:           vcr.Recording,
+				Mode:           vcr.Replaying,
 				Version:        provider.Private,
 			}); err != nil {
-				return fmt.Errorf("error uploading recording logs: %w", err)
+				return fmt.Errorf("error uploading replaying after recording logs: %w", err)
 			}
 		}
 		hasTerminatedTests := (len(recordingResult.PassedTests) + len(recordingResult.FailedTests)) < len(replayingResult.FailedTests)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

My guess is that these were just missed when initially written, but we previously appeared to not be uploading "recording" logs at all, and the "replaying after recording" logs were being mislabeled as "recording after recording". Both have been fixed to match what we already do for the other provider VCR.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
