### PR TITLE
Resolved gcs_data_source path variable not updated when reset to empty in google_storage_transfer_job

### DIFF
--- a/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
+++ b/mmv1/third_party/terraform/services/storagetransfer/resource_storage_transfer_job.go.tmpl
@@ -695,9 +695,23 @@ func gcsDataSchema() *schema.Resource {
 			},
 			"path": {
 				Optional:    true,
-				Computed:    true,
 				Type:        schema.TypeString,
 				Description: `Google Cloud Storage path in bucket to transfer`,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// This function returns 'true' to suppress (ignore) a diff.
+					// We only want to suppress a diff if the user has omitted the field
+					// in their config (new == "") and the old state from the API
+					// is also the default empty string (old == "").
+					// This prevents a "permadiff" while allowing all other changes.
+					if old == "" && new == "" {
+						return true
+					}
+
+					// In our key scenario of updating "foo" => "", this will be old="foo", new="".
+					// The condition above is false, so we fall through. Returning false below
+					// correctly shows the diff to the user.
+					return false
+				},
 			},
 		},
 	}


### PR DESCRIPTION
<!--

-->
Resolved gcs_data_source path variable not updated when reset to empty in google_storage_transfer_job.

Removed Computed:true and added a DiffSuppressFunc for it.
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
removed computed:true and added a DiffSuppressFunc in gcsDataSchema() to resolve gcs_data_source path variable not updated when reset to empty in google_storage_transfer_job


```
