### PR TITLE
Remove enable_flow_logs from google_compute_subnetwork

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -360,7 +360,6 @@ properties:
     fingerprint_name: 'fingerprint'
     custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.tmpl'
     custom_expand: 'templates/terraform/custom_expand/subnetwork_log_config.go.tmpl'
-    diff_suppress_func: 'subnetworkLogConfigDiffSuppress'
     properties:
       - name: 'aggregationInterval'
         type: Enum
@@ -512,16 +511,6 @@ properties:
     update_verb: 'PATCH'
     fingerprint_name: 'fingerprint'
     is_missing_in_cai: true
-  - name: 'enableFlowLogs'
-    type: Boolean
-    description: |
-      Whether to enable flow logging for this subnetwork. If this field is not explicitly set,
-      it will not appear in get listings. If not set the default behavior is determined by the
-      org policy, if there is no org policy specified, then it will default to disabled.
-      This field isn't supported if the subnet purpose field is set to REGIONAL_MANAGED_PROXY.
-    default_from_api: true
-    include_empty_value_in_cai: true
-    deprecation_message: 'This field is being removed in favor of log_config. If log_config is present, flow logs are enabled.'
   - name: 'state'
     type: Enum
     description: |

--- a/mmv1/templates/terraform/constants/subnetwork.tmpl
+++ b/mmv1/templates/terraform/constants/subnetwork.tmpl
@@ -48,15 +48,3 @@ func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDif
 
 	return nil
 }
-
-// DiffSuppressFunc for `log_config`.
-func subnetworkLogConfigDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// If enable_flow_logs is enabled and log_config is not set, ignore the diff
-	if enable_flow_logs := d.Get("enable_flow_logs"); enable_flow_logs.(bool) {
-		logConfig := d.GetRawConfig().GetAttr("log_config")
-		logConfigIsEmpty := logConfig.IsNull() || logConfig.LengthInt() == 0
-		return logConfigIsEmpty
-	}
-
-	return false
-}

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -120,6 +120,12 @@ Description of the change and how users should adjust their configuration (if ne
 
 `instance` has been removed in favor of `instance_name`.
 
+## Resource: `google_compute_subnetwork`
+
+### `enable_flow_logs`is now removed
+
+`enable_flow_logs` has been removed in favor of `log_config`.
+
 ## Resource: `google_notebooks_location` is now removed
 
 This resource is not functional.


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/22112

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: removed field `enable_flow_logs` from `google_compute_subnetwork`
```
