### PR TITLE
workbench: Make report-notebook-metrics settable but unmodifiable

### DIFF
--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -26,6 +26,7 @@ func WorkbenchInstanceLabelsDiffSuppress(k, old, new string, d *schema.ResourceD
 var WorkbenchInstanceSettableUnmodifiableDefaultMetadata = []string{
 	"install-monitoring-agent",
 	"serial-port-logging-enable",
+	"report-notebook-metrics",
 }
 
 var WorkbenchInstanceEUCProvidedAdditionalMetadata = []string{
@@ -84,7 +85,6 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "proxy-user-mail",
     "report-container-health",
     "report-event-url",
-    "report-notebook-metrics",
     "report-system-health",
     "report-system-status",
     "resource-url",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
workbench: made `report-notebook-metrics` metadata key settable for `google_workbench_instance`
```
