### PR TITLE
fix bug that causes updates on no-cp clusters without sa keys changing

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6548,11 +6548,17 @@ func expandUserManagedKeysConfig(configured interface{}) *container.UserManagedK
 	}
 	if v, ok := config["service_account_signing_keys"]; ok {
 		sk := v.(*schema.Set)
-		umkc.ServiceAccountSigningKeys = tpgresource.ConvertStringSet(sk)
+		skss := tpgresource.ConvertStringSet(sk)
+		if len(skss) > 0 {
+			umkc.ServiceAccountSigningKeys = skss
+		}
 	}
 	if v, ok := config["service_account_verification_keys"]; ok {
 		vk := v.(*schema.Set)
-		umkc.ServiceAccountVerificationKeys = tpgresource.ConvertStringSet(vk)
+		vkss := tpgresource.ConvertStringSet(vk)
+		if len(vkss) > 0 {
+			umkc.ServiceAccountVerificationKeys = vkss
+		}
 	}
 	return umkc
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -63,17 +63,50 @@ func TestAccContainerCluster_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				ResourceName:	     "google_container_cluster.primary",
+				ResourceName:	   "google_container_cluster.primary",
 				ImportStateId:     fmt.Sprintf("%s/us-central1-a/%s", envvar.GetTestProjectFromEnv(), clusterName),
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				ResourceName:	     "google_container_cluster.primary",
+				ResourceName:	   "google_container_cluster.primary",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+// This is to ensure that updates don't get trigerred with incorrect interpration of 
+// nil serviceAccount keys as empty array.
+func TestAccContainerCluster_basic_noCpaUpgrade(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:	  func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "services_ipv4_cidr"),
+					resource.TestCheckResourceAttrSet("google_container_cluster.primary", "self_link"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "networking_mode", "VPC_NATIVE"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_container_cluster.primary", plancheck.ResourceActionNoop),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
it is intended to fix an issue: https://github.com/hashicorp/terraform-provider-google/issues/23462

```release-note:bug
container: fixed faulty diff for arrays on user_managed_keys_config that caused faulty cluster updates to be triggered.
```
