### PR TITLE
google_iap_settings: use billing project instead of GetProject

### DIFF
--- a/mmv1/templates/terraform/custom_delete/clear_iap_settings.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/clear_iap_settings.go.tmpl
@@ -3,13 +3,10 @@ if err != nil {
 	return err
 }
 
-name := d.Get("name").(string)
-re := regexp.MustCompile("projects/([^/]+)")
-match := re.FindStringSubmatch(name)
-if len(match) < 2 {
-	return fmt.Errorf("could not parse project from name %q", name)
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
 }
-project := match[1]
 
 headers := make(http.Header)
 
@@ -20,7 +17,7 @@ log.Printf("[DEBUG] Updating Settings %q: %#v", d.Id(), obj)
 res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 	Config:    config,
 	Method:    "PATCH",
-	Project:   project,
+	Project:   billingProject,
 	RawURL:    url,
 	UserAgent: userAgent,
 	Body:      obj,

--- a/mmv1/templates/terraform/custom_delete/clear_iap_settings.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/clear_iap_settings.go.tmpl
@@ -3,10 +3,13 @@ if err != nil {
 	return err
 }
 
-project, err := tpgresource.GetProject(d, config)
-if err != nil {
-	return fmt.Errorf("Error fetching project for Settings: %s", err)
+name := d.Get("name").(string)
+re := regexp.MustCompile("projects/([^/]+)")
+match := re.FindStringSubmatch(name)
+if len(match) < 2 {
+	return fmt.Errorf("could not parse project from name %q", name)
 }
+project := match[1]
 
 headers := make(http.Header)
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/20643

previous attempts to replicate this where due to test environments having `GOOGLE_PROJECT` set. Create/Update use the billing project, so let's do the same here.

Verified the fix manually by attempting to delete the resource with and without the fix:
before:
```
╷
│ Error: Error fetching project for Settings: project: required field is not set
│ 
│ 
```
after:

```
Apply complete! Resources: 0 added, 0 changed, 1 destroyed.
```

```release-note:bug
iap: fixed an issue where deleting `google_iap_settings` without setting `GOOGLE_PROJECT` incorrectly failed
```
