### PR TITLE
Fix teamcity runs for modelarmor

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -562,12 +562,12 @@ var ServicesListBeta = mapOf(
         "path" to "./google-beta/services/mlengine"
     ),
     "modelarmor" to mapOf(
-        "name" to "ModelArmor",
+        "name" to "modelarmor",
         "displayName" to "ModelArmor",
         "path" to "./google-beta/services/modelarmor"
     ),
     "modelarmorglobal" to mapOf(
-        "name" to "ModelArmorGlobal",
+        "name" to "modelarmorglobal",
         "displayName" to "ModelArmorGlobal",
         "path" to "./google-beta/services/modelarmorglobal"
     ),

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -557,12 +557,12 @@ var ServicesListGa = mapOf(
         "path" to "./google/services/mlengine"
     ),
     "modelarmor" to mapOf(
-        "name" to "ModelArmor",
+        "name" to "modelarmor",
         "displayName" to "ModelArmor",
         "path" to "./google/services/modelarmor"
     ),
     "modelarmorglobal" to mapOf(
-        "name" to "ModelArmorGlobal",
+        "name" to "modelarmorglobal",
         "displayName" to "ModelArmorGlobal",
         "path" to "./google/services/modelarmorglobal"
     ),


### PR DESCRIPTION
This PR should fix the service name not matching issue for `modelarmor` and `modelarmorglobal`, which was introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/14457

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
