### PR TITLE
Add new field instanceLifecyclePolicy.onRepair.allowChangingZone to google_compute_region_instance_group_manager & google_compute_instance_group_manager

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
@@ -380,6 +380,28 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, true),
 							Description:  `Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: YES, NO. If YES and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If NO (default), then updates are applied in accordance with the group's update policy type.`,
 						},
+
+						{{- if ne $.TargetVersionName `ga` }}
+						"on_repair": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							MaxItems:    1,
+							Description: `Configuration for VM repairs in the MIG.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allow_changing_zone": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:     "NO",
+										ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, true),
+										Description:  `Specifies whether the MIG can change a VM's zone during a repair. If "YES", MIG can select a different zone for the VM during a repair. Else if "NO", MIG cannot change a VM's zone during a repair. The default value of allow_changing_zone is "NO".`,
+									},
+								},
+							},
+						},
+						{{- end }}
+
 					},
 				},
 			},
@@ -1362,12 +1384,28 @@ func expandInstanceLifecyclePolicy(configured []interface{}) *compute.InstanceGr
 		data := raw.(map[string]interface{})
 		instanceLifecyclePolicy.ForceUpdateOnRepair = data["force_update_on_repair"].(string)
 		instanceLifecyclePolicy.DefaultActionOnFailure = data["default_action_on_failure"].(string)
-{{ if ne $.TargetVersionName `ga` -}}
+
+		{{ if ne $.TargetVersionName `ga` -}}
 		instanceLifecyclePolicy.OnFailedHealthCheck = data["on_failed_health_check"].(string)
-{{- end }}
+		{{- end }}
+
+		{{- if ne $.TargetVersionName `ga` }}
+		instanceLifecyclePolicy.OnRepair = expandOnRepair(data["on_repair"].([]any))
+		{{- end }}
 	}
 	return instanceLifecyclePolicy
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func expandOnRepair(configured []any) *compute.InstanceGroupManagerInstanceLifecyclePolicyOnRepair {
+	onRepair := &compute.InstanceGroupManagerInstanceLifecyclePolicyOnRepair{}
+	for _, raw := range configured {
+		data := raw.(map[string]any)
+		onRepair.AllowChangingZone = data["allow_changing_zone"].(string)
+	}
+	return onRepair
+}
+{{- end }}
 
 func expandStandbyPolicy(d *schema.ResourceData) *compute.InstanceGroupManagerStandbyPolicy {
 	standbyPolicy := &compute.InstanceGroupManagerStandbyPolicy{}
@@ -1563,13 +1601,30 @@ func flattenInstanceLifecyclePolicy(instanceLifecyclePolicy *compute.InstanceGro
 		ilp := map[string]interface{}{}
 		ilp["force_update_on_repair"] = instanceLifecyclePolicy.ForceUpdateOnRepair
 		ilp["default_action_on_failure"] = instanceLifecyclePolicy.DefaultActionOnFailure
-{{ if ne $.TargetVersionName `ga` -}}
+
+		{{ if ne $.TargetVersionName `ga` -}}
 		ilp["on_failed_health_check"] = instanceLifecyclePolicy.OnFailedHealthCheck
-{{- end }}
+		{{- end }}
+
+		{{ if ne $.TargetVersionName `ga` -}}
+		ilp["on_repair"] = flattenOnRepair(instanceLifecyclePolicy.OnRepair)
+		{{- end }}
 		results = append(results, ilp)
 	}
 	return results
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func flattenOnRepair(onRepair *compute.InstanceGroupManagerInstanceLifecyclePolicyOnRepair) []map[string]any {
+	results := []map[string]any{}
+	if onRepair != nil {
+		or := map[string]any{}
+		or["allow_changing_zone"] = onRepair.AllowChangingZone
+		results = append(results, or)
+	}
+	return results
+}
+{{- end }}
 
 func expandAllInstancesConfig(old []interface{}, new []interface{}) *compute.InstanceGroupManagerAllInstancesConfig {
 	var properties *compute.InstancePropertiesPatch

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -172,9 +172,14 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Config: testAccInstanceGroupManager_update(template1, target1, description, igm),
 				Check: resource.ComposeTestCheckFunc(
 					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "DO_NOTHING"),
-{{- if ne $.TargetVersionName "ga" }}
-                 resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
-{{- end }}
+
+					       {{- if ne $.TargetVersionName "ga" }}
+					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
+					       {{- end }}
+
+					       {{- if ne $.TargetVersionName "ga" }}
+					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "NO"),
+					       {{- end }}
 							 ),
 			},
 			{
@@ -187,9 +192,14 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Config: testAccInstanceGroupManager_update2(template1, target1, target2, template2, description, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-{{- if ne $.TargetVersionName "ga" }}
-          resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
+					{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "NO"),
+					{{- end }}
 				),
 			},
 			{
@@ -984,9 +994,16 @@ resource "google_compute_instance_group_manager" "igm-update" {
   instance_lifecycle_policy {
     force_update_on_repair = "NO"
     default_action_on_failure = "REPAIR"
-{{- if ne $.TargetVersionName "ga" }}
+
+    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "REPAIR"
-{{- end }}
+    {{- end }}
+
+    {{- if ne $.TargetVersionName "ga" }}
+    on_repair {
+      allow_changing_zone  = "NO"
+    }
+    {{- end }}
   }
 }
 `, template1, target1, target2, template2, description, igm)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -336,6 +336,28 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, false),
 							Description:  `Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: YES, NO. If YES and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If NO (default), then updates are applied in accordance with the group's update policy type.`,
 						},
+
+						{{- if ne $.TargetVersionName `ga` }}
+						"on_repair": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Optional:    true,
+							MaxItems:    1,
+							Description: `Configuration for VM repairs in the MIG.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"allow_changing_zone": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										Default:     "NO",
+										ValidateFunc: validation.StringInSlice([]string{"YES", "NO"}, true),
+										Description:  `Specifies whether the MIG can change a VM's zone during a repair. If "YES", MIG can select a different zone for the VM during a repair. Else if "NO", MIG cannot change a VM's zone during a repair. The default value of allow_changing_zone is "NO".`,
+									},
+								},
+							},
+						},
+						{{- end }}
+
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -90,9 +90,16 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update(template1, target1, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "DO_NOTHING"),
-{{- if ne $.TargetVersionName "ga" }}
-          resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
-{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
+					{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "NO"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "NO"),
+					{{- end }}
+
 				),
 			},
 			{
@@ -105,9 +112,16 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-{{- if ne $.TargetVersionName "ga" }}
-          resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
+					{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "YES"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "YES"),
+					{{- end }}
+
 				),
 			},
 			{
@@ -120,9 +134,16 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update3(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-{{- if ne $.TargetVersionName "ga" }}
-          resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
+					{{- end }}
+
+					{{- if ne $.TargetVersionName "ga" }}
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "YES"),
+					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "YES"),
+					{{- end }}
+
 				),
 			},
 			{
@@ -719,11 +740,17 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
   }
 
   instance_lifecycle_policy {
+    {{- if ne $.TargetVersionName "ga" }}
+    force_update_on_repair = "NO"
+    {{- else }}
     force_update_on_repair = "YES"
+    {{- end }}
+
     default_action_on_failure = "DO_NOTHING"
-{{- if ne $.TargetVersionName "ga" }}
+
+    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "DO_NOTHING"
-{{- end }}
+    {{- end }}
   }
 }
 `, template, target, igm)
@@ -808,6 +835,9 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
   region                         = "us-central1"
   target_size                    = 3
   list_managed_instances_results = "PAGINATED"
+
+  distribution_policy_target_shape = "ANY"
+
   named_port {
     name = "customhttp"
     port = 8080
@@ -827,11 +857,23 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
   }
 
   instance_lifecycle_policy {
-    force_update_on_repair = "NO"
     default_action_on_failure = "REPAIR"
-{{- if ne $.TargetVersionName "ga" }}
+
+    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "REPAIR"
-{{- end }}
+    {{- end }}
+
+    {{- if ne $.TargetVersionName "ga" }}
+    force_update_on_repair = "YES"
+    {{- else }}
+    force_update_on_repair = "NO"
+    {{- end }}
+
+    {{- if ne $.TargetVersionName "ga" }}
+    on_repair {
+        allow_changing_zone = "YES"
+    }
+    {{- end }}
 
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -304,12 +304,27 @@ instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
   on_failed_health_check    = "DO_NOTHING"   //google-beta only
+  on_repair {                                //google-beta only
+    allow_changing_zone      = "YES"
+  }
 }
 ```
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Specifies the action that a MIG performs on a failed VM. If the value of the `on_failed_health_check` field is `DEFAULT_ACTION`, then the same action also applies to the VMs on which your application fails a health check. Valid options are: `DO_NOTHING`, `REPAIR`. If `DO_NOTHING`, then MIG does not repair a failed VM. If `REPAIR` (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG.
 * `on_failed_health_check` - (Optional, Beta), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG.
+* `on_repair` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)), Configuration for VM repairs in the MIG. Structure is [documented below](#nested_on_repair).
+- - -
+
+<a name="nested_on_repair"></a>The `on_repair` block supports:
+
+```hcl
+on_repair {
+  allow_changing_zone      = "NO"
+}
+```
+
+* `allow_changing_zone` - (Optional), Specifies whether the MIG can change a VM's zone during a repair. If "YES", MIG can select a different zone for the VM during a repair. Else if "NO", MIG cannot change a VM's zone during a repair. The default value of allow_changing_zone is "NO".
 
 - - -
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -256,13 +256,27 @@ instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
   on_failed_health_check    = "DO_NOTHING"   //google-beta only
-
+  on_repair {                                //google-beta only
+    allow_changing_zone      = "YES"
+  }
 }
 ```
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Specifies the action that a MIG performs on a failed VM. If the value of the `on_failed_health_check` field is `DEFAULT_ACTION`, then the same action also applies to the VMs on which your application fails a health check. Valid options are: `DO_NOTHING`, `REPAIR`. If `DO_NOTHING`, then MIG does not repair a failed VM. If `REPAIR` (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG.
 * `on_failed_health_check` - (Optional, Beta), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG. 
+* `on_repair` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)), Configuration for VM repairs in the MIG. Structure is [documented below](#nested_on_repair).
+- - -
+
+<a name="nested_on_repair"></a>The `on_repair` block supports:
+
+```hcl
+on_repair {
+  allow_changing_zone      = "YES"
+}
+```
+
+* `allow_changing_zone` - (Optional), Specifies whether the MIG can change a VM's zone during a repair. If "YES", MIG can select a different zone for the VM during a repair. Else if "NO", MIG cannot change a VM's zone during a repair. The default value of allow_changing_zone is "NO".
 
 - - -
 <a name="nested_instance_flexibility_policy"></a>The `instance_flexibility_policy` block supports:


### PR DESCRIPTION
Add instanceLifecyclePolicy.onRepair.allowChangingZone to google_compute_region_instance_group_manager & google_compute_instance_group_manager for beta api.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
compute: added new field `instance_lifecycle_policy.on_repair.allow_changing_zone` to `google_compute_region_instance_group_manager` & `google_compute_instance_group_manager`
```
