### PR TITLE
`resourceIdentity`: explcit conditional check of empty ID for identity import use

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -21,25 +21,15 @@ import (
 func ParseImportId(idRegexes []string, d TerraformResourceData, config *transport_tpg.Config) error {
 	for _, idFormat := range idRegexes {
 		re, err := regexp.Compile(idFormat)
-
 		if err != nil {
 			log.Printf("[DEBUG] Could not compile %s.", idFormat)
 			return fmt.Errorf("Import is not supported. Invalid regex formats.")
 		}
-
-		if d.Id() == "" {
-			identity, err := d.Identity()
-			if err != nil {
-				return err
-			}
-			if err := identityImport(re, identity, idFormat, d); err != nil {
-				return err
-			}
-			err = setDefaultValues(idRegexes[0], identity, d, config)
-			if err != nil {
-				return err
-			}
-		} else if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
+		identity, err := d.Identity()
+		if err != nil {
+			return err
+		}
+		if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
 			log.Printf("[DEBUG] matching ID %s to regex %s.", d.Id(), idFormat)
 			// Starting at index 1, the first match is the full string.
 			for i := 1; i < len(fieldValues); i++ {
@@ -60,12 +50,22 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 					if err = d.Set(fieldName, fieldValue); err != nil {
 						return err
 					}
+					if identity != nil {
+						if err = identity.Set(fieldName, fieldValue); err != nil {
+							return err
+						}
+					}
 				} else if _, ok := val.(int); ok {
 					if intVal, atoiErr := strconv.Atoi(fieldValue); atoiErr == nil {
 						// If the value can be parsed as an integer, we try to set the
 						// value as an integer.
 						if err = d.Set(fieldName, intVal); err != nil {
 							return err
+						}
+						if identity != nil {
+							if err = identity.Set(fieldName, intVal); err != nil {
+								return err
+							}
 						}
 					} else {
 						return fmt.Errorf("%s appears to be an integer, but %v cannot be parsed as an int", fieldName, fieldValue)
@@ -82,6 +82,20 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 				return err
 			}
 
+			err = setDefaultValues(idRegexes[0], identity, d, config)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		} else if d.Id() == "" {
+			if err := identityImport(re, identity, idFormat, d); err != nil {
+				return err
+			}
+			err = setDefaultValues(idRegexes[0], identity, d, config)
+			if err != nil {
+				return err
+			}
 			return nil
 		}
 	}
@@ -89,15 +103,21 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 }
 
 func identityImport(re *regexp.Regexp, identity *schema.IdentityData, idFormat string, d TerraformResourceData) error {
+	if identity == nil {
+		return nil
+	}
 	log.Print("[DEBUG] Using IdentitySchema to import resource")
 	namedGroups := re.SubexpNames()
-
 	for _, group := range namedGroups {
-		if identityValue, identityExists := identity.GetOk(group); identityExists {
-			log.Printf("[DEBUG] Importing %s = %s", group, identityValue)
+		if val, ok := d.GetOk(group); ok && group != "" {
+			log.Printf("[DEBUG] Group %s = %s Identity Group", group, val)
+			identity.Set(group, val)
+		}
+		if identityValue, identityExists := identity.GetOk(group); identityExists && group != "" {
+			log.Printf("[DEBUG] identity Importing %s = %s", group, identityValue)
 			d.Set(group, identityValue)
 		} else {
-			return fmt.Errorf("No value was found for %s during import", group)
+			return fmt.Errorf("[DEBUG] No value was found for %s during import", group)
 		}
 	}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->


This PR improves upon: 
- https://github.com/GoogleCloudPlatform/magic-modules/pull/13921

as we weren't explicitly checking whether the id was `""` or not something that must be done when wanting to use `ResourceIdentity` import since we do not provide an Id string when utilizing the new identity block

This fix comes after being able to run in [TC CI](https://hashicorp.teamcity.com/buildConfiguration/Development_TerraformProviderGoogle_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_TRANSCODER?branch=%3Cdefault%3E&buildTypeTab=overview) and detecting test failures, the most recent run is with this fix which was applied on [`identity_playground`](https://github.com/BBBmau/terraform-provider-google/commits/identity_playground/) branch which is where the CI is being run on.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
