### PR TITLE
compute: canonicalize backend.group self-links to avoid spurious diffs between v1/beta and variants

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -251,7 +251,7 @@ properties:
             Group resource using the fully-qualified URL, rather than a
             partial URL.
           required: true
-          diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+          diff_suppress_func: 'tpgresource.CompareSelfLinkCanonicalPaths'
           custom_flatten: 'templates/terraform/custom_flatten/guard_self_link.go.tmpl'
         - name: 'maxConnections'
           type: Integer

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -433,6 +433,283 @@ func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionBackendService_zonalILB(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-ilb-bs-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-ilb-hc-%s", acctest.RandString(t, 10))
+	checkName2 := fmt.Sprintf("tf-test-ilb-hc2-%s", acctest.RandString(t, 10))
+	negName := fmt.Sprintf("tf-test-ilb-neg-%s", acctest.RandString(t, 10))
+	negName2 := fmt.Sprintf("tf-test-ilb-neg2-%s", acctest.RandString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-ilb-vm-%s", acctest.RandString(t, 10))
+	instanceName2 := fmt.Sprintf("tf-test-ilb-vm2-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// STEP 1: base (self-link v1)
+			{
+				Config: testAccComputeRegionBackendService_zonalILB_withGroup(
+					testAccComputeRegionBackendService_common(checkName, negName, instanceName),
+					serviceName,
+					"google_compute_network_endpoint_group.neg.id",
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+		  // STEP 2: same NEG with /compute/beta/ (apply OK)
+			{
+				Config: fmt.Sprintf(`
+%s
+
+locals {
+  neg_beta = replace(google_compute_network_endpoint_group.neg.id, "/compute/v1/", "/compute/beta/")
+}
+
+%s
+`, testAccComputeRegionBackendService_common(checkName, negName, instanceName),
+					testAccComputeRegionBackendService_zonalILB_withGroup("", serviceName, "local.neg_beta"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// STEP 3: Invalid variation for API (UPPERCASE + "/") — tested only in PLAN
+			{
+				PlanOnly: true, // does not call the API; only exercises diff/canonicalization
+				Config: fmt.Sprintf(`
+%s
+
+locals {
+  neg_slash_upper = "${google_compute_network_endpoint_group.neg.id}"
+}
+
+%s
+`, testAccComputeRegionBackendService_common(checkName, negName, instanceName),
+					testAccComputeRegionBackendService_zonalILB_withGroup("", serviceName, "local.neg_slash_upper"),
+				),
+			},
+
+			// STEP 4: Modified scenario (changes NEG/HC/VM) — continues validating real updates
+			{
+				Config: testAccComputeRegionBackendService_zonalILBModified(serviceName, checkName, negName, instanceName, checkName2, negName2, instanceName2),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionBackendService_common(checkName, negName, instanceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name                    = "tf-test-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "tf-test-subnet"
+  ip_cidr_range = "10.10.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  http_health_check {
+    port         = 8080
+    request_path = "/status"
+  }
+}
+
+resource "google_compute_instance" "default" {
+  name         = "%s"
+  zone         = "us-central1-a"
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.default.id
+    subnetwork = google_compute_subnetwork.default.id
+    access_config {}
+  }
+}
+
+resource "google_compute_network_endpoint_group" "neg" {
+  name                  = "%s"
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  zone                  = "us-central1-a"
+  network_endpoint_type = "GCE_VM_IP_PORT"
+}
+
+resource "google_compute_network_endpoint" "endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  zone                   = "us-central1-a"
+  instance               = google_compute_instance.default.name
+  ip_address             = google_compute_instance.default.network_interface[0].network_ip
+  port                   = 8080
+}
+`, checkName, instanceName, negName)
+}
+
+func testAccComputeRegionBackendService_zonalILB_withGroup(commonHCL string, serviceName string, groupExpr string) string {
+	header := commonHCL
+	return fmt.Sprintf(`
+%s
+resource "google_compute_region_backend_service" "default" {
+  name                  = "%s"
+  region                = "us-central1"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_region_health_check.hc1.id]
+
+  backend {
+    group                 = %s
+    balancing_mode        = "RATE"
+    max_rate_per_endpoint = 100
+    capacity_scaler       = 1.0
+  }
+
+  session_affinity   = "CLIENT_IP"
+  locality_lb_policy = "ROUND_ROBIN"
+}
+`, header, serviceName, groupExpr)
+}
+
+func testAccComputeRegionBackendService_zonalILBModified(serviceName, checkName, negName, instanceName, checkName2, negName2, instanceName2 string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "default" {
+  name  = "tf-test-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "tf-test-subnet"
+  ip_cidr_range = "10.10.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  http_health_check {
+    port         = 8080
+    request_path = "/status"
+  }
+}
+
+resource "google_compute_instance" "default" {
+  name         = "%s"
+  zone         = "us-central1-a"
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.default.id
+    subnetwork = google_compute_subnetwork.default.id
+    access_config {}
+  }
+}
+
+resource "google_compute_network_endpoint_group" "neg" {
+  name                  = "%s"
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  zone                  = "us-central1-a"
+  network_endpoint_type = "GCE_VM_IP_PORT"
+}
+
+resource "google_compute_network_endpoint" "endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  zone                   = "us-central1-a"
+  instance               = google_compute_instance.default.name
+  ip_address             = google_compute_instance.default.network_interface[0].network_ip
+  port                   = 8080
+}
+
+resource "google_compute_instance" "instance2" {
+  name         = "%s"
+  zone         = "us-central1-a"
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.default.id
+    subnetwork = google_compute_subnetwork.default.id
+    access_config {}
+  }
+}
+
+resource "google_compute_region_health_check" "hc2" {
+  name   = "%s"
+  region = "us-central1"
+  http_health_check {
+    port = 80
+  }
+}
+
+resource "google_compute_network_endpoint_group" "neg2" {
+  name                  = "%s"
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  zone                  = "us-central1-a"
+  network_endpoint_type = "GCE_VM_IP_PORT"
+}
+
+resource "google_compute_network_endpoint" "endpoint2" {
+  network_endpoint_group = google_compute_network_endpoint_group.neg2.name
+  zone                   = "us-central1-a"
+  instance               = google_compute_instance.instance2.name
+  ip_address             = google_compute_instance.instance2.network_interface[0].network_ip
+  port                   = 8080
+}
+
+resource "google_compute_region_backend_service" "default" {
+  name                  = "%s"
+  region                = "us-central1"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_region_health_check.hc2.id]
+
+  backend {
+    group                 = google_compute_network_endpoint_group.neg2.id
+    balancing_mode        = "RATE"
+    max_rate_per_endpoint = 200
+    capacity_scaler       = 0.5
+  }
+}
+`, checkName, instanceName, negName, instanceName2, checkName2, negName2, serviceName)
+}
+
 func TestAccComputeRegionBackendService_withDynamicBackendCount(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
+++ b/mmv1/third_party/terraform/tpgresource/self_link_helpers.go
@@ -71,6 +71,40 @@ func CompareSelfLinkOrResourceName(_, old, new string, _ *schema.ResourceData) b
 	return CompareSelfLinkRelativePaths("", old, new, nil)
 }
 
+// canonicalizeSelfLink normalizes Compute API self-links by removing the version prefix (v1/beta),
+// ensuring a leading "/", collapsing duplicate slashes, trimming any trailing "/",
+// and lowercasing the result so logically identical links compare equal.
+func CompareSelfLinkCanonicalPaths(_, old, new string, _ *schema.ResourceData) bool {
+	return canonicalizeSelfLink(old) == canonicalizeSelfLink(new)
+}
+
+var (
+	rePrefix           = regexp.MustCompile(`(?i)^https?://[a-z0-9.-]*/compute/(v1|beta)/`)
+	reDuplicateSlashes = regexp.MustCompile(`/+`)
+)
+
+func canonicalizeSelfLink(link string) string {
+	if link == "" {
+		return ""
+	}
+
+	// Remove "https://…/compute/v1/" or "https://…/compute/beta/"
+	path := rePrefix.ReplaceAllString(link, "/")
+
+	// Ensure leading "/"
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	// Collapse "//"
+	path = reDuplicateSlashes.ReplaceAllString(path, "/")
+
+	// Remove trailing "/"
+	path = strings.TrimSuffix(path, "/")
+
+	return strings.ToLower(path)
+}
+
 // Hash the relative path of a self link.
 func SelfLinkRelativePathHash(selfLink interface{}) int {
 	path, _ := GetRelativePath(selfLink.(string))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Hello folks.

The `backend.group` field in `google_compute_region_backend_service` can show up in different self-link formats (e.g., `…/compute/v1/…`, `…/compute/beta/`, trailing slash, double slashes, case differences). These variations represent the same resource but today they trigger unwanted diffs in Terraform plans.  

**What this PR does**  

- Adds canonical comparison for `backend.group` using `tpgresource.CompareSelfLinkCanonicalPaths`.  
- Normalization removes API version prefix, ensures consistent slashes, trims trailing slash, and lowercases the path.  
- Hooks this into the schema with: 
- 
  ```yaml
  diff_suppress_func: 'tpgresource.CompareSelfLinkCanonicalPaths'
  custom_flatten: 'templates/terraform/custom_flatten/guard_self_link.go.tmpl'
  ```  
- No API changes — only improves plan stability for users.  

**Motivation**  

- Prevent noisy diffs when switching between `v1` and `beta` or when links are formatted slightly differently.  
- Make configs idempotent: same resource → no diff.  

**Tests**  

- **Step 1**: apply with v1 self-link.  
- **Step 2**: reapply with beta self-link → no diff.  
- **Step 3 (plan only)**: test casing/extra slashes → no diff in plan.  
- **Step 4**: update NEG/HC/VM → real changes still apply as expected.  

**Impact**  

- Resource: `google_compute_region_backend_service` (`backend.group`).  
- No breaking changes.  
- Minimal performance impact (regex compare only).  

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: backend-service improve of backend.group compare
```
