### PR TITLE
Enhance data residency guidance for Apigee with example configuration

### DIFF
--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -1,8 +1,3 @@
-// Note for DRZ Advanced Customers: To ensure DRZ Advanced compliance for data-in-transit,
-// you must use the appropriate multi-regional endpoint (mREP) for the `apigee_custom_endpoint`.
-// This is the primary configuration required from a customer's perspective to leverage
-// DRZ Advanced capabilities. Other guarantees for data-in-use and data-at-rest are
-// managed by the Apigee service and Google's underlying infrastructure.
 provider "google" {
   apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -1,3 +1,8 @@
+// Note for DRZ Advanced Customers: To ensure DRZ Advanced compliance for data-in-transit,
+// you must use the appropriate multi-regional endpoint (mREP) for the 'apigee_custom_endpoint'.
+// This is the primary configuration required from a customer's perspective to leverage
+// DRZ Advanced capabilities. Other guarantees for data-in-use and data-at-rest are
+// managed by the Apigee service and Google's underlying infrastructure.
 provider "google" {
   apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -1,3 +1,8 @@
+// Note for DRZ Advanced Customers: To ensure DRZ Advanced compliance for data-in-transit,
+// you must use the appropriate multi-regional endpoint (mREP) for the `apigee_custom_endpoint`.
+// This is the primary configuration required from a customer's perspective to leverage
+// DRZ Advanced capabilities. Other guarantees for data-in-use and data-at-rest are
+// managed by the Apigee service and Google's underlying infrastructure.
 provider "google" {
   apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -1,8 +1,5 @@
-// Note for DRZ Advanced Customers: To ensure DRZ Advanced compliance for data-in-transit,
-// you must use the appropriate multi-regional endpoint (mREP) for the 'apigee_custom_endpoint'.
-// This is the primary configuration required from a customer's perspective to leverage
-// DRZ Advanced capabilities. Other guarantees for data-in-use and data-at-rest are
-// managed by the Apigee service and Google's underlying infrastructure.
+// For advanced data residency customers: To ensure advanced data residency compliance for data
+// in transit, you must use the appropriate regional endpoint for the 'apigee_custom_endpoint'.
 provider "google" {
   apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
 }

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -368,6 +368,22 @@ Support for custom endpoints is on a best-effort basis. The underlying
 endpoint and default values for a resource can be changed at any time without
 being considered a breaking change.
 
+**Data Residency and DRZ Advanced**
+
+For services that support Data Residency, you can specify a regional endpoint to ensure your data is processed and stored in a specific geographic location.
+
+For services offering DRZ Advanced capabilities, it is critical to use the correct multi-regional endpoint (mREP) to ensure data remains within the chosen multi-region during transit. This is the main action required in your Terraform configuration to utilize a service's DRZ Advanced features. Other advanced guarantees, such as ensuring data is processed only within the selected location (data-in-use), are provided by the service's backend and Google's infrastructure and do not require specific Terraform configuration.
+
+Example for Apigee with a European Union mREP:
+
+```
+provider "google" {
+  apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
+}
+```
+
+Always consult the specific service documentation for the correct regional or multi-regional endpoint to use.
+
 ---
 
 * `universe_domain` - (Optional) Specify the GCP universe to deploy in.

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -368,11 +368,11 @@ Support for custom endpoints is on a best-effort basis. The underlying
 endpoint and default values for a resource can be changed at any time without
 being considered a breaking change.
 
-**Data Residency and DRZ Advanced**
+**Data Residency and Data Residency (DRZ) Advanced**
 
 For services that support Data Residency, you can specify a regional endpoint to ensure your data is processed and stored in a specific geographic location.
 
-For services offering DRZ Advanced capabilities, it is critical to use the correct multi-regional endpoint (mREP) to ensure data remains within the chosen multi-region during transit. This is the main action required in your Terraform configuration to utilize a service's DRZ Advanced features. Other advanced guarantees, such as ensuring data is processed only within the selected location (data-in-use), are provided by the service's backend and Google's infrastructure and do not require specific Terraform configuration.
+For services offering Data Residency (DRZ) Advanced capabilities, it is critical to use the correct multi-regional endpoint (mREP) to ensure data remains within the chosen multi-region during transit. This is the main action required in your Terraform configuration to utilize a service's DRZ Advanced features. Other advanced guarantees, such as ensuring data is processed only within the selected location (data-in-use), are provided by the service's backend and Google's infrastructure and do not require specific Terraform configuration.
 
 Example for Apigee with a European Union mREP:
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -378,7 +378,7 @@ Example for Apigee with a European Union mREP:
 
 ```
 provider "google" {
-  apigee_custom_endpoint = "https://eu-apigee.googleapis.com/v1/"
+  apigee_custom_endpoint = "https://apigee.eu.rep.googleapis.com/v1/"
 }
 ```
 

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -368,13 +368,15 @@ Support for custom endpoints is on a best-effort basis. The underlying
 endpoint and default values for a resource can be changed at any time without
 being considered a breaking change.
 
-**Data Residency and Data Residency (DRZ) Advanced**
+**Data residency at rest and advanced data residency**
 
-For services that support Data Residency, you can specify a regional endpoint to ensure your data is processed and stored in a specific geographic location.
+For services that support data residency at rest, you can specify a regional endpoint 
+to ensure your data is processed and stored in a specific geographic location.
 
-For services offering Data Residency (DRZ) Advanced capabilities, it is critical to use the correct multi-regional endpoint (mREP) to ensure data remains within the chosen multi-region during transit. This is the main action required in your Terraform configuration to utilize a service's DRZ Advanced features. Other advanced guarantees, such as ensuring data is processed only within the selected location (data-in-use), are provided by the service's backend and Google's infrastructure and do not require specific Terraform configuration.
+For services offering advanced data residency, it is critical to use the correct regional 
+endpoint to ensure data remains within the chosen region when at use, in use, and in transit.
 
-Example for Apigee with a European Union mREP:
+Example of Apigee regional endpoint for the European Union:
 
 ```
 provider "google" {


### PR DESCRIPTION
Improve documentation on data residency and DRZ Advanced capabilities for Apigee, including a specific example configuration for using a multi-regional endpoint.

```release-note:none
docs: Improve documentation on data residency and DRZ Advanced capabilities for Apigee, including a specific example configuration for using a multi-regional endpoint.
```