### PR TITLE
Update docs for `google_compute_forwarding_rule`

### DIFF
--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -506,9 +506,6 @@ properties:
 
       The forwarded traffic must be of a type appropriate to the target object.
       *  For load balancers, see the "Target" column in [Port specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
-      *  For Private Service Connect forwarding rules that forward traffic to Google APIs, provide the name of a supported Google API bundle:
-        *  `vpc-sc` - [ APIs that support VPC Service Controls](https://cloud.google.com/vpc-service-controls/docs/supported-products).
-        *  `all-apis` - [All supported Google APIs](https://cloud.google.com/vpc/docs/private-service-connect#supported-apis).
 
       For Private Service Connect forwarding rules that forward traffic to managed services, the target must be a service attachment.
     update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'


### PR DESCRIPTION
Hi this doesn't work for this resource. It only works with `google_compute_global_forwarding_rule`.

You don't have any tests regarding the `all-apis` keyword and i wasn't able to find a working configuration. The Google API translates it to a selflink by default and throws an error
<img width="675" height="171" alt="image" src="https://github.com/user-attachments/assets/882b3a90-9555-46a0-8596-a283e559a56f" />


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:fix
update docs regarding API bundles for `google_compute_forwarding_rule`
```
