### PR TITLE
Remove noisy grpc logs and compress the ones we want into the test logs

### DIFF
--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -564,10 +564,9 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 		TimestampFormat: "2006/01/02 15:04:05",
 		LogFormat:       "%time% [%lvl%] %msg% \n",
 	})
+	logger.SetOutput(log.Writer())
 
 	alwaysLoggingDeciderClient := func(ctx context.Context, fullMethodName string) bool { return true }
-	grpc_logrus.ReplaceGrpcLogger(logrus.NewEntry(logger))
-
 	c.gRPCLoggingOptions = append(
 		c.gRPCLoggingOptions, option.WithGRPCDialOption(grpc.WithUnaryInterceptor(
 			grpc_logrus.PayloadUnaryClientInterceptor(logrus.NewEntry(logger), alwaysLoggingDeciderClient))),


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/12159

grpc level logging isn't necessary. rogus will still give us the grpc req/resp payloads. verrified locally. Switched the logger to use the log.Writer stdout so we terraforms logs them with the rest of the SDK logs.

tldr: gets rid of logs the look like

```
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc00adca4e0] loopyWriter exiting with error: transport closed by client 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc00adca4e0] Closing: EOF 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc001fb84e0] loopyWriter exiting with error: transport closed by client 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc001fb84e0] Closing: EOF 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc001bcd860] loopyWriter exiting with error: transport closed by client 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc001bcd860] Closing: EOF 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc0031504e0] loopyWriter exiting with error: transport closed by client 
2025/07/09 20:54:44 [DEBUG] [transport] [server-transport 0xc0031504e0] Closing: EOF
```
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
