### PR TITLE
Added `IdleTtl` field for dataproc session template resource.

### DIFF
--- a/mmv1/products/dataproc/SessionTemplate.yaml
+++ b/mmv1/products/dataproc/SessionTemplate.yaml
@@ -165,6 +165,14 @@ properties:
             type: String
             description: |
               The Cloud KMS key to use for encryption.
+          - name: 'idleTtl'
+            type: String
+            description: |
+              The duration to keep the session alive while it's idling.
+              Exceeding this threshold causes the session to terminate. Minimum value is 10 minutes; maximum value is 14 day.
+              Defaults to 1 hour if not set. If both ttl and idleTtl are specified for an interactive session, the conditions
+              are treated as OR conditions: the workload will be terminated when it has been idle for idleTtl or when ttl has
+              been exceeded, whichever occurs first.
           - name: 'ttl'
             type: String
             description: |

--- a/mmv1/templates/terraform/examples/dataproc_session_templates_jupyter.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_session_templates_jupyter.tf.tmpl
@@ -10,7 +10,7 @@ resource "google_dataproc_session_template" "{{$.PrimaryResourceId}}" {
     environment_config {
       execution_config {
         subnetwork_uri = "{{index $.Vars "subnetwork_name"}}"
-        ttl            = "3600s"
+        idle_ttl       = "3600s"
         network_tags   = ["tag1"]
         authentication_config {
           user_workload_authentication_type = "END_USER_CREDENTIALS"


### PR DESCRIPTION
Added `IdleTtl` field for dataproc session template resource.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23647

```release-note:enhancement
dataproc: added `idle_ttl` field to `google_dataproc_session_template` resource
```
