### PR TITLE
add `TF_ACC_REFRESH_AFTER_APPLY` envvar for `plugin-testing` - `1.13.3` support

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/builds/build_parameters.kt
@@ -207,6 +207,7 @@ fun ParametrizedWithType.configureGoogleSpecificTestParameters(config: AccTestCo
 //  acceptance tests are templated
 fun ParametrizedWithType.acceptanceTestBuildParams(parallelism: Int, prefix: String, timeout: String, releaseDiffTest: String) {
     hiddenVariable("env.TF_ACC", "1", "Set to a value to run the Acceptance Tests")
+    hiddenVariable("env.TF_ACC_REFRESH_AFTER_APPLY", "1", "Set to a value to refresh the state after apply")
     text("PARALLELISM", "%d".format(parallelism))
     text("TEST_PREFIX", prefix)
     text("TIMEOUT", timeout)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

this resolves a version block of being able to bump to the latest version of `plugin-testing` due to https://github.com/hashicorp/terraform-plugin-testing/issues/327

it'll allow us to test `resource_identity` without diffs from occurring as stated in the original issue opened in `plugin-testing`

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
