### PR TITLE
Standardized required_with behavior for write-only fields

### DIFF
--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -222,30 +222,26 @@ properties:
       to a different credential configuration in the config will require an apply to update state.
     url_param_only: true
     properties:
-      - name: 'secretAccessKeyWoVersion'
-        type: Integer
-        url_param_only: true
-        required_with:
-          - 'sensitive_params.0.secretAccessKeyWo'
-        description: |
-          The version of the sensitive params - used to trigger updates of the write-only params. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)
       - name: 'secretAccessKey'
         type: String
         description: |
           The Secret Access Key of the AWS account transferring data from.
         sensitive: true
-        at_least_one_of:
-          - 'sensitive_params.0.secretAccessKey'
-          - 'sensitive_params.0.secretAccessKeyWo'
-        conflicts:
-          - 'sensitive_params.0.secretAccessKeyWo'
+        exactly_one_of:
+          - 'sensitive_params.0.secret_access_key'
+          - 'sensitive_params.0.secret_access_key_wo'
       - name: 'secretAccessKeyWo' # Wo is convention for write-only properties
         type: String
         description: |
           The Secret Access Key of the AWS account transferring data from.
         write_only: true
-        at_least_one_of:
-          - 'sensitive_params.0.secretAccessKeyWo'
-          - 'sensitive_params.0.secretAccessKey'
-        conflicts:
-          - 'sensitive_params.0.secretAccessKey'
+        exactly_one_of:
+          - 'sensitive_params.0.secret_access_key'
+          - 'sensitive_params.0.secret_access_key_wo'
+      - name: 'secretAccessKeyWoVersion'
+        type: Integer
+        url_param_only: true
+        required_with:
+          - 'sensitive_params.0.secret_access_key_wo'
+        description: |
+          The version of the sensitive params - used to trigger updates of the write-only params. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)

--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -227,17 +227,21 @@ properties:
         description: |
           The Secret Access Key of the AWS account transferring data from.
         sensitive: true
-        exactly_one_of:
+        at_least_one_of:
           - 'sensitive_params.0.secret_access_key'
+          - 'sensitive_params.0.secret_access_key_wo'
+        conflicts:
           - 'sensitive_params.0.secret_access_key_wo'
       - name: 'secretAccessKeyWo' # Wo is convention for write-only properties
         type: String
         description: |
           The Secret Access Key of the AWS account transferring data from.
         write_only: true
-        exactly_one_of:
+        at_least_one_of:
           - 'sensitive_params.0.secret_access_key'
           - 'sensitive_params.0.secret_access_key_wo'
+        conflicts:
+          - 'sensitive_params.0.secret_access_key'
       - name: 'secretAccessKeyWoVersion'
         type: Integer
         url_param_only: true

--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -238,10 +238,12 @@ properties:
           The Secret Access Key of the AWS account transferring data from.
         write_only: true
         at_least_one_of:
-          - 'sensitive_params.0.secret_access_key'
           - 'sensitive_params.0.secret_access_key_wo'
+          - 'sensitive_params.0.secret_access_key'
         conflicts:
           - 'sensitive_params.0.secret_access_key'
+        required_with:
+          - 'sensitive_params.0.secret_access_key_wo_version'
       - name: 'secretAccessKeyWoVersion'
         type: Integer
         url_param_only: true

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -247,16 +247,16 @@ properties:
             type: String
             description: The password to authenticate.
             exactly_one_of:
-              - 'password'
-              - 'password_wo'
+              - 'http_check.0.auth_info.0.password_wo'
+              - 'http_check.0.auth_info.0.password'
             sensitive: true
             custom_flatten: 'templates/terraform/custom_flatten/uptime_check_http_password.tmpl'
           - name: 'passwordWo'
             type: String
             description: The password to authenticate.
             exactly_one_of:
-              - 'passwordWo'
-              - 'password'
+              - 'http_check.0.auth_info.0.password_wo'
+              - 'http_check.0.auth_info.0.password'
             required_with:
               - 'http_check.0.auth_info.0.password_wo_version'
             write_only: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -173,7 +173,7 @@ properties:
         conflicts:
           - 'payload.0.secret_data'
         write_only: true
-      - name: 'SecretDataWoVersion'
+      - name: 'secretDataWoVersion'
         type: Integer
         default_value: 0
         url_param_only: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -161,7 +161,7 @@ properties:
         description: The secret data. Must be no larger than 64KiB.
         api_name: data
         conflicts:
-          - 'secretDataWo'
+          - 'payload.0.secret_data_wo'
         immutable: true
         sensitive: true
       - name: 'secretDataWo'
@@ -169,9 +169,9 @@ properties:
         description: The secret data. Must be no larger than 64KiB. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)
         api_name: data
         required_with:
-          - 'SecretDataWoVersion'
+          - 'payload.0.secret_data_wo_version'
         conflicts:
-          - 'payload.0.secretData'
+          - 'payload.0.secret_data'
         write_only: true
       - name: 'SecretDataWoVersion'
         type: Integer
@@ -179,3 +179,5 @@ properties:
         url_param_only: true
         description: Triggers update of secret data write-only. For more info see [updating write-only attributes](/docs/providers/google/guides/using_write_only_attributes.html#updating-write-only-attributes)
         immutable: true
+        required_with:
+          - 'payload.0.secret_data_wo'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -103,6 +103,7 @@ func ResourceSqlUser() *schema.Resource {
 				Optional:      true,
 				WriteOnly:     true,
 				ConflictsWith: []string{"password"},
+				RequiredWith:  []string{"password_wo_version"},
 				Description: `The password for the user. Can be updated. For Postgres instances this is a Required field, unless type is set to
 				either CLOUD_IAM_USER or CLOUD_IAM_SERVICE_ACCOUNT.`,
 			},

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -439,6 +439,7 @@ resource "google_sql_user" "user1" {
   instance = google_sql_database_instance.instance.name
   host     = "gmail.com"
   password_wo = "%s"
+  password_wo_version = 1
 }
 `, instance, password)
 }
@@ -460,7 +461,7 @@ resource "google_sql_user" "user1" {
   instance = google_sql_database_instance.instance.name
   host     = "gmail.com"
   password_wo = "%s"
-  password_wo_version = 1
+  password_wo_version = 2
 }
 `, instance, password)
 }

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -217,6 +217,12 @@ Remove `description` from your configuration after upgrade.
 
 Remove `post_startup_script_config` from your configuration after upgrade.
 
+## Resource: `google_monitoring_uptime_check_config`
+
+### Exactly one of `http_check.auth_info.password` and `http_check.auth_info.password_wo` must be set
+
+At least one must be set, and setting both would make it unclear which was being used.
+
 ## Resource: `google_network_services_lb_traffic_extension`
 
 ### `load_balancing_scheme` is now required
@@ -249,9 +255,15 @@ Remove `service_config.service` from your configuration after upgrade.
 
 Remove `template.containers.depends_on` from your configuration after upgrade.
 
+## Resource: `google_secret_manager_secret_version`
+
+### `secret_data_wo` and `secret_data_wo_version` must be set together
+
+This standardizes the behavior of write-only fields across the provider and makes it easier to remember to update the fields together.
+
 ## Resource: `google_sql_user`
 
-## `password_wo_version` is now required when `password_wo` is set
+### `password_wo_version` is now required when `password_wo` is set
 
 This standardizes the behavior of write-only fields across the provider and makes it easier to remember to update the fields together.
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_7_upgrade.html.markdown
@@ -249,6 +249,12 @@ Remove `service_config.service` from your configuration after upgrade.
 
 Remove `template.containers.depends_on` from your configuration after upgrade.
 
+## Resource: `google_sql_user`
+
+## `password_wo_version` is now required when `password_wo` is set
+
+This standardizes the behavior of write-only fields across the provider and makes it easier to remember to update the fields together.
+
 ## Resource: `google_vertex_ai_endpoint`
 
 ### `enable_secure_private_service_connect` is removed as it is not available in the GA version of the API, only in the beta version.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Clean-up / standardization for write-only fields that requires some small breaking changes. https://github.com/GoogleCloudPlatform/magic-modules/pull/14933#issuecomment-3211584254 for context.

I've gone through and tested the plan errors locally to compare the latest release with these changes.

Note: I believe the bigquerydatatransfer Config change is not breaking, because we already enforce it via a [customize diff func](https://github.com/hashicorp/terraform-provider-google-beta/blob/886372902bda169fb44f8224a3a38561f6d36b59/google-beta/services/bigquerydatatransfer/resource_bigquery_data_transfer_config.go#L57-L59). I'm not removing that in this PR to keep things simple. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:breaking-change
sql: on `google_sql_user`, made `password_wo_version` required when `password_wo` is set
```

```release-note:breaking-change
secretmanager: on `google_secret_manager_secret_version`, made `secret_data_wo` and `secret_data_wo_version` both required when one is set
```

```release-note:breaking-change
monitoring: on `google_monitoring_uptime_check_config`, made it required to set exactly one of `http_check.auth_info.password` and `http_check.auth_info.password_wo`
```