### PR TITLE
Fix Issue 24131 :  Add support for new_recognition_result_notification_config in google_dialogflow_conversation_profile

### DIFF
--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -45,10 +45,11 @@ examples:
     vars:
       profile_name: 'dialogflow-profile'
   - name: 'dialogflow_conversation_profile_recognition_result_notification'
-    primary_resource_id: 'basic_profile'
+    primary_resource_id: 'recognition_result_notification_profile'
     vars:
       profile_name: 'dialogflow-profile'
-      topic_name: 'dialogflow-profile'
+      topic_name: 'recognition-result-notification'
+      message_format: 'JSON'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -44,6 +44,11 @@ examples:
     primary_resource_id: 'basic_profile'
     vars:
       profile_name: 'dialogflow-profile'
+  - name: 'dialogflow_conversation_profile_recognition_result_notification'
+    primary_resource_id: 'basic_profile'
+    vars:
+      profile_name: 'dialogflow-profile'
+      topic_name: 'dialogflow-profile'
 parameters:
   - name: 'location'
     type: String
@@ -536,7 +541,7 @@ properties:
         description: |
           Whether to log conversation events
   - type: NestedObject
-    name: newMessageEventNotificationConfig
+    name: 'newMessageEventNotificationConfig'
     description: |
       Pub/Sub topic on which to publish new agent assistant events.
       Expects the format "projects/<Project ID>/locations/<Location ID>/topics/<Topic ID>"

--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -656,3 +656,23 @@ properties:
               - SSML_VOICE_GENDER_MALE
               - SSML_VOICE_GENDER_FEMALE
               - SSML_VOICE_GENDER_NEUTRAL
+  - type: NestedObject
+    name: 'newRecognitionResultNotificationConfig'
+    description: |
+      Optional. Configuration for publishing transcription intermediate results. Event will be sent in format of ConversationEvent. If configured, the following information will be populated as ConversationEvent Pub/Sub message attributes: - "participant_id" - "participantRole" - "message_id"
+    properties:
+      - type: string
+        name: 'topic'
+        description: |
+          Name of the Pub/Sub topic to publish conversation events like CONVERSATION_STARTED as serialized ConversationEvent protos.
+          For telephony integration to receive notification, make sure either this topic is in the same project as the conversation or you grant service-<Conversation Project Number>@gcp-sa-dialogflow.iam.gserviceaccount.com the Dialogflow Service Agent role in the topic project.
+          For chat integration to receive notification, make sure API caller has been granted the Dialogflow Service Agent role for the topic.
+          Format: projects/<Project ID>/locations/<Location ID>/topics/<Topic ID>.
+      - name: 'messageFormat'
+        type: Enum
+        description: |
+          Format of message.
+        enum_values:
+          - 'MESSAGE_FORMAT_UNSPECIFIED'
+          - 'PROTO'
+          - 'JSON'

--- a/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
@@ -6,18 +6,9 @@ resource "google_dialogflow_agent" "basic_agent" {
 resource "google_dialogflow_conversation_profile" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.Vars "profile_name"}}"
   location = "global"
-  automated_agent_config {
-    agent = "projects/${google_dialogflow_agent.basic_agent.id}/locations/global/agent/environments/draft"
-  }
-  human_agent_assistant_config {
-    message_analysis_config {
-      enable_entity_extraction  = true
-      enable_sentiment_analysis = true
-    }
-  }
   new_recognition_result_notification_config {
     topic = google_pubsub_topic.{{$.PrimaryResourceId}}.id
-    message_format = "JSON"
+    message_format =  "{{index $.Vars "message_format"}}"
   }
 }
 

--- a/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
@@ -17,6 +17,7 @@ resource "google_dialogflow_conversation_profile" "{{$.PrimaryResourceId}}" {
   }
   new_recognition_result_notification_config {
     topic = google_pubsub_topic.{{$.PrimaryResourceId}}.id
+    message_format = "JSON"
   }
 }
 

--- a/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
@@ -1,0 +1,25 @@
+resource "google_dialogflow_agent" "basic_agent" {
+  display_name = "example_agent"
+  default_language_code = "en-us"
+  time_zone = "America/New_York"
+}
+resource "google_dialogflow_conversation_profile" "{{$.PrimaryResourceId}}" {
+  display_name = "{{index $.Vars "profile_name"}}"
+  location = "global"
+  automated_agent_config {
+    agent = "projects/${google_dialogflow_agent.basic_agent.id}/locations/global/agent/environments/draft"
+  }
+  human_agent_assistant_config {
+    message_analysis_config {
+      enable_entity_extraction  = true
+      enable_sentiment_analysis = true
+    }
+  }
+  new_recognition_result_notification_config {
+    topic = google_pubsub_topic.{{$.PrimaryResourceId}}.id
+  }
+}
+
+resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "topic_name"}}"
+}

--- a/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_conversation_profile_recognition_result_notification.tf.tmpl
@@ -1,8 +1,3 @@
-resource "google_dialogflow_agent" "basic_agent" {
-  display_name = "example_agent"
-  default_language_code = "en-us"
-  time_zone = "America/New_York"
-}
 resource "google_dialogflow_conversation_profile" "{{$.PrimaryResourceId}}" {
   display_name = "{{index $.Vars "profile_name"}}"
   location = "global"


### PR DESCRIPTION
**Description**
Add support for new_recognition_result_notification_config in google_dialogflow_conversation_profile 

```release-note:enhancement
dialogflow:  added `new_recognition_result_notification_config` field to `google_dialogflow_conversation_profile ` resource
```

**New Configuration :**
```
resource "google_dialogflow_conversation_profile" "assist_profile" {
  project        = "my-project-id"
  display_name   = "Agent Assist Profile"
  location       = "global"

  automated_agent_config {
    agent = "projects/my-project-id/agent"
  }

  human_agent_assistant_config {
    notification_config {
      topic = google_pubsub_topic.recognition_results.id
    }
  }
  
  # Add support for this new block
  new_recognition_result_notification_config {
    topic = google_pubsub_topic.recognition_results.id
  }

  language_code = "en-US"

  depends_on = [google_pubsub_topic_iam_member.dialogflow_pubsub_publisher]
}
```
**References**
PR to solve issue: https://github.com/hashicorp/terraform-provider-google/issues/24131