### PR TITLE
artifactregistry: added `registry_uri` as attribute to `google_artifact_registry_repository`

### DIFF
--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -6,15 +6,12 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-    "github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccArtifactRegistryRepository_update(t *testing.T) {
 	t.Parallel()
 
 	repositoryID := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
-    project := envvar.GetTestProjectFromEnv()
-    expectedUri := fmt.Sprintf("us-central1-docker.pkg.dev/%s/%s", project, repositoryID)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -23,7 +20,6 @@ func TestAccArtifactRegistryRepository_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccArtifactRegistryRepository_update(repositoryID),
-				Check:  resource.TestCheckResourceAttr("google_artifact_registry_repository.test", "registry_uri", expectedUri),
 			},
 			{
 				ResourceName:      "google_artifact_registry_repository.test",


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/11355

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
artifactregistry: added `registry_uri` as attribute to `google_artifact_registry_repository`
```

**Tests:**

```
 make testacc TEST=./google/services/artifactregistry TESTARGS='-run=TestAccArtifactRegistryRepository_update'

.TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/artifactregistry -v -run=TestAccArtifactRegistryRepository_update -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"

=== RUN   TestAccArtifactRegistryRepository_update
=== PAUSE TestAccArtifactRegistryRepository_update
=== RUN   TestAccArtifactRegistryRepository_updateEmptyMvn
=== PAUSE TestAccArtifactRegistryRepository_updateEmptyMvn
=== CONT  TestAccArtifactRegistryRepository_update
=== CONT  TestAccArtifactRegistryRepository_updateEmptyMvn
--- PASS: TestAccArtifactRegistryRepository_update (16.29s)
--- PASS: TestAccArtifactRegistryRepository_updateEmptyMvn (25.40s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/artifactregistry 26.147s
```
