### PR TITLE
Fix dns_record_set with failover example

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dns_record_set.html.markdown
@@ -218,6 +218,7 @@ resource "google_dns_record_set" "a" {
 resource "google_dns_managed_zone" "prod" {
   name     = "prod-zone"
   dns_name = "prod.mydomain.com."
+  visibility = "private"
 }
 
 resource "google_compute_forwarding_rule" "prod" {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/19250 (b/363269342)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
Fixed google_dns_record_set with failover example
```
