### PR TITLE
google_sql_user doc change to indicate password policy is supported for PG

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -141,7 +141,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-The optional `password_policy` block is only supported by Mysql. The `password_policy` block supports:
+The optional `password_policy` block is only supported for creating MySQL and Postgres users. The `password_policy` block supports:
 
 * `allowed_failed_attempts` - (Optional) Number of failed attempts allowed before the user get locked.
 


### PR DESCRIPTION
google_sql_user documentation says password policy can only be set for MySQL users. Tested that this works for Postgres too. Making a documentation change reflecting the same.

```release-note:none

```
