### PR TITLE
Update provider generation to use generic naming for imports

### DIFF
--- a/mmv1/provider/provider.go
+++ b/mmv1/provider/provider.go
@@ -18,10 +18,8 @@ type Provider interface {
 const TERRAFORM_PROVIDER_GA = "github.com/hashicorp/terraform-provider-google"
 const TERRAFORM_PROVIDER_BETA = "github.com/hashicorp/terraform-provider-google-beta"
 const TGC_PROVIDER = "github.com/GoogleCloudPlatform/terraform-google-conversion/v6"
-const TERRAFORM_PROVIDER_PRIVATE = "internal/terraform-next"
 const RESOURCE_DIRECTORY_GA = "google"
 const RESOURCE_DIRECTORY_BETA = "google-beta"
-const RESOURCE_DIRECTORY_PRIVATE = "google-private"
 const RESOURCE_DIRECTORY_TGC = "pkg"
 
 // # TODO: Review all object interfaces and move to private methods
@@ -40,8 +38,8 @@ func ImportPathFromVersion(v string) string {
 		tpg = TERRAFORM_PROVIDER_BETA
 		dir = RESOURCE_DIRECTORY_BETA
 	default:
-		tpg = TERRAFORM_PROVIDER_PRIVATE
-		dir = RESOURCE_DIRECTORY_PRIVATE
+		tpg = "github.com/hashicorp/terraform-provider-google-" + v
+		dir = "google-" + v
 	}
 	return fmt.Sprintf("%s/%s", tpg, dir)
 }

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -286,10 +286,8 @@ func (t *Terraform) GenerateIamDocumentation(object api.Resource, templateData T
 func (t *Terraform) FolderName() string {
 	if t.TargetVersionName == "ga" {
 		return "google"
-	} else if t.TargetVersionName == "beta" {
-		return "google-beta"
 	}
-	return "google-private"
+	return "google-" + t.TargetVersionName
 }
 
 // Similar to FullResourceName, but override-aware to prevent things like ending in _test.
@@ -716,9 +714,8 @@ func (t Terraform) replaceImportPath(outputFolder, target string) {
 		tpg = TERRAFORM_PROVIDER_BETA
 		dir = RESOURCE_DIRECTORY_BETA
 	default:
-		tpg = TERRAFORM_PROVIDER_PRIVATE
-		dir = RESOURCE_DIRECTORY_PRIVATE
-
+		tpg = "github.com/hashicorp/terraform-provider-google-" + t.TargetVersionName
+		dir = "google-" + t.TargetVersionName
 	}
 
 	sourceByte = bytes.Replace(sourceByte, []byte(gaImportPath), []byte(tpg+"/"+dir), -1)
@@ -748,7 +745,7 @@ func (t Terraform) ProviderFromVersion() string {
 	case "beta":
 		dir = RESOURCE_DIRECTORY_BETA
 	default:
-		dir = RESOURCE_DIRECTORY_PRIVATE
+		dir = "google-" + t.TargetVersionName
 	}
 	return dir
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This slightly changes the logic for how we replace imports throughout the generated provider to match the provider version. Basically, besides the GA version, imports will use a simple pattern based on the version, instead of hardcoded values.

* GA - no impact or diff
* beta - no impact or diff
* private - `github.com/hashicorp/terraform-provider-google-private` will be used instead of `internal/terraform-next`, and we will use a simple find/replace function to adjust those imports during terraform-next generation (there is already a matching internal CL)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
