### PR TITLE
container: Removed instance type from resourceManagerTags test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -5559,7 +5559,6 @@ resource "google_container_node_pool" "primary_nodes" {
   node_count = 1
 
   node_config {
-    machine_type = "n1-standard-1" // can't be e2 because of local-ssd
     disk_size_gb = 15
 
     resource_manager_tags = {
@@ -5606,12 +5605,11 @@ resource "google_container_node_pool" "primary_nodes" {
   node_count = 1
 
   node_config {
-    machine_type = "n1-standard-1" // can't be e2 because of local-ssd
     disk_size_gb = 15
 
     resource_manager_tags = {
       "%{pid}/%{tagKey1}" = "%{tagValue1}"
-	  "%{pid}/%{tagKey2}" = "%{tagValue2}"
+      "%{pid}/%{tagKey2}" = "%{tagValue2}"
     }
   }
 }
@@ -5654,7 +5652,6 @@ resource "google_container_node_pool" "primary_nodes" {
   node_count = 1
 
   node_config {
-    machine_type = "n1-standard-1" // can't be e2 because of local-ssd
     disk_size_gb = 15
   }
 }


### PR DESCRIPTION
Remove the explicit instance type from `TestAccContainerNodePool_resourceManagerTags `

`n1` instance types may have stockout issues. Also, it doesn't appear that SSDs are needed anyway, so this was probably cargo-culted. The tests appear to pass with the default instance type.

Part of https://github.com/hashicorp/terraform-provider-google/issues/23597

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
