### PR TITLE
fix: (storage) added validation for cors parameters method, origin and response_header cannot be empty

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -27,6 +27,23 @@ import (
 	"google.golang.org/api/storage/v1"
 )
 
+func corsValidation(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	method, methodOk := d.GetOkExists("cors.0.method")
+	responseHeader, responseHeaderOk := d.GetOkExists("cors.0.response_header")
+	origin, originOk := d.GetOkExists("cors.0.origin")
+
+	if methodOk && len(method.([]interface{})) == 0 {
+		return fmt.Errorf("method cannot be empty")
+	}
+	if responseHeaderOk && len(responseHeader.([]interface{})) == 0 {
+		return fmt.Errorf("response_header cannot be empty")
+	}
+	if originOk && len(origin.([]interface{})) == 0 {
+		return fmt.Errorf("origin cannot be empty")
+	}
+	return nil
+}
+
 func ResourceStorageBucket() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceStorageBucketCreate,
@@ -39,6 +56,7 @@ func ResourceStorageBucket() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			customdiff.ForceNewIfChange("retention_policy.0.is_locked", isPolicyLocked),
 			tpgresource.SetLabelsDiff,
+			corsValidation,
 		),
 
 		Timeouts: &schema.ResourceTimeout{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
storage: added validation for cors parameters method, origin and response_header cannot be empty
```
