### PR TITLE
`resource_identity`: Add empty group check + remove error return in `import.go`

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -89,7 +89,7 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 
 			return nil
 		} else if d.Id() == "" {
-			if err := identityImport(re, identity, idFormat, d); err != nil {
+			if err := identityImport(re, identity, d); err != nil {
 				return err
 			}
 			err = setDefaultValues(idRegexes[0], identity, d, config)
@@ -102,7 +102,7 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 	return fmt.Errorf("Import id %q doesn't match any of the accepted formats: %v", d.Id(), idRegexes)
 }
 
-func identityImport(re *regexp.Regexp, identity *schema.IdentityData, idFormat string, d TerraformResourceData) error {
+func identityImport(re *regexp.Regexp, identity *schema.IdentityData, d TerraformResourceData) error {
 	if identity == nil {
 		return nil
 	}
@@ -119,7 +119,7 @@ func identityImport(re *regexp.Regexp, identity *schema.IdentityData, idFormat s
 		} else if group == "" {
 			continue
 		} else {
-			return fmt.Errorf("[DEBUG] No value was found for %s during import", group)
+			log.Printf("[DEBUG] No value was found for %s in identity import block", group)
 		}
 	}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We ran into a case where a group could be used despite it being `""` resulting in us running into the `else` condition where the value doesn't exist for a group which also doesn't exist. This logic will have the loop continue when a group is `""`

I also removed the return of the error that was produced when a value isn't found in import identity block. it now only appears when `TF_LOG=debug` is set.

In the event that a required value for importing is misssing it will just output the attribute. this code comes from core itself.

<img width="1848" height="474" alt="image" src="https://github.com/user-attachments/assets/b7eea9d2-1791-4e00-bbd4-332aa2486206" />


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
