### PR TITLE
Fix the bug that sql instance can not enable mcp

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -424,6 +424,7 @@ is set to true. Defaults to ZONAL.`,
 						"disk_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
+							// Default is likely 10gb, but it is undocumented and may change.
 							Computed:    true,
 							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED.`,
 						},
@@ -433,7 +434,7 @@ is set to true. Defaults to ZONAL.`,
 							Computed:         true,
 							ForceNew:         true,
 							DiffSuppressFunc: caseDiffDashSuppress,
-							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HYPERDISK_BALANCED.`,
+							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HyperDisk_Balanced `,
 						},
 {{- if ne $.TargetVersionName "ga" }}
 						"data_disk_provisioned_iops": {
@@ -2170,6 +2171,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	s := d.Get("settings")
 	instance = &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
+		DatabaseVersion = databaseVersion,
 	}
 	_settings := s.([]interface{})[0].(map[string]interface{})
 	// Instance.Patch operation on completion updates the settings proto version by +8. As terraform does not know this it tries

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1458,6 +1458,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		MaintenanceWindow:             expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
 		InsightsConfig:                expandInsightsConfig(_settings["insights_config"].([]interface{})),
 		PasswordValidationPolicy:      expandPasswordValidationPolicy(_settings["password_validation_policy"].([]interface{})),
+		ConnectionPoolConfig:          expandConnectionPoolConfig(_settings["connection_pool_config"].(*schema.Set).List()),
 	}
 
 	resize := _settings["disk_autoresize"].(bool)
@@ -2166,37 +2167,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	// Check if connection pool config is being updated.
-	if d.HasChange("settings.0.connection_pool_config") {
-		connectionPoolConfig := expandConnectionPoolConfig(d.Get("settings.0.connection_pool_config").(*schema.Set).List())
-		instance = &sqladmin.DatabaseInstance{
-			DatabaseVersion: databaseVersion,
-			Settings: &sqladmin.Settings{
-				ConnectionPoolConfig: connectionPoolConfig,
-			},
-		}
-		err = transport_tpg.Retry(transport_tpg.RetryOptions{
-			RetryFunc: func() (rerr error) {
-				op, rerr = config.NewSqlAdminClient(userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()
-				return rerr
-			},
-			Timeout:              d.Timeout(schema.TimeoutUpdate),
-			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
-		})
-		if err != nil {
-			return fmt.Errorf("Error, failed to patch instance connection pool config for %s: %s", d.Get("name").(string), err)
-		}
-		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return err
-		}
-		err = resourceSqlDatabaseInstanceRead(d, meta)
-		if err != nil {
-			return err
-		}
-	}
-
-
 	s := d.Get("settings")
 	instance = &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
@@ -2222,8 +2192,8 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	// Database Version is required for all calls with Google ML integration enabled or it will be rejected by the API.
-	if d.Get("settings.0.enable_google_ml_integration").(bool) {
-		instance.DatabaseVersion = databaseVersion
+	if d.Get("settings.0.enable_google_ml_integration").(bool) || len(_settings["connection_pool_config"].(*schema.Set).List()) > 0 {
+			instance.DatabaseVersion = databaseVersion
 	}
 
 	failoverDrReplicaName := d.Get("replication_cluster.0.failover_dr_replica_name").(string)

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -433,7 +433,7 @@ is set to true. Defaults to ZONAL.`,
 							Computed:         true,
 							ForceNew:         true,
 							DiffSuppressFunc: caseDiffDashSuppress,
-							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HYPERDISK_BALANCED. `,
+							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HYPERDISK_BALANCED.`,
 						},
 {{- if ne $.TargetVersionName "ga" }}
 						"data_disk_provisioned_iops": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -425,7 +425,7 @@ is set to true. Defaults to ZONAL.`,
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed:    true,
-							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED.`,
+							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED. `,
 						},
 						"disk_type": {
 							Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2171,7 +2171,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	s := d.Get("settings")
 	instance = &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
-		DatabaseVersion = databaseVersion,
+		DatabaseVersion: databaseVersion,
 	}
 	_settings := s.([]interface{})[0].(map[string]interface{})
 	// Instance.Patch operation on completion updates the settings proto version by +8. As terraform does not know this it tries

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -424,7 +424,6 @@ is set to true. Defaults to ZONAL.`,
 						"disk_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							// Default is likely 10gb, but it is undocumented and may change.
 							Computed:    true,
 							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED.`,
 						},
@@ -434,7 +433,7 @@ is set to true. Defaults to ZONAL.`,
 							Computed:         true,
 							ForceNew:         true,
 							DiffSuppressFunc: caseDiffDashSuppress,
-							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HyperDisk_Balanced `,
+							Description:      `The type of supported data disk is tier dependent and can be PD_SSD or PD_HDD or HYPERDISK_BALANCED. `,
 						},
 {{- if ne $.TargetVersionName "ga" }}
 						"data_disk_provisioned_iops": {
@@ -1454,7 +1453,6 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		UserLabels:                    tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration:           expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
 		DatabaseFlags:                 expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
-		ConnectionPoolConfig:      	   expandConnectionPoolConfig(_settings["connection_pool_config"].(*schema.Set).List()),
 		IpConfiguration:               expandIpConfiguration(_settings["ip_configuration"].([]interface{}), databaseVersion),
 		LocationPreference:            expandLocationPreference(_settings["location_preference"].([]interface{})),
 		MaintenanceWindow:             expandMaintenanceWindow(_settings["maintenance_window"].([]interface{})),
@@ -2168,10 +2166,40 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	// Check if connection pool config is being updated.
+	if d.HasChange("settings.0.connection_pool_config") {
+		connectionPoolConfig := expandConnectionPoolConfig(d.Get("settings.0.connection_pool_config").(*schema.Set).List())
+		instance = &sqladmin.DatabaseInstance{
+			DatabaseVersion: databaseVersion,
+			Settings: &sqladmin.Settings{
+				ConnectionPoolConfig: connectionPoolConfig,
+			},
+		}
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() (rerr error) {
+				op, rerr = config.NewSqlAdminClient(userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()
+				return rerr
+			},
+			Timeout:              d.Timeout(schema.TimeoutUpdate),
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
+		})
+		if err != nil {
+			return fmt.Errorf("Error, failed to patch instance connection pool config for %s: %s", d.Get("name").(string), err)
+		}
+		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+		err = resourceSqlDatabaseInstanceRead(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+
 	s := d.Get("settings")
 	instance = &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(desiredSetting.([]interface{}), databaseVersion),
-		DatabaseVersion: databaseVersion,
 	}
 	_settings := s.([]interface{})[0].(map[string]interface{})
 	// Instance.Patch operation on completion updates the settings proto version by +8. As terraform does not know this it tries

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -425,7 +425,7 @@ is set to true. Defaults to ZONAL.`,
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed:    true,
-							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED. `,
+							Description: `The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED.`,
 						},
 						"disk_type": {
 							Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -910,10 +910,6 @@ func TestAccSqlDatabaseInstance_updateMCPEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSqlDatabaseInstance_withoutMCPEnabled(instanceName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.connection_pooling_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.flags.#", "0"),
-				),
 			},
 			{
 				Config: testAccSqlDatabaseInstance_withMCPEnabled(instanceName),

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -897,6 +897,42 @@ func TestAccSqlDatabaseInstance_withoutMCPEnabled(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_updateMCPEnabled(t *testing.T) {
+	t.Parallel()
+
+	instanceName := "tf-test-" + acctest.RandString(t, 10)
+	resourceName := "google_sql_database_instance.instance"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_withoutMCPEnabled(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.connection_pooling_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.flags.#", "0"),
+				),
+			},
+			{
+				Config: testAccSqlDatabaseInstance_withMCPEnabled(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.connection_pooling_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "settings.0.connection_pool_config.0.flags.#", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+
 func TestAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
sql: fixed an error in updating `connection_pool_config` in `google_sql_database_instance`
```
