### PR TITLE
fix sweepers for resources with overridden names

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -408,7 +408,11 @@ func (r *Resource) SetDefault(product *Product) {
 		r.ApiName = r.Name
 	}
 	if r.CollectionUrlKey == "" {
-		r.CollectionUrlKey = google.Camelize(google.Plural(r.Name), "lower")
+		key := r.Name
+		if r.ApiResourceTypeKind != "" {
+			key = r.ApiResourceTypeKind
+		}
+		r.CollectionUrlKey = google.Camelize(google.Plural(key), "lower")
 	}
 	if r.IdFormat == "" {
 		r.IdFormat = r.SelfLinkUri()

--- a/mmv1/products/storagetransfer/AgentPool.yaml
+++ b/mmv1/products/storagetransfer/AgentPool.yaml
@@ -14,6 +14,7 @@
 ---
 name: 'AgentPool'
 api_resource_type_kind: agentPools
+collection_url_key: agentPools
 description: 'Represents an On-Premises Agent pool.'
 references:
   guides:


### PR DESCRIPTION
Currently, sweepers are not functioning correctly for resources with overridden names. It looks for terraform resource name instead of API name in the list response and as a result, fails to identify any sweepable resources. (example: google_tpu_v2_vm, [TC run](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS_SERVICE_SWEEPER/430956?buildTab=tests&name=tpu&expandedTest=build%3A%28id%3A430956%29%2Cid%3A2000000270)) This issue has been hidden because the sweeper tests pass with "no resources found"

This PR is to address the issue by changing `CollectionUrlKey` to default to the API name if `ApiResourceTypeKind` exists, otherwise falling back to the Terraform resource name (current behavior).

Tested the change locally for google_tpu_v2_vm sweeper, and confirmed it worked:
```
......
2025/08/05 20:52:15 [DEBUG] Google API Request Details:
---[ REQUEST ]---------------------------------------
DELETE /v2alpha1/projects/ci-test-project-nightly-beta/locations/us-central1-c/nodes/tf-test-test-tpuuv81i9j7rm?alt=json HTTP/1.1
Host: tpu.googleapis.com
Content-Type: application/json
Accept-Encoding: gzip


-----------------------------------------------------
2025/08/05 20:52:15 [DEBUG] Google API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
Content-Type: application/json; charset=UTF-8
Date: Wed, 06 Aug 2025 03:52:15 GMT
Server: ESF
Vary: Origin
Vary: X-Origin
Vary: Referer
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0

{
  "name": "projects/ci-test-project-nightly-beta/locations/us-central1-c/operations/operation-1754452335901-63baa4441b95a-6d40b400-982ff6a7",
  "metadata": {
    "@type": "type.googleapis.com/google.cloud.common.OperationMetadata",
    "createTime": "2025-08-06T03:52:15.927663832Z",
    "target": "projects/ci-test-project-nightly-beta/locations/us-central1-c/nodes/tf-test-test-tpuuv81i9j7rm",
    "verb": "delete",
    "cancelRequested": false,
    "apiVersion": "v2alpha1"
  },
  "done": false
}

-----------------------------------------------------
2025/08/05 20:52:15 [DEBUG] Retry Transport: Stopping retries, last request was successful
2025/08/05 20:52:15 [DEBUG] Retry Transport: Returning after 1 attempts
2025/08/05 20:52:15 [INFO][SWEEPER_LOG] Sent delete request for TpuV2Vm resource: tf-test-test-tpuuv81i9j7rm
--- PASS: TestAccExecuteSweepers (3.62s)
    --- PASS: TestAccExecuteSweepers/google_tpu_v2_vm (3.61s)
PASS
ok  	github.com/hashicorp/terraform-provider-google-beta/google-beta/sweeper	5.550s
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
