### PR TITLE
`teamcity`: add release_tests subproject

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_per_package.kt
@@ -20,7 +20,7 @@ import replaceCharsId
 
 // BuildConfigurationsForPackages accepts a map containing details of multiple packages in a provider and returns a list of build configurations for them all.
 // Intended to be used in projects where we're testing all packages, e.g. the nightly test projects
-fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration, testPrefix: String = "TestAcc"): List<BuildType> {
+fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration, testPrefix: String = "TestAcc", releaseDiffTest: String = "false"): List<BuildType> {
     val list = ArrayList<BuildType>()
 
     // Create build configurations for all packages, except sweeper
@@ -28,7 +28,7 @@ fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, p
         val path: String = info.getValue("path").toString()
         val displayName: String = info.getValue("displayName").toString()
 
-        val pkg = PackageDetails(packageName, displayName, providerName, parentProjectName)
+        val pkg = PackageDetails(packageName, displayName, providerName, parentProjectName, releaseDiffTest)
         val buildConfig = pkg.buildConfiguration(path, vcsRoot, sharedResources, environmentVariables, testPrefix = testPrefix)
         list.add(buildConfig)
     }
@@ -38,12 +38,12 @@ fun BuildConfigurationsForPackages(packages: Map<String, Map<String, String>>, p
 
 // BuildConfigurationForSinglePackage accepts details of a single package in a provider and returns a build configuration for it
 // Intended to be used in short-lived projects where we're testing specific packages, e.g. feature branch testing
-fun BuildConfigurationForSinglePackage(packageName: String, packagePath: String, packageDisplayName: String, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration, testPrefix: String = "TestAcc"): BuildType{
-    val pkg = PackageDetails(packageName, packageDisplayName, providerName, parentProjectName)
+fun BuildConfigurationForSinglePackage(packageName: String, packagePath: String, packageDisplayName: String, providerName: String, parentProjectName: String, vcsRoot: GitVcsRoot, sharedResources: List<String>, environmentVariables: AccTestConfiguration, testPrefix: String = "TestAcc", releaseDiffTest: String = "false"): BuildType{
+    val pkg = PackageDetails(packageName, packageDisplayName, providerName, parentProjectName, releaseDiffTest)
     return pkg.buildConfiguration(packagePath, vcsRoot, sharedResources, environmentVariables, testPrefix = testPrefix)
 }
 
-class PackageDetails(private val packageName: String, private val displayName: String, private val providerName: String, private val parentProjectName: String) {
+class PackageDetails(private val packageName: String, private val displayName: String, private val providerName: String, private val parentProjectName: String, private val releaseDiffTest: String) {
 
     // buildConfiguration returns a BuildType for a service package
     // For BuildType docs, see https://teamcity.jetbrains.com/app/dsl-documentation/root/build-type/index.html
@@ -91,7 +91,7 @@ class PackageDetails(private val packageName: String, private val displayName: S
 
             params {
                 configureGoogleSpecificTestParameters(environmentVariables)
-                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout)
+                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout, releaseDiffTest)
                 terraformLoggingParameters(environmentVariables, providerName)
                 terraformCoreBinaryTesting()
                 terraformShouldPanicForSchemaErrors()

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_sweepers.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_sweepers.kt
@@ -61,6 +61,7 @@ class SweeperDetails(private val sweeperName: String, private val parentProjectN
         // These hardcoded values affect the sweeper CLI command's behaviour
         val testPrefix = "TestAcc"
         val testTimeout = "12"
+        val releaseDiffTest = "false"
 
         return BuildType {
 
@@ -97,7 +98,7 @@ class SweeperDetails(private val sweeperName: String, private val parentProjectN
 
             params {
                 configureGoogleSpecificTestParameters(environmentVariables)
-                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout)
+                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout, releaseDiffTest)
                 sweeperParameters(sweeperRegions, sweeperRun)
                 terraformLoggingParameters(environmentVariables, providerName)
                 terraformCoreBinaryTesting()

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_vcr_recording.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_configuration_vcr_recording.kt
@@ -27,6 +27,7 @@ class VcrDetails(private val providerName: String, private val buildId: String, 
         val testTimeout = "12"
         val parallelism = DefaultParallelism
         val buildTimeout: Int = DefaultBuildTimeoutDuration
+        val releaseDiffTest = "false"
 
         // Path is just ./google(-beta) here, whereas nightly test builds use paths like ./google/something/specific
         // This helps VCR testing builds to run tests across multiple packages
@@ -70,7 +71,7 @@ class VcrDetails(private val providerName: String, private val buildId: String, 
             params {
                 configureGoogleSpecificTestParameters(environmentVariables)
                 vcrEnvironmentVariables(environmentVariables, providerName)
-                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout)
+                acceptanceTestBuildParams(parallelism, testPrefix, testTimeout, releaseDiffTest)
                 terraformLoggingParameters(environmentVariables, providerName)
                 terraformCoreBinaryTesting()
                 terraformShouldPanicForSchemaErrors()

--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
@@ -205,11 +205,12 @@ fun ParametrizedWithType.configureGoogleSpecificTestParameters(config: AccTestCo
 
 // ParametrizedWithType.acceptanceTestBuildParams sets build params that affect how commands to run
 //  acceptance tests are templated
-fun ParametrizedWithType.acceptanceTestBuildParams(parallelism: Int, prefix: String, timeout: String) {
+fun ParametrizedWithType.acceptanceTestBuildParams(parallelism: Int, prefix: String, timeout: String, releaseDiffTest: String) {
     hiddenVariable("env.TF_ACC", "1", "Set to a value to run the Acceptance Tests")
     text("PARALLELISM", "%d".format(parallelism))
     text("TEST_PREFIX", prefix)
     text("TIMEOUT", timeout)
+    text("RELEASE_DIFF", "true")
 }
 
 // ParametrizedWithType.sweeperParameters sets build parameters that affect how sweepers are run

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -20,8 +20,8 @@ const val DefaultParallelism = 6
 // this is updated semi-regularly
 const val DefaultTerraformCoreVersion = "1.11.0"
 
-// This represents a cron view of days of the week - we skip saturday to allow release diff tests to run
-const val DefaultDaysOfWeek = "1-6"
+// This represents a cron view of days of the week
+const val DefaultDaysOfWeek = "*"
 
 // Cron value for any day of month
 const val DefaultDaysOfMonth = "*"

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -21,7 +21,7 @@ const val DefaultParallelism = 6
 const val DefaultTerraformCoreVersion = "1.11.0"
 
 // This represents a cron view of days of the week - we skip saturday to allow release diff tests to run
-const val DefaultDaysOfWeek = "0-5"
+const val DefaultDaysOfWeek = "1-6"
 
 // Cron value for any day of month
 const val DefaultDaysOfMonth = "*"

--- a/mmv1/third_party/terraform/.teamcity/components/constants.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/constants.kt
@@ -8,6 +8,7 @@
 // Provider name that matches the name in the Registry
 const val ProviderNameGa = "google"
 const val ProviderNameBeta = "google-beta"
+const val ProviderNameBetaDiffTest = "google-beta-diff-test"
 
 // specifies the default hour (UTC) at which tests should be triggered, if enabled
 const val DefaultStartHour = 4
@@ -19,8 +20,8 @@ const val DefaultParallelism = 6
 // this is updated semi-regularly
 const val DefaultTerraformCoreVersion = "1.11.0"
 
-// This represents a cron view of days of the week
-const val DefaultDaysOfWeek = "*"
+// This represents a cron view of days of the week - we skip saturday to allow release diff tests to run
+const val DefaultDaysOfWeek = "0-5"
 
 // Cron value for any day of month
 const val DefaultDaysOfMonth = "*"
@@ -42,6 +43,7 @@ const val ServiceSweeperCronName = "$ServiceSweeperName - Cron"
 const val ServiceSweeperManualName = "$ServiceSweeperName - Manual"
 const val ProjectSweeperName = "Project Sweeper"
 const val NightlyTestsProjectId = "NightlyTests"
+const val WeeklyDiffTestsProjectId = "WeeklyDiffTests"
 const val MMUpstreamProjectId = "MMUpstreamTests"
 const val VcrRecordingProjectId = "VCRRecording"
 

--- a/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/google_beta_subproject.kt
@@ -12,6 +12,7 @@ import builds.*
 import jetbrains.buildServer.configs.kotlin.Project
 import projects.reused.mmUpstream
 import projects.reused.nightlyTests
+import projects.reused.weeklyDiffTests
 import projects.reused.vcrRecording
 import replaceCharsId
 import vcs_roots.HashiCorpVCSRootBeta
@@ -40,6 +41,9 @@ fun googleSubProjectBeta(allConfig: AllContextParameters): Project {
         // VCR recording project that allows VCR recordings to be made using hashicorp/terraform-provider-google-beta OR modular-magician/terraform-provider-google-beta
         // This is only present for the Beta provider, as only TPGB VCR recordings are used.
         subProject(vcrRecording(betaId, ProviderNameBeta, HashiCorpVCSRootBeta, ModularMagicianVCSRootBeta, vcrConfig))
+
+        // Beta Diff Test project that uses hashicorp/terraform-provider-google-beta-diff-test
+        subProject(weeklyDiffTests(betaId + "_DIFF_TEST", ProviderNameBeta, HashiCorpVCSRootBeta, betaConfig, NightlyTriggerConfiguration(daysOfWeek = "SAT", nightlyTestsEnabled = false)))
 
         params {
             readOnlySettings()

--- a/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/test_utils.kt
@@ -15,6 +15,7 @@ import org.junit.Assert.fail
 const val gaProjectName = "Google"
 const val betaProjectName = "Google Beta"
 const val nightlyTestsProjectName = "Nightly Tests"
+const val weeklyDiffTestsProjectName = "Weekly Diff Tests"
 const val mmUpstreamProjectName = "Upstream MM Testing"
 const val projectSweeperProjectName = "Project Sweeper"
 

--- a/mmv1/third_party/terraform/.teamcity/tests/weekly_diff_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/tests/weekly_diff_project.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// This file is maintained in the GoogleCloudPlatform/magic-modules repository and copied into the downstream provider repositories. Any changes to this file in the downstream will be overwritten.
+
+package tests
+
+import jetbrains.buildServer.configs.kotlin.triggers.ScheduleTrigger
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import projects.googleCloudRootProject
+
+class WeeklyDiffTestProjectsTests {
+    @Test
+    fun allBuildsShouldHaveTrigger() {
+        val root = googleCloudRootProject(testContextParameters())
+
+        // Find GA nightly test project
+        // var gaNightlyTestProject = getNestedProjectFromRoot(root, gaProjectName, weeklyDiffTestsProjectName)
+
+        // Find Beta nightly test project
+        var betaWeeklyDiffTestProject = getNestedProjectFromRoot(root, betaProjectName, weeklyDiffTestsProjectName)
+
+        // Make assertions about builds in both weekly diff test projects
+        (betaWeeklyDiffTestProject.buildTypes).forEach{bt ->
+            assertTrue("Build configuration `${bt.name}` should contain at least one trigger", bt.triggers.items.isNotEmpty())
+             // Look for at least one CRON trigger
+            var found: Boolean = false
+            lateinit var schedulingTrigger: ScheduleTrigger
+            for (item in bt.triggers.items){
+                if (item.type == "schedulingTrigger") {
+                    schedulingTrigger = item as ScheduleTrigger
+                    found = true
+                    break
+                }
+            }
+
+            assertTrue("Build configuration `${bt.name}` should contain a CRON/'schedulingTrigger' trigger", found)
+
+            // Check that weekly diff test is being ran on the nightly-test branch
+            var isNightlyTestBranch: Boolean = false
+            if (schedulingTrigger.branchFilter == "+:refs/heads/nightly-test"){
+                isNightlyTestBranch = true
+            }
+            assertTrue("Build configuration `${bt.name}` is using the nightly-test branch filter;", isNightlyTestBranch)
+        }
+    }
+}


### PR DESCRIPTION
I've setup a prototype of how the project will appear in TeamCity, the scheduling triggers are currently disabled for now.

`Weekly Diff Test` subproject in Google Beta within `Development` root project: https://hashicorp.teamcity.com/project/Development_TerraformProviderGoogleDiffTestProject?branch=refs%2Fheads%2Fauto-pr-12783&mode=builds

It adds `RELEASE_DIFF` envvar and sets it to true for the `Weekly Diff Test` project while also updating the cronjobs to ensure that we don't run nightly tests on saturday in order to run the weekly diff test that day. Sweepers remain the same as the sweepers are searching for resources in both GA + Beta upon build regardless of nightly or weekly

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
