### PR TITLE
Fix for desired_auto_created_endpoints incorrect update  v2

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -109,7 +109,7 @@ examples:
 virtual_fields:
   - name: 'desired_psc_auto_connections'
     description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead."
-    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead. Terrafrom import will work with desired_auto_created_endpoints only'
+    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead. `terraform import` will only work with desired_auto_created_endpoints`.'
     type: Array
     immutable: true
     conflicts:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -109,7 +109,7 @@ examples:
 virtual_fields:
   - name: 'desired_psc_auto_connections'
     description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead."
-    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead. `terraform import` will only work with desired_auto_created_endpoints`.'
+    deprecation_message: '`desired_psc_auto_connections` is deprecated. Use `desired_auto_created_endpoints` instead. `terraform import` will only work with desired_auto_created_endpoints`.'
     type: Array
     immutable: true
     conflicts:

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -108,7 +108,7 @@ examples:
       'secondary_instance_prevent_destroy': 'false'
 virtual_fields:
   - name: 'desired_psc_auto_connections'
-    description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead."
+    description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead `terraform import` will only work with desired_auto_created_endpoints`."
     deprecation_message: '`desired_psc_auto_connections` is deprecated. Use `desired_auto_created_endpoints` instead. `terraform import` will only work with desired_auto_created_endpoints`.'
     type: Array
     immutable: true

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -109,7 +109,7 @@ examples:
 virtual_fields:
   - name: 'desired_psc_auto_connections'
     description: "`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead."
-    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead.'
+    deprecation_message: '`desired_psc_auto_connections` is deprecated  Use `desired_auto_created_endpoints` instead. Terrafrom import will work with desired_auto_created_endpoints only'
     type: Array
     immutable: true
     conflicts:

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -85,10 +85,25 @@
 					}
 				}
 			}
+			// NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
+			// When desired_auto_created_endpoints is set this flow works as expected
+			// FLOW: Terraform  -> API Input -> API Output -> Terraform output
+			// CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
+			// CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
+			// The if else if below checks what is define by the user in order to set the correct fielt in the state
 			if len(transformed) > 0 {
-				d.Set("desired_auto_created_endpoints", transformed)
-				log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder for %#v", transformed)
-
+				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
+				_, okPsc := d.GetOk("desired_psc_auto_connections")
+				if okEndpoint {
+					d.Set("desired_auto_created_endpoints", transformed)
+					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
+				} else if okPsc {
+					d.Set("desired_psc_auto_connections", transformed)
+					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+				}
 			}
 		}
 

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -88,12 +88,13 @@
 			// NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
 			// When desired_auto_created_endpoints is set this flow works as expected
 			// FLOW: Terraform  -> API Input -> API Output -> Terraform output
-			// CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
-			// CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// 1. CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// 2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
+			// 3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
+			// 4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
 			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
 			// The if else if below checks what is define by the user in order to set the correct fielt in the state
+			// The code below fixes use case 2
 			if len(transformed) > 0 {
 				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
 				_, okPsc := d.GetOk("desired_psc_auto_connections")

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -92,7 +92,7 @@
 			// 2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
 			// 3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
 			// 4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
+			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections
 			// The if else if below checks what is define by the user in order to set the correct fielt in the state
 			// The code below fixes use case 2
 			// The else conditon is to handle importing as there is no clear way to tell what the user has set desired_auto_created_endpoints or desired_psc_auto_connections

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -93,10 +93,14 @@
 				if okEndpoint {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
+				} else if okPsc {
+					d.Set("desired_auto_created_endpoints", []interface{}{})
 				}
 				if okPsc {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+				} else if okEndpoint {
+					d.Set("desired_psc_auto_connections", []interface{}{})
 				}
 				// Set preferred field on import
 				if !okPsc && !okEndpoint {

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -85,7 +85,8 @@
 					}
 				}
 			}
-			// NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
+			// NOTE: We want to make these fields detect API-side drift, so if the API returns a value for them we set them in state
+			// SOULTION: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
 			// When desired_auto_created_endpoints is set this flow works as expected
 			// FLOW: Terraform  -> API Input -> API Output -> Terraform output
 			// 1. CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -92,8 +92,8 @@
 			// 2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
 			// 3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
 			// 4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections
-			// The if else if below checks what is define by the user in order to set the correct fielt in the state
+			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
+			// The if else if below checks what is define by the user in order to set the correct field in the state
 			// The code below fixes use case 2
 			// The else conditon is to handle importing as there is no clear way to tell what the user has set desired_auto_created_endpoints or desired_psc_auto_connections
 			// Default is to set endpoints and user will need to adjust thier Terraform config as to use desired_auto_created_endpoints
@@ -106,6 +106,7 @@
 				} else if okPsc {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+			    // Set preferred field on import
 				} else {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -85,30 +85,21 @@
 					}
 				}
 			}
-			// NOTE: We want to make these fields detect API-side drift, so if the API returns a value for them we set them in state
-			// SOULTION: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
-			// When desired_auto_created_endpoints is set this flow works as expected
-			// FLOW: Terraform  -> API Input -> API Output -> Terraform output
-			// 1. CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// 2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// 3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
-			// 4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
-			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
-			// The if else if below checks what is define by the user in order to set the correct field in the state
-			// The code below fixes use case 2
-			// The else conditon is to handle importing as there is no clear way to tell what the user has set desired_auto_created_endpoints or desired_psc_auto_connections
-			// Default is to set endpoints and user will need to adjust thier Terraform config as to use desired_auto_created_endpoints
+			// We want to make these fields detect API-side drift, so if the API returns a value for them and they're set in config, we set them in state.
+			// On import, we only set `desired_auto_created_endpoints` because that's the non-deprecated field.
 			if len(transformed) > 0 {
 				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
 				_, okPsc := d.GetOk("desired_psc_auto_connections")
 				if okEndpoint {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
-				} else if okPsc {
+				}
+				if okPsc {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
-			    // Set preferred field on import
-				} else {
+				}
+				// Set preferred field on import
+				if !okPsc && !okEndpoint {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
 				}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -95,14 +95,12 @@
 				if okEndpoint && modeValue != "CLUSTER_DISABLED" {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
-					// log.Printf("[DEBUG] Value of EndpointRawValue %#v", EndpointRawValue)
 				} else if okPsc {
 					d.Set("desired_auto_created_endpoints", []interface{}{})
 				}
 				if okPsc && modeValue == "CLUSTER_DISABLED" {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
-					// log.Printf("[DEBUG] Value of PscRawValue %#v", PscRawValue)
 				} else if okEndpoint {
 					d.Set("desired_psc_auto_connections", []interface{}{})
 				}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -90,22 +90,25 @@
 			if len(transformed) > 0 {
 				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
 				_, okPsc := d.GetOk("desired_psc_auto_connections")
-				if okEndpoint {
+				modeValue, _ := d.GetOk("mode")
+
+				if okEndpoint && modeValue != "CLUSTER_DISABLED" {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
+					// log.Printf("[DEBUG] Value of EndpointRawValue %#v", EndpointRawValue)
 				} else if okPsc {
 					d.Set("desired_auto_created_endpoints", []interface{}{})
 				}
-				if okPsc {
+				if okPsc && modeValue == "CLUSTER_DISABLED" {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+					// log.Printf("[DEBUG] Value of PscRawValue %#v", PscRawValue)
 				} else if okEndpoint {
 					d.Set("desired_psc_auto_connections", []interface{}{})
 				}
 				// Set preferred field on import
 				if !okPsc && !okEndpoint {
 					d.Set("desired_auto_created_endpoints", transformed)
-					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
 				}
 			}
 		}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -95,6 +95,8 @@
 			// The issue is that when CLUSTE_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.
 			// The if else if below checks what is define by the user in order to set the correct fielt in the state
 			// The code below fixes use case 2
+			// The else conditon is to handle importing as there is no clear way to tell what the user has set desired_auto_created_endpoints or desired_psc_auto_connections
+			// Default is to set endpoints and user will need to adjust thier Terraform config as to use desired_auto_created_endpoints
 			if len(transformed) > 0 {
 				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
 				_, okPsc := d.GetOk("desired_psc_auto_connections")
@@ -104,6 +106,9 @@
 				} else if okPsc {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
+				} else {
+					d.Set("desired_auto_created_endpoints", transformed)
+					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
 				}
 			}
 		}

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -1537,3 +1537,73 @@ data "google_project" "project" {
 }
 `, context)
 }
+
+func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"location":      "us-central1",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-cluster-disabled" {
+  instance_id                  = "tf-test-instance-psc%{random_suffix}"
+  shard_count                  = 1
+  desired_psc_auto_connections {
+    network                    = google_compute_network.producer_net.id
+    project_id                 = data.google_project.project.project_id
+  }
+  location                     = "%{location}"
+  deletion_protection_enabled  = false
+  mode                         = "CLUSTER_DISABLED"
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                           = "tf-test-my-policy%{random_suffix}"
+  location                       = "%{location}"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks                  = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name                           = "tf-test-my-subnet%{random_suffix}"
+  ip_cidr_range                  = "10.0.0.248/29"
+  region                         = "%{location}"
+  network                        = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                           = "tf-test-my-network%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -1552,7 +1552,7 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabledPscAutoConnections(context),
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_bothConnections(context),
 			},
 			{
 				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
@@ -1561,7 +1561,7 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 				ImportStateVerifyIgnore: []string{"desired_auto_created_endpoints.#", "desired_auto_created_endpoints.0.%", "desired_auto_created_endpoints.0.project_id", "desired_auto_created_endpoints.0.network", "desired_psc_auto_connections.#", "desired_psc_auto_connections.0.%", "desired_psc_auto_connections.0.network", "desired_psc_auto_connections.0.project_id"},
 			},
 			{
-				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_bothConnections(context),
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabledPscAutoConnections(context),
 			},
 			{
 				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -1555,9 +1555,10 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context),
 			},
 			{
-				ResourceName:      "google_memorystore_instance.instance-cluster-disabled",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"desired_auto_created_endpoints.#", "desired_auto_created_endpoints.0.%", "desired_auto_created_endpoints.0.project_id", "desired_auto_created_endpoints.0.network", "desired_psc_auto_connections.#", "desired_psc_auto_connections.0.%", "desired_psc_auto_connections.0.network", "desired_psc_auto_connections.0.project_id"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -1552,7 +1552,34 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context),
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabledPscAutoConnections(context),
+			},
+			{
+				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"desired_auto_created_endpoints.#", "desired_auto_created_endpoints.0.%", "desired_auto_created_endpoints.0.project_id", "desired_auto_created_endpoints.0.network", "desired_psc_auto_connections.#", "desired_psc_auto_connections.0.%", "desired_psc_auto_connections.0.network", "desired_psc_auto_connections.0.project_id"},
+			},
+			{
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_bothConnections(context),
+			},
+			{
+				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"desired_auto_created_endpoints.#", "desired_auto_created_endpoints.0.%", "desired_auto_created_endpoints.0.project_id", "desired_auto_created_endpoints.0.network", "desired_psc_auto_connections.#", "desired_psc_auto_connections.0.%", "desired_psc_auto_connections.0.network", "desired_psc_auto_connections.0.project_id"},
+			},
+			{
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_onlyAutoCreatedEndpoints(context),
+			},
+			{
+				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"desired_auto_created_endpoints.#", "desired_auto_created_endpoints.0.%", "desired_auto_created_endpoints.0.project_id", "desired_auto_created_endpoints.0.network", "desired_psc_auto_connections.#", "desired_psc_auto_connections.0.%", "desired_psc_auto_connections.0.network", "desired_psc_auto_connections.0.project_id"},
+			},
+			{
+				Config: testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_neitherConnection(context),
 			},
 			{
 				ResourceName:            "google_memorystore_instance.instance-cluster-disabled",
@@ -1564,7 +1591,7 @@ func TestAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(t *tes
 	})
 }
 
-func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled(context map[string]interface{}) string {
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabledPscAutoConnections(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_memorystore_instance" "instance-cluster-disabled" {
   instance_id                  = "tf-test-instance-psc%{random_suffix}"
@@ -1573,6 +1600,141 @@ resource "google_memorystore_instance" "instance-cluster-disabled" {
     network                    = google_compute_network.producer_net.id
     project_id                 = data.google_project.project.project_id
   }
+  location                     = "%{location}"
+  deletion_protection_enabled  = false
+  mode                         = "CLUSTER_DISABLED"
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                           = "tf-test-my-policy%{random_suffix}"
+  location                       = "%{location}"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks                  = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name                           = "tf-test-my-subnet%{random_suffix}"
+  ip_cidr_range                  = "10.0.0.248/29"
+  region                         = "%{location}"
+  network                        = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                           = "tf-test-my-network%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}
+
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_bothConnections(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-cluster-disabled" {
+  instance_id                  = "tf-test-instance-psc%{random_suffix}"
+  shard_count                  = 1
+  desired_psc_auto_connections {
+    network                    = google_compute_network.producer_net.id
+    project_id                 = data.google_project.project.project_id
+  }
+  desired_auto_created_endpoints {
+    network                    = google_compute_network.producer_net.id
+    project_id                 = data.google_project.project.project_id
+  }
+  location                     = "%{location}"
+  deletion_protection_enabled  = false
+  mode                         = "CLUSTER_DISABLED"
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                           = "tf-test-my-policy%{random_suffix}"
+  location                       = "%{location}"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks                  = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name                           = "tf-test-my-subnet%{random_suffix}"
+  ip_cidr_range                  = "10.0.0.248/29"
+  region                         = "%{location}"
+  network                        = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                           = "tf-test-my-network%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}
+
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_onlyAutoCreatedEndpoints(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-cluster-disabled" {
+  instance_id                  = "tf-test-instance-psc%{random_suffix}"
+  shard_count                  = 1
+  desired_auto_created_endpoints {
+    network                    = google_compute_network.producer_net.id
+    project_id                 = data.google_project.project.project_id
+  }
+  location                     = "%{location}"
+  deletion_protection_enabled  = false
+  mode                         = "CLUSTER_DISABLED"
+  depends_on = [
+    google_network_connectivity_service_connection_policy.default
+  ]
+}
+
+resource "google_network_connectivity_service_connection_policy" "default" {
+  name                           = "tf-test-my-policy%{random_suffix}"
+  location                       = "%{location}"
+  service_class                  = "gcp-memorystore"
+  description                    = "my basic service connection policy"
+  network                        = google_compute_network.producer_net.id
+  psc_config {
+    subnetworks                  = [google_compute_subnetwork.producer_subnet.id]
+  }
+}
+
+resource "google_compute_subnetwork" "producer_subnet" {
+  name                           = "tf-test-my-subnet%{random_suffix}"
+  ip_cidr_range                  = "10.0.0.248/29"
+  region                         = "%{location}"
+  network                        = google_compute_network.producer_net.id
+}
+
+resource "google_compute_network" "producer_net" {
+  name                           = "tf-test-my-network%{random_suffix}"
+  auto_create_subnetworks        = false
+}
+
+data "google_project" "project" {
+}
+`, context)
+}
+
+func testAccMemorystoreInstance_memorystorePscAutoInstanceClusterDisabled_neitherConnection(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_memorystore_instance" "instance-cluster-disabled" {
+  instance_id                  = "tf-test-instance-psc%{random_suffix}"
+  shard_count                  = 1
   location                     = "%{location}"
   deletion_protection_enabled  = false
   mode                         = "CLUSTER_DISABLED"


### PR DESCRIPTION
Related to https://github.com/terraform-google-modules/terraform-google-memorystore/issues/314

NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
When desired_auto_created_endpoints is set this flow works as expected
FLOW: Terraform  -> API Input -> API Output -> Terraform output
1. CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints

The issue is that when CLUSTER_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
memorystore:  `desired_auto_created_endpoints` field incorrectly updated when desired_psc_auto_connections should have been 
```