### PR TITLE
Add service account to datasource tests

### DIFF
--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_environment_test.go
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_environment_test.go
@@ -15,7 +15,8 @@ func TestAccDataSourceComposerEnvironment_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix":   acctest.RandString(t, 10),
+		"service_account": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -79,6 +80,7 @@ func testAccCheckGoogleComposerEnvironmentMeta(n string) resource.TestCheckFunc 
 
 func testAccDataSourceComposerEnvironment_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {}
 resource "google_composer_environment" "test" {
 	name   = "tf-test-composer-env-%{random_suffix}"
 	region = "us-central1"
@@ -88,6 +90,7 @@ resource "google_composer_environment" "test" {
 			network    = google_compute_network.test.self_link
 			subnetwork = google_compute_subnetwork.test.self_link
 			zone       = "us-central1-a"
+      service_account = google_service_account.test.name
 		}
 		software_config {
 			image_version = "composer-1-airflow-2"
@@ -96,6 +99,7 @@ resource "google_composer_environment" "test" {
 	labels = {
 		my-label = "my-label-value"
 	}
+  depends_on = [google_project_iam_member.composer-worker]
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
@@ -115,6 +119,15 @@ resource "google_compute_subnetwork" "test" {
 data "google_composer_environment" "test" {
 	name   = google_composer_environment.test.name
 	region = google_composer_environment.test.region
+}
+resource "google_service_account" "test" {
+  account_id   = "%{service_account}"
+  display_name = "Test Service Account for Composer Environment"
+}
+resource "google_project_iam_member" "composer-worker" {
+  project = data.google_project.project.project_id
+  role   = "roles/composer.worker"
+  member = "serviceAccount:${google_service_account.test.email}"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map_test.go
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_config_map_test.go
@@ -14,6 +14,7 @@ func TestAccDataSourceComposerUserWorkloadsConfigMap_basic(t *testing.T) {
 	context := map[string]interface{}{
 		"env_name":        fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t)),
 		"config_map_name": fmt.Sprintf("tf-test-composer-config-map-%d", acctest.RandInt(t)),
+		"service_account": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -33,13 +34,18 @@ func TestAccDataSourceComposerUserWorkloadsConfigMap_basic(t *testing.T) {
 
 func testAccDataSourceComposerUserWorkloadsConfigMap_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {}
 resource "google_composer_environment" "test" {
   name   = "%{env_name}"
   config {
     software_config {
       image_version = "composer-3-airflow-2"
     }
+    node_config {
+      service_account = google_service_account.test.name
+    }
   }
+  depends_on = [google_project_iam_member.composer-worker]
 }
 resource "google_composer_user_workloads_config_map" "test" {
   environment = google_composer_environment.test.name
@@ -52,6 +58,15 @@ resource "google_composer_user_workloads_config_map" "test" {
 data "google_composer_user_workloads_config_map" "test" {
   name        = google_composer_user_workloads_config_map.test.name
   environment = google_composer_environment.test.name
+}
+resource "google_service_account" "test" {
+  account_id   = "%{service_account}"
+  display_name = "Test Service Account for Composer Environment"
+}
+resource "google_project_iam_member" "composer-worker" {
+  project = data.google_project.project.project_id
+  role   = "roles/composer.worker"
+  member = "serviceAccount:${google_service_account.test.email}"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret_test.go
+++ b/mmv1/third_party/terraform/services/composer/data_source_google_composer_user_workloads_secret_test.go
@@ -15,8 +15,9 @@ func TestAccDataSourceComposerUserWorkloadsSecret_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"env_name":    fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t)),
-		"secret_name": fmt.Sprintf("%s-%d", testComposerUserWorkloadsSecretPrefix, acctest.RandInt(t)),
+		"env_name":        fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t)),
+		"secret_name":     fmt.Sprintf("%s-%d", testComposerUserWorkloadsSecretPrefix, acctest.RandInt(t)),
+		"service_account": fmt.Sprintf("tf-test-%d", acctest.RandInt(t)),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -76,13 +77,18 @@ func checkSecretDataSourceMatchesResource() resource.TestCheckFunc {
 
 func testAccDataSourceComposerUserWorkloadsSecret_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+data "google_project" "project" {}
 resource "google_composer_environment" "test" {
   name   = "%{env_name}"
   config {
     software_config {
       image_version = "composer-3-airflow-2"
     }
+    node_config {
+      service_account = google_service_account.test.name
+    }
   }
+  depends_on = [google_project_iam_member.composer-worker]
 }
 resource "google_composer_user_workloads_secret" "test" {
   environment = google_composer_environment.test.name
@@ -95,6 +101,15 @@ resource "google_composer_user_workloads_secret" "test" {
 data "google_composer_user_workloads_secret" "test" {
   name        = google_composer_user_workloads_secret.test.name
   environment = google_composer_environment.test.name
+}
+resource "google_service_account" "test" {
+  account_id   = "%{service_account}"
+  display_name = "Test Service Account for Composer Environment"
+}
+resource "google_project_iam_member" "composer-worker" {
+  project = data.google_project.project.project_id
+  role   = "roles/composer.worker"
+  member = "serviceAccount:${google_service_account.test.email}"
 }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes failing datasource tests by adding service account in configurations.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
