### PR TITLE
API implementation for fetch Resource Type of data source references

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -46,6 +46,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_backup_dr_backup":							backupdr.DataSourceGoogleCloudBackupDRBackup(),
 	"google_backup_dr_data_source":						backupdr.DataSourceGoogleCloudBackupDRDataSource(),
 	"google_backup_dr_backup_vault":					backupdr.DataSourceGoogleCloudBackupDRBackupVault(),
+	"google_backup_dr_data_source_references":			backupdr.DataSourceGoogleBackupDRDataSourceReferences(),
 	"google_beyondcorp_app_connection":                 beyondcorp.DataSourceGoogleBeyondcorpAppConnection(),
 	"google_beyondcorp_app_connector":                  beyondcorp.DataSourceGoogleBeyondcorpAppConnector(),
 	"google_beyondcorp_app_gateway":                    beyondcorp.DataSourceGoogleBeyondcorpAppGateway(),

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
@@ -1,0 +1,114 @@
+package backupdr
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleBackupDRDataSourceReferences() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleBackupDRDataSourceReferencesRead,
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The location to list the data source references from.",
+			},
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the project in which the resource belongs.",
+			},
+			"resource_type": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: `The resource type to get the data source references for. Examples include, "compute.googleapis.com/Instance", "sqladmin.googleapis.com/Instance".`,
+			},
+
+			// Output: a computed list of the data source references found
+			"data_source_references": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "A list of the data source references found.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"resource_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleBackupDRDataSourceReferencesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	location := d.Get("location").(string)
+	resourceType := d.Get("resource_type").(string)
+
+	url := fmt.Sprintf("https://backupdr.googleapis.com/v1/projects/%s/locations/%s/dataSourceReferences:fetchForResourceType?resourceType=%s", project, location, resourceType)
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return fmt.Errorf("Error reading DataSourceReferences: %s", err)
+	}
+
+	items, ok := res["dataSourceReferences"].([]interface{})
+	if !ok {
+		items = make([]interface{}, 0)
+	}
+
+	flattenedDataSourceReferences, err := flattenDataSourceReferences(items)
+	if err != nil {
+		return err
+	}
+
+	if err := d.Set("data_source_references", flattenedDataSourceReferences); err != nil {
+		return fmt.Errorf("Error setting data_source_references: %s", err)
+	}
+
+	d.SetId(url)
+
+	return nil
+}
+
+func flattenDataSourceReferences(items []interface{}) ([]map[string]interface{}, error) {
+	references := make([]map[string]interface{}, 0, len(items))
+	for _, item := range items {
+		data, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("cannot cast item to map[string]interface{}")
+		}
+		references = append(references, map[string]interface{}{
+			"name":          data["name"],
+			"resource_type": data["resourceType"],
+		})
+	}
+	return references, nil
+}

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference_test.go
@@ -1,0 +1,140 @@
+package backupdr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleBackupDRDataSourceReferences_basic(t *testing.T) {
+	t.Parallel()
+
+	projectDsName := "data.google_project.project"
+	var projectID string
+	context := map[string]interface{}{
+		"location":      "us-central1",
+		"resource_type": "sqladmin.googleapis.com/Instance",
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleBackupDRDataSourceReferences_basic(context),
+				Check: func(s *terraform.State) error {
+					// Extract project ID from the project data source in the state
+					project, ok := s.RootModule().Resources[projectDsName]
+					if !ok {
+						return fmt.Errorf("project data source not found: %s", projectDsName)
+					}
+					projectID = project.Primary.Attributes["project_id"]
+
+					// Now, run the regular checks using the extracted projectID
+					return resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.google_backup_dr_data_source_references.default", "project", projectID),
+						resource.TestCheckResourceAttr("data.google_backup_dr_data_source_references.default", "location", context["location"].(string)),
+						resource.TestCheckResourceAttr("data.google_backup_dr_data_source_references.default", "resource_type", context["resource_type"].(string)),
+						resource.TestCheckResourceAttrSet("data.google_backup_dr_data_source_references.default", "data_source_references.#"),
+						resource.TestCheckResourceAttrSet("data.google_backup_dr_data_source_references.default", "data_source_references.0.name"),
+					)(s)
+				},
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleBackupDRDataSourceReferences_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+
+
+data "google_project" "project" {}
+
+
+ resource "google_service_account" "default" {
+ account_id   = "tf-test-my-custom-%{random_suffix}"
+ display_name = "Custom SA for VM Instance"
+}
+
+
+resource "google_sql_database_instance" "instance" {
+ name             = "default-%{random_suffix}"
+ database_version = "MYSQL_8_0"
+ region          = "us-central1"
+ deletion_protection = false
+ settings {
+   tier = "db-f1-micro"
+   availability_type = "ZONAL"
+   activation_policy = "ALWAYS"
+ }
+}
+
+
+resource "google_backup_dr_backup_vault" "my-backup-vault" {
+   location ="us-central1"
+   backup_vault_id    = "tf-test-bv-%{random_suffix}"
+   description = "This is a second backup vault built by Terraform."
+   backup_minimum_enforced_retention_duration = "100000s"
+   labels = {
+     foo = "bar1"
+     bar = "baz1"
+   }
+   annotations = {
+     annotations1 = "bar1"
+     annotations2 = "baz1"
+   }
+   force_update = "true"
+   force_delete = "true"
+   allow_missing = "true"
+}
+
+
+resource "google_backup_dr_backup_plan" "foo" {
+ location       = "us-central1"
+ backup_plan_id = "tf-test-bp-test-%{random_suffix}"
+ resource_type  = "sqladmin.googleapis.com/Instance"
+ backup_vault   = google_backup_dr_backup_vault.my-backup-vault.name
+
+
+ backup_rules {
+   rule_id                = "rule-1"
+   backup_retention_days  = 2
+
+
+   standard_schedule {
+     recurrence_type     = "HOURLY"
+     hourly_frequency    = 6
+     time_zone           = "UTC"
+
+
+     backup_window {
+       start_hour_of_day = 12
+       end_hour_of_day   = 18
+     }
+   }
+ }
+}
+
+
+resource "google_backup_dr_backup_plan_association" "bpa" {
+ location = "us-central1"
+ backup_plan_association_id = "tf-test-bpa-test-%{random_suffix}"
+ resource = "projects/${data.google_project.project.project_id}/instances/${google_sql_database_instance.instance.name}"
+ resource_type= "sqladmin.googleapis.com/Instance"
+ backup_plan = google_backup_dr_backup_plan.foo.name
+ depends_on = [ google_sql_database_instance.instance ]
+}
+
+
+data "google_backup_dr_data_source_references" "default" {
+   project       = data.google_project.project.project_id
+   location      = "%{location}"
+   resource_type = "%{resource_type}"
+   depends_on= [ google_backup_dr_backup_plan_association.bpa ]
+   }
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
Added API implementation for fetch Resource Type for data source references in the data_source_backup_dr_data_source_reference.go `
```
