### PR TITLE
GKE Multi-Subnet additional_ip_ranges_config: Change test subnet and network name from main to msc_main

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -14283,7 +14283,6 @@ func bootstrapAdditionalIpRangesNetworkConfig(t *testing.T, name string, additio
 		SubnetName: mainSubnet,
 		RangeNames: []string{"pods"},
 	}
-
 	sri = append(sri, si)
 
 	cumulativeRangeIndex := 0


### PR DESCRIPTION
Potential fix to https://github.com/hashicorp/terraform-provider-google/issues/23863

Error message from test failure:

```
{
  "error": {
    "code": 409,
    "message": "The resource 'projects/ci-test-project-nightly-ga/regions/us-central1/subnetworks/main' already exists",
    "errors": [
      {
        "message": "The resource 'projects/ci-test-project-nightly-ga/regions/us-central1/subnetworks/main' already exists",
        "domain": "global",
        "reason": "alreadyExists"
      }
    ]
  }
}
```

The working theory is that in continuous runs, there is no project-level isolation between the `additional_ip_ranges_config`  test case and [this test case](https://github.com/GoogleCloudPlatform/magic-modules/blob/10cf9fc8af6e93c8ebd238550e2a13eada54d6f5/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl#L12358).

The fix here is to use a name that's guaranteed to be unique to this test case. We use the prefix `msc_` (Multi-Subnet Clusters, the name of the feature)

Reviewer, it would be fantastic if you could point me at the dashboard for continuous runs on the terraform-provider-google repo.

```release-note:none
container: test fix
```
