### PR TITLE
Add capability related fields to the folder schema

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_folder.go
@@ -54,6 +54,15 @@ func DataSourceGoogleFolder() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"configured_capabilities": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"management_project": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder.go
@@ -78,6 +78,17 @@ func ResourceGoogleFolder() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: `A map of resource manager tags. Resource manager tag keys and values have the same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/456. The field is ignored when empty. This field is only set at create time and modifying this field after creation will trigger recreation. To apply tags to an existing resource, see the google_tags_tag_value resource.`,
 			},
+			"configured_capabilities": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `A list of capabilities that are configured for this folder.`,
+			},
+			"management_project": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The Management Project associated with the folder's configured capabilities.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -178,6 +189,12 @@ func resourceGoogleFolderRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("create_time", folder.CreateTime); err != nil {
 		return fmt.Errorf("Error setting create_time: %s", err)
+	}
+	if err := d.Set("configured_capabilities", folder.ConfiguredCapabilities); err != nil {
+		return fmt.Errorf("Error setting configured_capabilities: %s", err)
+	}
+	if err := d.Set("management_project", folder.ManagementProject); err != nil {
+		return fmt.Errorf("Error setting management_project: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/resourcemanager3/resource_resource_manager_capability_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager3/resource_resource_manager_capability_test.go.tmpl
@@ -3,6 +3,7 @@ package resourcemanager3_test
 
 import (
 	"testing"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
@@ -17,6 +18,7 @@ func TestAccResourceManagerCapability_resourceManagerCapabilityExample_basic(t *
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 	}
+	folderTFResourceName := "google_folder.folder"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -27,6 +29,16 @@ func TestAccResourceManagerCapability_resourceManagerCapabilityExample_basic(t *
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourceManagerCapability_resourceManagerCapabilityExample_basic(context),
+			},
+			{
+				ResourceName:      folderTFResourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+				Check: resource.ComposeTestCheckFunc(
+					// Checks are now performed on the state *after* the import/refresh.
+					resource.TestCheckResourceAttr(folderTFResourceName, "configured_capabilities.#", "1"),
+					resource.TestMatchResourceAttr(folderTFResourceName, "management_project", regexp.MustCompile(".+")),
+				),
 			},
 			{
 				ResourceName:      "google_resource_manager_capability.capability",

--- a/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/folder.html.markdown
@@ -47,3 +47,5 @@ The following attributes are exported:
 * `create_time` - Timestamp when the Organization was created. A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
 * `lifecycle_state` - The Folder's current lifecycle state.
 * `organization` - If `lookup_organization` is enable, the resource name of the Organization that the folder belongs.
+* `configured_capabilities` - Optional capabilities configured for this folder.
+* `management_project` - Management Project associated with this folder (if capability is enabled).

--- a/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -69,6 +69,8 @@ exported:
 * `lifecycle_state` - The lifecycle state of the folder such as `ACTIVE` or `DELETE_REQUESTED`.
 * `create_time` - Timestamp when the Folder was created. Assigned by the server.
     A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
+* `configured_capabilities` - Optional capabilities configured for this folder.
+* `management_project` - Management Project associated with this folder (if capability is enabled).
 
 ## Import
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Adds two new fields to the Folders Schema: configured_capabilities and management_project. These fields are populated when a capability is enabled on a Folder. A capability is enabled/disabled as part of a UpdateCapability call. These fields are output only and cannot be manipulated by directly updating the Folder.  

Fixes b/422638425

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
resourcemanager: Added `management_project` and `configured_capabilities` fields to the `google_folder` resource.
```

