### PR TITLE
Add nil check and fix type assertion to flattenCloudSchedulerJobHttpTargetHeaders in `google_cloud_scheduler_job`

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/http_headers.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/http_headers.tmpl
@@ -11,23 +11,33 @@
 	limitations under the License.
 */ -}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (interface{}) {
-  var headers = v.(map[string]interface{})
+  if v == nil {
+    return nil
+  }
+  headers, ok := v.(map[string]interface{})
+  if !ok {
+    return nil
+  }
   if v, ok := headers["User-Agent"]; ok {
-    if v.(string) == "AppEngine-Google; (+http://code.google.com/appengine)" {
-      delete(headers, "User-Agent")
-    } else if v.(string) == "Google-Cloud-Scheduler" {
-      delete(headers, "User-Agent")
-    } else {
-      headers["User-Agent"] = strings.TrimSpace(strings.Replace(v.(string), "AppEngine-Google; (+http://code.google.com/appengine)","", -1))
+    if userAgent, ok := v.(string); ok {
+      if userAgent == "AppEngine-Google; (+http://code.google.com/appengine)" {
+        delete(headers, "User-Agent")
+      } else if userAgent == "Google-Cloud-Scheduler" {
+        delete(headers, "User-Agent")
+      } else {
+        headers["User-Agent"] = strings.TrimSpace(strings.Replace(userAgent, "AppEngine-Google; (+http://code.google.com/appengine)","", -1))
+      }
     }
   }
   if v, ok := headers["Content-Type"]; ok {
-    if v.(string) == "application/octet-stream" {
-      delete(headers, "Content-Type")
+    if contentType, ok := v.(string); ok {
+      if contentType == "application/octet-stream" {
+        delete(headers, "Content-Type")
+      }
     }
   }
   r := regexp.MustCompile(`(X-Google-|X-AppEngine-|Content-Length).*`)
-  for key := range headers { 
+  for key := range headers {
     if r.MatchString(key) {
       delete(headers, key)
     }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24354

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
cloudscheduler: fixed a type assertion panic in `google_cloud_scheduler_job` when processing HTTP headers with nil or unexpected data types
```
