### PR TITLE
Add datasource for google_redis_cluster

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -262,6 +262,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vpc_access_connector":                      vpcaccess.DataSourceVPCAccessConnector(),
 	"google_memorystore_instance":						memorystore.DataSourceMemorystoreInstance(),
 	"google_redis_instance":                            redis.DataSourceGoogleRedisInstance(),
+	"google_redis_cluster":                             redis.DataSourceRedisCluster(),
 	"google_vertex_ai_index":                           vertexai.DataSourceVertexAIIndex(),
 	"google_vmwareengine_cluster":                      vmwareengine.DataSourceVmwareengineCluster(),
 	"google_vmwareengine_external_access_rule":         vmwareengine.DataSourceVmwareengineExternalAccessRule(),

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster.go
@@ -26,9 +26,7 @@ func DataSourceRedisCluster() *schema.Resource {
 }
 
 func dataSourceRedisClusterRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*transport_tpg.Config)
-
-	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{region}}/clusters/{{name}}")
+	id, err := tpgresource.ReplaceVars(d, meta.(*transport_tpg.Config), "projects/{{project}}/locations/{{region}}/clusters/{{name}}")
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
@@ -36,6 +34,10 @@ func dataSourceRedisClusterRead(d *schema.ResourceData, meta interface{}) error 
 
 	err = resourceRedisClusterRead(d, meta)
 	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
 		return err
 	}
 

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package redis
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceRedisCluster() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceRedisCluster().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "region")
+
+	return &schema.Resource{
+		Read:   dataSourceRedisClusterRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceRedisClusterRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{region}}/clusters/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	err = resourceRedisClusterRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
@@ -30,37 +30,13 @@ func TestAccRedisClusterDatasource(t *testing.T) {
 
 func testAccRedisClusterDatasourceConfig(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_compute_network" "network" {
-  name = "tf-test-network%{random_suffix}"
-}
-
-resource "google_compute_global_address" "service_range" {
-  name          = "tf-test-address%{random_suffix}"
-  purpose       = "VPC_PEERING"
-  address_type  = "INTERNAL"
-  prefix_length = 16
-  network       = google_compute_network.network.id
-}
-
-resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.network.id
-  service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.service_range.name]
-}
-
 resource "google_redis_cluster" "cluster" {
-  name               = "tf-test-cluster%{random_suffix}"
-  region             = "us-central1"
-  shard_count        = 2
-  replica_count      = 1
-  transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
-  authorization_mode = "AUTH_MODE_DISABLED"
-  psc_configs {
-    network = google_compute_network.network.id
-  }
-  depends_on = [google_service_networking_connection.private_service_connection]
-  deletion_protection_enabled = false
-}
+  name                           = "tf-test-redis-cluster-%{random_suffix}"
+  shard_count                    = 1
+  region                         = "us-central1"
+  deletion_protection_enabled    = false 
+  
+}   
 
 data "google_redis_cluster" "default" {
   name   = google_redis_cluster.cluster.name

--- a/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/data_source_redis_cluster_test.go
@@ -1,0 +1,70 @@
+package redis_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccRedisClusterDatasource(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisClusterDatasourceConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_redis_cluster.default", "google_redis_cluster.cluster"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRedisClusterDatasourceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "network" {
+  name = "tf-test-network%{random_suffix}"
+}
+
+resource "google_compute_global_address" "service_range" {
+  name          = "tf-test-address%{random_suffix}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.network.id
+}
+
+resource "google_service_networking_connection" "private_service_connection" {
+  network                 = google_compute_network.network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.service_range.name]
+}
+
+resource "google_redis_cluster" "cluster" {
+  name               = "tf-test-cluster%{random_suffix}"
+  region             = "us-central1"
+  shard_count        = 2
+  replica_count      = 1
+  transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
+  authorization_mode = "AUTH_MODE_DISABLED"
+  psc_configs {
+    network = google_compute_network.network.id
+  }
+  depends_on = [google_service_networking_connection.private_service_connection]
+  deletion_protection_enabled = false
+}
+
+data "google_redis_cluster" "default" {
+  name   = google_redis_cluster.cluster.name
+  region = "us-central1"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/redis_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/redis_cluster.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "Memorystore (Redis)"
+description: |-
+  Fetches the details of a Redis Cluster.
+---
+
+# google_redis_cluster
+
+Use this data source to get information about a Redis Cluster. For more details, see the [API documentation](https://cloud.google.com/memorystore/docs/cluster/reference/rest/v1/projects.locations.clusters).
+
+## Example Usage
+
+```hcl
+data "google_redis_cluster" "default" {
+  name   = "my-redis-cluster"
+  region = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` -
+  (Required)
+  The name of the Redis cluster.
+
+* `region` -
+  (Required)
+  The region of the Redis cluster.
+
+* `project` - 
+  (optional) 
+  The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_redis_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_cluster) resource for details of all the available attributes.


### PR DESCRIPTION
Fix for https://github.com/hashicorp/terraform-provider-google/issues/23072

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_redis_cluster`
```
