### PR TITLE
Fix for unable to set `bgp_always_compare_med` in `google_compute_network` from `true` to `false`

### DIFF
--- a/mmv1/templates/terraform/update_encoder/compute_network.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/compute_network.go.tmpl
@@ -1,2 +1,12 @@
-delete(obj, "numeric_id") // Field doesn't exist in the API
-return obj, nil
+    //  BGP always-compare-med
+    if d.HasChange("bgp_always_compare_med") {
+        if _, ok := obj["routingConfig"]; !ok {
+            obj["routingConfig"] = make(map[string]interface{})
+        }
+        obj["routingConfig"].(map[string]interface{})["bgpAlwaysCompareMed"] = d.Get("bgp_always_compare_med").(bool)
+    }
+
+    // now clean up the rest
+    delete(obj, "numeric_id")
+    return obj, nil
+

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_test.go.tmpl
@@ -212,6 +212,14 @@ func TestAccComputeNetwork_bgpAlwaysCompareMedAndUpdate(t *testing.T) {
                    resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_always_compare_med", "bgp_always_compare_med", "true"),
                ),
            },
+		   {
+               Config: testAccComputeNetwork_bgp_always_compare_med(networkName, false),
+               Check: resource.ComposeTestCheckFunc(
+                   testAccCheckComputeNetworkExists(
+                       t, "google_compute_network.acc_network_bgp_always_compare_med", &network),
+                   resource.TestCheckResourceAttr("google_compute_network.acc_network_bgp_always_compare_med", "bgp_always_compare_med", "false"),
+               ),
+           },
        },
    })
 }


### PR DESCRIPTION
b/420958515
Issue: Terraform unable to set `bgp_always_compare_med` in `google_compute_network` from `true` to `false`

**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
compute: Fix for unable to set `bgp_always_compare_med` in `google_compute_network` from `true` to `false`
```