### PR TITLE
Added File Examples for Parameter Version Resources

### DIFF
--- a/mmv1/products/parametermanager/ParameterVersion.yaml
+++ b/mmv1/products/parametermanager/ParameterVersion.yaml
@@ -57,6 +57,22 @@ examples:
     vars:
       parameter_id: 'parameter'
       parameter_version_id: 'parameter_version'
+  - name: 'parameter_version_with_json_format_with_file'
+    primary_resource_id: 'parameter-version-with-json-format-with-file'
+    vars:
+      parameter_id: 'parameter'
+      parameter_version_id: 'parameter_version'
+      data: parameter-json-data.json
+    test_vars_overrides:
+      'data': '"./test-fixtures/parameter_data_json_format.json"'
+  - name: 'parameter_version_with_yaml_format_with_file'
+    primary_resource_id: 'parameter-version-with-yaml-format-with-file'
+    vars:
+      parameter_id: 'parameter'
+      parameter_version_id: 'parameter_version'
+      data: parameter-yaml-data.yaml
+    test_vars_overrides:
+      'data': '"./test-fixtures/parameter_data_yaml_format.yaml"'
 custom_code:
   custom_import: 'templates/terraform/custom_import/parameter_manager_parameter_version.go.tmpl'
 parameters:

--- a/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
@@ -58,6 +58,22 @@ examples:
     bootstrap_iam:
       - member: "serviceAccount:service-{project_number}@gcp-sa-pm.iam.gserviceaccount.com"
         role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  - name: 'regional_parameter_version_with_json_format_with_file'
+    primary_resource_id: 'regional-parameter-version-with-json-format-with-file'
+    vars:
+      parameter_id: 'regional_parameter'
+      parameter_version_id: 'regional_parameter_version'
+      data: regional-parameter-json-data.json
+    test_vars_overrides:
+      'data': '"./test-fixtures/regional_parameter_data_json_format.json"'
+  - name: 'regional_parameter_version_with_yaml_format_with_file'
+    primary_resource_id: 'regional-parameter-version-with-yaml-format-with-file'
+    vars:
+      parameter_id: 'regional_parameter'
+      parameter_version_id: 'regional_parameter_version'
+      data: regional-parameter-yaml-data.yaml
+    test_vars_overrides:
+      'data': '"./test-fixtures/regional_parameter_data_yaml_format.yaml"'
 custom_code:
   pre_create: 'templates/terraform/pre_create/parameter_manager_regional_parameter_version.go.tmpl'
   custom_import: 'templates/terraform/custom_import/parameter_manager_regional_parameter_version.go.tmpl'

--- a/mmv1/templates/terraform/examples/parameter_version_with_json_format_with_file.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_with_json_format_with_file.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_parameter_manager_parameter" "parameter-basic" {
+  parameter_id = "{{index $.Vars "parameter_id"}}"
+  format = "JSON"
+}
+
+resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_parameter.parameter-basic.id
+  parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
+  parameter_data = file("{{index $.Vars "data"}}") 
+}

--- a/mmv1/templates/terraform/examples/parameter_version_with_yaml_format_with_file.tf.tmpl
+++ b/mmv1/templates/terraform/examples/parameter_version_with_yaml_format_with_file.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_parameter_manager_parameter" "parameter-basic" {
+  parameter_id = "{{index $.Vars "parameter_id"}}"
+  format = "YAML"
+}
+
+resource "google_parameter_manager_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_parameter.parameter-basic.id
+  parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
+  parameter_data = file("{{index $.Vars "data"}}")
+}

--- a/mmv1/templates/terraform/examples/regional_parameter_version_with_json_format_with_file.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_version_with_json_format_with_file.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
+  parameter_id = "{{index $.Vars "parameter_id"}}"
+  format = "JSON"
+  location = "us-central1"
+}
+
+resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
+  parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
+  parameter_data = file("{{index $.Vars "data"}}")
+}

--- a/mmv1/templates/terraform/examples/regional_parameter_version_with_yaml_format_with_file.tf.tmpl
+++ b/mmv1/templates/terraform/examples/regional_parameter_version_with_yaml_format_with_file.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_parameter_manager_regional_parameter" "regional-parameter-basic" {
+  parameter_id = "{{index $.Vars "parameter_id"}}"
+  format = "YAML"
+  location = "us-central1"
+}
+
+resource "google_parameter_manager_regional_parameter_version" "{{$.PrimaryResourceId}}" {
+  parameter = google_parameter_manager_regional_parameter.regional-parameter-basic.id
+  parameter_version_id = "{{index $.Vars "parameter_version_id"}}"
+  parameter_data = file("{{index $.Vars "data"}}")
+}

--- a/mmv1/third_party/terraform/services/parametermanager/test-fixtures/parameter_data_json_format.json
+++ b/mmv1/third_party/terraform/services/parametermanager/test-fixtures/parameter_data_json_format.json
@@ -1,0 +1,6 @@
+{
+  "db_host": "localhost",
+  "db_name": "testdb",
+  "db_user": "testuser",
+  "db_port": 5432
+}

--- a/mmv1/third_party/terraform/services/parametermanager/test-fixtures/parameter_data_yaml_format.yaml
+++ b/mmv1/third_party/terraform/services/parametermanager/test-fixtures/parameter_data_yaml_format.yaml
@@ -1,0 +1,4 @@
+db_host: localhost
+db_port: 5432
+db_name: testdb
+db_user: testuser

--- a/mmv1/third_party/terraform/services/parametermanagerregional/test-fixtures/regional_parameter_data_json_format.json
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/test-fixtures/regional_parameter_data_json_format.json
@@ -1,0 +1,6 @@
+{
+  "db_host": "localhost",
+  "db_name": "testdb",
+  "db_user": "testuser",
+  "db_port": 5432
+}

--- a/mmv1/third_party/terraform/services/parametermanagerregional/test-fixtures/regional_parameter_data_yaml_format.yaml
+++ b/mmv1/third_party/terraform/services/parametermanagerregional/test-fixtures/regional_parameter_data_yaml_format.yaml
@@ -1,0 +1,4 @@
+db_host: localhost
+db_port: 5432
+db_name: testdb
+db_user: testuser


### PR DESCRIPTION
Add examples for using a file in the `parameter_data` field for both the `google_parameter_manager_parameter_version` and `google_parameter_manager_regional_parameter_version` resources, in `YAML` and `JSON` formats.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
added file usage examples to `parameter_data` in parameter version resources
```
