### PR TITLE
Add deletion_protection field to Metastore Service

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -50,13 +50,16 @@ iam_policy:
   import_format:
     - 'projects/{{project}}/locations/{{location}}/services/{{service_id}}'
     - '{{service_id}}'
-custom_code:
+custom_code: !ruby/object:Provider::Terraform::CustomCode
+  pre_delete: 'templates/terraform/pre_delete/metastore_service.go.tmpl'
 examples:
   - name: 'dataproc_metastore_service_basic'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-srv%s", context["random_suffix"])'
     vars:
       metastore_service_name: 'metastore-srv'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'dataproc_metastore_service_deletion_protection'
     primary_resource_id: 'default'
     primary_resource_name: 'fmt.Sprintf("tf-test-metastore-srv%s", context["random_suffix"])'
@@ -314,10 +317,13 @@ properties:
         description: |
           A Cloud Storage URI of a folder, in the format gs://<bucket_name>/<path_inside_bucket>. A sub-folder <backup_folder> containing backup files will be stored below it.
         required: true
-  - name: 'deletionProtection'
+  - name: 'deletion-protection'
     type: Boolean
     description: |
-      Indicates if the dataproc metastore should be protected against accidental deletions.
+      Indicates if the dataproc metastore should be protected against accidental deletions.Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the service will fail.
+    default_value: false
   - name: 'maintenanceWindow'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_metastore_service_basic.tf.tmpl
@@ -16,4 +16,5 @@ resource "google_dataproc_metastore_service" "{{$.PrimaryResourceId}}" {
   labels = {
     env = "test"
   }
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/metastore_service.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/metastore_service.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy metastore service without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
@@ -3,6 +3,7 @@ package dataprocmetastore_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -22,17 +23,19 @@ func TestAccDataprocMetastoreService_updateAndImport(t *testing.T) {
 				Config: testAccDataprocMetastoreService_updateAndImport(name, tier[0]),
 			},
 			{
-				ResourceName:      "google_dataproc_metastore_service.my_metastore",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_dataproc_metastore_service.my_metastore",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccDataprocMetastoreService_updateAndImport(name, tier[1]),
 			},
 			{
-				ResourceName:      "google_dataproc_metastore_service.my_metastore",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_dataproc_metastore_service.my_metastore",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -44,6 +47,7 @@ resource "google_dataproc_metastore_service" "my_metastore" {
 	service_id = "%s"
 	location   = "us-central1"
 	tier       = "%s"
+	deletion_protection = false
 
 	hive_metastore_config {
 		version = "2.3.6"
@@ -166,4 +170,48 @@ resource "google_storage_bucket" "bucket" {
   location = "us-central1"
 }
 `, context)
+}
+
+func TestAccDataprocMetastoreService_deletionProtection(t *testing.T) {
+	t.Parallel()
+
+	name := "tf-test-metastore-" + acctest.RandString(t, 10)
+	tier := [2]string{"DEVELOPER", "ENTERPRISE"}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocMetastoreService_deletionProtection(name, "us-central1", tier[0]),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_service.my_metastore",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config:      testAccDataprocMetastoreService_deletionProtection(name, "us-west2", tier[1]),
+				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
+			{
+				Config: testAccDataprocMetastoreService_updateAndImport(name, tier[0]),
+			},
+		},
+	})
+}
+
+func testAccDataprocMetastoreService_deletionProtection(name, location, tier string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_metastore_service" "my_metastore" {
+        service_id = "%s"
+        location   = "%s"
+        tier       = "%s"
+        deletion_protection = true
+        hive_metastore_config {
+                version = "2.3.6"
+        }
+}
+`, name, location, tier)
 }


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/366197455


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
metastore: added `deletion_protection` field to the `dataproc_metastore_service` resource to prevent accidental deletion
```

Please note, mandatory reviewer - @aniket-gupta 
