### PR TITLE
Add unique index support in Firestore

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -92,6 +92,12 @@ examples:
       database_id: 'database-id-sparse-any'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_unique'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id-unique'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
 parameters:
 properties:
   - name: 'name'
@@ -152,6 +158,12 @@ properties:
       definition reach or traverse an array, except via an explicit array
       index. Violations will result in errors. Note this field only applies to
       indexes with MONGODB_COMPATIBLE_API ApiScope.
+  - name: 'unique'
+    type: Boolean
+    default_value: false
+    description:
+      Optional. Whether it is an unique index. Unique index ensures all values for the
+      indexed field(s) are unique across documents.
   - name: 'fields'
     type: Array
     description: |
@@ -206,7 +218,7 @@ properties:
               send_empty_value: true
               allow_empty_object: true
               properties:
- # Meant to be an empty object with no properties.
+                # Meant to be an empty object with no properties.
                 []
     # Most composite indexes require at least two fields, but it is possible
     # for a user to require a single field index such as `__name__ DESC`.

--- a/mmv1/templates/terraform/examples/firestore_index_unique.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_unique.tf.tmpl
@@ -1,0 +1,32 @@
+resource "google_firestore_database" "database" {
+	project                  = "{{index $.TestEnvVars "project_id"}}"
+	name                     = "{{index $.Vars "database_id"}}"
+	location_id              = "nam5"
+	type                     = "FIRESTORE_NATIVE"
+	database_edition         = "ENTERPRISE"
+
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+	deletion_policy         = "DELETE"
+}
+
+resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
+	project     = "{{index $.TestEnvVars "project_id"}}"
+	database   = google_firestore_database.database.name
+	collection = "atestcollection"
+
+	api_scope   = "MONGODB_COMPATIBLE_API"
+	query_scope = "COLLECTION_GROUP"
+	multikey    = true
+	density     = "DENSE"
+	unique      = true
+
+	fields {
+		field_path = "name"
+		order      = "ASCENDING"
+	}
+
+	fields {
+		field_path = "description"
+		order      = "DESCENDING"
+	}
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

firestore: added `unique` field to `google_firestore_index` resource
