### PR TITLE
tgc-revival: retry 3 times for missing fields error

### DIFF
--- a/mmv1/third_party/tgc_next/go.mod
+++ b/mmv1/third_party/tgc_next/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/sethvargo/go-retry v0.3.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/exp v0.0.0-20240409090435-93d18d7e34b8

--- a/mmv1/third_party/tgc_next/go.sum
+++ b/mmv1/third_party/tgc_next/go.sum
@@ -235,6 +235,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
+github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -56,7 +56,7 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, ignoredAssetF
 
 		logger := zaptest.NewLogger(t)
 
-		// If the primary resource is available, only test the primary resource.
+		// If the primary resource is specified, only test the primary resource.
 		// Otherwise, test all of the resources in the test.
 		if primaryResource != "" {
 			t.Logf("Test for the primary resource %s begins.", primaryResource)

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl"
 	cai2hclconverters "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/cai2hcl/converters"
@@ -18,6 +19,7 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/caiasset"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai"
 	tfplan2caiconverters "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/pkg/tfplan2cai/converters"
+	"github.com/sethvargo/go-retry"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -32,38 +34,57 @@ var (
 )
 
 func BidirectionalConversion(t *testing.T, ignoredFields []string, ignoredAssetFields []string) {
-	resourceTestData, primaryResource, err := prepareTestData(t.Name())
-	if err != nil {
-		t.Fatal("Error preparing the input data:", err)
-	}
-
-	if resourceTestData == nil {
-		t.Skipf("The test data is unavailable.")
-	}
-
-	// Create a temporary directory for running terraform.
-	tfDir, err := os.MkdirTemp(tmpDir, "terraform")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(tfDir)
-
-	logger := zaptest.NewLogger(t)
-
-	// If the primary resource is available, only test the primary resource.
-	// Otherwise, test all of the resources in the test.
-	if primaryResource != "" {
-		t.Logf("Test for the primary resource %s begins.", primaryResource)
-		err = testSingleResource(t, t.Name(), resourceTestData[primaryResource], tfDir, ignoredFields, ignoredAssetFields, logger, true)
+	retries := 0
+	flakyAction := func(ctx context.Context) error {
+		log.Printf("Starting the retry %d", retries)
+		resourceTestData, primaryResource, err := prepareTestData(t.Name(), retries)
+		retries++
 		if err != nil {
-			t.Fatal("Test fails:", err)
+			return fmt.Errorf("error preparing the input data: %v", err)
 		}
-	} else {
-		for _, testData := range resourceTestData {
-			err = testSingleResource(t, t.Name(), testData, tfDir, ignoredFields, ignoredAssetFields, logger, false)
+
+		if resourceTestData == nil {
+			return retry.RetryableError(fmt.Errorf("fail: test data is unavailable"))
+		}
+
+		// Create a temporary directory for running terraform.
+		tfDir, err := os.MkdirTemp(tmpDir, "terraform")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tfDir)
+
+		logger := zaptest.NewLogger(t)
+
+		// If the primary resource is available, only test the primary resource.
+		// Otherwise, test all of the resources in the test.
+		if primaryResource != "" {
+			t.Logf("Test for the primary resource %s begins.", primaryResource)
+			err = testSingleResource(t, t.Name(), resourceTestData[primaryResource], tfDir, ignoredFields, ignoredAssetFields, logger, true)
 			if err != nil {
-				t.Fatal("Test fails: ", err)
+				return err
 			}
+		} else {
+			for _, testData := range resourceTestData {
+				err = testSingleResource(t, t.Name(), testData, tfDir, ignoredFields, ignoredAssetFields, logger, false)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
+	backoffPolicy := retry.WithMaxRetries(maxRetries, retry.NewConstant(50*time.Millisecond))
+
+	t.Log("Starting test with retry logic.")
+
+	if err := retry.Do(context.Background(), backoffPolicy, flakyAction); err != nil {
+		if strings.Contains(err.Error(), "test data is unavailable") {
+			t.Skipf("Test skipped because data was unavailable after all retries: %v", err)
+		} else {
+			t.Fatalf("Failed after all retries %d: %v", retries, err)
 		}
 	}
 }
@@ -151,8 +172,11 @@ func testSingleResource(t *testing.T, testName string, testData ResourceTestData
 
 	parsedExportConfig := exportResources[0].Attributes
 	missingKeys := compareHCLFields(testData.ParsedRawConfig, parsedExportConfig, ignoredFieldSet)
+
+	// Sometimes, the reason for missing fields could be CAI asset data issue.
 	if len(missingKeys) > 0 {
-		return fmt.Errorf("missing fields in resource %s after cai2hcl conversion:\n%s", testData.ResourceAddress, missingKeys)
+		log.Printf("missing fields in resource %s after cai2hcl conversion:\n%s", testData.ResourceAddress, missingKeys)
+		return retry.RetryableError(fmt.Errorf("missing fields"))
 	}
 	log.Printf("Step 1 passes for resource %s. All of the fields in raw config are in export config", testData.ResourceAddress)
 

--- a/mmv1/third_party/tgc_next/test/setup.go
+++ b/mmv1/third_party/tgc_next/test/setup.go
@@ -142,7 +142,7 @@ func readTestsDataFromGCSForRun(ctx context.Context, currentDate time.Time, buck
 	return metadata, nil
 }
 
-func prepareTestData(testName string) (map[string]ResourceTestData, string, error) {
+func prepareTestData(testName string, retries int) (map[string]ResourceTestData, string, error) {
 	var err error
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
@@ -153,23 +153,20 @@ func prepareTestData(testName string) (map[string]ResourceTestData, string, erro
 
 	var testMetadata TgcMetadataPayload
 	var resourceMetadata map[string]*ResourceMetadata
-	for _, run := range TestsMetadata {
-		var ok bool
-		testMetadata, ok = run.MetadataByTest[testName]
-		if ok {
-			log.Printf("Found metadata for %s from run on %s", testName, run.Date.Format(ymdFormat))
-			resourceMetadata = testMetadata.ResourceMetadata
-			if len(resourceMetadata) > 0 {
-				break
-			}
-		}
-		log.Printf("Missing metadata for %s from run on %s, looking at previous run", testName, run.Date.Format(ymdFormat))
-	}
 
-	if len(resourceMetadata) == 0 {
+	run := TestsMetadata[retries]
+	testMetadata, ok := run.MetadataByTest[testName]
+	if !ok {
 		log.Printf("Data of test is unavailable: %s", testName)
 		return nil, "", nil
 	}
+	resourceMetadata = testMetadata.ResourceMetadata
+	if len(resourceMetadata) == 0 {
+		log.Printf("Data of resource is unavailable: %s", testName)
+		return nil, "", nil
+	}
+
+	log.Printf("Found metadata for %s from run on %s", testName, run.Date.Format(ymdFormat))
 
 	rawTfFile := fmt.Sprintf("%s.tf", testName)
 	err = os.WriteFile(rawTfFile, []byte(testMetadata.RawConfig), 0644)
@@ -186,7 +183,7 @@ func prepareTestData(testName string) (map[string]ResourceTestData, string, erro
 	}
 
 	if len(rawResourceConfigs) == 0 {
-		return nil, "", fmt.Errorf("Test %s fails: raw config is unavailable", testName)
+		return nil, "", fmt.Errorf("test %s fails: raw config is unavailable", testName)
 	}
 
 	rawConfigMap := convertToConfigMap(rawResourceConfigs)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

`TestAccCertificateManagerCertificate_` failed in other PRs because the `data` in cai asset doesn't have all of the fields in some nightly test runs, only have `name` and `creationTime`. In this case, the test failed with the error of missing fields. 

But in previous nights' runs, `data` does have all of the fields. So retry 3 times to use the previous nights' test data.





**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
