### PR TITLE
Allow setting manual instance count to 0.

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -299,6 +299,7 @@ properties:
         type: Integer
         description: |
           The total number of instances in manual scaling mode.
+        send_empty_value: true
   - name: 'template'
     type: NestedObject
     description: |

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go.tmpl
@@ -614,3 +614,57 @@ resource "google_cloud_run_v2_worker_pool" "default" {
 
 `, context)
 }
+
+func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(t *testing.T) {
+  t.Parallel()
+  context := map[string]interface{} {
+    "random_suffix" : acctest.RandString(t, 10),
+  }
+  acctest.VcrTest(t, resource.TestCase {
+    PreCheck: func() { acctest.AccTestPreCheck(t)},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
+    Steps: []resource.TestStep{
+       {
+        Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_worker_pool.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+    }, 
+  })
+}
+
+func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_run_v2_worker_pool" "default" {
+  name     = "tf-test-cloudrun-worker-pool%{random_suffix}"
+  description = "description creating"
+  location = "us-central1"
+  deletion_protection = false
+  launch_stage = "BETA"
+  annotations = {
+    generated-by = "magic-modules"
+  }
+  scaling {
+    manual_instance_count = 0
+  }
+  
+  labels = {
+    label-1 = "value-1"
+  }
+  client = "client-1"
+  client_version = "client-version-1"
+  template {
+    containers {
+      name = "container-1"
+      image = "us-docker.pkg.dev/cloudrun/container/worker-pool"
+    }
+  }
+}
+
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
Allow setting manual instance count to 0 when creating worker pool.
```
