### PR TITLE
Add singular data source for retrieving an NPM package from an Artifact Registry repository

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -29,6 +29,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_artifact_registry_docker_image":            artifactregistry.DataSourceArtifactRegistryDockerImage(),
 	"google_artifact_registry_docker_images":           artifactregistry.DataSourceArtifactRegistryDockerImages(),
 	"google_artifact_registry_locations":               artifactregistry.DataSourceGoogleArtifactRegistryLocations(),
+	"google_artifact_registry_npm_package":             artifactregistry.DataSourceArtifactRegistryNpmPackage(),
 	"google_artifact_registry_package":                 artifactregistry.DataSourceArtifactRegistryPackage(),
 	"google_artifact_registry_repositories":            artifactregistry.DataSourceArtifactRegistryRepositories(),
 	"google_artifact_registry_repository":              artifactregistry.DataSourceArtifactRegistryRepository(),

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package.go
@@ -1,0 +1,295 @@
+package artifactregistry
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type NpmPackage struct {
+	name        string
+	packageName string
+	version     string
+	tags        []string
+	createTime  time.Time
+	updateTime  time.Time
+}
+
+func DataSourceArtifactRegistryNpmPackage() *schema.Resource {
+	return &schema.Resource{
+		Read: DataSourceArtifactRegistryNpmPackageRead,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Project ID of the project.",
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The region of the Artifact Registry repository.",
+			},
+			"repository_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The repository ID containing the Npm package.",
+			},
+			"package_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the Npm package.",
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The version of the Npm package.",
+			},
+			"tags": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The tags associated with the Npm package.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The fully qualified name of the Npm package.",
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time the package was created.",
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The time the package was last updated.",
+			},
+		},
+	}
+}
+
+func DataSourceArtifactRegistryNpmPackageRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	var res NpmPackage
+
+	packageName, version := parseNpmPackage(d.Get("package_name").(string))
+
+	if version != "" {
+		// fetch package by version
+		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.npmPackages/get
+		packageUrlSafe := url.QueryEscape(packageName)
+		urlRequest, err := tpgresource.ReplaceVars(d, config, fmt.Sprintf("{{ArtifactRegistryBasePath}}projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages/%s:%s", packageUrlSafe, version))
+		if err != nil {
+			return fmt.Errorf("Error setting api endpoint")
+		}
+
+		resGet, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			RawURL:    urlRequest,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return err
+		}
+
+		res = convertNpmPackageResponseToStruct(resGet)
+	} else {
+		// fetch the list of packages, ordered by update time
+		// https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.npmPackages/list
+		urlRequest, err := tpgresource.ReplaceVars(d, config, "{{ArtifactRegistryBasePath}}projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages")
+		if err != nil {
+			return fmt.Errorf("Error setting api endpoint")
+		}
+
+		// to reduce the number of pages we need to fetch, we set the pageSize to 1000(max)
+		urlRequest, err = transport_tpg.AddQueryParams(urlRequest, map[string]string{"pageSize": "1000"})
+		if err != nil {
+			return err
+		}
+
+		res, err = retrieveAndFilterNpmPackages(d, config, urlRequest, userAgent, packageName, version)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Set Terraform schema fields
+	if err := d.Set("project", project); err != nil {
+		return err
+	}
+	if err := d.Set("package_name", packageName); err != nil {
+		return err
+	}
+	if err := d.Set("name", res.name); err != nil {
+		return err
+	}
+	if err := d.Set("version", res.version); err != nil {
+		return err
+	}
+	if err := d.Set("tags", res.tags); err != nil {
+		return err
+	}
+	if err := d.Set("create_time", res.createTime.Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+	if err := d.Set("update_time", res.updateTime.Format(time.RFC3339Nano)); err != nil {
+		return err
+	}
+
+	d.SetId(res.name)
+
+	return nil
+}
+
+func parseNpmPackage(pkg string) (packageName string, version string) {
+	splitByColon := strings.Split(pkg, ":")
+
+	if len(splitByColon) == 2 {
+		packageName = splitByColon[0]
+		version = splitByColon[1]
+	} else {
+		packageName = pkg
+	}
+
+	return packageName, version
+}
+
+func retrieveAndFilterNpmPackages(d *schema.ResourceData, config *transport_tpg.Config, urlRequest string, userAgent string, packageName string, version string) (NpmPackage, error) {
+	// Paging through the list method until either:
+	// if a version was provided, the matching package name and version pair
+	// otherwise, return the first matching package name
+
+	var allPackages []NpmPackage
+
+	for {
+		resListNpmPackages, token, err := retrieveListOfNpmPackages(config, urlRequest, userAgent)
+		if err != nil {
+			return NpmPackage{}, err
+		}
+
+		for _, pkg := range resListNpmPackages {
+			if strings.Contains(pkg.name, "/"+url.QueryEscape(packageName)+":") {
+				allPackages = append(allPackages, pkg)
+			}
+		}
+
+		if token == "" {
+			break
+		}
+
+		urlRequest, err = transport_tpg.AddQueryParams(urlRequest, map[string]string{"pageToken": token})
+		if err != nil {
+			return NpmPackage{}, err
+		}
+	}
+
+	if len(allPackages) == 0 {
+		return NpmPackage{}, fmt.Errorf("Requested Npm package was not found.")
+	}
+
+	// Client-side sort by updateTime descending and createTime descending
+	sort.Slice(allPackages, func(i, j int) bool {
+		if !allPackages[i].updateTime.Equal(allPackages[j].updateTime) {
+			return allPackages[i].updateTime.After(allPackages[j].updateTime)
+		}
+		return allPackages[i].createTime.After(allPackages[j].createTime)
+	})
+
+	if version != "" {
+		for _, pkg := range allPackages {
+			if pkg.version == version {
+				return pkg, nil
+			}
+		}
+		return NpmPackage{}, fmt.Errorf("Requested version was not found.")
+	}
+
+	// Return the latest package if no version specified
+	return allPackages[0], nil
+}
+
+func retrieveListOfNpmPackages(config *transport_tpg.Config, urlRequest string, userAgent string) ([]NpmPackage, string, error) {
+	resList, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    urlRequest,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return make([]NpmPackage, 0), "", err
+	}
+
+	if nextPageToken, ok := resList["nextPageToken"].(string); ok {
+		return flattenNpmPackageDataSourceListResponse(resList), nextPageToken, nil
+	} else {
+		return flattenNpmPackageDataSourceListResponse(resList), "", nil
+	}
+}
+
+func flattenNpmPackageDataSourceListResponse(res map[string]interface{}) []NpmPackage {
+	var npmPackages []NpmPackage
+
+	resNpmPackages, _ := res["npmPackages"].([]interface{})
+
+	for _, resPackage := range resNpmPackages {
+		pkg, _ := resPackage.(map[string]interface{})
+		npmPackages = append(npmPackages, convertNpmPackageResponseToStruct(pkg))
+	}
+
+	return npmPackages
+}
+
+func convertNpmPackageResponseToStruct(res map[string]interface{}) NpmPackage {
+	var npmPackage NpmPackage
+
+	if name, ok := res["name"].(string); ok {
+		npmPackage.name = name
+	}
+
+	if packageName, ok := res["packageName"].(string); ok {
+		npmPackage.packageName = packageName
+	}
+
+	if version, ok := res["version"].(string); ok {
+		npmPackage.version = version
+	}
+
+	var tags []string
+	if rawTags, ok := res["tags"].([]interface{}); ok {
+		for _, tag := range rawTags {
+			if tagStr, ok := tag.(string); ok {
+				tags = append(tags, tagStr)
+			}
+		}
+	}
+	npmPackage.tags = tags
+
+	if createTimeStr, ok := res["createTime"].(string); ok {
+		npmPackage.createTime, _ = time.Parse(time.RFC3339, createTimeStr)
+	}
+
+	if updateTimeStr, ok := res["updateTime"].(string); ok {
+		npmPackage.updateTime, _ = time.Parse(time.RFC3339, updateTimeStr)
+	}
+
+	return npmPackage
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package_test.go
+++ b/mmv1/third_party/terraform/services/artifactregistry/data_source_artifact_registry_npm_package_test.go
@@ -1,0 +1,67 @@
+package artifactregistry_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceArtifactRegistryNpmPackage_basic(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	// At the moment there are no public Npm packages available in Artifact Registry.
+	// This test is skipped to avoid unnecessary failures.
+	// As soon as there are public packages available, this test can be enabled by removing the skip and adjusting the configuration accordingly.
+	t.Skip("No public Npm packages available in Artifact Registry")
+
+	resourceName := "data.google_artifact_registry_npm_package.test"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceArtifactRegistryNpmPackageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "project"),
+					resource.TestCheckResourceAttrSet(resourceName, "location"),
+					resource.TestCheckResourceAttrSet(resourceName, "repository_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "package_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+					validateNpmPackageTimestamps(resourceName),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceArtifactRegistryNpmPackageConfig = `
+data "google_artifact_registry_npm_package" "test" {
+  project       = "example-project"
+  location      = "us"
+  repository_id = "example-repo"
+  package_name  = "example-package"
+}
+`
+
+func validateNpmPackageTimestamps(dataSourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		res, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", dataSourceName)
+		}
+
+		for _, attr := range []string{"create_time", "update_time"} {
+			if ts, ok := res.Primary.Attributes[attr]; !ok || !isRFC3339(ts) {
+				return fmt.Errorf("%s is not RFC3339: %s", attr, ts)
+			}
+		}
+
+		return nil
+	}
+}

--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_npm_package.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_npm_package.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Artifact Registry"
+description: |-
+  Get information about an NPM package within a Google Artifact Registry Repository.
+---
+
+# google_artifact_registry_npm_package
+
+This data source fetches information from a provided Artifact Registry repository, based on a the latest version of the package and optional version.
+
+## Example Usage
+
+```hcl
+resource "google_artifact_registry_repository" "npm_repo" {
+  location      = "us-central1"
+  repository_id = "my-npm-repo"
+  format        = "NPM"
+}
+
+data "google_artifact_registry_npm_package" "latest" {
+  location      = google_artifact_registry_repository.npm_repo.location
+  repository_id = google_artifact_registry_repository.npm_repo.repository_id
+  package_name  = "example-pkg"
+}
+
+data "google_artifact_registry_npm_package" "with_version" {
+  location      = google_artifact_registry_repository.npm_repo.location
+  repository_id = google_artifact_registry_repository.npm_repo.repository_id
+  package_name  = "example-pkg:1.0.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` – (Required) The location of the Artifact Registry repository.
+
+* `repository_id` – (Required) The ID of the repository containing the NPM package.
+
+* `package_name` – (Required) The name of the package to fetch. Can optionally include a specific version (e.g., `my_pkg:1.2.3`). If no version is provided, the latest version is used.
+
+* `project` – (Optional) The ID of the project that owns the repository. If not provided, the provider-level project is used.
+
+## Attributes Reference
+
+The following computed attributes are exported:
+
+* `id` – The fully qualified name of the fetched package. Format:  
+  ```
+  projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages/{{package}}:{{version}}
+  ```
+
+* `name` – The fully qualified name of the fetched package. Format:  
+  ```
+  projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}/npmPackages/{{package}}:{{version}}
+  ```
+
+* `version` – The version of the NPM package.
+
+* `tags` - A list of all Tags attached to this package.
+
+* `create_time` – The time the package was created.
+
+* `update_time` – The time the package was last updated.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new data source `google_artifact_registry_npm_package`, allowing to retrieve an NPM package from an Artifact Registry repository.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23943

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_artifact_registry_npm_package`
```
