### PR TITLE
add support for updating iops, throughput, accessmode in google_compute_region_disk

### DIFF
--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -61,6 +61,7 @@ iam_policy:
 custom_code:
   encoder: 'templates/terraform/encoders/disk.tmpl'
   decoder: 'templates/terraform/decoders/disk.tmpl'
+  update_encoder: 'templates/terraform/update_encoder/hyper_disk.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/detach_disk.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("size", IsDiskShrinkage)'
@@ -402,12 +403,16 @@ properties:
       that the disk can handle. Values must be between 10,000 and 120,000.
       For more details, see the Extreme persistent disk [documentation](https://cloud.google.com/compute/docs/disks/extreme-persistent-disk).
     default_from_api: true
+    update_url: 'projects/{{project}}/regions/{{region}}/disks/{{name}}?paths=provisionedIops'
+    update_verb: 'PATCH'
   - name: 'provisionedThroughput'
     type: Integer
     description: |
       Indicates how much throughput to provision for the disk. This sets the number of throughput
       mb per second that the disk can handle. Values must be greater than or equal to 1.
     default_from_api: true
+    update_url: 'projects/{{project}}/regions/{{region}}/disks/{{name}}?paths=provisionedThroughput'
+    update_verb: 'PATCH'
 virtual_fields:
   - name: 'create_snapshot_before_destroy'
     type: Boolean

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/compute/v1"
@@ -89,6 +90,12 @@ func TestAccComputeRegionDisk_hyperdisk(t *testing.T) {
 			},
 			{
 				Config: testAccComputeRegionDisk_hyperdiskUpdated(diskName, "name"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+        					PreApply: []plancheck.PlanCheck{
+        						// Check that the update is done in-place
+        						plancheck.ExpectResourceAction("google_compute_region_disk.regiondisk", plancheck.ResourceActionUpdate),
+        					},
+        				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_disk.regiondisk", "access_mode", "READ_WRITE_SINGLE"),
 					resource.TestCheckResourceAttr("google_compute_region_disk.regiondisk", "provisioned_iops", "20000"),


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.



```release-note:enhancement
compute: added in-place update support for `provisioned_iops`, `provisioned_throughput`,  and `access_mode` fields in `google_compute_region_disk` resource
```


