### PR TITLE
remove dependsOn field as it is not supported for workerpools and fix failing test.

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -477,12 +477,6 @@ properties:
               type: String
               description: |-
                 Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image.
-            - name: 'dependsOn'
-              type: Array
-              description: |-
-                Containers which should be started before this container. If specified the container will wait to start until all containers with the listed names are healthy.
-              item_type:
-                type: String
       - name: 'volumes'
         type: Array
         description: |-

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -167,3 +167,9 @@ Remove `description` from your configuration after upgrade.
 ### `service_config.service` is changed from `Argument` to `Attribute`
 
 Remove `service_config.service` from your configuration after upgrade.
+
+## Resource: `google_cloud_run_v2_worker_pool`
+
+### `template.containers.depends_on` is reomved as it is not supported.
+
+Remove `template.containers.depends_on` from your configuration after upgrade.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/23307
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
Field `template.containers.depends_on` within `resource google_cloud_run_v2_worker_pool` removed
```
