### PR TITLE
Add deletion_protection field to Secret Manager Secret

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -42,6 +42,7 @@ iam_policy:
 custom_code:
   constants: 'templates/terraform/constants/secret_manager_secret.go.tmpl'
   pre_update: 'templates/terraform/pre_update/secret_manager_secret.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/secret_manager_secret.go.tmpl'
 custom_diff:
   - 'secretManagerSecretAutoCustomizeDiff'
 examples:
@@ -50,6 +51,8 @@ examples:
     primary_resource_name: 'fmt.Sprintf("secret%s", context["random_suffix"])'
     vars:
       secret_id: 'secret'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'secret_with_annotations'
     primary_resource_id: 'secret-with-annotations'
     vars:
@@ -250,3 +253,11 @@ properties:
         description: |
           The Duration between rotation notifications. Must be in seconds and at least 3600s (1h) and at most 3153600000s (100 years).
           If rotationPeriod is set, `next_rotation_time` must be set. `next_rotation_time` will be advanced by this period when the service automatically sends rotation notifications.
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the secret. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the secret will fail.
+    type: Boolean
+    default_value: false

--- a/mmv1/templates/terraform/examples/secret_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secret_config_basic.tf.tmpl
@@ -15,4 +15,5 @@ resource "google_secret_manager_secret" "{{$.PrimaryResourceId}}" {
       }
     }
   }
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/secret_manager_secret.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/secret_manager_secret.go.tmpl
@@ -1,0 +1,4 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy secret manager secret without setting deletion_protection=false and running `terraform apply`")
+}
+

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
@@ -464,7 +464,7 @@ func TestAccSecretManagerSecret_updateBetweenTtlAndExpireTime(t *testing.T) {
 	})
 }
 
-func TestAccSecretManagerSecret_DeletionProtectionUpdate(t *testing.T) {
+func TestAccSecretManagerSecret_DeletionProtection(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -476,7 +476,7 @@ func TestAccSecretManagerSecret_DeletionProtectionUpdate(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSecretManagerSecret_deletionprotectionBasic(context),
+				Config: testAccSecretManagerSecret_deletionprotectionTrue(context),
 			},
 			{
 				ResourceName:            "google_secret_manager_secret.secret-deletionprotection",
@@ -485,18 +485,7 @@ func TestAccSecretManagerSecret_DeletionProtectionUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection"},
 			},
 			{
-				Config: testAccSecretManagerSecret_deletionprotectionUpdate(context),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction("google_secret_manager_secret.secret-deletionprotection", plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-			{
-				ResourceName:            "google_secret_manager_secret.secret-deletionprotection",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection"},
+				Config: testAccSecretManagerSecret_deletionprotectionFalse(context),
 			},
 		},
 	})
@@ -1259,7 +1248,7 @@ resource "google_secret_manager_secret" "secret-basic" {
 `, context)
 }
 
-func testAccSecretManagerSecret_deletionprotectionBasic(context map[string]interface{}) string {
+func testAccSecretManagerSecret_deletionprotectionTrue(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-deletionprotection" {
 	secret_id = "tf-test-secret-%{random_suffix}"
@@ -1286,7 +1275,7 @@ resource "google_secret_manager_secret" "secret-deletionprotection" {
 `, context)
 }
 
-func testAccSecretManagerSecret_deletionprotectionUpdate(context map[string]interface{}) string {
+func testAccSecretManagerSecret_deletionprotectionFalse(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-deletionprotection" {
 	secret_id = "tf-test-secret-%{random_suffix}"

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
@@ -496,7 +496,7 @@ func TestAccSecretManagerSecret_DeletionProtectionUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-deletionprotection",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go
@@ -464,6 +464,44 @@ func TestAccSecretManagerSecret_updateBetweenTtlAndExpireTime(t *testing.T) {
 	})
 }
 
+func TestAccSecretManagerSecret_DeletionProtectionUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretManagerSecret_deletionprotectionBasic(context),
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-deletionprotection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection"},
+			},
+			{
+				Config: testAccSecretManagerSecret_deletionprotectionUpdate(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_secret_manager_secret.secret-deletionprotection", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_secret_manager_secret.secret-deletionprotection",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels", "deletion_protection},
+			},
+		},
+	})
+}
+
 func testAccSecretManagerSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_secret_manager_secret" "secret-basic" {
@@ -1217,6 +1255,60 @@ resource "google_secret_manager_secret" "secret-basic" {
 
   expire_time = "2122-09-26T10:55:55.163240682Z"
 
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_deletionprotectionBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-deletionprotection" {
+	secret_id = "tf-test-secret-%{random_suffix}"
+
+	labels = {
+		label = "my-label"
+	}
+
+	replication {
+		user_managed {
+			replicas {
+				location = "us-central1"
+			}
+			replicas {
+				location = "us-east1"
+			}
+		}
+	}
+
+	ttl = "3600s"
+
+	deletion_protection = true
+}
+`, context)
+}
+
+func testAccSecretManagerSecret_deletionprotectionUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_secret_manager_secret" "secret-deletionprotection" {
+	secret_id = "tf-test-secret-%{random_suffix}"
+
+	labels = {
+		label = "my-label"
+	}
+
+	replication {
+		user_managed {
+			replicas {
+				location = "us-central1"
+			}
+			replicas {
+				location = "us-east1"
+			}
+		}
+	}
+
+	ttl = "3600s"
+
+	deletion_protection = false
 }
 `, context)
 }


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/407700473

Part of https://github.com/hashicorp/terraform-provider-google/issues/18854

Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```
Secret Manager: added `deletion_protection` field to `Secret Manager Secret` to make deleting them require an explicit intent. `google_active_directory_domain` resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```