### PR TITLE
Revise the deprecation message for discovery_endpoints in Memorystore Instance resource

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,6 +288,13 @@ properties:
     type: Array
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
+    deprecation_message: |
+      This field is deprecated. As a result it will not be populated
+      if the connections are created using desired_auto_created_endpoints
+      parameter or google_memorystore_instance_desired_user_created_endpoints
+      resource. Instead of this parameter, for discovery, use
+      endpoints.connections.pscConnection and endpoints.connections.pscAutoConnection
+      with connectionType CONNECTION_TYPE_DISCOVERY.
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -290,11 +290,11 @@ properties:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
     deprecation_message:
       This field is deprecated. As a result it will not be populated
-      if the connections are created using desired_auto_created_endpoints
-      parameter or google_memorystore_instance_desired_user_created_endpoints
+      if the connections are created using `desired_auto_created_endpoints`
+      parameter or `google_memorystore_instance_desired_user_created_endpoints`
       resource. Instead of this parameter, for discovery, use
-      endpoints.connections.pscConnection and endpoints.connections.pscAutoConnection
-      with connectionType CONNECTION_TYPE_DISCOVERY.
+      `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection`
+      with `connectionType` CONNECTION_TYPE_DISCOVERY.
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,7 +288,7 @@ properties:
     type: Array
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
-    deprecation_message: 
+    deprecation_message:
       "`discovery_endpoints` is deprecated. As a result it will not be populated \n
       if the connections are created using `desired_auto_created_endpoints` \n
       parameter or `google_memorystore_instance_desired_user_created_endpoints` \n

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -287,9 +287,11 @@ properties:
   - name: 'discoveryEndpoints'
     type: Array
     description:
-      "Output only. Endpoints clients can connect to the instance through.
-      Currently only one\ndiscovery endpoint is supported. "
-    deprecation_message: '`discovery_endpoints` is deprecated  Use `endpoints` instead.'
+      "Deprecated. Output only. Endpoints clients can connect to the instance through."
+    deprecation_message: 
+      "`discovery_endpoints` is deprecated and is not guaranteed to be populated. \n
+      `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection` \n
+      with connectionType CONNECTION_TYPE_DISCOVERY should be used for discovery instead"
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -294,7 +294,7 @@ properties:
       parameter or `google_memorystore_instance_desired_user_created_endpoints` \n
       resource. Instead of this parameter, for discovery, use \n
       `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection` \n
-      with connectionType CONNECTION_TYPE_DISCOVERY. 
+      with connectionType CONNECTION_TYPE_DISCOVERY."
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -286,7 +286,8 @@ properties:
     required: true
   - name: 'discoveryEndpoints'
     type: Array
-    description: "Deprecated. Output only. Endpoints clients can connect to the instance through."
+    description:
+      "Deprecated. Output only. Endpoints clients can connect to the instance through."
     deprecation_message: |
       This field is deprecated. As a result it will not be populated
       if the connections are created using `desired_auto_created_endpoints`

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,13 +288,6 @@ properties:
     type: Array
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
-    deprecation_message: |
-      This field is deprecated. As a result it will not be populated
-      if the connections are created using `desired_auto_created_endpoints`
-      parameter or `google_memorystore_instance_desired_user_created_endpoints`
-      resource. Instead of this parameter, for discovery, use
-      `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection`
-      with connectionType CONNECTION_TYPE_DISCOVERY.
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -289,9 +289,12 @@ properties:
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
     deprecation_message: 
-      "`discovery_endpoints` is deprecated and is not guaranteed to be populated. \n
+      "`discovery_endpoints` is deprecated. As a result it will not be populated \n
+      if the connections are created using `desired_auto_created_endpoints` \n
+      parameter or `google_memorystore_instance_desired_user_created_endpoints` \n
+      resource. Instead of this parameter, for discovery, use \n
       `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection` \n
-      with connectionType CONNECTION_TYPE_DISCOVERY should be used for discovery instead"
+      with connectionType CONNECTION_TYPE_DISCOVERY. 
     output: true
     item_type:
       type: NestedObject

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,7 +288,7 @@ properties:
     type: Array
     description: "Deprecated. Output only. Endpoints clients can connect to the instance through."
     deprecation_message: |
-      `discovery_endpoints` is deprecated. As a result it will not be populated
+      This field is deprecated. As a result it will not be populated
       if the connections are created using `desired_auto_created_endpoints`
       parameter or `google_memorystore_instance_desired_user_created_endpoints`
       resource. Instead of this parameter, for discovery, use

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -286,8 +286,7 @@ properties:
     required: true
   - name: 'discoveryEndpoints'
     type: Array
-    description:
-      "Deprecated. Output only. Endpoints clients can connect to the instance through."
+    description: "Deprecated. Output only. Endpoints clients can connect to the instance through."
     deprecation_message: |
       `discovery_endpoints` is deprecated. As a result it will not be populated
       if the connections are created using `desired_auto_created_endpoints`

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,7 +288,7 @@ properties:
     type: Array
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
-    deprecation_message: |
+    deprecation_message:
       This field is deprecated. As a result it will not be populated
       if the connections are created using desired_auto_created_endpoints
       parameter or google_memorystore_instance_desired_user_created_endpoints

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -288,13 +288,13 @@ properties:
     type: Array
     description:
       "Deprecated. Output only. Endpoints clients can connect to the instance through."
-    deprecation_message:
-      "`discovery_endpoints` is deprecated. As a result it will not be populated \n
-      if the connections are created using `desired_auto_created_endpoints` \n
-      parameter or `google_memorystore_instance_desired_user_created_endpoints` \n
-      resource. Instead of this parameter, for discovery, use \n
-      `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection` \n
-      with connectionType CONNECTION_TYPE_DISCOVERY."
+    deprecation_message: |
+      `discovery_endpoints` is deprecated. As a result it will not be populated
+      if the connections are created using `desired_auto_created_endpoints`
+      parameter or `google_memorystore_instance_desired_user_created_endpoints`
+      resource. Instead of this parameter, for discovery, use
+      `endpoints.connections.pscConnection` and `endpoints.connections.pscAutoConnection`
+      with connectionType CONNECTION_TYPE_DISCOVERY.
     output: true
     item_type:
       type: NestedObject


### PR DESCRIPTION
Revise the deprecation message for discovery_endpoints in Memorystore Instance resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
