### PR TITLE
Set default_from_api for image field in VmwareNodePool

### DIFF
--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -127,6 +127,7 @@ properties:
       - name: 'image'
         type: String
         description: The OS image name in vCenter, only valid when using Windows.
+        default_from_api: true
       - name: 'bootDiskSizeGb'
         type: Integer
         description: VMware disk size to be used during creation.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
gkeonprem: set `default_from_api` in image field in `google_vmware_node_pool`
```
