### PR TITLE
tgc-revival: add IncludeInTGCNext field

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1991,11 +1991,11 @@ func (r Resource) TGCTestIgnorePropertiesToStrings(e resource.Examples) []string
 	for _, tp := range r.AllUserProperties() {
 		if tp.UrlParamOnly {
 			props = append(props, google.Underscore(tp.Name))
+		} else if tp.IsMissingInCai {
+			props = append(props, tp.MetadataLineage())
 		}
 	}
-	for _, tp := range e.TGCTestIgnoreExtra {
-		props = append(props, tp)
-	}
+	props = append(props, e.TGCTestIgnoreExtra...)
 
 	slices.Sort(props)
 	return props

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -230,6 +230,9 @@ type Resource struct {
 	// (i.e. terraform-provider-conversion)
 	ExcludeTgc bool `yaml:"exclude_tgc,omitempty"`
 
+	// If true, include resource in the new package of TGC (terraform-provider-conversion)
+	IncludeInTGCNext bool `yaml:"include_in_tgc_next_DO_NOT_USE,omitempty"`
+
 	// If true, skip sweeper generation for this resource
 	ExcludeSweeper bool `yaml:"exclude_sweeper,omitempty"`
 

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -293,6 +293,9 @@ type Type struct {
 	// The prefix used as part of the property expand/flatten function name
 	// flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}
 	Prefix string `yaml:"prefix,omitempty"`
+
+	// The field is not present in CAI asset
+	IsMissingInCai bool `yaml:"is_missing_in_cai,omitempty"`
 }
 
 const MAX_NAME = 20

--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -49,6 +49,7 @@ async:
   result:
     resource_inside_response: false
 collection_url_key: 'items'
+include_in_tgc_next_DO_NOT_USE: true
 custom_code:
   post_create: 'templates/terraform/post_create/labels.tmpl'
   tgc_encoder: 'templates/tgc_next/encoders/compute_address.go.tmpl'

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -37,7 +37,7 @@ import (
 type TerraformGoogleConversionNext struct {
 	ResourceCount int
 
-	ResourcesForVersion []map[string]string
+	ResourcesForVersion []ResourceIdentifier
 
 	TargetVersionName string
 
@@ -46,6 +46,12 @@ type TerraformGoogleConversionNext struct {
 	Product *api.Product
 
 	StartTime time.Time
+}
+
+type ResourceIdentifier struct {
+	ServiceName   string
+	TerraformName string
+	ResourceName  string
 }
 
 func NewTerraformGoogleConversionNext(product *api.Product, versionName string, startTime time.Time) TerraformGoogleConversionNext {
@@ -316,10 +322,10 @@ func (tgc *TerraformGoogleConversionNext) generateResourcesForVersion(products [
 
 			tgc.ResourceCount++
 
-			tgc.ResourcesForVersion = append(tgc.ResourcesForVersion, map[string]string{
-				"ServiceName":   service,
-				"TerraformName": object.TerraformName(),
-				"ResourceName":  object.ResourceName(),
+			tgc.ResourcesForVersion = append(tgc.ResourcesForVersion, ResourceIdentifier{
+				ServiceName:   service,
+				TerraformName: object.TerraformName(),
+				ResourceName:  object.ResourceName(),
 			})
 		}
 	}

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api"
@@ -34,6 +35,10 @@ import (
 // TerraformGoogleConversionNext is for both tfplan2cai and cai2hcl conversions
 // and copying other files, such as transport.go
 type TerraformGoogleConversionNext struct {
+	ResourceCount int
+
+	ResourcesForVersion []map[string]string
+
 	TargetVersionName string
 
 	Version product.Version
@@ -75,17 +80,7 @@ func (tgc TerraformGoogleConversionNext) Generate(outputFolder, productPath, res
 }
 
 func (tgc TerraformGoogleConversionNext) GenerateObject(object api.Resource, outputFolder, resourceToGenerate string, generateCode, generateDocs bool) {
-	if object.ExcludeTgc {
-		log.Printf("Skipping fine-grained resource %s", object.Name)
-		return
-	}
-
-	// TODO: remove it after supporting most of resources.
-	supportList := map[string]bool{
-		"ComputeAddress": true,
-	}
-
-	if ok := supportList[object.ResourceName()]; !ok {
+	if !object.IncludeInTGCNext {
 		return
 	}
 
@@ -138,6 +133,8 @@ func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resou
 }
 
 func (tgc TerraformGoogleConversionNext) CompileCommonFiles(outputFolder string, products []*api.Product, overridePath string) {
+	tgc.generateResourcesForVersion(products)
+
 	resourceConverters := map[string]string{
 		// common
 		"pkg/transport/config.go":                        "third_party/terraform/transport/config.go.tmpl",
@@ -145,6 +142,7 @@ func (tgc TerraformGoogleConversionNext) CompileCommonFiles(outputFolder string,
 		"pkg/tpgresource/common_diff_suppress.go":        "third_party/terraform/tpgresource/common_diff_suppress.go",
 		"pkg/provider/provider.go":                       "third_party/terraform/provider/provider.go.tmpl",
 		"pkg/provider/provider_validators.go":            "third_party/terraform/provider/provider_validators.go",
+		"pkg/provider/provider_mmv1_resources.go":        "templates/tgc_next/provider/provider_mmv1_resources.go.tmpl",
 
 		// tfplan2cai
 		"pkg/tfplan2cai/converters/resource_converters.go":                       "templates/tgc_next/tfplan2cai/resource_converters.go.tmpl",
@@ -291,6 +289,39 @@ func (tgc TerraformGoogleConversionNext) replaceImportPath(outputFolder, target 
 	err = os.WriteFile(targetFile, sourceByte, 0644)
 	if err != nil {
 		log.Fatalf("Cannot write file %s to replace import path: %s", target, err)
+	}
+}
+
+// Generates the list of resources, and gets the count of resources.
+// The resource object has the format
+//
+//	{
+//	   terraform_name:
+//	   resource_name:
+//	}
+//
+// The variable resources_for_version is used to generate resources in file
+// mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl
+func (tgc *TerraformGoogleConversionNext) generateResourcesForVersion(products []*api.Product) {
+	for _, productDefinition := range products {
+		service := strings.ToLower(productDefinition.Name)
+		for _, object := range productDefinition.Objects {
+			if object.Exclude || object.NotInVersion(productDefinition.VersionObjOrClosest(tgc.TargetVersionName)) {
+				continue
+			}
+
+			if !object.IncludeInTGCNext {
+				continue
+			}
+
+			tgc.ResourceCount++
+
+			tgc.ResourcesForVersion = append(tgc.ResourcesForVersion, map[string]string{
+				"ServiceName":   service,
+				"TerraformName": object.TerraformName(),
+				"ResourceName":  object.ResourceName(),
+			})
+		}
 	}
 }
 

--- a/mmv1/templates/tgc_next/cai2hcl/resource_converters.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/resource_converters.go.tmpl
@@ -29,7 +29,9 @@ package converters
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/models"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/services/compute"
+	{{- range $service := $.Products }}
+	  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/services/{{ lower $service.Name }}"
+	{{- end }}
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters/services/resourcemanager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -40,7 +42,14 @@ var provider *schema.Provider = tpg_provider.Provider()
 
 // ConverterMap is a collection of converters instances, indexed by cai asset type.
 var ConverterMap = map[string]models.Converter{
+	// ####### START handwritten resources ###########
 	resourcemanager.ProjectAssetType: resourcemanager.NewProjectConverter(provider),
 	compute.ComputeInstanceAssetType: compute.NewComputeInstanceConverter(provider),
-	compute.ComputeAddressAssetType:  compute.NewComputeAddressConverter(provider),
+	// ####### END handwritten resources ###########
+
+	{{- range $object := $.ResourcesForVersion }}
+		{{- if $object.ResourceName }}
+			{{ $object.ServiceName }}.{{ $object.ResourceName }}AssetType: {{ $object.ServiceName }}.New{{ $object.ResourceName -}}Converter(provider),
+		{{- end }}
+	{{- end }}
 }

--- a/mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl
@@ -12,7 +12,13 @@ var handwrittenTfplan2caiResources = map[string]*schema.Resource{
 	"google_compute_instance": compute.ResourceComputeInstance(),
 	"google_project":          resourcemanager.ResourceGoogleProject(),
 	// ####### END handwritten resources ###########
+}
 
-	// TODO: will generate it automatically for MMv1 resources.
-	"google_compute_address": compute.ResourceComputeAddress(),
+// Generated resources: {{ $.ResourceCount }}
+var generatedResources = map[string]*schema.Resource{
+	{{- range $object := $.ResourcesForVersion }}
+		{{- if $object.ResourceName }}
+			"{{ $object.TerraformName }}": {{ $object.ServiceName }}.Resource{{ $object.ResourceName -}}(),
+		{{- end }}
+	{{- end }}
 }

--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converters.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converters.go.tmpl
@@ -29,12 +29,21 @@ package converters
 
 import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/cai"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/services/compute"
+	{{- range $service := $.Products }}
+	  "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/services/{{ lower $service.Name }}"
+	{{- end }}
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters/services/resourcemanager"
 )
 
 var ConverterMap = map[string]cai.ResourceConverter{
+	// ####### START handwritten resources ###########
 	"google_project":          resourcemanager.ResourceConverterProject(),
 	"google_compute_instance": compute.ResourceConverterComputeInstance(),
-	"google_compute_address":  compute.ResourceConverterComputeAddress(),
+	// ####### END handwritten resources ###########
+
+	{{- range $object := $.ResourcesForVersion }}
+		{{- if $object.ResourceName }}
+			"{{ $object.TerraformName }}": {{ $object.ServiceName }}.ResourceConverter{{ $object.ResourceName -}}(),
+		{{- end }}
+	{{- end }}
 }

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -250,6 +250,7 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 {{- else }}
 	return mergeResourceMaps(
 		handwrittenTfplan2caiResources,
+		generatedResources,
 	)
 {{- end }}
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
1. Setting `IncludeInTGCNext` to true will add the resource to tgc new package. `include_in_tgc_next_DO_NOT_USE` is for our team to support resources, not ready for using by contributors.
2. If a field is not CAI asset, then add `is_missing_in_cai: true` to the field and ignore the field in the test.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
