### PR TITLE
Remove dynamic block from pubsub tests

### DIFF
--- a/mmv1/templates/terraform/examples/pubsub_subscription_multiple_smts.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_multiple_smts.tf.tmpl
@@ -2,9 +2,12 @@ resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "topic_name"}}"
 }
 
-locals {
-  smts = [
-    {
+resource "google_pubsub_subscription" "{{$.PrimaryResourceId}}" {
+  name  = "{{index $.Vars "subscription_name"}}"
+  topic = google_pubsub_topic.{{$.PrimaryResourceId}}.id
+
+  message_transforms {
+    javascript_udf {
       function_name = "redactSSN"
       code = <<EOF
 function redactSSN(message, metadata) {
@@ -14,36 +17,25 @@ function redactSSN(message, metadata) {
   return message;
 }
 EOF
-    },
-    {
-      function_name = "otherFunc",
+    }
+  }
+
+  message_transforms {
+    javascript_udf {
+      function_name = "otherFunc"
       code = <<EOF
 function otherFunc(message, metadata) {
   return null;
 }
 EOF
-    },
-    {
-      function_name = "someSMTWeDisabled",
-      code = "..."
-      disabled = true
     }
-  ]
-}
+  }
 
-resource "google_pubsub_subscription" "{{$.PrimaryResourceId}}" {
-  name  = "{{index $.Vars "subscription_name"}}"
-  topic = google_pubsub_topic.{{$.PrimaryResourceId}}.id
-
-  dynamic "message_transforms" {
-    for_each = local.smts
-
-    content {
-      disabled = lookup(message_transforms.value, "disabled", null)
-      javascript_udf {
-        function_name = message_transforms.value.function_name
-        code = message_transforms.value.code
-      }
+  message_transforms {
+    disabled = true
+    javascript_udf {
+      function_name = "someSMTWeDisabled"
+      code = "..."
     }
   }
 }

--- a/mmv1/templates/terraform/examples/pubsub_topic_multiple_smts.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_topic_multiple_smts.tf.tmpl
@@ -1,6 +1,8 @@
-locals {
-  smts = [
-    {
+resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "topic_name"}}"
+
+  message_transforms {
+    javascript_udf {
       function_name = "redactSSN"
       code = <<EOF
 function redactSSN(message, metadata) {
@@ -10,35 +12,25 @@ function redactSSN(message, metadata) {
   return message;
 }
 EOF
-    },
-    {
-      function_name = "otherFunc",
+    }
+  }
+
+  message_transforms {
+    javascript_udf {
+      function_name = "otherFunc"
       code = <<EOF
 function otherFunc(message, metadata) {
   return null;
 }
 EOF
-    },
-    {
-      function_name = "someSMTWeDisabled",
-      code = "..."
-      disabled = true
     }
-  ]
-}
+  }
 
-resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
-  name = "{{index $.Vars "topic_name"}}"
-
-  dynamic "message_transforms" {
-    for_each = local.smts
-
-    content {
-      disabled = lookup(message_transforms.value, "disabled", null)
-      javascript_udf {
-        function_name = message_transforms.value.function_name
-        code = message_transforms.value.code
-      }
+  message_transforms {
+    disabled = true
+    javascript_udf {
+      function_name = "someSMTWeDisabled"
+      code = "..."
     }
   }
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Remove dynamic block from pubsub tests, which caused the TGC integration test failure. 

For cai2hcl conversion, the cai asset will be converted into HCL without dynamic block. To compare the raw configuration and the converted configuration, the dynamic block needs to be removed from the raw config.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
