### PR TITLE
Fix for desired_auto_created_endpoints incorrect update v2 

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -43,6 +43,7 @@ async:
 custom_code:
   encoder: 'templates/terraform/encoders/memorystore_instance.go.tmpl'
   decoder: 'templates/terraform/decoders/memorystore_instance.go.tmpl'
+  constants: 'templates/terraform/constants/memorystore_diff.go.tmpl'
 examples:
   - name: 'memorystore_instance_basic'
     primary_resource_id: 'instance-basic'
@@ -114,6 +115,7 @@ virtual_fields:
     immutable: true
     conflicts:
       - desiredAutoCreatedEndpoints
+    diff_suppress_func: desiredPscAndEndpointCustomizeDiff
     item_type:
       type: NestedObject
       properties:

--- a/mmv1/templates/terraform/constants/memorystore_diff.go.tmpl
+++ b/mmv1/templates/terraform/constants/memorystore_diff.go.tmpl
@@ -1,0 +1,50 @@
+func desiredPscAndEndpointCustomizeDiff(_, old, new string, d *schema.ResourceData) bool {
+	// Use GetRawConfig to check if desired_psc_auto_connections field is set in the configuration
+	configRawPsc, _ := d.GetRawConfigAt(cty.GetAttrPath("desired_psc_auto_connections"))
+	configRawEndpoint, _ := d.GetRawConfigAt(cty.GetAttrPath("desired_auto_created_endpoints"))
+
+	// Check if the field is set (not null and known)
+	if !configRawPsc.IsNull() && configRawPsc.IsKnown() {
+		// Field is explicitly set in configuration
+		configSlice := configRawPsc.AsValueSlice()
+		if len(configSlice) > 0 {
+			// Field is set with values - perform any necessary diff logic here
+			// For example, you might want to force new resource creation or set computed values
+			log.Printf("[DEBUG] configRawPsc value in rawconfig is %#v", configRawPsc)
+
+			/*
+				// Example: Set a computed field based on the presence of desired_psc_auto_connections
+				if d.HasChange("desired_psc_auto_connections") {
+					// Handle changes to the field when it's explicitly configured
+					// This could include validation, setting other computed fields, etc.
+				}
+			*/
+		}
+	} else {
+		log.Printf("[DEBUG] set to nothing for configRawPsc")
+		d.Set("desired_psc_auto_connections", []interface{}{})
+
+	}
+	// Check if the field is set (not null and known)
+	if !configRawEndpoint.IsNull() && configRawEndpoint.IsKnown() {
+		// Field is explicitly set in configuration
+		configSlice := configRawEndpoint.AsValueSlice()
+		if len(configSlice) > 0 {
+			// Field is set with values - perform any necessary diff logic here
+			// For example, you might want to force new resource creation or set computed values
+			log.Printf("[DEBUG] configRawEndpoint value in rawconfig is %#v", configRawEndpoint)
+			/* // Example: Set a computed field based on the presence of desired_psc_auto_connections
+			if d.HasChange("desired_auto_created_endpoints") {
+				// Handle changes to the field when it's explicitly configured
+				// This could include validation, setting other computed fields, etc.
+			}
+			*/
+		}
+	} else {
+		log.Printf("[DEBUG] set to nothing for configRawEndpoint")
+		d.Set("desired_auto_created_endpoints", []interface{}{})
+
+	}
+
+	return false
+}

--- a/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
+++ b/mmv1/templates/terraform/decoders/memorystore_instance.go.tmpl
@@ -90,32 +90,19 @@
 			if len(transformed) > 0 {
 				_, okEndpoint := d.GetOk("desired_auto_created_endpoints")
 				_, okPsc := d.GetOk("desired_psc_auto_connections")
-				hasConfigEndpoint := false
-				hasConfigPsc := false
-				configEndpointRaw, _ := d.GetRawConfigAt(cty.GetAttrPath("desired_auto_created_endpoints"))
-				configPscRaw, _ := d.GetRawConfigAt(cty.GetAttrPath("desired_psc_auto_connections"))
 
-				if !configEndpointRaw.IsNull() && configEndpointRaw.IsKnown() {
-					hasConfigEndpoint = len(configEndpointRaw.AsValueSlice()) > 0
-				}
-
-				if !configPscRaw.IsNull() && configEndpointRaw.IsKnown() {
-					hasConfigPsc = len(configEndpointRaw.AsValueSlice()) > 0
-				}
-
-				log.Printf("[DEBUG] hasConfigEndpoint value in rawconfig is  %#v", hasConfigPsc)
-				log.Printf("[DEBUG] hasConfigPsc value in rawconfig is %#v", hasConfigEndpoint)
-
-				if hasConfigEndpoint {
+				if okEndpoint {
 					d.Set("desired_auto_created_endpoints", transformed)
 					log.Printf("[DEBUG] Setting desired_auto_created_endpoints in decoder within endpoints for %#v", transformed)
-				} else if hasConfigPsc {
+					// log.Printf("[DEBUG] Value of EndpointRawValue %#v", EndpointRawValue)
+				} else if okPsc {
 					d.Set("desired_auto_created_endpoints", []interface{}{})
 				}
-				if hasConfigPsc {
+				if okPsc {
 					d.Set("desired_psc_auto_connections", transformed)
 					log.Printf("[DEBUG] Setting desired_psc_auto_connections in decoder within endpoints for %#v", transformed)
-				} else if hasConfigEndpoint {
+					// log.Printf("[DEBUG] Value of PscRawValue %#v", PscRawValue)
+				} else if okEndpoint {
 					d.Set("desired_psc_auto_connections", []interface{}{})
 				}
 				// Set preferred field on import


### PR DESCRIPTION
Related to https://github.com/terraform-google-modules/terraform-google-memorystore/issues/314

NOTE: Due to how the api updates the backend. When mode is set to CLUSTER_DISABLED
When desired_auto_created_endpoints is set this flow works as expected
FLOW: Terraform  -> API Input -> API Output -> Terraform output
1. CLUSTER_DISABLED and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints
2. CLUSTER_DISABLED and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> Endpoints -> desired_auto_created_endpoints + Endpoints
3. CLUSTER and desired_psc_auto_connections defined: desired_psc_auto_connections -> psc_auto_connections -> psc_auto_connections -> desired_psc_auto_connections + psc_auto_connection
4. CLUSTER and desired_auto_created_endpoints defined: desired_auto_created_endpoints -> endpoints -> Endpoints -> desired_auto_created_endpoints + Endpoints

The issue is that when CLUSTER_DISABLED is set for that flow  API is updated Endpoints instead of psc_auto_connections.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
memorystore:  `desired_auto_created_endpoints` field incorrectly updated when desired_psc_auto_connections should have been 
```