### PR TITLE
Update Managed Kafka Cluster resource to support mTLS

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -151,3 +151,34 @@ properties:
     type: String
     description: "The current state of the cluster. Possible values: `STATE_UNSPECIFIED`, `CREATING`, `ACTIVE`, `DELETING`."
     output: true
+  - name: 'tlsConfig'
+    type: NestedObject
+    description: "TLS configuration for the Kafka cluster. This is used to configure mTLS authentication."
+    min_version: beta
+    properties:
+      - name: 'trustConfig'
+        type: NestedObject
+        description: "The configuration of the broker truststore. If specified, clients can use mTLS for authentication."
+        properties:
+          - name: 'casConfigs'
+            type: Array
+            description: "Configuration for the Google Certificate Authority Service. To support mTLS, you must specify at least one `cas_configs` block. A maximum of 10 CA pools can be specified. Additional CA pools may be specified with additional `cas_configs` blocks."
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'caPool'
+                  type: String
+                  description: "The name of the CA pool to pull CA certificates from. The CA pool does not need
+                    to be in the same project or location as the Kafka cluster. Must be in the format `projects/PROJECT_ID/locations/LOCATION/caPools/CA_POOL_ID."
+                  required: true
+                  diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+      - name: 'sslPrincipalMappingRules'
+        type: String
+        description: "The rules for mapping mTLS certificate Distinguished Names (DNs) to
+          shortened principal names for Kafka ACLs. This field corresponds exactly
+          to the ssl.principal.mapping.rules broker config and matches the format
+          and syntax defined in the Apache Kafka documentation. Setting or
+          modifying this field will trigger a rolling restart of the Kafka
+          brokers to apply the change. An empty string means that the default
+          Kafka behavior is used. Example: `RULE:^CN=(.?),OU=ServiceUsers.$/$1@example.com/,DEFAULT`"
+

--- a/mmv1/templates/terraform/examples/managedkafka_cluster_mtls.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_mtls.tf.tmpl
@@ -1,0 +1,46 @@
+resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
+  cluster_id = "{{index $.Vars "cluster_id"}}"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+    }
+  }
+  tls_config {
+    trust_config {
+      cas_configs {
+        ca_pool = "projects/${data.google_project.project.number}/locations/us-central1/caPools/test-ca-pool"
+      }
+    }
+    ssl_principal_mapping_rules = "RULE:pattern/replacement/L,DEFAULT"
+  }
+
+  provider = google-beta
+}
+
+#resource "google_project_service_identity" "kafka_service_identity" {
+#  project  = data.google_project.project.project_id
+#  service  = "managedkafka.googleapis.com"
+#
+#  provider = google-beta
+#}
+
+resource "google_privateca_ca_pool" "ca_pool" {
+  name = "test-ca-pool"
+  location = "us-central1"
+  tier = "ENTERPRISE"
+  publishing_options {
+    publish_ca_cert = true
+    publish_crl = true
+  }
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}


### PR DESCRIPTION
Update the Managed Kafka Cluster terraform resource to support mTLS.

Issue: https://buganizer.corp.google.com/issues/421246670

```release-note:enhancement
managedkafka: added `tls_config` field to `google_managed_kafak_cluster` resource (beta)
```