### PR TITLE
Documentation: google_sql_database_instance formatting & clarity

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -173,7 +173,7 @@ resource "google_sql_database_instance" "main" {
 }
 ```
 
-### Cloud SQL Instance with MCP
+### Cloud SQL Instance with Managed Connection Pooling
 ```hcl
 resource "google_sql_database_instance" "instance" {
   name:            = "mcp-enabled-main-instance"
@@ -347,9 +347,9 @@ The `settings` block supports:
 
 * `disk_autoresize_limit` - (Optional) The maximum size to which storage capacity can be automatically increased. The default value is 0, which specifies that there is no limit.
 
-* `disk_size` - (Optional) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for PD_SSD, PD_HDD and 20GB for HYPERDISK_BALANCED. Note that this value will override the resizing from `disk_autoresize` if that feature is enabled. To avoid this, set `lifecycle.ignore_changes` on this field.
+* `disk_size` - (Optional) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB for `PD_SSD`, `PD_HDD` and 20GB for `HYPERDISK_BALANCED`. Note that this value will override the resizing from `disk_autoresize` if that feature is enabled. To avoid this, set `lifecycle.ignore_changes` on this field.
 
-* `disk_type` - (Optional) The type of data disk: PD_SSD, PD_HDD, or HYPERDISK_BALANCED. Defaults to `PD_SSD`. HYPERDISK_BALANCED is preview.
+* `disk_type` - (Optional) The type of data disk: `PD_SSD`, `PD_HDD`, or `HYPERDISK_BALANCED`. Defaults to `PD_SSD`. `HYPERDISK_BALANCED` is preview.
 
 * `data_disk_provisioned_iops` - (Optional, Beta) Provisioned number of I/O operations per second for the data disk. This field is only used for `HYPERDISK_BALANCED` disk types.
 


### PR DESCRIPTION
Expanded the 'MCP' in [Cloud SQL Instance with MCP](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#cloud-sql-instance-with-mcp) to 'Managed Connection Pooling' as 'MCP' is more known as 'Model Context Protocol' and didn't want the heading be potentially misleading/confusing.

Put some missing backticks around the PD_SSD, PD_HDD, and HYPERDISK_BALANCED values in [disk_size](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#disk_size-1) and [disk_type](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#disk_type-1) for consistency in formatting.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
