### PR TITLE
Add nil check to exprOptions.RecaptchaOptions in `google_compute_security_policy`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1372,7 +1372,14 @@ func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprO
 		return nil
 	}
 
-  // We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty
+	// The API can return an explicit entry `exprOptions` object, causing evaluation of the `recaptcha_options` settings to fail as it's nil: https://github.com/hashicorp/terraform-provider-google/issues/24334
+	// Explicitly check it's available and exit early if not.
+	if exprOptions.RecaptchaOptions == nil {
+		return nil
+	}
+
+	// The API can return an explicit empty rule causing an issue: https://github.com/hashicorp/terraform-provider-google/issues/16882#issuecomment-2474528447
+	// We check if the API is returning a empty non-null value then we find the current value for this field in the rule config and check if its empty.
 	if (tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.ActionTokenSiteKeys)) &&
 		tpgresource.IsEmptyValue(reflect.ValueOf(exprOptions.RecaptchaOptions.SessionTokenSiteKeys))) &&
 		verifyRulePriorityCompareEmptyValues(d, rulePriority, "recaptcha_options") {
@@ -1380,7 +1387,9 @@ func flattenMatchExprOptions(exprOptions *compute.SecurityPolicyRuleMatcherExprO
 	}
 
 	data := map[string]interface{}{
+		// NOTE: when adding new entries, the recaptcha_options rule above will need to be revised
 		"recaptcha_options": flattenMatchExprOptionsRecaptchaOptions(exprOptions.RecaptchaOptions),
+		// NOTE: when adding new entries, the recaptcha_options rule above will need to be revised
 	}
 
 	return []map[string]interface{}{data}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24334

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a crash in `google_compute_security_policy` due to a changed API response for empty `match.0.expr_options` blocks
```
