### PR TITLE
Add singular data source for retrieving a package from an Artifact Registry repository

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -30,6 +30,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_artifact_registry_docker_images":           artifactregistry.DataSourceArtifactRegistryDockerImages(),
 	"google_artifact_registry_locations":               artifactregistry.DataSourceGoogleArtifactRegistryLocations(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),
+	"google_artifact_registry_package":                 artifactregistry.DataSourceArtifactRegistryPackage(),
 	"google_artifact_registry_version":                 artifactregistry.DataSourceArtifactRegistryVersion(),
 	"google_apphub_discovered_workload":		    apphub.DataSourceApphubDiscoveredWorkload(),
 	"google_app_engine_default_service_account":        appengine.DataSourceGoogleAppEngineDefaultServiceAccount(),

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_package.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_package.go
@@ -1,0 +1,136 @@
+package artifactregistry
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceArtifactRegistryPackage() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceArtifactRegistryPackageRead,
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"repository_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"annotations": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func DataSourceArtifactRegistryPackageRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry user agent: %s", err)
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry project: %s", err)
+	}
+
+	basePath, err := tpgresource.ReplaceVars(d, config, "{{ArtifactRegistryBasePath}}")
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry base path: %s", err)
+	}
+
+	resourcePath, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/packages/{{name}}"))
+	if err != nil {
+		return fmt.Errorf("Error setting resource path: %s", err)
+	}
+
+	urlRequest := basePath + resourcePath
+	headers := make(http.Header)
+
+	u, err := url.Parse(urlRequest)
+	if err != nil {
+		return fmt.Errorf("Error parsing URL: %s", err)
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    u.String(),
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error getting Artifact Registry package: %s", err)
+	}
+
+	annotations := make(map[string]string)
+	if anno, ok := res["annotations"].(map[string]interface{}); ok {
+		for k, v := range anno {
+			if val, ok := v.(string); ok {
+				annotations[k] = val
+			}
+		}
+	}
+
+	getString := func(m map[string]interface{}, key string) string {
+		if v, ok := m[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+
+	name := getString(res, "name")
+
+	if err := d.Set("project", project); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	if err := d.Set("display_name", getString(res, "displayName")); err != nil {
+		return err
+	}
+	if err := d.Set("create_time", getString(res, "createTime")); err != nil {
+		return err
+	}
+	if err := d.Set("update_time", getString(res, "updateTime")); err != nil {
+		return err
+	}
+	if err := d.Set("annotations", annotations); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_package_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_package_test.go
@@ -1,0 +1,37 @@
+package artifactregistry_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceArtifactRegistryPackage_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArtifactRegistryPackageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_artifact_registry_package.this", "name", "projects/go-containerregistry/locations/us/repositories/gcr.io/packages/gcrane"),
+				),
+			},
+		},
+	})
+}
+
+// Test the data source against the public AR repos
+// https://console.cloud.google.com/artifacts/docker/cloudrun/us/container
+// https://console.cloud.google.com/artifacts/docker/go-containerregistry/us/gcr.io
+const testAccDataSourceArtifactRegistryPackageConfig = `
+data "google_artifact_registry_package" "this" {
+  project       = "go-containerregistry"
+  location      = "us"
+  repository_id = "gcr.io"
+  name          = "gcrane"
+}
+`

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_package.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_package.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Artifact Registry"
+description: |-
+  Get information about a package within a Google Artifact Registry repository.
+---
+
+# google_artifact_registry_package
+This data source fetches information of a package from a provided Artifact Registry repository.
+
+## Example Usage
+
+```hcl
+resource "google_artifact_registry_package" "my_package" {
+  location      = "us-west1"
+  repository_id = "my-repository"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the artifact registry.
+
+* `repository_id` - (Required) The last part of the repository name to fetch from.
+
+* `name` - (Required) The name of the package.
+
+* `project` - (Optional) The project ID in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+The following computed attributes are exported:
+
+* `display_name` - The display name of the package.
+
+* `create_time` - The time, as a RFC 3339 string, this package was created. 
+
+* `update_time` - The time, as a RFC 3339 string, this package was last updated. This includes publishing a new version of the package.
+
+* `annotations` - Client specified annotations.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source `google_artifact_registry_package`, allowing to retrieve a package from an Artifact Registry repository.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23803

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_artifact_registry_package`
```