### PR TITLE
fix invalid build_config.worker_pool in cloudrunv2 example and test

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_service_function.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_function.tf.tmpl
@@ -16,7 +16,6 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
     image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
     base_image = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs22"
     enable_automatic_updates = true
-    worker_pool = "worker-pool"
     environment_variables = {
       FOO_KEY = "FOO_VALUE"
       BAR_KEY = "BAR_VALUE"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1446,7 +1446,6 @@ resource "google_cloud_run_v2_service" "default" {
     image_uri = "us-docker.pkg.dev/cloudrun/container/hello"
     base_image = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs22"
     enable_automatic_updates = true
-    worker_pool = "worker-pool"
     environment_variables = {
       FOO_KEY = "FOO_VALUE"
       BAR_KEY = "BAR_VALUE"
@@ -1512,7 +1511,6 @@ resource "google_cloud_run_v2_service" "default" {
     image_uri = "gcr.io/cloudrun/hello:latest"
     base_image = "us-central1-docker.pkg.dev/serverless-runtimes/google-22-full/runtimes/nodejs20"
     enable_automatic_updates = false
-    worker_pool = "worker-pool-2"
     environment_variables = {
       FOO_KEY_FOO = "FOO_VALUE_FOO"
       BAR_KEY_BAR = "BAR_VALUE_BAR"


### PR DESCRIPTION
This is to fix failed acceptance tests TestAccCloudRunV2Service 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
