### PR TITLE
Update unit test - AutomaticManagement is no longer supported on the gkehub api server for the ConfigManagement feature

### DIFF
--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.tmpl
@@ -489,9 +489,6 @@ func TestAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(t *testing.T)
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      {
-				Config: testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementEnableAutomaticManagementUpdate(context),
-			},
 			{
 				ResourceName:      "google_gke_hub_feature.feature",
 				ImportState:       true,
@@ -505,9 +502,6 @@ func TestAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(t *testing.T)
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      {
-				Config: testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementAutomaticManagement(context),
-			},
 			{
 				ResourceName:      "google_gke_hub_feature.feature",
 				ImportState:       true,
@@ -515,25 +509,6 @@ func TestAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(t *testing.T)
 			},
 		},
 	})
-}
-
-func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementAutomaticManagement(context map[string]interface{}) string {
-	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
-resource "google_gke_hub_feature" "feature" {
-  name = "configmanagement"
-  location = "global"
-  fleet_default_member_config {
-    configmanagement {
-      management = "MANAGEMENT_AUTOMATIC"
-      config_sync {
-        enabled = true
-      }
-    }
-  }
-  depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
-  project = google_project.project.project_id
-}
-`, context)
 }
 
 func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagement(context map[string]interface{}) string {
@@ -577,33 +552,6 @@ resource "google_gke_hub_feature" "feature" {
         prevent_drift = true
         source_format = "unstructured"
         metrics_gcp_service_account_email = "gke-cluster-metrics@gke-foo-nonprod.iam.gserviceaccount.com"
-        oci {
-          sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"
-          policy_dir = "/acm/nonprod-root/"
-          secret_type = "gcpserviceaccount"
-          sync_wait_secs = "15"
-          gcp_service_account_email = "gke-cluster@gke-foo-nonprod.iam.gserviceaccount.com"
-        }
-      }
-    }
-  }
-  depends_on = [google_project_service.anthos, google_project_service.gkehub, google_project_service.acm]
-  project = google_project.project.project_id
-}
-`, context)
-}
-
-func testAccGKEHubFeature_FleetDefaultMemberConfigConfigManagementEnableAutomaticManagementUpdate(context map[string]interface{}) string {
-	return gkeHubFeatureProjectSetupForGA(context) + acctest.Nprintf(`
-resource "google_gke_hub_feature" "feature" {
-  name = "configmanagement"
-  location = "global"
-  fleet_default_member_config {
-    configmanagement {
-      management = "MANAGEMENT_AUTOMATIC"
-      config_sync {
-        prevent_drift = true
-        source_format = "unstructured"
         oci {
           sync_repo = "us-central1-docker.pkg.dev/corp-gke-build-artifacts/acm/configs:latest"
           policy_dir = "/acm/nonprod-root/"


### PR DESCRIPTION
Delete unit tests for AutomaticManagement.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23734

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: none
fixed unit tests


```
