### PR TITLE
Add resource_manager_tags support to Region Backend Service api

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1550,12 +1550,12 @@ properties:
     immutable: true
     description: |
       Additional params passed with the request, but not persisted as part of resource payload
-      properties:
-        - name: 'resourceManagerTags'
-          type: KeyValuePairs
-          description: |
-            Resource manager tags to be bound to the region backend service. Tag keys and values have the
-            same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
-            and values are in the format tagValues/456.
-          api_name: resourceManagerTags
-          ignore_read: true
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the region backend service. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1544,3 +1544,18 @@ properties:
                 description: |
                   The name of the VM instance of the leader network endpoint. The instance must
                   already be attached to the NEG specified in the haPolicy.leader.backendGroup.
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload
+      properties:
+        - name: 'resourceManagerTags'
+          type: KeyValuePairs
+          description: |
+            Resource manager tags to be bound to the region backend service. Tag keys and values have the
+            same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+            and values are in the format tagValues/456.
+          api_name: resourceManagerTags
+          ignore_read: true

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1559,3 +1559,4 @@ properties:
           and values are in the format tagValues/456.
         api_name: resourceManagerTags
         ignore_read: true
+        immutable: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -500,7 +500,7 @@ func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 				ResourceName:      "google_compute_region_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"params"},
+				ImportStateVerifyIgnore: []string{"params"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -485,14 +485,13 @@ func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 	sharedTagkey,_ := tagKeyResult["shared_tag_key"]
 	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-rbs-tagvalue", sharedTagkey, org)
 
-
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRegionBackendService_withTags(serviceName, checkName, tagKeyResult, tagValueResult),
+				Config: testAccComputeRegionBackendService_withTags(serviceName, checkName, tagKeyResult["name"], tagValueResult["name"]),
 			},
 			{
 				ResourceName:      "google_compute_region_backend_service.foobar",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -500,6 +500,7 @@ func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 				ResourceName:      "google_compute_region_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"params"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -480,11 +480,11 @@ func TestAccComputeRegionBackendService_withDynamicBackendCount(t *testing.T) {
 func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 	t.Parallel()
 
-  org := envvar.GetTestOrgFromEnv(t)
+    org := envvar.GetTestOrgFromEnv(t)
 
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-  tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-rbs-tagkey", "organizations/"+org, make(map[string]interface{}))
+    tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-rbs-tagkey", "organizations/"+org, make(map[string]interface{}))
 	sharedTagkey,_ := tagKeyResult["shared_tag_key"]
 	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-rbs-tagvalue", sharedTagkey, org)
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccComputeRegionBackendService_basic(t *testing.T) {
@@ -478,6 +479,8 @@ func TestAccComputeRegionBackendService_withDynamicBackendCount(t *testing.T) {
 
 func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 	t.Parallel()
+
+  org := envvar.GetTestOrgFromEnv(t)
 
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
+    "github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccComputeRegionBackendService_basic(t *testing.T) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -481,9 +481,9 @@ func TestAccComputeRegionBackendService_withTags(t *testing.T) {
 
 	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-  tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-networks-tagkey", "organizations/"+org, make(map[string]interface{}))
+  tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-rbs-tagkey", "organizations/"+org, make(map[string]interface{}))
 	sharedTagkey,_ := tagKeyResult["shared_tag_key"]
-	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-networks-tagvalue", sharedTagkey, org)
+	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-rbs-tagvalue", sharedTagkey, org)
 
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -1542,5 +1542,5 @@ resource "google_compute_health_check" "zero" {
     port = "80"
   }
 }
-`, serviceName, checkName, tagKey, tagValue)
+`, serviceName, tagKey, tagValue, checkName)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -1542,5 +1542,5 @@ resource "google_compute_health_check" "zero" {
     port = "80"
   }
 }
-`, serviceName, checkName)
+`, serviceName, checkName, tagKey, tagValue)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -476,6 +476,33 @@ func TestAccComputeRegionBackendService_withDynamicBackendCount(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionBackendService_withTags(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+  tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-networks-tagkey", "organizations/"+org, make(map[string]interface{}))
+	sharedTagkey,_ := tagKeyResult["shared_tag_key"]
+	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-networks-tagvalue", sharedTagkey, org)
+
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withTags(serviceName, checkName, tagKeyResult, tagValueResult),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeRegionBackendService_withDynamicBackendCount(serviceName, netName, hcName, igName string) string {
 	return fmt.Sprintf(`
 locals {
@@ -1486,6 +1513,31 @@ resource "google_compute_region_health_check" "health_check" {
 
   http_health_check {
     port = 80
+  }
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeRegionBackendService_withTags(serviceName, checkName string, tagKey string, tagValue string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_health_check.zero.self_link]
+  region        = "us-central1"
+  params {
+    resource_manager_tags = {
+      "%s" = "%s"
+    }
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
   }
 }
 `, serviceName, checkName)


### PR DESCRIPTION
Added resource manager tags support to Ragion Backend Service.
Part of https://github.com/hashicorp/terraform-provider-google/issues/23979

#### Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: add `params.resourceManagerTags` field to the `google_compute_region_backend_service`
```