### PR TITLE
Revert "Fix partial match regexes"

### DIFF
--- a/mmv1/templates/terraform/custom_import/extract_taxonomy.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/extract_taxonomy.go.tmpl
@@ -1,7 +1,7 @@
 	config := meta.(*transport_tpg.Config)
 
 	if err := tpgresource.ParseImportId([]string{
-		"^(?P<taxonomy>projects/[^/]+/locations/[^/]+/taxonomies/[^/]+)/policyTags/(?P<name>.+)$"}, d, config); err != nil {
+		"(?P<taxonomy>projects/[^/]+/locations/[^/]+/taxonomies/[^/]+)/policyTags/(?P<name>.+)"}, d, config); err != nil {
 		return nil, err
 	}
 

--- a/mmv1/templates/terraform/custom_import/vertex_ai_tensorboard_import.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/vertex_ai_tensorboard_import.go.tmpl
@@ -1,9 +1,9 @@
     config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/tensorboards/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<region>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/tensorboards/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
@@ -324,8 +324,8 @@ func resourceApigeeApiDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceApigeeApiImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/apis/(?P<name>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<name>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/apis/(?P<name>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
@@ -223,8 +223,8 @@ func resourceApigeeFlowhookDelete(d *schema.ResourceData, meta interface{}) erro
 func resourceApigeeFlowhookImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/flowhooks/(?P<flow_hook_point>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<flow_hook_point>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/flowhooks/(?P<flow_hook_point>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<flow_hook_point>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_key_cert_file.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_key_cert_file.go
@@ -362,8 +362,8 @@ func resourceApigeeKeystoresAliasesKeyCertFileDelete(d *schema.ResourceData, met
 func resourceApigeeKeystoresAliasesKeyCertFileImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/keystores/(?P<keystore>[^/]+)/aliases/(?P<alias>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<keystore>[^/]+)/(?P<alias>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/keystores/(?P<keystore>[^/]+)/aliases/(?P<alias>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<keystore>[^/]+)/(?P<alias>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
@@ -299,8 +299,8 @@ func ResourceApigeeKeystoresAliasesPkcs12Delete(d *schema.ResourceData, meta int
 func ResourceApigeeKeystoresAliasesPkcs12Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/keystores/(?P<keystore>[^/]+)/aliases/(?P<alias>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<keystore>[^/]+)/(?P<alias>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/keystores/(?P<keystore>[^/]+)/aliases/(?P<alias>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<keystore>[^/]+)/(?P<alias>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -324,8 +324,8 @@ func resourceApigeeSharedFlowDelete(d *schema.ResourceData, meta interface{}) er
 func resourceApigeeSharedFlowImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/sharedflows/(?P<name>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<name>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/sharedflows/(?P<name>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -229,7 +229,6 @@ func resourceApigeeSharedflowDeploymentImport(d *schema.ResourceData, meta inter
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
 		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/sharedflows/(?P<sharedflow_id>[^/]+)/revisions/(?P<revision>[^/]+)$",
-		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/sharedflows/(?P<sharedflow_id>[^/]+)/revisions/(?P<revision>[^/]+)/deployments$",
 		"^(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<sharedflow_id>[^/]+)/(?P<revision>[^/]+)$",
 	}, d, config); err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -228,8 +228,8 @@ func resourceApigeeSharedflowDeploymentDelete(d *schema.ResourceData, meta inter
 func resourceApigeeSharedflowDeploymentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/sharedflows/(?P<sharedflow_id>[^/]+)/revisions/(?P<revision>[^/]+)$",
-		"^(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<sharedflow_id>[^/]+)/(?P<revision>[^/]+)$",
+		"organizations/(?P<org_id>[^/]+)/environments/(?P<environment>[^/]+)/sharedflows/(?P<sharedflow_id>[^/]+)/revisions/(?P<revision>[^/]+)",
+		"(?P<org_id>[^/]+)/(?P<environment>[^/]+)/(?P<sharedflow_id>[^/]+)/(?P<revision>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -3501,9 +3501,9 @@ func flattenSerDeInfo(si *bigquery.SerDeInfo) []map[string]interface{} {
 func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/datasets/(?P<dataset_id>[^/]+)/tables/(?P<table_id>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)$",
-		"^(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)$",
+		"projects/(?P<project>[^/]+)/datasets/(?P<dataset_id>[^/]+)/tables/(?P<table_id>[^/]+)",
+		"(?P<project>[^/]+)/(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)",
+		"(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_authorized_view.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_authorized_view.go
@@ -355,9 +355,9 @@ func resourceBigtableAuthorizedViewDestroy(d *schema.ResourceData, meta interfac
 func resourceBigtableAuthorizedViewImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/instances/(?P<instance_name>[^/]+)/tables/(?P<table_name>[^/]+)/authorizedViews/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<instance_name>[^/]+)/(?P<table_name>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<instance_name>[^/]+)/(?P<table_name>[^/]+)/(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/instances/(?P<instance_name>[^/]+)/tables/(?P<table_name>[^/]+)/authorizedViews/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<instance_name>[^/]+)/(?P<table_name>[^/]+)/(?P<name>[^/]+)",
+		"(?P<instance_name>[^/]+)/(?P<table_name>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -829,9 +829,9 @@ func resourceBigtableInstanceClusterReorderTypeListFunc(diff tpgresource.Terrafo
 func resourceBigtableInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_table.go
@@ -686,9 +686,9 @@ func FlattenColumnFamily(families []bigtable.FamilyInfo) ([]map[string]interface
 func resourceBigtableTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/instances/(?P<instance_name>[^/]+)/tables/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<instance_name>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<instance_name>[^/]+)/(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/instances/(?P<instance_name>[^/]+)/tables/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<instance_name>[^/]+)/(?P<name>[^/]+)",
+		"(?P<instance_name>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/services/cloudfunctions/resource_cloudfunctions_function.go
@@ -65,9 +65,9 @@ func (s *CloudFunctionId) locationId() string {
 
 func parseCloudFunctionId(d *schema.ResourceData, config *transport_tpg.Config) (*CloudFunctionId, error) {
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/functions/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/functions/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3436,9 +3436,9 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 func resourceComputeInstanceImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instances/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<zone>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instances/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<zone>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
@@ -455,9 +455,9 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 func resourceComputeInstanceGroupImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instanceGroups/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<zone>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<zone>[^/]+)/(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/instanceGroups/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<zone>[^/]+)/(?P<name>[^/]+)",
+		"(?P<zone>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.tmpl
@@ -184,8 +184,8 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 func resourceComputeProjectMetadataItemImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/meta-data/(?P<key>[^/]+)$",
-		"^(?P<key>[^/]+)$",
+		"projects/(?P<project>[^/]+)/meta-data/(?P<key>[^/]+)",
+		"(?P<key>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.tmpl
@@ -571,10 +571,10 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 func resourceTargetPoolStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/targetPools/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<region>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/targetPools/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -648,9 +648,9 @@ func resourceDnsRecordSetUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceDnsRecordSetImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/managedZones/(?P<managed_zone>[^/]+)/rrsets/(?P<name>[^/]+)/(?P<type>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<managed_zone>[^/]+)/(?P<name>[^/]+)/(?P<type>[^/]+)$",
-		"^(?P<managed_zone>[^/]+)/(?P<name>[^/]+)/(?P<type>[^/]+)$",
+		"projects/(?P<project>[^/]+)/managedZones/(?P<managed_zone>[^/]+)/rrsets/(?P<name>[^/]+)/(?P<type>[^/]+)",
+		"(?P<project>[^/]+)/(?P<managed_zone>[^/]+)/(?P<name>[^/]+)/(?P<type>[^/]+)",
+		"(?P<managed_zone>[^/]+)/(?P<name>[^/]+)/(?P<type>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_os_policy_assignment.go
@@ -1445,9 +1445,9 @@ func resourceOSConfigOSPolicyAssignmentDelete(d *schema.ResourceData, meta inter
 func resourceOSConfigOSPolicyAssignmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/osPolicyAssignments/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<location>[^/]+)/(?P<name>[^/]+)$",
+		"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/osPolicyAssignments/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<name>[^/]+)",
+		"(?P<location>[^/]+)/(?P<name>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_organization_policy.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_folder_organization_policy.go
@@ -47,9 +47,9 @@ func resourceFolderOrgPolicyImporter(d *schema.ResourceData, meta interface{}) (
 	config := meta.(*transport_tpg.Config)
 
 	if err := tpgresource.ParseImportId([]string{
-		"^folders/(?P<folder>[^/]+)/constraints/(?P<constraint>[^/]+)$",
-		"^folders/(?P<folder>[^/]+)/(?P<constraint>[^/]+)$",
-		"^(?P<folder>[^/]+)/(?P<constraint>[^/]+)$"},
+		"folders/(?P<folder>[^/]+)/constraints/(?P<constraint>[^/]+)",
+		"folders/(?P<folder>[^/]+)/(?P<constraint>[^/]+)",
+		"(?P<folder>[^/]+)/(?P<constraint>[^/]+)"},
 		d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -238,9 +238,9 @@ func resourceGoogleProjectIamCustomRoleDelete(d *schema.ResourceData, meta inter
 func resourceGoogleProjectIamCustomRoleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/roles/(?P<role_id>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<role_id>[^/]+)$",
-		"^(?P<role_id>[^/]+)$",
+		"projects/(?P<project>[^/]+)/roles/(?P<role_id>[^/]+)",
+		"(?P<project>[^/]+)/(?P<role_id>[^/]+)",
+		"(?P<role_id>[^/]+)",
 	}, d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_organization_policy.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_organization_policy.go
@@ -47,9 +47,9 @@ func resourceProjectOrgPolicyImporter(d *schema.ResourceData, meta interface{}) 
 	config := meta.(*transport_tpg.Config)
 
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+):constraints/(?P<constraint>[^/]+)$",
-		"^(?P<project>[^/]+):constraints/(?P<constraint>[^/]+)$",
-		"^(?P<project>[^/]+):(?P<constraint>[^/]+)$"},
+		"projects/(?P<project>[^/]+):constraints/(?P<constraint>[^/]+)",
+		"(?P<project>[^/]+):constraints/(?P<constraint>[^/]+)",
+		"(?P<project>[^/]+):(?P<constraint>[^/]+)"},
 		d, config); err != nil {
 		return nil, err
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account.go
@@ -321,9 +321,9 @@ func resourceGoogleServiceAccountUpdate(d *schema.ResourceData, meta interface{}
 func resourceGoogleServiceAccountImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/serviceAccounts/(?P<email>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<email>[^/]+)$",
-		"^(?P<email>[^/]+)$"}, d, config); err != nil {
+		"projects/(?P<project>[^/]+)/serviceAccounts/(?P<email>[^/]+)",
+		"(?P<project>[^/]+)/(?P<email>[^/]+)",
+		"(?P<email>[^/]+)"}, d, config); err != nil {
 		return nil, err
 	}
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2367,9 +2367,9 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 func resourceSqlDatabaseInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*transport_tpg.Config)
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)$",
-		"^(?P<project>[^/]+)/(?P<name>[^/]+)$",
-		"^(?P<name>[^/]+)$"}, d, config); err != nil {
+		"projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)"}, d, config); err != nil {
 		return nil, err
 	}
 

--- a/tpgtools/ignored_handwritten/custom_import.go
+++ b/tpgtools/ignored_handwritten/custom_import.go
@@ -10,8 +10,8 @@ import (
 
 func sourceRepoImport(d *schema.ResourceData, config *transport_tpg.Config) error {
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/repos/(?P<name>.+)$",
-		"^(?P<name>.+)$",
+		"projects/(?P<project>[^/]+)/repos/(?P<name>.+)",
+		"(?P<name>.+)",
 	}, d, config); err != nil {
 		return err
 	}
@@ -28,8 +28,8 @@ func sourceRepoImport(d *schema.ResourceData, config *transport_tpg.Config) erro
 
 func runtimeconfigVariableImport(d *schema.ResourceData, config *transport_tpg.Config) error {
 	if err := tpgresource.ParseImportId([]string{
-		"^projects/(?P<project>[^/]+)/configs/(?P<parent>[^/]+)/variables/(?P<name>.+)$",
-		"^(?P<parent>[^/]+)/(?P<name>.+)$",
+		"projects/(?P<project>[^/]+)/configs/(?P<parent>[^/]+)/variables/(?P<name>.+)",
+		"(?P<parent>[^/]+)/(?P<name>.+)",
 	}, d, config); err != nil {
 		return err
 	}


### PR DESCRIPTION

This reverts the import id change https://github.com/GoogleCloudPlatform/magic-modules/commit/496b240ba31fa8d67907893c5605c9705d4a0471 and the following fix 376bf5c4b97c06aee6da730f9dcdf8c6b089fc9f

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
provider: fixed many import functions throughout the provider that erroneously matched a subset of the provided input, leading to unclear error messages when using `terraform input` with invalid resource IDs (revert)
```
