### PR TITLE
feature: Adding IAP Brand data source.

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -141,6 +141,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_iam_testable_permissions":                  resourcemanager.DataSourceGoogleIamTestablePermissions(),
 	"google_iam_workload_identity_pool":                iambeta.DataSourceIAMBetaWorkloadIdentityPool(),
 	"google_iam_workload_identity_pool_provider":       iambeta.DataSourceIAMBetaWorkloadIdentityPoolProvider(),
+	"google_iap_brand":                                 iap.DataSourceGoogleIapBrand(),
 	"google_iap_client":                                iap.DataSourceGoogleIapClient(),
 	"google_kms_crypto_key":                            kms.DataSourceGoogleKmsCryptoKey(),
 	"google_kms_crypto_keys":                           kms.DataSourceGoogleKmsCryptoKeys(),

--- a/mmv1/third_party/terraform/services/iap/data_source_iap_brand.go
+++ b/mmv1/third_party/terraform/services/iap/data_source_iap_brand.go
@@ -1,0 +1,40 @@
+package iap
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleIapBrand() *schema.Resource {
+
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceIapBrand().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleIapBrandRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleIapBrandRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/brands/{{project}}")
+
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	err = resourceIapBrandRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/iap/data_source_iap_brand.go
+++ b/mmv1/third_party/terraform/services/iap/data_source_iap_brand.go
@@ -2,6 +2,7 @@ package iap
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -13,6 +14,13 @@ func DataSourceGoogleIapBrand() *schema.Resource {
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceIapBrand().Schema)
 	tpgresource.AddRequiredFieldsToSchema(dsSchema, "project")
 
+	dsSchema["brand"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		Description: "The ID of the brand. If not provided, the project's brand will be returned.",
+	}
+
 	return &schema.Resource{
 		Read:   dataSourceGoogleIapBrandRead,
 		Schema: dsSchema,
@@ -22,19 +30,55 @@ func DataSourceGoogleIapBrand() *schema.Resource {
 func dataSourceGoogleIapBrandRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 
-	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/brands/{{project}}")
+	// If brand ID is not provided, we must fetch it using the project ID,
+	// as the brand ID is the project number.
+	if v, ok := d.GetOk("brand"); !ok || v.(string) == "" {
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return err
+		}
+
+		projectID, err := tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+
+		rmClient := config.NewResourceManagerClient(userAgent)
+		getProjectCall := rmClient.Projects.Get(projectID)
+
+		// Handle UserProjectOverride if it's enabled
+		if config.UserProjectOverride {
+			billingProject := projectID
+			if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+				billingProject = bp
+			}
+			getProjectCall.Header().Add("X-Goog-User-Project", billingProject)
+		}
+
+		project, err := getProjectCall.Do()
+		if err != nil {
+			return fmt.Errorf("Error fetching project details for '%s': %w", projectID, err)
+		}
+
+		if err := d.Set("brand", strconv.FormatInt(project.ProjectNumber, 10)); err != nil {
+			return fmt.Errorf("Error setting brand: %s", err)
+		}
+	}
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/brands/{{brand}}")
 
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
+
 	err = resourceIapBrandRead(d, meta)
 	if err != nil {
 		return err
 	}
 
 	if d.Id() == "" {
-		return fmt.Errorf("%s not found", id)
+		return fmt.Errorf("IAP Brand not found for project %s", d.Get("project"))
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/services/iap/data_source_iap_brand_test.go
+++ b/mmv1/third_party/terraform/services/iap/data_source_iap_brand_test.go
@@ -1,0 +1,64 @@
+package iap_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccIapBrand_Datasource_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIapBrandDatasourceConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_iap_brand.project",
+						"google_iap_brand.project",
+						map[string]struct{}{
+							"project": {},
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccIapBrandDatasourceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "project_service" {
+  project = google_project.project.project_id
+  service = "iap.googleapis.com"
+}
+	  
+resource "google_iap_brand" "project" {
+  support_email     = "support@%{org_domain}"
+  application_title = "Cloud IAP protected Application"
+  project           = google_project_service.project_service.project
+}
+
+data "google_iap_brand" "project" {
+  project = google_iap_brand.project.project
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/iap/data_source_iap_brand_test.go
+++ b/mmv1/third_party/terraform/services/iap/data_source_iap_brand_test.go
@@ -24,13 +24,45 @@ func TestAccIapBrand_Datasource_basic(t *testing.T) {
 			{
 				Config: testAccIapBrandDatasourceConfig(context),
 				Check: resource.ComposeTestCheckFunc(
+					// Check that brand is set automatically by the data source
+					resource.TestCheckResourceAttrSet("data.google_iap_brand.project", "brand"),
+					// Check that the automatically discovered brand ID matches the project's actual number
+					resource.TestCheckResourceAttrPair("data.google_iap_brand.project", "brand", "google_project.project", "number"),
+					// Check that the rest of the data source state matches the resource state
 					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
 						"data.google_iap_brand.project",
 						"google_iap_brand.project",
 						map[string]struct{}{
 							"project": {},
+							"brand":   {},
 						},
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIapBrand_Datasource_WithBrand(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIapBrandDatasourceConfigWithBrand(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that the explicitly provided brand ID is correctly used and matches
+					resource.TestCheckResourceAttrPair("data.google_iap_brand.project", "brand", "google_project.project", "number"),
+					// Check another attribute to ensure the read was successful
+					resource.TestCheckResourceAttr("data.google_iap_brand.project", "application_title", "Cloud IAP protected Application"),
 				),
 			},
 		},
@@ -59,6 +91,33 @@ resource "google_iap_brand" "project" {
 
 data "google_iap_brand" "project" {
   project = google_iap_brand.project.project
+}
+`, context)
+}
+
+func testAccIapBrandDatasourceConfigWithBrand(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "project_service" {
+  project = google_project.project.project_id
+  service = "iap.googleapis.com"
+}
+
+resource "google_iap_brand" "project" {
+  support_email     = "support@%{org_domain}"
+  application_title = "Cloud IAP protected Application"
+  project           = google_project_service.project_service.project
+}
+
+data "google_iap_brand" "project" {
+  project = google_iap_brand.project.project
+  brand   = google_project.project.number
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/d/iap_brand.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iap_brand.html.markdown
@@ -26,6 +26,8 @@ The following arguments are supported:
 
 * `project` - (Required) The name of the brand.
 
+* `brand` - (Optional) The brand id which is the project number. By default, the data source retrieve the project number automatically if `brand` is not specified.
+
 ## Attributes Reference
 
 See [google_iap_client](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_brand) resource for details of the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/iap_brand.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/iap_brand.html.markdown
@@ -1,0 +1,31 @@
+---
+subcategory: "Identity-Aware Proxy"
+description: |-
+  Provides the information of the Identity Aware Proxy brand.
+---
+# google_iap_brand
+
+Get info about a Google Cloud IAP Brand.
+
+## Example Usage
+
+```tf
+data "google_project" "project" {
+  project_id = "foobar"
+}
+
+data "google_iap_brand" "project" {
+  project =  data.google_project.project.id
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The name of the brand.
+
+## Attributes Reference
+
+See [google_iap_client](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_brand) resource for details of the available attributes.


### PR DESCRIPTION
The Goal is to get Project's Brand information. If you want to create multiple Client ID from different modules, It could be interesting to get the configured brand of the project.

Fixing https://github.com/hashicorp/terraform-provider-google/issues/23368

```release-note:new-datasource
`google_iap_brand`
```
