### PR TITLE
feat(agenspace): initial scaffold for `project` resource

### DIFF
--- a/mmv1/products/agentspace/Project.yaml
+++ b/mmv1/products/agentspace/Project.yaml
@@ -1,0 +1,63 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Project'
+description: 'Provisions the project resource.'
+min_version: 'beta'
+references:
+  guides:
+    'Get started with Agentspace Enterprise': 'https://cloud.google.com/agentspace/docs/quickstart-agentspace'
+  api: 'https://cloud.google.com/agentspace/docs/reference/rest/v1/projects/provision'
+docs:
+id_format: 'projects/{{project}}'
+# no GET endpoint available yet
+base_url: 'projects/{{project}}'
+self_link: 'projects/{{project}}'
+create_url: 'projects/{{project}}:provision'
+# no DELETE endpoint available yet
+# delete_url: 'tbd'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+autogen_async: true
+min_verion: 'beta'
+async:
+  actions: ['create']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+properties:
+  - name: 'acceptDataUseTerms'
+    type: Boolean
+    required: true
+    description: |
+      Set to true to specify that caller has read and would like to give consent to the [Terms for data use](https://cloud.google.com/retail/data-use-terms?hl=en).
+  - name: 'dataUseTermsVersion'
+    type: String
+    required: true
+    description: |
+      The version of the [Terms for data use](https://cloud.google.com/retail/data-use-terms?hl=en) that caller has read and would like to give consent to.
+      Acceptable version is 2022-11-23, and this may change over time.
+  - name: 'saasParams'
+    type: NestedObject
+    description: |
+      Parameters for Agentspace.
+    properties:
+      - name: 'acceptBizQos'
+        type: Boolean
+        description: |
+          Set to true to specify that caller has read and would like to give consent to the [Terms for Agent Space quality of service](tbd).

--- a/mmv1/products/agentspace/product.yaml
+++ b/mmv1/products/agentspace/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'AgentSpace'
+display_name: 'Discovery Engine API.'
+versions:
+  - name: 'ga'
+    base_url: 'https://discoveryengine.googleapis.com/v1/'
+  - name: 'beta'
+    base_url: 'https://discoveryengine.googleapis.com/v1beta1/'
+scopes:
+  - 'https://www.googleapis.com/auth/cloud-platform'


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/24303

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_agentspace_project`
```

Still initial scaffold, I don't think the API is in a good enough shape yet to implement the full resource (e.g. GET endpoint is missing). See comment: https://github.com/hashicorp/terraform-provider-google/issues/24303#issuecomment-3265104457, waiting for another update on this before proceeding with full implementation.
