### PR TITLE
Update service perimeter test for user types

### DIFF
--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
@@ -25,7 +25,7 @@ func testAccAccessContextManagerAccessLevelCondition_basicTest(t *testing.T) {
 	vpcName := fmt.Sprintf("test-vpc-%s", acctest.RandString(t, 10))
 
 	expected := map[string]interface{}{
-		"members": []interface{}{"user:test@google.com", "user:test2@google.com", fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", serviceAccountName, project)},
+		"members": []interface{}{fmt.Sprintf("serviceAccount:%s@%s.iam.gserviceaccount.com", serviceAccountName, project)},
 		"devicePolicy": map[string]interface{}{
 			"requireCorpOwned": true,
 			"osConstraints": []interface{}{
@@ -164,7 +164,7 @@ resource "google_compute_network" "vpc_network" {
 
 resource "google_access_context_manager_access_level_condition" "access-level-condition" {
   access_level = google_access_context_manager_access_level.test-access.name
-  members = ["user:test@google.com", "user:test2@google.com", "serviceAccount:${google_service_account.created-later.email}"]
+  members = ["serviceAccount:${google_service_account.created-later.email}"]
   negate = false
   device_policy {
     require_screen_lock = false

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -258,7 +258,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		ingress_policies {
 			title = "ingress policy 2"
 			ingress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			ingress_to {
 				resources = ["*"]
@@ -267,7 +267,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		ingress_policies {
 			title = "ingress policy 3"
 			ingress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			ingress_to {
 				resources = ["*"]
@@ -302,7 +302,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		egress_policies {
 			title = "egress policy 2"
 			egress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			egress_to {
 				resources = ["*"]
@@ -311,7 +311,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		egress_policies {
 			title = "egress policy 3"
 			egress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			egress_to {
 				resources = ["*"]
@@ -368,7 +368,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		ingress_policies {
 			title = "ingress policy 2"
 			ingress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			ingress_to {
 				resources = ["*"]
@@ -403,7 +403,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 		egress_policies {
 			title = "egress policy 2"
 			egress_from {
-				identities = ["user:test@google.com"]
+				identities = ["group:test@google.com"]
 			}
 			egress_to {
 				resources = ["*"]

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
@@ -260,7 +260,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
     	ingress_policies {
     		title = "ingress policy title 2"
     		ingress_from {
-    			identities = ["user:test@google.com"]
+    			identities = ["group:test@google.com"]
     		}
     		ingress_to {
     			resources = ["*"]
@@ -286,7 +286,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
     	egress_policies {
     		title = "egress policy title 2"
     		egress_from {
-    			identities = ["user:test@google.com"]
+    			identities = ["group:test@google.com"]
     		}
     		egress_to {
     			resources = ["*"]
@@ -350,7 +350,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
       ingress_policies {
         title = "ingress policy title 2"
         ingress_from {
-          identities = ["user:test@google.com"]
+          identities = ["group:test@google.com"]
         }
         ingress_to {
           resources = ["*"]
@@ -376,7 +376,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
       egress_policies {
         title = "egress policy title 2"
         egress_from {
-          identities = ["user:test@google.com"]
+          identities = ["group:test@google.com"]
         }
         egress_to {
           resources = ["*"]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
Bug fix for a test case- not user impacting.
```

Similar to #14311 except for the service perimeter test case. These test identities are actually groups, but were incorrectly being passed as users.
