### PR TITLE
Add access mode to compute region disk

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -555,11 +555,12 @@ properties:
   - name: 'accessMode'
     type: String
     description: |
-      The accessMode of the disk.
+      The access mode of the disk.
       For example:
-      * READ_WRITE_SINGLE
-      * READ_WRITE_MANY
-      * READ_ONLY_SINGLE
+        * READ_WRITE_SINGLE: The default AccessMode, means the disk can be attached to single instance in RW mode.
+        * READ_WRITE_MANY: The AccessMode means the disk can be attached to multiple instances in RW mode.
+        * READ_ONLY_SINGLE: The AccessMode means the disk can be attached to multiple instances in RO mode.
+      The AccessMode is only valid for Hyperdisk disk types.
     required: false
     immutable: false
     default_from_api: true

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -84,6 +84,11 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-my-region-disk%s", context["random_suffix"])'
     vars:
       region_disk_name: 'my-region-features-disk'
+  - name: 'region_disk_hyperdisk_balanced_ha_write_many'
+    primary_resource_id: 'primary'
+    primary_resource_name: 'fmt.Sprintf("tf-test-my-region-disk%s", context["random_suffix"])'
+    vars:
+      region_disk_name: 'my-region-hyperdisk'
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -376,6 +381,20 @@ properties:
       description: 'An applicable license URI'
       resource: 'License'
       imports: 'selfLink'
+  - name: 'accessMode'
+    type: String
+    description: |
+      The access mode of the disk.
+      For example:
+        * READ_WRITE_SINGLE: The default AccessMode, means the disk can be attached to single instance in RW mode.
+        * READ_WRITE_MANY: The AccessMode means the disk can be attached to multiple instances in RW mode.
+        * READ_ONLY_SINGLE: The AccessMode means the disk can be attached to multiple instances in RO mode.
+      The AccessMode is only valid for Hyperdisk disk types.
+    required: false
+    immutable: false
+    default_from_api: true
+    update_url: 'projects/{{project}}/regions/{{region}}/disks/{{name}}?paths=accessMode'
+    update_verb: 'PATCH'
 virtual_fields:
   - name: 'create_snapshot_before_destroy'
     type: Boolean

--- a/mmv1/templates/terraform/examples/region_disk_hyperdisk_balanced_ha_write_many.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_disk_hyperdisk_balanced_ha_write_many.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_compute_region_disk" "primary" {
+  name                      = "{{index $.Vars "region_disk_name"}}"
+  type                      = "hyperdisk-balanced-high-availability"
+  region                    = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  access_mode = "READ_WRITE_MANY"
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Also updates the field description in zonal disk and adds an example of a balanced high availability hyperdisk with `READ_WRITE_MANY` (aka multiwriter) access mode.


b/414672615

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `access_mode` field to `google_compute_region_disk` resource
```
