### PR TITLE
(GA) support for SM-GKE Auto rotation

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1678,7 +1678,6 @@ func ResourceContainerCluster() *schema.Resource {
 							Required:    true,
 							Description: `Enable the Secret manager csi component.`,
 						},
-						{{- if ne $.TargetVersionName "ga" }}
 						"rotation_config" : {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -1701,7 +1700,6 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-						{{- end }}
 					},
 				},
 			},
@@ -6408,7 +6406,6 @@ func expandSecretManagerConfig(configured interface{}) *container.SecretManagerC
 		Enabled:         config["enabled"].(bool),
 		ForceSendFields: []string{"Enabled"},
 	}
-	{{- if ne $.TargetVersionName "ga" }}
 	if autoRotation, ok := config["rotation_config"]; ok {
 		if autoRotationList, ok := autoRotation.([]interface{}); ok {
 			if len(autoRotationList) > 0 {
@@ -6426,7 +6423,6 @@ func expandSecretManagerConfig(configured interface{}) *container.SecretManagerC
 		    }
 		}
 	}
-		{{- end }}
 	return sc
 }
 
@@ -7485,7 +7481,6 @@ func flattenSecretManagerConfig(c *container.SecretManagerConfig) []map[string]i
 
 	result["enabled"] = c.Enabled
 
-	{{- if ne $.TargetVersionName "ga" }}
 	rotationList := []map[string]interface{}{}
 	if c.RotationConfig != nil {
 		rotationConfigMap := map[string]interface{}{
@@ -7497,7 +7492,6 @@ func flattenSecretManagerConfig(c *container.SecretManagerConfig) []map[string]i
 		rotationList = append(rotationList, rotationConfigMap)
 	}
 	result["rotation_config"] = rotationList
-	{{- end }}
 	return []map[string]interface{}{result}
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -11713,12 +11713,10 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   secret_manager_config {
     enabled = true
-{{- if ne $.TargetVersionName "ga" }}
   rotation_config {
     enabled = true
     rotation_interval = "300s"
     }
-{{- end }}
   }
   deletion_protection = false
   network    = "%s"
@@ -11741,12 +11739,10 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   secret_manager_config {
     enabled = true
-{{- if ne $.TargetVersionName "ga" }}
   rotation_config {
     enabled = true
     rotation_interval = "120s"
     }
-{{- end }}
   }
   deletion_protection = false
   network    = "%s"
@@ -11769,12 +11765,10 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 1
   secret_manager_config {
     enabled = true
-{{- if ne $.TargetVersionName "ga" }}
   rotation_config {
     enabled = false
     rotation_interval = "120s"
     }
-{{- end }}
   }
   deletion_protection = false
   network    = "%s"

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1285,7 +1285,7 @@ notification_config {
 <a name="nested_secret_manager_config"></a>The `secret_manager_config` block supports:
 
 * `enabled` (Required) - Enable the Secret Manager add-on for this cluster.
-* `rotation_config` (Optional, Beta) - config for secret manager auto rotation. Structure is [docuemented below](#rotation_config)
+* `rotation_config` (Optional) - config for secret manager auto rotation. Structure is [docuemented below](#rotation_config)
 
 <a name="rotation_config"></a>The `rotation_config` block supports:
 


### PR DESCRIPTION
Added a new field `rotation_config` to `google_container_cluster` in resource for `terraform-provider-google`

This field provides auto rotation in secret manager gke add on.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `secret_manager_config.rotation_config` field to `google_container_cluster` resource
```
