### PR TITLE
Secure Source Manager (SSM): make CA pool optional for private instances

### DIFF
--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -80,6 +80,13 @@ examples:
       'deletion_policy': '"DELETE"'
     ignore_read_extra:
       - 'update_time'
+  - name: 'secure_source_manager_instance_private_trusted_cert'
+    primary_resource_id: 'default'
+    primary_resource_name: 'fmt.Sprintf("tf-test-my-instance%s", context["random_suffix"])'
+    vars:
+      instance_id: 'my-instance'
+    ignore_read_extra:
+      - 'update_time'
   - name: 'secure_source_manager_instance_private'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-my-instance%s", context["random_suffix"])'
@@ -262,7 +269,6 @@ properties:
         type: String
         description: |
           CA pool resource, resource must in the format of `projects/{project}/locations/{location}/caPools/{ca_pool}`.
-        required: true
         immutable: true
       - name: 'httpServiceAttachment'
         type: String

--- a/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
@@ -1,0 +1,8 @@
+resource "google_secure_source_manager_instance" "{{$.PrimaryResourceId}}" {
+  instance_id = "{{index $.Vars "instance_id"}}"
+  location    = "us-central1"
+
+  private_config {
+    is_private = true
+  }
+}


### PR DESCRIPTION
SSM: makes CA pool optional for private instances that use Google-managed trusted certificates.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
secure-source-manager: made `caPool` argument optional.
```
