### PR TITLE
Adds UnitKind provider for SaasRuntime

### DIFF
--- a/mmv1/products/saasservicemgmt/UnitKind.yaml
+++ b/mmv1/products/saasservicemgmt/UnitKind.yaml
@@ -1,0 +1,213 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: UnitKind
+description: A UnitKind serves as a template or type definition for a group of Units. Units that belong to the same UnitKind are managed together, follow the same release model, and are typically updated together through rollouts.
+base_url: projects/{{project}}/locations/{{location}}/unitKinds
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/unitKinds/{{unit_kind_id}}
+create_url: projects/{{project}}/locations/{{location}}/unitKinds?unitKindId={{unit_kind_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/unitKinds/{{unit_kind_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/unitKinds/{{unit_kind_id}}
+min_version: beta
+examples:
+  - name: saas_runtime_unit_kind_basic
+    primary_resource_id: "example"
+    min_version: 'beta'
+    vars:
+      saas_name: example-saas
+      cluster_unitkind_name: cluster-unitkind
+      app_unitkind_name: app-unitkind
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-saasservicemgmt.iam.gserviceaccount.com"
+        role: "roles/saasservicemgmt.serviceAgent"
+autogen_async: false
+autogen_status: VW5pdEtpbmQ=
+parameters:
+  - name: location
+    type: String
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: unitKindId
+    type: String
+    description: The ID value for the new unit kind.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: annotations
+    type: KeyValueAnnotations
+    description: |-
+      Annotations is an unstructured key-value map stored with a resource that
+      may be set by external tools to store and retrieve arbitrary metadata.
+      They are not queryable and should be preserved when modifying objects.
+
+      More info: https://kubernetes.io/docs/user-guide/annotations
+  - name: createTime
+    type: String
+    description: The timestamp when the resource was created.
+    output: true
+  - name: defaultRelease
+    type: String
+    description: |-
+      A reference to the Release object to use as default for creating new units
+      of this UnitKind (optional).
+
+      If not specified, a new unit must explicitly reference which release to use
+      for its creation.
+  - name: dependencies
+    type: Array
+    description: |-
+      List of other unit kinds that this release will depend on. Dependencies
+      will be automatically provisioned if not found. Maximum 10.
+    immutable: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: alias
+          type: String
+          description: An alias for the dependency. Used for input variable mapping.
+          required: true
+        - name: unitKind
+          type: String
+          description: The unit kind of the dependency.
+          immutable: true
+          required: true
+  - name: etag
+    type: String
+    description: |-
+      An opaque value that uniquely identifies a version or
+      generation of a resource. It can be used to confirm that the client
+      and server agree on the ordering of a resource being written.
+    output: true
+  - name: inputVariableMappings
+    type: Array
+    description: |-
+      List of inputVariables for this release that will either be retrieved from
+      a dependency’s outputVariables, or will be passed on to a dependency’s
+      inputVariables. Maximum 100.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: from
+          type: NestedObject
+          description: Output variables whose values will be passed on to dependencies
+          properties:
+            - name: dependency
+              type: String
+              description: Alias of the dependency that the outputVariable will pass its value to
+              required: true
+            - name: outputVariable
+              type: String
+              description: Name of the outputVariable on the dependency
+              required: true
+        - name: to
+          type: NestedObject
+          description: Input variables whose values will be passed on to dependencies
+          properties:
+            - name: dependency
+              type: String
+              description: Alias of the dependency that the inputVariable will pass its value to
+              required: true
+            - name: ignoreForLookup
+              type: Boolean
+              description: Tells SaaS Runtime if this mapping should be used during lookup or not
+            - name: inputVariable
+              type: String
+              description: Name of the inputVariable on the dependency
+              required: true
+        - name: variable
+          type: String
+          description: name of the variable
+          required: true
+  - name: labels
+    type: KeyValueLabels
+    description: |-
+      The labels on the resource, which can be used for categorization.
+      similar to Kubernetes resource labels.
+  - name: name
+    type: String
+    description: |-
+      Identifier. The resource name (full URI of the resource) following the standard naming
+      scheme:
+
+      "projects/{project}/locations/{location}/unitKinds/{unitKind}"
+    output: true
+  - name: outputVariableMappings
+    type: Array
+    description: |-
+      List of outputVariables for this unit kind will be passed to this unit's
+      outputVariables. Maximum 100.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: from
+          type: NestedObject
+          description: Output variables whose values will be passed on to dependencies
+          properties:
+            - name: dependency
+              type: String
+              description: Alias of the dependency that the outputVariable will pass its value to
+              required: true
+            - name: outputVariable
+              type: String
+              description: Name of the outputVariable on the dependency
+              required: true
+        - name: to
+          type: NestedObject
+          description: Input variables whose values will be passed on to dependencies
+          properties:
+            - name: dependency
+              type: String
+              description: Alias of the dependency that the inputVariable will pass its value to
+              required: true
+            - name: ignoreForLookup
+              type: Boolean
+              description: Tells SaaS Runtime if this mapping should be used during lookup or not
+            - name: inputVariable
+              type: String
+              description: Name of the inputVariable on the dependency
+              required: true
+        - name: variable
+          type: String
+          description: name of the variable
+          required: true
+  - name: saas
+    type: String
+    description: |-
+      A reference to the Saas that defines the product (managed service) that
+      the producer wants to manage with SaaS Runtime. Part of the SaaS Runtime
+      common data model. Immutable once set.
+    immutable: true
+    required: true
+  - name: uid
+    type: String
+    description: |-
+      The unique identifier of the resource. UID is unique in the time
+      and space for this resource within the scope of the service. It is
+      typically generated by the server on successful creation of a resource
+      and must not be changed. UID is used to uniquely identify resources
+      with resource name reuses. This should be a UUID4.
+    output: true
+  - name: updateTime
+    type: String
+    description: |-
+      The timestamp when the resource was last updated. Any
+      change to the resource made by users must refresh this value.
+      Changes to a resource made by the service should refresh this value.
+    output: true

--- a/mmv1/templates/terraform/examples/saas_runtime_unit_kind_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/saas_runtime_unit_kind_basic.tf.tmpl
@@ -1,0 +1,28 @@
+resource "google_saas_runtime_saas" "example_saas" {
+  provider = google-beta
+  saas_id  = "{{index $.Vars "saas_name"}}"
+  location = "global"
+
+  locations {
+    name = "us-central1"
+  }
+}
+
+resource "google_saas_runtime_unit_kind" "cluster_unit_kind" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "{{index $.Vars "cluster_unitkind_name"}}"
+  saas = google_saas_runtime_saas.example_saas.id
+}
+
+resource "google_saas_runtime_unit_kind" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "{{index $.Vars "app_unitkind_name"}}"
+  saas = google_saas_runtime_saas.example_saas.id
+
+  dependencies {
+    unit_kind = google_saas_runtime_unit_kind.cluster_unit_kind.id
+    alias     = "cluster"
+  }
+}

--- a/mmv1/third_party/terraform/services/saasruntime/resource_saas_runtime_unit_kind_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/saasruntime/resource_saas_runtime_unit_kind_test.go.tmpl
@@ -1,0 +1,155 @@
+package saasruntime_test
+
+{{ if ne $.TargetVersionName `ga` -}}
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccSaasRuntimeUnitKind_update(t *testing.T) {
+	t.Parallel()
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@gcp-sa-saasservicemgmt.iam.gserviceaccount.com",
+			Role:   "roles/saasservicemgmt.serviceAgent",
+		},
+	})
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSaasRuntimeUnitKind_basic(context),
+			},
+			{
+				ResourceName:            "google_saas_runtime_unit_kind.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "terraform_labels", "unit_kind_id"},
+			},
+			{
+				Config: testAccSaasRuntimeUnitKind_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_saas_runtime_unit_kind.example", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_saas_runtime_unit_kind.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"annotations", "labels", "location", "terraform_labels", "unit_kind_id"},
+			},
+		},
+	})
+}
+
+func testAccSaasRuntimeUnitKind_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_saas_runtime_saas" "example_saas" {
+  provider = google-beta
+  saas_id  = "tf-test-example-saas%{random_suffix}"
+  location = "global"
+
+  locations {
+    name = "us-central1"
+  }
+}
+
+resource "google_saas_runtime_unit_kind" "cluster_unit_kind" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "tf-test-cluster-unitkind%{random_suffix}"
+  saas = google_saas_runtime_saas.example_saas.id
+}
+
+resource "google_saas_runtime_unit_kind" "example" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "tf-test-app-unitkind%{random_suffix}"
+  saas = google_saas_runtime_saas.example_saas.id
+
+  dependencies {
+    unit_kind = google_saas_runtime_unit_kind.cluster_unit_kind.id
+    alias     = "cluster"
+  }
+}
+`, context)
+}
+
+func testAccSaasRuntimeUnitKind_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_saas_runtime_saas" "example_saas" {
+  provider = google-beta
+  saas_id  = "tf-test-example-saas%{random_suffix}"
+  location = "global"
+
+  locations {
+    name = "us-central1"
+  }
+}
+
+resource "google_saas_runtime_unit_kind" "cluster_unit_kind" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "tf-test-cluster-unitkind%{random_suffix}"
+  saas = google_saas_runtime_saas.example_saas.id
+}
+
+resource "google_saas_runtime_unit_kind" "example" {
+  provider = google-beta
+  location = "global"
+  unit_kind_id = "tf-test-app-unitkind%{random_suffix}"
+  saas = google_saas_runtime_saas.example_saas.id
+
+  dependencies {
+    unit_kind = google_saas_runtime_unit_kind.cluster_unit_kind.id
+    alias     = "cluster"
+  }
+
+  input_variable_mappings {
+    variable = "cluster_endpoint"
+    from {
+      dependency      = "cluster"
+      output_variable = "endpoint"
+    }
+  }
+
+  input_variable_mappings {
+    variable = "tenant_project_number"
+    to {
+      dependency     = "cluster"
+      input_variable = "tenant_project_number"
+    }
+  }
+
+  input_variable_mappings {
+    variable = "tenant_project_id"
+    to {
+      dependency     = "cluster"
+      input_variable = "tenant_project_id"
+    }
+  }
+
+  output_variable_mappings {
+    variable = "app_cluster_endpoint"
+    from {
+      dependency      = "cluster"
+      output_variable = "endpoint"
+    }
+  }
+}
+`, context)
+}
+{{- end }}


### PR DESCRIPTION
Adds UnitKind resource provider for SaasRuntime API. (beta)

```release-note:new-resource
`google_saas_runtime_unit_kind`
```
