### PR TITLE
Fix non-idempotent behavior in google_compute_region_network_endpoint_group when network is omitted

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -163,6 +163,7 @@ properties:
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Network'
     imports: 'selfLink'
+    default_from_api: true
   - name: 'subnetwork'
     type: ResourceRef
     description: |

--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_psc_service_attachment.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_psc_service_attachment.tf.tmpl
@@ -64,6 +64,5 @@ resource "google_compute_region_network_endpoint_group" "{{$.PrimaryResourceId}}
   psc_data {
     producer_port = "88"
   }
-  network               = google_compute_network.default.self_link
   subnetwork            = google_compute_subnetwork.default.self_link
 }


### PR DESCRIPTION
Modify `network` field in `RegionNetworkEndpoint.yaml` to be marked as `default_from_api`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23805


```release-note:bug
compute: marked `network` field in `google_compute_region_network_endpoint_group` as `default_from_api`, to fix creating PSC NEGs creation without specifying the network
```
