### PR TITLE
osconfig: fix permadiff where `patch_config.yum.minimal` doesn't send `false` for empty values

### DIFF
--- a/mmv1/products/osconfig/PatchDeployment.yaml
+++ b/mmv1/products/osconfig/PatchDeployment.yaml
@@ -254,6 +254,7 @@ properties:
               - 'patch_config.0.yum.0.excludes'
               - 'patch_config.0.yum.0.exclusive_packages'
           - name: 'minimal'
+            send_empty_value: true
             type: Boolean
             description: |
               Will cause patch to run yum update-minimal instead.

--- a/mmv1/templates/terraform/decoders/os_config_patch_deployment.go.tmpl
+++ b/mmv1/templates/terraform/decoders/os_config_patch_deployment.go.tmpl
@@ -4,6 +4,14 @@ if  res["patchConfig"] != nil {
 		patchConfig["goo"].(map[string]interface{})["enabled"] = true
 		res["patchConfig"] = patchConfig
 	}
+
+    if patchConfig["yum"] != nil {
+        patchConfigYum := patchConfig["yum"].(map[string]interface{})
+        if _, ok := patchConfigYum["minimal"]; !ok {
+            patchConfigYum["minimal"] = false
+        }
+        patchConfig["yum"] = patchConfigYum
+    }
 }
 
 return res, nil

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_patch_deployment_test.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_patch_deployment_test.go
@@ -1,0 +1,58 @@
+package osconfig_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckOSConfigPatchDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_os_config_patch_deployment.patch", "patch_config.yum.minimal", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_os_config_patch_deployment.patch",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"patch_deployment_id"},
+			},
+		},
+	})
+}
+
+func testAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_os_config_patch_deployment" "patch" {
+  patch_deployment_id = "tf-test-patch-deploy%{random_suffix}"
+
+  instance_filter {
+    all = true
+  }
+
+  patch_config {
+    yum {
+      minimal = true
+    }
+  }
+
+  one_time_schedule {
+    execute_time = "2999-10-10T10:10:10.045123456Z"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/osconfig/resource_os_config_patch_deployment_test.go
+++ b/mmv1/third_party/terraform/services/osconfig/resource_os_config_patch_deployment_test.go
@@ -22,7 +22,7 @@ func TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic(t *testing
 			{
 				Config: testAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic(context),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_os_config_patch_deployment.patch", "patch_config.yum.minimal", "true"),
+					resource.TestCheckResourceAttr("google_os_config_patch_deployment.patch", "patch_config.0.yum.0.minimal", "false"),
 				),
 			},
 			{
@@ -46,7 +46,7 @@ resource "google_os_config_patch_deployment" "patch" {
 
   patch_config {
     yum {
-      minimal = true
+      minimal = false
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/23962

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
osconfig: fix permadiff where `patch_config.yum.minimal` doesn't send `false` for empty values
```

Implemented a specific test to reproduce the permadiff, but I'm fine removing it if it is too much overhead.

**Acceptance tests:**

```
❮ make testacc TEST=./google/services/osconfig TESTARGS='-run=TestAccOSConfigPatchDeployment_'
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/osconfig -v -run=TestAccOSConfigPatchDeployment_ -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeploymentBasicExample
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeploymentBasicExample
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyExample
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyExample
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyMidnightExample
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyMidnightExample
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeploymentInstanceExample
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeploymentInstanceExample
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeploymentFullExample
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeploymentFullExample
=== RUN   TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic
=== PAUSE TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeploymentBasicExample
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeploymentFullExample
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeploymentInstanceExample
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyMidnightExample
=== CONT  TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyExample
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeploymentBasicExample (5.41s)
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeployment_yum_basic (5.41s)
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyMidnightExample (5.43s)
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeploymentDailyExample (5.43s)
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeploymentFullExample (5.76s)
--- PASS: TestAccOSConfigPatchDeployment_osConfigPatchDeploymentInstanceExample (128.94s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/osconfig 129.689s

```

Had to update the decoder as welll, because even if you provide `false` in the POST for the `patchConfig.yum.minimal`, the GET returns an empty object:

```
  "patchConfig": {
    "yum": {}
  },
```
