### PR TITLE
fixing permadiff create_without_validation

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -41,6 +41,7 @@ async:
     resource_inside_response: true
 custom_code:
     constants: 'templates/terraform/constants/datastream_connection_profile.go.tmpl'
+    pre_create: 'templates/terraform/pre_create/datastream_connection_profile.go.tmpl'
 examples:
   - name: 'datastream_connection_profile_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -40,8 +40,8 @@ async:
   result:
     resource_inside_response: true
 custom_code:
-    constants: 'templates/terraform/constants/datastream_connection_profile.go.tmpl'
-    pre_create: 'templates/terraform/pre_create/datastream_connection_profile.go.tmpl'
+  constants: 'templates/terraform/constants/datastream_connection_profile.go.tmpl'
+  pre_create: 'templates/terraform/pre_create/datastream_connection_profile.go.tmpl'
 examples:
   - name: 'datastream_connection_profile_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -23,7 +23,7 @@ docs:
 id_format: 'projects/{{project}}/locations/{{location}}/connectionProfiles/{{connection_profile_id}}'
 base_url: 'projects/{{project}}/locations/{{location}}/connectionProfiles'
 self_link: 'projects/{{project}}/locations/{{location}}/connectionProfiles/{{connection_profile_id}}'
-create_url: 'projects/{{project}}/locations/{{location}}/connectionProfiles?connectionProfileId={{connection_profile_id}}&force={{create_without_validation}}'
+create_url: 'projects/{{project}}/locations/{{location}}/connectionProfiles?connectionProfileId={{connection_profile_id}}'
 update_verb: 'PATCH'
 update_mask: true
 import_format:

--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -40,6 +40,7 @@ async:
   result:
     resource_inside_response: true
 custom_code:
+    constants: 'templates/terraform/constants/datastream_connection_profile.go.tmpl'
 examples:
   - name: 'datastream_connection_profile_basic'
     primary_resource_id: 'default'
@@ -122,6 +123,7 @@ parameters:
     required: false
     immutable: true
     default_value: false
+    diff_suppress_func: 'resourceDataStreamStreamCreateWithoutValidationDiffSuppress'
   - name: 'location'
     type: String
     description: |

--- a/mmv1/templates/terraform/constants/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/constants/datastream_connection_profile.go.tmpl
@@ -14,7 +14,7 @@
 func resourceDataStreamStreamCreateWithoutValidationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// If the old value was "false" and the new value is now unset (empty string),
 	// return true to suppress the diff.
-	if old == "false" && new == "" {
+	if (old == "" && new == "false") || (old == "false" && new == "") {
 		d.Set("create_without_validation", "false")
 		return true
 	}

--- a/mmv1/templates/terraform/constants/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/constants/datastream_connection_profile.go.tmpl
@@ -1,0 +1,24 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+
+func resourceDataStreamStreamCreateWithoutValidationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// If the old value was "false" and the new value is now unset (empty string),
+	// return true to suppress the diff.
+	if old == "false" && new == "" {
+		d.Set("create_without_validation", "false")
+		return true
+	}
+
+	// Otherwise, do not suppress the diff.
+	return false
+}

--- a/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
@@ -12,7 +12,7 @@
 */ -}}
 
 if d.Get("create_without_validation").(bool) {
-		url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "true"})
-	} else {
-		url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "false"})
-	}
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "true"})
+} else {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "false"})
+}

--- a/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
@@ -11,4 +11,8 @@
 	limitations under the License.
 */ -}}
 
-d.Set("create_without_validation", false)
+
+if !d.Get("create_without_validation").(bool) {
+	url += "false"
+	d.Set("create_without_validation", false)
+}

--- a/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
@@ -11,8 +11,8 @@
 	limitations under the License.
 */ -}}
 
-
-if !d.Get("create_without_validation").(bool) {
+_, exists := d.GetOk("create_without_validation")
+if !exists {
 	url += "false"
 	d.Set("create_without_validation", false)
 }

--- a/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
@@ -11,8 +11,8 @@
 	limitations under the License.
 */ -}}
 
-_, exists := d.GetOk("create_without_validation")
-if !exists {
-	url += "false"
-	d.Set("create_without_validation", false)
-}
+if d.Get("create_without_validation").(bool) {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "true"})
+	} else {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": "false"})
+	}

--- a/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/datastream_connection_profile.go.tmpl
@@ -11,13 +11,4 @@
 	limitations under the License.
 */ -}}
 
-func resourceDataStreamStreamCreateWithoutValidationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// If the old value was "false" and the new value is now unset (empty string),
-	// return true to suppress the diff.
-	if (old == "" && new == "false") || (old == "false" && new == "") {
-		return true
-	}
-
-	// Otherwise, do not suppress the diff.
-	return false
-}
+d.Set("create_without_validation", false)

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -36,7 +36,7 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_datastream_connection_profile.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location"},
+				ImportStateVerifyIgnore: []string{"create_without_validation", "connection_profile_id", "location"},
 			},
 			{
 				Config: testAccDatastreamConnectionProfile_update2(context, true),
@@ -45,7 +45,7 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_datastream_connection_profile.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "postgresql_profile.0.password"},
+				ImportStateVerifyIgnore: []string{"create_without_validation", "connection_profile_id", "location", "postgresql_profile.0.password"},
 			},
 			{
 				// Disable prevent_destroy
@@ -58,7 +58,7 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
+				ImportStateVerifyIgnore: []string{"create_without_validation", "connection_profile_id", "location", "mysql_profile.0.password"},
 			},
 			{
 				// run once more to update the password. it should update it in-place
@@ -68,7 +68,7 @@ func TestAccDatastreamConnectionProfile_update(t *testing.T) {
 				ResourceName:            "google_datastream_connection_profile.mysql_con_profile",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"connection_profile_id", "location", "mysql_profile.0.password"},
+				ImportStateVerifyIgnore: []string{"create_without_validation", "connection_profile_id", "location", "mysql_profile.0.password"},
 			},
 			{
 				// Disable prevent_destroy


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21780 - a permadiff regarding the create_without_validation field within datastream

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
datastore: Fixed a permadiff related to datastream 'create_without_validation' field
```
