### PR TITLE
feat: Allow GKE Autopilot clusters to configure access to private registries

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6523,6 +6523,10 @@ func expandNodePoolAutoConfig(configured interface{}) *container.NodePoolAutoCon
 		npac.ResourceManagerTags = expandResourceManagerTags(v)
 	}
 
+	if v, ok := config["containerd_config"]; ok {
+	    npac.ContainerdConfig = expandContainerdConfig(v)
+	}
+
 	return npac
 }
 
@@ -7508,8 +7512,22 @@ func flattenNodePoolAutoConfig(c *container.NodePoolAutoConfig) []map[string]int
 			{"cgroup_mode": c.LinuxNodeConfig.CgroupMode},
 		}
 	}
+	if c.ContainerdConfig != nil {
+		result["containerd_config"] = flattenContainerdConfig(c.ContainerdConfig)
+	}
 
 	return []map[string]interface{}{result}
+}
+
+func flattenContainerdConfig(c *container.ContainerdConfig) []map[string]interface{} {
+    if c == nil {
+        return nil
+    }
+    result := make(map[string]interface{})
+    if c.ContainerdConfig != nil {
+        result["containerd_configs"] = c.ContainerdConfig
+    }
+    return []map[string]interface{}{result]
 }
 
 func flattenNodePoolAutoConfigNetworkTags(c *container.NetworkTags) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -7527,7 +7527,7 @@ func flattenContainerdConfig(c *container.ContainerdConfig) []map[string]interfa
     if c.ContainerdConfig != nil {
         result["containerd_configs"] = c.ContainerdConfig
     }
-    return []map[string]interface{}{result]
+    return []map[string]interface{}{result}
 }
 
 func flattenNodePoolAutoConfigNetworkTags(c *container.NetworkTags) []map[string]interface{} {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1564,6 +1564,7 @@ func ResourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"node_kubelet_config": schemaNodePoolAutoConfigNodeKubeletConfig(),
 						"linux_node_config":   schemaNodePoolAutoConfigLinuxNodeConfig(),
+						"containerd_config": schemaContainerdConfig(),
 						"network_tags": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -4889,6 +4890,21 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		log.Printf("[INFO] GKE cluster %s node pool auto config node_kubelet_config parameters have been updated", d.Id())
 	}
+
+	if d.HasChange("node_pool_auto_config.0.containerd_config") {
+	    if v, ok := d.GetOk("node_pool_auto_config.0.containerd_config"); ok {
+            req := &container.UpdateClusterRequest{
+                Update: &container.ClusterUpdate{
+                    DesiredContainerdConfig: expandContainerdConfig(v),
+                },
+            }
+            updateF := updateFunc(req, "updating GKE containerd config")
+            if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+                return err
+            }
+            log.Printf("[INFO] GKE cluster %s containerd config has been updated to %#v", d.Id(), req.Update.DesiredContainerdConfig)
+    		}
+    	}
 
 	if d.HasChange("node_pool_auto_config.0.network_tags.0.tags") {
 		tags := d.Get("node_pool_auto_config.0.network_tags.0.tags").([]interface{})

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -14318,6 +14318,6 @@ resource "google_container_cluster" "primary" {
 
   deletion_protection = false
 }
-`, secretID, clusterName, nodePoolName, networkName, subnetworkName)
+`, secretID, clusterName, networkName, subnetworkName)
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -14156,3 +14156,168 @@ resource "google_container_cluster" "primary" {
 }
  `, name, networkName, subnetworkName, mode)
 }
+
+
+func TestAccContainerCluster_autopilotPrivateRegistry(t *testing.T) {
+	// This test also checks containerd_config and its updates
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	secretID := fmt.Sprintf("tf-test-secret-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withAutopilotPrivateRegistryEnabled(secretID, clusterName, networkName, subnetworkName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_container_cluster.primary",
+						"node_pool_auto_config.0.containerd_config.0.private_registry_access_config.0.enabled",
+						"true",
+					),
+					resource.TestCheckResourceAttr(
+						"google_container_cluster.primary",
+						"node_pool_auto_config.0.containerd_config.0.private_registry_access_config.0.certificate_authority_domain_config.#",
+						"2",
+					),
+					// First CA config
+					resource.TestCheckResourceAttr(
+						"google_container_cluster.primary",
+						"node_pool_auto_config.0.containerd_config.0.private_registry_access_config.0.certificate_authority_domain_config.0.fqdns.0",
+						"custom.example.com",
+					),
+					// Second CA config
+					resource.TestCheckResourceAttr(
+						"google_container_cluster.primary",
+						"node_pool_auto_config.0.containerd_config.0.private_registry_access_config.0.certificate_authority_domain_config.1.fqdns.0",
+						"10.1.2.32",
+					),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_privateRegistryDisabled(clusterName, networkName, subnetworkName),
+				// Don't check for no deletions here, since the secret etc. are getting destroyed.
+				Check: resource.TestCheckResourceAttr(
+					"google_container_cluster.primary",
+					"node_pool_defaults.0.node_config_defaults.0.containerd_config.0.private_registry_access_config.0.enabled",
+					"false",
+				),
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_withAutopilotPrivateRegistryEnabled(secretID, clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+data "google_project" "test_project" {}
+
+resource "google_secret_manager_secret" "secret_basic" {
+  secret_id = "%s"
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+    }
+  }
+}
+resource "google_secret_manager_secret_version" "secret_version_basic" {
+  secret      = google_secret_manager_secret.secret_basic.id
+  secret_data = "dummypassword"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_iam" {
+  secret_id  = google_secret_manager_secret.secret_basic.id
+  role       = "roles/secretmanager.admin"
+  member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com"
+  depends_on = [google_secret_manager_secret_version.secret_version_basic]
+}
+resource "google_container_cluster" "primary" {
+  name     = "%s"
+  location = "us-central1-a"
+  enable_autopilot = true
+
+  node_pool_auto_config {
+
+      containerd_config {
+        private_registry_access_config {
+          enabled = true
+          certificate_authority_domain_config {
+            fqdns = ["custom.example.com", "10.0.0.127:8888"]
+            gcp_secret_manager_certificate_config {
+              secret_uri = google_secret_manager_secret_version.secret_version_basic.name
+            }
+          }
+        }
+      }
+    }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, secretID, clusterName, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withAutopilotPrivateRegistryDisabled(secretID, clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+data "google_project" "test_project" {}
+
+resource "google_secret_manager_secret" "secret_basic" {
+  secret_id = "%s"
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+    }
+  }
+}
+resource "google_secret_manager_secret_version" "secret_version_basic" {
+  secret      = google_secret_manager_secret.secret_basic.id
+  secret_data = "dummypassword"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret_iam" {
+  secret_id  = google_secret_manager_secret.secret_basic.id
+  role       = "roles/secretmanager.admin"
+  member     = "serviceAccount:${data.google_project.test_project.number}-compute@developer.gserviceaccount.com"
+  depends_on = [google_secret_manager_secret_version.secret_version_basic]
+}
+resource "google_container_cluster" "primary" {
+  name     = "%s"
+  location = "us-central1-a"
+  enable_autopilot = true
+
+  node_pool_auto_config {
+
+      containerd_config {
+        private_registry_access_config {
+          enabled = false
+          certificate_authority_domain_config {
+            fqdns = ["custom.example.com", "10.0.0.127:8888"]
+            gcp_secret_manager_certificate_config {
+              secret_uri = google_secret_manager_secret_version.secret_version_basic.name
+            }
+          }
+        }
+      }
+    }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, secretID, clusterName, nodePoolName, networkName, subnetworkName)
+}
+

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1166,6 +1166,8 @@ Structure is [documented below](#nested_node_kubelet_config).
 
 * `linux_node_config` (Optional) -  Linux system configuration for the cluster's automatically provisioned node pools. Only `cgroup_mode` field is supported in `node_pool_auto_config`. Structure is [documented below](#nested_linux_node_config).
 
+* `containerd_config` - (Optional) Parameters to customize containerd runtime. Structure is [documented below](#nested_containerd_config).
+
 <a name="nested_node_kubelet_config"></a>The `node_kubelet_config` block supports:
 
 * `insecure_kubelet_readonly_port_enabled` - (Optional) Controls whether the kubelet read-only port is enabled. It is strongly recommended to set this to `FALSE`. Possible values: `TRUE`, `FALSE`.
@@ -1173,6 +1175,7 @@ Structure is [documented below](#nested_node_kubelet_config).
 <a name="nested_network_tags"></a>The `network_tags` block supports:
 
 * `tags` (Optional) - List of network tags applied to auto-provisioned node pools.
+
 
 ```hcl
 node_pool_auto_config {


### PR DESCRIPTION
```release-note:enhancement
container_cluster: added `containerd_config` subfield to `node_pool_auto_config` block of `google_container_cluster` resource
```
