### PR TITLE
Update resource_network_connectivity_spoke_test.go

### DIFF
--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -268,11 +268,11 @@ resource "google_network_connectivity_spoke" "primary" {
   hub = google_network_connectivity_hub.basic_hub.id
   linked_vpc_network {
     exclude_export_ranges = [
-      "198.51.100.0/24",
+      "192.168.0.0/24",
       "10.10.0.0/16"
     ]
     include_export_ranges = [
-      "198.51.100.0/23", 
+      "192.168.0.0/16", 
       "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
@@ -307,11 +307,11 @@ resource "google_network_connectivity_spoke" "primary" {
   hub = google_network_connectivity_hub.basic_hub.id
   linked_vpc_network {
     exclude_export_ranges = [
-      "198.51.100.0/24",
+      "100.64.0.0/16",
       "10.10.0.0/16"
     ]
     include_export_ranges = [
-      "198.51.100.0/23", 
+      "100.64.0.0/10", 
       "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
@@ -561,11 +561,12 @@ resource "google_network_connectivity_spoke" "primary" {
   hub = google_network_connectivity_hub.basic_hub.id
   linked_vpc_network {
     exclude_export_ranges = [
-      "198.51.100.0/24",
+      "172.16.0.0/24",
+      "172.16.0.1/24",
       "10.10.0.0/16"
     ]
     include_export_ranges = [
-      "198.51.100.0/23", 
+      "172.16.0.0/16", 
       "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link
@@ -600,11 +601,11 @@ resource "google_network_connectivity_spoke" "primary" {
   hub = google_network_connectivity_hub.basic_hub.id
   linked_vpc_network {
     exclude_export_ranges = [
-      "198.51.100.0/24",
+      "198.51.100.0/22",
       "10.10.0.0/16"
     ]
     include_export_ranges = [
-      "198.51.100.0/23", 
+      "198.51.100.0/24", 
       "10.0.0.0/8"
     ]
     uri = google_compute_network.network.self_link


### PR DESCRIPTION
198.51.100.0/23 is not currently supported 

https://cloud.google.com/vpc/docs/subnets#valid-ranges

contains valid cidr ranges until PUPI is supported.


Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

PUPI is not currently supported, this corrects the tests to use valid private ranges: referenced from - https://cloud.google.com/vpc/docs/subnets#valid-ranges

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23387.  / b/427331085

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
networkconnectivity: invalid include ranges used in test's spoke include export ranges.
```
