### PR TITLE
fix permadiff when specify IPv6 CIDR in a firewall

### DIFF
--- a/mmv1/products/compute/Firewall.yaml
+++ b/mmv1/products/compute/Firewall.yaml
@@ -172,6 +172,7 @@ properties:
       must be expressed in CIDR format. IPv4 or IPv6 ranges are supported.
     is_set: true
     default_from_api: true
+    diff_suppress_func: 'diffSuppressDestinationRanges'
     item_type:
       type: String
   - name: 'direction'

--- a/mmv1/templates/terraform/constants/firewall.tmpl
+++ b/mmv1/templates/terraform/constants/firewall.tmpl
@@ -107,6 +107,30 @@ func diffSuppressSourceRanges(k, old, new string, d *schema.ResourceData) bool {
 			return true
 		}
 	}
-	// For any other source_ranges value diff, don't suppress
-	return false
+
+	return diffSuppressCIDR("source_ranges", d)
+}
+
+func diffSuppressDestinationRanges(k, old, new string, d *schema.ResourceData) bool {
+	return diffSuppressCIDR("destination_ranges", d)
+}
+
+func diffSuppressCIDR (key string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(key)
+	oldRanges := o.(*schema.Set).List()
+	newRanges := n.(*schema.Set).List()
+
+	if len(oldRanges) != len(newRanges) {
+		return false
+	}
+
+	for i := 0; i < len(oldRanges); i++ {
+		oldCIDR := netip.MustParsePrefix(oldRanges[i].(string))
+		newCIDR := netip.MustParsePrefix(newRanges[i].(string))
+
+		if oldCIDR != newCIDR {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23169

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed IPv6 CIDR perma-diff in `google_compute_firewall`
```
