### PR TITLE
support updating user_managed_keys_config on GKE Clusters

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2414,7 +2414,6 @@ func ResourceContainerCluster() *schema.Resource {
 			"user_managed_keys_config": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				ForceNew:    true,
 				MaxItems:    1,
 				Description: `The custom keys configuration of the cluster.`,
 				Elem: &schema.Resource{
@@ -2422,21 +2421,25 @@ func ResourceContainerCluster() *schema.Resource {
 						"cluster_ca": {
 							Type:              schema.TypeString,
 							Optional:          true,
+							ForceNew:          true,
 							Description:       `The Certificate Authority Service caPool to use for the cluster CA in this cluster.`,
 						},
 						"etcd_api_ca": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							ForceNew:         true,
 							Description:      `The Certificate Authority Service caPool to use for the etcd API CA in this cluster.`,
 						},
 						"etcd_peer_ca": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							ForceNew:         true,
 							Description:      `The Certificate Authority Service caPool to use for the etcd peer CA in this cluster.`,
 						},
 						"aggregation_ca": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							ForceNew:         true,
 							Description:      `The Certificate Authority Service caPool to use for the aggreation CA in this cluster.`,
 						},
 						"service_account_signing_keys": {
@@ -5119,6 +5122,22 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		log.Printf("[INFO] GKE cluster %s's WorkloadALTSConfig has been updated", d.Id())
 	}
 {{- end }}
+
+	if d.HasChange("user_managed_keys_config") {
+		req := &container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredUserManagedKeysConfig: expandUserManagedKeysConfig(d.Get("user_managed_keys_config")),
+			},
+		}
+
+		updateF := updateFunc(req, "updating user managed keys config")
+		if err := transport_tpg.LockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s user managed keys config has been updated to %#v", d.Id(), req.Update.DesiredUserManagedKeysConfig)
+	}
+
 	return resourceContainerClusterRead(d, meta)
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -5990,7 +5990,6 @@ func TestAccContainerCluster_WithCPAFeatures(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				// We are only supporting CPA features on create for now.
 				Config: testAccContainerCluster_EnableCPAFeatures(context),
 			},
 			{
@@ -14107,6 +14106,140 @@ resource "google_container_cluster" "primary" {
   }
 }
  `, name, networkName, subnetworkName, mode)
+}
+
+func TestAccContainerCluster_WithCPAFeaturesUpdate(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", suffix)
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	// Bootstrap KMS keys and needed IAM role.
+	diskKey := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "control-plane-disk-encryption")
+	signingKey1 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ASYMMETRIC_SIGN", "us-central1", "rs256-service-account-signing-1")
+	signingKey2 := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ASYMMETRIC_SIGN", "us-central1", "rs256-service-account-signing-2")
+	backupKey := acctest.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "etcd-backups")
+
+	// Here, we are granting the container engine service agent permissions on
+	// *ALL* Cloud KMS keys in the project.  A more realistic usage would be to
+	// grant the service agent the necessary roles only on the individual keys
+	// we have created.
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role: "roles/container.cloudKmsKeyUser",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role: "roles/privateca.certificateManager",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role: "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+		{
+			Member: "serviceAccount:service-{project_number}@container-engine-robot.iam.gserviceaccount.com",
+			Role: "roles/cloudkms.cryptoKeyEncrypterDecrypterViaDelegation",
+		},
+	})
+
+	// Find an active cryptoKeyVersion on the signing key.
+	var signingCryptoKeyVersion1 *cloudkms.CryptoKeyVersion
+	for _, ckv := range signingKey1.CryptoKeyVersions {
+		if ckv.State == "ENABLED" && ckv.Algorithm == "RSA_SIGN_PKCS1_4096_SHA256" {
+		  signingCryptoKeyVersion1 = ckv
+		}
+	}
+	if signingCryptoKeyVersion1 == nil {
+		t.Fatal("Didn't find an appropriate cryptoKeyVersion for signingCryptoKeyVersion1 to use as the service account signing key")
+	}
+
+	var signingCryptoKeyVersion2 *cloudkms.CryptoKeyVersion
+	for _, ckv := range signingKey2.CryptoKeyVersions {
+		if ckv.State == "ENABLED" && ckv.Algorithm == "RSA_SIGN_PKCS1_4096_SHA256" {
+		  signingCryptoKeyVersion2 = ckv
+		}
+	}
+	if signingCryptoKeyVersion2 == nil {
+		t.Fatal("Didn't find an appropriate cryptoKeyVersion for signingCryptoKeyVersion2 to use as the service account signing key")
+	}
+
+	context := map[string]interface{}{
+		"resource_name":            clusterName,
+		"networkName":              networkName,
+		"subnetworkName":           subnetworkName,
+		"disk_key":                 diskKey.CryptoKey.Name,
+		"backup_key":               backupKey.CryptoKey.Name,
+		"signing_cryptokeyversion": signingCryptoKeyVersion1.Name,
+		"random_suffix":            suffix,
+	}
+
+	updateContext:= map[string]interface{}{
+		"resource_name":            clusterName,
+		"networkName":              networkName,
+		"subnetworkName":           subnetworkName,
+		"disk_key":                 diskKey.CryptoKey.Name,
+		"backup_key":               backupKey.CryptoKey.Name,
+		"signing_cryptokeyversion": signingCryptoKeyVersion2.Name,
+		"random_suffix":            suffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_EnableCPAFeaturesWithSAkeys(context),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_cpa_features",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_EnableCPAFeaturesWithSAkeys(updateContext),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_cluster.with_cpa_features", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:      "google_container_cluster.with_cpa_features",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_EnableCPAFeaturesWithSAkeys(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+		resource "google_container_cluster" "with_cpa_features" {
+			name               = "%{resource_name}"
+			location           = "us-central1-a"
+			initial_node_count = 1
+			release_channel {
+				channel = "RAPID"
+			}
+			user_managed_keys_config {
+				service_account_signing_keys = [
+					"%{signing_cryptokeyversion}",
+				]
+				service_account_verification_keys = [
+					"%{signing_cryptokeyversion}",
+				]
+			}
+			deletion_protection = false
+			network    = "%{networkName}"
+			subnetwork    = "%{subnetworkName}"
+		}
+		`, context)
 }
 
 func TestAccContainerCluster_RbacBindingConfig(t *testing.T) {


### PR DESCRIPTION
Support updating UserManagedKeysConfig on GKE clusters. 

using these fields requires an organization / folder / project to be internally allowlisted.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added in-place update support for `user_managed_keys_config` field in `google_container_cluster` resource
```
