### PR TITLE
Launch domainName forwarding target to GA

### DIFF
--- a/mmv1/products/dns/ManagedZone.yaml
+++ b/mmv1/products/dns/ManagedZone.yaml
@@ -358,7 +358,6 @@ properties:
             - name: 'domainName'
               type: String
               description: 'Fully qualified domain name for the forwarding target.'
-              min_version: 'beta'
             - name: 'forwardingPath'
               type: Enum
               description: |

--- a/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
@@ -714,7 +714,6 @@ resource "google_dns_managed_zone" "private" {
 }
 
 resource "google_compute_network" "network-1" {
-  provider = google-beta
   name                    = "tf-test-net-1-%s"
   auto_create_subnetworks = false
 }

--- a/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_managed_zone_test.go.tmpl
@@ -662,7 +662,6 @@ resource "google_dns_managed_zone" "foobar" {
 `, suffix, suffix, description, project)
 }
 
-{{ if not (or (eq $.TargetVersionName ``) (eq $.TargetVersionName `ga`)) }}
 func TestAccDNSManagedZone_privateForwardingWithDomainNameUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -670,7 +669,7 @@ func TestAccDNSManagedZone_privateForwardingWithDomainNameUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckDNSManagedZoneDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -696,7 +695,6 @@ func TestAccDNSManagedZone_privateForwardingWithDomainNameUpdate(t *testing.T) {
 func testAccDnsManagedZone_privateForwardingWithDomainNameUpdate(suffix, domain_name, forwarding_path string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "private" {
-  provider = google-beta
   name        = "private-zone-%s"
   dns_name    = "private.example.com."
   description = "Example private DNS zone"
@@ -723,6 +721,7 @@ resource "google_compute_network" "network-1" {
 `, suffix, domain_name, forwarding_path, suffix)
 }
 
+{{ if not (or (eq $.TargetVersionName ``) (eq $.TargetVersionName `ga`)) }}
 func TestAccDNSManagedZone_dnsManagedZoneUpdateWithServiceDirectory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dns: added `target_name_servers.domain_name` field to `google_dns_managed_zone` resource (GA)
```

Previous PR for preview launch: https://github.com/GoogleCloudPlatform/magic-modules/pull/13182
