### PR TITLE
add final_backup_config field to google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -798,7 +798,7 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							},
 							Description: `Config used to determine the final backup settings for the instance`,
 
-						}
+						},
 					},
 				},
 				Description: `The settings to use for the database. The configuration is detailed below.`,
@@ -1502,7 +1502,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		EnableGoogleMlIntegration:     _settings["enable_google_ml_integration"].(bool),
 		EnableDataplexIntegration:     _settings["enable_dataplex_integration"].(bool),
 		RetainBackupsOnDelete:         _settings["retain_backups_on_delete"].(bool),
-		FinalBackupConfig:			   expandFinalBackupConfig(_settings["finala_backup_config"].([]interface{})),
+		FinalBackupConfig:			   expandFinalBackupConfig(_settings["final_backup_config"].([]interface{})),
 		UserLabels:                    tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration:           expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
 		DatabaseFlags:                 expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
@@ -1753,7 +1753,8 @@ func expandFinalBackupConfig(configured []interface{}) *sqladmin.FinalBackupConf
 	_finalBackupConfig := configured[0].(map[string]interface{})
 	return &sqladmin.FinalBackupConfig{
 		Enabled: _finalBackupConfig["enabled"].(bool),
-		RetentionDays: int(_finalBackupConfig["retention_days"].(int)),
+		RetentionDays: int64(_finalBackupConfig["retention_days"].(int)),
+		ForceSendFields:             []string{"Enabled"},
 	}
 }
 
@@ -2475,6 +2476,10 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["backup_configuration"] = flattenBackupConfiguration(settings.BackupConfiguration)
 	}
 
+	if settings.FinalBackupConfig != nil {
+		data["final_backup_config"] = flattenFinalBackupConfig(settings.FinalBackupConfig)
+	}
+
 	if settings.DatabaseFlags != nil {
 		data["database_flags"] = flattenDatabaseFlags(settings.DatabaseFlags)
 	}
@@ -2554,6 +2559,15 @@ func flattenBackupConfiguration(backupConfiguration *sqladmin.BackupConfiguratio
 		"point_in_time_recovery_enabled": backupConfiguration.PointInTimeRecoveryEnabled,
 		"backup_retention_settings":      flattenBackupRetentionSettings(backupConfiguration.BackupRetentionSettings),
 		"transaction_log_retention_days": backupConfiguration.TransactionLogRetentionDays,
+	}
+
+	return []map[string]interface{}{data}
+}
+
+func flattenFinalBackupConfig(finalBackupConfig *sqladmin.FinalBackupConfig) []map[string]interface{} {
+	data := map[string]interface{}{
+		"enabled":             finalBackupConfig.Enabled,
+		"retention_days":                        finalBackupConfig.RetentionDays,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -777,6 +777,28 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							Optional:    true,
 							Description: `When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The ON_DEMAND backup will be retained until customer deletes the backup or the project. The AUTOMATED backup will be retained based on the backups retention setting.`,
 						},
+						"final_backup_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:         schema.TypeBool,
+										Optional:     true,
+										Description:  `When this parameter is set to true, the final backup is enabled for the instance`,
+									},
+									"retention_days": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 365),
+										Description:  `The number of days to retain the final backup after the instance deletion (1-). The final backup will be purged at (time_of_instance_deletion + retention_days).`,
+									},
+								},
+							},
+							Description: `Config used to determine the final backup settings for the instance`,
+
+						}
 					},
 				},
 				Description: `The settings to use for the database. The configuration is detailed below.`,
@@ -1480,6 +1502,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		EnableGoogleMlIntegration:     _settings["enable_google_ml_integration"].(bool),
 		EnableDataplexIntegration:     _settings["enable_dataplex_integration"].(bool),
 		RetainBackupsOnDelete:         _settings["retain_backups_on_delete"].(bool),
+		FinalBackupConfig:			   expandFinalBackupConfig(_settings["finala_backup_config"].([]interface{})),
 		UserLabels:                    tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
 		BackupConfiguration:           expandBackupConfiguration(_settings["backup_configuration"].([]interface{})),
 		DatabaseFlags:                 expandDatabaseFlags(_settings["database_flags"].(*schema.Set).List()),
@@ -1719,6 +1742,18 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 		TransactionLogRetentionDays: int64(_backupConfiguration["transaction_log_retention_days"].(int)),
 		PointInTimeRecoveryEnabled:  _backupConfiguration["point_in_time_recovery_enabled"].(bool),
 		ForceSendFields:             []string{"BinaryLogEnabled", "Enabled", "PointInTimeRecoveryEnabled"},
+	}
+}
+
+func expandFinalBackupConfig(configured []interface{}) *sqladmin.FinalBackupConfig{
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	_finalBackupConfig := configured[0].(map[string]interface{})
+	return &sqladmin.FinalBackupConfig{
+		Enabled: _finalBackupConfig["enabled"].(bool),
+		RetentionDays: int(_finalBackupConfig["retention_days"].(int)),
 	}
 }
 
@@ -2409,6 +2444,7 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		"time_zone":                        settings.TimeZone,
 		"deletion_protection_enabled":      settings.DeletionProtectionEnabled,
 		"retain_backups_on_delete":         settings.RetainBackupsOnDelete,
+		"final_backup_config": settings.FinalBackupConfig,
 	}
 
 	if data["availability_type"] == "" {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -1615,6 +1615,38 @@ func TestAccSqlDatabaseInstance_RetainBackupOnDelete(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_FinalBackupConfig(t *testing.T) {
+	t.Parallel()
+
+	masterID := acctest.RandInt(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_FinalBackupConfig(masterID, true, 10),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_FinalBackupConfig(masterID, false, -1),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -6345,6 +6377,40 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, retainBackupOnDelete)
+}
+
+func testGoogleSqlDatabaseInstance_FinalBackupConfig(masterID int, enabled bool, retention_days int64) string {
+	retentionSetting := ""
+	if retention_days >= 0 {
+		retentionSetting = fmt.Sprintf(`retention_days = %d`, retention_days)
+	}
+
+	finalBackupConfig := fmt.Sprintf(`final_backup_config {
+		enabled = %v
+		%v
+	}`, enabled, retentionSetting)
+
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "tf-test-%d"
+  region              = "us-central1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  settings {
+    tier = "db-g1-small"
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "00:00"
+      binary_log_enabled             = true
+	  transaction_log_retention_days = 2
+	  backup_retention_settings {
+	    retained_backups = 4
+	  }
+    }
+%v
+  }
+}
+`, masterID, finalBackupConfig)
 }
 
 func testAccSqlDatabaseInstance_beforeBackup(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -390,6 +390,12 @@ The `settings` block supports:
 
 * `retain_backups_on_delete` - (Optional) When this parameter is set to true, Cloud SQL retains backups of the instance even after the instance is deleted. The `ON_DEMAND` backup will be retained until customer deletes the backup or the project. The `AUTOMATED` backup will be retained based on the backups retention setting.
 
+The optional `final_backup_config` subblock supports:
+
+* `enabled` - (Optional) True if enabled final backup.
+
+* `retention_days` - (Optional) The number of days we retain the final backup after instance deletion. The number of days of retain final backup can be set from 1 to 365.
+
 The optional `settings.advanced_machine_features` subblock supports:
 
 * `threads_per_core` - (Optional) The number of threads per core. The value of this flag can be 1 or 2. To disable SMT, set this flag to 1. Only available in Cloud SQL for SQL Server instances. See [smt](https://cloud.google.com/sql/docs/sqlserver/create-instance#smt-create-instance) for more details.


### PR DESCRIPTION
<!--
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/24032
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

sql: add `final_backup_config` field to `google_sql_database_instance` resource

```
