### PR TITLE
fix(compute): fixed google_compute_security_policy crash

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1372,8 +1372,8 @@ func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprO
 		return nil
 	}
 
-  // We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
-	if (tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.ActionTokenSiteKeys)) &&
+	if (exprOptions.RecaptchaOptions != nil &&
+		tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.ActionTokenSiteKeys)) &&
 		tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.SessionTokenSiteKeys))) &&
 		verifyRulePriorityCompareEmptyValues(d, rulePriority, "recaptcha_options") {
 		return nil


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24334

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
compute: fixed `expr_options` field panic in `google_compute_security_policy ` resource
```
