### PR TITLE
MMv1 field: changed `write_only` to `write_only_legacy` and marked field as deprecated

### DIFF
--- a/docs/content/reference/field.md
+++ b/docs/content/reference/field.md
@@ -107,7 +107,7 @@ Example:
 sensitive: true
 ```
 
-### `write_only`
+### `write_only_legacy` (deprecated)
 If true, the field is considered "write-only", which means that its value will
 be obscured in Terraform output as well as not be stored in state. This field is meant to replace `sensitive` as it doesn't store the value in state.
 See [Ephemerality in Resources - Use Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only)
@@ -121,8 +121,10 @@ This field cannot be used in conjuction with `immutable` or `sensitive`.
 Example:
 
 ```yaml
-write_only: true
+write_only_legacy: true
 ```
+
+**Deprecated**: This field is deprecated and will be removed in a future release.
 
 ### `ignore_read`
 If true, the provider sets the field's value in the resource state based only

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -617,7 +617,7 @@ func (r Resource) SensitiveProps() []*Type {
 func (r Resource) WriteOnlyProps() []*Type {
 	props := r.AllNestedProperties(r.RootProperties())
 	return google.Select(props, func(p *Type) bool {
-		return p.WriteOnly
+		return p.WriteOnlyLegacy
 	})
 }
 

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -171,7 +171,9 @@ type Type struct {
 
 	Sensitive bool `yaml:"sensitive,omitempty"` // Adds `Sensitive: true` to the schema
 
-	WriteOnly bool `yaml:"write_only,omitempty"` // Adds `WriteOnly: true` to the schema
+	// TODO: remove this field after all references are migrated
+	// see: https://github.com/GoogleCloudPlatform/magic-modules/pull/14933#pullrequestreview-3166578379
+	WriteOnlyLegacy bool `yaml:"write_only_legacy,omitempty"` // Adds `WriteOnlyLegacy: true` to the schema
 
 	// Does not set this value to the returned API value.  Useful for fields
 	// like secrets where the returned API value is not helpful.
@@ -395,11 +397,11 @@ func (t *Type) Validate(rName string) {
 		log.Fatalf("'default_value' and 'default_from_api' cannot be both set in resource %s", rName)
 	}
 
-	if t.WriteOnly && (t.DefaultFromApi || t.Output) {
+	if t.WriteOnlyLegacy && (t.DefaultFromApi || t.Output) {
 		log.Fatalf("Property %s cannot be write_only and default_from_api or output at the same time in resource %s", t.Name, rName)
 	}
 
-	if t.WriteOnly && t.Sensitive {
+	if t.WriteOnlyLegacy && t.Sensitive {
 		log.Fatalf("Property %s cannot be write_only and sensitive at the same time in resource %s", t.Name, rName)
 	}
 
@@ -750,7 +752,7 @@ func (t Type) WriteOnlyProperties() []*Type {
 		}
 	case t.IsA("NestedObject"):
 		props = google.Select(t.UserProperties(), func(p *Type) bool {
-			return p.WriteOnly
+			return p.WriteOnlyLegacy
 		})
 	case t.IsA("Map"):
 		props = google.Reject(t.ValueType.WriteOnlyProperties(), func(p *Type) bool {
@@ -1224,8 +1226,8 @@ func (t *Type) IsForceNew() bool {
 		return t.Immutable
 	}
 
-	// WriteOnly fields are never immutable
-	if t.WriteOnly {
+	// WriteOnlyLegacy fields are never immutable
+	if t.WriteOnlyLegacy {
 		return false
 	}
 

--- a/mmv1/products/bigquerydatatransfer/Config.yaml
+++ b/mmv1/products/bigquerydatatransfer/Config.yaml
@@ -243,7 +243,7 @@ properties:
         type: String
         description: |
           The Secret Access Key of the AWS account transferring data from.
-        write_only: true
+        write_only_legacy: true
         at_least_one_of:
           - 'sensitive_params.0.secretAccessKeyWo'
           - 'sensitive_params.0.secretAccessKey'

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -259,7 +259,7 @@ properties:
               - 'password'
             required_with:
               - 'http_check.0.auth_info.0.password_wo_version'
-            write_only: true
+            write_only_legacy: true
           - name: 'passwordWoVersion'
             type: String
             immutable: true

--- a/mmv1/products/secretmanager/SecretVersion.yaml
+++ b/mmv1/products/secretmanager/SecretVersion.yaml
@@ -172,7 +172,7 @@ properties:
           - 'SecretDataWoVersion'
         conflicts:
           - 'payload.0.secretData'
-        write_only: true
+        write_only_legacy: true
       - name: 'SecretDataWoVersion'
         type: Integer
         default_value: 0


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
MMv1: changed field `write_only` to `write_only_legacy` and marked field as deprecated
```
