### PR TITLE
use project name in TestAccComputeBackendBucket_backendBucketGlobalIlbExample

### DIFF
--- a/mmv1/templates/terraform/examples/backend_bucket_global_ilb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_bucket_global_ilb.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_project_service" "project" {
 
 resource "google_compute_backend_bucket" "{{$.PrimaryResourceId}}" {
   name                  = "{{index $.Vars "backend_bucket_name"}}"
-  project               = google_project.unarmored.number
+  project               = google_project.unarmored.name
   bucket_name           = google_storage_bucket.{{$.PrimaryResourceId}}.name
   load_balancing_scheme = "INTERNAL_MANAGED"
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The cai asset name with the format `//compute.googleapis.com/projects/PROJECT_ID/global/backendBuckets/BACKEND_BUCKET` is used to call CAI API to get cai asset history. `PROJECT_ID` instead of `PROJECT_NUMBER` should be used for `project` in the test.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
