### PR TITLE
[BigQuery Analytics Hub] Added support for listing.bigqueryDataset.restrictedExportPolicy field

### DIFF
--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -220,6 +220,23 @@ properties:
         required: true
         immutable: true
         diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+      - name: 'restrictedExportPolicy'
+        type: NestedObject
+        description: Restricted export policy used to configure restricted export on linked dataset
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description: If true, enable restricted export.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'restrictDirectTableAccess'
+            type: Boolean
+            description: If true, restrict direct table access (read api/tabledata.list) on linked table.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'restrictQueryResult'
+            type: Boolean
+            description: If true, restrict export of query result derived from restricted linked dataset table.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - name: 'selectedResources'
         type: Array
         description: Resource in this dataset that is selectively shared. This field is required for data clean room exchanges.

--- a/mmv1/products/bigqueryanalyticshub/Listing.yaml
+++ b/mmv1/products/bigqueryanalyticshub/Listing.yaml
@@ -106,6 +106,15 @@ examples:
       data_exchange_id: 'my_data_exchange'
       listing_id: 'my_listing'
       desc: 'example public listing'
+  - name: 'bigquery_analyticshub_restricted_export_policy_listing'
+    primary_resource_id: 'listing'
+    primary_resource_name: 'fmt.Sprintf("tf_test_my_data_exchange%s", context["random_suffix"]), fmt.Sprintf("tf_test_my_listing%s", context["random_suffix"])'
+    region_override: 'US'
+    vars:
+      data_exchange_id: 'my_data_exchange'
+      listing_id: 'my_listing'
+      dataset_id: 'tf_test_dataset'
+      desc: 'example listing with restricted export policy'
   - name: 'bigquery_analyticshub_listing_marketplace'
     primary_resource_id: 'listing'
     primary_resource_name: 'fmt.Sprintf("tf_test_my_data_exchange%s", context["random_suffix"]), fmt.Sprintf("tf_test_my_listing%s", context["random_suffix"])'
@@ -220,6 +229,23 @@ properties:
         required: true
         immutable: true
         diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+      - name: 'restrictedExportPolicy'
+        type: NestedObject
+        description: Restricted export policy used to configure restricted export on linked dataset
+        diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description: If true, enable restricted export.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'restrictDirectTableAccess'
+            type: Boolean
+            description: If true, restrict direct table access (read api/tabledata.list) on linked table.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'restrictQueryResult'
+            type: Boolean
+            description: If true, restrict export of query result derived from restricted linked dataset table.
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
       - name: 'selectedResources'
         type: Array
         description: Resource in this dataset that is selectively shared. This field is required for data clean room exchanges.

--- a/mmv1/templates/terraform/examples/bigquery_analyticshub_restricted_export_policy_listing.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_analyticshub_restricted_export_policy_listing.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_bigquery_analytics_hub_data_exchange" "{{$.PrimaryResourceId}}" {
+  location         = "us"
+  data_exchange_id = "{{index $.Vars "data_exchange_id"}}"
+  display_name     = "{{index $.Vars "data_exchange_id"}}"
+  description      = "{{index $.Vars "desc"}}"
+}
+
+resource "google_bigquery_analytics_hub_listing" "{{$.PrimaryResourceId}}" {
+  location         = "us"
+  data_exchange_id = google_bigquery_analytics_hub_data_exchange.{{$.PrimaryResourceId}}.data_exchange_id
+  listing_id       = "{{index $.Vars "listing_id"}}"
+  display_name     = "{{index $.Vars "listing_id"}}"
+  description      = "{{index $.Vars "desc"}}"
+
+  bigquery_dataset {
+    dataset = google_bigquery_dataset.{{$.PrimaryResourceId}}.id
+    restricted_export_policy {
+        enabled = true
+        restrict_direct_table_access = true
+        restrict_query_result = true
+    }
+  }
+}
+
+resource "google_bigquery_dataset" "{{$.PrimaryResourceId}}" {
+  dataset_id                  = "{{index $.Vars "listing_id"}}"
+  friendly_name               = "{{index $.Vars "listing_id"}}"
+  description                 = "{{index $.Vars "desc"}}"
+  location                    = "US"
+}

--- a/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_test.go
@@ -265,3 +265,75 @@ resource "google_bigquery_dataset" "listing" {
 }
 `, context)
 }
+
+func TestAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPolicyListingUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigqueryAnalyticsHubListingDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPolicyListingExample(context),
+			},
+			{
+				ResourceName:            "google_bigquery_analytics_hub_listing.listing",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_exchange_id", "listing_id", "location"},
+			},
+			{
+				Config: testAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPolicyListingUpdate(context),
+			},
+			{
+				ResourceName:            "google_bigquery_analytics_hub_listing.listing",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"data_exchange_id", "listing_id", "location"},
+			},
+		},
+	})
+}
+
+func testAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPolicyListingUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_analytics_hub_data_exchange" "listing" {
+  location         = "US"
+  data_exchange_id = "tf_test_my_data_exchange%{random_suffix}"
+  display_name     = "tf_test_my_data_exchange%{random_suffix}"
+  description      = "example public listing%{random_suffix}"
+  discovery_type   = "DISCOVERY_TYPE_PRIVATE"
+}
+
+resource "google_bigquery_analytics_hub_listing" "listing" {
+  location         = "US"
+  data_exchange_id = google_bigquery_analytics_hub_data_exchange.listing.data_exchange_id
+  listing_id       = "tf_test_my_listing%{random_suffix}"
+  display_name     = "tf_test_my_listing%{random_suffix}"
+  description      = "example public listing%{random_suffix}"
+  discovery_type   = "DISCOVERY_TYPE_PRIVATE"
+  allow_only_metadata_sharing= false
+
+  bigquery_dataset {
+    dataset = google_bigquery_dataset.listing.id
+    restricted_export_policy {
+      enabled = true
+      restrict_direct_table_access = true
+      restrict_query_result = true
+    }
+  }
+}
+
+resource "google_bigquery_dataset" "listing" {
+  dataset_id                  = "tf_test_my_listing%{random_suffix}"
+  friendly_name               = "tf_test_my_listing%{random_suffix}"
+  description                 = "example public listing%{random_suffix}"
+  location                    = "US"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryanalyticshub/resource_bigquery_analytics_hub_listing_test.go
@@ -303,19 +303,19 @@ func TestAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPoli
 func testAccBigqueryAnalyticsHubListing_bigqueryAnalyticshubRestrictedExportPolicyListingUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_analytics_hub_data_exchange" "listing" {
-  location         = "US"
+  location         = "us"
   data_exchange_id = "tf_test_my_data_exchange%{random_suffix}"
   display_name     = "tf_test_my_data_exchange%{random_suffix}"
-  description      = "example public listing%{random_suffix}"
+  description      = "example listing with restricted export policy%{random_suffix}"
   discovery_type   = "DISCOVERY_TYPE_PRIVATE"
 }
 
 resource "google_bigquery_analytics_hub_listing" "listing" {
-  location         = "US"
+  location         = "us"
   data_exchange_id = google_bigquery_analytics_hub_data_exchange.listing.data_exchange_id
   listing_id       = "tf_test_my_listing%{random_suffix}"
   display_name     = "tf_test_my_listing%{random_suffix}"
-  description      = "example public listing%{random_suffix}"
+  description      = "example listing with restricted export policy%{random_suffix}"
   discovery_type   = "DISCOVERY_TYPE_PRIVATE"
   allow_only_metadata_sharing= false
 
@@ -332,8 +332,8 @@ resource "google_bigquery_analytics_hub_listing" "listing" {
 resource "google_bigquery_dataset" "listing" {
   dataset_id                  = "tf_test_my_listing%{random_suffix}"
   friendly_name               = "tf_test_my_listing%{random_suffix}"
-  description                 = "example public listing%{random_suffix}"
-  location                    = "US"
+  description                 = "example listing with restricted export policy%{random_suffix}"
+  location                    = "us"
 }
 `, context)
 }


### PR DESCRIPTION
[BigQuery Analytics Hub] Added support for listing.bigqueryDataset.restrictedExportPolicy field

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigqueryanalyticshub: added `bigquery_dataset.restricted_export_policy` field to `google_bigquery_analytics_hub_listing` resource
```
