### PR TITLE
fix(google_sql_database_instance): Connection Pool requires Enterprise Plus

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -5470,7 +5470,8 @@ resource "google_sql_database_instance" "instance" {
   database_version    = "POSTGRES_16"
   deletion_protection = false
   settings {
-    tier = "db-perf-optimized-N-2"
+    tier    = "db-perf-optimized-N-2"
+    edition = "ENTERPRISE_PLUS"
 	connection_pool_config {
 		connection_pooling_enabled = true
 		flags {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -176,11 +176,12 @@ resource "google_sql_database_instance" "main" {
 ### Cloud SQL Instance with Managed Connection Pooling
 ```hcl
 resource "google_sql_database_instance" "instance" {
-  name:            = "mcp-enabled-main-instance"
+  name             = "mcp-enabled-main-instance"
   region           = "us-central1"
   database_version = "POSTGRES_16"
   settings {
-    tier = "db-perf-optimized-N-2"
+    tier    = "db-perf-optimized-N-2"
+    edition = "ENTERPRISE_PLUS"
 	  connection_pool_config {
 		  connection_pooling_enabled = true
       flags {


### PR DESCRIPTION
I got burnt when trying to only add a connection pool to a non-Enterprise Plus instance: 
```
googleapi: Error 400: Invalid request: Connection pool is only supported for Enterprise Plus edition.., invalid
```

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:note
Fixed the `google_sql_database_instance` examples to include `edition = "ENTERPRISE_PLUS"` when using `connection_pool_config`, since connection pooling requires Enterprise Plus.
```
