### PR TITLE
Remove use of MODIFIED_FILE_PATH in EAP VCR

### DIFF
--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -31,7 +31,6 @@ var tevRequiredEnvironmentVariables = [...]string{
 	"GOOGLE_IMPERSONATE_SERVICE_ACCOUNT",
 	"KOKORO_ARTIFACTS_DIR",
 	"HOME",
-	"MODIFIED_FILE_PATH",
 	"PATH",
 	"USER",
 }
@@ -125,7 +124,7 @@ The following environment variables are required:
 			return fmt.Errorf("wrong number of arguments %d, expected 1", len(args))
 		}
 
-		return execTestEAPVCR(args[0], env["GEN_PATH"], env["KOKORO_ARTIFACTS_DIR"], env["MODIFIED_FILE_PATH"], rnr, vt)
+		return execTestEAPVCR(args[0], env["GEN_PATH"], env["KOKORO_ARTIFACTS_DIR"], rnr, vt)
 	},
 }
 
@@ -137,7 +136,7 @@ func listTEVEnvironmentVariables() string {
 	return result
 }
 
-func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath string, rnr ExecRunner, vt *vcr.Tester) error {
+func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir string, rnr ExecRunner, vt *vcr.Tester) error {
 	vt.SetRepoPath(provider.Private, genPath)
 	if err := rnr.PushDir(genPath); err != nil {
 		return fmt.Errorf("error changing to gen path: %w", err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This was previously needed to provide a file that could be used for the Gerrit comment. However, there is now the `/PATCHSET_LEVEL` option, so we don't need a file name.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
