### PR TITLE
Update IAM template docs to cover WIF principals

### DIFF
--- a/mmv1/templates/terraform/resource_iam.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource_iam.html.markdown.tmpl
@@ -230,7 +230,7 @@ The following arguments are supported:
   * **projectOwner:projectid**: Owners of the given project. For example, "projectOwner:my-example-project"
   * **projectEditor:projectid**: Editors of the given project. For example, "projectEditor:my-example-project"
   * **projectViewer:projectid**: Viewers of the given project. For example, "projectViewer:my-example-project"
-  * **principal identifiers**: One or more federated identities in a workload or workforce identity pool. Refer to the [Principal identifiers documentation](https://cloud.google.com/iam/docs/principal-identifiers#allow) for a list of valid principals. For example, "principal://iam.googleapis.com/locations/global/workforcePools/example-contractors/subject/joe@example.com"
+  * **Federated identities**: One or more federated identities in a workload or workforce identity pool, workload running on GKE, etc. Refer to the [Principal identifiers documentation](https://cloud.google.com/iam/docs/principal-identifiers#allow) for examples of targets and valid configuration. For example, "principal://iam.googleapis.com/locations/global/workforcePools/example-contractors/subject/joe@example.com"
 
 * `role` - (Required) The role that should be applied. Only one
     `{{ $.IamTerraformName }}_binding` can be used per role. Note that custom roles must be of the format


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
--> Requesting an update to enhance clarity for customers using WIF. The current documentation lists types like user:, serviceAccount:, group:, etc., but omits the principal:// and principalSet:// formats crucial for WIF.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
Enhanced documentation for the `member`/`members` argument across Google Cloud IAM binding resources (such as `google_project_iam_member`, `google_storage_bucket_iam_member`, etc.). The argument description now explicitly lists and provides examples for Workload Identity Federation and Workforce Identity Federation identifiers, including the `principal://` and `principalSet://` syntaxes. This aims to reduce user confusion and make it clearer that federated identities are fully supported as direct members in IAM policies.
```
