### PR TITLE
fix storage bucket retention_period migration crash

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket_600_migration.go
@@ -2,9 +2,10 @@ package storage
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
 	"math"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1571,8 +1572,14 @@ func ResourceStorageBucketStateUpgradeV3(_ context.Context, rawState map[string]
 		retentionPolicies := rawState["retention_policy"].([]interface{})
 		if len(retentionPolicies) > 0 {
 			retentionPolicy := retentionPolicies[0].(map[string]interface{})
-			if v, ok := retentionPolicy["retention_period"]; ok {
-				retentionPolicy["retention_period"] = strconv.Itoa(v.(int))
+			// nil check
+			if v, ok := retentionPolicy["retention_period"]; ok && v != nil {
+				// number conversion check to error rather than crash
+				if num, ok := v.(json.Number); ok {
+					retentionPolicy["retention_period"] = num.String()
+				} else {
+					return rawState, fmt.Errorf("retention_period in state has unexpected type %T", v)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

fixes https://github.com/hashicorp/terraform-provider-google/issues/24174

conversion error introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/14442

base conversion logic pulled from https://github.com/GoogleCloudPlatform/magic-modules/pull/14996

crash recreation log: gpaste/4732963077750784
fix confirmation log: gpaste//6385541050007552

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
storage: fixed a conversion crash in `google_storage_bucket` state migration
```
