### PR TITLE
fix(bigquery_dataset): fixed handling of non-legacy roles for access …

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -129,6 +129,7 @@ properties:
     is_set: true
     default_from_api: true
     is_missing_in_cai: true
+    set_hash_func: 'resourceBigqueryDatasetAccessHash'
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
@@ -1,5 +1,11 @@
 const datasetIdRegexp = `^[0-9A-Za-z_]+$`
 
+var bigqueryDatasetAccessPrimitiveToRoleMap = map[string]string{
+	"OWNER":  "roles/bigquery.dataOwner",
+	"WRITER": "roles/bigquery.dataEditor",
+	"READER": "roles/bigquery.dataViewer",
+}
+
 func validateDatasetId(v interface{}, k string) (ws []string, errors []error) {
     value := v.(string)
     if !regexp.MustCompile(datasetIdRegexp).MatchString(value) {
@@ -23,3 +29,30 @@ func validateDefaultTableExpirationMs(v interface{}, k string) (ws []string, err
 
     return
 }
+
+{{- if ne $.Compiler "terraformgoogleconversion-codegen" }}
+// bigqueryDatasetAccessHash is a custom hash function for the access block.
+// It normalizes the 'role' field before hashing, treating legacy roles
+// and their modern IAM equivalents as the same.
+func resourceBigqueryDatasetAccessHash(v interface{}) int {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	// Make a copy of the map to avoid modifying the underlying data.
+	copy := make(map[string]interface{}, len(m))
+	for k, val := range m {
+		copy[k] = val
+	}
+
+	// Normalize the role if it exists and matches a legacy role.
+	if role, ok := copy["role"].(string); ok {
+		if newRole, ok := bigqueryDatasetAccessPrimitiveToRoleMap[role]; ok {
+			copy["role"] = newRole
+		}
+	}
+
+	// Use the default HashResource function on the (potentially modified) copy.
+	return schema.HashResource(bigqueryDatasetAccessSchema())(copy)
+}
+{{- end }}

--- a/mmv1/templates/terraform/examples/bigquery_dataset_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_basic.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
   }
 
   access {
-    role          = "OWNER"
+    role          = "roles/bigquery.dataOwner"
     user_by_email = google_service_account.bqowner.email
   }
 


### PR DESCRIPTION
Added a flag to prevent Terraform from showing diff for server generated schema columns(like hive partitioned ones)

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8370

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: fixed handling of non-legacy roles for access block inside `google_bigquery_dataset`
```
