### PR TITLE
cloudfunctions2: changed `service` argument in `service_config` of `google_cloudfunctions2_function` to attribute

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -504,6 +504,7 @@ properties:
         description: |
           Name of the service associated with a Function.
         default_from_api: true
+        output: true
       - name: 'timeoutSeconds'
         type: Integer
         description: |


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23717

Will cause a breaking change, might need to wait for `v7.0.0`?

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudfunctions2: changed `service` argument in `service_config` of `google_cloudfunctions2_function` to attribute
```
