### PR TITLE
Remove the default value of view.use_legacy_sql in google_bigquery_table

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -1051,13 +1051,12 @@ func ResourceBigQueryTable() *schema.Resource {
 						},
 
 						// UseLegacySQL: [Optional] Specifies whether to use BigQuery's
-						// legacy SQL for this view. The default value is true. If set to
-						// false, the view will use BigQuery's standard SQL:
+						// legacy SQL for this view. If set to false, the view will use
+						// BigQuery's standard SQL:
 						"use_legacy_sql": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Default:     true,
-							Description: `Specifies whether to use BigQuery's legacy SQL for this view. The default value is true. If set to false, the view will use BigQuery's standard SQL`,
+							Description: `Specifies whether to use BigQuery's legacy SQL for this view. If set to false, the view will use BigQuery's standard SQL`,
 						},
 					},
 				},

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -102,6 +102,12 @@ Description of the change and how users should adjust their configuration (if ne
 
 ## Resources
 
+## Resource: `google_bigquery_table`
+
+### `view.use_legacy_sql` no longer has a default value of `True`
+
+If `view.use_legacy_sql` is not specified in the configuration, no value is sent to the API.
+
 ## Resource: `google_bigtable_table_iam_binding`
 
 ### `instance` is now removed

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -425,7 +425,7 @@ The following arguments are supported:
 * `query` - (Required) A query that BigQuery executes when the view is referenced.
 
 * `use_legacy_sql` - (Optional) Specifies whether to use BigQuery's legacy SQL for this view.
-    The default value is true. If set to false, the view will use BigQuery's standard SQL.
+    If set to false, the view will use BigQuery's standard SQL.
     -> **Note**: Starting in provider version `7.0.0`, no default value is
     provided for this field unless explicitly set in the configuration.
 


### PR DESCRIPTION
Context of the breaking change: https://github.com/GoogleCloudPlatform/magic-modules/pull/12390#discussion_r1941991099
Documentation update in `main`: https://github.com/GoogleCloudPlatform/magic-modules/pull/14574

The API accepts three values: `null`, `true`, `false`, and treats `null` and `false` as separate values. I tested in TF before to confirm they are different since the input of not setting vs setting to false comes back from the API response as `null` vs `false`.

For a user without it in their config, after upgrading to this version, they will see `true -> (none)`.

This change is required for an upcoming feature where this field can't be set, so TF users of that feature need to leave it out in their config, and also there can't be a TF default value when they leave it unset.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
bigquery: removed the default value of `view.use_legacy_sql` in `google_bigquery_table`
```
