### PR TITLE
Update Gemini GeminiGcpEnablementSetting resource -- add the web_grounding_type field

### DIFF
--- a/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
+++ b/mmv1/products/gemini/GeminiGcpEnablementSetting.yaml
@@ -70,4 +70,13 @@ properties:
     description: Whether customer data sharing should be enabled.
   - name: disableWebGrounding
     type: Boolean
-    description: Whether web grounding should be disabled.
+    description: |-
+      Whether web grounding should be disabled.
+      DEPRECATED: Use web_grounding_type instead.
+  - name: webGroundingType
+    type: String
+    description: |-
+      Web grounding type.
+      Possible values:
+      GROUNDING_WITH_GOOGLE_SEARCH
+      WEB_GROUNDING_FOR_ENTERPRISE

--- a/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_basic.tf.tmpl
@@ -4,4 +4,5 @@ resource "google_gemini_gemini_gcp_enablement_setting" "{{$.PrimaryResourceId}}"
     labels = {"my_key": "my_value"}
     enable_customer_data_sharing = true
     disable_web_grounding = true
+    web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
 }

--- a/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_gemini_gcp_enablement_setting_binding_basic.tf.tmpl
@@ -4,6 +4,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
     labels = {"my_key": "my_value"}
     enable_customer_data_sharing = true
     disable_web_grounding = true
+    web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
 }
 
 resource "google_gemini_gemini_gcp_enablement_setting_binding" "{{$.PrimaryResourceId}}" {

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_binding_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_binding_test.go
@@ -60,6 +60,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
     labels = {"my_key": "my_value"}
     enable_customer_data_sharing = true
 	disable_web_grounding = true
+	web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
 }
 
 resource "google_gemini_gemini_gcp_enablement_setting_binding" "basic_binding" {
@@ -82,6 +83,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "basic" {
     labels = {"my_key" = "my_value"}
     enable_customer_data_sharing = false
 	disable_web_grounding = false
+	web_grounding_type = "GROUNDING_WITH_GOOGLE_SEARCH"
 }
 
 resource "google_gemini_gemini_gcp_enablement_setting_binding" "basic_binding" {

--- a/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
+++ b/mmv1/third_party/terraform/services/gemini/resource_gemini_gemini_gcp_enablement_setting_test.go
@@ -52,6 +52,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     labels = {"my_key" = "my_value"}
     enable_customer_data_sharing = true
 	disable_web_grounding = true
+	web_grounding_type = "WEB_GROUNDING_FOR_ENTERPRISE"
 }
 `, context)
 }
@@ -63,6 +64,7 @@ resource "google_gemini_gemini_gcp_enablement_setting" "example" {
     labels = {"my_key" = "my_value"}
     enable_customer_data_sharing = false
 	disable_web_grounding = false
+	web_grounding_type = "GROUNDING_WITH_GOOGLE_SEARCH"
 }
 `, context)
 }


### PR DESCRIPTION
```release-note:enhancement
gemini: added `web_grounding_type` field to `google_gemini_gemini_gcp_enablement_setting` resource
```
```release-note:enhancement
gemini: description of the `disable_web_grounding` in the `google_gemini_gemini_gcp_enablement_setting` resource now says the field is deprecated 
```

