### PR TITLE
Fix JWKS JSON permadiff for workload identity pool provider

### DIFF
--- a/mmv1/products/iambeta/WorkloadIdentityPoolProvider.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPoolProvider.yaml
@@ -310,6 +310,7 @@ properties:
           }
           ```
         required: false
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
   - name: 'saml'
     type: NestedObject
     description:


### PR DESCRIPTION
## Summary
Fixes JWKS JSON permadiff issues for workload identity pool providers by implementing state_func normalization.

## Description
This PR addresses the permadiff issue where GCP normalizes JWKS JSON formatting (whitespace, key ordering) causing Terraform to detect false diffs on every plan/apply cycle.

### Solution
Uses \`state_func\` with \`structure.NormalizeJsonString()\` to normalize JSON values when stored in state. This approach:

- Follows the established pattern used in BigQuery and other Google provider resources
- Normalizes JSON on storage, eliminating the need for custom diff suppression
- Is cleaner and more maintainable than custom diff logic

### Implementation
- **Added**: \`state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'\` to the jwks_json field
- **Pattern**: Mirrors the approach used in [BigQuery table schema normalization](https://github.com/hashicorp/terraform-provider-google-beta/blob/73b34d8a4ecfcdfde6e3a6db5aa2f1a55176326e/google-beta/services/bigquery/resource_bigquery_table.go#L580-L584)

### Benefits
- ✅ Eliminates permadiff for JWKS JSON formatting differences
- ✅ Handles whitespace variations and key ordering 
- ✅ Uses standard Terraform provider patterns
- ✅ No custom code maintenance burden
- ✅ Works consistently with other JSON fields in the provider

## Release Note Template
```release-note:bug
iambeta: fixed permadiff issue with `jwks_json` field in `google_iam_workload_identity_pool_provider` resource when GCP normalizes JSON formatting
```