### PR TITLE
Make contributor membership checker warn instead of fail

### DIFF
--- a/.ci/magician/cloudbuild/community.go
+++ b/.ci/magician/cloudbuild/community.go
@@ -30,7 +30,8 @@ func (cb *Client) ApproveDownstreamGenAndTest(prNumber, commitSha string) error 
 	}
 
 	if buildId == "" {
-		return fmt.Errorf("Failed to find pending build for PR %s", prNumber)
+		fmt.Printf("WARNING: Failed to find pending build for PR %s\nThis build may have been approved already.\n", prNumber)
+		return nil
 	}
 
 	err = approveBuild(PROJECT_ID, buildId)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The good build approver is now approving downstream generation and test directly. This change should make contributor membership checker still succeed when it can't find a pending build because the build has already been approved.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
