### PR TITLE
Revert "Add support for GPU redundancy to Cloud Run v2 job"

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -781,11 +781,6 @@ properties:
                 description:
                   The GPU to attach to an instance. See https://cloud.google.com/run/docs/configuring/jobs/gpu for configuring GPU.
                 required: true
-          - name: 'gpuZonalRedundancyDisabled'
-            type: Boolean
-            description: True if GPU zonal redundancy is disabled on this execution.
-            default_from_api: true
-            send_empty_value: true
   - name: 'observedGeneration'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_gpu.tf.tmpl
@@ -11,7 +11,6 @@ resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
       node_selector {
         accelerator = "nvidia-l4"
       }
-      gpu_zonal_redundancy_disabled = true
     }
   }
 }

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
@@ -1059,7 +1059,6 @@ func testAccCloudRunV2Job_cloudrunv2JobWithGpu(context map[string]interface{}) s
         node_selector {
           accelerator = "nvidia-l4"
         }
-        gpu_zonal_redundancy_disabled = true
       }
     }
     lifecycle {

--- a/mmv1/third_party/tgc/tests/data/example_cloud_run_v2_job.json
+++ b/mmv1/third_party/tgc/tests/data/example_cloud_run_v2_job.json
@@ -18,8 +18,7 @@
                         "image":"us-docker.pkg.dev/cloudrun/container/hello"
                      }
                   ],
-                  "maxRetries":3,
-                  "gpuZonalRedundancyDisabled":false
+                  "maxRetries":3
                }
             }
          }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#14519

```release-note:none
cloudrunv2: added `gpu_zonal_redundancy_disabled` field to `google_cloud_run_v2_job` resource. (revert)
```