### PR TITLE
`mmv1`: add `custom_identity_read` custom code support in yaml

### DIFF
--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -132,6 +132,9 @@ type CustomCode struct {
 	// inserts that for you - do not include it in your custom code.
 	CustomIdentitySchema *string `yaml:"custom_identity_schema,omitempty"`
 
+	// This code is run in the Read method to set the identity.
+	CustomIdentityRead string `yaml:"custom_identity_read"`
+
 	// This code is run just after the import method succeeds - it
 	// is useful for parsing attributes that are necessary for
 	// the Read() method to succeed.

--- a/mmv1/products/apigee/AddonsConfig.yaml
+++ b/mmv1/products/apigee/AddonsConfig.yaml
@@ -42,6 +42,7 @@ custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_addons.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/apigee_addons_override.go.tmpl'
   custom_identity_schema: 'templates/terraform/custom_identity_schema/apigee_addons.go.tmpl'
+  custom_identity_read: 'templates/terraform/custom_identity_read/apigee_addons.go.tmpl'
 examples:
   - name: 'apigee_addons_basic'
     exclude_test: true

--- a/mmv1/products/iap/Brand.yaml
+++ b/mmv1/products/iap/Brand.yaml
@@ -54,6 +54,7 @@ identity:
 custom_code:
   custom_import: 'templates/terraform/custom_import/iap_brand.go.tmpl'
   custom_identity_schema: 'templates/terraform/custom_identity_schema/iap_brand.go.tmpl'
+  custom_identity_read: 'templates/terraform/custom_identity_read/iap_brand.go.tmpl'
 examples:
   - name: 'iap_brand'
     primary_resource_id: 'project_brand'

--- a/mmv1/templates/terraform/custom_identity_read/apigee_addons.go.tmpl
+++ b/mmv1/templates/terraform/custom_identity_read/apigee_addons.go.tmpl
@@ -1,0 +1,10 @@
+	identity, err := d.Identity()
+	if err != nil {
+		return fmt.Errorf("Error getting identity: %s", err)
+	}
+	if v, ok := identity.GetOk("org"); ok && v != "" {
+		err = identity.Set("org", d.Get("org").(string))
+		if err != nil {
+			return fmt.Errorf("Error setting org: %s", err)
+		}
+	}

--- a/mmv1/templates/terraform/custom_identity_read/iap_brand.go.tmpl
+++ b/mmv1/templates/terraform/custom_identity_read/iap_brand.go.tmpl
@@ -1,0 +1,10 @@
+	identity, err := d.Identity()
+	if err != nil {
+		return fmt.Errorf("Error getting identity: %s", err)
+	}
+	if v, ok := identity.GetOk("project"); ok && v != "" {
+		err = identity.Set("project", d.Get("project").(string))
+		if err != nil {
+			return fmt.Errorf("Error setting project: %s", err)
+		}
+	}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -718,6 +718,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     }
 {{- end}}
 
+{{- if $.CustomCode.CustomIdentityRead }}
+    {{ $.CustomTemplate $.CustomCode.CustomIdentityRead true -}}
+{{- else }}
 	identity, err := d.Identity()
 	if err != nil {
 		return fmt.Errorf("Error getting identity: %s", err)
@@ -730,8 +733,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
             }     
     }
     {{- end }}
-    return nil
+{{- end }}
 {{  end -}}
+    return nil
 }
 
 {{if $.Updatable -}}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

follows the same problem that we ran into for two resources when it comes to `identity_schema` based on generation implementation. We've also need to add this to support the generation of read in both of these resources as well

follows same generation implementations found in:
 - https://github.com/GoogleCloudPlatform/magic-modules/pull/14166

<img width="1434" height="822" alt="image" src="https://github.com/user-attachments/assets/4a243f9e-43c5-4180-8def-7f24fed8600c" />

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
