### PR TITLE
Remove extra double quote in securesourcemanager docs

### DIFF
--- a/mmv1/products/securesourcemanager/BranchRule.yaml
+++ b/mmv1/products/securesourcemanager/BranchRule.yaml
@@ -47,7 +47,7 @@ examples:
       branch_rule_id: 'my-basic-branchrule'
       repository_id: 'my-basic-repository'
       instance_id: 'my-basic-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -58,7 +58,7 @@ examples:
       branch_rule_id: 'my-initial-branchrule'
       repository_id: 'my-initial-repository'
       instance_id: 'my-initial-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:

--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -59,7 +59,7 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-my-instance%s", context["random_suffix"])'
     vars:
       instance_id: 'my-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -72,7 +72,7 @@ examples:
     vars:
       instance_id: 'my-instance'
       kms_key_name: 'my-key'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
       'kms_key_name': 'acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-secure-source-manager-key1").CryptoKey.Name'
@@ -87,7 +87,7 @@ examples:
       instance_id: 'my-instance'
       ca_pool_id: 'ca-pool'
       root_ca_id: 'root-ca'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -110,7 +110,7 @@ examples:
       instance_id: 'my-instance'
       ca_pool_id: 'ca-pool'
       root_ca_id: 'root-ca'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -130,7 +130,7 @@ examples:
       instance_id: 'my-instance'
       ca_pool_id: 'ca-pool'
       root_ca_id: 'root-ca'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -143,7 +143,7 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-my-instance%s", context["random_suffix"])'
     vars:
       instance_id: 'my-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -55,7 +55,7 @@ examples:
     vars:
       repository_id: 'my-repository'
       instance_id: 'my-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:
@@ -66,7 +66,7 @@ examples:
     vars:
       repository_id: 'my-repository'
       instance_id: 'my-instance'
-      deletion_policy: '"PREVENT"'
+      deletion_policy: 'PREVENT'
     test_vars_overrides:
       'deletion_policy': '"DELETE"'
     oics_vars_overrides:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
securesourcemanager: removed extra double quote in deletion_policy example documentation
```
