### PR TITLE
Adding Tags support for GkeBackup - Backup Plan and Restore Plan

### DIFF
--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -484,3 +484,11 @@ properties:
     description: |
       Detailed description of why BackupPlan is in its current state.
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -640,3 +640,11 @@ properties:
     description: |
       Detailed description of why RestorePlan is in its current state.
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -522,3 +522,11 @@ properties:
         enum_values:
           - 'LEGACY'
           - 'JSON'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
@@ -3,6 +3,7 @@ package dataprocmetastore_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -164,6 +165,65 @@ resource "google_dataproc_metastore_service" "backup" {
 resource "google_storage_bucket" "bucket" {
   name     = "tf-test-backup%{random_suffix}"
   location = "us-central1"
+}
+`, context)
+}
+
+func TestAccMetastoreService_tags(t *testing.T) {
+	t.Parallel()
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "metastore-service-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestOrganizationTagValue(t, "metastore-service-tagvalue", tagKey),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocMetastoreServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetastoreServiceTags(context),
+				Check: resource.TestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_dataproc_metastore_service.default", "tags.%"),
+				),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_id", "location", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccMetastoreServiceTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataproc_metastore_service" "default" {
+  service_id   = "tf-test-my-service-%{random_suffix}"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+   }
+
+  hive_metastore_config {
+    version = "2.3.6"
+  }
+
+  labels = {
+    env = "test"
+  }
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go
@@ -364,3 +364,77 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 }
 `, context)
 }
+
+func TestAccGKEBackupBackupPlan_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "gkeBackup-backup-plan-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"random_suffix":   acctest.RandString(t, 10),
+		"org":             envvar.GetTestOrgFromEnv(t),
+		"tagKey":          tagKey,
+		"tagValue":        acctest.BootstrapSharedTestOrganizationTagValue(t, "gkeBackup-backup-plan-tagvalue", tagKey),
+		"project":         envvar.GetTestProjectFromEnv(),
+		"network_name":    acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name": acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGKEBackupBackupPlanDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEBackupBackupPlanTags(context),
+				Check: resource.TestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_gke_backup_backup_plan.backupplan", "tags.%"),
+				),
+			},
+			{
+				ResourceName:            "google_gke_backup_backup_plan.backupplan",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccGKEBackupBackupPlanTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "tf-test-testcluster%{random_suffix}"
+  location           = "us-central1"
+  initial_node_count = 1
+  workload_identity_config {
+    workload_pool = "%{project}.svc.id.goog"
+  }
+  addons_config {
+    gke_backup_agent_config {
+      enabled = true
+    }
+  }
+  deletion_protection = false
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
+}
+
+resource "google_gke_backup_backup_plan" "backupplan" {
+  name = "tf-test-testplan%{random_suffix}"
+  cluster = google_container_cluster.primary.id
+  location = "us-central1"
+  backup_config {
+    include_volume_data = false
+    include_secrets = false
+    all_namespaces = true
+  }
+  labels = {
+    "some-key-1": "some-value-1"
+  }
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_plan_test.go
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_restore_plan_test.go
@@ -202,3 +202,116 @@ resource "google_gke_backup_restore_plan" "restore_plan" {
 }
 `, context)
 }
+
+func TestAccGKEBackupRestorePlan_tags(t *testing.T) {
+	t.Parallel()
+
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "gke_backup_restore_plan_tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"project":             envvar.GetTestProjectFromEnv(),
+		"deletion_protection": false,
+		"network_name":        acctest.BootstrapSharedTestNetwork(t, "gke-cluster"),
+		"subnetwork_name":     acctest.BootstrapSubnet(t, "gke-cluster", acctest.BootstrapSharedTestNetwork(t, "gke-cluster")),
+		"random_suffix":       acctest.RandString(t, 10),
+		"org":                 envvar.GetTestOrgFromEnv(t),
+		"tagKey":              tagKey,
+		"tagValue":            acctest.BootstrapSharedTestOrganizationTagValue(t, "gke_backup_restore_plan_tagvalue", tagKey),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGKEBackupRestorePlanTags(context),
+				Check: resource.TestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_gke_backup_restore_plan.restore_plan", "tags.%"),
+				),
+			},
+			{
+				ResourceName:            "google_gke_backup_restore_plan.restore_plan",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccGKEBackupRestorePlanTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "tf-test-restore-plan%{random_suffix}-cluster"
+  location           = "us-central1"
+  initial_node_count = 1
+  workload_identity_config {
+    workload_pool = "%{project}.svc.id.goog"
+  }
+  addons_config {
+    gke_backup_agent_config {
+      enabled = true
+    }
+  }
+  deletion_protection  = "%{deletion_protection}"
+  network       = "%{network_name}"
+  subnetwork    = "%{subnetwork_name}"
+}
+
+resource "google_gke_backup_backup_plan" "basic" {
+  name = "tf-test-restore-plan%{random_suffix}"
+  cluster = google_container_cluster.primary.id
+  location = "us-central1"
+  backup_config {
+    include_volume_data = true
+    include_secrets = true
+    all_namespaces = true
+  }
+}
+
+resource "google_gke_backup_restore_plan" "restore_plan" {
+  name = "tf-test-restore-plan%{random_suffix}"
+  location = "us-central1"
+  backup_plan = google_gke_backup_backup_plan.basic.id
+  cluster = google_container_cluster.primary.id
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
+  restore_config {
+    all_namespaces = true
+    namespaced_resource_restore_mode = "MERGE_SKIP_ON_CONFLICT"
+    volume_data_restore_policy = "RESTORE_VOLUME_DATA_FROM_BACKUP"
+    cluster_resource_restore_scope {
+      all_group_kinds = true
+    }
+    cluster_resource_conflict_policy = "USE_EXISTING_VERSION"
+    restore_order {
+        group_kind_dependencies {
+            satisfying {
+                resource_group = "stable.example.com"
+                resource_kind = "kindA"
+            }
+            requiring {
+                resource_group = "stable.example.com"
+                resource_kind = "kindB"
+            }
+        }
+        group_kind_dependencies {
+            satisfying {
+                resource_group = "stable.example.com"
+                resource_kind = "kindB"
+            }
+            requiring {
+                resource_group = "stable.example.com"
+                resource_kind = "kindC"
+            }
+        }
+    }
+    volume_data_restore_policy_bindings {
+        policy = "RESTORE_VOLUME_DATA_FROM_BACKUP"
+        volume_type = "GCE_PERSISTENT_DISK"
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Add tags field to instance resource to allow setting tags on backupPlan and restorePlan resources at creation time.
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
gkebackup: added `tags' field to backupPlan and restorePlan resources, allowing users to set tags during resource creation.
```

Requesting mandatory review from @aniket-gupta 

IMPORTANT: Please do not merge the PR unless confirmed from us on the PR. We would like to wait for the changes to be deployed on Google Infra before merging PR here.
