### PR TITLE
Add support for `networksecurity.googleapis.com/BackendAuthenticationConfig` to TGC cai2hcl

### DIFF
--- a/mmv1/third_party/cai2hcl/convert_test.go
+++ b/mmv1/third_party/cai2hcl/convert_test.go
@@ -29,5 +29,6 @@ func TestConvertNetworksecurity(t *testing.T) {
 		"./services/networksecurity/testdata",
 		[]string{
 			"server_tls_policy",
+			"backend_authentication_config",
 		})
 }

--- a/mmv1/third_party/cai2hcl/converter_map.go
+++ b/mmv1/third_party/cai2hcl/converter_map.go
@@ -24,7 +24,8 @@ var AssetTypeToConverter = map[string]string{
 	resourcemanager.ProjectAssetType:        "google_project",
 	resourcemanager.ProjectBillingAssetType: "google_project",
 
-	networksecurity.ServerTLSPolicyAssetType: "google_network_security_server_tls_policy",
+	networksecurity.ServerTLSPolicyAssetType:             "google_network_security_server_tls_policy",
+	networksecurity.BackendAuthenticationConfigAssetType: "google_network_security_backend_authentication_config",
 }
 
 // ConverterMap is a collection of converters instances, indexed by name.
@@ -39,5 +40,6 @@ var ConverterMap = map[string]common.Converter{
 
 	"google_project": resourcemanager.NewProjectConverter(provider),
 
-	"google_network_security_server_tls_policy": networksecurity.NewServerTLSPolicyConverter(provider),
+	"google_network_security_server_tls_policy":             networksecurity.NewServerTLSPolicyConverter(provider),
+	"google_network_security_backend_authentication_config": networksecurity.NewBackendAuthenticationConfigConverter(provider),
 }

--- a/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
@@ -31,7 +31,7 @@ func NewBackendAuthenticationConfigConverter(provider *schema.Provider) common.C
 	}
 }
 
-// Convert converts CAI assets to HCL resource blocks (Provider version: 6.45.0)
+// Convert converts CAI assets to HCL resource blocks (Provider version: 7.0.1)
 func (c *BackendAuthenticationConfigConverter) Convert(assets []*caiasset.Asset) ([]*common.HCLResourceBlock, error) {
 	var blocks []*common.HCLResourceBlock
 	var err error

--- a/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
@@ -1,9 +1,12 @@
 package networksecurity
 
 import (
+	"errors"
+	"fmt"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	netsecapi "google.golang.org/api/networksecurity/v1"
 )
 
 // BackendAuthenticationConfigAssetType is the CAI asset type name.
@@ -33,5 +36,59 @@ func (c *BackendAuthenticationConfigConverter) Convert(assets []*caiasset.Asset)
 	var blocks []*common.HCLResourceBlock
 	var err error
 
+	for _, asset := range assets {
+		if asset == nil {
+			continue
+		} else if asset.Resource == nil || asset.Resource.Data == nil {
+			return nil, fmt.Errorf("INVALID_ARGUMENT: Asset resource data is nil")
+		} else if asset.Type != BackendAuthenticationConfigAssetType {
+			return nil, fmt.Errorf("INVALID_ARGUMENT: Expected asset of type %s, but received %s", BackendAuthenticationConfigAssetType, asset.Type)
+		}
+		block, errConvert := c.convertResourceData(asset)
+		blocks = append(blocks, block)
+		if errConvert != nil {
+			err = errors.Join(err, errConvert)
+		}
+	}
 	return blocks, err
+}
+
+func (c *BackendAuthenticationConfigConverter) convertResourceData(asset *caiasset.Asset) (*common.HCLResourceBlock, error) {
+	if asset == nil || asset.Resource == nil || asset.Resource.Data == nil {
+		return nil, fmt.Errorf("INVALID_ARGUMENT: Asset resource data is nil")
+	}
+
+	hcl, _ := flattenBackendAuthenticationConfig(asset.Resource)
+
+	ctyVal, err := common.MapToCtyValWithSchema(hcl, c.schema)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceName := hcl["name"].(string)
+	return &common.HCLResourceBlock{
+		Labels: []string{c.name, resourceName},
+		Value:  ctyVal,
+	}, nil
+}
+
+func flattenBackendAuthenticationConfig(resource *caiasset.AssetResource) (map[string]any, error) {
+	result := make(map[string]any)
+
+	var backendAuthenticationConfig *netsecapi.BackendAuthenticationConfig
+	if err := common.DecodeJSON(resource.Data, &backendAuthenticationConfig); err != nil {
+		return nil, err
+	}
+
+	result["name"] = flattenName(backendAuthenticationConfig.Name)
+	result["labels"] = backendAuthenticationConfig.Labels
+	result["description"] = backendAuthenticationConfig.Description
+	result["client_certificate"] = backendAuthenticationConfig.ClientCertificate
+	result["trust_config"] = backendAuthenticationConfig.TrustConfig
+	result["well_known_roots"] = backendAuthenticationConfig.WellKnownRoots
+	result["project"] = flattenProjectName(backendAuthenticationConfig.Name)
+
+	result["location"] = resource.Location
+
+	return result, nil
 }

--- a/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
@@ -1,0 +1,37 @@
+package networksecurity
+
+import (
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// BackendAuthenticationConfigAssetType is the CAI asset type name.
+const BackendAuthenticationConfigAssetType string = "networksecurity.googleapis.com/BackendAuthenticationConfig"
+
+// BackendAuthenticationConfigSchemaName is the TF resource schema name.
+const BackendAuthenticationConfigSchemaName string = "google_network_security_backend_authentication_config"
+
+// BackendAuthenticationConfigConverter for networksecurity backend authentication config resource.
+type BackendAuthenticationConfigConverter struct {
+	name   string
+	schema map[string]*schema.Schema
+}
+
+// NewBackendAuthenticationConfigConverter returns an HCL converter.
+func NewBackendAuthenticationConfigConverter(provider *schema.Provider) common.Converter {
+	schema := provider.ResourcesMap[BackendAuthenticationConfigSchemaName].Schema
+
+	return &BackendAuthenticationConfigConverter{
+		name:   BackendAuthenticationConfigSchemaName,
+		schema: schema,
+	}
+}
+
+// Convert converts CAI assets to HCL resource blocks (Provider version: 6.45.0)
+func (c *BackendAuthenticationConfigConverter) Convert(assets []*caiasset.Asset) ([]*common.HCLResourceBlock, error) {
+	var blocks []*common.HCLResourceBlock
+	var err error
+
+	return blocks, err
+}

--- a/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config_test.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config_test.go
@@ -1,0 +1,13 @@
+package networksecurity_test
+
+import (
+	cai2hcl_testing "github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/testing"
+	"testing"
+)
+
+func TestBackendAuthenticationConfig(t *testing.T) {
+	cai2hcl_testing.AssertTestFiles(
+		t,
+		"./testdata",
+		[]string{"backend_authentication_config"})
+}

--- a/mmv1/third_party/cai2hcl/services/networksecurity/server_tls_policy.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/server_tls_policy.go
@@ -7,7 +7,6 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	netsecapi "google.golang.org/api/networksecurity/v1"
-	"strings"
 )
 
 // ServerTLSPolicyAssetType is the CAI asset type name.
@@ -94,11 +93,6 @@ func flattenServerTLSPolicy(resource *caiasset.AssetResource) (map[string]any, e
 	return result, nil
 }
 
-func flattenName(name string) string {
-	tokens := strings.Split(name, "/")
-	return tokens[len(tokens)-1]
-}
-
 func flattenServerCertificate(certificate *netsecapi.GoogleCloudNetworksecurityV1CertificateProvider) []map[string]any {
 	if certificate == nil {
 		return nil
@@ -162,12 +156,4 @@ func flattenClientValidationCA(cas []*netsecapi.ValidationCA) []map[string]any {
 	}
 
 	return result
-}
-
-func flattenProjectName(name string) string {
-	tokens := strings.Split(name, "/")
-	if len(tokens) < 2 || tokens[0] != "projects" {
-		return ""
-	}
-	return tokens[1]
 }

--- a/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.json
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.json
@@ -28,7 +28,7 @@
         "createTime": "2025-09-01T12:22:50.489447184Z",
         "etag": "hI87OGITW_38twEfrG1qMbgXTjulOs0PvGVm5zgpNfQ",
         "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test2",
-        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "trustConfig": "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
         "updateTime": "2025-09-01T12:22:56.430273835Z",
         "wellKnownRoots": "PUBLIC_ROOTS"
       },
@@ -47,7 +47,7 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test3",
     "resource": {
       "data": {
-        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "clientCertificate": "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101",
         "createTime": "2025-09-01T12:23:21.187162159Z",
         "etag": "TbNENVDPeneynkqLnTmLvn757xA-GnuI_XTsk2F00y0",
         "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test3",
@@ -68,11 +68,11 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test4",
     "resource": {
       "data": {
-        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "clientCertificate": "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101",
         "createTime": "2025-09-01T12:23:59.175425527Z",
         "etag": "MtMLKQSPwOIjp25H_ndWUe9zKCcVvtHdoHxv5XvBvHU",
         "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test4",
-        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "trustConfig": "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
         "updateTime": "2025-09-01T12:24:09.189436548Z",
         "wellKnownRoots": "PUBLIC_ROOTS"
       },
@@ -93,7 +93,7 @@
         "createTime": "2025-09-01T12:24:38.165237290Z",
         "etag": "q-3pJ_Ae7LorXoNfPMbuxSiwH4JiS4KMlk6Ojm50qbo",
         "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test5",
-        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "trustConfig": "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
         "updateTime": "2025-09-01T12:24:42.574599551Z",
         "wellKnownRoots": "NONE"
       },
@@ -111,11 +111,11 @@
     "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test7",
     "resource": {
       "data": {
-        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "clientCertificate": "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101",
         "createTime": "2025-09-01T12:25:29.338526364Z",
         "etag": "5dYcNBll7z2KaHuJd2nxr9Qp4U1JPuPBzJtFkVdRO_k",
         "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test7",
-        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "trustConfig": "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
         "updateTime": "2025-09-01T12:25:36.419856961Z",
         "wellKnownRoots": "NONE"
       },

--- a/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.json
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.json
@@ -1,0 +1,195 @@
+[
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test1",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:06:59.449575828Z",
+        "etag": "tyOJj9L43CxYuKifz5lEwq4SkQqs5426-4H7BCgyUMw",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test1",
+        "updateTime": "2025-09-01T12:07:03.557427913Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:07:03.557427913Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test2",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:22:50.489447184Z",
+        "etag": "hI87OGITW_38twEfrG1qMbgXTjulOs0PvGVm5zgpNfQ",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test2",
+        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "updateTime": "2025-09-01T12:22:56.430273835Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:22:56.430273835Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test3",
+    "resource": {
+      "data": {
+        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "createTime": "2025-09-01T12:23:21.187162159Z",
+        "etag": "TbNENVDPeneynkqLnTmLvn757xA-GnuI_XTsk2F00y0",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test3",
+        "updateTime": "2025-09-01T12:23:25.982840761Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:23:25.982840761Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test4",
+    "resource": {
+      "data": {
+        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "createTime": "2025-09-01T12:23:59.175425527Z",
+        "etag": "MtMLKQSPwOIjp25H_ndWUe9zKCcVvtHdoHxv5XvBvHU",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test4",
+        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "updateTime": "2025-09-01T12:24:09.189436548Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:24:09.189436548Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test5",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:24:38.165237290Z",
+        "etag": "q-3pJ_Ae7LorXoNfPMbuxSiwH4JiS4KMlk6Ojm50qbo",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test5",
+        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "updateTime": "2025-09-01T12:24:42.574599551Z",
+        "wellKnownRoots": "NONE"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:24:42.574599551Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test7",
+    "resource": {
+      "data": {
+        "clientCertificate": "projects/307841421122/locations/global/certificates/anatolisaukhin-27101",
+        "createTime": "2025-09-01T12:25:29.338526364Z",
+        "etag": "5dYcNBll7z2KaHuJd2nxr9Qp4U1JPuPBzJtFkVdRO_k",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test7",
+        "trustConfig": "projects/307841421122/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9",
+        "updateTime": "2025-09-01T12:25:36.419856961Z",
+        "wellKnownRoots": "NONE"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:25:36.419856961Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test8",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:28:43.012225935Z",
+        "description": "My test description",
+        "etag": "jAgYExhvS1-odwm8v6WzKxXcWqnMgOqyQNxz0LpLzcE",
+        "labels": {
+          "foo": "bar"
+        },
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test8",
+        "updateTime": "2025-09-01T12:28:48.571512164Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:28:48.571512164Z"
+  },
+
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/europe-west1/backendAuthenticationConfigs/laurenzk-test9",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:37:43.341940613Z",
+        "etag": "DQgzWLri0AvaD72f8Xk5SBtT6nEoH4B3krtcsjS7V2A",
+        "name": "projects/ccm-breakit/locations/europe-west1/backendAuthenticationConfigs/laurenzk-test9",
+        "updateTime": "2025-09-01T12:37:43.402977101Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "europe-west1",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:37:43.402977101Z"
+  },
+  {
+    "ancestors": ["projects/307841421122"],
+    "asset_type": "networksecurity.googleapis.com/BackendAuthenticationConfig",
+    "name": "//networksecurity.googleapis.com/projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test10",
+    "resource": {
+      "data": {
+        "createTime": "2025-09-01T12:28:42.936655254Z",
+        "etag": "7hxmlYo8sLeaML92DAHdBZGpNDehxn6ksGJsTQDXcHE",
+        "name": "projects/ccm-breakit/locations/global/backendAuthenticationConfigs/laurenzk-test10",
+        "updateTime": "2025-09-01T12:28:46.761498301Z",
+        "wellKnownRoots": "PUBLIC_ROOTS"
+      },
+      "discovery_document_uri": "https://networksecurity.googleapis.com/$discovery/rest",
+      "discovery_name": "BackendAuthenticationConfig",
+      "location": "global",
+      "parent": "//cloudresourcemanager.googleapis.com/projects/307841421122",
+      "version": "v1"
+    },
+    "updateTime": "2025-09-01T12:28:46.761498301Z"
+  }
+]

--- a/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
@@ -1,36 +1,48 @@
 resource "google_network_security_backend_authentication_config" "laurenzk-test1" {
+  location         = "global"
   name             = "laurenzk-test1"
+  project          = "ccm-breakit"
   well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test2" {
+  location         = "global"
   name             = "laurenzk-test2"
+  project          = "ccm-breakit"
   trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test3" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  location           = "global"
   name               = "laurenzk-test3"
+  project            = "ccm-breakit"
   well_known_roots   = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test4" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  location           = "global"
   name               = "laurenzk-test4"
+  project            = "ccm-breakit"
   trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots   = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test5" {
+  location         = "global"
   name             = "laurenzk-test5"
+  project          = "ccm-breakit"
   trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots = "NONE"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test7" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  location           = "global"
   name               = "laurenzk-test7"
+  project            = "ccm-breakit"
   trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots   = "NONE"
 }
@@ -42,17 +54,21 @@ resource "google_network_security_backend_authentication_config" "laurenzk-test8
     foo = "bar"
   }
 
+  location         = "global"
   name             = "laurenzk-test8"
+  project          = "ccm-breakit"
   well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test9" {
   location         = "europe-west1"
   name             = "laurenzk-test9"
+  project          = "ccm-breakit"
   well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test10" {
+  location         = "global"
   name             = "laurenzk-test10"
   project          = "ccm-breakit"
   well_known_roots = "PUBLIC_ROOTS"

--- a/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
@@ -1,38 +1,38 @@
 resource "google_network_security_backend_authentication_config" "laurenzk-test1" {
-  well_known_roots = "PUBLIC_ROOTS"
   name             = "laurenzk-test1"
+  well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test2" {
+  name             = "laurenzk-test2"
   trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots = "PUBLIC_ROOTS"
-  name             = "laurenzk-test2"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test3" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
-  well_known_roots   = "PUBLIC_ROOTS"
   name               = "laurenzk-test3"
+  well_known_roots   = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test4" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  name               = "laurenzk-test4"
   trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots   = "PUBLIC_ROOTS"
-  name               = "laurenzk-test4"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test5" {
+  name             = "laurenzk-test5"
   trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots = "NONE"
-  name             = "laurenzk-test5"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test7" {
   client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  name               = "laurenzk-test7"
   trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
   well_known_roots   = "NONE"
-  name               = "laurenzk-test7"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test8" {
@@ -42,18 +42,18 @@ resource "google_network_security_backend_authentication_config" "laurenzk-test8
     foo = "bar"
   }
 
-  well_known_roots = "PUBLIC_ROOTS"
   name             = "laurenzk-test8"
+  well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test9" {
   location         = "europe-west1"
-  well_known_roots = "PUBLIC_ROOTS"
   name             = "laurenzk-test9"
+  well_known_roots = "PUBLIC_ROOTS"
 }
 
 resource "google_network_security_backend_authentication_config" "laurenzk-test10" {
+  name             = "laurenzk-test10"
   project          = "ccm-breakit"
   well_known_roots = "PUBLIC_ROOTS"
-  name             = "laurenzk-test10"
 }

--- a/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/testdata/backend_authentication_config.tf
@@ -1,0 +1,59 @@
+resource "google_network_security_backend_authentication_config" "laurenzk-test1" {
+  well_known_roots = "PUBLIC_ROOTS"
+  name             = "laurenzk-test1"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test2" {
+  trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
+  well_known_roots = "PUBLIC_ROOTS"
+  name             = "laurenzk-test2"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test3" {
+  client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  well_known_roots   = "PUBLIC_ROOTS"
+  name               = "laurenzk-test3"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test4" {
+  client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
+  well_known_roots   = "PUBLIC_ROOTS"
+  name               = "laurenzk-test4"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test5" {
+  trust_config     = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
+  well_known_roots = "NONE"
+  name             = "laurenzk-test5"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test7" {
+  client_certificate = "projects/ccm-breakit/locations/global/certificates/anatolisaukhin-27101"
+  trust_config       = "projects/ccm-breakit/locations/global/trustConfigs/id-2de0d4b7-89cf-476f-893d-4567b3791ca9"
+  well_known_roots   = "NONE"
+  name               = "laurenzk-test7"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test8" {
+  description = "My test description"
+
+  labels = {
+    foo = "bar"
+  }
+
+  well_known_roots = "PUBLIC_ROOTS"
+  name             = "laurenzk-test8"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test9" {
+  location         = "europe-west1"
+  well_known_roots = "PUBLIC_ROOTS"
+  name             = "laurenzk-test9"
+}
+
+resource "google_network_security_backend_authentication_config" "laurenzk-test10" {
+  project          = "ccm-breakit"
+  well_known_roots = "PUBLIC_ROOTS"
+  name             = "laurenzk-test10"
+}

--- a/mmv1/third_party/cai2hcl/services/networksecurity/utils.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/utils.go
@@ -1,0 +1,16 @@
+package networksecurity
+
+import "strings"
+
+func flattenName(name string) string {
+	tokens := strings.Split(name, "/")
+	return tokens[len(tokens)-1]
+}
+
+func flattenProjectName(name string) string {
+	tokens := strings.Split(name, "/")
+	if len(tokens) < 2 || tokens[0] != "projects" {
+		return ""
+	}
+	return tokens[1]
+}


### PR DESCRIPTION
### Summary

This PR adds support for converting Networksecurity Backend Authentication Config resources from CAI to HCL in TGC. It includes mapping logic for the resource and tests for validating mapping equivalence between HCL and CAI.

Backend Authentication Configs are not yet onboarded to CAIS. Based on implementation of other networksecurity CAI resources we assume the GET API Object is serialized as Asset Resource Data.

### Context

CCM is planning on using terraform-google-conversion for equivalent Terraform features, as discussed with @zli82016 

```release-note:none
```