### PR TITLE
secretmanager: added `fetch_secret_data` to `google_secret_manager_secret_version` to be able to skip fetching the secret data

### DIFF
--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version.go
@@ -57,6 +57,11 @@ func DataSourceSecretManagerSecretVersion() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"fetch_secret_data": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -137,16 +142,32 @@ func dataSourceSecretManagerSecretVersionRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("error setting version: %s", err)
 	}
 
-	url = fmt.Sprintf("%s:access", url)
-	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   project,
-		RawURL:    url,
-		UserAgent: userAgent,
-	})
-	if err != nil {
-		return fmt.Errorf("error retrieving available secret manager secret version access: %s", err.Error())
+	if d.Get("fetch_secret_data").(bool) {
+		url = fmt.Sprintf("%s:access", url)
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("error retrieving available secret manager secret version access: %s", err.Error())
+		}
+		data := resp["payload"].(map[string]interface{})
+		var secretData string
+		if d.Get("is_secret_data_base64").(bool) {
+			secretData = data["data"].(string)
+		} else {
+			payloadData, err := base64.StdEncoding.DecodeString(data["data"].(string))
+			if err != nil {
+				return fmt.Errorf("error decoding secret manager secret version data: %s", err.Error())
+			}
+			secretData = string(payloadData)
+		}
+		if err := d.Set("secret_data", secretData); err != nil {
+			return fmt.Errorf("error setting secret_data: %s", err)
+		}
 	}
 
 	if err := d.Set("create_time", version["createTime"].(string)); err != nil {
@@ -162,21 +183,6 @@ func dataSourceSecretManagerSecretVersionRead(d *schema.ResourceData, meta inter
 	}
 	if err := d.Set("enabled", true); err != nil {
 		return fmt.Errorf("error setting enabled: %s", err)
-	}
-
-	data := resp["payload"].(map[string]interface{})
-	var secretData string
-	if d.Get("is_secret_data_base64").(bool) {
-		secretData = data["data"].(string)
-	} else {
-		payloadData, err := base64.StdEncoding.DecodeString(data["data"].(string))
-		if err != nil {
-			return fmt.Errorf("error decoding secret manager secret version data: %s", err.Error())
-		}
-		secretData = string(payloadData)
-	}
-	if err := d.Set("secret_data", secretData); err != nil {
-		return fmt.Errorf("error setting secret_data: %s", err)
 	}
 
 	d.SetId(nameValue.(string))

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_version_test.go
@@ -32,6 +32,27 @@ func TestAccDatasourceSecretManagerSecretVersion_basic(t *testing.T) {
 	})
 }
 
+func TestAccDatasourceSecretManagerSecretVersion_fetchSecretDataFalse(t *testing.T) {
+	t.Parallel()
+
+	randomString := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerSecretVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceSecretManagerSecretVersion_fetchSecretDataFalse(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatasourceSecretManagerSecretVersion("data.google_secret_manager_secret_version.basic", "1"),
+					resource.TestCheckNoResourceAttr("data.google_secret_manager_secret_version.basic", "secret_data"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatasourceSecretManagerSecretVersion_latest(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +206,31 @@ resource "google_secret_manager_secret_version" "secret-version-basic" {
 data "google_secret_manager_secret_version" "basic" {
   secret = google_secret_manager_secret_version.secret-version-basic.secret
   version = 1
+}
+`, randomString, randomString)
+}
+
+func testAccDatasourceSecretManagerSecretVersion_fetchSecretDataFalse(randomString string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_secret" "secret-basic" {
+  secret_id = "tf-test-secret-version-%s"
+  labels = {
+    label = "my-label"
+  }
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.secret-basic.name
+  secret_data = "my-tf-test-secret-%s"
+}
+
+data "google_secret_manager_secret_version" "basic" {
+  secret 			= google_secret_manager_secret_version.secret-version-basic.secret
+  version 			= 1
+  fetch_secret_data = false
 }
 `, randomString, randomString)
 }

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
     expected to be base64-encoded string.
 
 * `fetch_secret_data` - (Optional) If set to 'false', the `secret_data` 
-    will not be fetched.
+    will not be fetched. Default is `true`.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -31,6 +31,10 @@ The following arguments are supported:
 * `is_secret_data_base64` - (Optional) If set to 'true', the secret data is
     expected to be base64-encoded string.
 
+* `fetch_secret_data` - (Optional) If set to 'false', the `secret_data` 
+    will not be fetched.
+
+
 ## Attributes Reference
 
 The following attributes are exported:

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -28,10 +28,10 @@ The following arguments are supported:
 * `version` - (Optional) The version of the secret to get. If it
     is not provided, the latest version is retrieved.
 
-* `is_secret_data_base64` - (Optional) If set to 'true', the secret data is
+* `is_secret_data_base64` - (Optional) If set to `true`, the secret data is
     expected to be base64-encoded string.
 
-* `fetch_secret_data` - (Optional) If set to 'false', the `secret_data` 
+* `fetch_secret_data` - (Optional) If set to `false`, the `secret_data` 
     will not be fetched. Default is `true`.
 
 ## Attributes Reference

--- a/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/secret_manager_secret_version.html.markdown
@@ -34,7 +34,6 @@ The following arguments are supported:
 * `fetch_secret_data` - (Optional) If set to 'false', the `secret_data` 
     will not be fetched.
 
-
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23236

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
secretmanager: added `fetch_secret_data` to `google_secret_manager_secret_version` to be able to skip fetching the secret data
```
