### PR TITLE
Add CMEK support for Memorystore Instance

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -69,6 +69,8 @@ examples:
     test_vars_overrides:
       'prevent_destroy': 'false'
       'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
+    ignore_read_extra:
+      - 'update_time'
   - name: 'memorystore_instance_persistence_aof'
     primary_resource_id: 'instance-persistence-aof'
     vars:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -56,14 +56,19 @@ examples:
       'prevent_destroy': 'false'
   - name: 'memorystore_instance_full'
     primary_resource_id: 'instance-full'
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@cloud-redis.iam.gserviceaccount.com"
+        role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     vars:
       instance_name: 'full-instance'
       policy_name: 'my-policy'
       subnet_name: 'my-subnet'
       network_name: 'my-network'
       prevent_destroy: 'true'
+      kms_key_name: "my-key"
     test_vars_overrides:
       'prevent_destroy': 'false'
+      'kms_key_name': 'acctest.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
   - name: 'memorystore_instance_persistence_aof'
     primary_resource_id: 'instance-persistence-aof'
     vars:
@@ -126,7 +131,6 @@ virtual_fields:
     description: "Immutable. User inputs for the auto-created
       endpoints connections. "
     type: Array
-    # is_set: true
     immutable: true
     conflicts:
       - desiredPscAutoConnections
@@ -802,3 +806,8 @@ properties:
       The backup collection full resource name.
       Example: projects/{project}/locations/{location}/backupCollections/{collection}
     output: true
+  - name: kmsKey
+    type: String
+    description: The KMS key used to encrypt the at-rest data of the cluster
+    immutable: true
+

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -57,7 +57,7 @@ examples:
   - name: 'memorystore_instance_full'
     primary_resource_id: 'instance-full'
     bootstrap_iam:
-      - member: "serviceAccount:service-{project_number}@cloud-redis.iam.gserviceaccount.com"
+      - member: "serviceAccount:service-{project_number}@gcp-sa-memorystore.iam.gserviceaccount.com"
         role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
     vars:
       instance_name: 'full-instance'
@@ -810,4 +810,3 @@ properties:
     type: String
     description: The KMS key used to encrypt the at-rest data of the cluster
     immutable: true
-

--- a/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
@@ -10,6 +10,7 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   node_type               = "SHARED_CORE_NANO"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_DISABLED"
   authorization_mode      = "AUTH_DISABLED"
+  kms_key                 = "{{index $.Vars "kms_key_name"}}"
   engine_configs = {
     maxmemory-policy = "volatile-ttl"
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
memorystore: added `kms_key` field to `google_memorystore_instance` resource
```
