### PR TITLE
added qos support

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -189,6 +189,7 @@ properties:
     type: String
     description: |
       Optional. Custom Performance Total Throughput of the pool (in MiB/s).
+    default_from_api: true
   - name: 'totalIops'
     type: String
     description: |
@@ -207,3 +208,18 @@ properties:
       Flag indicating that the hot-tier threshold will be auto-increased by 10% of the hot-tier when it hits 100%. Default is true.
       The increment will kick in only if the new size after increment is still less than or equal to storage pool size.
     min_version: 'beta'
+  - name: 'qosType'
+    type: Enum
+    description: |
+      QoS (Quality of Service) type of the storage pool.
+      Possible values are: AUTO, MANUAL.
+    enum_values:
+      - 'QOS_TYPE_UNSPECIFIED'
+      - 'AUTO'
+      - 'MANUAL'
+  - name: 'availableThroughputMibps'
+    type: String
+    description: |
+      Available throughput of the storage pool (in MiB/s).
+    output: true
+

--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -222,4 +222,3 @@ properties:
     description: |
       Available throughput of the storage pool (in MiB/s).
     output: true
-

--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -218,7 +218,7 @@ properties:
       - 'AUTO'
       - 'MANUAL'
   - name: 'availableThroughputMibps'
-    type: String
+    type: Double
     description: |
       Available throughput of the storage pool (in MiB/s).
     output: true

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -568,7 +568,7 @@ properties:
           Optional. Labels to be added to the replication as the key value pairs.
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   - name: 'throughputMibps'
-    type: String
+    type: Double
     description: |
       Optional. Custom Performance Total Throughput of the pool (in MiB/s).
     default_from_api: true

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -567,3 +567,9 @@ properties:
         description: |
           Optional. Labels to be added to the replication as the key value pairs.
           An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+  - name: 'throughputMibps'
+    type: String
+    description: |
+      Optional. Custom Performance Total Throughput of the pool (in MiB/s).
+    default_from_api: true
+

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -572,4 +572,3 @@ properties:
     description: |
       Optional. Custom Performance Total Throughput of the pool (in MiB/s).
     default_from_api: true
-

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
@@ -871,4 +871,104 @@ data "google_compute_network" "default" {
 }
 `, context)
 }
+
+func TestAccNetappStoragePool_ManualQos(t *testing.T) {
+	context := map[string]interface{}{
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetappVolumeDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetappVolume_ManualQosAuto(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+			{
+				Config: testAccNetappVolume_ManualQosManual(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetappVolume_ManualQosAuto(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "test_pool" {
+  name = "tf-test-pool%{random_suffix}"
+  location = "us-east4"
+  service_level = "EXTREME"
+  capacity_gib = "2048"
+  network = data.google_compute_network.default.id
+  qos_type = "AUTO"
+}
+
+resource "time_sleep" "wait_3_minutes" {
+    depends_on = [google_netapp_storage_pool.test_pool]
+    create_duration = "3m"
+}
+
+resource "google_netapp_volume" "test_volume" {
+    location = "us-east4"
+    name = "tf-test-test-volume%{random_suffix}"
+    capacity_gib = "100"
+    share_name = "tf-test-test-volume%{random_suffix}"
+    storage_pool = google_netapp_storage_pool.test_pool.name
+    protocols = ["NFSV3"]
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
+}
+`, context)
+}
+
+func testAccNetappVolume_ManualQosManual(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_netapp_storage_pool" "test_pool" {
+  name = "tf-test-pool%{random_suffix}"
+  location = "us-east4"
+  service_level = "EXTREME"
+  capacity_gib = "2048"
+  network = data.google_compute_network.default.id
+  qos_type = "MANUAL"
+}
+
+resource "time_sleep" "wait_3_minutes" {
+    depends_on = [google_netapp_storage_pool.test_pool]
+    create_duration = "3m"
+}
+
+resource "google_netapp_volume" "test_volume" {
+    location = "us-east4"
+    name = "tf-test-test-volume%{random_suffix}"
+    capacity_gib = "100"
+    description = "This is a test description for manual qos volume"
+    share_name = "tf-test-test-volume%{random_suffix}"
+    storage_pool = google_netapp_storage_pool.test_pool.name
+    protocols = ["NFSV3"]
+    throughput_mibps = "12.5"
+}
+
+data "google_compute_network" "default" {
+    name = "%{network_name}"
+}
+`, context)
+}
 {{ end }}

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
@@ -760,7 +760,6 @@ data "google_compute_network" "default" {
 `, context)
 }
 
-
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappVolume_flexAutoTierNetappVolume_update(t *testing.T) {
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
@@ -962,7 +962,7 @@ resource "google_netapp_volume" "test_volume" {
     share_name = "tf-test-test-volume%{random_suffix}"
     storage_pool = google_netapp_storage_pool.test_pool.name
     protocols = ["NFSV3"]
-    throughput_mibps = "12.5"
+    throughput_mibps = 12.5
 }
 
 data "google_compute_network" "default" {


### PR DESCRIPTION
```release-note:enhancement
netapp: added  `qosType` and `availableThroughputMibps` fields to `netapp_storage_pool` resource
```

```release-note:enhancement
netapp: added  `throughputMibps` field to `netapp_volume` resource
```

This commit introduces features for managing Quality of Service (QoS) at the Storage Pool level and allows specifying custom throughput for Volumes.

Changes include:

-   **StoragePool.yaml:**
    -   Added `qosType` enum field to specify QoS type (`AUTO` or `MANUAL`).
    -   Added `availableThroughputMibps` field to expose available throughput.

-   **Volume.yaml:**
    -   Added `throughputMibps` field to allow setting custom throughput on a Volume, intended for use with Storage Pools in `MANUAL` QoS mode.

-   **resource_netapp_volume_test.go.tmpl:**
    -   Added new acceptance test `TestAccNetappStoragePool_ManualQos`.
    -   This test verifies Volume creation and updates within Storage Pools configured with both `AUTO` and `MANUAL` `qosType`.
    -   The test for `MANUAL` QoS includes setting the `throughput_mibps` on the Volume.