### PR TITLE
Add datasource for google_certificate_manager_dns_authorization

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -57,6 +57,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_bigquery_default_service_account":          bigquery.DataSourceGoogleBigqueryDefaultServiceAccount(),
 	"google_certificate_manager_certificates":          certificatemanager.DataSourceGoogleCertificateManagerCertificates(),
 	"google_certificate_manager_certificate_map":       certificatemanager.DataSourceGoogleCertificateManagerCertificateMap(),
+	"google_certificate_manager_dns_authorization":     certificatemanager.DataSourceGoogleCertificateManagerDnsAuthorization(),
 	"google_cloudbuild_trigger":                        cloudbuild.DataSourceGoogleCloudBuildTrigger(),
 	"google_cloudfunctions_function":                   cloudfunctions.DataSourceGoogleCloudFunctionsFunction(),
 	"google_cloudfunctions2_function":                  cloudfunctions2.DataSourceGoogleCloudFunctions2Function(),

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_dns_authorization.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_dns_authorization.go
@@ -1,0 +1,46 @@
+package certificatemanager
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleCertificateManagerDnsAuthorization() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceCertificateManagerDnsAuthorization().Schema)
+
+	// Set 'Required' schema elements
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name", "domain")
+	// Set 'Optional' schema elements
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "location")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleCertificateManagerDnsAuthorizationRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleCertificateManagerDnsAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := tpgresource.ReplaceVars(d, meta.(*transport_tpg.Config), "projects/{{project}}/locations/{{location}}/dnsAuthorizations/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	err = resourceCertificateManagerDnsAuthorizationRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetDataSourceLabels(d); err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_dns_authorization_test.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_dns_authorization_test.go
@@ -1,0 +1,48 @@
+package certificatemanager_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccCertificateManagerDnsAuthorizationDatasource(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCertificateManagerDnsAuthorizationDatasourceConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceState("data.google_certificate_manager_dns_authorization.default", "google_certificate_manager_dns_authorization.default"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCertificateManagerDnsAuthorizationDatasourceConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = "tf-test-dns-auth-%{random_suffix}"
+  location    = "global"
+  description = "The default dns"
+  domain      = "%{random_suffix}.hashicorptest.com"
+
+}
+
+data "google_certificate_manager_dns_authorization" "default" {
+  name        = google_certificate_manager_dns_authorization.default.name
+  domain      = "%{random_suffix}.hashicorptest.com"
+  location    = "global"
+
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/certificate_manager_dns_authorization.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/certificate_manager_dns_authorization.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Certificate Manager"
+description: |-
+  Fetches the details of a Certificate Manager DNS Authorization.
+---
+
+# google_certificate_manager_dns_authorization
+
+Use this data source to get information about a Certificate Manager DNS Authorization. For more details, see the [API documentation](https://cloud.google.com/certificate-manager/docs/reference/rest/v1/projects.locations.dnsAuthorizations).
+
+## Example Usage
+
+```hcl
+data "google_certificate_manager_dns_authorization" "default" {
+  name     = "my-dns-auth"
+  location = "global"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` -
+  (Required)
+  The name of the DNS Authorization.
+
+* `domain` -
+  (Required)
+  The name of the DNS Authorization.
+
+* `location` -
+  (Optional)
+  The Certificate Manager location. If not specified, "global" is used.
+
+* `project` -
+  (Optional)
+  The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_certificate_manager_dns_authorization](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_dns_authorization) resource for details of all the available attributes.


### PR DESCRIPTION
Adding in datasource to fix https://github.com/hashicorp/terraform-provider-google/issues/20422

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_certificate_manager_dns_authorization`
```
