### PR TITLE
Fix google_container_cluster test failing at transparent_hugepage

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -8546,8 +8546,8 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings_in
 	min_node_cpus = 1
       }
       linux_node_config {
-        transparent_hugepage_defrag  = %s
-	transparent_hugepage_enabled = %s
+        transparent_hugepage_defrag  = "%s"
+	transparent_hugepage_enabled = "%s"
       }
     }
   }


### PR DESCRIPTION
Change-Id: I44a8d1b16b9897467a7b6d5122b32656e8197ea8

Fixed https://github.com/hashicorp/terraform-provider-google/issues/24017

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
