### PR TITLE
Skip unspecified values in autogen generation of enum fields

### DIFF
--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -357,7 +357,7 @@ func writeObject(name string, obj *openapi3.SchemaRef, objType openapi3.Types, u
 		if len(obj.Value.Enum) > 0 {
 			var enums []string
 			for _, enum := range obj.Value.Enum {
-				if strings.HasSuffix(enum, "_UNSPECIFIED") {
+				if strings.HasSuffix(fmt.Sprintf("%v", enum), "_UNSPECIFIED") {
 					continue
 				}
 				enums = append(enums, fmt.Sprintf("%v", enum))


### PR DESCRIPTION
Unspecified values are generally not meaningful to users.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
