### PR TITLE
Add db_aligned_atomic_writes_config setting to google_sql_database_instance.

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -61,6 +61,19 @@ var sqlDatabaseFlagSchemaElem *schema.Resource = &schema.Resource{
 	},
 }
 
+var dbAlignedAtomicWritesSchemaElem = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"db_aligned_atomic_writes": {
+			Type:         schema.TypeBool,
+			Optional:     true,
+			Default:      false,
+			ExactlyOneOf: dbAlignedAtomicWritesConfigKeys,
+			ForceNew:     true,
+			Description:  `Enable Database Engine Aligned Atomic Writes setting.`,
+		},
+	},
+}
+
 var (
 	backupConfigurationKeys = []string{
 		"settings.0.backup_configuration.0.binary_log_enabled",
@@ -76,6 +89,10 @@ var (
 	connectionPoolConfigKeys = []string{
 		"settings.0.connection_pool_config.0.connection_pooling_enabled",
 		"settings.0.connection_pool_config.0.flags",
+	}
+
+	dbAlignedAtomicWritesConfigKeys = []string{
+		"settings.0.db_aligned_atomic_writes_config.0.db_aligned_atomic_writes",
 	}
 
 	ipConfigurationKeys = []string{
@@ -498,6 +515,15 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							Optional: true,
 							Set:      schema.HashResource(sqlDatabaseFlagSchemaElem),
 							Elem:     sqlDatabaseFlagSchemaElem,
+						},
+						"db_aligned_atomic_writes_config": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							ForceNew:    true,
+							Set:         schema.HashResource(dbAlignedAtomicWritesSchemaElem),
+							Elem:        dbAlignedAtomicWritesSchemaElem,
+							MaxItems:    1,
+							Description: `Enables DB Engine Aligned Atomic Writes. Can be used with MySQL only.`,
 						},
 						"disk_autoresize": {
 							Type:        schema.TypeBool,
@@ -1751,6 +1777,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 {{- end }}
 		PricingPlan:                   _settings["pricing_plan"].(string),
 		DeletionProtectionEnabled:     _settings["deletion_protection_enabled"].(bool),
+		DbAlignedAtomicWritesConfig:   expandDbAlignedAtomicWritesConfig(_settings["db_aligned_atomic_writes_config"].(*schema.Set).List()),
 		EnableGoogleMlIntegration:     _settings["enable_google_ml_integration"].(bool),
 		EnableDataplexIntegration:     _settings["enable_dataplex_integration"].(bool),
 		RetainBackupsOnDelete:         _settings["retain_backups_on_delete"].(bool),
@@ -1937,6 +1964,18 @@ func expandConnectionPoolConfig(configured []interface{}) *sqladmin.ConnectionPo
 	return &sqladmin.ConnectionPoolConfig{
 		ConnectionPoolingEnabled:		_connectionPoolConfig["connection_pooling_enabled"].(bool),
 		Flags:			expandFlags(_connectionPoolConfig["flags"].(*schema.Set).List()),
+	}
+}
+
+func expandDbAlignedAtomicWritesConfig(configured []interface{}) *sqladmin.DbAlignedAtomicWritesConfig {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	_dbAlignedAtomicWritesConfig := configured[0].(map[string]interface{})
+
+	return &sqladmin.DbAlignedAtomicWritesConfig{
+		DbAlignedAtomicWrites: _dbAlignedAtomicWritesConfig["db_aligned_atomic_writes"].(bool),
 	}
 }
 
@@ -2861,6 +2900,10 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
 	}
 
+	if settings.DbAlignedAtomicWritesConfig != nil {
+		data["db_aligned_atomic_writes_config"] = flattenDbAlignedAtomicWritesConfig(settings.DbAlignedAtomicWritesConfig)
+	}
+
 	if settings.IpConfiguration != nil {
 		data["ip_configuration"] = flattenIpConfiguration(settings.IpConfiguration, d)
 	}
@@ -3085,6 +3128,21 @@ func flattenConnectionPoolConfig(connectionPoolConfig *sqladmin.ConnectionPoolCo
         "flags":                      flattenConnectionPoolFlags(connectionPoolConfig.Flags), // Corrected key
     }
     return []interface{}{data}
+}
+
+func flattenDbAlignedAtomicWritesConfig(dbAlignedAtomicWritesConfig *sqladmin.DbAlignedAtomicWritesConfig) []interface{} {
+	if dbAlignedAtomicWritesConfig == nil {
+		return []interface{}{
+			map[string]interface{}{
+				"db_aligned_atomic_writes": false,
+			},
+		}
+	}
+
+	data := map[string]interface{}{
+		"db_aligned_atomic_writes": dbAlignedAtomicWritesConfig.DbAlignedAtomicWrites,
+	}
+	return []interface{}{data}
 }
 
 func flattenIpConfiguration(ipConfiguration *sqladmin.IpConfiguration, d *schema.ResourceData) interface{} {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -93,6 +93,8 @@ fields:
   - api_field: 'settings.activationPolicy'
   - api_field: 'settings.activeDirectoryConfig.domain'
   - api_field: 'settings.advancedMachineFeatures.threadsPerCore'
+  - api_field: 'settings.dbAlignedAtomicWritesConfig.dbAlignedAtomicWrites'
+    field: 'settings.db_aligned_atomic_writes_config.db_aligned_atomic_writes'
   - api_field: 'settings.availabilityType'
   - api_field: 'settings.availabilityType'
     field: 'settings.effective_availability_type'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2042,6 +2042,70 @@ func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabledForSqlServer(t *testin
 	})
 }
 
+func TestAccSqlDatabaseInstance_withDbAlignedAtomicWritesEnabled(t *testing.T) {
+	t.Parallel()
+
+	masterID := acctest.RandInt(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDbAlignedAtomicWrites(masterID, true, "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDbAlignedAtomicWrites(masterID, true, "db-custom-2-10240"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+		},
+	})
+}
+
+func TestAccSqlDatabaseInstance_withoutDbAlignedAtomicWritesEnabled(t *testing.T) {
+	t.Parallel()
+
+	masterID := acctest.RandInt(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDbAlignedAtomicWrites(masterID, false, "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_EnableDbAlignedAtomicWrites(masterID, false, "db-custom-2-10240"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_EnableGoogleMlIntegration(t *testing.T) {
 	t.Parallel()
 
@@ -7737,6 +7801,24 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, dbVersion, masterID, pointInTimeRecoveryEnabled)
+}
+
+func testGoogleSqlDatabaseInstance_EnableDbAlignedAtomicWrites(masterID int, enableDbAlignedAtomicWrites bool, tier string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "tf-test-%d"
+  region              = "us-central1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  root_password		    = "rand-pwd-%d"
+  settings {
+    tier                            = "%s"
+    db_aligned_atomic_writes_config {
+      db_aligned_atomic_writes = %t
+    }
+  }
+}
+`, masterID, masterID, tier, enableDbAlignedAtomicWrites)
 }
 
 func testGoogleSqlDatabaseInstance_EnableGoogleMlIntegration(masterID int, enableGoogleMlIntegration bool, dbVersion string, tier string) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -193,6 +193,21 @@ resource "google_sql_database_instance" "instance" {
 }
 ```
 
+### Cloud SQL Instance with DB Engine Aligned Atomic Writes
+```hcl
+resource "google_sql_database_instance" "instance" {
+  name:            = "db-aligned-atomic-writes-enabled-instance"
+  region           = "us-central1"
+  database_version = "MYSQL_8_0"
+  settings {
+    tier = "db-perf-optimized-N-2"
+    db_aligned_atomic_writes_config {
+      db_aligned_atomic_writes = true
+    }
+  }
+}
+```
+
 ### Cloud SQL Instance with PSC connectivity
 
 ```hcl
@@ -747,6 +762,10 @@ The optional `settings.connection_pool_config.flags` sublist supports:
 * `name` - (Required) Name of the flag.
 
 * `value` - (Required) Value of the flag.
+
+The optional `settings.db_aligned_atomic_writes_config` subblock supports:
+
+* `db_aligned_atomic_writes`: (Optional) If set to `true`, enables Database Engine Aligned Atomic Writes for an instance to write data pages aligned to the database instead of the underlying operating system. Defaults to `false`. Can be used with MySQL only.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds support for the new field `db_aligned_atomic_writes_config` to `google_sql_database_instance` settings.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: added `db_aligned_atomic_writes_config` field to `google_sql_database_instance` resource.
```