### PR TITLE
Added GET data source references functionality

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -49,6 +49,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_backup_dr_data_source":						backupdr.DataSourceGoogleCloudBackupDRDataSource(),
 	"google_backup_dr_backup_vault":					backupdr.DataSourceGoogleCloudBackupDRBackupVault(),
 	"google_backup_dr_data_source_references":			backupdr.DataSourceGoogleCloudBackupDRDataSourceReferences(),
+	"google_backup_dr_data_source_reference":			backupdr.DataSourceGoogleCloudBackupDRDataSourceReference(),
 	"google_beyondcorp_app_connection":                 beyondcorp.DataSourceGoogleBeyondcorpAppConnection(),
 	"google_beyondcorp_app_connector":                  beyondcorp.DataSourceGoogleBeyondcorpAppConnector(),
 	"google_beyondcorp_app_gateway":                    beyondcorp.DataSourceGoogleBeyondcorpAppGateway(),

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/googleapi"
 )
 
 func DataSourceGoogleCloudBackupDRDataSourceReferences() *schema.Resource {
@@ -164,4 +165,137 @@ func flattenDataSourceReferences(items []interface{}) ([]map[string]interface{},
 		references = append(references, ref)
 	}
 	return references, nil
+}
+
+func DataSourceGoogleCloudBackupDRDataSourceReference() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleCloudBackupDRDataSourceReferenceRead,
+		Schema: map[string]*schema.Schema{
+			"data_source_reference_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The `id` of the data source reference.",
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The location of the data source reference.",
+			},
+			"project": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The ID of the project in which the resource belongs.",
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data_source": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The underlying data source resource.",
+			},
+			"backup_config_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The state of the backup config for the data source.",
+			},
+			"backup_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of backups for the data source.",
+			},
+			"last_backup_state": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The state of the last backup.",
+			},
+			"last_successful_backup_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The last time a successful backup was made.",
+			},
+			"gcp_resource_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The GCP resource name for the data source.",
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleCloudBackupDRDataSourceReferenceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	location := d.Get("location").(string)
+	dataSourceReferenceId := d.Get("data_source_reference_id").(string)
+	url := fmt.Sprintf("%sprojects/%s/locations/%s/dataSourceReferences/%s", config.BackupDRBasePath, project, location, dataSourceReferenceId)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			d.SetId("") // Resource not found
+			return nil
+		}
+		return fmt.Errorf("Error reading DataSourceReference: %s", err)
+	}
+
+	if err := flattenDataSourceReference(d, res); err != nil {
+		return err
+	}
+
+	d.SetId(res["name"].(string))
+	return nil
+}
+
+func flattenDataSourceReference(d *schema.ResourceData, data map[string]interface{}) error {
+	ref, err := flattenDataSourceReferenceToMap(data)
+	if err != nil {
+		return err
+	}
+	for k, v := range ref {
+		if err := d.Set(k, v); err != nil {
+			return fmt.Errorf("Error setting %s: %s", k, err)
+		}
+	}
+	return nil
+}
+
+func flattenDataSourceReferenceToMap(data map[string]interface{}) (map[string]interface{}, error) {
+	ref := map[string]interface{}{
+		"name":                data["name"],
+		"data_source":         data["dataSource"],
+		"backup_config_state": data["dataSourceBackupConfigState"],
+	}
+	if v, ok := data["dataSourceBackupCount"].(string); ok {
+		if i, err := strconv.Atoi(v); err == nil {
+			ref["backup_count"] = i
+		}
+	}
+	if configInfo, ok := data["dataSourceBackupConfigInfo"].(map[string]interface{}); ok {
+		ref["last_backup_state"] = configInfo["lastBackupState"]
+		ref["last_successful_backup_time"] = configInfo["lastSuccessfulBackupConsistencyTime"]
+	}
+	if resourceInfo, ok := data["dataSourceGcpResourceInfo"].(map[string]interface{}); ok {
+		ref["gcp_resource_name"] = resourceInfo["gcpResourcename"]
+		ref["resource_type"] = resourceInfo["type"]
+	}
+	return ref, nil
 }

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference_test.go
@@ -146,3 +146,129 @@ data "google_backup_dr_data_source_references" "default" {
    }
 `, context)
 }
+
+func TestAccDataSourceGoogleBackupDRDataSourceReference_basic(t *testing.T) {
+	t.Parallel()
+
+	dsRefDataSourceName := "data.google_backup_dr_data_source_reference.default"
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				// All logic is now in a single HCL block and a single step.
+				Config: testAccDataSourceGoogleBackupDRDataSourceReference_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Check that the singular data source has been populated
+					resource.TestCheckResourceAttrSet(dsRefDataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(dsRefDataSourceName, "data_source"),
+					resource.TestCheckResourceAttrSet(dsRefDataSourceName, "backup_config_state"),
+					resource.TestCheckResourceAttrSet(dsRefDataSourceName, "gcp_resource_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleBackupDRDataSourceReference_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_service_account" "default" {
+ account_id   = "tf-test-my-custom-%{random_suffix}"
+ display_name = "Custom SA for VM Instance"
+}
+
+resource "google_sql_database_instance" "instance" {
+ name             = "default-%{random_suffix}"
+ database_version = "MYSQL_8_0"
+ region          = "us-central1"
+ deletion_protection = false
+ settings {
+   tier = "db-f1-micro"
+   availability_type = "ZONAL"
+   activation_policy = "ALWAYS"
+ }
+}
+
+resource "google_backup_dr_backup_vault" "my-backup-vault" {
+   location ="us-central1"
+   backup_vault_id    = "tf-test-bv-%{random_suffix}"
+   description = "This is a second backup vault built by Terraform."
+   backup_minimum_enforced_retention_duration = "100000s"
+   labels = {
+     foo = "bar1"
+     bar = "baz1"
+   }
+   annotations = {
+     annotations1 = "bar1"
+     annotations2 = "baz1"
+   }
+   force_update = "true"
+   force_delete = "true"
+   allow_missing = "true"
+}
+
+resource "google_backup_dr_backup_plan" "foo" {
+ location       = "us-central1"
+ backup_plan_id = "tf-test-bp-test-%{random_suffix}"
+ resource_type  = "sqladmin.googleapis.com/Instance"
+ backup_vault   = google_backup_dr_backup_vault.my-backup-vault.name
+
+ backup_rules {
+   rule_id                = "rule-1"
+   backup_retention_days  = 2
+
+   standard_schedule {
+     recurrence_type     = "HOURLY"
+     hourly_frequency    = 6
+     time_zone           = "UTC"
+
+     backup_window {
+       start_hour_of_day = 12
+       end_hour_of_day   = 18
+     }
+   }
+ }
+}
+
+resource "google_backup_dr_backup_plan_association" "bpa" {
+ location = "us-central1"
+ backup_plan_association_id = "tf-test-bpa-test-%{random_suffix}"
+ resource = "projects/${data.google_project.project.project_id}/instances/${google_sql_database_instance.instance.name}"
+ resource_type= "sqladmin.googleapis.com/Instance"
+ backup_plan = google_backup_dr_backup_plan.foo.name
+ depends_on = [ google_sql_database_instance.instance ]
+}
+
+data "google_backup_dr_data_source_references" "all_refs" {
+	project       = data.google_project.project.project_id
+	location      = "us-central1"
+	resource_type = "sqladmin.googleapis.com/Instance"
+	depends_on    = [google_backup_dr_backup_plan_association.bpa]
+}
+
+locals {
+	// Directly get the name from the first item in the list.
+	ds_ref_name = data.google_backup_dr_data_source_references.all_refs.data_source_references[0].name
+
+	// Split the name string and take the last element, which is the ID.
+	data_source_reference_id = element(split("/", local.ds_ref_name), 5)
+}
+
+// Now, use the singular data source to fetch the specific reference by its ID.
+data "google_backup_dr_data_source_reference" "default" {
+	project                  = data.google_project.project.project_id
+	location                 = "us-central1"
+	data_source_reference_id = local.data_source_reference_id
+}
+
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
backupdr: added new RPC GET dataSourceReferences in `data_source_backup_data_source_reference.go` . This rpc will allow users to describe the specific  data source reference using the data_source_reference_id . 

```
