### PR TITLE
Revert "feat: support PSC outbound's network attachment field"

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -532,11 +532,6 @@ is set to true. Defaults to ZONAL.`,
 													Set:         schema.HashString,
 													Description: `List of consumer projects that are allow-listed for PSC connections to this instance. This instance can be connected to with PSC from any network in these projects. Each consumer project in this list may be represented by a project number (numeric) or by a project id (alphanumeric).`,
 												},
-												"network_attachment_uri": {
-													Type:        schema.TypeString,
-													Optional:    true,
-													Description: `Name of network attachment resource used to authorize a producer service to connect a PSC interface to the consumer's VPC. For example: "projects/myProject/regions/myRegion/networkAttachments/myNetworkAttachment". This is required to enable outbound connection on a PSC instance.`,
-												},
 												"psc_auto_connections": {
 													Type:     schema.TypeList,
 													Optional: true,
@@ -1601,7 +1596,6 @@ func expandPscConfig(configured []interface{}) *sqladmin.PscConfig {
 		return &sqladmin.PscConfig{
 			PscEnabled:              _entry["psc_enabled"].(bool),
 			AllowedConsumerProjects: tpgresource.ConvertStringArr(_entry["allowed_consumer_projects"].(*schema.Set).List()),
-			NetworkAttachmentUri:    _entry["network_attachment_uri"].(string),
 			PscAutoConnections:      expandPscAutoConnectionConfig(_entry["psc_auto_connections"].([]interface{})),
 		}
 	}
@@ -2647,7 +2641,6 @@ func flattenPscConfigs(pscConfig *sqladmin.PscConfig) interface{} {
 	data := map[string]interface{}{
 		"psc_enabled":               pscConfig.PscEnabled,
 		"allowed_consumer_projects": schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(pscConfig.AllowedConsumerProjects)),
-		"network_attachment_uri":    pscConfig.NetworkAttachmentUri,
 		"psc_auto_connections":      flattenPscAutoConnections(pscConfig.PscAutoConnections),
 	}
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -1183,86 +1183,6 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withIpV4Enabled(t *testing.T) {
 	})
 }
 
-func TestAccSqlDatabaseInstance_withPscEnabled_withNetworkAttachmentUri_thenRemoveNetworkAttachment(t *testing.T) {
-	t.Parallel()
-
-	random_suffix := acctest.RandString(t, 10)
-	instanceName := "tf-test-" + random_suffix
-	projectId := envvar.GetTestProjectFromEnv()
-	region := "us-central1"
-	networkNameStr := "tf-test-cloud-sql-network-" + random_suffix
-	subnetworkNameStr := "tf-test-cloud-sql-subnetwork-" + random_suffix
-	networkAttachmentNameStr := "tf-test-cloud-sql-update-na-" + random_suffix
-	networkName := acctest.BootstrapSharedTestNetwork(t, networkNameStr)
-	subnetworkName := acctest.BootstrapSubnet(t, subnetworkNameStr, networkName)
-	networkAttachmentName := acctest.BootstrapNetworkAttachment(t, networkAttachmentNameStr, subnetworkName)
-	networkAttachmentUri := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", projectId, region, networkAttachmentName)
-
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutPscOutbound(instanceName),
-				Check:  resource.ComposeTestCheckFunc(verifyPscNetorkAttachmentOperation("google_sql_database_instance.instance", true, true, "")),
-			},
-			{
-				ResourceName:            "google_sql_database_instance.instance",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s/", projectId),
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withNetworkAttachmentUri(instanceName, networkAttachmentUri),
-				Check:  resource.ComposeTestCheckFunc(verifyPscNetorkAttachmentOperation("google_sql_database_instance.instance", true, true, networkAttachmentUri)),
-			},
-			{
-				ResourceName:            "google_sql_database_instance.instance",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateIdPrefix:     fmt.Sprintf("%s/", projectId),
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withoutPscOutbound(instanceName),
-				Check:  resource.ComposeTestCheckFunc(verifyPscNetorkAttachmentOperation("google_sql_database_instance.instance", true, true, "")),
-			},
-		},
-	})
-}
-
-func TestAccSqlDatabaseInstance_withPscEnabled_withNetworkAttachmentUriOnCreate(t *testing.T) {
-	t.Parallel()
-
-	random_suffix := acctest.RandString(t, 10)
-	instanceName := "tf-test-" + random_suffix
-	projectId := envvar.GetTestProjectFromEnv()
-	region := "us-central1"
-	networkNameStr := "tf-test-cloud-sql-network-" + random_suffix
-	subnetworkNameStr := "tf-test-cloud-sql-subnetwork-" + random_suffix
-	networkAttachmentNameStr := "tf-test-cloud-sql-update-na-" + random_suffix
-	networkName := acctest.BootstrapSharedTestNetwork(t, networkNameStr)
-	subnetworkName := acctest.BootstrapSubnet(t, subnetworkNameStr, networkName)
-	networkAttachmentName := acctest.BootstrapNetworkAttachment(t, networkAttachmentNameStr, subnetworkName)
-	networkAttachmentUri := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", projectId, region, networkAttachmentName)
-
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSqlDatabaseInstance_withPSCEnabled_withNetworkAttachmentUri(instanceName, networkAttachmentUri),
-				ExpectError: regexp.MustCompile(`.*Network attachment used for Private Service Connect interfaces can not be assigned with instance creation.*`),
-			},
-		},
-	})
-}
-
 func TestAccSqlDatabaseInstance_withPrivateNetwork_withAllocatedIpRange(t *testing.T) {
 
 	t.Parallel()
@@ -4923,49 +4843,6 @@ func verifyPscAutoConnectionsOperation(resourceName string, isPscConfigExpected 
 	}
 }
 
-func verifyPscNetorkAttachmentOperation(resourceName string, isPscConfigExpected bool, expectedPscEnabled bool, expectedNetworkAttachmentUri string ) func(*terraform.State) error {
-	return func(s *terraform.State) error {
-		resource, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return fmt.Errorf("Can't find %s in state", resourceName)
-		}
-
-		resourceAttributes := resource.Primary.Attributes
-		_, ok = resourceAttributes["settings.0.ip_configuration.#"]
-		if !ok {
-			return fmt.Errorf("settings.0.ip_configuration.# block is not present in state for %s", resourceName)
-		}
-
-		if isPscConfigExpected {
-			_, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.#"]
-			if !ok {
-				return fmt.Errorf("settings.0.ip_configuration.0.psc_config property is not present or set in state of %s", resourceName)
-			}
-
-			pscEnabledStr, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.0.psc_enabled"]
-			pscEnabled, err := strconv.ParseBool(pscEnabledStr)
-			if err != nil || pscEnabled != expectedPscEnabled {
-				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.psc_enabled property value is not set as expected in state of %s, expected %v, actual %v", resourceName, expectedPscEnabled, pscEnabled)
-			}
-
-			networkAttachmentUriStr, ok := resourceAttributes["settings.0.ip_configuration.0.psc_config.0.network_attachment_uri"]
-			if !ok {
-				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.network_attachment_uri block is not present in state for %s", resourceName)
-			}
-
-			if networkAttachmentUriStr != expectedNetworkAttachmentUri && len(networkAttachmentUriStr) == 0 {
-				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.network_attachment_uri block is not set in state for %s", resourceName)
-			}
-
-			if networkAttachmentUriStr != expectedNetworkAttachmentUri {
-				return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.network_attachment_uri block does not match the expected value for %s", resourceName)
-			}
-		}
-
-		return nil
-	}
-}
-
 func testAccSqlDatabaseInstance_withoutMCPEnabled(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
@@ -5026,32 +4903,6 @@ resource "google_sql_database_instance" "instance" {
 `, instanceName)
 }
 
-func testAccSqlDatabaseInstance_withPSCEnabled_withoutPscOutbound(instanceName string) string {
-	return fmt.Sprintf(`
-resource "google_sql_database_instance" "instance" {
-  name                = "%s"
-  region              = "us-central1"
-  database_version    = "MYSQL_8_0"
-  deletion_protection = false
-  settings {
-    tier = "db-g1-small"
-    ip_configuration {
-		psc_config {
-			psc_enabled = true
-			network_attachment_uri = ""
-		}
-		ipv4_enabled = false
-    }
-	backup_configuration {
-		enabled = true
-		binary_log_enabled = true
-	}
-	availability_type = "REGIONAL"
-  }
-}
-`, instanceName)
-}
-
 func testAccSqlDatabaseInstance_withPSCEnabled_withPscAutoConnections(instanceName string, projectId string, networkName string) string {
 	return fmt.Sprintf(`
 data "google_compute_network" "testnetwork" {
@@ -5083,32 +4934,6 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, networkName, instanceName, projectId, networkName, projectId)
-}
-
-func testAccSqlDatabaseInstance_withPSCEnabled_withNetworkAttachmentUri(instanceName string, networkAttachmentUri string) string {
-	return fmt.Sprintf(`
-
-resource "google_sql_database_instance" "instance" {
-  name                = "%s"
-  region              = "us-central1"
-  database_version    = "MYSQL_8_0"
-  deletion_protection = false
-  settings {
-    tier = "db-g1-small"
-    ip_configuration {
-		psc_config {
-			psc_enabled = true
-			network_attachment_uri = "%s"
-		}
-		ipv4_enabled = false
-    }
-	backup_configuration {
-		enabled = true
-		binary_log_enabled = true
-	}
-	availability_type = "REGIONAL"
-  }
-}`, instanceName, networkAttachmentUri)
 }
 
 func testAccSqlDatabaseInstance_withPrivateNetwork_withoutAllocatedIpRange(databaseName, networkName string, specifyPrivatePathOption bool, enablePrivatePath bool) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -244,31 +244,6 @@ resource "google_sql_database_instance" "main" {
 }
 ```
 
-### Cloud SQL Instance with PSC outbound
-
-```hcl
-resource "google_sql_database_instance" "main" {
-  name             = "psc-enabled-main-instance"
-  database_version = "MYSQL_8_0"
-  settings {
-    tier    = "db-f1-micro"
-    ip_configuration {
-      psc_config {
-        psc_enabled = true
-        allowed_consumer_projects = ["allowed-consumer-project-name"]
-        network_attachment_uri = "network-attachment-uri"
-      }
-      ipv4_enabled = false
-    }
-    backup_configuration {
-      enabled = true
-      binary_log_enabled = true
-    }
-    availability_type = "REGIONAL"
-  }
-}
-```
-
 ## Argument Reference
 
 The following arguments are supported:
@@ -489,8 +464,6 @@ The optional `settings.ip_configuration.psc_config` sublist supports:
 * The optional `psc_config.psc_auto_connections` subblock - (Optional) A comma-separated list of networks or a comma-separated list of network-project pairs. Each project in this list is represented by a project number (numeric) or by a project ID (alphanumeric). This allows Private Service Connect connections to be created automatically for the specified networks.
 
 * `consumer_network` - "The consumer network of this consumer endpoint. This must be a resource path that includes both the host project and the network name. For example, `projects/project1/global/networks/network1`. The consumer host project of this network might be different from the consumer service project."
-
-* `network_attachment_uri` - (Optional) Network Attachment URI in the format `projects/project1/regions/region1/networkAttachments/networkAttachment1` to enable outbound connectivity on PSC instance.
 
 * `consumer_service_project_id` - (Optional) The project ID of consumer service project of this consumer endpoint.
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#14462

```release-note:none
sql: added `network_attachment_uri` field to `google_sql_database_instance` (reverted)
```
