### PR TITLE
feat: add OdbNetwork support in OracleDatabase CloudVmCluster resource

### DIFF
--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -65,6 +65,30 @@ examples:
       # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
       cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-vmcluster-basic-%s", acctest.RandString(t, 10))'
       cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-basic-%s", acctest.RandString(t, 10))'
+  - name: 'oracledatabase_cloud_vmcluster_odbnetwork'
+    primary_resource_id: 'my_vmcluster'
+    vars:
+      project: 'my-project'
+      cloud_vm_cluster_id: 'my-instance'
+      cloud_exadata_infrastructure_id: 'my-exadata'
+      odb_network: 'projects/my-project/locations/europe-west2/odbNetworks/my-odbnetwork'
+      odb_subnet: 'projects/my-project/locations/europe-west2/odbNetworks/my-odbnetwork/odbSubnets/my-odbsubnet'
+      backup_odb_subnet: 'projects/my-project/locations/europe-west2/odbNetworks/my-odbnetwork/odbSubnets/my-backup-odbsubnet'
+      deletion_protection: 'true'
+    ignore_read_extra:
+      - 'deletion_protection'
+    test_vars_overrides:
+      deletion_protection: 'false'
+      project: '"oci-terraform-testing-prod"'
+      # ofake- prefix is needed to create a dummy resource for testing purposes only
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/19983#issuecomment-2516403770
+      # As a result these resources are not sweepable
+      # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
+      cloud_vm_cluster_id: 'fmt.Sprintf("ofake-tf-test-vmcluster-odbnetwork-%s", acctest.RandString(t, 10))'
+      cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-odbnetwork-%s", acctest.RandString(t, 10))'
+      odb_network: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork"'
+      odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
+      backup_odb_subnet: '"projects/oci-terraform-testing-prod/locations/europe-west2/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-backup-odbsubnet"'
   - name: 'oracledatabase_cloud_vmcluster_full'
     primary_resource_id: 'my_vmcluster'
     vars:
@@ -290,12 +314,32 @@ properties:
   - name: 'cidr'
     type: String
     description: 'Network settings. CIDR to use for cluster IP allocation. '
-    required: true
+    required: false
   - name: 'backupSubnetCidr'
     type: String
     description: 'CIDR range of the backup subnet. '
-    required: true
+    required: false
   - name: 'network'
     type: String
     description: "The name of the VPC network.\nFormat: projects/{project}/global/networks/{network} "
-    required: true
+    required: false
+  - name: odbNetwork
+    type: String
+    description: |-
+      The name of the OdbNetwork associated with the VM Cluster.
+      Format:
+      projects/{project}/locations/{location}/odbNetworks/{odb_network}
+      It is optional but if specified, this should match the parent ODBNetwork of
+      the odb_subnet and backup_odb_subnet.
+  - name: odbSubnet
+    type: String
+    description: |-
+      The name of the OdbSubnet associated with the VM Cluster for
+      IP allocation. Format:
+      projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}
+  - name: backupOdbSubnet
+    type: String
+    description: |-
+      The name of the backup OdbSubnet associated with the VM Cluster.
+      Format:
+      projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}

--- a/mmv1/templates/terraform/examples/oracledatabase_cloud_vmcluster_odbnetwork.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_cloud_vmcluster_odbnetwork.tf.tmpl
@@ -1,0 +1,34 @@
+resource "google_oracle_database_cloud_vm_cluster" "{{$.PrimaryResourceId}}"{
+  cloud_vm_cluster_id = "{{index $.Vars "cloud_vm_cluster_id"}}"
+  display_name = "{{index $.Vars "cloud_vm_cluster_id"}} displayname"
+  location = "europe-west2"
+  project = "{{index $.Vars "project"}}"
+  exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.cloudExadataInfrastructures.id
+  odb_network = "{{index $.Vars "odb_network"}}"
+  odb_subnet = "{{index $.Vars "odb_subnet"}}"
+  backup_odb_subnet = "{{index $.Vars "backup_odb_subnet"}}"
+  properties {
+    license_type = "LICENSE_INCLUDED"
+    ssh_public_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCz1X2744t+6vRLmE5u6nHi6/QWh8bQDgHmd+OIxRQIGA/IWUtCs2FnaCNZcqvZkaeyjk5v0lTA/n+9jvO42Ipib53athrfVG8gRt8fzPL66C6ZqHq+6zZophhrCdfJh/0G4x9xJh5gdMprlaCR1P8yAaVvhBQSKGc4SiIkyMNBcHJ5YTtMQMTfxaB4G1sHZ6SDAY9a6Cq/zNjDwfPapWLsiP4mRhE5SSjJX6l6EYbkm0JeLQg+AbJiNEPvrvDp1wtTxzlPJtIivthmLMThFxK7+DkrYFuLvN5AHUdo9KTDLvHtDCvV70r8v0gafsrKkM/OE9Jtzoo0e1N/5K/ZdyFRbAkFT4QSF3nwpbmBWLf2Evg//YyEuxnz4CwPqFST2mucnrCCGCVWp1vnHZ0y30nM35njLOmWdRDFy5l27pKUTwLp02y3UYiiZyP7d3/u5pKiN4vC27VuvzprSdJxWoAvluOiDeRh+/oeQDowxoT/Oop8DzB9uJmjktXw8jyMW2+Rpg+ENQqeNgF1OGlEzypaWiRskEFlkpLb4v/s3ZDYkL1oW0Nv/J8LTjTOTEaYt2Udjoe9x2xWiGnQixhdChWuG+MaoWffzUgx1tsVj/DBXijR5DjkPkrA1GA98zd3q8GKEaAdcDenJjHhNYSd4+rE9pIsnYn7fo5X/tFfcQH1XQ== nobody@google.com"]
+    cpu_core_count = "4"
+    gi_version = "19.0.0.0"
+    hostname_prefix = "hostname1"
+  }
+
+  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+}
+
+resource "google_oracle_database_cloud_exadata_infrastructure" "cloudExadataInfrastructures"{
+  cloud_exadata_infrastructure_id = "{{index $.Vars "cloud_exadata_infrastructure_id"}}"
+  display_name = "{{index $.Vars "cloud_exadata_infrastructure_id"}} displayname"
+  location = "europe-west2"
+  project = "{{index $.Vars "project"}}"
+  properties {
+    shape = "Exadata.X9M"
+    compute_count= "2"
+    storage_count= "3"
+  }
+
+  deletion_protection = "{{index $.Vars "deletion_protection"}}"
+}
+


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

ref https://github.com/hashicorp/terraform-provider-google/issues/23651

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
oracledatabase: added `odb_network`, `odb_subnet` and `backup_odb_subnet` fields, and make `network`, `cidr` and `backup_subnet_cidr` fields optional in `google_oracle_database_cloud_vm_cluster` resource
```
