### PR TITLE
doc: fix expample in google_artifact_registry_package data

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/artifact_registry_package.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/artifact_registry_package.html.markdown
@@ -10,9 +10,10 @@ This data source fetches information of a package from a provided Artifact Regis
 ## Example Usage
 
 ```hcl
-resource "google_artifact_registry_package" "my_package" {
+data "google_artifact_registry_package" "my_package" {
   location      = "us-west1"
   repository_id = "my-repository"
+  name          = "app"
 }
 ```
 


### PR DESCRIPTION
We have a data source that shows an example for a resource. Furthermore, a required field is not part of the example.
I assume there was a simple oversight.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
`google_artifact_registry_package`: Fix documentation example
```
