### PR TITLE
Fix VCR comment for EAP to be more readable

### DIFF
--- a/.ci/magician/cmd/templates/vcr/post_replay_eap.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay_eap.tmpl
@@ -1,0 +1,46 @@
+{{- if or (gt (len .NotRunBetaTests) 0) (gt (len .NotRunGATests) 0)}}
+#### Non-exercised tests
+
+{{if gt (len .NotRunBetaTests) 0 -}}
+{{color "red" "Tests were added that are skipped in VCR:"}}
+{{range .NotRunBetaTests}}{{. | printf "- %s\n"}}{{end}}
+{{end}}
+
+{{if gt (len .NotRunGATests) 0 -}}
+{{color "red" "Tests were added that are GA-only additions and require manual runs:"}}
+{{range .NotRunGATests}}{{. | printf "- %s\n"}}{{end}}
+{{end}}
+{{end}}
+#### Tests analytics
+Total tests: {{add (add (len .ReplayingResult.PassedTests) (len .ReplayingResult.SkippedTests)) (len .ReplayingResult.FailedTests) }}
+Passed tests: {{len .ReplayingResult.PassedTests}}
+Skipped tests: {{len .ReplayingResult.SkippedTests}}
+Affected tests: {{len .ReplayingResult.FailedTests}}
+
+Affected service packages:
+{{if .RunFullVCR}}
+All service packages are affected
+{{else if gt (len .AffectedServices) 0}}
+{{range .AffectedServices}}
+`{{.}}` {{/* remove trailing whitespace */ -}}
+{{end}}
+{{else}}
+None
+{{end}}
+{{ if gt (len .ReplayingResult.FailedTests) 0 -}}
+#### Action taken
+Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Affected tests:
+{{range .ReplayingResult.FailedTests}}
+`{{.}}` {{/* remove trailing whitespace */ -}}
+{{end}}
+
+[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/develop/test/test/)
+{{ else -}}
+{{- if .ReplayingErr -}}
+{{color "red" "Errors occurred during REPLAYING mode. Please fix them to complete your PR."}}
+{{- else -}}
+{{color "green" "All tests passed!"}}
+{{- end}}
+
+View the [build log](https://storage.cloud.google.com/{{.LogBucket}}/{{.Version}}/refs/heads/{{.Head}}/artifacts/{{.BuildID}}/build-log/replaying_test.log)
+{{- end}}

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -15,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	//go:embed templates/vcr/post_replay_eap.tmpl
+	postReplayEAPTmplText string
+)
+
 var tevRequiredEnvironmentVariables = [...]string{
 	"GEN_PATH",
 	"GOCACHE",
@@ -190,7 +195,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir, modifiedFilePath 
 		Version:          provider.Private.String(),
 		Head:             head,
 	}
-	comment, err := formatPostReplay(postReplayData)
+	comment, err := formatPostReplayEAP(postReplayData)
 	if err != nil {
 		return fmt.Errorf("error formatting post replay comment: %w", err)
 	}
@@ -290,4 +295,8 @@ View the [build log](https://storage.cloud.google.com/ci-vcr-logs/%s/refs/heads/
 
 func init() {
 	rootCmd.AddCommand(testEAPVCRCmd)
+}
+
+func formatPostReplayEAP(data postReplay) (string, error) {
+	return formatComment("post_replay_eap.tmpl", postReplayEAPTmplText, data)
 }

--- a/.ci/magician/cmd/test_eap_vcr_test.go
+++ b/.ci/magician/cmd/test_eap_vcr_test.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"magician/provider"
+	"magician/vcr"
+)
+
+func TestAnalyticsCommentEAP(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         postReplay
+		wantContains []string
+	}{
+		{
+			name: "run full vcr is false and no affected services",
+			data: postReplay{
+				ReplayingResult: vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       false,
+				AffectedServices: []string{},
+			},
+			wantContains: []string{
+				"#### Tests analytics",
+				"Total tests: 6",
+				"Passed tests: 3",
+				"Skipped tests: 2",
+				"Affected tests: 1",
+				"Affected service packages",
+				"None",
+			},
+		},
+		{
+			name: "run full vcr is false and has affected services",
+			data: postReplay{
+				ReplayingResult: vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       false,
+				AffectedServices: []string{"svc-a", "svc-b"},
+			},
+			wantContains: []string{
+				"#### Tests analytics",
+				"Total tests: 6",
+				"Passed tests: 3",
+				"Skipped tests: 2",
+				"Affected tests: 1",
+				"Affected service packages",
+				"`svc-a`",
+				"`svc-b`",
+			},
+		},
+		{
+			name: "run full vcr is true",
+			data: postReplay{
+				ReplayingResult: vcr.Result{
+					PassedTests:  []string{"a", "b", "c"},
+					SkippedTests: []string{"d", "e"},
+					FailedTests:  []string{"f"},
+				},
+				RunFullVCR:       true,
+				AffectedServices: []string{},
+			},
+			wantContains: []string{
+				"#### Tests analytics",
+				"Total tests: 6",
+				"Passed tests: 3",
+				"Skipped tests: 2",
+				"Affected tests: 1",
+				"Affected service packages",
+				"All service packages are affected",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatPostReplayEAP(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			for _, wc := range tc.wantContains {
+				if !strings.Contains(got, wc) {
+					t.Errorf("formatPostReplayEAP() returned %q, which does not contain %q", got, wc)
+				}
+			}
+		})
+	}
+}
+
+func TestNonExercisedTestsCommentEAP(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         postReplay
+		wantContains []string
+	}{
+		{
+			name: "with not run beta tests",
+			data: postReplay{
+				NotRunBetaTests: []string{"beta-1", "beta-2"},
+			},
+			wantContains: []string{
+				"#### Non-exercised tests",
+				"",
+				color("red", "Tests were added that are skipped in VCR:"),
+				"- beta-1",
+				"- beta-2",
+			},
+		},
+		{
+			name: "with not run ga tests",
+			data: postReplay{
+				NotRunGATests: []string{"ga-1", "ga-2"},
+			},
+			wantContains: []string{
+				"#### Non-exercised tests",
+				"",
+				"",
+				"",
+				color("red", "Tests were added that are GA-only additions and require manual runs:"),
+				"- ga-1",
+				"- ga-2",
+			},
+		},
+		{
+			name: "with not run ga tests and not run beta tests",
+			data: postReplay{
+				NotRunGATests:   []string{"ga-1", "ga-2"},
+				NotRunBetaTests: []string{"beta-1", "beta-2"},
+			},
+			wantContains: []string{
+				"#### Non-exercised tests",
+				"",
+				color("red", "Tests were added that are skipped in VCR:"),
+				"- beta-1",
+				"- beta-2",
+				"",
+				"",
+				"",
+				color("red", "Tests were added that are GA-only additions and require manual runs:"),
+				"- ga-1",
+				"- ga-2",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatPostReplayEAP(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			for _, wc := range tc.wantContains {
+				if !strings.Contains(got, wc) {
+					t.Errorf("formatPostReplayEAP() returned %q, which does not contain %q", got, wc)
+				}
+			}
+		})
+	}
+}
+
+func TestWithReplayFailedTestsEAP(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         postReplay
+		wantContains []string
+	}{
+		{
+			name: "with failed tests",
+			data: postReplay{
+				ReplayingResult: vcr.Result{
+					FailedTests: []string{"a", "b"},
+				},
+			},
+			wantContains: []string{
+				"#### Action taken",
+				"Found 2 affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Affected tests",
+				"`a`",
+				"`b`",
+				"[Get to know how VCR tests work](https://googlecloudplatform.github.io/magic-modules/develop/test/test/)",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatPostReplayEAP(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			for _, wc := range tc.wantContains {
+				if !strings.Contains(got, wc) {
+					t.Errorf("formatPostReplayEAP() returned %q, which does not contain %q", got, wc)
+				}
+			}
+		})
+	}
+}
+
+func TestWithoutReplayFailedTestsEAP(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         postReplay
+		wantContains []string
+	}{
+		{
+			name: "with replay error",
+			data: postReplay{
+				ReplayingErr: fmt.Errorf("some error"),
+				BuildID:      "build-123",
+				Head:         "auto-pr-123",
+				LogBucket:    "ci-vcr-logs",
+				Version:      provider.Beta.String(),
+			},
+			wantContains: []string{
+				color("red", "Errors occurred during REPLAYING mode. Please fix them to complete your PR."),
+				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+			},
+		},
+		{
+			name: "without replay error",
+			data: postReplay{
+				BuildID:   "build-123",
+				Head:      "auto-pr-123",
+				LogBucket: "ci-vcr-logs",
+				Version:   provider.Beta.String(),
+			},
+			wantContains: []string{
+				color("green", "All tests passed!"),
+				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := formatPostReplayEAP(tc.data)
+			if err != nil {
+				t.Fatalf("Failed to format comment: %v", err)
+			}
+			for _, wc := range tc.wantContains {
+				if !strings.Contains(got, wc) {
+					t.Errorf("formatPostReplayEAP() returned %q, which does not contain %q", got, wc)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Basically, the html we use in the GitHub comments doesn't work for Gerrit comments. So this change creates an EAP-specific version of the template that doesn't include the html.

Below is the diff between the templates. You can see I've kept everything the same except for some small html changes:

<img width="810" height="648" alt="Screenshot 2025-08-19 at 11 13 39 AM" src="https://github.com/user-attachments/assets/b73be903-95c9-4742-9402-e331ffadab31" />

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
