### PR TITLE
Fixing hive partitioning diff

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -1349,7 +1349,7 @@ func ResourceBigQueryTable() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: `Whether Terraform will be prevent implicitly added columns in schema to show diff.`,
+				Description: `Whether Terraform will prevent implicitly added columns in schema from showing diff.`,
 			},
 
 			// TableConstraints: [Optional] Defines the primary key and foreign keys.
@@ -1634,6 +1634,8 @@ func filterLiveSchemaByConfig(liveSchema *bigquery.TableSchema, configSchema *bi
 		if _, ok := configFieldsMap[liveField.Name]; ok {
 			// ...then it's a field we care about. Add it to our filtered list.
 			filteredFields = append(filteredFields, liveField)
+		} else {
+			log.Printf("[DEBUG] auto-generated column `%s` dropped during Table read.", liveField.Name)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -3626,7 +3626,7 @@ resource "google_bigquery_table" "test" {
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
-	ignore_auto_generated_schema = true
+  ignore_auto_generated_schema = true
 
   schema = <<EOF
   %s

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -147,6 +147,8 @@ The following arguments are supported:
 * `ignore_schema_changes` - (Optional)  A list of fields which should be ignored for each column in schema.
     **NOTE:** Right now only `dataPolicies` field is supported. We might support others in the future.
 
+* `ignore_auto_generated_schema` - (Optional)  If true, Terraform will prevent columns added by the server(e.g. hive partitioned columns) in schema from showing diff.
+
 * `schema_foreign_type_info` - (Optional) Specifies metadata of the foreign data
     type definition in field schema. Structure is [documented below](#nested_schema_foreign_type_info).
 


### PR DESCRIPTION
Added a flag to prevent Terraform from showing diff for server generated schema columns(like hive partitioned ones)

b/420688695, b/300616880

Fixes https://github.com/hashicorp/terraform-provider-google/issues/12465, https://github.com/hashicorp/terraform-provider-google/issues/16907

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added `ignore_auto_generated_schema` virtual field to `google_bigquery_table` resource to ignore server-added columns in the `schema` field
```
