### PR TITLE
Add advanced_options_config to regional security policies.

### DIFF
--- a/mmv1/products/compute/RegionSecurityPolicy.yaml
+++ b/mmv1/products/compute/RegionSecurityPolicy.yaml
@@ -132,6 +132,58 @@ properties:
           - 'ADVANCED'
           - 'ADVANCED_PREVIEW'
           - 'STANDARD'
+  - name: "advancedOptionsConfig"
+    type: NestedObject
+    description: |
+      Advanced Options Config of this security policy.
+    properties:
+      - name: "jsonParsing"
+        type: Enum
+        description: |
+          JSON body parsing. Supported values include: "DISABLED", "STANDARD", "STANDARD_WITH_GRAPHQL".
+        enum_values:
+          - "DISABLED"
+          - "STANDARD"
+          - "STANDARD_WITH_GRAPHQL"
+      - name: "jsonCustomConfig"
+        type: NestedObject
+        description: |
+          Custom configuration to apply the JSON parsing. Only applicable when JSON parsing is set to STANDARD.
+        properties:
+          - name: "contentTypes"
+            type: Array
+            description: |
+              A list of custom Content-Type header values to apply the JSON parsing.
+            item_type:
+              type: String
+            is_set: true
+            required: true
+      - name: "logLevel"
+        type: Enum
+        description: |
+          Logging level. Supported values include: "NORMAL", "VERBOSE".
+        enum_values:
+          - "NORMAL"
+          - "VERBOSE"
+      - name: "userIpRequestHeaders"
+        type: Array
+        description: |
+          An optional list of case-insensitive request header names to use for resolving the callers client IP address.
+        item_type:
+          type: String
+        is_set: true
+      - name: requestBodyInspectionSize
+        type: Enum
+        description: |
+          The maximum request size chosen by the customer with Waf enabled. Values supported are "8KB", "16KB, "32KB", "48KB" and "64KB".
+          Values are case insensitive.
+        enum_values:
+          - "8KB"
+          - "16KB"
+          - "32KB"
+          - "48KB"
+          - "64KB"
+        min_version: beta
   - name: 'selfLink'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/region_security_policy_with_advanced_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_security_policy_with_advanced_options.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_compute_region_security_policy" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.Vars "sec_policy_name"}}"
+  description = "with advanced config"
+  type        = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD_WITH_GRAPHQL"
+    json_custom_config {
+      content_types = ["application/json"]
+    }
+    log_level               = "VERBOSE"
+    user_ip_request_headers = ["x-forwarded-for"]
+  }
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_security_policy_test.go.tmpl
@@ -1115,4 +1115,76 @@ func testAccComputeRegionSecurityPolicy_withNetworkMatch_update(context map[stri
 	}
 	`, context)
 }
+
+func TestAccComputeRegionSecurityPolicy_withAdvancedOptions(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionSecurityPolicy_withAdvancedOptions(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionSecurityPolicy_withAdvancedOptionsUpdate(context),
+			},
+			{
+				ResourceName:      "google_compute_region_security_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionSecurityPolicy_withAdvancedOptions(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_security_policy" "policy" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD_WITH_GRAPHQL"
+    json_custom_config {
+      content_types = ["application/json"]
+    }
+    log_level                    = "VERBOSE"
+    user_ip_request_headers      = ["x-forwarded-for"]
+    request_body_inspection_size = "8KB"
+  }
+}
+`, context)
+}
+
+func testAccComputeRegionSecurityPolicy_withAdvancedOptionsUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_region_security_policy" "policy" {
+  name        = "tf-test%{random_suffix}"
+  description = "basic region security policy"
+  type        = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD"
+    json_custom_config {
+      content_types = ["text/json"]
+    }
+    log_level                    = "NORMAL"
+    user_ip_request_headers      = ["x-real-ip"]
+    request_body_inspection_size = "16KB"
+  }
+}
+`, context)
+}
 {{- end }}


### PR DESCRIPTION
Add `advanced_options_config` field to regional Cloud Armor policies.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `advanced_options_config` field to `google_compute_region_security_policy` resource
```
