### PR TITLE
Document deprecated GKE Enterprise fields.

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2523,12 +2523,14 @@ func ResourceContainerCluster() *schema.Resource {
 				MaxItems:    1,
 				Computed:    true,
 				Description: `Defines the config needed to enable/disable GKE Enterprise`,
+				Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cluster_tier": {
 							Type:             schema.TypeString,
 							Computed:         true,
 							Description:      `Indicates the effective cluster tier. Available options include STANDARD and ENTERPRISE.`,
+							Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
 						},
 						"desired_tier": {
 							Type:             schema.TypeString,
@@ -2536,6 +2538,7 @@ func ResourceContainerCluster() *schema.Resource {
 							Computed:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
 							Description:      `Indicates the desired cluster tier. Available options include STANDARD and ENTERPRISE.`,
+							Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
 							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
 						},
 					},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2523,14 +2523,14 @@ func ResourceContainerCluster() *schema.Resource {
 				MaxItems:    1,
 				Computed:    true,
 				Description: `Defines the config needed to enable/disable GKE Enterprise`,
-				Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
+				Deprecated:  `GKE Enterprise features are now available without an Enterprise tier. This field is deprecated and will be removed in a future major release`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"cluster_tier": {
 							Type:             schema.TypeString,
 							Computed:         true,
 							Description:      `Indicates the effective cluster tier. Available options include STANDARD and ENTERPRISE.`,
-							Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
+							Deprecated:  `GKE Enterprise features are now available without an Enterprise tier. This field is deprecated and will be removed in a future major release`,
 						},
 						"desired_tier": {
 							Type:             schema.TypeString,
@@ -2538,7 +2538,7 @@ func ResourceContainerCluster() *schema.Resource {
 							Computed:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"STANDARD", "ENTERPRISE"}, false),
 							Description:      `Indicates the desired cluster tier. Available options include STANDARD and ENTERPRISE.`,
-							Deprecated:  `GKE Enterprise features have been unbundled from Enterprise tier.`,
+							Deprecated:  `GKE Enterprise features are now available without an Enterprise tier. This field is deprecated and will be removed in a future major release`,
 							DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("CLUSTER_TIER_UNSPECIFIED"),
 						},
 					},

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -421,7 +421,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
   Configuration for [direct-path (via ALTS) with workload identity.](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#workloadaltsconfig). Structure is [documented below](#nested_workload_alts_config).
 
 * `enterprise_config` - (Optional)
-  Configuration for [Enterprise edition].(https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/gke-editions). Structure is [documented below](#nested_enterprise_config).
+  (DEPRECATED) Configuration for [Enterprise edition].(https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/gke-editions). Structure is [documented below](#nested_enterprise_config).
 
 * `anonymous_authentication_config` - (Optional)
   Configuration for [anonymous authentication restrictions](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access). Structure is [documented below](#anonymous_authentication_config).
@@ -1643,7 +1643,7 @@ linux_node_config {
 
 <a name="nested_enterprise_config"></a>The `enterprise_config` block supports:
 
-* `desired_tier` - (Optional) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
+* `desired_tier` - (DEPRECATED) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
 
 <a name="anonymous_authentication_config"></a>The `anonymous_authentication_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -421,7 +421,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
   Configuration for [direct-path (via ALTS) with workload identity.](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#workloadaltsconfig). Structure is [documented below](#nested_workload_alts_config).
 
 * `enterprise_config` - (Optional)
-  (DEPRECATED) Configuration for [Enterprise edition].(https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/gke-editions). Structure is [documented below](#nested_enterprise_config).
+  (DEPRECATED) Configuration for [Enterprise edition].(https://cloud.google.com/kubernetes-engine/enterprise/docs/concepts/gke-editions). Structure is [documented below](#nested_enterprise_config). Deprecated as GKE Enterprise features are now available without an Enterprise tier. See https://cloud.google.com/blog/products/containers-kubernetes/gke-gets-new-pricing-and-capabilities-on-10th-birthday for the announcement of this change.
 
 * `anonymous_authentication_config` - (Optional)
   Configuration for [anonymous authentication restrictions](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#restrict-anon-access). Structure is [documented below](#anonymous_authentication_config).
@@ -1643,7 +1643,7 @@ linux_node_config {
 
 <a name="nested_enterprise_config"></a>The `enterprise_config` block supports:
 
-* `desired_tier` - (Optional) (DEPRECATED) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
+* `desired_tier` - (Optional) (DEPRECATED) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`. Deprecated as GKE Enterprise features are now available without an Enterprise tier. See https://cloud.google.com/blog/products/containers-kubernetes/gke-gets-new-pricing-and-capabilities-on-10th-birthday for the announcement of this change.
 
 <a name="anonymous_authentication_config"></a>The `anonymous_authentication_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1643,7 +1643,7 @@ linux_node_config {
 
 <a name="nested_enterprise_config"></a>The `enterprise_config` block supports:
 
-* `desired_tier` - (DEPRECATED) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
+* `desired_tier` - (Optional) (DEPRECATED) Sets the tier of the cluster. Available options include `STANDARD` and `ENTERPRISE`.
 
 <a name="anonymous_authentication_config"></a>The `anonymous_authentication_config` block supports:
 


### PR DESCRIPTION
Fixes
https://github.com/hashicorp/terraform-provider-google/issues/24071.

Signed-off-by: Brad Hoekstra <bhoekstra@google.com>

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
container: deprecated `enterprise_config` field in `google_container_cluster` resource. GKE Enterprise features are now available without an Enterprise tier.
```
