### PR TITLE
`resourceIdentity`: add `Identity()` support for `bigquery_table` resource

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -468,6 +468,29 @@ func ResourceBigQueryTable() *schema.Resource {
 			resourceBigQueryTableSchemaCustomizeDiff,
 			tpgresource.SetLabelsDiff,
 		),
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+						Description:       `The project that the service account belongs to.`,
+					},
+					"dataset_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+						Description:       `The dataset ID to create the table in. Changing this forces a new resource to be created.`,
+					},
+					"table_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+						Description:       `A unique ID for the resource. Changing this forces a new resource to be created.`,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			// TableId: [Required] The ID of the table. The ID must contain only
 			// letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
@@ -2148,6 +2171,23 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	identity, err := d.Identity()
+	if err != nil {
+		return fmt.Errorf("Error getting identity: %s", err)
+	}
+	err = identity.Set("project", project)
+	if err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	err = identity.Set("dataset_id", datasetID)
+	if err != nil {
+		return fmt.Errorf("Error setting dataset_id: %s", err)
+	}
+	err = identity.Set("table_id", tableID)
+	if err != nil {
+		return fmt.Errorf("Error setting table_id: %s", err)
+	}
+	
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -1995,6 +1995,27 @@ func TestAccBigQueryTable_foreignTypeInfo(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryTable_ResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_dataset_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_table_%s", acctest.RandString(t, 10))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableBasicSchema(datasetID, tableID),
+			},
+			{
+				ResourceName:    "google_bigquery_table.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
