### PR TITLE
Fix network field in google_compute_region_backend_service to force new on change

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1439,10 +1439,13 @@ properties:
     type: ResourceRef
     description: |
       The URL of the network to which this backend service belongs.
-      This field can only be specified when the load balancing scheme is set to INTERNAL.
+      This field must be set for Internal Passthrough Network Load Balancers when the haPolicy is enabled, and for External Passthrough Network Load Balancers when the haPolicy fastIpMove is enabled.
+      This field can only be specified when the load balancing scheme is set to INTERNAL, or when the load balancing scheme is set to EXTERNAL and haPolicy fastIpMove is enabled.
+      Changes to this field force recreation of the resource.
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Network'
     imports: 'selfLink'
+    immutable: true
   - name: 'subsetting'
     type: NestedObject
     description: |


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#23039

## Description
The network field of google_compute_region_backend_service cannot be modified after creation according to the GCP API. This change marks the field as immutable so Terraform will know to recreate the resource instead of trying to update it in place. This resolves the "Network field cannot be modified" error that occurs when users try to add a network to an existing resource.

## Affected resources
- google_compute_region_backend_service

This replaces PR #15123 with a clean branch containing only the necessary change.

```release-note:bug
compute: The network field in 'google_compute_region_backend_service' is now correctly handled, forcing a new resource on change. This resolves the "Network field cannot be modified" error when trying to add, remove, or modify a network on an existing resource
```
