### PR TITLE
Use us-west2 for one google_cloud_scheduler_job test

### DIFF
--- a/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
@@ -86,6 +86,7 @@ resource "google_cloud_scheduler_job" "job" {
   schedule         = "*/8 * * * *"
   time_zone        = "America/New_York"
   attempt_deadline = "320s"
+  region           = "us-west2"
 
   retry_config {
     retry_count = 1
@@ -109,6 +110,7 @@ resource "google_cloud_scheduler_job" "job" {
   schedule         = "*/8 * * * *"
   time_zone        = "America/New_York"
   attempt_deadline = "320s"
+  region           = "us-west2"
 
   retry_config {
     retry_count = 1


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Modify the test to verify the fix in https://github.com/GoogleCloudPlatform/magic-modules/pull/15128.

This issue only happens in us-west2

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
