### PR TITLE
Remove validation from authConfigs in integration connector's connection resource.

### DIFF
--- a/mmv1/products/integrationconnectors/Connection.yaml
+++ b/mmv1/products/integrationconnectors/Connection.yaml
@@ -306,12 +306,6 @@ properties:
         type: NestedObject
         description: |
           User password for Authentication.
-        exactly_one_of:
-          - 'auth_config.0.user_password'
-          - 'auth_config.0.oauth2_jwt_bearer'
-          - 'auth_config.0.oauth2_client_credentials'
-          - 'auth_config.0.ssh_public_key'
-          - 'auth_config.0.oauth2_auth_code_flow'
         properties:
           - name: 'username'
             type: String
@@ -333,12 +327,6 @@ properties:
         type: NestedObject
         description: |
           OAuth2 JWT Bearer for Authentication.
-        exactly_one_of:
-          - 'auth_config.0.user_password'
-          - 'auth_config.0.oauth2_jwt_bearer'
-          - 'auth_config.0.oauth2_client_credentials'
-          - 'auth_config.0.ssh_public_key'
-          - 'auth_config.0.oauth2_auth_code_flow'
         properties:
           - name: 'clientKey'
             type: NestedObject
@@ -374,12 +362,6 @@ properties:
         type: NestedObject
         description: |
           OAuth3 Client Credentials for Authentication.
-        exactly_one_of:
-          - 'auth_config.0.user_password'
-          - 'auth_config.0.oauth2_jwt_bearer'
-          - 'auth_config.0.oauth2_client_credentials'
-          - 'auth_config.0.ssh_public_key'
-          - 'auth_config.0.oauth2_auth_code_flow'
         properties:
           - name: 'clientId'
             type: String
@@ -401,12 +383,6 @@ properties:
         type: NestedObject
         description: |
           SSH Public Key for Authentication.
-        exactly_one_of:
-          - 'auth_config.0.user_password'
-          - 'auth_config.0.oauth2_jwt_bearer'
-          - 'auth_config.0.oauth2_client_credentials'
-          - 'auth_config.0.ssh_public_key'
-          - 'auth_config.0.oauth2_auth_code_flow'
         properties:
           - name: 'username'
             type: String
@@ -443,12 +419,6 @@ properties:
         type: NestedObject
         description: |
           Parameters to support Oauth 2.0 Auth Code Grant Authentication.
-        exactly_one_of:
-          - 'auth_config.0.user_password'
-          - 'auth_config.0.oauth2_jwt_bearer'
-          - 'auth_config.0.oauth2_client_credentials'
-          - 'auth_config.0.ssh_public_key'
-          - 'auth_config.0.oauth2_auth_code_flow'
         properties:
           - name: 'clientId'
             type: String


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This will help in resolving one of the internal bug where static check of exactly_one_of is not needed with authType UNSPECIFIED.

<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

release-note:bug
`google_integration_connectors_connection`


Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23426