### PR TITLE
Make metadata required in Vertex AI Index resource

### DIFF
--- a/mmv1/products/vertexai/Index.yaml
+++ b/mmv1/products/vertexai/Index.yaml
@@ -85,8 +85,8 @@ properties:
   - name: 'metadata'
     type: NestedObject
     description: |-
-      Additional information about the Index. 
-      Although this field is not marked as required in the API specification, it is currently required when creating an Index and must be provided. 
+      Additional information about the Index.
+      Although this field is not marked as required in the API specification, it is currently required when creating an Index and must be provided.
       Attempts to create an Index without this field will result in an API error.
     properties:
       - name: 'contentsDeltaUri'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR updates the Vertex AI Index resource schema to make the metadata field required. This aligns with the expectations of the Vertex AI API

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
