### PR TITLE
compute: add support for `acced_mode`, `provisioned_iops` and `provisioned_throughput` in `google_compute_region_disk`

### DIFF
--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -376,6 +376,27 @@ properties:
       description: 'An applicable license URI'
       resource: 'License'
       imports: 'selfLink'
+  - name: 'accessMode'
+    type: Enum
+    description: |
+      The access mode of the disk.
+      The AccessMode is only valid for Hyperdisk disk types.
+    default_from_api: true
+    enum_values:
+      - 'READ_WRITE_SINGLE'
+      - 'READ_WRITE_MANY'
+      - 'READ_ONLY_MANY'
+  - name: 'provisionedIops'
+    type: Integer
+    description: |
+      Indicates how many IOPS to provision for the disk. This sets the number of I/O operations per second
+      that the disk can handle. Values must be between 10,000 and 120,000.
+      For more details, see the Extreme persistent disk [documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
+  - name: 'provisionedThroughput'
+    type: Integer
+    description: |
+      Indicates how much throughput to provision for the disk. This sets the number of throughput
+      mb per second that the disk can handle. Values must be greater than or equal to 1.
 virtual_fields:
   - name: 'create_snapshot_before_destroy'
     type: Boolean


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23361

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: add support for `acced_mode`, `provisioned_iops` and `provisioned_throughput` in `google_compute_region_disk`
```
