### PR TITLE
tgc-revival: fix build errors from *AssetType constants

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -58,6 +58,9 @@ type Product struct {
 	// base URL. Specific to defining the resource as a CAI asset.
 	CaiBaseUrl string
 
+	// Names of resources that already have an AssetType constant defined in the product.
+	ResourcesWithCaiAssetType map[string]struct{}
+
 	// A function reference designed for the rare case where you
 	// need to use retries in operation calls. Used for the service api
 	// as it enables itself (self referential) and can result in occasional

--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -58,7 +58,7 @@ type Product struct {
 	// base URL. Specific to defining the resource as a CAI asset.
 	CaiBaseUrl string
 
-	// ApiResourceName of resources that already have an AssetType constant defined in the product.
+	// ApiResourceType of resources that already have an AssetType constant defined in the product.
 	ResourcesWithCaiAssetType map[string]struct{}
 
 	// A function reference designed for the rare case where you

--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -58,7 +58,7 @@ type Product struct {
 	// base URL. Specific to defining the resource as a CAI asset.
 	CaiBaseUrl string
 
-	// Names of resources that already have an AssetType constant defined in the product.
+	// ApiResourceName of resources that already have an AssetType constant defined in the product.
 	ResourcesWithCaiAssetType map[string]struct{}
 
 	// A function reference designed for the rare case where you

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1842,10 +1842,10 @@ func (r Resource) DefineAssetTypeForResourceInProduct() bool {
 	if r.ProductMetadata.ResourcesWithCaiAssetType == nil {
 		r.ProductMetadata.ResourcesWithCaiAssetType = make(map[string]struct{}, 1)
 	}
-	if _, alreadyDefined := r.ProductMetadata.ResourcesWithCaiAssetType[r.Name]; alreadyDefined {
+	if _, alreadyDefined := r.ProductMetadata.ResourcesWithCaiAssetType[r.ApiResourceType()]; alreadyDefined {
 		return false
 	}
-	r.ProductMetadata.ResourcesWithCaiAssetType[r.Name] = struct{}{}
+	r.ProductMetadata.ResourcesWithCaiAssetType[r.ApiResourceType()] = struct{}{}
 	return true
 }
 
@@ -2009,7 +2009,13 @@ func (r Resource) MarkdownHeader(templatePath string) string {
 // ====================
 // Lists fields that test.BidirectionalConversion should ignore
 func (r Resource) TGCTestIgnorePropertiesToStrings(e resource.Examples) []string {
-	var props []string
+	props := []string{
+		"depends_on",
+		"count",
+		"for_each",
+		"provider",
+		"lifecycle",
+	}
 	for _, tp := range r.VirtualFields {
 		props = append(props, google.Underscore(tp.Name))
 	}

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1824,6 +1824,31 @@ func (r Resource) CaiProductBackendName(caiProductBaseUrl string) string {
 	return strings.ToLower(backendUrl)
 }
 
+// Returns the asset type for this resource.
+func (r Resource) CaiAssetType() string {
+	baseURL := r.CaiProductBaseUrl()
+	productBackendName := r.CaiProductBackendName(baseURL)
+	assetName := r.Name
+	if r.ApiResourceTypeKind != "" {
+		assetName = r.ApiResourceTypeKind
+	}
+	return fmt.Sprintf("%s.googleapis.com/%s", productBackendName, assetName)
+}
+
+// DefineAssetTypeForResourceInProduct marks the AssetType constant for this resource as defined.
+// It returns true if this is the first time it's been called for this resource,
+// and false otherwise, preventing duplicate definitions.
+func (r Resource) DefineAssetTypeForResourceInProduct() bool {
+	if r.ProductMetadata.ResourcesWithCaiAssetType == nil {
+		r.ProductMetadata.ResourcesWithCaiAssetType = make(map[string]struct{}, 1)
+	}
+	if _, alreadyDefined := r.ProductMetadata.ResourcesWithCaiAssetType[r.Name]; alreadyDefined {
+		return false
+	}
+	r.ProductMetadata.ResourcesWithCaiAssetType[r.Name] = struct{}{}
+	return true
+}
+
 // Gets the Cai asset name template, which could include version
 // For example: //monitoring.googleapis.com/v3/projects/{{project}}/services/{{service_id}}
 func (r Resource) rawCaiAssetNameTemplate(productBackendName string) string {

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -12,7 +12,8 @@
 # limitations under the License.
 
 ---
-name: 'Function'
+name: 'function'
+api_resource_type_kind: Function
 description: |
   A Cloud Function that contains user computation executed in response to an event.
 references:

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -32,7 +32,6 @@ timeouts:
   insert_minutes: 60
   update_minutes: 60
   delete_minutes: 60
-include_in_tgc_next_DO_NOT_USE: true
 autogen_async: true
 async:
   actions: ['create', 'delete', 'update']

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -31,6 +31,7 @@ timeouts:
   insert_minutes: 60
   update_minutes: 60
   delete_minutes: 60
+include_in_tgc_next_DO_NOT_USE: true
 autogen_async: true
 async:
   actions: ['create', 'delete', 'update']

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 ---
-name: 'function'
-api_resource_type_kind: Function
+name: 'Function'
 description: |
   A Cloud Function that contains user computation executed in response to an event.
 references:

--- a/mmv1/templates/tgc_next/services/resource.go.tmpl
+++ b/mmv1/templates/tgc_next/services/resource.go.tmpl
@@ -26,11 +26,8 @@ import (
   "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/verify"
 )
 
-{{- $caiProductBaseUrl := $.CaiProductBaseUrl }}
-{{- $productBackendName := $.CaiProductBackendName $caiProductBaseUrl }}
-
-{{- if not $.ApiResourceTypeKind }}
-const {{ $.ApiResourceType -}}AssetType string = "{{ $productBackendName }}.googleapis.com/{{ $.Name -}}"
+{{ if $.DefineAssetTypeForResourceInProduct -}}
+const {{ $.ResourceName -}}AssetType string = "{{ $.CaiAssetType }}"
 {{- end }}
 
 const {{ $.ResourceName -}}SchemaName string = "{{ $.TerraformName }}"

--- a/mmv1/templates/tgc_next/services/resource.go.tmpl
+++ b/mmv1/templates/tgc_next/services/resource.go.tmpl
@@ -27,7 +27,7 @@ import (
 )
 
 {{ if $.DefineAssetTypeForResourceInProduct -}}
-const {{ $.ResourceName -}}AssetType string = "{{ $.CaiAssetType }}"
+const {{ $.ApiResourceType -}}AssetType string = "{{ $.CaiAssetType }}"
 {{- end }}
 
 const {{ $.ResourceName -}}SchemaName string = "{{ $.TerraformName }}"

--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
@@ -62,17 +62,19 @@ func Get{{ $.ResourceName -}}CaiAssets(d tpgresource.TerraformResourceData, conf
         if location == "" && strings.Contains(name, "/global/") {
             location = "global"
         }
-        return []caiasset.Asset{{"{{"}}
-            Name: name,
-            Type: {{ $.ApiResourceType -}}AssetType,
-            Resource: &caiasset.AssetResource{
-                Version: "{{ $apiVersion }}",
-                DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/{{ $productBackendName }}/{{ $apiVersion }}/rest",
-                DiscoveryName: "{{ or $.ApiResourceTypeKind $.Name }}",
-                Data: obj,
-                Location:             location,
+        return []caiasset.Asset{
+            {
+                Name: name,
+                Type: {{ $.ApiResourceType -}}AssetType,
+                Resource: &caiasset.AssetResource{
+                    Version: "{{ $apiVersion }}",
+                    DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/{{ $productBackendName }}/{{ $apiVersion }}/rest",
+                    DiscoveryName: "{{ or $.ApiResourceTypeKind $.Name }}",
+                    Data: obj,
+                    Location:             location,
+                },
             },
-        {{"}}"}}, nil
+        }, nil
     } else {
         return []caiasset.Asset{}, err
     }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

*AssetType constants are now named according to `ApiResourceType`, which matches `ResourcesGroupedByApiResourceType`.

A map in the `ProductMetadata` object prevents double-definition.

Also added [meta arguments](https://developer.hashicorp.com/terraform/language/meta-arguments/depends_on) to `TGCTestIgnorePropertiesToStrings`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
