### PR TITLE
Remove cloudrun add-on from resource_container_cluster_test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6877,9 +6877,6 @@ resource "google_container_cluster" "primary" {
     gcp_filestore_csi_driver_config {
       enabled = false
     }
-    cloudrun_config {
-      disabled = true
-    }
     dns_cache_config {
       enabled = false
     }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -242,15 +242,6 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			{
-				Config: testAccContainerCluster_withInternalLoadBalancer(pid, clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:            "google_container_cluster.primary",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6953,7 +6953,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
     }
     cloudrun_config {
-      disabled = false
+      disabled = true
     }
     dns_cache_config {
       enabled = true

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6949,9 +6949,6 @@ resource "google_container_cluster" "primary" {
     gcp_filestore_csi_driver_config {
       enabled = true
     }
-    cloudrun_config {
-      disabled = true
-    }
     dns_cache_config {
       enabled = true
     }
@@ -6992,46 +6989,6 @@ resource "google_container_cluster" "primary" {
     }
 {{- end }}
 	}
-  network    = "%s"
-  subnetwork = "%s"
-
-  deletion_protection = false
-}
-`, projectID, clusterName, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_withInternalLoadBalancer(projectID string, clusterName, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  min_master_version = "latest"
-
-  workload_identity_config {
-    workload_pool = "${data.google_project.project.project_id}.svc.id.goog"
-  }
-
-  addons_config {
-    http_load_balancing {
-      disabled = false
-    }
-    horizontal_pod_autoscaling {
-      disabled = false
-    }
-    network_policy_config {
-      disabled = false
-    }
-    cloudrun_config {
-      disabled           = false
-      load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
-    }
-  }
   network    = "%s"
   subnetwork = "%s"
 


### PR DESCRIPTION
Cloud Run add-on has been deprecated. 
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23126.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
