### PR TITLE
tgc-revival: decide the cai identifier automatically

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -387,9 +387,8 @@ type TGCResource struct {
 	TGCIgnoreTerraformEncoder bool `yaml:"tgc_ignore_terraform_encoder,omitempty"`
 
 	// [Optional] The parameter that uniquely identifies the resource.
-	// Generally, it's safe to leave empty, in which case it defaults to `name`.
-	// Other values are normally useful in cases where an object has a parent
-	// and is identified by some non-name value, such as an ip+port pair.
+	// Generally, it shouldn't be set when the identity can be decided.
+	// Otherswise, it should be set.
 	CaiIdentity string `yaml:"cai_identity,omitempty"`
 }
 
@@ -1910,20 +1909,70 @@ func (r Resource) DefineAssetTypeForResourceInProduct() bool {
 // For example: //monitoring.googleapis.com/v3/projects/{{project}}/services/{{service_id}}
 func (r Resource) rawCaiAssetNameTemplate(productBackendName string) string {
 	caiBaseUrl := ""
-	caiId := "name"
+	caiId := ""
 	if r.CaiIdentity != "" {
 		caiId = r.CaiIdentity
+	} else {
+		caiId = r.getCaiId()
 	}
+	caiIdTemplate := fmt.Sprintf("{{%s}}", caiId)
 	if r.CaiBaseUrl != "" {
-		caiBaseUrl = fmt.Sprintf("%s/{{%s}}", r.CaiBaseUrl, caiId)
+		if caiId == "" || strings.Contains(r.CaiBaseUrl, caiIdTemplate) {
+			caiBaseUrl = r.CaiBaseUrl
+		} else {
+			caiBaseUrl = fmt.Sprintf("%s/%s", r.CaiBaseUrl, caiIdTemplate)
+		}
 	}
 	if caiBaseUrl == "" {
 		caiBaseUrl = r.SelfLink
 	}
 	if caiBaseUrl == "" {
-		caiBaseUrl = fmt.Sprintf("%s/{{%s}}", r.BaseUrl, caiId)
+		if caiId == "" || strings.Contains(r.BaseUrl, caiIdTemplate) {
+			caiBaseUrl = r.BaseUrl
+		} else {
+			caiBaseUrl = fmt.Sprintf("%s/%s", r.BaseUrl, caiIdTemplate)
+		}
 	}
 	return fmt.Sprintf("//%s.googleapis.com/%s", productBackendName, caiBaseUrl)
+}
+
+// Guesses the identifier of the resource, as "name" is not always the identifier
+// For example, the cai identifier is feed_id in google_cloud_asset_folder_feed
+func (r Resource) getCaiId() string {
+	for _, p := range r.AllUserProperties() {
+		if p.Name == "name" && !p.Output {
+			return "name"
+		}
+	}
+
+	// Get the last identifier extracted from selfLink
+	id := r.getCandidateCaiId(r.SelfLink)
+	if id != "" {
+		return id
+	}
+
+	// Get the last identifier extracted from createUrl
+	id = r.getCandidateCaiId(r.CreateUrl)
+	if id != "" {
+		return id
+	}
+
+	return ""
+}
+
+// Extracts the last identifier from the url, if it is not computed,
+// then it is the candidate identifier
+func (r Resource) getCandidateCaiId(url string) string {
+	identifiers := r.ExtractIdentifiers(url)
+	if len(identifiers) > 0 {
+		id := identifiers[len(identifiers)-1]
+		for _, p := range r.AllUserProperties() {
+			if google.Underscore(p.Name) == id && !p.Output {
+				return id
+			}
+		}
+	}
+	return ""
 }
 
 // Gets the Cai asset name template, which doesn't include version

--- a/mmv1/products/cloudasset/FolderFeed.yaml
+++ b/mmv1/products/cloudasset/FolderFeed.yaml
@@ -42,7 +42,6 @@ custom_code:
 supports_indirect_user_project_override: true
 include_in_tgc_next_DO_NOT_USE: true
 cai_base_url: 'folders/{{folder}}/feeds'
-cai_identity: 'feed_id'
 tgc_ignore_terraform_encoder: true
 examples:
   - name: 'cloud_asset_folder_feed'

--- a/mmv1/products/cloudasset/OrganizationFeed.yaml
+++ b/mmv1/products/cloudasset/OrganizationFeed.yaml
@@ -42,7 +42,6 @@ custom_code:
 supports_indirect_user_project_override: true
 include_in_tgc_next_DO_NOT_USE: true
 cai_base_url: 'organizations/{{org_id}}/feeds'
-cai_identity: 'feed_id'
 tgc_ignore_terraform_encoder: true
 examples:
   - name: 'cloud_asset_organization_feed'

--- a/mmv1/products/cloudasset/ProjectFeed.yaml
+++ b/mmv1/products/cloudasset/ProjectFeed.yaml
@@ -40,7 +40,6 @@ custom_code:
   custom_import: 'templates/terraform/custom_import/cloud_asset_feed.go.tmpl'
 include_in_tgc_next_DO_NOT_USE: true
 cai_base_url: 'projects/{{project}}/feeds'
-cai_identity: 'feed_id'
 tgc_ignore_terraform_encoder: true
 examples:
   - name: 'cloud_asset_project_feed'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Guess the cai identity from create_url and self_link automatically if we can.


`cai_identity` in only needed if we cannot guess the cai identity.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
