### PR TITLE
Removing fields as they are not visible to customer due to code yellow

### DIFF
--- a/mmv1/products/cloudquotas/QuotaAdjusterSettings.yaml
+++ b/mmv1/products/cloudquotas/QuotaAdjusterSettings.yaml
@@ -67,25 +67,15 @@ properties:
     type: String
     description: |
       The resource container that determines if the quota adjuster is set for this project.
+      Expect this field to be empty currently.
     output: true
   - name: 'effectiveEnablement'
     type: Enum
     description: |
       Based on the effective container`s setting above, determines Whether this resource container has the quota adjuster enabled.
+      Expect this field to be empty currently.
     output: true
     enum_values:
       - 'DEFAULT'
       - 'ENABLED'
       - 'DISABLED'
-  - name: 'inherited'
-    type: Boolean
-    description: |
-      Indicates whether the setting is inherited or explicitly specified.
-    output: true
-  - name: 'inheritedFrom'
-    type: String
-    description: |
-      The resource container from which the setting is inherited. This refers to the  nearest ancestor with enablement set (either ENABLED or DISABLED).
-      The value can be `organizations/{organization_id}`, `folders/{folder_id}`, or can be `default` if no ancestor exists with enablement set.
-      The value will be empty when `enablement` is specified on this resource container.
-    output: true


### PR DESCRIPTION
```release-note:none
cloudquotas: remove `inherited`  and `inherited_from` fields from `google_cloud_quotas_quota_adjuster_settings` resource. This is revert of PR:14204 and won't affect customers.
```