### PR TITLE
firestore_database: Remove the deprecation message for deletion_policy

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -145,7 +145,9 @@ virtual_fields:
       See also `delete_protection`.
     type: String
     default_value: "ABANDON"
-    deprecation_message: '`deletion_policy` is deprecated and will be removed in a future major release. Use `delete_protection_state` instead.'
+    # `deletion_policy` is deprecated and will be removed in a future major release.
+    # Once that release happens, you should use `delete_protection_state` instead.
+    # For now though, setting this field is necessary if you wish for your Firestore databases to be deleted upon `terraform destroy`.
 parameters:
 properties:
   - name: 'name'


### PR DESCRIPTION
This is still deprecated, but this deprecation message caused more confusion than benefit. If you want your databases to be deleted upon running `terraform destroy`, you have no real choice other than to keep using this field (until we merge it with `delete_protection_state` in a future major release). The message should probably have never been included, because it wasn't truly actionable at the time for users with requirements to delete these databases.

```release-note:enhancement
firestore: revoked deprecation of `deletion_policy` field in `google_firestore_database` resource
```
