### PR TITLE
tgc-revival: make test data fall back to most recent run

### DIFF
--- a/mmv1/third_party/tgc_next/test/setup.go
+++ b/mmv1/third_party/tgc_next/test/setup.go
@@ -27,6 +27,11 @@ type CaiData struct {
 	CaiAsset caiasset.Asset `json:"cai_asset,omitempty"`
 }
 
+type NightlyRun struct {
+	MetadataByTest map[string]TgcMetadataPayload
+	Date           time.Time
+}
+
 type TgcMetadataPayload struct {
 	TestName         string                       `json:"test_name"`
 	RawConfig        string                       `json:"raw_config"`
@@ -45,49 +50,50 @@ type Resource struct {
 	Attributes map[string]struct{} `json:"attributes"`
 }
 
+const ymdFormat = "2006-01-02"
+
 var (
-	TestsMetadata = make(map[string]TgcMetadataPayload)
+	TestsMetadata = make([]NightlyRun, 30)
 	setupDone     = false
 )
 
-func ReadTestsDataFromGcs() (map[string]TgcMetadataPayload, error) {
+func ReadTestsDataFromGcs() ([]NightlyRun, error) {
 	if !setupDone {
 		bucketName := "cai_assets_metadata"
 		currentDate := time.Now()
+		ctx := context.Background()
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("storage.NewClient: %v", err)
+		}
+		defer client.Close()
 
-		for len(TestsMetadata) == 0 {
-			objectName := fmt.Sprintf("nightly_tests/%s/nightly_tests_meta.json", currentDate.Format("2006-01-02"))
-			log.Printf("Read object  %s from the bucket %s", objectName, bucketName)
+		bucket := client.Bucket(bucketName)
 
-			ctx := context.Background()
-			client, err := storage.NewClient(ctx)
+		var allErrs error
+		for i := 0; i < len(TestsMetadata); i++ {
+			metadata, err := readTestsDataFromGCSForRun(ctx, currentDate, bucketName, bucket)
 			if err != nil {
-				return nil, fmt.Errorf("storage.NewClient: %v", err)
-			}
-			defer client.Close()
-
-			currentDate = currentDate.AddDate(0, 0, -1)
-
-			rc, err := client.Bucket(bucketName).Object(objectName).NewReader(ctx)
-			if err != nil {
-				if err == storage.ErrObjectNotExist {
-					log.Printf("Object '%s' in bucket '%s' does NOT exist.\n", objectName, bucketName)
-					continue
+				if allErrs == nil {
+					allErrs = fmt.Errorf("reading tests data from gcs: %v", err)
 				} else {
-					return nil, fmt.Errorf("Object(%q).NewReader: %v", objectName, err)
+					allErrs = fmt.Errorf("%v, %v", allErrs, err)
 				}
 			}
-			defer rc.Close()
-
-			data, err := io.ReadAll(rc)
-			if err != nil {
-				return nil, fmt.Errorf("io.ReadAll: %v", err)
+			if metadata == nil {
+				// Keep looking until we find a date with metadata.
+				i--
+			} else {
+				TestsMetadata[i] = NightlyRun{
+					MetadataByTest: metadata,
+					Date:           currentDate,
+				}
 			}
+			currentDate = currentDate.AddDate(0, 0, -1)
+		}
 
-			err = json.Unmarshal(data, &TestsMetadata)
-			if err != nil {
-				return nil, fmt.Errorf("json.Unmarshal: %v", err)
-			}
+		if allErrs != nil {
+			return nil, allErrs
 		}
 
 		if os.Getenv("WRITE_FILES") != "" {
@@ -96,6 +102,35 @@ func ReadTestsDataFromGcs() (map[string]TgcMetadataPayload, error) {
 		setupDone = true
 	}
 	return TestsMetadata, nil
+}
+
+func readTestsDataFromGCSForRun(ctx context.Context, currentDate time.Time, bucketName string, bucket *storage.BucketHandle) (map[string]TgcMetadataPayload, error) {
+	metadata := make(map[string]TgcMetadataPayload)
+	objectName := fmt.Sprintf("nightly_tests/%s/nightly_tests_meta.json", currentDate.Format(ymdFormat))
+	log.Printf("Read object  %s from the bucket %s", objectName, bucketName)
+
+	rc, err := bucket.Object(objectName).NewReader(ctx)
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			log.Printf("Object '%s' in bucket '%s' does NOT exist.\n", objectName, bucketName)
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("Object(%q).NewReader: %v", objectName, err)
+		}
+	}
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, fmt.Errorf("io.ReadAll: %v", err)
+	}
+
+	err = json.Unmarshal(data, &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("json.Unmarshal: %v", err)
+	}
+
+	return metadata, nil
 }
 
 func prepareTestData(testName string) (map[string]ResourceTestData, string, error) {
@@ -107,8 +142,21 @@ func prepareTestData(testName string) (map[string]ResourceTestData, string, erro
 		return nil, "", err
 	}
 
-	testMetadata := TestsMetadata[testName]
-	resourceMetadata := testMetadata.ResourceMetadata
+	var testMetadata TgcMetadataPayload
+	var resourceMetadata map[string]*ResourceMetadata
+	for _, run := range TestsMetadata {
+		var ok bool
+		testMetadata, ok = run.MetadataByTest[testName]
+		if ok {
+			log.Printf("Found metadata for %s from run on %s", testName, run.Date.Format(ymdFormat))
+			resourceMetadata = testMetadata.ResourceMetadata
+			if len(resourceMetadata) > 0 {
+				break
+			}
+		}
+		log.Printf("Missing metadata for %s from run on %s, looking at previous run", testName, run.Date.Format(ymdFormat))
+	}
+
 	if len(resourceMetadata) == 0 {
 		log.Printf("Data of test is unavailable: %s", testName)
 		return nil, "", nil

--- a/mmv1/third_party/tgc_next/test/setup.go
+++ b/mmv1/third_party/tgc_next/test/setup.go
@@ -71,6 +71,7 @@ func ReadTestsDataFromGcs() ([]NightlyRun, error) {
 		bucket := client.Bucket(bucketName)
 
 		var allErrs error
+		retriesRemaining := 30
 		for i := 0; i < len(TestsMetadata); i++ {
 			metadata, err := readTestsDataFromGCSForRun(ctx, currentDate, bucketName, bucket)
 			if err != nil {
@@ -83,6 +84,10 @@ func ReadTestsDataFromGcs() ([]NightlyRun, error) {
 			if metadata == nil {
 				// Keep looking until we find a date with metadata.
 				i--
+				retriesRemaining--
+				if retriesRemaining < 0 {
+					return nil, fmt.Errorf("too many retries, %v", allErrs)
+				}
 			} else {
 				TestsMetadata[i] = NightlyRun{
 					MetadataByTest: metadata,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Currently the behavior is to always use the most recent run. This will make it so that we use the most recent of the last 30 runs that has  at least one `ResourceMetadata`. We could still fail to find data if a run results in resource metadata without having the resource we're interested in, but I think we can prevent this from happening by controlling how the data gets stored.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
