### PR TITLE
(Beta) support for SM GKE auto rotation

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1633,6 +1633,30 @@ func ResourceContainerCluster() *schema.Resource {
 							Required:    true,
 							Description: `Enable the Secret manager csi component.`,
 						},
+						{{- if ne $.TargetVersionName "ga" }}
+						"rotation_config" : {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Computed:    true,
+							MaxItems:    1,
+							Description: `Configuration for Secret Manager auto rotation.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Enable the Secret manager auto rotation.`,
+									},
+									"rotation_interval": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+										Description: `The interval between two consecutive rotations. Default rotation interval is 2 minutes`,
+									},
+								},
+							},
+						},
+						{{- end }}
 					},
 				},
 			},
@@ -6010,10 +6034,30 @@ func expandSecretManagerConfig(configured interface{}) *container.SecretManagerC
 	}
 
 	config := l[0].(map[string]interface{})
-	return &container.SecretManagerConfig{
+	sc := &container.SecretManagerConfig{
 		Enabled:         config["enabled"].(bool),
 		ForceSendFields: []string{"Enabled"},
 	}
+	{{- if ne $.TargetVersionName "ga" }}
+	if autoRotation, ok := config["rotation_config"]; ok {
+		    if autoRotationList, ok := autoRotation.([]interface{}); ok {
+		        if len(autoRotationList) > 0 {
+		            autoRotationConfig := autoRotationList[0].(map[string]interface{})
+					if rotationInterval, ok := autoRotationConfig["rotation_interval"].(string); ok && rotationInterval != "" {
+						sc.RotationConfig = &container.RotationConfig{
+						Enabled:         autoRotationConfig["enabled"].(bool),
+						RotationInterval: rotationInterval,
+						}
+					} else {
+						sc.RotationConfig = &container.RotationConfig{
+							Enabled:         autoRotationConfig["enabled"].(bool),
+						}
+					}
+		        }
+		    }
+		}
+		{{- end }}
+	return sc
 }
 
 func expandDefaultMaxPodsConstraint(v interface{}) *container.MaxPodsConstraint {
@@ -7007,11 +7051,25 @@ func flattenSecretManagerConfig(c *container.SecretManagerConfig) []map[string]i
 			},
 		}
 	}
-	return []map[string]interface{}{
-		{
-			"enabled": c.Enabled,
-		},
+
+	result := make(map[string]interface{})
+
+	result["enabled"] = c.Enabled
+
+	{{- if ne $.TargetVersionName "ga" }}
+	rotationList := []map[string]interface{}{}
+	if c.RotationConfig != nil {
+		rotationConfigMap := map[string]interface{}{
+            "enabled": c.RotationConfig.Enabled,
+        }
+		if c.RotationConfig.RotationInterval != "" {
+			rotationConfigMap["rotation_interval"] = c.RotationConfig.RotationInterval
+		}
+		rotationList = append(rotationList, rotationConfigMap)
 	}
+	result["rotation_config"] = rotationList
+	{{- end }}
+	return []map[string]interface{}{result}
 }
 
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -11445,6 +11445,12 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   secret_manager_config {
     enabled = true
+{{- if ne $.TargetVersionName "ga" }}
+	rotation_config {
+		enabled = true
+		rotation_interval = "300s"
+	}
+{{- end }}
   }
   deletion_protection = false
   network    = "%s"

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1229,6 +1229,12 @@ notification_config {
 <a name="nested_secret_manager_config"></a>The `secret_manager_config` block supports:
 
 * `enabled` (Required) - Enable the Secret Manager add-on for this cluster.
+* `rotation_config` (Optional, Beta) - config for secret manager auto rotation. Structure is [docuemented below](#rotation_config)
+
+<a name="rotation_config"></a>The `rotation_config` block supports:
+
+* `enabled` (Optional) - Enable the roation in Secret Manager add-on for this cluster.
+* `rotation_interval` (Optional) - The interval between two consecutive rotations. Default rotation interval is 2 minutes.
 
 <a name="nested_user_managed_keys_config"></a>The `user_managed_keys_config` block supports:
 


### PR DESCRIPTION
Added a new field `rotation_config` to `google_container_cluster` in resource for `terraform-provider-google-beta`

This field provides auto rotation in secret manager gke add on.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `rotation_config` field to `google_container_cluster` resource (beta)
```
