### PR TITLE
feat: enable default_from_api flag for ODB Network related fields in Oracledatabase AutonomousDatabase resource

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -666,12 +666,14 @@ properties:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}
       It is optional but if specified, this should match the parent ODBNetwork of
       the odb_subnet and backup_odb_subnet.
+    default_from_api: true
   - name: odbSubnet
     type: String
     description: |-
       The name of the OdbSubnet associated with the Autonomous Database for
       IP allocation. Format:
       projects/{project}/locations/{location}/odbNetworks/{odb_network}/odbSubnets/{odb_subnet}
+    default_from_api: true
   - name: 'createTime'
     type: String
     description: 'The date and time that the Autonomous Database was created. '


### PR DESCRIPTION

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/23930
ref https://github.com/hashicorp/terraform-provider-google/issues/23651

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
oracledatabase: enable default_from_api flag for ODB Network related fields in `google_oracle_database_autonomous_database` resource
```
