### PR TITLE
Remove post_startup_script_config field from google_colab_runtime_template resource

### DIFF
--- a/mmv1/products/colab/RuntimeTemplate.yaml
+++ b/mmv1/products/colab/RuntimeTemplate.yaml
@@ -209,21 +209,3 @@ properties:
                             If a variable cannot be resolved, the reference in the input string will be unchanged.
                             The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
                             references will never be expanded, regardless of whether the variable exists or not.'
-      - name: 'postStartupScriptConfig'
-        deprecation_message: '`post_startup_script_config` is deprecated and will be removed in a future major release. New resource creation with this field is unavailable at this time.'
-        type: NestedObject
-        description: 'Post startup script config.'
-        properties:
-          - name: 'postStartupScript'
-            type: String
-            description: 'Post startup script to run after runtime is started.'
-          - name: 'postStartupScriptUrl'
-            type: String
-            description: 'Post startup script url to download. Example: https://bucket/script.sh.'
-          - name: 'postStartupScriptBehavior'
-            type: Enum
-            description: 'Post startup script behavior that defines download and execution behavior.'
-            enum_values:
-              - 'RUN_ONCE'
-              - 'RUN_EVERY_START'
-              - 'DOWNLOAD_AND_RUN_EVERY_START'

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -168,6 +168,12 @@ To reflect the new type explicitly, surround the current integer value in quotes
 
 Remove `description` from your configuration after upgrade.
 
+## Resource: `google_colab_runtime_template`
+
+### `post_startup_script_config` is now removed.
+
+Remove `post_startup_script_config` from your configuration after upgrade.
+
 ## Resource: `google_network_services_lb_traffic_extension`
 
 ### `load_balancing_scheme` is now required


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
fixes https://github.com/hashicorp/terraform-provider-google/issues/23130


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
colab: `post_startup_script_config` field has been removed from  from `google_colab_runtime_template` resource
```
