### PR TITLE
Add singular data source for retrieving an Artifact Registry tag

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -32,6 +32,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_artifact_registry_package":                 artifactregistry.DataSourceArtifactRegistryPackage(),
 	"google_artifact_registry_repositories":            artifactregistry.DataSourceArtifactRegistryRepositories(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),
+	"google_artifact_registry_tag":                     artifactregistry.DataSourceArtifactRegistryTag(),
 	"google_artifact_registry_tags":                    artifactregistry.DataSourceArtifactRegistryTags(),
 	"google_artifact_registry_version":                 artifactregistry.DataSourceArtifactRegistryVersion(),
 	"google_apphub_discovered_workload":		    apphub.DataSourceApphubDiscoveredWorkload(),

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_tag.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_tag.go
@@ -1,0 +1,122 @@
+package artifactregistry
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceArtifactRegistryTag() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceArtifactRegistryTagRead,
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"repository_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"package_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tag_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func DataSourceArtifactRegistryTagRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry user agent: %s", err)
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry project: %s", err)
+	}
+
+	basePath, err := tpgresource.ReplaceVars(d, config, "{{ArtifactRegistryBasePath}}")
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry base path: %s", err)
+	}
+
+	resourcePath, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/packages/{{package_name}}/tags/{{tag_name}}"))
+	if err != nil {
+		return fmt.Errorf("Error setting resource path: %s", err)
+	}
+
+	urlRequest := basePath + resourcePath
+	headers := make(http.Header)
+
+	u, err := url.Parse(urlRequest)
+	if err != nil {
+		return fmt.Errorf("Error parsing URL: %s", err)
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    u.String(),
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error getting Artifact Registry tag: %s", err)
+	}
+
+	annotations := make(map[string]string)
+	if anno, ok := res["annotations"].(map[string]interface{}); ok {
+		for k, v := range anno {
+			if val, ok := v.(string); ok {
+				annotations[k] = val
+			}
+		}
+	}
+
+	getString := func(m map[string]interface{}, key string) string {
+		if v, ok := m[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+
+	name := getString(res, "name")
+
+	if err := d.Set("project", project); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	if err := d.Set("version", res["version"].(string)); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_tag_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_tag_test.go
@@ -1,0 +1,38 @@
+package artifactregistry_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceArtifactRegistryTag_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArtifactRegistryTagConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_artifact_registry_tag.this", "name", "projects/go-containerregistry/locations/us/repositories/gcr.io/packages/gcrane/tags/latest"),
+				),
+			},
+		},
+	})
+}
+
+// Test the data source against the public AR repos
+// https://console.cloud.google.com/artifacts/docker/cloudrun/us/container
+// https://console.cloud.google.com/artifacts/docker/go-containerregistry/us/gcr.io
+const testAccDataSourceArtifactRegistryTagConfig = `
+data "google_artifact_registry_tag" "this" {
+  project       = "go-containerregistry"
+  location      = "us"
+  repository_id = "gcr.io"
+  package_name  = "gcrane"
+  tag_name      = "latest"
+}
+`

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_tag.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_tag.html.markdown
@@ -1,0 +1,41 @@
+---
+subcategory: "Artifact Registry"
+description: |-
+  Get information about a tag within a Google Artifact Registry repository.
+---
+
+# google_artifact_registry_tag
+This data source fetches information of a tag from a provided Artifact Registry repository.
+
+## Example Usage
+
+```hcl
+data "google_artifact_registry_tags" "my_tags" {
+  location      = "us-central1"
+  repository_id = "example-repo"
+  package_name  = "example-package"
+  tag_name      = "latest"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the artifact registry.
+
+* `repository_id` - (Required) The last part of the repository name to fetch from.
+
+* `package_name` - (Required) The name of the package.
+
+* `tag_name` - (Required) The name of the tag.
+
+* `project` - (Optional) The project ID in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+The following computed attributes are exported:
+
+* `name` - The name of the tag, for example: `projects/p1/locations/us-central1/repositories/repo1/packages/pkg1/tags/tag1`. If the package part contains slashes, the slashes are escaped.
+
+* `version` - The version of the tag.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source `google_artifact_registry_tag`, allowing to retrieve a tag from an Artifact Registry package.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23836

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_artifact_registry_tag`
```
