### PR TITLE
Fix manual_assign type in google_gkeonprem_bare_metal_cluster

### DIFF
--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -497,7 +497,7 @@ properties:
                     If true, avoid using IPs ending in .0 or .255.
                     This avoids buggy consumer devices mistakenly dropping IPv4 traffic for those special IP addresses.
                 - name: 'manualAssign'
-                  type: String
+                  type: Boolean
                   description: |
                     If true, prevent IP addresses from being automatically assigned.
           - name: 'loadBalancerNodePoolConfig'

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go
@@ -453,7 +453,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLbStart(context m
             "10.200.0.14/32",
             "fd00:1::12/128"
           ]
-	  manual_assign = true
+          manual_assign = true
         }
         load_balancer_node_pool_config {
           node_pool_config {

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_bare_metal_cluster_test.go
@@ -453,6 +453,7 @@ func testAccGkeonpremBareMetalCluster_bareMetalClusterUpdateBgpLbStart(context m
             "10.200.0.14/32",
             "fd00:1::12/128"
           ]
+	  manual_assign = true
         }
         load_balancer_node_pool_config {
           node_pool_config {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23419

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
gkeonprem: fixed type of `load_balancer.0.bgp_lb_config.0.address_pools.0.manual_assign` in `google_gkeonprem_bare_metal_cluster`, making it a boolean instead of a string
```
