### PR TITLE
secretmanager: set default for `secret_data_wo_version` in `google_secret_manager_secret_version` back to `0`

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -786,9 +786,9 @@ func buildWriteOnlyVersionField(name string, originalField *Type, writeOnlyField
 		propertyWithClientSide(true),
 	}
 
-	// TODO(anymore) remove with next major release + add migration guide
+	// TODO: remove this branch with the next major release + add migration guide
 	if name == "secretDataWoVersion" {
-		options = append(options, propertyWithDefaultValue("0"))
+		options = append(options, propertyWithDefaultValue(0))
 	}
 
 	return NewProperty(name, name, options)

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -737,7 +737,7 @@ func (r Resource) GetIdentity() []*Type {
 	})
 }
 
-func buildWriteOnlyField(name string, versionFieldName string, originalField *Type, originalFieldLineage string) *Type {
+func buildWriteOnlyField(resourceName string, name string, versionFieldName string, originalField *Type, originalFieldLineage string) *Type {
 	description := fmt.Sprintf("%s Note: This property is write-only and will not be read from the API. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)", originalField.Description)
 	fieldPathOriginalField := originalFieldLineage
 	fieldPathCurrentField := strings.ReplaceAll(originalFieldLineage, google.Underscore(originalField.Name), google.Underscore(name))
@@ -759,7 +759,7 @@ func buildWriteOnlyField(name string, versionFieldName string, originalField *Ty
 
 	// TODO: remove this branch with the next major release + add migration guide
 	// In the future (next major) the secret_data_wo_version is required and should always be set explicitly (so no default, required with the _wo field)
-	if name != "secretDataWo" {
+	if name != "secretDataWo" && resourceName != "SecretVersion" {
 		options = append(options, propertyWithRequiredWith([]string{requiredWith}))
 	}
 
@@ -779,7 +779,7 @@ func buildWriteOnlyField(name string, versionFieldName string, originalField *Ty
 	return NewProperty(name, originalField.ApiName, options)
 }
 
-func buildWriteOnlyVersionField(name string, originalField *Type, writeOnlyField *Type, originalFieldLineage string) *Type {
+func buildWriteOnlyVersionField(resourceName string, name string, originalField *Type, writeOnlyField *Type, originalFieldLineage string) *Type {
 	description := fmt.Sprintf("Triggers update of %s write-only. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)", google.Underscore(writeOnlyField.Name))
 	requiredWith := strings.ReplaceAll(originalFieldLineage, google.Underscore(originalField.Name), google.Underscore(writeOnlyField.Name))
 
@@ -792,7 +792,7 @@ func buildWriteOnlyVersionField(name string, originalField *Type, writeOnlyField
 
 	// TODO: remove this branch with the next major release + add migration guide
 	// In the future (next major) the secret_data_wo_version is required and should always be set explicitly (so no default, required with the _wo field)
-	if name == "secretDataWoVersion" {
+	if name == "secretDataWoVersion" && resourceName == "SecretVersion" {
 		options = append(options, propertyWithDefaultValue(0))
 	} else {
 		propertyWithRequiredWith([]string{requiredWith})
@@ -807,8 +807,8 @@ func (r *Resource) addWriteOnlyFields(props []*Type, propWithWoConfigured *Type,
 	}
 	woFieldName := fmt.Sprintf("%sWo", propWithWoConfigured.Name)
 	woVersionFieldName := fmt.Sprintf("%sVersion", woFieldName)
-	writeOnlyField := buildWriteOnlyField(woFieldName, woVersionFieldName, propWithWoConfigured, propWithWoConfiguredLineagePath)
-	writeOnlyVersionField := buildWriteOnlyVersionField(woVersionFieldName, propWithWoConfigured, writeOnlyField, propWithWoConfiguredLineagePath)
+	writeOnlyField := buildWriteOnlyField(r.Name, woFieldName, woVersionFieldName, propWithWoConfigured, propWithWoConfiguredLineagePath)
+	writeOnlyVersionField := buildWriteOnlyVersionField(r.Name, woVersionFieldName, propWithWoConfigured, writeOnlyField, propWithWoConfiguredLineagePath)
 	props = append(props, writeOnlyField, writeOnlyVersionField)
 	return props
 }

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -782,13 +782,15 @@ func buildWriteOnlyVersionField(name string, originalField *Type, writeOnlyField
 		propertyWithType("String"),
 		propertyWithImmutable(originalField.Immutable),
 		propertyWithDescription(description),
-		propertyWithRequiredWith([]string{requiredWith}),
 		propertyWithClientSide(true),
 	}
 
 	// TODO: remove this branch with the next major release + add migration guide
+	// In the future (next major) the secret_data_wo_version is required and should always be set explicitly (so no default, required with the _wo field)
 	if name == "secretDataWoVersion" {
 		options = append(options, propertyWithDefaultValue(0))
+	} else {
+		propertyWithRequiredWith([]string{requiredWith})
 	}
 
 	return NewProperty(name, name, options)

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -786,6 +786,11 @@ func buildWriteOnlyVersionField(name string, originalField *Type, writeOnlyField
 		propertyWithClientSide(true),
 	}
 
+	// TODO(anymore) remove with next major release + add migration guide
+	if name == "secretDataWoVersion" {
+		options = append(options, propertyWithDefaultValue("0"))
+	}
+
 	return NewProperty(name, name, options)
 }
 

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -755,7 +755,12 @@ func buildWriteOnlyField(name string, versionFieldName string, originalField *Ty
 		propertyWithWriteOnly(true),
 		propertyWithApiName(apiName),
 		propertyWithIgnoreRead(true),
-		propertyWithRequiredWith([]string{requiredWith}),
+	}
+
+	// TODO: remove this branch with the next major release + add migration guide
+	// In the future (next major) the secret_data_wo_version is required and should always be set explicitly (so no default, required with the _wo field)
+	if name != "secretDataWo" {
+		options = append(options, propertyWithRequiredWith([]string{requiredWith}))
 	}
 
 	if originalField.Required {

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -977,6 +977,12 @@ func propertyWithDescription(description string) func(*Type) {
 	}
 }
 
+func propertyWithDefaultValue(defaultValue string) func(*Type) {
+	return func(p *Type) {
+		p.DefaultValue = defaultValue
+	}
+}
+
 func propertyWithMinVersion(minVersion string) func(*Type) {
 	return func(p *Type) {
 		p.MinVersion = minVersion

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -977,7 +977,7 @@ func propertyWithDescription(description string) func(*Type) {
 	}
 }
 
-func propertyWithDefaultValue(defaultValue string) func(*Type) {
+func propertyWithDefaultValue(defaultValue int) func(*Type) {
 	return func(p *Type) {
 		p.DefaultValue = defaultValue
 	}


### PR DESCRIPTION
@melinath 

Closes https://github.com/hashicorp/terraform-provider-google/issues/24044

Still needs to be rebased onto `v6.49.0`, however, I am not sure what the normal flow is for hotfixes within magic-modules. Couldn't find a branch nor tag for this to start the branch from.

Ideally requires a new patch release.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
secretmanager: set default for `secret_data_wo_version` in `google_secret_manager_secret_version` back to `0`
```
