### PR TITLE
Adding effective_reserved_ip_range and fix for null value in redis datasource 

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -445,6 +445,16 @@ properties:
     # but will be a subset of the range.
     ignore_read: true
     default_from_api: true
+  - name: 'effectiveReservedIpRange'
+    type: String
+    description: |
+      The CIDR range of internal addresses that are reserved for this
+      instance. If not provided, the service will choose an unused /29
+      block, for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be
+      unique and non-overlapping with existing subnets in an authorized
+      network.
+    output: true
+    api_name: reservedIpRange
   - name: 'tier'
     type: Enum
     description: |

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_instance.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_instance.go
@@ -39,9 +39,26 @@ func dataSourceGoogleRedisInstanceRead(d *schema.ResourceData, meta interface{})
 	if err := tpgresource.SetDataSourceLabels(d); err != nil {
 		return err
 	}
+	// added to resolve a null value for reserved_ip_range. This was not getting populated due to the addtion of ignore_read
+	if err := SetDataSourceReservedIpRange(d); err != nil {
+		return err
+	}
 
 	if d.Id() == "" {
 		return fmt.Errorf("%s not found", id)
 	}
+	return nil
+}
+
+func SetDataSourceReservedIpRange(d *schema.ResourceData) error {
+	effectiveReservedIpRange := d.Get("effective_reserved_ip_range")
+	if effectiveReservedIpRange == nil {
+		return nil
+	}
+
+	if err := d.Set("reserved_ip_range", effectiveReservedIpRange); err != nil {
+		return fmt.Errorf("Error setting reserved_ip_range in data source: %s", err)
+	}
+
 	return nil
 }

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_instance_test.go
@@ -19,6 +19,7 @@ func TestAccRedisInstanceDatasource_basic(t *testing.T) {
 				Config: testAccRedisInstanceDatasourceConfig(acctest.RandString(t, 10)),
 				Check: resource.ComposeTestCheckFunc(
 					acctest.CheckDataSourceStateMatchesResourceState("data.google_redis_instance.redis", "google_redis_instance.redis"),
+					resource.TestCheckResourceAttrSet("data.google_redis_instance.redis", "reserved_ip_range"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/14154
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement 
redis: added output-only `effective_reserved_ip_range` field in `google_redis_instance` resource to display the value of `reservedIpRange` from API
```

```release-note:bug 
redis: fixed the bug that the `reserved_ip_range` field is null in `google_redis_instance` data source
```
