### PR TITLE
container: Used zonal cluster for network config test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4172,7 +4172,7 @@ resource "google_container_node_pool" "with_tier1_net" {
   cluster    = google_container_cluster.cluster.name
   node_count = 1
   node_locations = [
-    "us-central1-a",
+    "us-central1-c",
   ]
   network_config {
     network_performance_config {


### PR DESCRIPTION
- Use zonal cluster for `TestAccContainerNodePool_withNetworkConfig` test. Pick zone c (though a is used for most other zonal tests). This should result in 1/3 or 1/4 of the nodes being created for each of the multiple node pools in this test, which should improve both the speed and the reliability of this test
- Fix formatting

Noted while working on #14834

Note: I haven't been able to test this locally, both because of quota issues, and because of this error:
`Disabling pod cidr overprovision is not allowed for this project`
on my personal test project

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
