### PR TITLE
Revert "Update service account creation to prevent failures due to eventual consistency"

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -122,59 +122,54 @@ func resourceGoogleServiceAccountCreate(d *schema.ResourceData, meta interface{}
 		ServiceAccount: sa,
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", project, aid, project))
-
-	iamClient := config.NewIamClient(userAgent)
-	sa, err = iamClient.Projects.ServiceAccounts.Create("projects/"+project, r).Do()
+	sa, err = config.NewIamClient(userAgent).Projects.ServiceAccounts.Create("projects/"+project, r).Do()
 	if err != nil {
 		gerr, ok := err.(*googleapi.Error)
 		alreadyExists := ok && gerr.Code == 409 && d.Get("create_ignore_already_exists").(bool)
 		if alreadyExists {
-			err = transport_tpg.Retry(transport_tpg.RetryOptions{
-				RetryFunc: func() (operr error) {
-					sa, saerr := iamClient.Projects.ServiceAccounts.Get(d.Id()).Do()
-
-					if saerr != nil {
-						return saerr
-					}
-					return populateResourceData(d, sa)
-				},
-				Timeout: d.Timeout(schema.TimeoutCreate),
-				ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{
-					transport_tpg.IsNotFoundRetryableError("service account creation"),
-				},
-			})
-
-			return nil
+			sa = &iam.ServiceAccount{
+				Name: fmt.Sprintf("projects/%s/serviceAccounts/%s@%s.iam.gserviceaccount.com", project, aid, project),
+			}
 		} else {
 			return fmt.Errorf("Error creating service account: %s", err)
 		}
 	}
 
-	// We poll until the resource is found due to eventual consistency issue
-	// on part of the api https://cloud.google.com/iam/docs/overview#consistency.
-	// Wait for at least 3 successful responses in a row to ensure result is consistent.
-	// IAM API returns 403 when the queried SA is not found, so we must ignore both 404 & 403 errors
-	transport_tpg.PollingWaitTime(
-		resourceServiceAccountPollRead(d, meta),
-		transport_tpg.PollCheckForExistence,
-		"Creating Service Account",
-		d.Timeout(schema.TimeoutCreate),
-		3, // Number of consecutive occurences.
-	)
+	d.SetId(sa.Name)
 
-	populateResourceData(d, sa)
+	err = transport_tpg.Retry(transport_tpg.RetryOptions{
+		RetryFunc: func() (operr error) {
+			_, saerr := config.NewIamClient(userAgent).Projects.ServiceAccounts.Get(d.Id()).Do()
+			return saerr
+		},
+		Timeout: d.Timeout(schema.TimeoutCreate),
+		ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{
+			transport_tpg.IsNotFoundRetryableError("service account creation"),
+			transport_tpg.IsForbiddenIamServiceAccountRetryableError("service account creation"),
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error reading service account after creation: %s", err)
+	}
+
+	// We poll until the resource is found due to eventual consistency issue
+	// on part of the api https://cloud.google.com/iam/docs/overview#consistency
+	// IAM API returns 403 when the queried SA is not found, so we must ignore both 404 & 403 errors
+	err = transport_tpg.PollingWaitTime(resourceServiceAccountPollRead(d, meta), transport_tpg.PollCheckForExistenceWith403, "Creating Service Account", d.Timeout(schema.TimeoutCreate), 1)
+
+	if err != nil {
+		return err
+	}
 
 	// We can't guarantee complete consistency even after polling,
 	// so sleep for some additional time to reduce the likelihood of
 	// eventual consistency failures.
 	time.Sleep(10 * time.Second)
 
-	return nil
+	return resourceGoogleServiceAccountRead(d, meta)
 }
 
-// PollReadFunc for checking Service Account existence.
-// If resourceData is not nil, it will be updated with the response.
 func resourceServiceAccountPollRead(d *schema.ResourceData, meta interface{}) transport_tpg.PollReadFunc {
 	return func() (map[string]interface{}, error) {
 		config := meta.(*transport_tpg.Config)
@@ -206,10 +201,6 @@ func resourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}) 
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Service Account %q", d.Id()))
 	}
 
-	return populateResourceData(d, sa)
-}
-
-func populateResourceData(d *schema.ResourceData, sa *iam.ServiceAccount) error {
 	if err := d.Set("email", sa.Email); err != nil {
 		return fmt.Errorf("Error setting email: %s", err)
 	}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#14447

[TestAccSdkProvider_scopes/the_scopes_argument_impacts_provisioning_resources](mmv1/third_party/terraform/provider/provider_scopes_test.go) fails due to [this change](https://github.com/GoogleCloudPlatform/magic-modules/pull/14447/files#r2201500020)

```release-note:note
iam: Update service account creation to prevent failures due to eventual consistency (reverted)
```