### PR TITLE
cloudfunctions2: changed `service` argument in `service_config` of `google_cloudfunctions2_function` to attribute

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -504,6 +504,7 @@ properties:
         description: |
           Name of the service associated with a Function.
         default_from_api: true
+        output: true
       - name: 'timeoutSeconds'
         type: Integer
         description: |

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -503,7 +503,6 @@ properties:
         type: String
         description: |
           Name of the service associated with a Function.
-        default_from_api: true
         output: true
       - name: 'timeoutSeconds'
         type: Integer

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -155,3 +155,9 @@ Remove `description` from your configuration after upgrade.
 ### `replication_spec.gcs_data_source.path` Implemented validation to prevent strings from starting with a '/' character, while still permitting empty strings."
 
 ### `replication_spec.gcs_data_sink.path` Implemented validation to prevent strings from starting with a '/' character, while still permitting empty strings."
+
+## Resource: `google_cloudfunctions2_function`
+
+### `service_config.service` is changed from `Argument` to `Attribute`
+
+Remove `service_config.service` from your configuration after upgrade.


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23717

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudfunctions2: changed `service_config.service` of `google_cloudfunctions2_function` resource to be output-only
```
