### PR TITLE
Use map instead of BAC API type as intermediate type for TGC cai2hcl conversion of networksecurity BackendAuthenticationConfig 

### DIFF
--- a/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/backend_authentication_config.go
@@ -6,7 +6,6 @@ import (
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/cai2hcl/common"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v6/caiasset"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	netsecapi "google.golang.org/api/networksecurity/v1"
 )
 
 // BackendAuthenticationConfigAssetType is the CAI asset type name.
@@ -75,20 +74,16 @@ func (c *BackendAuthenticationConfigConverter) convertResourceData(asset *caiass
 func flattenBackendAuthenticationConfig(resource *caiasset.AssetResource) (map[string]any, error) {
 	result := make(map[string]any)
 
-	var backendAuthenticationConfig *netsecapi.BackendAuthenticationConfig
-	if err := common.DecodeJSON(resource.Data, &backendAuthenticationConfig); err != nil {
-		return nil, err
-	}
+	resourceData := resource.Data
 
-	result["name"] = flattenName(backendAuthenticationConfig.Name)
-	result["labels"] = backendAuthenticationConfig.Labels
-	result["description"] = backendAuthenticationConfig.Description
-	result["client_certificate"] = backendAuthenticationConfig.ClientCertificate
-	result["trust_config"] = backendAuthenticationConfig.TrustConfig
-	result["well_known_roots"] = backendAuthenticationConfig.WellKnownRoots
-	result["project"] = flattenProjectName(backendAuthenticationConfig.Name)
-
-	result["location"] = resource.Location
+	result["name"] = flattenName(resourceData["name"].(string))
+	result["labels"] = resourceData["labels"]
+	result["description"] = resourceData["description"]
+	result["client_certificate"] = resourceData["clientCertificate"]
+	result["trust_config"] = resourceData["trustConfig"]
+	result["well_known_roots"] = resourceData["wellKnownRoots"]
+	result["project"] = flattenProjectName(resourceData["name"].(string))
+	result["location"] = flattenLocation(resourceData["name"].(string))
 
 	return result, nil
 }

--- a/mmv1/third_party/cai2hcl/services/networksecurity/utils.go
+++ b/mmv1/third_party/cai2hcl/services/networksecurity/utils.go
@@ -14,3 +14,11 @@ func flattenProjectName(name string) string {
 	}
 	return tokens[1]
 }
+
+func flattenLocation(name string) string {
+	tokens := strings.Split(name, "/")
+	if len(tokens) < 6 || tokens[2] != "locations" {
+		return ""
+	}
+	return tokens[3]
+}


### PR DESCRIPTION
### Summary

This PR changes the intermediate type used during TGC `cai2hcl` conversion for `networksecurity.googleapis.com/BackendAuthenticationConfig` from google.golang.org/api BAC type to map type. 

### Context

Done for consistency reasons with TGC v5. See: https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/4449

Discussed with @zli82016 

```release-note:none
```
