### PR TITLE
google_compute_service_attachment: allow use of global target forwarding rules

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -98,7 +98,7 @@ examples:
   - name: 'service_attachment_cross_region_ilb'
     primary_resource_id: 'psc_ilb_service_attachment'
     vars:
-      name: 'tf-test'
+      name: 'sa'
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -95,6 +95,10 @@ examples:
       producer_forwarding_rule_name: 'producer-forwarding-rule'
       consumer_address_name: 'psc-ilb-consumer-address'
       consumer_forwarding_rule_name: 'psc-ilb-consumer-forwarding-rule'
+  - name: 'service_attachment_cross_region_ilb'
+    primary_resource_id: 'psc_ilb_service_attachment'
+    vars:
+      name: 'tf-test'
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
@@ -4,13 +4,5 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 		return nil, fmt.Errorf("invalid value for target_service")
 	}
 
-	resourceKind := resource[len(resource)-2]
-	resourceBound := resource[len(resource)-4]
-
-	_, err := tpgresource.ParseRegionalFieldValue(resourceKind, v.(string), "project", resourceBound, "zone", d, config, true)
-	if err != nil {
-		return nil, fmt.Errorf("invalid value for target_service: %w", err)
-	}
-
 	return v, nil
 }

--- a/mmv1/templates/terraform/examples/service_attachment_cross_region_ilb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/service_attachment_cross_region_ilb.tf.tmpl
@@ -1,0 +1,77 @@
+resource "google_compute_service_attachment" "{{$.PrimaryResourceId}}" {
+  name                  = "{{index $.Vars "name"}}"
+  region                = "us-central1"
+  description           = "A service attachment configured with Terraform"
+  connection_preference = "ACCEPT_AUTOMATIC"
+  enable_proxy_protocol = false
+  nat_subnets           = [google_compute_subnetwork.subnetwork_psc.id]
+  target_service        = google_compute_global_forwarding_rule.forwarding_rule.id
+}
+
+resource "google_compute_global_forwarding_rule" "forwarding_rule" {
+  name                  = "{{index $.Vars "name"}}"
+  target                = google_compute_target_http_proxy.http_proxy.id
+  network               = google_compute_network.network.id
+  subnetwork            = google_compute_subnetwork.subnetwork.id
+  port_range            = "80"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+
+  depends_on = [google_compute_subnetwork.subnetwork_proxy]
+}
+
+resource "google_compute_target_http_proxy" "http_proxy" {
+  name        = "{{index $.Vars "name"}}"
+  description = "a description"
+  url_map     = google_compute_url_map.url_map.id
+}
+
+resource "google_compute_url_map" "url_map" {
+  name            = "{{index $.Vars "name"}}"
+  description     = "Url map."
+  default_service = google_compute_backend_service.backend_service.id
+}
+
+resource "google_compute_backend_service" "backend_service" {
+  name                  = "{{index $.Vars "name"}}"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_health_check.health_check.id]
+}
+
+resource "google_compute_health_check" "health_check" {
+  name               = "{{index $.Vars "name"}}"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_subnetwork" "subnetwork_psc" {
+  name          = "psc-{{index $.Vars "name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+  purpose       =  "PRIVATE_SERVICE_CONNECT"
+  ip_cidr_range = "10.1.0.0/16"
+}
+
+resource "google_compute_subnetwork" "subnetwork_proxy" {
+  name          = "proxy-{{index $.Vars "name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+  purpose       =  "GLOBAL_MANAGED_PROXY"
+  role          = "ACTIVE"
+  ip_cidr_range = "10.2.0.0/16"
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "{{index $.Vars "name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network" "network" {
+  name                    = "{{index $.Vars "name"}}"
+  auto_create_subnetworks = false
+}

--- a/mmv1/templates/terraform/examples/service_attachment_cross_region_ilb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/service_attachment_cross_region_ilb.tf.tmpl
@@ -48,7 +48,7 @@ resource "google_compute_health_check" "health_check" {
 }
 
 resource "google_compute_subnetwork" "subnetwork_psc" {
-  name          = "psc-{{index $.Vars "name"}}"
+  name          = "{{index $.Vars "name"}}-psc"
   region        = "us-central1"
   network       = google_compute_network.network.id
   purpose       =  "PRIVATE_SERVICE_CONNECT"
@@ -56,7 +56,7 @@ resource "google_compute_subnetwork" "subnetwork_psc" {
 }
 
 resource "google_compute_subnetwork" "subnetwork_proxy" {
-  name          = "proxy-{{index $.Vars "name"}}"
+  name          = "{{index $.Vars "name"}}-proxy"
   region        = "us-central1"
   network       = google_compute_network.network.id
   purpose       =  "GLOBAL_MANAGED_PROXY"


### PR DESCRIPTION
Adds the ability for `google_compute_service_attachment` to use global target forwarding rules.

Right now the custom expander prevents global forwarding rules to be added as targets. Indeed, before it was possible to only link regional forwarding rules.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
compute: added the ability to use global target forwarding rule for `target_service` field in `google_compute_service_attachment` resource
```
