### PR TITLE
Deprecate Cloud TPU tpu_tensorflow_versions resoruce

### DIFF
--- a/mmv1/third_party/terraform/services/tpu/data_source_tpu_tensorflow_versions.go
+++ b/mmv1/third_party/terraform/services/tpu/data_source_tpu_tensorflow_versions.go
@@ -12,24 +12,11 @@ import (
 
 func DataSourceTpuTensorflowVersions() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceTpuTensorFlowVersionsRead,
-		Schema: map[string]*schema.Schema{
-			"project": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"zone": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"versions": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-		},
+   ...
+   DeprecationMessage: "`google_tpu_node` is deprecated and will be removed in a future major release.
+  Use `google_tpu_v2_vm` instead." + "For moving from TPU Node to TPU VM architecture, see
+  https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#from-tpu-node-to-tpu-vm.",
+   ...
 	}
 }
 

--- a/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/tpu_tensorflow_versions.html.markdown
@@ -3,6 +3,10 @@ subcategory: "Cloud TPU"
 description: |-
   Get available TensorFlow versions.
 ---
+~> **Warning:** 
+`google_tpu_node` is deprecated and will be removed in a future major release.
+  Use `google_tpu_v2_vm` instead. For moving from TPU Node to TPU VM architecture, see
+  https://cloud.google.com/tpu/docs/system-architecture-tpu-vm#from-tpu-node-to-tpu-vm.
 
 # google_tpu_tensorflow_versions
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: breaking-change
[Deprecate Cloud TPU tpu_tensorflow_versions resource](tpu: deprecated `tpu_tensorflow_versions` resource. `tpu_tensorflow_versions` is deprecated and will be removed in a future major release. )

```
