### PR TITLE
tgc-revival: set an object to nil if its all values are nil during cai2hcl

### DIFF
--- a/mmv1/templates/terraform/flatten_property_method.go.tmpl
+++ b/mmv1/templates/terraform/flatten_property_method.go.tmpl
@@ -47,6 +47,11 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}{{$prop.TitlelizeProperty}}(original["{{ $prop.ApiName }}"], d, config)
       {{- end }}
     {{- end }}
+    {{- if and $.ResourceMetadata.IsTgcCompiler (not $.AllowEmptyObject) }}
+    if tgcresource.AllValuesAreNil(transformed) {
+      return nil
+    }
+    {{- end }}
   return []interface{}{transformed}
   {{- else if and ($.IsA "Array") ($.ItemType.IsA "NestedObject") }}
   if v == nil {

--- a/mmv1/third_party/tgc_next/pkg/tgcresource/utils.go
+++ b/mmv1/third_party/tgc_next/pkg/tgcresource/utils.go
@@ -61,3 +61,18 @@ func MergeFlattenedProperties(hclData map[string]interface{}, flattenedProp inte
 	}
 	return nil
 }
+
+// Checks if all values in the map are nil
+func AllValuesAreNil(m map[string]interface{}) bool {
+	if len(m) == 0 {
+		return true
+	}
+
+	for _, v := range m {
+		if v != nil {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->



In an CAI asset, it is possible that an object field only has output fields. But the output fields are not converted during cai2hcl. The field will be an empty object in converted HCL.


This PR set an object to nil if its all values are nil during cai2hcl. With this change, the field will not show up  instead of empty object in converted HCL.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
