### PR TITLE
Treat skip_initial_version_creation as a create-only parameter for Cloud KMS keys

### DIFF
--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -76,7 +76,7 @@ parameters:
       You must use the `google_kms_crypto_key_version` resource to create a new CryptoKeyVersion
       or `google_kms_key_ring_import_job` resource to import the CryptoKeyVersion.
     url_param_only: true
-    immutable: true
+    ignore_read: true
 properties:
   - name: 'name'
     type: String

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -75,6 +75,7 @@ parameters:
       If set to true, the request will create a CryptoKey without any CryptoKeyVersions.
       You must use the `google_kms_crypto_key_version` resource to create a new CryptoKeyVersion
       or `google_kms_key_ring_import_job` resource to import the CryptoKeyVersion.
+      This field is only applicable during initial CryptoKey creation.
     url_param_only: true
     ignore_read: true
 properties:

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key.go.tmpl
@@ -13,17 +13,6 @@
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
 
-	versionTemplate, ok := d.GetOk("version_template")
-	if !ok {
-		return nil, fmt.Errorf("Error retrieving version_template: %s", err)
-	}
-
-	// skip_initial_version_creation must be true for external keys
-	protectionLevel := versionTemplate.(map[string]interface{})["protection_level"].(string)
-	if err := d.Set("skip_initial_version_creation", protectionLevel == "EXTERNAL" || protectionLevel == "EXTERNAL_VPC"); err != nil {
-		return nil, fmt.Errorf("Error setting skip_initial_version_creation: %s", err)
-	}
-
 	id, err := tpgresource.ReplaceVars(d, config, "{{$.GetIdFormat}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key.go.tmpl
@@ -13,7 +13,14 @@
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
 
-	if err := d.Set("skip_initial_version_creation", false); err != nil {
+	versionTemplate, ok := d.GetOk("version_template")
+	if !ok {
+		return nil, fmt.Errorf("Error retrieving version_template: %s", err)
+	}
+
+	// skip_initial_version_creation must be true for external keys
+	protectionLevel := versionTemplate.(map[string]interface{})["protection_level"].(string)
+	if err := d.Set("skip_initial_version_creation", protectionLevel == "EXTERNAL" || protectionLevel == "EXTERNAL_VPC"); err != nil {
 		return nil, fmt.Errorf("Error setting skip_initial_version_creation: %s", err)
 	}
 

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
@@ -158,7 +158,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 				ResourceName:            "google_kms_crypto_key.crypto_key",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
 			},
 			// Test importing with a short id
 			{
@@ -166,7 +166,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateId:           fmt.Sprintf("%s/%s/%s/%s", projectId, location, keyRingName, cryptoKeyName),
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
@@ -203,25 +203,28 @@ func TestAccKmsCryptoKey_rotation(t *testing.T) {
 				Config: testGoogleKmsCryptoKey_rotation(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			{
 				Config: testGoogleKmsCryptoKey_rotation(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, updatedRotationPeriod),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			{
 				Config: testGoogleKmsCryptoKey_rotationRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
@@ -256,17 +259,19 @@ func TestAccKmsCryptoKey_template(t *testing.T) {
 				Config: testGoogleKmsCryptoKey_template(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, algorithm),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			{
 				Config: testGoogleKmsCryptoKey_template(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, updatedAlgorithm),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
@@ -302,7 +307,7 @@ func TestAccKmsCryptoKey_destroyDuration(t *testing.T) {
 				ResourceName:            "google_kms_crypto_key.crypto_key",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
@@ -344,7 +349,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 				ResourceName:            "google_kms_crypto_key.crypto_key",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleKmsCryptoKey_keyAccessJustificationsPolicy(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, updatedAllowedAccessReason),
@@ -353,7 +358,7 @@ func TestAccKmsCryptoKey_keyAccessJustificationsPolicy(t *testing.T) {
 				ResourceName:            "google_kms_crypto_key.crypto_key",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

There is a lot of custom logic that sets the value of `skip_initial_version_creation` to `false`, which breaks imports for external keys. External keys are required to be set `skip_initial_version_creation = true`. Since this field is marked as immutable, Terraform currently attempts to replace the resource by deleting and recreating it. Cloud KMS keys cannot be deleted, which leaves these keys in permadiff. This change fixes this behavior to only update state for changes to `skip_initial_version_creation`.

`skip_initial_version_creation` is a create-only parameter on the crypto_key resource. It is neither returned from the Cloud KMS API, nor does it affect the resource after initial creation. Changing its value should not result in any remote changes.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
kms: `skip_initial_version_creation` field is no longer immutable in `google_kms_crypto_key`, but is still only settable at-creation
```
