### PR TITLE
Secret Manager: Fix panic in SecretVersion flatten when AccessSecretVersion API call fails

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/secret_version_access.go.tmpl
@@ -26,15 +26,18 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	}
 
 	// if "enabled" does not exist or is false, preserve what we already have in the state
-	if v, ok := d.GetOk("enabled"); !ok {
+	enabledVal, exists := d.GetOk("enabled")
+	if !exists {
 		return safeTransformed(d.Get("secret_data"))
-	} else if enabled, _ := v.(bool); !enabled {
+	}
+	if enabled, _ := enabledVal.(bool); !enabled {
 		return safeTransformed(d.Get("secret_data"))
 	}
 
 	// build access URL; if it fails, preserve state
 	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}SecretManagerBasePath{{"}}"}}{{"{{"}}name{{"}}"}}:access")
 	if err != nil {
+		log.Printf("[ERROR] Failed to build secret access URL: %v", err)
 		return safeTransformed(d.Get("secret_data"))
 	}
 
@@ -42,12 +45,14 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	nameStr, _ := d.Get("name").(string)
 	parts := strings.Split(nameStr, "/")
 	if len(parts) < 2 {
+		log.Printf("[WARN] Unexpected secret name format %q, preserving state", nameStr)
 		return safeTransformed(d.Get("secret_data"))
 	}
 	project := parts[1]
 
 	ua, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
+		log.Printf("[ERROR] Failed to generate user agent string: %v", err)
 		return safeTransformed(d.Get("secret_data"))
 	}
 
@@ -59,6 +64,8 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 		UserAgent: ua,
 	})
 	if err != nil {
+		// per review: add explicit log to diagnose underlying url/transport error
+		log.Printf("[ERROR] Failed to access secret version at %q: %v", url, err)
 		return safeTransformed(d.Get("secret_data"))
 	}
 
@@ -72,6 +79,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 		}
 	}
 	if dataB64 == "" {
+		log.Printf("[WARN] No payload.data found in secret access response for %q, preserving state", nameStr)
 		return safeTransformed(d.Get("secret_data"))
 	}
 
@@ -83,6 +91,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 
 	decoded, decErr := base64.StdEncoding.DecodeString(dataB64)
 	if decErr != nil {
+		log.Printf("[ERROR] Failed to decode base64 secret payload for %q: %v", nameStr, decErr)
 		return safeTransformed(d.Get("secret_data"))
 	}
 	return safeTransformed(string(decoded))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Hello folks,

this PR is to fix this issue https://github.com/hashicorp/terraform-provider-google/issues/23924

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
secretmanager: fixed a panic in `google_secret_manager_secret_version` in a `secret_manager`
```
