### PR TITLE
Add deletion_protection field to Secret Manager - Regional Secret

### DIFF
--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -43,12 +43,15 @@ iam_policy:
     - '{{secret_id}}'
 custom_code:
   pre_update: 'templates/terraform/pre_update/secret_manager_regional_secret.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/regional_secret.go.tmpl'
 examples:
   - name: 'regional_secret_config_basic'
     primary_resource_id: 'regional-secret-basic'
     primary_resource_name: 'fmt.Sprintf("tf-test-tf-reg-secret%s", context["random_suffix"])'
     vars:
       secret_id: 'tf-reg-secret'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'regional_secret_with_cmek'
     primary_resource_id: 'regional-secret-with-cmek'
     vars:
@@ -221,3 +224,11 @@ properties:
       For secret with versionDestroyTtl>0, version destruction doesn't happen immediately
       on calling destroy instead the version goes to a disabled state and
       the actual destruction happens after this TTL expires. It must be atleast 24h.
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the regional secret. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the federation will fail.
+    type: Boolean
+    default_value: false

--- a/mmv1/templates/terraform/examples/regional_secret_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_secret_config_basic.tf.tmpl
@@ -11,4 +11,5 @@ resource "google_secret_manager_regional_secret" "{{$.PrimaryResourceId}}" {
     key2 = "value2",
     key3 = "value3"
   }
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/regional_secret.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/regional_secret.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy secretmanager regional secret without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/secretmanagerregional/resource_secret_manager_regional_secret_test.go.tmpl
@@ -1,6 +1,7 @@
 package secretmanagerregional_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -24,9 +25,9 @@ func TestAccSecretManagerRegionalRegionalSecret_import(t *testing.T) {
 				Config: testAccSecretManagerRegionalSecret_basic(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-basic",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 		},
@@ -49,36 +50,36 @@ func TestAccSecretManagerRegionalRegionalSecret_labelsUpdate(t *testing.T) {
 				Config: testAccSecretManagerRegionalSecret_withoutLabels(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_labelsUpdate(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_labelsUpdateOther(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_withoutLabels(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-labels",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-labels",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 		},
@@ -101,36 +102,36 @@ func TestAccSecretManagerRegionalRegionalSecret_annotationsUpdate(t *testing.T) 
 				Config: testAccSecretManagerRegionalSecret_withoutAnnotations(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_annotationsUpdate(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_annotationsUpdateOther(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerRegionalSecret_withoutAnnotations(context),
 			},
 			{
-				ResourceName:      "google_secret_manager_regional_secret.regional-secret-with-annotations",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-with-annotations",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
 			},
 		},
@@ -141,9 +142,9 @@ func TestAccSecretManagerRegionalRegionalSecret_cmekUpdate(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"kms_key_name":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key3").CryptoKey.Name,
-		"kms_key_name_other":  acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key4").CryptoKey.Name,
-		"random_suffix": acctest.RandString(t, 10),
+		"kms_key_name":       acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key3").CryptoKey.Name,
+		"kms_key_name_other": acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-secret-manager-managed-central-key4").CryptoKey.Name,
+		"random_suffix":      acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -546,6 +547,38 @@ func TestAccSecretManagerRegionalRegionalSecret_versionAliasesUpdate(t *testing.
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func TestAccSecretManagerRegionalRegionalSecret_deletionprotection(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckSecretManagerRegionalRegionalSecretDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerRegionalSecretDeletionProtectionL1(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_regional_secret.regional-secret-deletion-protection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "secret_id", "terraform_labels", "deletion_protection"},
+			},
+			{
+				Config:      testAccSecretManagerRegionalSecretDeletionProtectionL2(context),
+				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
+			{
+				Config: testAccSecretManagerRegionalSecretDeletionProtectionFalse(context),
 			},
 		},
 	})
@@ -1304,6 +1337,36 @@ resource "google_secret_manager_regional_secret_version" "reg-secret-version-4" 
   secret = google_secret_manager_regional_secret.regional-secret-with-version-aliases.id
 
   secret_data = "very secret data keep it down %{random_suffix}-4"
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecretDeletionProtectionL1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-deletion-protection" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = true
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecretDeletionProtectionL2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-deletion-protection" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-west2"
+  deletion_protection = true
+}
+`, context)
+}
+
+func testAccSecretManagerRegionalSecretDeletionProtectionFalse(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_regional_secret" "regional-secret-deletion-protection" {
+  secret_id = "tf-test-reg-secret%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
 }
 `, context)
 }


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854
Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.
```
secretmanager: added `deletion_protection` field to `regional_secret` to allow setting tags for regional_secrets at creation time
```