### PR TITLE
No longer skip if env IdentityUserEnvVars not set

### DIFF
--- a/mmv1/third_party/terraform/envvar/envvar_utils.go
+++ b/mmv1/third_party/terraform/envvar/envvar_utils.go
@@ -146,7 +146,6 @@ func GetTestCredsFromEnv() string {
 
 // Returns googleapis.com if there's no universe set.
 func GetTestUniverseDomainFromEnv(t *testing.T) string {
-	SkipIfEnvNotSet(t, IdentityUserEnvVars...)
 	return transport_tpg.MultiEnvSearch(UniverseDomainEnvVars)
 }
 


### PR DESCRIPTION
There's a quirk where when I run tests without setting `GOOGLE_IDENTITY_USER` the destroy producer will skip out after the test completes. 

https://github.com/hashicorp/terraform-provider-google-beta/blob/a1adfe857f1701abf7cd65734cd831de882989c7/google-beta/acctest/provider_test_utils.go#L62-L67

Looks like this was a relatively recent change. Was wondering the context and why we don't fallback in testing and instead error out. It's weird because since destroy producer runs as cleanup after the test, everything runs 99% of the way through before the test is marked as skipped.

https://github.com/hashicorp/terraform-provider-google-beta/blob/a1adfe857f1701abf7cd65734cd831de882989c7/google-beta/services/compute/resource_compute_instance_test.go#L5015-L5016

If this env is required for all destroy producers then we should skip before the test begins. Not after the test has completed.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
