### PR TITLE
Improve root_password and password_validation_policy updates in sql instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2060,70 +2060,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	// Check if the root_password is being updated, because updating root_password is an atomic operation and can not be
-	// performed with other fields, we first update root password before updating the rest of the fields.
-	if d.HasChange("root_password") {
-		oldPwd, newPwd := d.GetChange("root_password")
-		password := newPwd.(string)
-		dv := d.Get("database_version").(string)
-		name := ""
-		host := ""
-		if strings.Contains(dv, "MYSQL") {
-			name = "root"
-			host = "%"
-		} else if strings.Contains(dv, "POSTGRES") {
-			name = "postgres"
-		} else if strings.Contains(dv, "SQLSERVER") {
-			name = "sqlserver"
-			if len(password) == 0 {
-				if err := d.Set("root_password", oldPwd.(string)); err != nil {
-					return fmt.Errorf("Error re-setting root_password: %s", err)
-				}
-				return fmt.Errorf("Error, root password cannot be empty for SQL Server instance.")
-			}
-		} else {
-			if err := d.Set("root_password", oldPwd.(string)); err != nil {
-				return fmt.Errorf("Error re-setting root_password: %s", err)
-			}
-			return fmt.Errorf("Error, invalid database version")
-		}
-		instance := d.Get("name").(string)
-
-		user := &sqladmin.User{
-			Name:     name,
-			Instance: instance,
-			Password: password,
-		}
-
-		transport_tpg.MutexStore.Lock(instanceMutexKey(project, instance))
-		defer transport_tpg.MutexStore.Unlock(instanceMutexKey(project, instance))
-		var op *sqladmin.Operation
-		updateFunc := func() error {
-			op, err = config.NewSqlAdminClient(userAgent).Users.Update(project, instance, user).Host(host).Name(name).Do()
-			return err
-		}
-		err = transport_tpg.Retry(transport_tpg.RetryOptions{
-			RetryFunc: updateFunc,
-			Timeout:   d.Timeout(schema.TimeoutUpdate),
-		})
-
-		if err != nil {
-			if err := d.Set("root_password", oldPwd.(string)); err != nil {
-				return fmt.Errorf("Error re-setting root_password: %s", err)
-			}
-			return fmt.Errorf("Error, failed to update root_password : %s", err)
-		}
-
-		err = SqlAdminOperationWaitTime(config, op, project, "Insert User", userAgent, d.Timeout(schema.TimeoutUpdate))
-
-		if err != nil {
-			if err := d.Set("root_password", oldPwd.(string)); err != nil {
-				return fmt.Errorf("Error re-setting root_password: %s", err)
-			}
-			return fmt.Errorf("Error, failed to update root_password : %s", err)
-		}
-	}
-
 	// Check if the maintenance version is being updated, because patching maintenance version is an atomic operation and can not be
 	// performed with other fields, we first patch maintenance version before updating the rest of the fields.
 	if d.HasChange("maintenance_version") {
@@ -2310,6 +2246,71 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
            return err
          }
       }
+
+	// Check if the root_password is being updated, because updating root_password is an atomic operation and can not be
+	// performed with other fields, we update root password after updating the rest of the fields.
+	// We change the root password after the settings which may contain an updated password validation policy.
+	if d.HasChange("root_password") {
+		oldPwd, newPwd := d.GetChange("root_password")
+		password := newPwd.(string)
+		dv := d.Get("database_version").(string)
+		name := ""
+		host := ""
+		if strings.Contains(dv, "MYSQL") {
+			name = "root"
+			host = "%"
+		} else if strings.Contains(dv, "POSTGRES") {
+			name = "postgres"
+		} else if strings.Contains(dv, "SQLSERVER") {
+			name = "sqlserver"
+			if len(password) == 0 {
+				if err := d.Set("root_password", oldPwd.(string)); err != nil {
+					return fmt.Errorf("Error re-setting root_password: %s", err)
+				}
+				return fmt.Errorf("Error, root password cannot be empty for SQL Server instance.")
+			}
+		} else {
+			if err := d.Set("root_password", oldPwd.(string)); err != nil {
+				return fmt.Errorf("Error re-setting root_password: %s", err)
+			}
+			return fmt.Errorf("Error, invalid database version")
+		}
+		instance := d.Get("name").(string)
+
+		user := &sqladmin.User{
+			Name:     name,
+			Instance: instance,
+			Password: password,
+		}
+
+		transport_tpg.MutexStore.Lock(instanceMutexKey(project, instance))
+		defer transport_tpg.MutexStore.Unlock(instanceMutexKey(project, instance))
+		var op *sqladmin.Operation
+		updateFunc := func() error {
+			op, err = config.NewSqlAdminClient(userAgent).Users.Update(project, instance, user).Host(host).Name(name).Do()
+			return err
+		}
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: updateFunc,
+			Timeout:   d.Timeout(schema.TimeoutUpdate),
+		})
+
+		if err != nil {
+			if err := d.Set("root_password", oldPwd.(string)); err != nil {
+				return fmt.Errorf("Error re-setting root_password: %s", err)
+			}
+			return fmt.Errorf("Error, failed to update root_password : %s", err)
+		}
+
+		err = SqlAdminOperationWaitTime(config, op, project, "Insert User", userAgent, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			if err := d.Set("root_password", oldPwd.(string)); err != nil {
+				return fmt.Errorf("Error re-setting root_password: %s", err)
+			}
+			return fmt.Errorf("Error, failed to update root_password : %s", err)
+		}
+	}
 
       return resourceSqlDatabaseInstanceRead(d, meta)
 }

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2,6 +2,7 @@ package sql_test
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
@@ -2436,6 +2437,56 @@ func TestAccSqlDatabaseInstance_sqlMysqlInstancePvpExample(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_PvpAndPasswordOrder(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-pvp-order-" + acctest.RandString(t, 10)
+	initialPassword10 := acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_pvpAndPasswordOrder(map[string]interface{}{
+					"name":     databaseName,
+					"password": initialPassword10,
+				}),
+			},
+			{
+				Config: testAccSqlDatabaseInstance_pvpAndPasswordOrder(map[string]interface{}{
+					"name":       databaseName,
+					"password":   initialPassword10,
+					"min_length": 12,
+				}),
+			},
+			{
+				// This will set the new password validation policy, but will fail to update the password.
+				Config: testAccSqlDatabaseInstance_pvpAndPasswordOrder(map[string]interface{}{
+					"name":       databaseName,
+					"password":   acctest.RandString(t, 10),
+					"min_length": 16,
+				}),
+				ExpectError: regexp.MustCompile("password is not long enough"),
+			},
+			{
+				Config: testAccSqlDatabaseInstance_pvpAndPasswordOrder(map[string]interface{}{
+					"name":       databaseName,
+					"password":   acctest.RandString(t, 16),
+					"min_length": 16,
+				}),
+			},
+			{
+				Config: testAccSqlDatabaseInstance_pvpAndPasswordOrder(map[string]interface{}{
+					"name":       databaseName,
+					"password":   acctest.RandString(t, 10),
+					"min_length": 8,
+				}),
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_updateReadReplicaWithBinaryLogEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -3734,6 +3785,35 @@ resource "google_sql_database_instance" "mysql_pvp_instance_name" {
   deletion_protection =  "%{deletion_protection}"
 }
 `, context)
+}
+
+func testAccSqlDatabaseInstance_pvpAndPasswordOrder(context map[string]interface{}) string {
+	pvp := ""
+	if _, ok := context["min_length"]; ok {
+		pvp = acctest.Nprintf(`
+	password_validation_policy {
+		enable_password_policy = true
+		min_length = %{min_length}
+	}
+`, context)
+	}
+
+	newContext := maps.Clone(context)
+	newContext["password_validation_policy"] = pvp
+
+	return acctest.Nprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "%{name}"
+  region              = "us-central1"
+  database_version    = "POSTGRES_15"
+  root_password       = "%{password}"
+  deletion_protection = false
+  settings {
+	tier = "db-f1-micro"
+	%{password_validation_policy}
+  }
+}
+`, newContext)
 }
 
 var testGoogleSqlDatabaseInstance_basic2 = `


### PR DESCRIPTION
In cases where both the password_validation_policy and the root_password are being changed - it is important to first update the password_validation_policy and only then update the password.

Consider the case where mistakenly we set a too strict policy and now the password updates are failing - we now want to loosen the policy, but we always fail on updates since the password change always happens first. This requires now doing a "two-step" terraform apply instead of single one.

Also always update the settings first - this is needed in cases where update failed mid-run but we still have updated the settingsVersion which causes subsequent failures. (Similar change is being done here: https://github.com/GoogleCloudPlatform/magic-modules/pull/14952)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: Improve root_password and password_validation_policy updates in sql instance
```
