### PR TITLE
Cloud Composer - handle "empty changes" to recovery_config

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -1528,7 +1528,9 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				patchObj.Config.RecoveryConfig = config.RecoveryConfig
 			}
 			err = resourceComposerEnvironmentPatchField("config.RecoveryConfig.ScheduledSnapshotsConfig", userAgent, patchObj, d, tfConfig)
-			if err != nil {
+			// Empty ScheduledSnapshotsConfig and config with scheduled snapshots explicitly disabled (and nothing else configured) represent in fact the same configuration.
+                        // If applying a change fails specifically because it does not bring any actual modification, this error should be silently ignored.
+                        if err != nil && !strings.Contains(err.Error(), "No change in configuration."){
 				return err
 			}
 		}


### PR DESCRIPTION
When a Composer environment configuration is fetched, Composer API skips `recovery_config` with scheduled snapshots disabled. As a result `terraform plan` identifies a "change" that does not bring any actual modification to the configuration (together with any real changes). `terraform apply` applies changes to the configuration (to various elements of the configuration - as required by Composer API) one by one. The not-real change to the `recovery_config` causes Composer API to report an error (`No change in configuration.`).

Instead of replicating internal logic that controls how configuration is returned (and how to decide if a change is "real") and to avoid the need to chase subtle changes to the API, it makes more sense to silently swallow an error related to "changes" that do not bring any actual modification.

Tested manually.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23685

```release-note: bug
composer: fixed updates failing for recovery_config with explicitly disabled scheduled snapshots
```
