### PR TITLE
(Breaking Change) google_firestore_database: Consolidate deletion_policy and delete_protection_state

### DIFF
--- a/mmv1/products/firestore/Database.yaml
+++ b/mmv1/products/firestore/Database.yaml
@@ -52,12 +52,13 @@ custom_code:
 examples:
   - name: 'firestore_default_database'
     primary_resource_id: 'database'
+    vars:
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
     test_env_vars:
       project_id: 'PROJECT_NAME'
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
     exclude_test: true
   - name: 'firestore_database'
     primary_resource_id: 'database'
@@ -71,7 +72,6 @@ examples:
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
   - name: 'firestore_database_with_tags'
     primary_resource_id: 'database'
     vars:
@@ -86,7 +86,6 @@ examples:
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
     exclude_test: true
   - name: 'firestore_cmek_database'
     primary_resource_id: 'database'
@@ -102,15 +101,15 @@ examples:
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
   - name: 'firestore_default_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
+    vars:
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
     test_env_vars:
       project_id: 'PROJECT_NAME'
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
     exclude_test: true
   - name: 'firestore_database_in_datastore_mode'
     primary_resource_id: 'datastore_mode_database'
@@ -124,7 +123,6 @@ examples:
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
   - name: 'firestore_cmek_database_in_datastore_mode'
     primary_resource_id: 'database'
     vars:
@@ -139,7 +137,6 @@ examples:
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
   - name: 'firestore_database_enterprise'
     primary_resource_id: 'enterprise-db'
     vars:
@@ -147,23 +144,11 @@ examples:
       delete_protection_state: 'DELETE_PROTECTION_ENABLED'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
     ignore_read_extra:
       - 'project'
       - 'etag'
-      - 'deletion_policy'
-virtual_fields:
-  - name: 'deletion_policy'
-    description: |
-      Deletion behavior for this database.
-      If the deletion policy is `ABANDON`, the database will be removed from Terraform state but not deleted from Google Cloud upon destruction.
-      If the deletion policy is `DELETE`, the database will both be removed from Terraform state and deleted from Google Cloud upon destruction.
-      The default value is `ABANDON`.
-      See also `delete_protection`.
-    type: String
-    default_value: "ABANDON"
-    # `deletion_policy` is deprecated and will be removed in a future major release.
-    # Once that release happens, you should use `delete_protection_state` instead.
-    # For now though, setting this field is necessary if you wish for your Firestore databases to be deleted upon `terraform destroy`.
 parameters:
 properties:
   - name: 'name'
@@ -249,11 +234,9 @@ properties:
     description: |
       State of delete protection for the database.
       When delete protection is enabled, this database cannot be deleted.
-      The default value is `DELETE_PROTECTION_STATE_UNSPECIFIED`, which is currently equivalent to `DELETE_PROTECTION_DISABLED`.
-      **Note:** Additionally, to delete this database using `terraform destroy`, `deletion_policy` must be set to `DELETE`.
-    default_from_api: true
+      The default value is `DELETE_PROTECTION_ENABLED'.
+    default_value: 'DELETE_PROTECTION_ENABLED'
     enum_values:
-      - 'DELETE_PROTECTION_STATE_UNSPECIFIED'
       - 'DELETE_PROTECTION_ENABLED'
       - 'DELETE_PROTECTION_DISABLED'
   - name: 'etag'

--- a/mmv1/products/firestore/Document.yaml
+++ b/mmv1/products/firestore/Document.yaml
@@ -48,18 +48,24 @@ examples:
   - name: 'firestore_document_basic'
     primary_resource_id: 'mydoc'
     vars:
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
       document_id: 'my-doc-id'
       project_id: 'project-id'
     test_env_vars:
       org_id: 'ORG_ID'
     external_providers: ["random", "time"]
+    test_vars_overrides:
+      'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
   - name: 'firestore_document_nested_document'
     primary_resource_id: 'mydoc'
     vars:
+      delete_protection_state: 'DELETE_PROTECTION_ENABLED'
       document_id: 'my-doc-id'
       project_id: 'project-id'
     test_env_vars:
       org_id: 'ORG_ID'
+    test_vars_overrides:
+      'delete_protection_state': '"DELETE_PROTECTION_DISABLED"'
     external_providers: ["random", "time"]
 parameters:
   - name: 'database'

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_daily.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_backup_schedule" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_backup_schedule_weekly.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_backup_schedule" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_cmek_database.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database.tf.tmpl
@@ -10,7 +10,6 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
   delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy                   = "DELETE"
   cmek_config {
     kms_key_name                    = google_kms_crypto_key.crypto_key.id
   }

--- a/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_cmek_database_in_datastore_mode.tf.tmpl
@@ -10,7 +10,6 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
   delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy                   = "DELETE"
   cmek_config {
     kms_key_name                    = google_kms_crypto_key.crypto_key.id
   }

--- a/mmv1/templates/terraform/examples/firestore_database.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database.tf.tmpl
@@ -7,5 +7,4 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
   delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy                   = "DELETE"
 }

--- a/mmv1/templates/terraform/examples/firestore_database_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database_enterprise.tf.tmpl
@@ -4,5 +4,5 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
 	location_id              = "nam5"
 	type                     = "FIRESTORE_NATIVE"
 	database_edition         = "ENTERPRISE"
-	deletion_policy          = "DELETE"
+	delete_protection_state  = "{{index $.Vars "delete_protection_state"}}"
 }

--- a/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database_in_datastore_mode.tf.tmpl
@@ -7,5 +7,4 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   app_engine_integration_mode       = "DISABLED"
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
   delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy                   = "DELETE"
 }

--- a/mmv1/templates/terraform/examples/firestore_database_with_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_database_with_tags.tf.tmpl
@@ -4,7 +4,6 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   location_id                       = "nam5"
   type                              = "FIRESTORE_NATIVE"
   delete_protection_state           = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy                   = "DELETE"
   tags = {
     "{{index $.Vars "tag_key_id"}}" = "{{index $.Vars "tag_value_id"}}"
   }

--- a/mmv1/templates/terraform/examples/firestore_default_database.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_default_database.tf.tmpl
@@ -3,4 +3,6 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   name        = "(default)"
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
 }

--- a/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_default_database_in_datastore_mode.tf.tmpl
@@ -3,4 +3,6 @@ resource "google_firestore_database" "{{$.PrimaryResourceId}}" {
   name        = "(default)"
   location_id = "nam5"
   type        = "DATASTORE_MODE"
+
+  delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
 }

--- a/mmv1/templates/terraform/examples/firestore_document_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_document_basic.tf.tmpl
@@ -25,6 +25,8 @@ resource "google_firestore_database" "database" {
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
 
+  delete_protection_state  = "{{index $.Vars "delete_protection_state"}}"
+
   depends_on = [google_project_service.firestore]
 }
 

--- a/mmv1/templates/terraform/examples/firestore_document_nested_document.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_document_nested_document.tf.tmpl
@@ -25,6 +25,8 @@ resource "google_firestore_database" "database" {
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
 
+  delete_protection_state  = "{{index $.Vars "delete_protection_state"}}"
+
   depends_on = [google_project_service.firestore]
 }
 

--- a/mmv1/templates/terraform/examples/firestore_field_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_field_basic.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_field_match_override.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_field_match_override.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_field_timestamp.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_field_timestamp.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_field" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_field_wildcard.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_field_wildcard.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
 	type        = "FIRESTORE_NATIVE"
 
 	delete_protection_state = "{{index $.Vars "delete_protection_state"}}"
-	deletion_policy         = "DELETE"
   }
 
   resource "google_firestore_field" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_index_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_basic.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "DELETE_PROTECTION_DISABLED"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_datastore_mode.tf.tmpl
@@ -5,7 +5,6 @@ resource "google_firestore_database" "database" {
   type        = "DATASTORE_MODE"
 
   delete_protection_state = "DELETE_PROTECTION_DISABLED"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/firestore_index_mongodb_compatible_scope.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_mongodb_compatible_scope.tf.tmpl
@@ -1,16 +1,15 @@
 resource "google_firestore_database" "database" {
-	project                  = "{{index $.TestEnvVars "project_id"}}"
-	name                     = "{{index $.Vars "database_id"}}"
-	location_id              = "nam5"
-	type                     = "FIRESTORE_NATIVE"
-	database_edition         = "ENTERPRISE"
+	project                 = "{{index $.TestEnvVars "project_id"}}"
+	name                    = "{{index $.Vars "database_id"}}"
+	location_id             = "nam5"
+	type                    = "FIRESTORE_NATIVE"
+	database_edition        = "ENTERPRISE"
 
 	delete_protection_state = "DELETE_PROTECTION_DISABLED"
-	deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
-	project     = "{{index $.TestEnvVars "project_id"}}"
+	project    = "{{index $.TestEnvVars "project_id"}}"
 	database   = google_firestore_database.database.name
 	collection = "atestcollection"
 

--- a/mmv1/templates/terraform/examples/firestore_index_name_descending.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_name_descending.tf.tmpl
@@ -5,11 +5,10 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "DELETE_PROTECTION_DISABLED"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
-  project     = "{{index $.TestEnvVars "project_id"}}"
+  project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
   collection = "atestcollection"
 

--- a/mmv1/templates/terraform/examples/firestore_index_sparse_any.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_sparse_any.tf.tmpl
@@ -1,16 +1,15 @@
 resource "google_firestore_database" "database" {
-	project                  = "{{index $.TestEnvVars "project_id"}}"
-	name                     = "{{index $.Vars "database_id"}}"
-	location_id              = "nam5"
-	type                     = "FIRESTORE_NATIVE"
-	database_edition         = "ENTERPRISE"
+	project                 = "{{index $.TestEnvVars "project_id"}}"
+	name                    = "{{index $.Vars "database_id"}}"
+	location_id             = "nam5"
+	type                    = "FIRESTORE_NATIVE"
+	database_edition        = "ENTERPRISE"
 
 	delete_protection_state = "DELETE_PROTECTION_DISABLED"
-	deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
-	project     = "{{index $.TestEnvVars "project_id"}}"
+	project    = "{{index $.TestEnvVars "project_id"}}"
 	database   = google_firestore_database.database.name
 	collection = "atestcollection"
 

--- a/mmv1/templates/terraform/examples/firestore_index_vector.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_vector.tf.tmpl
@@ -5,11 +5,10 @@ resource "google_firestore_database" "database" {
   type        = "FIRESTORE_NATIVE"
 
   delete_protection_state = "DELETE_PROTECTION_DISABLED"
-  deletion_policy         = "DELETE"
 }
 
 resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
-  project     = "{{index $.TestEnvVars "project_id"}}"
+  project    = "{{index $.TestEnvVars "project_id"}}"
   database   = google_firestore_database.database.name
   collection = "atestcollection"
 

--- a/mmv1/templates/terraform/pre_delete/firestore_database.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/firestore_database.go.tmpl
@@ -1,7 +1,3 @@
-if deletionPolicy := d.Get("deletion_policy"); deletionPolicy != "DELETE" {
-    log.Printf("[WARN] Firestore database %q deletion_policy is not set to 'DELETE', skipping deletion", d.Get("name").(string))
-    return nil
-}
 if deleteProtection := d.Get("delete_protection_state"); deleteProtection == "DELETE_PROTECTION_ENABLED" {
-    return fmt.Errorf("Cannot delete Firestore database %s: Delete Protection is enabled. Set delete_protection_state to DELETE_PROTECTION_DISABLED for this resource and run \"terraform apply\" before attempting to delete it.", d.Get("name").(string))
+	return fmt.Errorf("Cannot delete Firestore database %s: Delete Protection is enabled. Set delete_protection_state to DELETE_PROTECTION_DISABLED for this resource and run \"terraform apply\" before attempting to delete it.", d.Get("name").(string))
 }

--- a/mmv1/third_party/terraform/services/firestore/data_source_google_firestore_document_test.go
+++ b/mmv1/third_party/terraform/services/firestore/data_source_google_firestore_document_test.go
@@ -73,6 +73,8 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+
 	depends_on = [google_project_service.firestore]
 }
 `, randomSuffix, randomSuffix, orgId)

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_test.go
@@ -32,7 +32,7 @@ func TestAccFirestoreDatabase_tags(t *testing.T) {
 				ResourceName:            "google_firestore_database.database",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project", "etag", "deletion_policy", "tags"},
+				ImportStateVerifyIgnore: []string{"project", "etag", "tags"},
 			},
 		},
 	})
@@ -45,7 +45,6 @@ func testAccFirestoreDatabaseTags(context map[string]interface{}) string {
       location_id                       = "nam5"
       type                              = "FIRESTORE_NATIVE"
       delete_protection_state           = "DELETE_PROTECTION_DISABLED"
-      deletion_policy                   = "DELETE"
       tags = {
         "%{pid}/%{tagKey}" = "%{tagValue}"
       }

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_database_update_test.go
@@ -2,9 +2,10 @@ package firestore_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -122,6 +123,7 @@ resource "google_firestore_database" "database" {
   type             = "DATASTORE_MODE"
   location_id      = "nam5"
   concurrency_mode = "%s"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
 }
 `, projectId, randomSuffix, concurrencyMode)
 }
@@ -134,6 +136,7 @@ resource "google_firestore_database" "database" {
   type                              = "DATASTORE_MODE"
   location_id                       = "nam5"
   point_in_time_recovery_enablement = "%s"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
 }
 `, projectId, randomSuffix, pointInTimeRecoveryEnablement)
 }

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_document_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_document_test.go
@@ -71,6 +71,8 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+
 	depends_on = [google_project_service.firestore]
 }
 `, randomSuffix, randomSuffix, orgId)

--- a/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
+++ b/mmv1/third_party/terraform/services/firestore/resource_firestore_field_test.go
@@ -101,6 +101,8 @@ resource "google_firestore_database" "database" {
 	location_id = "nam5"
 	type        = "FIRESTORE_NATIVE"
 
+	delete_protection_state = "DELETE_PROTECTION_DISABLED"
+
 	# used to control delete order
 	depends_on = [
 		google_project_service.firestore,
@@ -117,7 +119,6 @@ resource "google_firestore_database" "database" {
 	type        = "FIRESTORE_NATIVE"
 
 	delete_protection_state = "DELETE_PROTECTION_DISABLED"
-	deletion_policy         = "DELETE"
 }
 `, context)
 	}

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -250,3 +250,15 @@ Remove `template.containers.depends_on` from your configuration after upgrade.
 The default value for `disable_on_destroy` has been changed to `false`. The previous default (`true`) created a risk of unintended service disruptions, as destroying a single `google_project_service` resource would disable the API for the entire project.
 
 Now, destroying the resource will only remove it from Terraform's state and leave the service enabled. To disable a service when the resource is destroyed, you must now make an explicit decision by setting `disable_on_destroy = true`.
+
+## Resource: `google_firestore_database`
+
+### `deletion_policy` has been removed, `delete_protection_state` now defaults to `'DELETE_PROTECTION_ENABLED'`, and `delete_protection_state` no longer supports `'DELETE_PROTECTION_STATE_UNSPECIFIED`'.
+
+The previously available Terraform-only field `deletion_policy` has been removed as it conflicted with `delete_protection_state`.
+
+Additionally, the new default value of `delete_protection_state` is `'DELETE_PROTECTION_ENABLED'`. `DELETE_PROTECTION_STATE_UNSPECIFIED` is no longer supported.
+
+Destroying the resource will, if `delete_protection_state` is `DELETE_PROTECTION_ENABLED`, be disallowed. Users needing to destroy a resource will need to set `delete_protection_state` to `'DELETE_PROTECTION_DISABLED'`, run `terraform apply`, and subsequently run `terraform destroy`.
+
+To upgrade, users should remove all references to `deletion_policy` for Firestore databases. Any references to `'DELETE_PROTECTION_STATE_UNSPECIFIED'` should be changed to `'DELETE_PROTECTION_ENABLED'` (recommended) or `'DELETE_PROTECTION_DISABLED'` as required. To retain the previous delete protection state, choose `'DELETE_PROTECTION_DISABLED'`.


### PR DESCRIPTION
This breaking change removes `deletion_policy` from `google_firestore_database` and instead prioritizes `delete_protection_state`, which is what the Firestore API uses.

```release-note:breaking-change
firestore: removed `deletion_policy` on `google_firestore_database`
```
```release-note:breaking-change
firestore: removed option `DELETE_PROTECTION_STATE_UNSPECIFIED` on field `delete_protection_state` of `google_firestore_database`
```
```release-note:breaking-change
firestore: made `DELETE_PROTECTION_ENABLED` the default value of `delete_protection_state` on `google_firestore_database`
```
