### PR TITLE
Add 'suspended' field in rules for google_dataplex_datascan

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -370,6 +370,10 @@ properties:
               description: |
                 Description of the rule.
                 The maximum length is 1,024 characters.
+            - name: 'suspended'
+              type: Boolean
+              description: |
+                Whether the Rule is active or suspended. Default is false.
             - name: 'rangeExpectation'
               type: NestedObject
               description: |

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_quality.tf.tmpl
@@ -73,7 +73,6 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
       }
     }
 
-
     rules {
       column = "address"
       dimension = "UNIQUENESS"
@@ -112,6 +111,15 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
       sql_assertion {
         sql_statement = "select * from bigquery-public-data.austin_bikeshare.bikeshare_stations where station_id is null"
       }
+    }
+
+    rules {
+      column = "footprint_length"
+      dimension = "VALIDITY"
+      row_condition_expectation {
+        sql_expression = "footprint_length > 0 AND footprint_length <= 100"
+      }
+      suspended = true
     }
   }
 

--- a/mmv1/templates/terraform/examples/dataplex_datascan_full_quality_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_datascan_full_quality_test.tf.tmpl
@@ -175,6 +175,15 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
         sql_statement = "select * from {{index $.TestEnvVars "project_name"}}.${google_bigquery_dataset.tf_test_dataset.dataset_id}.${google_bigquery_table.tf_test_table.table_id} where address is null"
       }
     }
+
+    rules {
+      column = "footprint_length"
+      dimension = "VALIDITY"
+      row_condition_expectation {
+        sql_expression = "footprint_length > 0 AND footprint_length <= 100"
+      }
+      suspended = true
+    }
   }
 
 

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_datascan_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_datascan_test.go
@@ -209,6 +209,7 @@ resource "google_dataplex_datascan" "full_quality" {
       dimension = "VALIDITY"
       threshold = 0.99
       non_null_expectation {}
+      suspended = true
     }
 
     rules {


### PR DESCRIPTION


See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataplex: added `suspended` field to `rules` in `google_dataplex_datascan` resource
```
