### PR TITLE
Add max instance count field to Cloud Run Service

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -340,6 +340,10 @@ properties:
         type: Integer
         description: |
           Minimum number of instances for the service, to be divided among all revisions receiving traffic.
+      - name: 'maxInstanceCount'
+        type: Integer
+        description: |
+          Combined maximum number of instances for all revisions receiving traffic.
       - name: 'scalingMode'
         type: Enum
         description: |

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_basic.tf.tmpl
@@ -3,6 +3,10 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
+
+  scaling {
+    max_instance_count = 100
+  }
   
   template {
     containers {

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_gpu.tf.tmpl
@@ -4,6 +4,10 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
 
+  scaling {
+    max_instance_count = 1
+  }
+
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
@@ -20,8 +24,5 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
       accelerator = "nvidia-l4"
     }
     gpu_zonal_redundancy_disabled = true
-    scaling {
-      max_instance_count = 1
-    }
   }
 }

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_sql.tf.tmpl
@@ -4,11 +4,11 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   deletion_protection = false
   ingress = "INGRESS_TRAFFIC_ALL"
   
-  template {
-    scaling {
-      max_instance_count = 2
-    }
-  
+  scaling {
+    max_instance_count = 2
+  }
+
+  template { 
     volumes {
       name = "cloudsql"
       cloud_sql_instance {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -63,6 +63,10 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-1"
   client_version = "client-version-1"
+  scaling {
+    min_instance_count = 1
+    max_instance_count = 3
+  }
   template {
     labels = {
       label-1 = "value-1"
@@ -70,10 +74,6 @@ resource "google_cloud_run_v2_service" "default" {
     timeout = "300s"
     service_account = google_service_account.service_account.email
     execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
-    scaling {
-      max_instance_count = 3
-      min_instance_count = 1
-    }
     annotations = {
       generated-by = "magic-modules"
     }
@@ -131,7 +131,10 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-update"
   client_version = "client-version-update"
-
+  scaling {
+    min_instance_count = 1
+    max_instance_count = 2
+  }
   template {
     labels = {
       label-1 = "value-update"
@@ -139,10 +142,6 @@ resource "google_cloud_run_v2_service" "default" {
     timeout = "500s"
     service_account = google_service_account.service_account.email
     execution_environment = "EXECUTION_ENVIRONMENT_GEN1"
-    scaling {
-      max_instance_count = 2
-      min_instance_count = 1
-    }
     annotations = {
       generated-by = "magic-modules"
     }
@@ -253,6 +252,10 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-1"
   client_version = "client-version-1"
+  scaling {
+    min_instance_count = 1
+    max_instance_count = 3
+  }
   template {
     labels = {
       label-1 = "value-1"
@@ -260,10 +263,6 @@ resource "google_cloud_run_v2_service" "default" {
     timeout = "300s"
     service_account = google_service_account.service_account.email
     execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
-    scaling {
-      max_instance_count = 3
-      min_instance_count = 1
-    }
     annotations = {
       generated-by = "magic-modules"
     }
@@ -1327,6 +1326,9 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-1"
   client_version = "client-version-1"
+  scaling {
+    max_instance_count = 1
+  }
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
@@ -1337,9 +1339,6 @@ resource "google_cloud_run_v2_service" "default" {
         }
         startup_cpu_boost = true
       }
-    }
-    scaling {
-      max_instance_count = 1
     }
   }
 }
@@ -1362,6 +1361,9 @@ resource "google_cloud_run_v2_service" "default" {
   }
   client = "client-1"
   client_version = "client-version-1"
+  scaling {
+    max_instance_count = 1
+  }
   template {
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
@@ -1378,9 +1380,6 @@ resource "google_cloud_run_v2_service" "default" {
       accelerator = "nvidia-l4"
     }
     gpu_zonal_redundancy_disabled = true
-    scaling {
-      max_instance_count = 1
-    }
   }
 }
 `, context)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add Max Instance Count field to Cloud Run v2 Service

This also updates the examples and tests to encourage the top-level field rather than the template. We consider this a safer path for most users where the behavior is to distribute instances across the service rather than specify a count per revision.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `max_instance_count` field to `google_cloud_run_v2_service` resource.
```
