### PR TITLE
Update dataproc cluster_config.security_config to include support for identity_config

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -1300,8 +1300,12 @@ func ResourceDataprocCluster() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"kerberos_config": {
 										Type:        schema.TypeList,
-										Required:    true,
 										Description: "Kerberos related configuration",
+										Optional: true,
+										AtLeastOneOf: []string{
+											"cluster_config.0.security_config.0.kerberos_config",
+											"cluster_config.0.security_config.0.identity_config",
+										},
 										MaxItems:    1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -1382,6 +1386,25 @@ by Dataproc`,
 													Type:        schema.TypeString,
 													Optional:    true,
 													Description: `The Cloud Storage URI of the truststore file used for SSL encryption. If not provided, Dataproc will provide a self-signed certificate.`,
+												},
+											},
+										},
+										"identity_config": {
+										Type:        schema.TypeList,
+										Description: "Identity related configuration",
+										Optional: true,
+										AtLeastOneOf: []string{
+											"cluster_config.0.security_config.0.kerberos_config",
+											"cluster_config.0.security_config.0.identity_config",
+										},
+										MaxItems:    1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"user_service_account_mapping": {
+													Type:        schema.TypeMap,
+													Required:    true,
+													Elem:        &schema.Schema{Type: schema.TypeString},
+													Description: `User to service account mappings for multi-tenancy.`,
 												},
 											},
 										},
@@ -2286,7 +2309,28 @@ func expandGceClusterConfig(d *schema.ResourceData, config *transport_tpg.Config
 func expandSecurityConfig(cfg map[string]interface{}) *dataproc.SecurityConfig {
 	conf := &dataproc.SecurityConfig{}
 	if kfg, ok := cfg["kerberos_config"]; ok {
-		conf.KerberosConfig = expandKerberosConfig(kfg.([]interface{})[0].(map[string]interface{}))
+		k := kfg.([]interface{})
+		if len(k) > 0 {
+			conf.KerberosConfig = expandKerberosConfig(k[0].(map[string]interface{}))
+		}
+	}
+	if ifg, ok := cfg["identity_config"]; ok {
+		i := ifg.([]interface{})
+		if len(i) > 0 {
+			conf.IdentityConfig = expandIdentityConfig(i[0].(map[string]interface{}))
+		}
+	}
+	return conf
+}
+
+func expandIdentityConfig(cfg map[string]interface{}) *dataproc.IdentityConfig {
+	conf := &dataproc.IdentityConfig{}
+	if v, ok := cfg["user_service_account_mapping"]; ok {
+		m := make(map[string]string)
+		for k, val := range v.(map[string]interface{}) {
+			m[k] = val.(string)
+		}
+		conf.UserServiceAccountMapping = m
 	}
 	return conf
 }
@@ -2966,6 +3010,7 @@ func flattenSecurityConfig(d *schema.ResourceData, sc *dataproc.SecurityConfig) 
 	}
 	data := map[string]interface{}{
 		"kerberos_config": flattenKerberosConfig(d, sc.KerberosConfig),
+		"identity_config": flattenIdentityConfig(d, sc.IdentityConfig),
 	}
 
 	return []map[string]interface{}{data}
@@ -2991,6 +3036,14 @@ func flattenKerberosConfig(d *schema.ResourceData, kfg *dataproc.KerberosConfig)
 		"kdc_db_key_uri":                        kfg.KdcDbKeyUri,
 		"tgt_lifetime_hours":                    kfg.TgtLifetimeHours,
 		"realm":                                 kfg.Realm,
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenIdentityConfig(d *schema.ResourceData, ifg *dataproc.IdentityConfig) []map[string]interface{} {
+	data := map[string]interface{}{
+		"user_service_account_mapping": d.Get("cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping").(map[string]interface{}),
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
@@ -85,6 +85,7 @@ fields:
   - field: 'cluster_config.security_config.kerberos_config.tgt_lifetime_hours'
   - field: 'cluster_config.security_config.kerberos_config.truststore_password_uri'
   - field: 'cluster_config.security_config.kerberos_config.truststore_uri'
+  - field: 'cluster_config.security_config.identity_config.user_service_account_mapping'
   - field: 'cluster_config.software_config.image_version'
   - field: 'cluster_config.software_config.optional_components'
   - field: 'cluster_config.software_config.override_properties'

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -1100,6 +1100,30 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	})
 }
 
+func TestAccDataprocCluster_withIdentityConfig(t *testing.T) {
+	t.Parallel()
+
+	rnd := acctest.RandString(t, 10)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "dataproc-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "dataproc-cluster", networkName)
+	acctest.BootstrapFirewallForDataprocSharedNetwork(t, "dataproc-cluster", networkName)
+
+	var cluster dataproc.Cluster
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withIdentityConfig(rnd, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.identity_config", &cluster),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -2639,6 +2663,27 @@ resource "google_dataproc_cluster" "kerb" {
   }
 }
 `, rnd, rnd, rnd, subnetworkName, kmsKey)
+}
+
+func testAccDataprocCluster_withIdentityConfig(rnd, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_cluster" "identity_config" {
+  name   = "tf-test-dproc-%s"
+  region = "us-central1"
+  cluster_config {
+    gce_cluster_config {
+      subnetwork = "%s"
+    }
+    security_config {
+      identity_config {
+        user_service_account_mapping = {
+          "bob@company.com" = "bob-sa@iam.gserviceaccouts.com"
+        }
+      }
+    }
+  }
+}
+`, rnd, subnetworkName)
 }
 
 func testAccDataprocCluster_withAutoscalingPolicy(rnd, subnetworkName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -716,11 +716,17 @@ cluster_config {
       kms_key_uri = "projects/projectId/locations/locationId/keyRings/keyRingId/cryptoKeys/keyId"
       root_principal_password_uri = "bucketId/o/objectId"
     }
+    identity_config {
+      user_service_account_mapping = {
+        "user@company.com" = "service-account@iam.gserviceaccounts.com"
+      }
+    }
   }
 }
 ```
 
-* `kerberos_config` (Required) Kerberos Configuration
+* `kerberos_config` (Optional) Kerberos Configuration. At least one of `identity_config`
+       or `kerberos_config` is required.
 
     * `cross_realm_trust_admin_server` - (Optional) The admin server (IP or hostname) for the
        remote trusted realm in a cross realm trust relationship.
@@ -767,6 +773,12 @@ cluster_config {
 
     * `truststore_uri` - (Optional) The Cloud Storage URI of the truststore file used for
        SSL encryption. If not provided, Dataproc will provide a self-signed certificate.
+
+* `identity_config` (Optional) Identity Configuration. At least one of `identity_config`
+       or `kerberos_config` is required.
+
+    * `user_service_account_mapping` - (Required) The end user to service account mappings
+       in a service account based multi-tenant cluster
 
 - - -
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**
Relevant Issue: https://github.com/hashicorp/terraform-provider-google/issues/23257

```dataproc: added `cluster_config.security_config.identity_config` field to `google_dataproc_cluster` resource```
