### PR TITLE
Deprecation of Field allow_fewer_zone_deployment

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -525,6 +525,7 @@ properties:
       the instance creation, the instance will only be deployed in 2 zones, and
       stay within the 2 zones for its lifecycle.
     immutable: true
+    deprecation_message: 'allow_fewer_zone_deployment flag will no longer be a user settable field, default behaviour will be as if set to true'
   - name: 'deletionProtectionEnabled'
     type: Boolean
     description: "Optional. If set to true deletion of the instance will fail. "

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -386,6 +386,7 @@ properties:
       cluster in less than 3 zones. Once set, if there is a zonal outage during
       the cluster creation, the cluster will only be deployed in 2 zones, and
       stay within the 2 zones for its lifecycle.
+    deprecation_message: 'allow_fewer_zone_deployment flag will no longer be a user settable field, default behaviour will be as if set to true'
   - name: 'pscConfigs'
     type: Array
     description: |


### PR DESCRIPTION
Ref https://github.com/hashicorp/terraform-provider-google/issues/24027

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
memorystore: deprecated `allow_fewer_zones_deployment` field on `google_memorystore_instance` resource
```

```release-note:deprecation
redis: deprecated `allow_fewer_zones_deployment` field on `google_redis_cluster` resource
```
