### PR TITLE
added GOOGLE_CLOUD_NETAPP_VOLUMES to google_vmwareengine_network_peering

### DIFF
--- a/mmv1/products/vmwareengine/NetworkPeering.yaml
+++ b/mmv1/products/vmwareengine/NetworkPeering.yaml
@@ -138,6 +138,7 @@ properties:
       - 'NETAPP_CLOUD_VOLUMES'
       - 'THIRD_PARTY_SERVICE'
       - 'DELL_POWERSCALE'
+      - 'GOOGLE_CLOUD_NETAPP_VOLUMES'
   - name: 'uid'
     type: String
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23623

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
vmwareengine: added `GOOGLE_CLOUD_NETAPP_VOLUMES` peering type to resource `google_vmwareengine_network_peering`
```
