### PR TITLE
fix: (storage) change retention period to string instead of int

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -409,9 +409,8 @@ func ResourceStorageBucket() *schema.Resource {
 							Description: `If set to true, the bucket will be locked and permanently restrict edits to the bucket's retention policy.  Caution: Locking a bucket is an irreversible action.`,
 						},
 						"retention_period": {
-							Type:         schema.TypeInt,
+							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.IntBetween(1, math.MaxInt32),
 							Description:  `The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 3,155,760,000 seconds.`,
 						},
 					},
@@ -853,7 +852,11 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 			retentionPolicy := retention_policies[0].(map[string]interface{})
 
 			if v, ok := retentionPolicy["retention_period"]; ok {
-				sb.RetentionPolicy.RetentionPeriod = int64(v.(int))
+				value, err := strconv.ParseInt(v.(string), 10, 64)
+				if err != nil {
+					return err
+				}
+				sb.RetentionPolicy.RetentionPeriod = int64(value)
 			}
 		}
 	}
@@ -1478,7 +1481,7 @@ func flattenBucketRetentionPolicy(bucketRetentionPolicy *storage.BucketRetention
 
 	retentionPolicy := map[string]interface{}{
 		"is_locked":        bucketRetentionPolicy.IsLocked,
-		"retention_period": bucketRetentionPolicy.RetentionPeriod,
+		"retention_period": fmt.Sprintf("%d", bucketRetentionPolicy.RetentionPeriod),
 	}
 
 	bucketRetentionPolicies = append(bucketRetentionPolicies, retentionPolicy)

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -255,7 +255,7 @@ The following arguments are supported:
 
 * `is_locked` - (Optional) If set to `true`, the bucket will be [locked](https://cloud.google.com/storage/docs/using-bucket-lock#lock-bucket) and permanently restrict edits to the bucket's retention policy.  Caution: Locking a bucket is an irreversible action.
 
-* `retention_period` - (Required) The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 2,147,483,647 seconds.
+* `retention_period` - (Required) The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted, overwritten, or archived. The value must be less than 3,155,760,000 seconds.
 
 <a name="nested_logging"></a>The `logging` block supports:
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
storage: change `retention_period` from int to string in resource `google_storage_bucket`
```
