### PR TITLE
Feature gap: Add skip_guest_os_shutdown for scheduling in instance

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -352,9 +352,6 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 		"provisioning_model":          resp.ProvisioningModel,
 		"instance_termination_action": resp.InstanceTerminationAction,
 		"availability_domain":         resp.AvailabilityDomain,
-{{ if ne $.TargetVersionName `ga` -}}
-		"skip_guest_os_shutdown":      resp.SkipGuestOsShutdown,
-{{ end }}
 		"termination_time":            resp.TerminationTime,
 	}
 
@@ -371,6 +368,8 @@ func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 	}
 
 {{ if ne $.TargetVersionName `ga` -}}
+	schedulingMap["skip_guest_os_shutdown"] = resp.SkipGuestOsShutdown
+
 	if resp.HostErrorTimeoutSeconds != 0 {
 		schedulingMap["host_error_timeout_seconds"] = resp.HostErrorTimeoutSeconds
 	}

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -190,6 +190,11 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 		scheduling.GracefulShutdown = transformedGracefulShutdown
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "GracefulShutdown")
 	}
+
+	if v, ok := original["skip_guest_os_shutdown"]; ok {
+		scheduling.SkipGuestOsShutdown = v.(bool)
+		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "SkipGuestOsShutdown")
+	}
 {{- end }}
 	if v, ok := original["local_ssd_recovery_timeout"]; ok {
 		transformedLocalSsdRecoveryTimeout, err := expandComputeLocalSsdRecoveryTimeout(v)
@@ -341,13 +346,16 @@ func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error)
 
 func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
 	schedulingMap := map[string]interface{}{
-		"on_host_maintenance": resp.OnHostMaintenance,
-		"preemptible":         resp.Preemptible,
-		"min_node_cpus":       resp.MinNodeCpus,
-		"provisioning_model":  resp.ProvisioningModel,
+		"on_host_maintenance":         resp.OnHostMaintenance,
+		"preemptible":                 resp.Preemptible,
+		"min_node_cpus":               resp.MinNodeCpus,
+		"provisioning_model":          resp.ProvisioningModel,
 		"instance_termination_action": resp.InstanceTerminationAction,
-		"availability_domain": resp.AvailabilityDomain,
-		"termination_time":    resp.TerminationTime,
+		"availability_domain":         resp.AvailabilityDomain,
+{{ if ne $.TargetVersionName `ga` -}}
+		"skip_guest_os_shutdown":      resp.SkipGuestOsShutdown,
+{{ end }}
+		"termination_time":            resp.TerminationTime,
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -849,6 +857,10 @@ func schedulingHasChangeWithoutReboot(d *schema.ResourceData) bool {
 	}
 {{- if ne $.TargetVersionName "ga" }}
 	if oScheduling["host_error_timeout_seconds"] != newScheduling["host_error_timeout_seconds"] {
+		return true
+	}
+
+	if oScheduling["skip_guest_os_shutdown"] != newScheduling["skip_guest_os_shutdown"] {
 		return true
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -121,6 +121,7 @@ var (
 		"scheduling.0.maintenance_interval",
 		"scheduling.0.host_error_timeout_seconds",
 		"scheduling.0.graceful_shutdown",
+		"scheduling.0.skip_guest_os_shutdown",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
 	}
@@ -1242,6 +1243,12 @@ be from 0 to 999,999,999 inclusive.`,
 									},
 								},
 							},
+						},
+						"skip_guest_os_shutdown": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: `Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.`,
 						},
 						{{- end }}
 					},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -43,6 +43,7 @@ var (
 		"scheduling.0.maintenance_interval",
 		"scheduling.0.host_error_timeout_seconds",
 		"scheduling.0.graceful_shutdown",
+		"scheduling.0.skip_guest_os_shutdown",
 {{- end }}
 		"scheduling.0.local_ssd_recovery_timeout",
 	}
@@ -938,6 +939,12 @@ be from 0 to 999,999,999 inclusive.`,
 									},
 								},
 							},
+						},
+						"skip_guest_os_shutdown": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: `Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.`,
 						},
 {{- end }}
 					},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -1998,6 +1998,40 @@ func TestAccComputeInstanceTemplate_gracefulShutdown(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeInstanceTemplate_schedulingSkipGuestOSShutdown(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+
+	variant_1 := map[string]interface{}{
+		"instance_name": instanceName,
+		"skip_guest_os_shutdown": true,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_schedulingSkipGuestOSShutdown(variant_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_instance_template.foobar", "scheduling.0.skip_guest_os_shutdown", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
 {{- end }}
 
 func TestUnitComputeInstanceTemplate_IpCidrRangeDiffSuppress(t *testing.T) {
@@ -5206,6 +5240,48 @@ resource "google_compute_instance_template" "foobar" {
 		%{nanos}
 	  }
 	}
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  service_account {
+    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+  }
+
+  labels = {
+    my_label = "foobar"
+  }
+}
+`, context)
+}
+
+func testAccComputeInstanceTemplate_schedulingSkipGuestOSShutdown(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "%{instance_name}"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+	skip_guest_os_shutdown = %{skip_guest_os_shutdown}
   }
 
   metadata = {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -4478,6 +4478,37 @@ func TestAccComputeInstance_GracefulShutdownWithoutResetUpdate(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_schedulingSkipGuestOSShutdown(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_schedulingSkipGuestOSShutdown(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_schedulingSkipGuestOSShutdownUpdated(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
 func testAccComputeInstance_nic_securityPolicyCreateWithTwoAccessConfigs(t *testing.T) {
 	var instance compute.Instance
 	var instanceName = fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
@@ -4810,6 +4841,64 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, context)
+}
+
+func testAccComputeInstance_schedulingSkipGuestOSShutdown(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    skip_guest_os_shutdown = true
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_schedulingSkipGuestOSShutdownUpdated(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    skip_guest_os_shutdown = false
+  }
+}
+`, instance)
 }
 
 {{ end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -894,6 +894,12 @@ be from 0 to 999,999,999 inclusive.`,
 								},
 							},
 						},
+						"skip_guest_os_shutdown": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: `Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.`,
+						},
 {{- end }}
 					},
 				},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -1641,6 +1641,40 @@ func TestAccComputeRegionInstanceTemplate_gracefulShutdown(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeRegionInstanceTemplate_schedulingSkipGuestOSShutdown(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+
+	variant_1 := map[string]interface{}{
+		"instance_name": instanceName,
+		"skip_guest_os_shutdown": true,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_schedulingSkipGuestOSShutdown(variant_1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionInstanceTemplateExists(
+						t, "google_compute_region_instance_template.foobar", &instanceTemplate),
+					resource.TestCheckResourceAttr("google_compute_region_instance_template.foobar", "scheduling.0.skip_guest_os_shutdown", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
 {{- end }}
 
 func TestAccComputeRegionInstanceTemplate_GuestOsFeatures(t *testing.T) {
@@ -4685,6 +4719,35 @@ resource "google_compute_region_instance_template" "foobar" {
 		%{nanos}
 	  }
 	}
+  }
+}
+`, context)
+}
+
+func testAccComputeRegionInstanceTemplate_schedulingSkipGuestOSShutdown(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
+  region       = "us-central1"
+
+  disk {
+	source_image = data.google_compute_image.my_image.self_link
+	auto_delete  = true
+	boot         = true
+  }
+
+  network_interface {
+	network = "default"
+  }
+
+  scheduling {
+	skip_guest_os_shutdown = %{skip_guest_os_shutdown}
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -586,6 +586,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
 
+* `skip_guest_os_shutdown` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Boolean parameter. Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.
+
 <a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
 
 * `enabled` - (Required) Opts-in for graceful shutdown.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -687,6 +687,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
 
+* `skip_guest_os_shutdown` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Boolean parameter. Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.
+
 <a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
 
 * `enabled` - (Required) Opts-in for graceful shutdown.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -669,6 +669,8 @@ specified, then this instance will have no external IPv6 Internet access. Struct
 
 * `graceful_shutdown` -  (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Settings for the instance to perform a graceful shutdown. Structure is [documented below](#nested_graceful_shutdown).
 
+* `skip_guest_os_shutdown` - (Optional) [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) Boolean parameter. Default is false and there will be 120 seconds between GCE ACPI G2 Soft Off and ACPI G3 Mechanical Off for Standard VMs and 30 seconds for Spot VMs.
+
 <a name="nested_graceful_shutdown"></a>The `graceful_shutdown` block supports:
 
 * `enabled` - (Required) Opts-in for graceful shutdown.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This patch provides new field for Instance beta API `"scheduling.0.skip_guest_os_shutdown"`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `scheduling.0.skip_guest_os_shutdown` field to `google_compute_instance` resource (beta)
```

```release-note:enhancement
compute: added `scheduling.0.skip_guest_os_shutdown` field to `google_compute_instance_template` resource (beta)
```

```release-note:enhancement
compute: added `scheduling.0.skip_guest_os_shutdown` field to `google_compute_region_instance_template` resource (beta)
```

