### PR TITLE
Fixed regex to not capture re or er

### DIFF
--- a/.github/workflows/reassign-reviewer.yml
+++ b/.github/workflows/reassign-reviewer.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc # v2.0.2
         with:
           text: ${{ github.event.comment.body }}
-          regex: '.*@modular-magician (re)?assign[- ]review(er)? ?@?([a-zA-Z0-9-_]*).*'
+          regex: '.*@modular-magician (?:re)?assign[- ]review(?:er)? ?@?([a-zA-Z0-9-_]*).*'
       - name: Checkout Repository
         if: steps.read-comment.outputs.match != ''
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2


### PR DESCRIPTION
The current regex tries to assign the review to user `re` every time. Rather than spamming them with reviews, we should make these groups non-capturing.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
