### PR TITLE
Add support for eTag in AutokeyConfig

### DIFF
--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -3,7 +3,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,18 +15,18 @@
 name: 'AutokeyConfig'
 # This resource is currently in public preview.
 description: |
- `AutokeyConfig` is a singleton resource used to configure the auto-provisioning
- flow of CryptoKeys for CMEK.
+  `AutokeyConfig` is a singleton resource used to configure the auto-provisioning
+  flow of CryptoKeys for CMEK.
 
 
- ~> \*\*Note:\*\* AutokeyConfigs cannot be deleted from Google Cloud Platform.
- Destroying a Terraform-managed AutokeyConfig will remove it from state but
- \*will not delete the resource from the project.\*
+  ~> **Note:** AutokeyConfigs cannot be deleted from Google Cloud Platform.
+  Destroying a Terraform-managed AutokeyConfig will remove it from state but
+  *will not delete the resource from the project.*
 min_version: 'beta'
 references:
- guides:
- 'Cloud KMS with Autokey': 'https://cloud.google.com/kms/docs/kms-with-autokey'
- api: 'https://cloud.google.com/kms/docs/reference/rest/v1/AutokeyConfig'
+  guides:
+    'Cloud KMS with Autokey': 'https://cloud.google.com/kms/docs/kms-with-autokey'
+  api: 'https://cloud.google.com/kms/docs/reference/rest/v1/AutokeyConfig'
 docs:
 id_format: 'folders/{{folder}}/autokeyConfig'
 base_url: 'folders/{{folder}}/autokeyConfig'
@@ -40,51 +40,51 @@ update_verb: 'PATCH'
 delete_url: 'folders/{{folder}}/autokeyConfig?updateMask=keyProject'
 delete_verb: 'PATCH'
 import_format:
- - 'folders/{{folder}}/autokeyConfig'
+  - 'folders/{{folder}}/autokeyConfig'
 timeouts:
- insert_minutes: 20
- update_minutes: 20
- delete_minutes: 20
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
 custom_code:
- constants: 'templates/terraform/constants/autokey_config_folder_diff.go.tmpl'
- pre_create: 'templates/terraform/pre_create/kms_autokey_config_folder.go.tmpl'
- pre_read: 'templates/terraform/pre_read/kms_autokey_config_folder.go.tmpl'
- pre_update: 'templates/terraform/pre_update/kms_autokey_config_folder.go.tmpl'
- pre_delete: 'templates/terraform/pre_delete/kms_autokey_config_folder.go.tmpl'
- post_create: 'templates/terraform/post_create/sleep.go.tmpl'
- post_update: 'templates/terraform/post_create/sleep.go.tmpl'
- test_check_destroy: 'templates/terraform/custom_check_destroy/kms_autokey_config.go.tmpl'
+  constants: 'templates/terraform/constants/autokey_config_folder_diff.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/kms_autokey_config_folder.go.tmpl'
+  pre_read: 'templates/terraform/pre_read/kms_autokey_config_folder.go.tmpl'
+  pre_update: 'templates/terraform/pre_update/kms_autokey_config_folder.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/kms_autokey_config_folder.go.tmpl'
+  post_create: 'templates/terraform/post_create/sleep.go.tmpl'
+  post_update: 'templates/terraform/post_create/sleep.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/kms_autokey_config.go.tmpl'
 # Using a handwritten sweeper because of pre_delete.
 exclude_sweeper: true
 examples:
- - name: 'kms_autokey_config_all'
-   primary_resource_id: 'example-autokeyconfig'
-   min_version: 'beta'
-   vars:
-     folder_name: 'my-folder'
-     key_project_name: 'key-proj'
-   test_env_vars:
-     org_id: 'ORG_ID'
-     billing_account: 'BILLING_ACCT'
-   external_providers: ["random", "time"]
+  - name: 'kms_autokey_config_all'
+    primary_resource_id: 'example-autokeyconfig'
+    min_version: 'beta'
+    vars:
+      folder_name: 'my-folder'
+      key_project_name: 'key-proj'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    external_providers: ["random", "time"]
 parameters:
- - name: 'folder'
-   type: String
-   description: |
-     The folder for which to retrieve config.
-   min_version: 'beta'
-   url_param_only: true
-   required: true
-   immutable: true
-   diff_suppress_func: 'folderPrefixSuppress'
+  - name: 'folder'
+    type: String
+    description: |
+      The folder for which to retrieve config.
+    min_version: 'beta'
+    url_param_only: true
+    required: true
+    immutable: true
+    diff_suppress_func: 'folderPrefixSuppress'
 properties:
- - name: 'keyProject'
-   type: String
-   description: |
-     The target key project for a given folder where KMS Autokey will provision a
-     CryptoKey for any new KeyHandle the Developer creates. Should have the form
-     `projects/<project_id_or_number>`.
-   min_version: 'beta'
+  - name: 'keyProject'
+    type: String
+    description: |
+      The target key project for a given folder where KMS Autokey will provision a
+      CryptoKey for any new KeyHandle the Developer creates. Should have the form
+      `projects/<project_id_or_number>`.
+    min_version: 'beta'
  - name: 'etag'
    type: String
    description: 'The etag of the AutokeyConfig for optimistic concurrency control.'


### PR DESCRIPTION
Add support for eTag in AutokeyConfig
KMS AutokeyConfig now has new field eTag for the concurrency management, as a part of this cl we will have comply with those backend changes
