### PR TITLE
Add singular data source for retrieving an Artifact Registry version

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -30,6 +30,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_artifact_registry_docker_images":           artifactregistry.DataSourceArtifactRegistryDockerImages(),
 	"google_artifact_registry_locations":               artifactregistry.DataSourceGoogleArtifactRegistryLocations(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),
+	"google_artifact_registry_version":                 artifactregistry.DataSourceArtifactRegistryVersion(),
 	"google_apphub_discovered_workload":		    apphub.DataSourceApphubDiscoveredWorkload(),
 	"google_app_engine_default_service_account":        appengine.DataSourceGoogleAppEngineDefaultServiceAccount(),
 	"google_apphub_application":						apphub.DataSourceGoogleApphubApplication(),

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_version.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_version.go
@@ -1,0 +1,206 @@
+package artifactregistry
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceArtifactRegistryVersion() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceArtifactRegistryVersionRead,
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"repository_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"package_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"version_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"view": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "BASIC",
+				ValidateFunc: validateViewArtifactRegistryVersion,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"related_tags": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"annotations": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func DataSourceArtifactRegistryVersionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry user agent: %s", err)
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry project: %s", err)
+	}
+
+	basePath, err := tpgresource.ReplaceVars(d, config, "{{ArtifactRegistryBasePath}}")
+	if err != nil {
+		return fmt.Errorf("Error setting Artifact Registry base path: %s", err)
+	}
+
+	resourcePath, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/packages/{{package_name}}/versions/{{version_name}}"))
+	if err != nil {
+		return fmt.Errorf("Error setting resource path: %s", err)
+	}
+
+	view := d.Get("view").(string)
+
+	urlRequest := basePath + resourcePath
+
+	u, err := url.Parse(urlRequest)
+	if err != nil {
+		return fmt.Errorf("Error parsing URL: %s", err)
+	}
+
+	q := u.Query()
+	q.Set("view", view)
+	u.RawQuery = q.Encode()
+	urlRequest = u.String()
+
+	headers := make(http.Header)
+
+	u, err = url.Parse(urlRequest)
+	if err != nil {
+		return fmt.Errorf("Error parsing URL: %s", err)
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    u.String(),
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error getting Artifact Registry version: %s", err)
+	}
+
+	var relatedTags []map[string]interface{}
+	if rawTags, ok := res["relatedTags"].([]interface{}); ok {
+		for _, rawTag := range rawTags {
+			if tagMap, ok := rawTag.(map[string]interface{}); ok {
+				entry := map[string]interface{}{
+					"name":    tagMap["name"],
+					"version": tagMap["version"],
+				}
+				relatedTags = append(relatedTags, entry)
+			}
+		}
+	}
+
+	annotations := make(map[string]string)
+	if anno, ok := res["annotations"].(map[string]interface{}); ok {
+		for k, v := range anno {
+			if val, ok := v.(string); ok {
+				annotations[k] = val
+			}
+		}
+	}
+
+	getString := func(m map[string]interface{}, key string) string {
+		if v, ok := m[key].(string); ok {
+			return v
+		}
+		return ""
+	}
+
+	name := getString(res, "name")
+
+	if err := d.Set("project", project); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	if err := d.Set("description", getString(res, "description")); err != nil {
+		return err
+	}
+	if err := d.Set("related_tags", relatedTags); err != nil {
+		return err
+	}
+	if err := d.Set("create_time", getString(res, "createTime")); err != nil {
+		return err
+	}
+	if err := d.Set("update_time", getString(res, "updateTime")); err != nil {
+		return err
+	}
+	if err := d.Set("annotations", annotations); err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return nil
+}
+
+func validateViewArtifactRegistryVersion(val interface{}, key string) ([]string, []error) {
+	v := val.(string)
+	var errs []error
+
+	if v != "BASIC" && v != "FULL" {
+		errs = append(errs, fmt.Errorf("%q must be either 'BASIC' or 'FULL', got %q", key, v))
+	}
+
+	return nil, errs
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_version_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_version_test.go
@@ -1,0 +1,38 @@
+package artifactregistry_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceArtifactRegistryVersion_basic(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArtifactRegistryVersionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_artifact_registry_version.this", "name", "projects/go-containerregistry/locations/us/repositories/gcr.io/packages/gcrane/versions/sha256:c0cf52c2bd8c636bbf701c6c74c5ff819447d384dc957d52a52a668de63e8f5d"),
+				),
+			},
+		},
+	})
+}
+
+// Test the data source against the public AR repos
+// https://console.cloud.google.com/artifacts/docker/cloudrun/us/container
+// https://console.cloud.google.com/artifacts/docker/go-containerregistry/us/gcr.io
+const testAccDataSourceArtifactRegistryVersionConfig = `
+data "google_artifact_registry_version" "this" {
+  project       = "go-containerregistry"
+  location      = "us"
+  repository_id = "gcr.io"
+  package_name  = "gcrane"
+  version_name  = "sha256:c0cf52c2bd8c636bbf701c6c74c5ff819447d384dc957d52a52a668de63e8f5d"
+}
+`

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_version.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_version.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Artifact Registry"
+description: |-
+  Get information about a version within a Google Artifact Registry repository.
+---
+
+# google_artifact_registry_version
+This data source fetches information of a version from a provided Artifact Registry repository.
+
+## Example Usage
+
+```hcl
+data "google_artifact_registry_versions" "my_versions" {
+  location      = "us-central1"
+  repository_id = "example-repo"
+  package_name  = "example-package"
+  version_name      = "latest"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the artifact registry.
+
+* `repository_id` - (Required) The last part of the repository name to fetch from.
+
+* `package_name` - (Required) The name of the package.
+
+* `version_name` - (Required) The name of the version.
+
+* `view` - (Optional) The view, which determines what version information is returned in a response. Possible values are `"BASIC"` and `"FULL"`. Defaults to `"BASIC"`.
+
+* `project` - (Optional) The project ID in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+The following computed attributes are exported:
+
+* `name` - The name of the version, for example: `projects/p1/locations/us-central1/repositories/repo1/packages/pkg1/versions/version1`. If the package part contains slashes, the slashes are escaped.
+
+* `description` - Description of the version, as specified in its metadata.
+
+* `related_tags` - A list of related tags. Will contain up to 100 tags that reference this version.
+
+* `create_time` - The time, as a RFC 3339 string, this package was created. 
+
+* `update_time` - The time, as a RFC 3339 string, this package was last updated. This includes publishing a new version of the package.
+
+* `annotations` - Client specified annotations.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source `google_artifact_registry_version`, allowing to retrieve a version from an Artifact Registry package.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23848

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_artifact_registry_version`
```
