### PR TITLE
tgc-revival: fix getting primary resource bug

### DIFF
--- a/mmv1/third_party/terraform/acctest/tgc_utils.go
+++ b/mmv1/third_party/terraform/acctest/tgc_utils.go
@@ -129,8 +129,7 @@ func determineImportMetadata(steps []resource.TestStep, currentStepIndex int, re
 		nextStep := steps[currentStepIndex+1]
 
 		// Check if it's an import step for our resource
-		if nextStep.ImportState && (nextStep.ResourceName == resourceName ||
-			strings.HasSuffix(nextStep.ResourceName, "."+strings.Split(resourceName, ".")[1])) {
+		if nextStep.ImportState && nextStep.ResourceName == resourceName {
 			// Capture ignored fields if present
 			if nextStep.ImportStateVerify && len(nextStep.ImportStateVerifyIgnore) > 0 {
 				metadata.IgnoredFields = nextStep.ImportStateVerifyIgnore


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
In the test [example](TestAccComputeAutoscaler_autoscalerSingleInstanceExample), the primary resource is `google_compute_instance_template.default`, which is incorrect. The reason is that `google_compute_instance_template.default` has the suffix `default`. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
