### PR TITLE
Modify test file generation to use resource ImportPath

### DIFF
--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -144,7 +144,7 @@ func (td *TemplateData) GenerateTestFile(filePath string, resource api.Resource)
 	}
 	tmplInput := TestInput{
 		Res:                  resource,
-		ImportPath:           td.ImportPath(),
+		ImportPath:           resource.ImportPath,
 		PROJECT_NAME:         "my-project-name",
 		CREDENTIALS:          "my/credentials/filename.json",
 		REGION:               "us-west1",
@@ -279,15 +279,6 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 	if err != nil {
 		glog.Exit(err)
 	}
-}
-
-func (td *TemplateData) ImportPath() string {
-	if td.VersionName == GA_VERSION {
-		return "github.com/hashicorp/terraform-provider-google/google"
-	} else if td.VersionName == ALPHA_VERSION || td.VersionName == PRIVATE_VERSION {
-		return "internal/terraform-next/google-private"
-	}
-	return "github.com/hashicorp/terraform-provider-google-beta/google-beta"
 }
 
 func FixImports(outputPath string, dumpDiffs bool) {


### PR DESCRIPTION
All of our other generated files use the `resource.ImportPath`, so this change just follows that pattern, and removes the need for a dedicated ImportPath function on the template data. There should be no change to generation.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
