### PR TITLE
Make reassign-reviewer regex less strict

### DIFF
--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc # v2.0.2
         with:
           text: ${{ github.event.comment.body }}
-          regex: '(?:^|\n|\r)@modular-magician reassign-reviewer ?@?([a-zA-Z0-9-]+)?(?:$|\n|\r)'
+          regex: '.*@modular-magician reassign[- ]reviewer ?@?([a-zA-Z0-9-_]+)?.*'
       - name: Checkout Repository
         if: steps.read-comment.outputs.match != ''
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The existing regex misses comments that contain the command string with anything else on the same line.

The new regex will match comments such as

```
On vacation next week, @modular-magician reassign review @trodge.

Could you take over this review?
```
```
@modular-magician reassign-review @trodge # (extra space)
```
or
```
@modular-magician reassign-review @hypothetical_enterprise_managed_user
```


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
