### PR TITLE
Fix TestAccDataSourceGoogleGkeHubFeature_basic failing in VCR

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub2/data_source_google_gke_hub_feature_test.go
+++ b/mmv1/third_party/terraform/services/gkehub2/data_source_google_gke_hub_feature_test.go
@@ -20,9 +20,9 @@ func TestAccDataSourceGoogleGkeHubFeature_basic(t *testing.T) {
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
-		Providers:    acctest.TestAccProviders,
-		CheckDestroy: testAccCheckGoogleGkeHubFeatureDestroyProducer(t),
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGoogleGkeHubFeatureDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceGoogleGkeHubFeature_basic(context),


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22091

This test runs and passes in VCR, but nothing is recorded. I notcied it is the only test using `Providers:    acctest.TestAccProviders`, so I've updated that in hopes that it fixes the issue. I'm wondering if there is something happening with beta vs ga when we use the old config.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
