### PR TITLE
Remove write-only resource validation warnings

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -40,7 +40,6 @@ custom_code:
   decoder: 'templates/terraform/decoders/bigquery_data_transfer.go.tmpl'
   pre_update: 'templates/terraform/pre_update/bigquerydatatransfer_config.tmpl'
   custom_import: 'templates/terraform/custom_import/bigquery_data_transfer_self_link_as_name_set_location.go.tmpl'
-  raw_resource_config_validation: 'templates/terraform/validation/bigquery_data_transfer_config.go.tmpl'
 custom_diff:
   - 'sensitiveParamCustomizeDiff'
   - 'paramsCustomizeDiff'

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -49,7 +49,6 @@ custom_code:
   custom_update: 'templates/terraform/custom_update/secret_version.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/secret_version_deletion_policy.go.tmpl'
   custom_import: 'templates/terraform/custom_import/secret_version.go.tmpl'
-  raw_resource_config_validation: 'templates/terraform/validation/secret_version.go.tmpl'
   constants: 'templates/terraform/constants/secret_version.go.tmpl'
 # Sweeper skipped as this resource has customized deletion.
 exclude_sweeper: true

--- a/mmv1/templates/terraform/validation/bigquery_data_transfer_config.go.tmpl
+++ b/mmv1/templates/terraform/validation/bigquery_data_transfer_config.go.tmpl
@@ -1,1 +1,0 @@
-validation.PreferWriteOnlyAttribute(cty.GetAttrPath("sensitive_params").IndexInt(0).GetAttr("secret_access_key"),cty.GetAttrPath("sensitive_params").IndexInt(0).GetAttr("secret_access_key_wo"))

--- a/mmv1/templates/terraform/validation/secret_version.go.tmpl
+++ b/mmv1/templates/terraform/validation/secret_version.go.tmpl
@@ -1,1 +1,0 @@
-validation.PreferWriteOnlyAttribute(cty.GetAttrPath("secret_data"),cty.GetAttrPath("secret_data_wo"))

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -62,10 +62,6 @@ func ResourceSqlUser() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 		),
 
-		ValidateRawResourceConfigFuncs: []schema.ValidateRawResourceConfigFunc{
-			validation.PreferWriteOnlyAttribute(cty.GetAttrPath("password"), cty.GetAttrPath("password_wo")),
-		},
-
 		SchemaVersion: 1,
 		MigrateState:  resourceSqlUserMigrateState,
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
sql: no longer surface warnings when using `password` on `google_sql_user`
```
```release-note:bug
secretmanager: no longer surface warnings when using `secret_data` on `google_secret_manager_secret_version`
```
```release-note:bug
bigquerydatatransfer: no longer surface warnings when using `secret_access_key` on `google_bigquery_data_transfer_config`
```
