### PR TITLE
Add support for name in GcpUserAccessBinding

### DIFF
--- a/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
+++ b/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
@@ -1,4 +1,4 @@
-    # Copyright 2024 Google Inc.
+# Copyright 2024 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
+++ b/mmv1/products/accesscontextmanager/GcpUserAccessBinding.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google Inc.
+    # Copyright 2024 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -131,12 +131,16 @@ properties:
                 - name: restrictedClientApplication
                   type: NestedObject
                   description: |
-                    Optional. The application that is subject to this binding's scope.
+                    Optional. The application that is subject to this binding's scope. Only one of clientId or name should be specified.
                   properties:
                     - name: clientId
                       type: String
                       description: |
                         The OAuth client ID of the application.
+                    - name: name
+                      type: String
+                      description: |
+                        The name of the application. Example: "Cloud Console"
         - name: 'activeSettings'
           type: NestedObject
           description: |

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -119,7 +119,6 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
   		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   	  ]
   	  session_settings {
-  		  max_inactivity = "300s"
   		  session_length = "1800s"
   		  session_length_enabled = true
   		  session_reauth_method = "LOGIN"

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -41,6 +41,15 @@ func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"organization_id"},
 			},
+			{
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
+			},
+			{
+				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization_id"},
+			},
 		},
 	})
 }
@@ -92,7 +101,6 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
     google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   ]
   session_settings {
-    max_inactivity = "300s"
     session_length = "1800s"
     session_length_enabled = true
     session_reauth_method = "LOGIN"
@@ -103,6 +111,88 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
       client_scope {
         restricted_client_application {
 	        client_id = "TEST_APPLICATION"
+         }
+      }
+    }
+    active_settings {
+  	  access_levels = [
+  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  	  ]
+  	  session_settings {
+  		  max_inactivity = "300s"
+  		  session_length = "1800s"
+  		  session_length_enabled = true
+  		  session_reauth_method = "LOGIN"
+  		  use_oidc_max_age = false
+  	  }
+  	}
+  	dry_run_settings {
+  	  access_levels = [
+  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  	  ]
+  	}
+  }
+}
+`, context)
+}
+
+func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_identity_group" "group" {
+  display_name = "tf-test-my-identity-group%{random_suffix}"
+
+  parent = "customers/%{cust_id}"
+
+  group_key {
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}
+
+resource "google_access_context_manager_access_level" "tf_test_access_level_id_for_user_access_binding%{random_suffix}" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/tf_test_chromeos_no_lock%{random_suffix}"
+  title  = "tf_test_chromeos_no_lock%{random_suffix}"
+  basic {
+    conditions {
+      device_policy {
+        require_screen_lock = true
+        os_constraints {
+          os_type = "DESKTOP_CHROME_OS"
+        }
+      }
+      regions = [
+  "US",
+      ]
+    }
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/%{org_id}"
+  title  = "my policy"
+}
+
+resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_access_binding" {
+  organization_id = "%{org_id}"
+  group_key       = trimprefix(google_cloud_identity_group.group.id, "groups/")
+  access_levels   = [
+    google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  ]
+  session_settings {
+    session_length = "1800s"
+    session_length_enabled = true
+    session_reauth_method = "LOGIN"
+    use_oidc_max_age = false
+  }
+  scoped_access_settings {
+    scope {
+      client_scope {
+        restricted_client_application {
+	        name = "Cloud Console"
          }
       }
     }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -200,7 +200,7 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
   		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   	  ]
   	  session_settings {
-  		  max_inactivity = "300s"
+  		  max_inactivity = "400s"
   		  session_length = "1800s"
   		  session_length_enabled = true
   		  session_reauth_method = "LOGIN"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Add `name` field to ScopedAccessSettings in GcpUserAccessBinding in AccessContextManager

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23608

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
accesscontextmanager: added `name` to `google_access_context_manager_gcp_user_access_binding` resource
```
