### PR TITLE
Update Access Context Manager Test for user types

### DIFF
--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -218,7 +218,7 @@ resource "google_access_context_manager_access_level" "test-access" {
     combining_function = "AND"
     conditions {
       ip_subnetworks = ["192.0.4.0/24"]
-      members = ["user:test@google.com", "user:test2@google.com"]
+      members = ["group:test@google.com", "group:test2@google.com"]
       negate = false
       device_policy {
         require_screen_lock = false

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -203,22 +203,44 @@ resource "google_access_context_manager_access_level" "test-access" {
 }
 
 func testAccAccessContextManagerAccessLevel_full(org, policyTitle, levelTitleName string) string {
-	return fmt.Sprintf(`
+  context := map[string]interface{}{
+    "org_id":           org,
+    "billing_account":  envvar.GetTestBillingAccountFromEnv(t),
+    "random_suffix":    acctest.RandString(t, 10),
+    "policy_title":     policyTitle,
+    "level_title_name": levelTitleName
+  }
+
+	return acctest.Nprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
-  parent = "organizations/%s"
-  title  = "%s"
+  parent = "organizations/%{org_id}"
+  title  = "%{policy_title}"
+}
+
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_service_account" "test-account" {
+  account_id   = "tf-test-account%{random_suffix}"
+  display_name = "Test Service Account"
+  project      = google_project.project.project_id
 }
 
 resource "google_access_context_manager_access_level" "test-access" {
   parent      = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
-  name        = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
-  title       = "%s"
+  name        = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%{level_title_name}"
+  title       = "%{level_title_name}"
   description = "hello"
   basic {
     combining_function = "AND"
     conditions {
       ip_subnetworks = ["192.0.4.0/24"]
-      members = ["group:test@google.com", "group:test2@google.com"]
+      members = ["serviceAccount:${google_service_account.test-account.email}"]
       negate = false
       device_policy {
         require_screen_lock = false
@@ -236,5 +258,5 @@ resource "google_access_context_manager_access_level" "test-access" {
     }
   }
 }
-`, org, policyTitle, levelTitleName, levelTitleName)
+`, context)
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -46,7 +46,13 @@ func testAccAccessContextManagerAccessLevel_basicTest(t *testing.T) {
 }
 
 func testAccAccessContextManagerAccessLevel_fullTest(t *testing.T) {
-	org := envvar.GetTestOrgFromEnv(t)
+  context := map[string]interface{}{
+    "org_id":           envvar.GetTestOrgFromEnv(t),
+    "billing_account":  envvar.GetTestBillingAccountFromEnv(t),
+    "random_suffix":    acctest.RandString(t, 10),
+    "policy_title":     "my policy",
+    "level_title_name": "level",
+  }
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -54,7 +60,7 @@ func testAccAccessContextManagerAccessLevel_fullTest(t *testing.T) {
 		CheckDestroy: testAccCheckAccessContextManagerAccessLevelDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessContextManagerAccessLevel_full(org, "my policy", "level"),
+				Config: testAccAccessContextManagerAccessLevel_full(context),
 			},
 			{
 				ResourceName:      "google_access_context_manager_access_level.test-access",
@@ -202,14 +208,7 @@ resource "google_access_context_manager_access_level" "test-access" {
 `, org, policyTitle, levelTitleName, levelTitleName)
 }
 
-func testAccAccessContextManagerAccessLevel_full(org, policyTitle, levelTitleName string) string {
-  context := map[string]interface{}{
-    "org_id":           org,
-    "billing_account":  envvar.GetTestBillingAccountFromEnv(t),
-    "random_suffix":    acctest.RandString(t, 10),
-    "policy_title":     policyTitle,
-    "level_title_name": levelTitleName,
-  }
+func testAccAccessContextManagerAccessLevel_full(context map[string]interface{}) string {
 
 	return acctest.Nprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -208,7 +208,7 @@ func testAccAccessContextManagerAccessLevel_full(org, policyTitle, levelTitleNam
     "billing_account":  envvar.GetTestBillingAccountFromEnv(t),
     "random_suffix":    acctest.RandString(t, 10),
     "policy_title":     policyTitle,
-    "level_title_name": levelTitleName
+    "level_title_name": levelTitleName,
   }
 
 	return acctest.Nprintf(`


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```

I think this test is failing because the members in the access level are incorrect. The IAM principal prefix should match the type of the principal. The principal type in this case should be group not user since the principals are groups.