### PR TITLE
tgc-revival: support google_compute_backend_bucket

### DIFF
--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -183,6 +183,12 @@ type Examples struct {
 	// These properties are present in Terraform resources schema, but not in CAI assets.
 	// Virtual Fields and url parameters are already ignored by default and do not need to be duplicated here.
 	TGCTestIgnoreExtra []string `yaml:"tgc_test_ignore_extra,omitempty"`
+	// The properties ignored in CAI assets. It is rarely used and only used
+	// when the nested field has sent_empty_value: true.
+	// But its parent field is C + O and not specified in raw_config.
+	// Example: ['resource.cdnPolicy.signedUrlCacheMaxAgeSec'].
+	// "resource" means that the property is for resource data in CAI asset.
+	TGCTestIgnoreInAsset []string `yaml:"tgc_test_ignore_in_asset,omitempty"`
 }
 
 // Set default value for fields

--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -186,8 +186,8 @@ type Examples struct {
 	// The properties ignored in CAI assets. It is rarely used and only used
 	// when the nested field has sent_empty_value: true.
 	// But its parent field is C + O and not specified in raw_config.
-	// Example: ['resource.cdnPolicy.signedUrlCacheMaxAgeSec'].
-	// "resource" means that the property is for resource data in CAI asset.
+	// Example: ['RESOURCE.cdnPolicy.signedUrlCacheMaxAgeSec'].
+	// "RESOURCE" means that the property is for resource data in CAI asset.
 	TGCTestIgnoreInAsset []string `yaml:"tgc_test_ignore_in_asset,omitempty"`
 }
 

--- a/mmv1/products/compute/BackendBucket.yaml
+++ b/mmv1/products/compute/BackendBucket.yaml
@@ -41,6 +41,7 @@ async:
   result:
     resource_inside_response: false
 collection_url_key: 'items'
+include_in_tgc_next_DO_NOT_USE: true
 iam_policy:
   parent_resource_attribute: 'name'
   example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
@@ -59,6 +60,7 @@ examples:
     vars:
       backend_bucket_name: 'image-backend-bucket'
       bucket_name: 'image-store-bucket'
+    tgc_test_ignore_in_asset: ['resource.cdnPolicy.signedUrlCacheMaxAgeSec']
   - name: 'backend_bucket_full'
     primary_resource_id: 'image_backend_full'
     vars:

--- a/mmv1/products/compute/BackendBucket.yaml
+++ b/mmv1/products/compute/BackendBucket.yaml
@@ -60,7 +60,7 @@ examples:
     vars:
       backend_bucket_name: 'image-backend-bucket'
       bucket_name: 'image-store-bucket'
-    tgc_test_ignore_in_asset: ['resource.cdnPolicy.signedUrlCacheMaxAgeSec']
+    tgc_test_ignore_in_asset: ['RESOURCE.cdnPolicy.signedUrlCacheMaxAgeSec']
   - name: 'backend_bucket_full'
     primary_resource_id: 'image_backend_full'
     vars:

--- a/mmv1/templates/tgc_next/test/test_file.go.tmpl
+++ b/mmv1/templates/tgc_next/test/test_file.go.tmpl
@@ -31,6 +31,11 @@ func TestAcc{{ $e.TestSlug $.ProductMetadata.Name $.Name }}(t *testing.T) {
 	"{{ $field }}",
 {{- end }}
 		},
+		[]string{
+{{- range $field := $e.TGCTestIgnoreInAsset }}
+	"{{ $field }}",
+{{- end }}
+		},
 	)
 }
 {{- end }}

--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
@@ -102,6 +102,9 @@ func Get{{ $.ResourceName -}}CaiAssets(d tpgresource.TerraformResourceData, conf
     }
     if obj, err := Get{{ $.ResourceName -}}CaiObject(d, config); err == nil {
         location, _ := tpgresource.GetLocation(d, config)
+        if location == "" && strings.Contains(name, "/global/") {
+            location = "global"
+        }
         return []caiasset.Asset{{"{{"}}
             Name: name,
             Type: {{ $.ApiResourceType -}}AssetType,

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -353,19 +353,19 @@ func deleteFieldsFromAsset(assets []caiasset.Asset, ignoredResourceDataFields []
 		if len(parts) <= 1 {
 			continue
 		}
-		if parts[0] == "resource" {
-			if _, ok := ignoredFieldsMap["resource"]; !ok {
-				ignoredFieldsMap["resource"] = make([]Field, 0)
+		if parts[0] == "RESOURCE" {
+			if _, ok := ignoredFieldsMap["RESOURCE"]; !ok {
+				ignoredFieldsMap["RESOURCE"] = make([]Field, 0)
 			}
 			f := Field{Path: parts[1:]}
-			ignoredFieldsMap["resource"] = append(ignoredFieldsMap["resource"], f)
+			ignoredFieldsMap["RESOURCE"] = append(ignoredFieldsMap["RESOURCE"], f)
 		}
 	}
 
 	for _, asset := range assets {
 		if asset.Resource != nil && asset.Resource.Data != nil {
 			data := asset.Resource.Data
-			for _, ignoredField := range ignoredFieldsMap["resource"] {
+			for _, ignoredField := range ignoredFieldsMap["RESOURCE"] {
 				path := ignoredField.Path
 				deleteMapFieldByPath(data, path)
 			}

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -344,7 +344,7 @@ type Field struct {
 	Path []string
 }
 
-// Deletes fileds from the resource data of CAI assets
+// Deletes fields from the resource data of CAI assets
 func deleteFieldsFromAssets(assets []caiasset.Asset, ignoredResourceDataFields []string) []caiasset.Asset {
 	// The key is the content type, such as "resource"
 	ignoredFieldsMap := make(map[string][]Field, 0)

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -345,7 +345,7 @@ type Field struct {
 }
 
 // Deletes fileds from the resource data of CAI assets
-func deleteFieldsFromAsset(assets []caiasset.Asset, ignoredResourceDataFields []string) []caiasset.Asset {
+func deleteFieldsFromAssets(assets []caiasset.Asset, ignoredResourceDataFields []string) []caiasset.Asset {
 	// The key is the content type, such as "resource"
 	ignoredFieldsMap := make(map[string][]Field, 0)
 	for _, ignoredField := range ignoredResourceDataFields {

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -314,7 +314,7 @@ func getRoundtripConfig(t *testing.T, testName string, tfDir string, ancestryCac
 		return nil, nil, err
 	}
 
-	deleteFieldsFromAsset(roundtripAssets, ignoredAssetFields)
+	deleteFieldsFromAssets(roundtripAssets, ignoredAssetFields)
 
 	// Uncomment these lines when debugging issues locally
 	// roundtripAssetFile := fmt.Sprintf("%s_roundtrip.json", t.Name())


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/products/compute/BackendBucket.yaml


The field `cdn_policy` is C + O
The raw_config in one test doesn’t have `cdn_policy`.
In the exported cai asset, `cdnPolicy` doesn't have `signedUrlCacheMaxAgeSec`
After the cai2hcl from the exported cai asset, the converted exported_config has `cdn_policy`.
After tfplan2cai from exported_config, in the converted cai asset (roundtrip_asset), "signedUrlCacheMaxAgeSec": 0 as it has `send_empty_value: true`. 
`signedUrlCacheMaxAgeSec` is removed from the roundtrip_asset during the test with `tgc_test_ignore_in_asset` in yaml file. Then the roundtrip_asset will be converted to roundtrip_config.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
