### PR TITLE
Fixed incorrect immutable flag on linked_router_appliance_instances instances

### DIFF
--- a/mmv1/products/networkconnectivity/Spoke.yaml
+++ b/mmv1/products/networkconnectivity/Spoke.yaml
@@ -226,7 +226,6 @@ properties:
         type: Array
         description: The list of router appliance instances
         required: true
-        immutable: true
         item_type:
           description: The list of router appliance instances
           type: NestedObject
@@ -234,13 +233,11 @@ properties:
             - name: 'virtualMachine'
               type: String
               description: The URI of the virtual machine resource
-              immutable: true
               required: true
               diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
             - name: 'ipAddress'
               type: String
               description: The IP address on the VM to use for peering.
-              immutable: true
               required: true
       - name: 'siteToSiteDataTransfer'
         type: Boolean

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -3,8 +3,8 @@ package networkconnectivity_test
 import (
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
@@ -113,14 +113,14 @@ func TestAccNetworkConnectivitySpoke_RouterApplianceHandWritten(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-      {
-        Config: testAccNetworkConnectivitySpoke_RouterApplianceHandWrittenUpdate1(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
-          PreApply: []plancheck.PlanCheck{
-            plancheck.ExpectResourceAction("google_network_connectivity_spoke.primary", plancheck.ResourceActionUpdate),
-          },
-        },
-      },
+			{
+				Config: testAccNetworkConnectivitySpoke_RouterApplianceHandWrittenUpdate1(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_network_connectivity_spoke.primary", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
 			{
 				ResourceName:            "google_network_connectivity_spoke.primary",
 				ImportState:             true,

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_spoke_test.go
@@ -3,6 +3,7 @@ package networkconnectivity_test
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -112,9 +113,14 @@ func TestAccNetworkConnectivitySpoke_RouterApplianceHandWritten(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
-			{
-				Config: testAccNetworkConnectivitySpoke_RouterApplianceHandWrittenUpdate1(context),
-			},
+      {
+        Config: testAccNetworkConnectivitySpoke_RouterApplianceHandWrittenUpdate1(context),
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+          PreApply: []plancheck.PlanCheck{
+            plancheck.ExpectResourceAction("google_network_connectivity_spoke.primary", plancheck.ResourceActionUpdate),
+          },
+        },
+      },
 			{
 				ResourceName:            "google_network_connectivity_spoke.primary",
 				ImportState:             true,
@@ -356,6 +362,27 @@ resource "google_compute_instance" "router-instance1" {
   }
 }
 
+resource "google_compute_instance" "router-instance2" {
+  name         = "tf-test-router-instance2%{random_suffix}"
+  machine_type = "e2-medium"
+  can_ip_forward = true
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/debian-10-buster-v20210817"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork.name
+    network_ip = "10.0.0.3"
+    access_config {
+        network_tier = "PREMIUM"
+    }
+  }
+}
+
 resource "google_network_connectivity_hub" "basic_hub" {
   name        = "tf-test-hub%{random_suffix}"
   description = "A sample hub"
@@ -419,6 +446,27 @@ resource "google_compute_instance" "router-instance1" {
   }
 }
 
+resource "google_compute_instance" "router-instance2" {
+  name         = "tf-test-router-instance2%{random_suffix}"
+  machine_type = "e2-medium"
+  can_ip_forward = true
+  zone         = "%{zone}"
+
+  boot_disk {
+    initialize_params {
+      image = "projects/debian-cloud/global/images/debian-10-buster-v20210817"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork.name
+    network_ip = "10.0.0.3"
+    access_config {
+        network_tier = "PREMIUM"
+    }
+  }
+}
+
 resource "google_network_connectivity_hub" "basic_hub" {
   name        = "tf-test-hub%{random_suffix}"
   description = "A sample hub"
@@ -440,6 +488,7 @@ resource "google_network_connectivity_spoke" "primary" {
         virtual_machine = google_compute_instance.router-instance1.self_link
         ip_address = "10.0.0.2"
     }
+    include_import_ranges = ["ALL_IPV4_RANGES"]
     site_to_site_data_transfer = true
   }
 }
@@ -516,7 +565,7 @@ resource "google_network_connectivity_spoke" "primary" {
   location = "%{region}"
   description = "An UPDATED sample spoke with two linked routher appliance instances"
   labels = {
-    label-two = "value-two"
+    label-two = "value-three"
   }
   hub = google_network_connectivity_hub.basic_hub.id
   linked_router_appliance_instances {


### PR DESCRIPTION
```release-note:bug
networkconnectivity: fixed `instances[].ip_address` & `instances[].virtual_machine` fields in `linked_router_appliance_instances` block being incorrectly treated as immutable for `google_network_connectivity_spoke` resource
```