### PR TITLE
Add support for Lustre CSI Driver on GKE

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -97,6 +97,7 @@ var (
 		"addons_config.0.stateful_ha_config",
 		"addons_config.0.ray_operator_config",
 		"addons_config.0.parallelstore_csi_driver_config",
+		"addons_config.0.lustre_csi_driver_config",
 	{{- if ne $.TargetVersionName "ga" }}
 		"addons_config.0.istio_config",
 		"addons_config.0.kalm_config",
@@ -487,6 +488,29 @@ func ResourceContainerCluster() *schema.Resource {
 									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
+									},
+								},
+							},
+						},
+						"lustre_csi_driver_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `Configuration for the Lustre CSI driver. Defaults to disabled; set enabled = true to enable.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+										Description: `Whether the Lustre CSI driver is enabled for this cluster.`,
+									},
+									"enable_legacy_lustre_port": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Description: `If set to true, the Lustre CSI driver will initialize LNet (the virtual network layer for Lustre kernel module) using port 6988.
+										This flag is required to workaround a port conflict with the gke-metadata-server on GKE nodes.`,
 									},
 								},
 							},
@@ -5290,6 +5314,20 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
+	if v, ok := config["lustre_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
+        lustreConfig := v.([]interface{})[0].(map[string]interface{})
+        ac.LustreCsiDriverConfig = &container.LustreCsiDriverConfig{
+            Enabled: lustreConfig["enabled"].(bool),
+            ForceSendFields: []string{"Enabled"},
+        }
+
+        // Check for enable_legacy_lustre_port
+        if val, ok := lustreConfig["enable_legacy_lustre_port"]; ok {
+            ac.LustreCsiDriverConfig.EnableLegacyLustrePort = val.(bool)
+            ac.LustreCsiDriverConfig.ForceSendFields = append(ac.LustreCsiDriverConfig.ForceSendFields, "EnableLegacyLustrePort")
+        }
+    }
+
 {{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
@@ -6716,6 +6754,15 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		result["parallelstore_csi_driver_config"] = []map[string]interface{}{
 			{
 				"enabled": c.ParallelstoreCsiDriverConfig.Enabled,
+			},
+		}
+	}
+	if c.LustreCsiDriverConfig != nil {
+		lustreConfig := c.LustreCsiDriverConfig
+		result["lustre_csi_driver_config"] = []map[string]interface{}{
+			{
+				"enabled": lustreConfig.Enabled,
+				"enable_legacy_lustre_port":lustreConfig.EnableLegacyLustrePort,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6904,6 +6904,9 @@ resource "google_container_cluster" "primary" {
 	parallelstore_csi_driver_config {
       enabled = false
     }
+    lustre_csi_driver_config {
+      enabled = false
+    }
 {{- if ne $.TargetVersionName "ga" }}
     istio_config {
       disabled = true
@@ -6982,8 +6985,12 @@ resource "google_container_cluster" "primary" {
         enabled = true
       }
     }
-	parallelstore_csi_driver_config {
+    parallelstore_csi_driver_config {
       enabled = true
+    }
+    lustre_csi_driver_config {
+      enabled = true
+      enable_legacy_lustre_port=true
     }
 {{- if ne $.TargetVersionName "ga" }}
     istio_config {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -513,6 +513,15 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
    It is enabled by default for Autopilot clusters with version 1.29 or later; set `enabled = true` to enable it explicitly.
    See [Enable the Parallelstore CSI driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/parallelstore-csi-new-volume#enable) for more information.
 
+*  `lustre_csi_driver_config` - (Optional) The status of the Lustre CSI driver addon,
+   which allows the usage of a Lustre instances as volumes.
+   It is disabled by default for Standard clusters; set `enabled = true` to enable.
+   It is disabled by default for Autopilot clusters; set `enabled = true` to enable.
+   Lustre CSI Driver Config has optional subfield
+   `enable_legacy_lustre_port` which allows the Lustre CSI driver to initialize LNet (the virtual networklayer for Lustre kernel module) using port 6988. 
+   This flag is required to workaround a port conflict with the gke-metadata-server on GKE nodes.
+   See [Enable Lustre CSI driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/lustre-csi-driver-new-volume) for more information.
+
 This example `addons_config` disables two addons:
 
 ```hcl


### PR DESCRIPTION
This PR allows Lustre for GKE addon to be configured with lustre_csi_driver_config for cluster creation and update. This PR is a draft until `LustreCsiDriverConfig` is imported by the terraform providers.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `addons_config.lustre_csi_driver_config` field to `google_container_cluster` resource
```
