### PR TITLE
Breaking Change: Remove allow_fewer_zones_deployment from Memorystore and Redis Cluster

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -517,14 +517,6 @@ properties:
         enum_values:
           - 'MULTI_ZONE'
           - 'SINGLE_ZONE'
-  - name: 'allowFewerZonesDeployment'
-    type: Boolean
-    description: |
-      Allows customers to specify if they are okay with deploying a multi-zone
-      instance in less than 3 zones. Once set, if there is a zonal outage during
-      the instance creation, the instance will only be deployed in 2 zones, and
-      stay within the 2 zones for its lifecycle.
-    immutable: true
   - name: 'deletionProtectionEnabled'
     type: Boolean
     description: "Optional. If set to true deletion of the instance will fail. "

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -378,14 +378,6 @@ properties:
         type: String
         description: |
           Immutable. The zone for single zone Memorystore Redis cluster.
-  - name: 'allowFewerZonesDeployment'
-    type: Boolean
-    immutable: true
-    description: |
-      Allows customers to specify if they are okay with deploying a multi-zone
-      cluster in less than 3 zones. Once set, if there is a zonal outage during
-      the cluster creation, the cluster will only be deployed in 2 zones, and
-      stay within the 2 zones for its lifecycle.
   - name: 'pscConfigs'
     type: Array
     description: |

--- a/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/memorystore_instance_full.tf.tmpl
@@ -14,7 +14,6 @@ resource "google_memorystore_instance" "{{$.PrimaryResourceId}}" {
   engine_configs = {     
     maxmemory-policy           = "volatile-ttl"
   }
-  allow_fewer_zones_deployment = true
   zone_distribution_config {
     mode                       = "SINGLE_ZONE"
     zone                       = "us-central1-b"

--- a/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
+++ b/mmv1/templates/terraform/examples/redis_cluster_aof.tf.tmpl
@@ -13,7 +13,6 @@ resource "google_redis_cluster" "{{$.PrimaryResourceId}}" {
     maxmemory-policy	= "volatile-ttl"
   }
   deletion_protection_enabled = {{index $.Vars "deletion_protection_enabled"}}
-  allow_fewer_zones_deployment = true
   zone_distribution_config {
     mode = "MULTI_ZONE"
   }

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -238,3 +238,11 @@ Remove `template.containers.depends_on` from your configuration after upgrade.
 The default value for `disable_on_destroy` has been changed to `false`. The previous default (`true`) created a risk of unintended service disruptions, as destroying a single `google_project_service` resource would disable the API for the entire project.
 
 Now, destroying the resource will only remove it from Terraform's state and leave the service enabled. To disable a service when the resource is destroyed, you must now make an explicit decision by setting `disable_on_destroy = true`.
+
+## Resource: `google_memorystore_instance`
+
+ `allow_fewer_zones_Deployment` has been removed as user configurable but will be set to true at creation
+
+## Resource: `google_redis_cluster`
+
+ `allow_fewer_zones_Deployment` has been removed as user configurable and will be set to true at creation

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -245,4 +245,4 @@ Now, destroying the resource will only remove it from Terraform's state and leav
 
 ## Resource: `google_redis_cluster`
 
- `allow_fewer_zones_Deployment` has been removed because it isn't user-configurable.
+ `allow_fewer_zones_deployment` has been removed because it isn't user-configurable.

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -245,4 +245,4 @@ Now, destroying the resource will only remove it from Terraform's state and leav
 
 ## Resource: `google_redis_cluster`
 
- `allow_fewer_zones_Deployment` has been removed as user configurable and will be set to true at creation
+ `allow_fewer_zones_Deployment` has been removed because it isn't user-configurable.

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -241,7 +241,7 @@ Now, destroying the resource will only remove it from Terraform's state and leav
 
 ## Resource: `google_memorystore_instance`
 
- `allow_fewer_zones_Deployment` has been removed as user configurable but will be set to true at creation
+ `allow_fewer_zones_deployment` has been removed because it isn't user-configurable.
 
 ## Resource: `google_redis_cluster`
 


### PR DESCRIPTION
Fixes  https://github.com/hashicorp/terraform-provider-google/issues/24027

Deprecation for fields in main branch https://github.com/GoogleCloudPlatform/magic-modules/pull/14887

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
memorystore: remove `allow_fewer_zones_deployment` field from `google_memorystore_instance` resource because it isn't user-configurable
```

```release-note:breaking-change
redis: remove `allow_fewer_zones_deployment` field from `google_redis_cluster` resource because it isn't user-configurable
```

