### PR TITLE
Adding Tags support for Redis - Instance

### DIFF
--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -578,3 +578,11 @@ properties:
       Optional. The KMS key reference that you want to use to encrypt the data at rest for this Redis
       instance. If this is provided, CMEK is enabled.
     immutable: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_key_value}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_instance_test.go
@@ -407,3 +407,49 @@ resource "google_redis_instance" "test" {
 }
 `, name)
 }
+
+func TestAccRedisInstance_tags(t *testing.T) {
+
+	t.Parallel()
+
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "redis-instances-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestOrganizationTagValue(t, "redis-instances-tagvalue", tagKey),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckRedisInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisInstanceTags(context),
+				Check: resource.TestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_redis_instance.test", "tags.%"),
+				),
+			},
+			{
+				ResourceName:            "google_redis_instance.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"tags"},
+			},
+		},
+	})
+}
+
+func testAccRedisInstanceTags(context map[string]interface{}) string {
+
+	return acctest.Nprintf(`
+	resource "google_redis_instance" "test" {
+	  name = "tf-test-instance-%{random_suffix}"
+	  memory_size_gb = 5
+	  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add tags field to Redis to allow setting tags on instance resources at creation time.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
redis: added `tags' field to instance resources, allowing users to set tags during resource creation.
```

Requesting mandatory review from @aniket-gupta 

IMPORTANT: Please do not merge the PR unless the backend changes are deployed and confirmed by us on this PR. 
