### PR TITLE
Add deletion support for Endpoint With Model Garden Deployment resource

### DIFF
--- a/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
+++ b/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
@@ -33,8 +33,8 @@ self_link: "projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}"
 create_url: "projects/{{project}}/locations/{{location}}:deploy"
 immutable: true
 exclude_read: true
-exclude_delete: true  # the resource does not yet support deletion
-exclude_import: true  # the resource does not support import
+exclude_delete: true # the resource does not yet support deletion
+exclude_import: true # the resource does not support import
 timeouts:
   insert_minutes: 180
 autogen_status: RW5kcG9pbnRXaXRoTW9kZWxHYXJkZW5EZXBsb3ltZW50
@@ -74,6 +74,16 @@ properties:
       Resource ID segment making up resource `endpoint`. It identifies the
       resource within its parent collection as described in https://google.aip.dev/122.
     url_param_only: true
+    output: true
+  - name: deployedModelIds
+    type: Array
+    item_type:
+      type: String
+    description: |
+      Output only. The numeric ID of all models deployed in this endpoint.
+      Vertex AI assigns this unique numeric ID to each model at the moment it is deployed to an endpoint,
+      and it is required to make API calls to undeploy the model as described in
+      https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/undeployModel
     output: true
   - name: publisherModelName
     type: String

--- a/mmv1/templates/terraform/post_create/resource_vertexai_endpoint_with_model_garden_deployment.go.tmpl
+++ b/mmv1/templates/terraform/post_create/resource_vertexai_endpoint_with_model_garden_deployment.go.tmpl
@@ -56,4 +56,67 @@ if err := d.Set("endpoint", endpoint); err != nil {
 d.SetId(endpointFull)
 log.Printf("[DEBUG] Set Terraform resource ID to: %s", endpointFull)
 
-return nil
+
+// Make API call to read the endpoint and retrieve deployed model IDs
+read_url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}VertexAIBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/endpoints/{{"{{"}}endpoint{{"}}"}}")
+if err != nil {
+	return err
+}
+
+read_headers := make(http.Header)
+read_res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    read_url,
+	UserAgent: userAgent,
+	Headers:   read_headers,
+})
+if err != nil {
+	return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("VertexAIEndpointWithModelGardenDeployment %q", d.Id()))
+}
+
+//  Access the 'deployedModels' attribute from the response.
+deployedModelsRaw, ok := read_res["deployedModels"]
+if !ok || deployedModelsRaw == nil {
+	log.Printf("[ERROR] No deployed models found in the endpoint response")
+	return fmt.Errorf("Error creating EndpointWithModelGardenDeployment: No deployed models found in the endpoint response.")
+}
+
+// Assert the type to a slice of interfaces
+deployedModels, ok := deployedModelsRaw.([]interface{})
+if !ok {
+	log.Printf("[ERROR] 'deployedModels' field of endpoint response is not an array as expected")
+	return fmt.Errorf("Error creating EndpointWithModelGardenDeployment: 'deployedModels' field is not an array as expected.")
+}
+
+// Log the number of deployed models for debugging purposes
+log.Printf("[DEBUG] Found %d deployed model(s).", len(deployedModels))
+
+// Retrieve deployed model IDs of all deployed models
+var deployedModelIds []string
+
+for i := 0; i < len(deployedModels); i++ {
+	deployedModelRaw := deployedModels[i]
+
+	// Assert each deployed model to a map so ID field can be retrieved
+	deployedModel, ok := deployedModelRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Error creating EndpointWithModelGardenDeployment: model in 'deployedModels' field of endpoint response is not a map as expected.")
+	}
+
+	// Retrieve and Log model ID with display name for debugging purposes
+	if modelId, ok := deployedModel["id"].(string); ok {
+		deployedModelIds = append(deployedModelIds, modelId)
+		log.Printf("[DEBUG] Retrieved ID of deployed model %d: %s", i, modelId)
+	}
+
+	if displayName, ok := deployedModel["displayName"].(string); ok {
+		log.Printf("[DEBUG] Display name of deployed model %d: %s", i, displayName)
+	}
+}
+
+// set Terraform field for deployed model IDs
+if err := d.Set("deployed_model_ids", tpgresource.ConvertStringArrToInterface(deployedModelIds)); err != nil {
+	return fmt.Errorf("Error creating EndpointWithModelGardenDeployment: %s", err)
+}


### PR DESCRIPTION
This PR adds the necessary custom code templates and resource configuration fields to enable the `vertexai_endpoint_with_model_garden_deployment`  resource via `terraform destroy`.

Specifically, this PR:
- Adds a new field to the EndpointWithModelGardenDeployment.yaml file for storing the deployed model IDs of the models deployed to the Endpoint.  
 - Updates the post_create template to read the deployed model IDs from an API call and populate the field's value.  
 - Adds a custom_delete template that undeploys all models deployed to the endpoint using the deployed model IDs and deletes the endpoint.  
 - Updates acceptance tests to verify that resource is deleted.

Vertex AI Model Garden service
Based on:
 - [ModelGardenService.deploy](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations/deploy)   
 -  [EndpointService.undeployModel](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.endpoints/undeployModel)
 - [EndpointService.deleteEndpoint](https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.endpoints/delete)

Addresses:
 - https://github.com/hashicorp/terraform-provider-google/issues/23217 
 - https://github.com/hashicorp/terraform-provider-google/issues/22478

`google_vertex_ai_endpoint_with_model_garden_deployment`
