### PR TITLE
Update beta api endpoint from v1beta1 to v1beta as v1beta1 will be deprecated soon

### DIFF
--- a/mmv1/products/gkehub/Membership.yaml
+++ b/mmv1/products/gkehub/Membership.yaml
@@ -122,12 +122,6 @@ properties:
     description: |
       The unique identifier of the membership.
     output: true
-  - name: 'description'
-    type: String
-    description: |
-      The name of this entity type to be displayed on the console. This field is unavailable in v1 of the API.
-    min_version: 'beta'
-    deprecation_message: '`description` is deprecated and will be removed in a future major release.'
   - name: 'labels'
     type: KeyValueLabels
     description: |

--- a/mmv1/products/gkehub/product.yaml
+++ b/mmv1/products/gkehub/product.yaml
@@ -17,7 +17,7 @@ legacy_name: 'gke_hub'
 display_name: 'GKEHub'
 versions:
   - name: 'beta'
-    base_url: 'https://gkehub.googleapis.com/v1beta1/'
+    base_url: 'https://gkehub.googleapis.com/v1beta/'
   - name: 'ga'
     base_url: 'https://gkehub.googleapis.com/v1/'
 scopes:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/16950

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
gkehub: updated beta api endpoint from v1beta1 to v1beta
```
