### PR TITLE
write-only: modified expander behavior for write-only arguments

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -648,6 +648,10 @@ func (r Resource) SettableProperties() []*Type {
 		return v.IsA("KeyValueLabels") || v.IsA("KeyValueAnnotations")
 	})
 
+	props = google.Reject(props, func(v *Type) bool {
+		return v.ClientSide
+	})
+
 	return props
 }
 

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -508,6 +508,10 @@ func (t Type) TitlelizeProperty() string {
 	return google.Camelize(t.Name, "upper")
 }
 
+func (t Type) CamelizeProperty() string {
+	return google.Camelize(t.Name, "lower")
+}
+
 // If the Prefix field is already set, returns the value.
 // Otherwise, set the Prefix field and returns the value.
 func (t *Type) GetPrefix() string {

--- a/mmv1/templates/terraform/post_create/interconnect_attachment.go.tmpl
+++ b/mmv1/templates/terraform/post_create/interconnect_attachment.go.tmpl
@@ -1,6 +1,6 @@
 
 {{- if $.HasLabelsField }}
-if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
+if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, effectiveLabelsProp)) {
 	labels := d.Get("labels")
 	terraformLables := d.Get("terraform_labels")
 

--- a/mmv1/templates/terraform/post_create/labels.tmpl
+++ b/mmv1/templates/terraform/post_create/labels.tmpl
@@ -1,6 +1,6 @@
 {{- if $.HasLabelsField }}
-if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, labelsProp)) {
-	labels := d.Get("labels")
+if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, effectiveLabelsProp)) {
+	userLabels := d.Get("labels")
 	terraformLables := d.Get("terraform_labels")
 
 	// Labels cannot be set in a create.  We'll have to set them here.
@@ -50,7 +50,7 @@ if v, ok := d.GetOkExists("effective_labels"); !tpgresource.IsEmptyValue(reflect
 	}
 
 	// Set back the labels field, as it is needed to decide the value of "labels" in the state in the read function.
-	if err := d.Set("labels", labels); err != nil {
+	if err := d.Set("labels", userLabels); err != nil {
 		return fmt.Errorf("Error setting back labels: %s", err)
 	}
 

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -54,7 +54,7 @@ import (
 {{- end}}
 )
 
-{{if $.CustomCode.Constants -}}
+{{if $.CustomCode.Constants -}} 
     {{- $.CustomTemplate $.CustomCode.Constants true -}}
 {{- end}}
 
@@ -138,7 +138,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
             {{- range $prop := $.VirtualFields }}
 {{template "SchemaFields" $prop -}}
             {{- end }}
-{{- if $.CustomCode.ExtraSchemaEntry }}
+{{- if $.CustomCode.ExtraSchemaEntry }} 
     {{ $.CustomTemplate $.CustomCode.ExtraSchemaEntry false -}}
 {{- end}}
 {{ if $.HasProject -}}
@@ -406,7 +406,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{        end  -}}
 {{      end -}}{{/*if ($.GetAsync.IsA "OpAsync")*/}}
 {{    end -}}{{/*if and $.GetAsync ($.GetAsync.Allow "Create")*/}}
-{{if $.CustomCode.PostCreate -}}
+{{if $.CustomCode.PostCreate -}} 
     {{- $.CustomTemplate $.CustomCode.PostCreate false -}}
 {{- end}}
 
@@ -997,7 +997,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         }
 {{-                     end}}
 {{-                 end}}
-    }
+    } 
 {{-             end  }}{{/*range PropertiesByCustomUpdate*/}}
 {{ "" }}
   d.Partial(false)
@@ -1033,7 +1033,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
         return err
     }
-{{ if $.CustomCode.CustomDelete }}
+{{ if $.CustomCode.CustomDelete }} 
 {{ $.CustomTemplate $.CustomCode.CustomDelete false -}}
 {{- else }}
 
@@ -1090,7 +1090,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     }
 
     headers := make(http.Header)
-    {{- if $.CustomCode.PreDelete }}
+    {{- if $.CustomCode.PreDelete }} 
         {{ $.CustomTemplate $.CustomCode.PreDelete false -}}
     {{- end }}
 

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -54,7 +54,7 @@ import (
 {{- end}}
 )
 
-{{if $.CustomCode.Constants -}} 
+{{if $.CustomCode.Constants -}}
     {{- $.CustomTemplate $.CustomCode.Constants true -}}
 {{- end}}
 
@@ -138,7 +138,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
             {{- range $prop := $.VirtualFields }}
 {{template "SchemaFields" $prop -}}
             {{- end }}
-{{- if $.CustomCode.ExtraSchemaEntry }} 
+{{- if $.CustomCode.ExtraSchemaEntry }}
     {{ $.CustomTemplate $.CustomCode.ExtraSchemaEntry false -}}
 {{- end}}
 {{ if $.HasProject -}}
@@ -186,19 +186,19 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     obj := make(map[string]interface{})
 
 {{- range $prop := $.SettableProperties }}
-    {{ $prop.ApiName -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}({{ if $prop.FlattenObject }}nil{{ else }}d.Get("{{ underscore $prop.Name }}"){{ end }}, d, config)
+    {{ $prop.CamelizeProperty -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{ end }}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}({{ if $prop.FlattenObject }}nil{{ else if $prop.WriteOnly }}tpgresource.GetRawConfigAttributeAsString(d, "{{ underscore $prop.Name }}"){{ else }}d.Get("{{ underscore $prop.Name }}"){{ end }}, d, config)
     if err != nil {
         return err
-{{- if $prop.SendEmptyValue -}}
-    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop) {
-{{-      else if $prop.FlattenObject -}}
-    } else if !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.ApiName -}}Prop)) {
-{{-      else -}}
-    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.ApiName -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop)) {
-{{- end}}
-        obj["{{ $prop.ApiName -}}"] = {{ $prop.ApiName -}}Prop
+    {{- if $prop.SendEmptyValue -}}
+    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
+    {{-      else if $prop.FlattenObject -}}
+    } else if !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) {
+    {{-      else -}}
+    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
+    {{- end}}
+        obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }
-{{- end}}
+    {{- end}}
 
 {{if $.CustomCode.Encoder -}}
     obj, err = resource{{ $.ResourceName -}}Encoder(d, meta, obj)
@@ -406,7 +406,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{        end  -}}
 {{      end -}}{{/*if ($.GetAsync.IsA "OpAsync")*/}}
 {{    end -}}{{/*if and $.GetAsync ($.GetAsync.Allow "Create")*/}}
-{{if $.CustomCode.PostCreate -}} 
+{{if $.CustomCode.PostCreate -}}
     {{- $.CustomTemplate $.CustomCode.PostCreate false -}}
 {{- end}}
 
@@ -723,17 +723,17 @@ func resource{{ $.ResourceName -}}Update(d *schema.ResourceData, meta interface{
     obj := make(map[string]interface{})
 {{-             range $prop := $.UpdateBodyProperties }}
     {{/* flattened $s won't have something stored in state so instead nil is passed to the next expander. */}}
-    {{- $prop.ApiName -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}({{ if $prop.FlattenObject }}nil{{else}}d.Get("{{underscore $prop.Name}}"){{ end }}, d, config)
+    {{- $prop.CamelizeProperty -}}Prop, err := expand{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper"  -}}({{ if $prop.FlattenObject }}nil{{ else if $prop.WriteOnly }}tpgresource.GetRawConfigAttributeAsString(d, "{{ underscore $prop.Name }}"){{else}}d.Get("{{underscore $prop.Name}}"){{ end }}, d, config)
     if err != nil {
         return err
 {{-                 if $prop.SendEmptyValue -}}
-    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop) {
+    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
 {{-                 else if $prop.FlattenObject -}}
-    } else if !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.ApiName -}}Prop)) {
+    } else if !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) {
 {{-                 else -}}
-    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop)) {
+    } else if v, ok := d.GetOkExists("{{ underscore $prop.Name -}}"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{-                 end}}
-        obj["{{ $prop.ApiName -}}"] = {{ $prop.ApiName -}}Prop
+        obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }
 {{-             end}}
 
@@ -997,7 +997,7 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         }
 {{-                     end}}
 {{-                 end}}
-    } 
+    }
 {{-             end  }}{{/*range PropertiesByCustomUpdate*/}}
 {{ "" }}
   d.Partial(false)
@@ -1033,7 +1033,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
         return err
     }
-{{ if $.CustomCode.CustomDelete }} 
+{{ if $.CustomCode.CustomDelete }}
 {{ $.CustomTemplate $.CustomCode.CustomDelete false -}}
 {{- else }}
 
@@ -1090,7 +1090,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     }
 
     headers := make(http.Header)
-    {{- if $.CustomCode.PreDelete }} 
+    {{- if $.CustomCode.PreDelete }}
         {{ $.CustomTemplate $.CustomCode.PreDelete false -}}
     {{- end }}
 

--- a/mmv1/templates/tgc/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc/resource_converter.go.tmpl
@@ -81,18 +81,18 @@ func Get{{ $.ResourceName -}}ApiObject(d tpgresource.TerraformResourceData, conf
     obj := make(map[string]interface{})
 {{- range $prop := $.SettableProperties }}
 {{- if $prop.FlattenObject }}
-    {{ $prop.ApiName -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(nil, d, config)
+    {{ $prop.CamelizeProperty -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(nil, d, config)
 {{- else }}
-    {{ $prop.ApiName -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(d.Get("{{underscore $prop.Name}}"), d, config)
+    {{ $prop.CamelizeProperty -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(d.Get("{{underscore $prop.Name}}"), d, config)
 {{- end}}
     if err != nil {
         return nil, err
 {{- if not $prop.SendEmptyValue }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.ApiName -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop)) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- else }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
 {{- end }}
-        obj["{{ $prop.ApiName -}}"] = {{ $prop.ApiName -}}Prop
+        obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }
 {{- end}}
 

--- a/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/tfplan2cai/resource_converter.go.tmpl
@@ -84,18 +84,18 @@ func Get{{ $.ResourceName -}}CaiObject(d tpgresource.TerraformResourceData, conf
     obj := make(map[string]interface{})
 {{- range $prop := $.SettableProperties }}
 {{- if $prop.FlattenObject }}
-    {{ $prop.ApiName -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(nil, d, config)
+    {{ $prop.CamelizeProperty -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(nil, d, config)
 {{- else }}
-    {{ $prop.ApiName -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(d.Get("{{underscore $prop.Name}}"), d, config)
+    {{ $prop.CamelizeProperty -}}Prop, err := expand{{ $.ResourceName -}}{{$prop.TitlelizeProperty}}(d.Get("{{underscore $prop.Name}}"), d, config)
 {{- end}}
     if err != nil {
         return nil, err
 {{- if and (not $prop.SendEmptyValue) (not $prop.TGCSendEmptyValue) }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.ApiName -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop)) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); !tpgresource.IsEmptyValue(reflect.ValueOf({{ $prop.CamelizeProperty -}}Prop)) && (ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop)) {
 {{- else }}
-    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.ApiName -}}Prop) {
+    } else if v, ok := d.GetOkExists("{{underscore $prop.Name}}"); ok || !reflect.DeepEqual(v, {{ $prop.CamelizeProperty -}}Prop) {
 {{- end }}
-        obj["{{ $prop.ApiName -}}"] = {{ $prop.ApiName -}}Prop
+        obj["{{ $prop.ApiName -}}"] = {{ $prop.CamelizeProperty -}}Prop
     }
 {{- end}}
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -912,3 +912,33 @@ func ReducedPrefixedUniqueId(prefix string) string {
 	date := uniqueId[2:8]
 	return prefix + date + counter
 }
+
+// GetRawConfigAttributeAsString retrieves an attribute directly from the raw config
+// This is useful for retrieving values that are not directly accessible via the
+// standard schema.ResourceData.Get method, such as write-only attributes.
+func GetRawConfigAttributeAsString(d *schema.ResourceData, key string) string {
+	// see https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/write-only-arguments#retrieving-write-only-values
+	parts := strings.Split(key, ".")
+
+	var path cty.Path
+	if len(parts) > 0 {
+		path = cty.GetAttrPath(parts[0])
+	}
+
+	for i := 1; i < len(parts); i++ {
+		part := parts[i]
+
+		if index, err := strconv.Atoi(part); err == nil {
+			path = path.IndexInt(index)
+		} else {
+			path = path.GetAttr(part)
+		}
+	}
+
+	woCty, diags := d.GetRawConfigAt(path)
+	if len(diags) == 0 && !woCty.IsNull() && woCty.Type().Equals(cty.String) {
+		return woCty.AsString()
+	}
+
+	return ""
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23211

@melinath 

- encountered some potential duplicates with the `exactly_one_of` fields etc. Therefore added deduplication logic.
- added new method `CamelizeProperty` to return a camelized variant of the property name. Was indending to use `TitelizeProperty` first but noticed this breaks a lot of tests because it changes a lot of property names, makes more sense to try to keep the name closer to what it was. With `CamelizeProperty` I only had to change some `labelsProp` references to `effectiveLabelsProp`.
- added `GetRawConfigAttributeAsString` as util method, to be able to retrieve the value of the write-only argument so it can be used when creating the request data object.

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
write-only: modified expander behavior for write-only arguments
```

Came across these shortcomings in, but probably better to put in a separate (this) PR:

https://github.com/GoogleCloudPlatform/magic-modules/pull/14138
https://github.com/GoogleCloudPlatform/magic-modules/pull/13847
