### PR TITLE
Add allow_fewer_zones_deployment to Redis Cluster

### DIFF
--- a/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
@@ -13,6 +13,7 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
     maxmemory-policy	= "volatile-ttl"
   }
   deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
+  allow_fewer_zones_deployment = true
   zone_distribution_config {
     mode = "MULTI_ZONE"
   }

--- a/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
+++ b/mmv1/third_party/terraform/services/redis/resource_redis_cluster_test.go
@@ -322,47 +322,6 @@ resource "google_redis_cluster" "cluster_abc" {
 `, context)
 }
 
-// Validate that allow_fewer_zones_deployment is set correctly for the cluster
-func TestAccRedisCluster_allowFewerZonesDeployment(t *testing.T) {
-	t.Parallel()
-
-	context := map[string]interface{}{
-		"random_suffix":                acctest.RandString(t, 10),
-		"allow_fewer_zones_deployment": "true",
-	}
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckRedisClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				// create cluster with allow_fewer_zones_deployment set to false (default)
-				Config: testAccRedisCluster_allowFewerZonesDeployment(context),
-			},
-			{
-				ResourceName:            "google_redis_cluster.cluster_afz_main",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"psc_configs"},
-			},
-		},
-	})
-}
-
-func testAccRedisCluster_allowFewerZonesDeployment(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_redis_cluster" "cluster_afz_main" {
-  name                           = "tf-test-afz-main-%{random_suffix}"
-  shard_count                    = 2
-  region                         = "us-central1"
-  deletion_protection_enabled    = false
-  allow_fewer_zones_deployment = %{allow_fewer_zones_deployment}
-
-}
-`, context)
-}
-
 func testAccRedisCluster_automatedBackupConfigWithout(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_redis_cluster" "cluster_abc" {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.


```release-note:enhancement
memorystore: added `allow_fewer_zones_deployment` field to `google_redis_cluster` resource
```

