### PR TITLE
Skip openidconnect call for user email if universe_domain detected

### DIFF
--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -1520,6 +1520,12 @@ func ConfigureBasePaths(c *Config) {
 }
 
 func GetCurrentUserEmail(config *Config, userAgent string) (string, error) {
+	ud := config.UniverseDomain
+	if ud != "" && ud != "googleapis.com" {
+		log.Printf("[INFO] Configured universe domain detected. Skipping user email retrieval.")
+		return "", nil
+	}
+
 	// When environment variables UserProjectOverride and BillingProject are set for the provider,
 	// the header X-Goog-User-Project is set for the API requests.
 	// But it causes an error when calling GetCurrentUserEmail. Set the project to be "NO_BILLING_PROJECT_OVERRIDE".
@@ -1528,9 +1534,10 @@ func GetCurrentUserEmail(config *Config, userAgent string) (string, error) {
 	// See https://github.com/golang/oauth2/issues/306 for a recommendation to do this from a Go maintainer
 	// URL retrieved from https://accounts.google.com/.well-known/openid-configuration
 	res, err := SendRequest(SendRequestOptions{
-		Config: config,
-		Method: "GET",
+		Config:  config,
+		Method:  "GET",
 		Project: "NO_BILLING_PROJECT_OVERRIDE",
+		// URL does not need to be universe domain-aware since we return early for non-GDU universes
 		RawURL: "https://openidconnect.googleapis.com/v1/userinfo",
 		UserAgent: userAgent,
 	})


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

previous log of failure: 

- gpaste/5875768646959104

log after this implementation:

- gpaste/5107182957494272

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
provider: fixed an issue with `universe_domain` where the provider tried to connect to "googleapis.com" for user email logging when `universe_domain` was set
```
