### PR TITLE
alloydb: Revert incorrect removal of machine_type from machine_config (it is GA)

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -257,7 +257,6 @@ properties:
   - name: 'observabilityConfig'
     type: NestedObject
     description: 'Configuration for enhanced query insights.'
-    min_version: 'beta'
     default_from_api: true
     properties:
       - name: 'enabled'

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
@@ -81,9 +81,7 @@ resource "google_alloydb_instance" "default" {
 
   machine_config {
     cpu_count = 4
-	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-4"
-    {{ end }}
   }
 
   labels = {
@@ -956,9 +954,7 @@ resource "google_alloydb_instance" "default" {
   instance_type = "PRIMARY"
   machine_config {
     cpu_count = 2
-	{{- if ne $.TargetVersionName "ga" }}
     machine_type = "n2-highmem-2"
-    {{ end }}
   }
   psc_instance_config {
 	allowed_consumer_projects = ["${data.google_project.project.number}"]


### PR DESCRIPTION
Restored support for the machine_type field in the machine_config block. The field was previously removed due to an incorrect assumption that it was not GA.  While the field is GA, the documentation had not yet reflected this; it is currently being updated.

```release-note:bug
Restored support for the machine_type field in the machine_config block. It is GA.
```
