### PR TITLE
fix: access_contetx_manager_access_policy scopes field should be immutable

### DIFF
--- a/mmv1/products/accesscontextmanager/AccessPolicy.yaml
+++ b/mmv1/products/accesscontextmanager/AccessPolicy.yaml
@@ -90,6 +90,7 @@ parameters:
     description: |
       Folder or project on which this policy is applicable.
       Format: 'folders/{{folder_id}}' or 'projects/{{project_number}}'
+    immutable: true
     item_type:
       type: String
     max_size: 1


### PR DESCRIPTION
GCP does not allow in-place update for AccessPolicy resources when the scopes field is changed.

```release-note: bug
accesscontextmanager: made `scopes` field as immutable for `access_context_manager_access_policy` resource.
```

--- 

This is based on the error I am receiving when running `terraform apply` using `hashicorp/google v6.46.0`.

```
Code: INVALID_ARGUMENT [google.rpc.error_details_ext] { message: \"Cannot change scopes of access policy; delete and recreate.\" }
```
