### PR TITLE
Fixes issue #24052 related to google_chronicle_reference_list resource

### DIFF
--- a/mmv1/products/chronicle/ReferenceList.yaml
+++ b/mmv1/products/chronicle/ReferenceList.yaml
@@ -34,7 +34,7 @@ examples:
     primary_resource_id: 'example'
     vars:
       reference_list_id: reference_list_id
-      data_access_scope_id: test_scope_id
+      data_access_scope_id: scope-id
     test_env_vars:
       chronicle_id: 'CHRONICLE_ID'
 
@@ -98,7 +98,6 @@ properties:
       - name: referenceListScope
         type: NestedObject
         description: ReferenceListScope specifies the list of scope names of the reference list.
-        required: true
         properties:
           - name: scopeNames
             type: Array
@@ -108,6 +107,7 @@ properties:
               "projects/{project}/locations/{location}/instances/{instance}/dataAccessScopes/{scope_name}".
             item_type:
               type: String
+            diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
   - name: displayName
     type: String
     description: Output only. The unique display name of the reference list.

--- a/mmv1/products/chronicle/ReferenceList.yaml
+++ b/mmv1/products/chronicle/ReferenceList.yaml
@@ -34,6 +34,7 @@ examples:
     primary_resource_id: 'example'
     vars:
       reference_list_id: reference_list_id
+      data_access_scope_id: test_scope_id
     test_env_vars:
       chronicle_id: 'CHRONICLE_ID'
 
@@ -92,7 +93,6 @@ properties:
           required: true
   - name: scopeInfo
     type: NestedObject
-    output: true
     description: ScopeInfo specifies the scope info of the reference list.
     properties:
       - name: referenceListScope

--- a/mmv1/templates/terraform/examples/chronicle_referencelist_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_referencelist_basic.tf.tmpl
@@ -17,8 +17,8 @@ resource "google_chronicle_reference_list" "{{$.PrimaryResourceId}}" {
     value = "referencelist-entry-value"
   }
   syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"
-  scope_info = {
-    reference_list_scope = {
+  scope_info {
+    reference_list_scope {
       scope_names = [
         google_chronicle_data_access_scope.test_scope.name
       ]

--- a/mmv1/templates/terraform/examples/chronicle_referencelist_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_referencelist_basic.tf.tmpl
@@ -1,10 +1,27 @@
+resource "google_chronicle_data_access_scope" "test_scope" {
+  location = "us"
+  instance = "{{index $.TestEnvVars "chronicle_id"}}"
+  data_access_scope_id = "{{index $.Vars "data_access_scope_id"}}"
+  description = "test scope description"
+  allowed_data_access_labels {
+    log_type = "GCP_CLOUDAUDIT"
+  }
+}
+
 resource "google_chronicle_reference_list" "{{$.PrimaryResourceId}}" {
- location = "us"
- instance = "{{index $.TestEnvVars "chronicle_id"}}"
- reference_list_id = "{{index $.Vars "reference_list_id"}}"
- description = "referencelist-description"
- entries {
-  value = "referencelist-entry-value"
- }
- syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"
+  location = "us"
+  instance = "{{index $.TestEnvVars "chronicle_id"}}"
+  reference_list_id = "{{index $.Vars "reference_list_id"}}"
+  description = "referencelist-description"
+  entries {
+    value = "referencelist-entry-value"
+  }
+  syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"
+  scope_info = {
+    reference_list_scope = {
+      scope_names = [
+        google_chronicle_data_access_scope.test_scope.name
+      ]
+    }
+  }
 }

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_reference_list_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_reference_list_test.go
@@ -13,8 +13,10 @@ func TestAccChronicleReferenceList_chronicleReferencelistBasicExample_update(t *
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"chronicle_id":  envvar.GetTestChronicleInstanceIdFromEnv(t),
-		"random_suffix": acctest.RandString(t, 10),
+		"chronicle_id":             envvar.GetTestChronicleInstanceIdFromEnv(t),
+		"random_suffix":            acctest.RandString(t, 10),
+		"data_access_scope_id":     "test_scope_id" + acctest.RandString(t, 5),
+		"data_access_scope_id_new": "new_test_scope_id" + acctest.RandString(t, 5),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -45,6 +47,16 @@ func TestAccChronicleReferenceList_chronicleReferencelistBasicExample_update(t *
 
 func testAccChronicleReferenceList_chronicleReferencelistBasicExample_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_chronicle_data_access_scope" "test_scope" {
+  location = "us"
+  instance = "%{chronicle_id}"
+  data_access_scope_id = "%{data_access_scope_id}"
+  description = "test scope description"
+  allowed_data_access_labels {
+    log_type = "GCP_CLOUDAUDIT"
+  }
+}
+
 resource "google_chronicle_reference_list" "example" {
  location = "us"
  instance = "%{chronicle_id}"
@@ -54,12 +66,29 @@ resource "google_chronicle_reference_list" "example" {
   value = "referencelist-entry-value"
  }
  syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"
+ scope_info = {
+    reference_list_scope = {
+      scope_names = [
+        google_chronicle_data_access_scope.test_scope.name
+      ]
+    }
+  }
 }
 `, context)
 }
 
 func testAccChronicleReferenceList_chronicleReferencelistBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_chronicle_data_access_scope" "test_scope" {
+  location = "us"
+  instance = "%{chronicle_id}"
+  data_access_scope_id = "%{data_access_scope_id_new}"
+  description = "test scope description"
+  allowed_data_access_labels {
+    log_type = "GITHUB"
+  }
+}
+
 resource "google_chronicle_reference_list" "example" {
  location = "us"
  instance = "%{chronicle_id}"
@@ -69,6 +98,13 @@ resource "google_chronicle_reference_list" "example" {
   value = "referencelist-entry-value-updated"
  }
  syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_REGEX"
+ scope_info = {
+    reference_list_scope = {
+      scope_names = [
+        google_chronicle_data_access_scope.test_scope.name
+      ]
+    }
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_reference_list_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_reference_list_test.go
@@ -15,8 +15,8 @@ func TestAccChronicleReferenceList_chronicleReferencelistBasicExample_update(t *
 	context := map[string]interface{}{
 		"chronicle_id":             envvar.GetTestChronicleInstanceIdFromEnv(t),
 		"random_suffix":            acctest.RandString(t, 10),
-		"data_access_scope_id":     "test_scope_id" + acctest.RandString(t, 5),
-		"data_access_scope_id_new": "new_test_scope_id" + acctest.RandString(t, 5),
+		"data_access_scope_id":     "test-scope-id" + acctest.RandString(t, 5),
+		"data_access_scope_id_new": "new-test-scope-id" + acctest.RandString(t, 5),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -66,8 +66,8 @@ resource "google_chronicle_reference_list" "example" {
   value = "referencelist-entry-value"
  }
  syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_PLAIN_TEXT_STRING"
- scope_info = {
-    reference_list_scope = {
+ scope_info {
+    reference_list_scope {
       scope_names = [
         google_chronicle_data_access_scope.test_scope.name
       ]
@@ -98,8 +98,8 @@ resource "google_chronicle_reference_list" "example" {
   value = "referencelist-entry-value-updated"
  }
  syntax_type = "REFERENCE_LIST_SYNTAX_TYPE_REGEX"
- scope_info = {
-    reference_list_scope = {
+ scope_info {
+    reference_list_scope {
       scope_names = [
         google_chronicle_data_access_scope.test_scope.name
       ]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
chronicle: made the `scope_info` field in `google_chronicle_reference_list` configurable
```
