### PR TITLE
tgc-revival: fix the maximum number of retries

### DIFF
--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -76,7 +76,8 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, ignoredAssetF
 		return nil
 	}
 
-	backoffPolicy := retry.WithMaxRetries(maxRetries, retry.NewConstant(50*time.Millisecond))
+	// Note maxAttempts-1 is retries, not attempts.
+	backoffPolicy := retry.WithMaxRetries(maxAttempts-1, retry.NewConstant(50*time.Millisecond))
 
 	t.Log("Starting test with retry logic.")
 

--- a/mmv1/third_party/tgc_next/test/setup.go
+++ b/mmv1/third_party/tgc_next/test/setup.go
@@ -51,12 +51,12 @@ type Resource struct {
 }
 
 const (
-	ymdFormat  = "2006-01-02"
-	maxRetries = 3
+	ymdFormat   = "2006-01-02"
+	maxAttempts = 3
 )
 
 var (
-	TestsMetadata = make([]NightlyRun, maxRetries)
+	TestsMetadata = make([]NightlyRun, maxAttempts)
 	setupDone     = false
 )
 
@@ -88,8 +88,8 @@ func ReadTestsDataFromGcs() ([]NightlyRun, error) {
 				// Keep looking until we find a date with metadata.
 				i--
 				retries++
-				if retries > maxRetries {
-					// Stop looking when we find maxRetries dates with no metadata.
+				if retries > maxAttempts {
+					// Stop looking when we find maxAttempts dates with no metadata.
 					return nil, fmt.Errorf("too many retries, %v", allErrs)
 				}
 			} else {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Function `retry.WithMaxRetries` takes `retries`, not attempts.
backoffPolicy := retry.WithMaxRetries(maxAttempts-1, retry.NewConstant(50*time.Millisecond))

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
