### PR TITLE
Adding Tags support for Regional Secrets

### DIFF
--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -221,3 +221,11 @@ properties:
       For secret with versionDestroyTtl>0, version destruction doesn't happen immediately
       on calling destroy instead the version goes to a disabled state and
       the actual destruction happens after this TTL expires. It must be atleast 24h.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -550,6 +551,36 @@ func TestAccSecretManagerRegionalRegionalSecret_versionAliasesUpdate(t *testing.
 		},
 	})
 }
+
+func TestAccSecretManagerRegionalRegionalSecret_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "secretmanager_regional_regionalsecret-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestOrganizationTagValue(t, "secretmanager_regional_regionalsecret-tagvalue", tagKey),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecret_basic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
 
 func testAccSecretManagerRegionalSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
@@ -1304,6 +1335,18 @@ resource "google_secret_manager_regional_secret_version" "reg-secret-version-4" 
   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
 
   secret_data = "very secret data keep it down %{random_suffix}-4"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecretTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-basic" {
+  secret_id = "tf-test-reg-secret-%{random_suffix}"
+  location = "us-central1"
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
 }
 `, context)
 }


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on instance resources at creation time.

Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```
secretmanager: added `tags` field to `regional_secret` to allow setting tags for regional_secrets at creation time
```