### PR TITLE
feat: enable default_from_api flag for ODB Network related fields in Oracledatabase CloudVmCluster

### DIFF
--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -331,15 +331,18 @@ properties:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}
       It is optional but if specified, this should match the parent ODBNetwork of
       the odb_subnet and backup_odb_subnet.
+    default_from_api: true
   - name: odbSubnet
     type: String
     description: |-
       The name of the OdbSubnet associated with the VM Cluster for
       IP allocation. Format:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}
+    default_from_api: true
   - name: backupOdbSubnet
     type: String
     description: |-
       The name of the backup OdbSubnet associated with the VM Cluster.
       Format:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}
+    default_from_api: true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
oracledatabase: enable default_from_api flag for ODB Network related fields in `google_oracle_database_cloud_vm_cluster` resource
```
