### PR TITLE
Fix artifactRegistryRepositoryRemoteAptExample test + update docs

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -99,7 +99,7 @@ examples:
   - name: 'artifact_registry_repository_remote_apt'
     primary_resource_id: 'my-repo'
     vars:
-      repository_id: 'debian-buster'
+      repository_id: 'debian-stable'
       desc: 'example remote apt repository'
   - name: 'artifact_registry_repository_remote_yum'
     primary_resource_id: 'my-repo'
@@ -483,7 +483,7 @@ properties:
               - name: 'repositoryBase'
                 type: Enum
                 description: |-
-                  A common public repository base for Apt, e.g. `"debian/dists/buster"`
+                  A common public repository base for Apt, e.g. `"debian/dists/stable"`
                 required: true
                 immutable: true
                 enum_values:

--- a/mmv1/templates/terraform/examples/artifact_registry_repository_remote_apt.tf.tmpl
+++ b/mmv1/templates/terraform/examples/artifact_registry_repository_remote_apt.tf.tmpl
@@ -5,11 +5,11 @@ resource "google_artifact_registry_repository" "{{$.PrimaryResourceId}}" {
   format        = "APT"
   mode          = "REMOTE_REPOSITORY"
   remote_repository_config {
-    description = "Debian buster remote repository"
+    description = "Debian stable remote repository"
     apt_repository {
       public_repository {
         repository_base = "DEBIAN"
-        repository_path = "debian/dists/buster"
+        repository_path = "debian/dists/stable"
       }
     }
   }


### PR DESCRIPTION
Replaces references to the Debian repository "buster" with "stable" in docs and tests.

Fixes a failing test `TestAccArtifactRegistryRepository_artifactRegistryRepositoryRemoteAptExample`

**Release Note Template for Downstream PRs (will be copied)**


```release-note:none
```
