### PR TITLE
Mark `load_balancing_scheme` field required.

### DIFF
--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -201,6 +201,7 @@ properties:
       For more information, refer to [Choosing a load balancer](https://cloud.google.com/load-balancing/docs/backend-service) and
       [Supported application load balancers](https://cloud.google.com/service-extensions/docs/callouts-overview#supported-lbs).
     immutable: true
+    required: true
     enum_values:
       - 'INTERNAL_MANAGED'
       - 'EXTERNAL_MANAGED'

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -146,6 +146,12 @@ To reflect the new type explicitly, surround the current integer value in quotes
 
 Remove `description` from your configuration after upgrade.
 
+## Resource: `google_network_services_lb_traffic_extension`
+
+### `load_balancing_scheme` is now required
+
+`load_balancing_scheme` is now a required field.
+
 ## Resource: `google_storage_transfer_job`
 
 ### `transfer_spec.gcs_data_sink.path` Implemented validation to prevent strings from starting with a '/' character, while still permitting empty strings."


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-google/issues/18196

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
networkservices: `load_balancing_scheme` field is now required in `google_network_services_lb_traffic_extension`
```
