### PR TITLE
Update MetricDescriptor.yaml

### DIFF
--- a/mmv1/products/monitoring/MetricDescriptor.yaml
+++ b/mmv1/products/monitoring/MetricDescriptor.yaml
@@ -161,15 +161,15 @@ properties:
     type: String
     description:
       A detailed description of the metric, which can be used in documentation.
-    required: true
-    immutable: true
+    required: false
+    immutable: false
   - name: 'displayName'
     type: String
     description:
       A concise name for the metric, which can be displayed in user interfaces.
       Use sentence case without an ending period, for example "Request count".
-    required: true
-    immutable: true
+    required: false
+    immutable: false
   - name: 'metadata'
     type: NestedObject
     description: Metadata which can be used to guide usage of the metric.


### PR DESCRIPTION
Allow description and displayName to be both optional and mutable.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22949
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7682

**Release Note Template for Downstream PRs (will be copied)**

```release-note:
monitoring: made `description` and `displayName` optional and mutable in `google_monitoring_metric_descriptor`
```
