### PR TITLE
deprecate `google_service_account_key.project`

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
@@ -32,6 +32,7 @@ func DataSourceGoogleServiceAccountKey() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Deprecated:  "`project` is deprecated and will be removed in a future major release. This field is non-functional and can be removed from your configuration safely.",
 			},
 			"key_algorithm": {
 				Type:     schema.TypeString,

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_key.go
@@ -30,9 +30,9 @@ func DataSourceGoogleServiceAccountKey() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"TYPE_NONE", "TYPE_X509_PEM_FILE", "TYPE_RAW_PUBLIC_KEY"}, false),
 			},
 			"project": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Deprecated:  "`project` is deprecated and will be removed in a future major release. This field is non-functional and can be removed from your configuration safely.",
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "`project` is deprecated and will be removed in a future major release. This field is non-functional and can be removed from your configuration safely.",
 			},
 			"key_algorithm": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
field is non functional
part of https://github.com/hashicorp/terraform-provider-google/issues/20477

field is not in any other documentation


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
resourcemanager: `project` field in `google_service_account_key` data source has been deprecated. The field is non functional and can safely be removed from your configuration.
```
