### PR TITLE
Adds new IP Filter access fields

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -635,7 +635,7 @@ func ResourceStorageBucket() *schema.Resource {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Description: `Whether to allow cross-org VPCs in the bucket's IP filter configuration.`,
-              RequiredWith: []string{"ip_filter.0.vpc_network_sources"},
+							RequiredWith: []string{"ip_filter.0.vpc_network_sources"},
 						},
 						"allow_all_service_agent_access" : {
 							Type:        schema.TypeBool,

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -631,6 +631,17 @@ func ResourceStorageBucket() *schema.Resource {
 								},
 							},
 						},
+						"allow_cross_org_vpcs" : {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to allow cross-org VPCs in the bucket's IP filter configuration.`,
+              RequiredWith: []string{"ip_filter.0.vpc_network_sources"},
+						},
+						"allow_all_service_agent_access" : {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: `Whether to allow all service agents to access the bucket regardless of the IP filter configuration.`,
+						},
 					},
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
@@ -2036,6 +2047,8 @@ func flattenBucketIpFilter(ipFilter *storage.BucketIpFilter) []map[string]interf
 
 	filterItem := map[string]interface{}{
 		"mode": ipFilter.Mode,
+		"allow_cross_org_vpcs": ipFilter.AllowCrossOrgVpcs,
+		"allow_all_service_agent_access": ipFilter.AllowAllServiceAgentAccess,
 	}
 
 	if publicSrc := flattenBucketIpFilterPublicNetworkSource(ipFilter.PublicNetworkSource); publicSrc != nil {
@@ -2087,7 +2100,9 @@ func expandBucketIpFilter(v interface{}) (*storage.BucketIpFilter) {
 		Mode:                ipFilter["mode"].(string),
 		PublicNetworkSource: expandBucketIpFilterPublicNetworkSource(ipFilter["public_network_source"]),
 		VpcNetworkSources:   expandBucketIpFilterVpcNetworkSources(ipFilter["vpc_network_sources"]),
-		ForceSendFields:     []string{"PublicNetworkSource", "VpcNetworkSources"},
+		AllowCrossOrgVpcs:   ipFilter["allow_cross_org_vpcs"].(bool),
+		AllowAllServiceAgentAccess:  ipFilter["allow_all_service_agent_access"].(bool),
+		ForceSendFields:     []string{"PublicNetworkSource", "VpcNetworkSources",  "AllowCrossOrgVpcs", "AllowAllServiceAgentAccess"},
 	}
 }
 

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -1596,6 +1596,21 @@ func TestAccStorageBucket_IPFilter(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"force_destroy"},
 			},
 			{
+				Config: testAccStorageBucket_IPFilter_update(
+					bucketName, nwSuffix, project, serviceAccount,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStorageBucketExists(
+						t, "google_storage_bucket.bucket", bucketName, &bucket),
+				),
+			},
+			{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+			{
 				Config: testAccStorageBucket_IPFilter_disable(bucketName, nwSuffix, project, serviceAccount),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
@@ -2820,6 +2835,56 @@ resource "google_storage_bucket" "bucket" {
       network = google_compute_network.vpc_gcs_ipfilter1.id
       allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
     }
+    allow_cross_org_vpcs = true
+    allow_all_service_agent_access = true
+  }
+}
+`, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)
+}
+
+func testAccStorageBucket_IPFilter_update(bucketName string, nwSuffix string, project string, serviceAccount string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "vpc_gcs_ipfilter1" {
+  name = "tf-test-storage-ipfilter1-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "ipfilter_1" {
+  name          = "tf-test-storage-ipfilter1-%s"
+  ip_cidr_range = "10.201.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.vpc_gcs_ipfilter1.id
+}
+
+resource "google_project_iam_custom_role" "ipfilter_exempt_role" {
+  role_id     = "_%s"
+  title       = "IP Filter Exempt Role"
+  description = "A custom role to bypass IP Filtering on GCS bucket."
+  permissions = ["storage.buckets.exemptFromIpFilter"]
+}
+
+resource "google_project_iam_member" "primary" {
+  project = "%s"
+  role    = "projects/%s/roles/${google_project_iam_custom_role.ipfilter_exempt_role.role_id}"
+  member  = "serviceAccount:%s"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "%s"
+  location = "us-central1"
+  uniform_bucket_level_access = true
+  force_destroy = true
+  ip_filter  {
+    mode = "Enabled"
+    public_network_source {
+      allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
+    }
+    vpc_network_sources {
+      network = google_compute_network.vpc_gcs_ipfilter1.id
+      allowed_ip_cidr_ranges = ["0.0.0.0/0"]
+    }
+    allow_cross_org_vpcs = false
+    allow_all_service_agent_access = false
   }
 }
 `, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -2944,8 +2944,8 @@ resource "google_storage_bucket" "bucket" {
       network = google_compute_network.vpc_gcs_ipfilter2.id
       allowed_ip_cidr_ranges = ["10.201.0.0/16", "10.202.0.0/16"]
     }
-		allow_cross_org_vpcs = false
-		allow_all_service_agent_access = false
+    allow_cross_org_vpcs = false
+    allow_all_service_agent_access = false
   }
 }
 `, nwSuffix, nwSuffix, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -2876,9 +2876,6 @@ resource "google_storage_bucket" "bucket" {
   force_destroy = true
   ip_filter  {
     mode = "Enabled"
-    public_network_source {
-      allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
-    }
     vpc_network_sources {
       network = google_compute_network.vpc_gcs_ipfilter1.id
       allowed_ip_cidr_ranges = ["0.0.0.0/0"]

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -2944,6 +2944,8 @@ resource "google_storage_bucket" "bucket" {
       network = google_compute_network.vpc_gcs_ipfilter2.id
       allowed_ip_cidr_ranges = ["10.201.0.0/16", "10.202.0.0/16"]
     }
+		allow_cross_org_vpcs = false
+		allow_all_service_agent_access = false
   }
 }
 `, nwSuffix, nwSuffix, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)

--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_test.go
@@ -2835,7 +2835,6 @@ resource "google_storage_bucket" "bucket" {
       network = google_compute_network.vpc_gcs_ipfilter1.id
       allowed_ip_cidr_ranges = ["0.0.0.0/0", "::/0"]
     }
-    allow_cross_org_vpcs = true
     allow_all_service_agent_access = true
   }
 }
@@ -2944,8 +2943,6 @@ resource "google_storage_bucket" "bucket" {
       network = google_compute_network.vpc_gcs_ipfilter2.id
       allowed_ip_cidr_ranges = ["10.201.0.0/16", "10.202.0.0/16"]
     }
-    allow_cross_org_vpcs = false
-    allow_all_service_agent_access = false
   }
 }
 `, nwSuffix, nwSuffix, nwSuffix, nwSuffix, nwSuffix, project, project, serviceAccount, bucketName)

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -299,6 +299,10 @@ The following arguments are supported:
 
 * `mode` - (Required) The state of the IP filter configuration. Valid values are `Enabled` and `Disabled`. When set to `Enabled`, IP filtering rules are applied to a bucket and all incoming requests to the bucket are evaluated against these rules. When set to `Disabled`, IP filtering rules are not applied to a bucket.
 
+* `allow_cross_org_vpcs` - (Optional) While set `true`, allows cross-org VPCs in the bucket's IP filter configuration.
+
+* `allow_all_service_agent_access` (Optional) While set `true`, allows all service agents to access the bucket regardless of the IP filter configuration.
+
 * `public_network_source` - (Optional) The public network IP address ranges that can access the bucket and its data. Structure is [documented below](#nested_public_network_source).
 
 * `vpc_network_sources` - (Optional) The list of VPC networks that can access the bucket. Structure is [documented below](#nested_vpc_network_sources).

--- a/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -297,7 +297,7 @@ The following arguments are supported:
 
 <a name="nested_ip_filter"></a>The `ip_filter` block supports:
 
-* `mode` - (Required) The state of the IP filter configuration. Valid values are `Enabled` and `Disabled`. When set to `Enabled`, IP filtering rules are applied to a bucket and all incoming requests to the bucket are evaluated against these rules. When set to `Disabled`, IP filtering rules are not applied to a bucket.
+* `mode` - (Required) The state of the IP filter configuration. Valid values are `Enabled` and `Disabled`. When set to `Enabled`, IP filtering rules are applied to a bucket and all incoming requests to the bucket are evaluated against these rules. When set to `Disabled`, IP filtering rules are not applied to a bucket. **Note**: `allow_all_service_agent_access` must be supplied when `mode` is set to `Enabled`, it can be ommited for other values.
 
 * `allow_cross_org_vpcs` - (Optional) While set `true`, allows cross-org VPCs in the bucket's IP filter configuration.
 


### PR DESCRIPTION
This PR adds two new boolean fields to the `google_storage_bucket.ip_filter` block,
1. allow_cross_org_vpcs
2. allow_all_service_agent_access


```release-note:enhancement
storage: added `allow_cross_org_vpcs` and `allow_all_service_agent_access` fields to `google_storage_bucket` resource.
```
