### PR TITLE
Update cloud sql instance tier from db-f1-micro to db-custom-2-3840 in tests

### DIFF
--- a/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/bootstrap_test_utils.go.tmpl
@@ -1098,7 +1098,7 @@ func BootstrapSharedSQLInstanceBackupRun(t *testing.T) string {
 			PointInTimeRecoveryEnabled: true,
 		}
 		settings := &sqladmin.Settings{
-			Tier:                "db-f1-micro",
+			Tier:                "db-custom-2-3840",
 			BackupConfiguration: backupConfig,
 		}
 		bootstrapInstance = &sqladmin.DatabaseInstance{


### PR DESCRIPTION
Update cloud sql instance tier from db-f1-micro to db-custom-2-3840 in tests. Creating share-core instances are easily to make test timeout