### PR TITLE
Fix typo on word 'Certificate' for map description

### DIFF
--- a/mmv1/products/certificatemanager/CertificateMapEntry.yaml
+++ b/mmv1/products/certificatemanager/CertificateMapEntry.yaml
@@ -59,7 +59,7 @@ parameters:
   - name: 'map'
     type: ResourceRef
     description: |
-      A map entry that is inputted into the cetrificate map
+      A map entry that is inputted into the certificate map
     url_param_only: true
     required: true
     immutable: true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
certificatemanager: Fixed typo for map entry description on word 'Certificate'
```
