### PR TITLE
Add support to pause google_cloud_tasks_queue resources

### DIFF
--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -35,6 +35,7 @@ iam_policy:
 custom_code:
   constants: 'templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go.tmpl'
   post_create: 'templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl'
+  post_update: 'templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl'
 examples:
   - name: 'queue_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -34,6 +34,7 @@ iam_policy:
     - '{{name}}'
 custom_code:
   constants: 'templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go.tmpl'
+  post_create: 'templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl'
 examples:
   - name: 'queue_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -218,6 +218,15 @@ properties:
           This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the
           default and means that no operations are logged.
         required: true
+  - name: 'state'
+    type: Enum
+    description: |
+      The current state of the queue.
+    output: true
+    enum_values:
+      - 'RUNNING'
+      - 'PAUSED'
+      - 'DISABLED'
   - name: 'httpTarget'
     type: NestedObject
     description: Modifies HTTP target for HTTP tasks.

--- a/mmv1/products/cloudtasks/Queue.yaml
+++ b/mmv1/products/cloudtasks/Queue.yaml
@@ -56,6 +56,18 @@ examples:
     primary_resource_id: 'http_target_oauth'
     vars:
       name: 'cloud-tasks-queue-http-target-oauth'
+virtual_fields:
+  - name: 'desired_state'
+    type: Enum
+    description: |
+      The desired state of the queue. Use this to pause and resume the queue.
+      
+      * RUNNING: The queue is running. Tasks can be dispatched.
+      * PAUSED: The queue is paused. Tasks are not dispatched but can be added to the queue.
+    default_value: 'RUNNING'
+    enum_values:
+      - 'RUNNING'
+      - 'PAUSED'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl
+++ b/mmv1/templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl
@@ -1,6 +1,6 @@
 // Handle desired state after queue creation
 if v, ok := d.GetOk("desired_state"); ok && v.(string) == "PAUSED" {
-  pauseUrl := fmt.Sprintf("%s%s:pause", config.CloudTasksBasePath, url)
+  pauseUrl := fmt.Sprintf("%s%s:pause", config.CloudTasksBasePath, id)
 
   _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
     Config:    config,

--- a/mmv1/templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl
+++ b/mmv1/templates/terraform/post_create/cloud_tasks_queue_state.go.tmpl
@@ -1,0 +1,16 @@
+// Handle desired state after queue creation
+if v, ok := d.GetOk("desired_state"); ok && v.(string) == "PAUSED" {
+  pauseUrl := fmt.Sprintf("%s%s:pause", config.CloudTasksBasePath, url)
+
+  _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "POST",
+    Project:   billingProject,
+    RawURL:    pauseUrl,
+    UserAgent: userAgent,
+  })
+
+  if err != nil {
+    return fmt.Errorf("Error pausing queue %q: %s", d.Id(), err)
+  }
+}

--- a/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
+++ b/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
@@ -3,14 +3,18 @@ if d.HasChange("desired_state") {
   old, new := d.GetChange("desired_state")
 
   if old.(string) != new.(string) {
-    var actionUrl string
     var action string
 
+    actionUrl, err := tpgresource.ReplaceVars(d, config, "{{CloudTasksBasePath}}projects/{{project}}/locations/{{location}}/queues/{{name}}")
+		if err != nil {
+			return err
+		}
+
     if new.(string) == "PAUSED" {
-      actionUrl = fmt.Sprintf("%s%s:pause", config.CloudTasksBasePath, url)
+      actionUrl = fmt.Sprintf("%s:pause", actionUrl)
       action = "pausing"
     } else if new.(string) == "RUNNING" {
-      actionUrl = fmt.Sprintf("%s%s:resume", config.CloudTasksBasePath, url)
+      actionUrl = fmt.Sprintf("%s:resume", actionUrl)
       action = "resuming"
     }
 

--- a/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
+++ b/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
@@ -5,7 +5,7 @@ if d.HasChange("desired_state") {
   if old.(string) != new.(string) {
     var action string
 
-    actionUrl, err := tpgresource.ReplaceVars(d, config, "{{CloudTasksBasePath}}projects/{{project}}/locations/{{location}}/queues/{{name}}")
+    actionUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}CloudTasksBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/queues/{{"{{"}}name{{"}}"}}")
 		if err != nil {
 			return err
 		}

--- a/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
+++ b/mmv1/templates/terraform/post_update/cloud_tasks_queue_state.go.tmpl
@@ -1,0 +1,31 @@
+// Handle desired state changes
+if d.HasChange("desired_state") {
+  old, new := d.GetChange("desired_state")
+
+  if old.(string) != new.(string) {
+    var actionUrl string
+    var action string
+
+    if new.(string) == "PAUSED" {
+      actionUrl = fmt.Sprintf("%s%s:pause", config.CloudTasksBasePath, url)
+      action = "pausing"
+    } else if new.(string) == "RUNNING" {
+      actionUrl = fmt.Sprintf("%s%s:resume", config.CloudTasksBasePath, url)
+      action = "resuming"
+    }
+
+    if actionUrl != "" {
+      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config:    config,
+        Method:    "POST",
+        Project:   billingProject,
+        RawURL:    actionUrl,
+        UserAgent: userAgent,
+      })
+            
+      if err != nil {
+        return fmt.Errorf("Error %s queue %q: %s", action, d.Id(), err)
+      }
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go
+++ b/mmv1/third_party/terraform/services/cloudtasks/resource_cloud_tasks_queue_test.go
@@ -173,6 +173,37 @@ func TestAccCloudTasksQueue_HttpTargetOAuth_update(t *testing.T) {
 	})
 }
 
+func TestAccCloudTasksQueue_paused(t *testing.T) {
+	t.Parallel()
+
+	name := "cloudtasksqueuetest-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudTasksQueue_full(name),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_engine_routing_override.0.service", "app_engine_routing_override.0.version", "app_engine_routing_override.0.instance"},
+			},
+			{
+				Config: testAccCloudTasksQueue_paused(name),
+			},
+			{
+				ResourceName:            "google_cloud_tasks_queue.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app_engine_routing_override.0.service", "app_engine_routing_override.0.version", "app_engine_routing_override.0.instance"},
+			},
+		},
+	})
+}
+
 func testAccCloudTasksQueue_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_tasks_queue" "default" {
@@ -192,6 +223,7 @@ func testAccCloudTasksQueue_full(name string) string {
 resource "google_cloud_tasks_queue" "default" {
   name = "%s"
   location = "us-central1"
+  desired_state = "RUNNING"
 
   app_engine_routing_override {
     service = "worker"
@@ -377,4 +409,37 @@ resource "google_service_account" "test" {
 }
 
 `, name, serviceAccountID)
+}
+
+func testAccCloudTasksQueue_paused(name string) string {
+	return fmt.Sprintf(`
+resource "google_cloud_tasks_queue" "default" {
+  name = "%s"
+  location = "us-central1"
+  desired_state = "PAUSED"
+
+  app_engine_routing_override {
+    service = "main"
+    version = "2.0"
+    instance = "beta"
+  }
+
+  rate_limits {
+    max_concurrent_dispatches = 4
+    max_dispatches_per_second = 3
+  }
+
+  retry_config {
+    max_attempts = 6
+    max_retry_duration = "5s"
+    max_backoff = "4s"
+    min_backoff = "3s"
+    max_doublings = 2
+	}
+
+	stackdriver_logging_config {
+		sampling_ratio = 0.1
+	}
+}
+`, name)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/15165.

I mainly looked at https://github.com/GoogleCloudPlatform/magic-modules/pull/8368 for inspiration on adding the functionality. This will be my first time contribution to this repository so will appreciate the feedback. The new field `desired_state` supports the the ability to control the state of the google_cloud_tasks_queue resource. The new field is backwards compatible with the state being set to `RUNNING` when omitted.

What I have done:
* Tested locally on terraform-provider-google:

## resource creation
```
# main.tf
provider "google" {
  project     = "project"
  region      = "australia-southeast1"
}

terraform {
  backend "local" {
    path = "terraform.tfstate"
  }
  required_providers {
    google = {
      version = "6.34.1"
    }
  }
}

resource "google_cloud_tasks_queue" "default" {
  name          = "cloud-tasks-queue-test-10"
  location      = "australia-southeast1"
  desired_state = "PAUSED"
}

```

resource creation apply output:
```
Terraform will perform the following actions:

  # google_cloud_tasks_queue.default will be created
  + resource "google_cloud_tasks_queue" "default" {
      + desired_state = "PAUSED"
      + id            = (known after apply)
      + location      = "australia-southeast1"
      + name          = "cloud-tasks-queue-test"
      + project       = "project"
      + state         = (known after apply)

      + retry_config (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

google_cloud_tasks_queue.default: Creating...
google_cloud_tasks_queue.default: Creation complete after 1s [id=projects/project/locations/australia-southeast1/queues/cloud-tasks-queue-test]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

## resource update:
```
# main.tf
provider "google" {
  project     = "project"
  region      = "australia-southeast1"
}

terraform {
  backend "local" {
    path = "terraform.tfstate"
  }
  required_providers {
    google = {
      version = "6.34.1"
    }
  }
}

resource "google_cloud_tasks_queue" "default" {
  name          = "cloud-tasks-queue-test-10"
  location      = "australia-southeast1"
  desired_state = "RUNNING"
}

```

resource creation update output:
```
Terraform will perform the following actions:

  # google_cloud_tasks_queue.default will be updated in-place
  ~ resource "google_cloud_tasks_queue" "default" {
      ~ desired_state = "PAUSED" -> "RUNNING"
        id            = "projects/project/locations/australia-southeast1/queues/cloud-tasks-queue-test"
        name          = "cloud-tasks-queue-test"
        # (3 unchanged attributes hidden)

      - rate_limits {
          - max_burst_size            = 100 -> null
          - max_concurrent_dispatches = 1000 -> null
          - max_dispatches_per_second = 500 -> null
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

google_cloud_tasks_queue.default: Modifying... [id=projects/project/locations/australia-southeast1/queues/cloud-tasks-queue-test]
google_cloud_tasks_queue.default: Modifications complete after 2s [id=projects/project/locations/australia-southeast1/queues/cloud-tasks-queue-test]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME
cloud_tasks: added `desired_state` field to `google_cloud_tasks_queue ` resource
```
