### PR TITLE
Fix for desired_auto_created_endpoints incorrect update

### DIFF
--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -85,10 +85,25 @@
 					}
 				}
 			}
+			// NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
+			// When desired_auto_created_endpoints is set this flow works as expected
+			// FLOW: Terraform  -> API Input -> API Output -> Terraform output
+			// CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
+			// CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
+			// The if else if below checks what is define by the user in order to set the correct fielt in the state
 			if len(transformed) > 0 {
-				d.Set("desired_auto_created_endpoints", transformed)
-				log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder for %#v", transformed)
-
+				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
+				_, okPsc := d.GetOk("desired_psc_auto_connections")
+				if okEndpoint {
+					d.Set("desired_auto_created_endpoints", transformed)
+					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
+				} else if okPsc {
+					d.Set("desired_psc_auto_connections", transformed)
+					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+				}
 			}
 		}
 

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -1537,3 +1537,73 @@ data "google_project" "project" {
 }
 `, context)
 }
+
+func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"location":      "us-central1",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-cluster-disabled" {
+  instance_id                  = "tf-test-instance-psc%{random_suffix}"
+  shard_count                  = 1
+  desired_psc_auto_connections {
+    network                    = google_compute_network.producer_net.id
+    project_id                 = data.google_project.project.project_id
+  }
+  location                     = "%{location}"
+  deletion_protection_enabled  = false
+  mode                         = "CLUSTER_DISABLED"
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                           = "tf-test-my-policy%{random_suffix}"
+  location                       = "%{location}"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks                  = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name                           = "tf-test-my-subnet%{random_suffix}"
+  ip_cidr_range                  = "10.0.0.248/29"
+  region                         = "%{location}"
+  network                        = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                           = "tf-test-my-network%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}


### PR DESCRIPTION
Fix for issue https://github.com/terraform-google-modules/terraform-google-memorystore/issues/314

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
memorystore:  `desired_auto_created_endpoints` field incorrectly updated when desired_psc_auto_connections should have been 
```