### PR TITLE
Support the new `Broker` type of mirroring endpoint group.

### DIFF
--- a/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
+++ b/mmv1/products/networksecurity/MirroringEndpointGroup.yaml
@@ -52,6 +52,14 @@ examples:
       network_name: 'example-network'
       deployment_group_id: 'example-dg'
       endpoint_group_id: 'example-eg'
+  - name: 'network_security_mirroring_endpoint_group_broker_basic'
+    config_path: 'templates/terraform/examples/network_security_mirroring_endpoint_group_broker_basic.tf.tmpl'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      network_name: 'example-network'
+      deployment_group_id: 'example-dg'
+      endpoint_group_id: 'example-eg'
 parameters:
   - name: 'location'
     type: String
@@ -99,8 +107,22 @@ properties:
       The deployment group that this DIRECT endpoint group is connected to, for example:
       `projects/123456789/locations/global/mirroringDeploymentGroups/my-dg`.
       See https://google.aip.dev/124.
-    required: true
     immutable: true
+    conflicts:
+      - 'mirroringDeploymentGroups'
+  - name: 'mirroringDeploymentGroups'
+    type: Array
+    description: |-
+      A list of the deployment groups that this BROKER endpoint group is
+      connected to, for example:
+      `projects/123456789/locations/global/mirroringDeploymentGroups/my-dg`.
+      See https://google.aip.dev/124.
+    min_version: 'beta'
+    immutable: true
+    item_type:
+      type: String
+    conflicts:
+      - 'mirroringDeploymentGroup'
   - name: 'state'
     type: String
     description: |-
@@ -123,6 +145,17 @@ properties:
       operation (e.g. adding a new association to the group).
       See https://google.aip.dev/128.
     output: true
+  - name: 'type'
+    type: String
+    description: |-
+      The type of the endpoint group.
+      If left unspecified, defaults to DIRECT.
+      Possible values:
+      DIRECT
+      BROKER
+    min_version: 'beta'
+    default_value: 'DIRECT'
+    immutable: true
   - name: description
     type: String
     description: |-

--- a/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_broker_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_security_mirroring_endpoint_group_broker_basic.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_compute_network" "network" {
+  provider                = google-beta
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_security_mirroring_deployment_group" "deployment_group" {
+  provider                      = google-beta
+  mirroring_deployment_group_id = "{{index $.Vars "deployment_group_id"}}"
+  location                      = "global"
+  network                       = google_compute_network.network.id
+}
+
+resource "google_network_security_mirroring_endpoint_group" "{{$.PrimaryResourceId}}" {
+  provider                    = google-beta
+  mirroring_endpoint_group_id = "{{index $.Vars "endpoint_group_id"}}"
+  location                    = "global"
+  type                        = "BROKER"
+  mirroring_deployment_groups = [google_network_security_mirroring_deployment_group.deployment_group.id]
+  description                 = "some description"
+  labels = {
+    foo = "bar"
+  }
+}


### PR DESCRIPTION
Mirroring endpoint groups support DIRECT and BROKER types.
The default type (and existing type) is DIRECT, and this PR allows users of the beta provider to create resources with the new BROKER type.

```release-note:enhancement
networksecurity: added `type` and `mirroringDeploymentGroups` fields to `google_network_security_mirroring_endpoint_group` resource
```
