### PR TITLE
Fix links used for EAP VCR by omitting artifacts/buildId

### DIFF
--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -2,7 +2,7 @@
 {{color "green" "Tests passed during RECORDING mode:"}}
 {{range .RecordingResult.PassedTests -}}
 `{{.}}` {{/* remove trailing whitespace */ -}}
-  [[Debug log](https://storage.cloud.google.com/{{$.LogBucket}}/{{$.Version}}/refs/heads/{{$.Head}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
+  [[Debug log]({{$.LogBaseUrl}}/recording/{{.}}.log)]
 {{/* remove trailing whitespace */ -}}
 {{end}}
 
@@ -11,8 +11,8 @@
 {{color "red" "Tests failed when rerunning REPLAYING mode:"}}
 {{range .ReplayingAfterRecordingResult.FailedTests -}}
 `{{.}}` {{/* remove trailing whitespace */ -}}
-  [[Error message](https://storage.cloud.google.com/{{$.LogBucket}}/{{$.Version}}/refs/heads/{{$.Head}}/artifacts/{{$.BuildID}}/build-log/replaying_build_after_recording/{{compoundTest .}}_replaying_test.log)] {{/* remove trailing whitespace */ -}}
-  [[Debug log](https://storage.cloud.google.com/{{$.LogBucket}}/{{$.Version}}/refs/heads/{{$.Head}}/artifacts/{{$.BuildID}}/replaying_after_recording/{{.}}.log)]
+  [[Error message]({{$.LogBaseUrl}}/build-log/replaying_build_after_recording/{{compoundTest .}}_replaying_test.log)] {{/* remove trailing whitespace */ -}}
+  [[Debug log]({{$.LogBaseUrl}}/replaying_after_recording/{{.}}.log)]
 {{/* remove trailing whitespace */ -}}
 {{end}}
 
@@ -30,8 +30,8 @@ Please fix these to complete your PR. If you believe these test failures to be i
 {{color "red" "Tests failed during RECORDING mode:"}}
 {{range .RecordingResult.FailedTests -}}
 `{{.}}` {{/* remove trailing whitespace */ -}}
-  [[Error message](https://storage.cloud.google.com/{{$.LogBucket}}/{{$.Version}}/refs/heads/{{$.Head}}/artifacts/{{$.BuildID}}/build-log/recording_build/{{compoundTest .}}_recording_test.log)] {{/* remove trailing whitespace */ -}}
-  [[Debug log](https://storage.cloud.google.com/{{$.LogBucket}}/{{$.Version}}/refs/heads/{{$.Head}}/artifacts/{{$.BuildID}}/recording/{{.}}.log)]
+  [[Error message]({{$.LogBaseUrl}}/build-log/recording_build/{{compoundTest .}}_recording_test.log)] {{/* remove trailing whitespace */ -}}
+  [[Debug log]({{$.LogBaseUrl}}/recording/{{.}}.log)]
 {{/* remove trailing whitespace */ -}}
 {{end}}
 {{end}} {{- /* end of if gt (len .RecordingResult.FailedTests) 0 */ -}}
@@ -42,5 +42,5 @@ Please fix these to complete your PR. If you believe these test failures to be i
 
 {{if .AllRecordingPassed}}{{color "green" "All tests passed!"}}{{end}}
 
-View the [build log](https://storage.cloud.google.com/{{.LogBucket}}/{{.Version}}/refs/heads/{{.Head}}/artifacts/{{.BuildID}}/build-log/recording_test.log) {{/* remove trailing whitespace */ -}}
-or the [debug log](https://console.cloud.google.com/storage/browser/{{.LogBucket}}/{{.Version}}/refs/heads/{{.Head}}/artifacts/{{.BuildID}}/recording) for each test
+View the [build log]({{.LogBaseUrl}}/build-log/recording_test.log) {{/* remove trailing whitespace */ -}}
+or the [debug log]({{.BrowseLogBaseUrl}}/recording) for each test

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -77,6 +77,8 @@ type recordReplay struct {
 	Version                       string
 	Head                          string
 	BuildID                       string
+	LogBaseUrl                    string
+	BrowseLogBaseUrl              string
 }
 
 var testTerraformVCRCmd = &cobra.Command{
@@ -528,5 +530,11 @@ func formatPostReplay(data postReplay) (string, error) {
 }
 
 func formatRecordReplay(data recordReplay) (string, error) {
+	logBasePath := fmt.Sprintf("%s/%s/refs/heads/%s/artifacts/%s", data.LogBucket, data.Version, data.Head, data.BuildID)
+	if data.BuildID == "" {
+		logBasePath = fmt.Sprintf("%s/%s/refs/heads/%s", data.LogBucket, data.Version, data.Head)
+	}
+	data.LogBaseUrl = fmt.Sprintf("https://storage.cloud.google.com/%s", logBasePath)
+	data.BrowseLogBaseUrl = fmt.Sprintf("https://console.cloud.google.com/storage/browser/%s", logBasePath)
 	return formatComment("record_replay.tmpl", recordReplayTmplText, data)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

All of the links to logs in our templates have urls that include `artifacts/<BuildID>`, but the EAP version of VCR does not use build IDs. Instead, the links should have the `artifacts/<BuildID>` piece removed. To prevent duplicating this logic on several lines, I introduced `*BaseUrl` variables that can be set in one place depending on the presence of a valid BuildID.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
