### PR TITLE
Adding Tags support for Regional Secrets

### DIFF
--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -221,3 +221,11 @@ properties:
       For secret with versionDestroyTtl>0, version destruction doesn't happen immediately
       on calling destroy instead the version goes to a disabled state and
       the actual destruction happens after this TTL expires. It must be atleast 24h.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on instance resources at creation time.

Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```
secretmanager: added `tags` field to `regional_secret` to allow setting tags for regional_secrets at creation time
```
