### PR TITLE
alloydb: `machine_type` in the `machine_config` block is not yet GA in the API

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -312,6 +312,7 @@ properties:
           E.g. "n2-highmem-4", "n2-highmem-8", "c4a-highmem-4-lssd".
           `cpu_count` must match the number of vCPUs in the machine type.
         default_from_api: true
+        min_version: 'beta'
   - name: 'clientConnectionConfig'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
@@ -81,7 +81,9 @@ resource "google_alloydb_instance" "default" {
 
   machine_config {
     cpu_count = 4
+	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-4"
+	{{- end -}}
   }
 
   labels = {
@@ -954,7 +956,9 @@ resource "google_alloydb_instance" "default" {
   instance_type = "PRIMARY"
   machine_config {
     cpu_count = 2
+	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-2"
+	{{- end -}}
   }
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
@@ -83,7 +83,7 @@ resource "google_alloydb_instance" "default" {
     cpu_count = 4
 	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-4"
-	{{- end -}}
+    {{ end }}
   }
 
   labels = {
@@ -958,7 +958,7 @@ resource "google_alloydb_instance" "default" {
     cpu_count = 2
 	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-2"
-	{{- end -}}
+    {{ end }}
   }
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23383

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
alloydb: `machine_type` in the `machine_config` block is not yet GA in the API
```
