### PR TITLE
make event_type required in `google_cloudfunctions2_function` resource

### DIFF
--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -678,6 +678,7 @@ properties:
         default_from_api: true
       - name: 'eventType'
         type: String
+        required: true
         description: 'Required. The type of event to observe.'
       - name: 'eventFilters'
         type: Array

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -164,6 +164,10 @@ Remove `description` from your configuration after upgrade.
 
 ## Resource: `google_cloudfunctions2_function`
 
+### `event_trigger.event_type` is now required
+
+The `event_type` field is now required when `event_trigger` is configured.
+
 ### `service_config.service` is changed from `Argument` to `Attribute`
 
 Remove `service_config.service` from your configuration after upgrade.


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/18961
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
cloudfunctions2: made `event_type` a required field for `event_trigger` in `google_cloudfunctions2_function`
```
