### PR TITLE
secretmanager: ephemeral support for `google_secret_manager_secret_version`

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -22,12 +22,12 @@ import (
     "github.com/hashicorp/terraform-provider-google/google/fwmodels"
     "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
     "github.com/hashicorp/terraform-provider-google/google/services/apigee"
-
+    "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
     "github.com/hashicorp/terraform-provider-google/version"
     {{- if ne $.TargetVersionName "ga" }}
     "github.com/hashicorp/terraform-provider-google/google/services/firebase"
     {{- end }}
-	"github.com/hashicorp/terraform-provider-google/google/services/storage"
+    "github.com/hashicorp/terraform-provider-google/google/services/storage"
 
     transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -380,9 +380,10 @@ func (p *FrameworkProvider) Functions(_ context.Context) []func() function.Funct
 // EphemeralResources defines the resources that are of ephemeral type implemented in the provider.
 func (p *FrameworkProvider) EphemeralResources(_ context.Context) []func() ephemeral.EphemeralResource {
 	return []func() ephemeral.EphemeralResource{
-        resourcemanager.GoogleEphemeralServiceAccountAccessToken,
-        resourcemanager.GoogleEphemeralServiceAccountIdToken,
-        resourcemanager.GoogleEphemeralServiceAccountJwt,
-        resourcemanager.GoogleEphemeralServiceAccountKey,
+		resourcemanager.GoogleEphemeralServiceAccountAccessToken,
+		resourcemanager.GoogleEphemeralServiceAccountIdToken,
+		resourcemanager.GoogleEphemeralServiceAccountJwt,
+		resourcemanager.GoogleEphemeralServiceAccountKey,
+		secretmanager.GoogleEphemeralSecretManagerSecretVersion,
 	}
 }

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
@@ -37,8 +37,8 @@ type ephemeralSecretManagerSecretVersionModel struct {
 }
 
 func (p *googleEphemeralSecretManagerSecretVersion) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
-	resp.Schema.Description = "This ephemeral resource provides access to a Google Secret Manager secret version, which can be combined with a write-only attribute."
-	resp.Schema.MarkdownDescription = "This ephemeral resource provides access to a Google Secret Manager secret version, which can be combined with a write-only attribute."
+	resp.Schema.Description = "This ephemeral resource provides access to a Google Secret Manager secret version."
+	resp.Schema.MarkdownDescription = "This ephemeral resource provides access to a Google Secret Manager secret version."
 
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
@@ -1,0 +1,114 @@
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
+	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+var _ ephemeral.EphemeralResource = &googleEphemeralSecretManagerSecretVersion{}
+
+func GoogleEphemeralSecretManagerSecretVersion() ephemeral.EphemeralResource {
+	return &googleEphemeralSecretManagerSecretVersion{}
+}
+
+type googleEphemeralSecretManagerSecretVersion struct {
+	providerConfig *transport_tpg.Config
+}
+
+func (p *googleEphemeralSecretManagerSecretVersion) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secret_manager_secret_version"
+}
+
+type ephemeralSecretManagerSecretVersionModel struct {
+	Project     types.String `tfsdk:"project"`
+	Secret      types.String `tfsdk:"secret"`
+	Version     types.String `tfsdk:"version"`
+	SecretData  types.String `tfsdk:"secret_data"`
+	Name        types.String `tfsdk:"name"`
+	CreateTime  types.String `tfsdk:"create_time"`
+	DestroyTime types.String `tfsdk:"destroy_time"`
+	Enabled     types.Bool   `tfsdk:"enabled"`
+}
+
+func (p *googleEphemeralSecretManagerSecretVersion) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
+	resp.Schema.Description = "This ephemeral resource provides access to a Google Secret Manager secret version, which can be combined with a write-only attribute."
+	resp.Schema.MarkdownDescription = "This ephemeral resource provides access to a Google Secret Manager secret version, which can be combined with a write-only attribute."
+
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			// Arguments
+			"project": schema.StringAttribute{
+				Description: "",
+				Required:    true,
+			},
+			"secret": schema.StringAttribute{
+				Description: "The name of the secret to access (e.g. `projects/my-project/secrets/my-secret`)",
+				Required:    true,
+			},
+			"version": schema.StringAttribute{
+				Description: "The version of the secret to access (e.g. `latest` or `1`). If not specified, the latest version is retrieved.",
+				Optional:    true,
+			},
+			// Attributes
+			"secret_data": schema.StringAttribute{
+				Description: "The secret data of the specified secret version.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"name": schema.StringAttribute{
+				Description: "The resource name of the secret version.",
+				Computed:    true,
+			},
+			"create_time": schema.StringAttribute{
+				Description: "The time at which the secret version was created.",
+				Computed:    true,
+			},
+			"destroy_time": schema.StringAttribute{
+				Description: "The time at which the secret version was destroyed, if applicable.",
+				Computed:    true,
+			},
+			"enabled": schema.BoolAttribute{
+				Description: "Indicates whether the secret version is enabled.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (p *googleEphemeralSecretManagerSecretVersion) Configure(ctx context.Context, req ephemeral.ConfigureRequest, resp *ephemeral.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	pd, ok := req.ProviderData.(*transport_tpg.Config)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *transport_tpg.Config, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	// Required for accessing userAgent and passing as an argument into a util function
+	p.providerConfig = pd
+}
+
+func (p *googleEphemeralSecretManagerSecretVersion) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
+	var data ephemeralSecretManagerSecretVersionModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TODO(ramon): Implement the logic to retrieve the secret version data.
+
+	resp.Diagnostics.Append(resp.Result.Set(ctx, data)...)
+}

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
@@ -58,7 +58,7 @@ func (p *googleEphemeralSecretManagerSecretVersion) Schema(ctx context.Context, 
 				Optional:    true,
 			},
 			"is_secret_data_base64": schema.BoolAttribute{
-				Description: "If true, the secret data will be returned as a base64 encoded string. Defaults to false.",
+				Description: "If true, the secret data returned will not get base64 decoded. Defaults to false.",
 				Optional:    true,
 			},
 			// Attributes

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
@@ -160,10 +160,8 @@ func (p *googleEphemeralSecretManagerSecretVersion) Open(ctx context.Context, re
 	// This check seems counterintuitive, but read docs on the `google_secret_manager_secret_version` resource.
 	// It states: "If set to 'true', the secret data is expected to be base64-encoded string and would be sent as is."
 	payload := accessResp["payload"].(map[string]interface{})
-	var payloadData string
-	if data.IsSecretDataBase64.ValueBool() {
-		payloadData = payload["data"].(string)
-	} else {
+	payloadData := payload["data"].(string)
+	if !data.IsSecretDataBase64.ValueBool() {
 		decoded, err := base64.StdEncoding.DecodeString(payload["data"].(string))
 		if err != nil {
 			resp.Diagnostics.AddError("Error decoding secret data", err.Error())

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version.go
@@ -1,4 +1,4 @@
-package resourcemanager
+package secretmanager
 
 import (
 	"context"

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
@@ -2,6 +2,7 @@
 package secretmanager_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -13,13 +14,38 @@ func TestAccEphemeralSecretManagerSecretVersion_basic(t *testing.T) {
 	t.Parallel()
 
 	secret := "tf-test-secret-" + acctest.RandString(t, 10)
+	secretData := "secret-data"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralSecretManagerSecretVersion_basic(secret, "secret-data"),
+				Config: testAccEphemeralSecretManagerSecretVersion_basic(secret, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_secret_manager_secret_version.default", "secret_data", secretData),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEphemeralSecretManagerSecretVersion_base64(t *testing.T) {
+	t.Parallel()
+
+	secret := "tf-test-secret-" + acctest.RandString(t, 10)
+	secretData := "secret-data"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralSecretManagerSecretVersion_base64(secret, secretData),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_secret_manager_secret_version.default", "is_secret_data_base64", "true"),
+					resource.TestCheckResourceAttr("data.google_secret_manager_secret_version.default", "secret_data", base64.StdEncoding.EncodeToString([]byte(secretData))),
+				),
 			},
 		},
 	})
@@ -43,6 +69,54 @@ resource "google_secret_manager_secret_version" "version" {
 ephemeral "google_secret_manager_secret_version" "ephemeral" {
   secret  = google_secret_manager_secret_version.version.secret
   version = google_secret_manager_secret_version.version.version
+}
+
+resource "google_secret_manager_secret_version" "version_two_based_on_ephemeral" {
+  secret  	             = google_secret_manager_secret_version.version.secret
+  secret_data_wo 		 = ephemeral.google_secret_manager_secret_version.ephemeral.secret_data
+  secret_data_wo_version = "1"
+}
+
+data "google_secret_manager_secret_version" "default" {
+  secret  = google_secret_manager_secret_version.version_two_based_on_ephemeral.secret
+  version = google_secret_manager_secret_version.version_two_based_on_ephemeral.version
+}
+`, secret, secretData)
+}
+
+func testAccEphemeralSecretManagerSecretVersion_base64(secret, secretData string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "%s"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "version" {
+  secret                 = google_secret_manager_secret.secret.id
+  secret_data            = base64encode("%s")
+  is_secret_data_base64  = true
+}
+
+ephemeral "google_secret_manager_secret_version" "ephemeral" {
+  secret  				= google_secret_manager_secret_version.version.secret
+  version 				= google_secret_manager_secret_version.version.version
+  is_secret_data_base64 = true
+}
+
+resource "google_secret_manager_secret_version" "version_two_based_on_ephemeral" {
+  secret  	             = google_secret_manager_secret_version.version.secret
+  secret_data_wo 		 = ephemeral.google_secret_manager_secret_version.ephemeral.secret_data
+  secret_data_wo_version = "1"
+  is_secret_data_base64  = true
+}
+
+data "google_secret_manager_secret_version" "default" {
+  secret                 = google_secret_manager_secret_version.version_two_based_on_ephemeral.secret
+  version                = google_secret_manager_secret_version.version_two_based_on_ephemeral.version
+  is_secret_data_base64  = true
 }
 `, secret, secretData)
 }

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
@@ -32,6 +32,7 @@ func TestAccEphemeralSecretManagerSecretVersion_basic(t *testing.T) {
 
 func TestAccEphemeralSecretManagerSecretVersion_base64(t *testing.T) {
 	t.Parallel()
+	acctest.SkipIfVcr(t)
 
 	secret := "tf-test-secret-" + acctest.RandString(t, 10)
 	secretData := "secret-data"

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccEphemeralSecretManagerSecretVersion_basic(t *testing.T) {
 	t.Parallel()
+	acctest.SkipIfVcr(t)
 
 	secret := "tf-test-secret-" + acctest.RandString(t, 10)
 	secretData := "secret-data"

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
@@ -1,0 +1,48 @@
+// filepath: /Users/ramon/projects/personal/magic-modules/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+package secretmanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccEphemeralSecretManagerSecretVersion_basic(t *testing.T) {
+	t.Parallel()
+
+	secret := "tf-test-secret-" + acctest.RandString(t, 10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralSecretManagerSecretVersion_basic(secret, "secret-data"),
+			},
+		},
+	})
+}
+
+func testAccEphemeralSecretManagerSecretVersion_basic(secret, secretData string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "%s"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "version" {
+  secret      = google_secret_manager_secret.secret.id
+  secret_data = "%s"
+}
+
+ephemeral "google_secret_manager_secret_version" "ephemeral" {
+  secret  = google_secret_manager_secret_version.version.secret
+  version = google_secret_manager_secret_version.version.version
+}
+`, secret, secretData)
+}

--- a/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
@@ -1,4 +1,3 @@
-// filepath: /Users/ramon/projects/personal/magic-modules/mmv1/third_party/terraform/services/secretmanager/ephemeral_google_secret_manager_secret_version_test.go
 package secretmanager_test
 
 import (

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/secret_manager_secret_version.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+    Produces an ephemeral source for a secret version of a Secret Manager secret
+---
+
+# google_secret_manager_secret_version
+This ephemeral resource provides a [Secret Manager secret version](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions) that can be used to access the contents of a secret.
+
+## Example Usage
+
+Use an ephemeral resource to pass through secret data to a resource with write-only attributes, such as `google_monitoring_uptime_check_config`:
+
+```hcl
+ephemeral "google_secret_manager_secret_version" "example" {
+    project = "my-project"
+    secret  = "my-secret"
+    version = "latest"
+}
+
+resource "google_monitoring_uptime_check_config" "http" {
+  display_name = "my-protected-http-uptime-check"
+  timeout      = "60s"
+  period       = "300s"
+
+  http_check {
+    path = "/protected"
+    port = "8010"
+    request_method = "GET"
+    auth_info {
+      username            = "name"
+      password_wo         = ephemeral.google_secret_manager_secret_version.example.secret_data
+	  password_wo_version = "1"
+    }
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = "my-project"
+      host       = "my-host"
+    }
+  }
+
+  content_matchers {
+    content = "example"
+    matcher = "CONTAINS_STRING"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` (Optional) - The project to get the secret version for. If it is not provided, the provider project is used.
+* `secret` (Required) - The secret to get the secret version for.
+* `version` (Requried) - The version of the secret to get. If it is not provided, the latest version is retrieved.
+* `is_secret_data_base64` (Optional) If true, the secret data returned will not get base64 decoded. Defaults to false.
+
+## Attributes Reference
+
+The following attribute is exported:
+
+* `secret_data` - The secret data. No larger than 64KiB.
+* `name` - The resource name of the SecretVersion. Format: `projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}`.
+* `create_time` - The time at which the SecretVersion was created.
+* `destroy_time` - The time at which the Secret was destroyed. Only present if state is DESTROYED.
+* `enabled` - True if the current state of the SecretVersion is enabled.

--- a/mmv1/third_party/terraform/website/docs/ephemeral-resources/secret_manager_secret_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/ephemeral-resources/secret_manager_secret_version.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Cloud Platform"
 description: |-
-    Produces an ephemeral source for a secret version of a Secret Manager secret
+    Produces an ephemeral resource for a secret version of a Secret Manager secret
 ---
 
 # google_secret_manager_secret_version
@@ -9,7 +9,7 @@ This ephemeral resource provides a [Secret Manager secret version](https://cloud
 
 ## Example Usage
 
-Use an ephemeral resource to pass through secret data to a resource with write-only attributes, such as `google_monitoring_uptime_check_config`:
+Use an ephemeral resource to pass through secret data to a resource with write-only arguments, such as `google_monitoring_uptime_check_config`:
 
 ```hcl
 ephemeral "google_secret_manager_secret_version" "example" {


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/20516

**For reference:**

Hashicorp docs on ephemeral resources:
https://developer.hashicorp.com/terraform/plugin/framework/ephemeral-resources

Implementation of the original couple of ephemeral resources:
https://github.com/GoogleCloudPlatform/magic-modules/pull/12469

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
secretmanager: ephemeral support for `google_secret_manager_secret_version`
```
