### PR TITLE
Firestore Tags R2401 terraform support

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -72,6 +72,22 @@ examples:
       - 'project'
       - 'etag'
       - 'deletion_policy'
+  - name: 'firestore_database_with_tags'
+    primary_resource_id: 'database'
+    vars:
+      database_id: 'database-with-tags-id'
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
+      tag_key_id: 'keyname'
+      tag_value_id: 'valuename'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
+    ignore_read_extra:
+      - 'project'
+      - 'etag'
+      - 'deletion_policy'
+    exclude_test: true
   - name: 'firestore_cmek_database'
     primary_resource_id: 'database'
     vars:
@@ -315,3 +331,14 @@ properties:
         output: true
         item_type:
           type: String
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      Input only. A map of resource manager tags. Resource manager tag keys
+      and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456.
+      The field is ignored when empty. The field is immutable and causes
+      resource replacement when mutated. To apply tags to an existing resource, see
+      the `google_tags_tag_value` resource.
+    immutable: true
+    ignore_read: true

--- a/mmv1/templates/terraform/examples/firestore_database_with_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database_with_tags.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
+  project                           = "{{index $.TestEnvVars "project_id"}}"
+  name                              = "{{index $.Vars "database_id"}}"
+  location_id                       = "nam5"
+  type                              = "FIRESTORE_NATIVE"
+  delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
+  deletion_policy                   = "DELETE"
+  tags = {
+    "{{index $.Vars "tag_key_id"}}": "{{index $.Vars "tag_value_id"}}"
+  }
+}

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_test.go.tmpl
@@ -1,0 +1,54 @@
+package firestore_test
+
+import (
+  "testing"
+
+  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccFirestoreDatabase_tags(t *testing.T) {
+  t.Parallel()
+
+  // Bootstrap shared tag key and value
+  tagKey := acctest.BootstrapSharedTestProjectTagKey(t, "firestore-databases-tagkey", map[string]interface{}{})
+  context := map[string]interface{}{
+    "pid":           envvar.GetTestProjectFromEnv(),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestProjectTagValue(t, "firestore-databases-tagvalue", tagKey),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckFirestoreDatabaseDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccFirestoreDatabaseTags(context),
+      },
+      {
+        ResourceName:            "google_firestore_database.database",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"project", "etag", "deletion_policy", "tags"},
+      },
+    },
+  })
+}
+
+func testAccFirestoreDatabaseTags(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+    resource "google_firestore_database" "database" {
+      name                              = "tf-test-database-%{random_suffix}"
+      location_id                       = "nam5"
+      type                              = "FIRESTORE_NATIVE"
+      delete_protection_state           = "DELETE_PROTECTION_DISABLED"
+      deletion_policy                   = "DELETE"
+      tags = {
+	      "%{pid}/%{tagKey}" = "%{tagValue}"
+      }
+    }
+  `, context)
+}


### PR DESCRIPTION
This commit adds support for the tags field to the Firestore Database resource. The tags field is a map<string, string>. This allows users to perform database actions and setting tag bindings at the same time.

`firestore: add `tags` field to `database` resource`
