### PR TITLE
Update AutokeyConfig.yaml

### DIFF
--- a/mmv1/products/kms/AutokeyConfig.yaml
+++ b/mmv1/products/kms/AutokeyConfig.yaml
@@ -85,3 +85,8 @@ properties:
       CryptoKey for any new KeyHandle the Developer creates. Should have the form
       `projects/<project_id_or_number>`.
     min_version: 'beta'
+  - name: 'etag'
+    type: String
+    description: 'The etag of the AutokeyConfig for optimistic concurrency control.'
+    min_version: 'beta'
+    output: true


### PR DESCRIPTION
Update AutokeyConfig.yaml to support eTag.

```release-note:enhancement
cloudkms: added support for `etag` output field to `google_kms_autokey_config` resource
```


GetAuokeyConfig response now contains eTag, 
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/4b5ac340-8ea0-4f3b-b5a5-92b00e060e6d" />

Update Operation with eTag is successful
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/c74ac6e2-7e0b-4906-b3c8-3bbb68cb95a4" />
