### PR TITLE
Adding support for refresh subscription resource.

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/RefreshDataExchangeSubscription.yaml
+++ b/mmv1/products/bigqueryanalyticshub/RefreshDataExchangeSubscription.yaml
@@ -1,0 +1,62 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'RefreshDataExchangeSubscription'
+description: |
+  Represents a resource to refresh a DataExchange Subscription,
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/bigquery/docs/analytics-hub-introduction'
+create_url: 'projects/{{project}}/locations/{{location}}/subscriptions/{{subscription_id}}:refresh'
+immutable: true
+exclude_delete: true
+exclude_read: true
+exclude_import: true
+exclude_sweeper: true
+min_version: beta
+examples:
+  - name: 'bigquery_analyticshub_refresh_dataexchange_subscription'
+    primary_resource_id: 'refreshdxsubscription'
+    primary_resource_name: 'fmt.Sprintf("tf_test_subscription_%s", context["random_suffix"])'
+    region_override: 'us'
+    vars:
+      data_exchange_id: 'my_test_dataexchange'
+      listing_dataset_id: 'listing_src_dataset'
+      listing_table_id: 'listing_src_table'
+      listing_id: 'my_test_listing'
+      subscription_id: 'my_subscription_id'
+      subscriber_contact_email: 'testuser@example.com'
+      destination_dataset_id: 'subscribed_dest_dataset'
+      destination_dataset_friendly_name: 'Subscribed Destination Dataset'
+    exclude_import_test: true
+custom_code:
+  pre_create: 'templates/terraform/pre_create/bigquery_refresh_dx_subscription.go.tmpl'
+properties:
+  - name: 'location'
+    type: String
+    description: 'The geographic location where the Subscription resides.'
+    required: true
+    url_param_only: true
+    immutable: true
+  - name: 'subscription_id'
+    type: String
+    description: 'The ID of the subscription to be refreshed.'
+    required: true
+    url_param_only: true
+    immutable: true
+  - name: 'refreshTime'
+    type: String
+    description: 'The last time when subscription was refreshed. Set this to timestamp() if refreshing is required otherwise set to a static value'
+    immutable: true
+    url_param_only: true

--- a/mmv1/templates/terraform/examples/bigquery_analyticshub_refresh_dataexchange_subscription.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_analyticshub_refresh_dataexchange_subscription.tf.tmpl
@@ -1,0 +1,102 @@
+resource "google_bigquery_analytics_hub_data_exchange" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location            = "us"
+  data_exchange_id    = "{{index $.Vars "data_exchange_id"}}"
+  display_name        = "{{index $.Vars "data_exchange_id"}}"
+  description         = "Test Data Exchange"
+  sharing_environment_config {
+    dcr_exchange_config {}
+  }
+}
+
+resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  dataset_id    = "{{index $.Vars "listing_dataset_id"}}"
+  friendly_name = "{{index $.Vars "listing_dataset_id"}}"
+  description   = "Dataset for Listing"
+  location      = "us"
+}
+
+resource "google_bigquery_table" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  deletion_protection = false
+  table_id            = "{{index $.Vars "listing_table_id"}}"
+  dataset_id          = google_bigquery_dataset.{{$.PrimaryResourceId}}.dataset_id
+  schema              = <<EOF
+[
+  {
+    "name": "name",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "post_abbr",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "date",
+    "type": "DATE",
+    "mode": "NULLABLE"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_analytics_hub_listing" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location             = "us"
+  data_exchange_id     = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.data_exchange_id
+  listing_id           = "{{index $.Vars "listing_id"}}"
+  display_name         = "{{index $.Vars "listing_id"}}"
+  description          = "Test Listing"
+
+  restricted_export_config {
+    enabled = true
+  }
+
+  bigquery_dataset {
+    dataset = google_bigquery_dataset.{{$.PrimaryResourceId}}.id
+    selected_resources {
+      table = google_bigquery_table.{{$.PrimaryResourceId}}.id
+    }
+  }
+}
+
+resource "google_bigquery_analytics_hub_data_exchange_subscription" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  project                = google_bigquery_dataset.{{$.PrimaryResourceId}}.project #Subscriber's project
+  location               = "us"
+
+  data_exchange_project  = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.project
+  data_exchange_location = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.location
+  data_exchange_id       = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.data_exchange_id
+
+  subscription_id    = "{{index $.Vars "subscription_id"}}"
+  subscriber_contact = "{{index $.Vars "subscriber_contact_email"}}"
+
+  destination_dataset {
+    location = "us"
+
+    dataset_reference {
+      project_id = google_bigquery_dataset.{{$.PrimaryResourceId}}.project #Subscriber's project
+      dataset_id = "{{index $.Vars "destination_dataset_id"}}"
+    }
+    friendly_name = "{{index $.Vars "destination_dataset_friendly_name"}}"
+    description   = "Destination dataset for subscription"
+    labels = {
+      environment = "development"
+      owner       = "team-a"
+    }
+  }
+
+  refresh_policy="NEVER"
+}
+
+resource "google_bigquery_analytics_hub_refresh_data_exchange_subscription" "subscription" {
+  provider = google-beta
+  location               = "us"
+  subscription_id        = "{{index $.Vars "subscription_id"}}"
+  refresh_time           = "2026-01-01T00:00:00Z" #use timestamp() function here if refreshing the subscription is needed
+  depends_on = [google_bigquery_analytics_hub_data_exchange_subscription.{{$.PrimaryResourceId}}]
+}

--- a/mmv1/templates/terraform/pre_create/bigquery_refresh_dx_subscription.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/bigquery_refresh_dx_subscription.go.tmpl
@@ -1,0 +1,6 @@
+if _, ok := d.GetOkExists("refresh_time"); !ok {
+		currentTime := time.Now().Format(time.RFC3339)
+		if err := d.Set("refresh_time", currentTime); err != nil {
+			return fmt.Errorf("error setting refresh_time to current time: %v", err)
+		}
+}


### PR DESCRIPTION
This Pull Request introduces a new resource refresh resource for Analytics Hub.  This resource is made for calling the Refresh API which is an important API for the subscription resource.

```release-note:new-resource
`google_bigquery_analytics_hub_refresh_data_exchange_subscription` (beta)
```
