### PR TITLE
Adding support for log_linked_dataset_query_user_email attribute for BigQuery Analytics Hub Listing Subscriptions.

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/ListingSubscription.yaml
@@ -194,3 +194,7 @@ properties:
           type: string
           description: Output only. Name of the linked dataset, e.g. projects/subscriberproject/datasets/linkedDataset
           output: true
+  - name: 'logLinkedDatasetQueryUserEmail'
+    type: Boolean
+    description: 'Output only. By default, false. If true, the Subscriber agreed to the email sharing mandate that is enabled for Listing.'
+    output: true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This Pull Request introduces support for the log_linked_dataset_query_user_email attribute within the google_bigquery_analytics_hub_listing_subscription resource.

This new field provides visibility into whether the email of the user querying a linked dataset will be logged. As an output-only field, its value is determined by the Google Cloud API after resource creation. [API reference](https://cloud.google.com/bigquery/docs/reference/analytics-hub/rest/v1/projects.locations.subscriptions)

@c2thorn @shashambhavi

```release-note:enhancement
bigqueryanalyticshub: added `log_linked_dataset_query_user_email` field to `google_bigquery_analytics_hub_listing_subscription` resource
```
