### PR TITLE
Add auto_upgrade_enabled setting to google_sql_database_instance.

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -425,6 +425,12 @@ API (for read pools, effective_availability_type may differ from availability_ty
 							Optional:    true,
 							Description: `Enables Vertex AI Integration.`,
 						},
+						"auto_upgrade_enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: `Enables Automatic Version Upgrade feature. Can be used with MySQL only.`,
+						},
 						"enable_dataplex_integration": {
 							Type:             schema.TypeBool,
 							Optional:         true,
@@ -1487,7 +1493,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		Tier:                          _settings["tier"].(string),
 		Edition:                       _settings["edition"].(string),
 		AdvancedMachineFeatures:       expandSqlServerAdvancedMachineFeatures(_settings["advanced_machine_features"].([]interface{})),
-		ForceSendFields:               []string{"StorageAutoResize", "EnableGoogleMlIntegration", "EnableDataplexIntegration", "RetainBackupsOnDelete"},
+		ForceSendFields:               []string{"AutoUpgradeEnabled", "StorageAutoResize", "EnableGoogleMlIntegration", "EnableDataplexIntegration", "RetainBackupsOnDelete"},
 		ActivationPolicy:              _settings["activation_policy"].(string),
 		ActiveDirectoryConfig:         expandActiveDirectoryConfig(_settings["active_directory_config"].([]interface{})),
 		DenyMaintenancePeriods:        expandDenyMaintenancePeriod(_settings["deny_maintenance_period"].([]interface{})),
@@ -1505,6 +1511,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, databaseVersion
 		PricingPlan:                   _settings["pricing_plan"].(string),
 		DeletionProtectionEnabled:     _settings["deletion_protection_enabled"].(bool),
 		EnableGoogleMlIntegration:     _settings["enable_google_ml_integration"].(bool),
+		AutoUpgradeEnabled:            _settings["auto_upgrade_enabled"].(bool),
 		EnableDataplexIntegration:     _settings["enable_dataplex_integration"].(bool),
 		RetainBackupsOnDelete:         _settings["retain_backups_on_delete"].(bool),
 		UserLabels:                    tpgresource.ConvertStringMap(_settings["user_labels"].(map[string]interface{})),
@@ -2255,9 +2262,9 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		instance.NodeCount = int64(d.Get("node_count").(int))
 	}
 
-	// Database Version is required for all calls with Google ML integration enabled or it will be rejected by the API.
-	if d.Get("settings.0.enable_google_ml_integration").(bool) || len(_settings["connection_pool_config"].(*schema.Set).List()) > 0 {
-			instance.DatabaseVersion = databaseVersion
+	// Database Version is required for all calls with Google ML Integration, Auto Upgrade, or Connection Pool enabled, or it will be rejected by the API.
+	if d.Get("settings.0.enable_google_ml_integration").(bool) || d.Get("settings.0.auto_upgrade_enabled").(bool) || len(_settings["connection_pool_config"].(*schema.Set).List()) > 0 {
+		instance.DatabaseVersion = databaseVersion
 	}
 
 	failoverDrReplicaName := d.Get("replication_cluster.0.failover_dr_replica_name").(string)
@@ -2500,6 +2507,7 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 	data["disk_autoresize"] = settings.StorageAutoResize
 	data["disk_autoresize_limit"] = settings.StorageAutoResizeLimit
 
+	data["auto_upgrade_enabled"] = settings.AutoUpgradeEnabled
 	data["enable_google_ml_integration"] = settings.EnableGoogleMlIntegration
 	data["enable_dataplex_integration"] = settings.EnableDataplexIntegration
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml
@@ -59,6 +59,7 @@ fields:
   - field: 'settings.activation_policy'
   - field: 'settings.active_directory_config.domain'
   - field: 'settings.advanced_machine_features.threads_per_core'
+  - field: 'settings.auto_upgrade_enabled'
   - field: 'settings.availability_type'
   - field: 'settings.backup_configuration.backup_retention_settings.retained_backups'
   - field: 'settings.backup_configuration.backup_retention_settings.retention_unit'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -1806,6 +1806,56 @@ func TestAccSqlDatabaseInstance_EnableGoogleMlIntegration(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_AutoUpgradeEnabled(t *testing.T) {
+	t.Parallel()
+
+	masterID := acctest.RandInt(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_AutoUpgradeEnabled(masterID, false, "MYSQL_8_0_31", "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_AutoUpgradeEnabled(masterID, false, "MYSQL_8_0_36", "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_AutoUpgradeEnabled(masterID, true, "MYSQL_8_0_36", "db-custom-2-13312"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_AutoUpgradeEnabled(masterID, true, "MYSQL_8_0_36", "db-custom-2-10240"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password"},
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_EnableGoogleDataplexIntegration(t *testing.T) {
 	t.Parallel()
 
@@ -6367,6 +6417,22 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, dbVersion, masterID, tier, enableGoogleMlIntegration)
+}
+
+func testGoogleSqlDatabaseInstance_AutoUpgradeEnabled(masterID int, autoUpgradeEnabled bool, dbVersion string, tier string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name                = "tf-test-%d"
+  region              = "us-central1"
+  database_version    = "%s"
+  deletion_protection = false
+  root_password		  = "rand-pwd-%d"
+  settings {
+    tier                 = "%s"
+    auto_upgrade_enabled = %t
+  }
+}
+`, masterID, dbVersion, masterID, tier, autoUpgradeEnabled)
 }
 
 func testGoogleSqlDatabaseInstance_EnableDataplexIntegration(masterID int, enableDataplexIntegration bool) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -353,6 +353,11 @@ The `settings` block supports:
 
 * `user_labels` - (Optional) A set of key/value user label pairs to assign to the instance.
 
+* `auto_upgrade_enabled` - Enables Automatic Version Upgrade feature. When this
+    field is set to `true`, Automatic Upgrade is enabled for `MYSQL_8_0` based
+    minor versions. The `database_version` must be `MYSQL_8_0_35` or higher.
+    Can be used with MySQL only.
+
 * `activation_policy` - (Optional) This specifies when the instance should be
     active. Can be either `ALWAYS`, `NEVER` or `ON_DEMAND`.
 


### PR DESCRIPTION
This PR adds support for the new field `auto_upgrade_enabled` to `google_sql_database_instance` settings.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
sql: added `auto_upgrade_enabled` field to `google_sql_database_instance` resource.
```