### PR TITLE
container: add rbac config binding

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2551,6 +2551,27 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"rbac_binding_config": {
+			  Type:        schema.TypeList,
+			  Optional:    true,
+				MaxItems:    1,
+				Computed:    true,
+				Description: `RBACBindingConfig allows user to restrict ClusterRoleBindings an RoleBindings that can be created.`,
+				Elem: &schema.Resource{
+          Schema: map[string]*schema.Schema{
+        		"enable_insecure_binding_system_unauthenticated": {
+              Type:              schema.TypeBool,
+              Optional:          true,
+              Description:       `Setting this to true will allow any ClusterRoleBinding and RoleBinding with subjects system:anonymous or system:unauthenticated.`,
+             },
+            "enable_insecure_binding_system_authenticated": {
+              Type:              schema.TypeBool,
+              Optional:          true,
+              Description:       `Setting this to true will allow any ClusterRoleBinding and RoleBinding with subjects system:authenticated.`,
+            },
+          },
+        },
+			},
 		},
 	}
 }
@@ -2880,9 +2901,13 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.EnterpriseConfig = expandEnterpriseConfig(v)
 	}
 
-    if v, ok := d.GetOk("anonymous_authentication_config"); ok {
-        cluster.AnonymousAuthenticationConfig = expandAnonymousAuthenticationConfig(v)
-    }
+  if v, ok := d.GetOk("anonymous_authentication_config"); ok {
+      cluster.AnonymousAuthenticationConfig = expandAnonymousAuthenticationConfig(v)
+  }
+
+  if v, ok := d.GetOk("rbac_binding_config"); ok {
+    cluster.RbacBindingConfig = expandRBACBindingConfig(v)
+  }
 
   needUpdateAfterCreate := false
 
@@ -3467,6 +3492,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("anonymous_authentication_config", flattenAnonymousAuthenticationConfig(cluster.AnonymousAuthenticationConfig)); err != nil {
 		return err
 	}
+
+	if err := d.Set("rbac_binding_config", flattenRBACBindingConfig(cluster.RbacBindingConfig)); err != nil {
+    return err
+  }
 
 	return nil
 }
@@ -5002,6 +5031,22 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 	}
+
+  if d.HasChange("rbac_binding_config") {
+    req := &container.UpdateClusterRequest{
+      Update: &container.ClusterUpdate{
+        DesiredRbacBindingConfig: expandRBACBindingConfig(d.Get("rbac_binding_config")),
+        ForceSendFields:          []string{"DesiredRbacBindingConfig"},
+      }}
+
+    updateF := updateFunc(req, "updating GKE cluster RBAC binding config")
+    // Call update serially.
+    if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+      return err
+    }
+
+    log.Printf("[INFO] GKE cluster %s's RBAC binding config has been updated", d.Id())
+  }
 
 	d.Partial(false)
 
@@ -6577,6 +6622,20 @@ func expandWorkloadAltsConfig(configured interface{}) *container.WorkloadALTSCon
 }
 {{- end }}
 
+func expandRBACBindingConfig(configured interface{}) *container.RBACBindingConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	config := l[0].(map[string]interface{})
+	return &container.RBACBindingConfig{
+		EnableInsecureBindingSystemUnauthenticated: config["enable_insecure_binding_system_unauthenticated"].(bool),
+		EnableInsecureBindingSystemAuthenticated:   config["enable_insecure_binding_system_authenticated"].(bool),
+		ForceSendFields:                            []string{"EnableInsecureBindingSystemUnauthenticated", "EnableInsecureBindingSystemAuthenticated"},
+	}
+}
+
 func flattenNotificationConfig(c *container.NotificationConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -7567,6 +7626,18 @@ func flattenWorkloadAltsConfig(c *container.WorkloadALTSConfig) []map[string]int
 	}
 }
 {{- end }}
+
+func flattenRBACBindingConfig(c *container.RBACBindingConfig) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"enable_insecure_binding_system_authenticated":   c.EnableInsecureBindingSystemAuthenticated,
+			"enable_insecure_binding_system_unauthenticated": c.EnableInsecureBindingSystemUnauthenticated,
+		},
+	}
+}
 
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -14108,3 +14108,67 @@ resource "google_container_cluster" "primary" {
 }
  `, name, networkName, subnetworkName, mode)
 }
+
+func TestAccContainerCluster_RbacBindingConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_RbacBindingConfig(clusterName, networkName, subnetworkName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.0.enable_insecure_binding_system_unauthenticated", "true"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.0.enable_insecure_binding_system_authenticated", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_RbacBindingConfig(clusterName, networkName, subnetworkName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.0.enable_insecure_binding_system_unauthenticated", "false"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "rbac_binding_config.0.enable_insecure_binding_system_authenticated", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_RbacBindingConfig(clusterName, networkName, subnetworkName string, unauthenticated, authenticated bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  rbac_binding_config {
+	enable_insecure_binding_system_unauthenticated = %t
+	enable_insecure_binding_system_authenticated   = %t
+  }
+
+  deletion_protection = false
+}
+`, clusterName, networkName, subnetworkName, unauthenticated, authenticated)
+}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -426,6 +426,8 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
 * `anonymous_authentication_config` - (Optional)
   Configuration for [anonymous authentication restrictions](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access). Structure is [documented below](#anonymous_authentication_config).
 
+* `rbac_binding_config` - (Optional)
+  RBACBindingConfig allows user to restrict ClusterRoleBindings an RoleBindings that can be created. Structure is [documented below](#nested_rbac_binding_config).
 
 <a name="nested_default_snat_status"></a>The `default_snat_status` block supports
 
@@ -1559,6 +1561,11 @@ linux_node_config {
 <a name="anonymous_authentication_config"></a>The `anonymous_authentication_config` block supports:
 
 * `mode` - (Optional) Sets or removes authentication restrictions. Available options include `LIMITED` and `ENABLED`.
+
+<a name="nested_rbac_binding_config"></a>The `rbac_binding_config` block supports:
+
+* `enable_insecure_binding_system_unauthenticated` - (Optional) Setting this to true will allow any ClusterRoleBinding and RoleBinding with subjects system:anonymous or system:unauthenticated.
+* `enable_insecure_binding_system_authenticated` - (Optional) Setting this to true will allow any ClusterRoleBinding and RoleBinding with subjects system:authenticated.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Closes hashicorp/terraform-provider-google#22746

copy from #22746

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added support for `rbac_binding_config` in `google_container_cluster`
```
