### PR TITLE
Updated deprecation date for IAP OAuth APIs

### DIFF
--- a/mmv1/products/iap/Brand.yaml
+++ b/mmv1/products/iap/Brand.yaml
@@ -14,7 +14,7 @@
 ---
 name: 'Brand'
 deprecation_message: >-
-  after July 2025, the `google_iap_brand` Terraform resource will no longer function as intended due to the deprecation of the IAP OAuth Admin API
+  After Jan 19, 2026 the `google_iap_brand` Terraform resource will no longer function as intended due to the deprecation of the IAP OAuth Admin APIs. New projects will not be able to use these APIs. March 19, 2026 The IAP OAuth Admin APIs will be permanently shut down. Access to this feature will no longer be available
 description: |
   OAuth brand data. Only "Organization Internal" brands can be created
   programmatically via API. To convert it into an external brands

--- a/mmv1/products/iap/Client.yaml
+++ b/mmv1/products/iap/Client.yaml
@@ -15,7 +15,7 @@
 name: 'Client'
 api_resource_type_kind: IdentityAwareProxyClient
 deprecation_message: >-
-  After July 2025, the `google_iap_client` Terraform resource will no longer function as intended due to the deprecation of the IAP OAuth Admin API
+  After Jan 19, 2026 the `google_iap_client` Terraform resource will no longer function as intended due to the deprecation of the IAP OAuth Admin APIs. New projects will not be able to use these APIs. March 19, 2026 The IAP OAuth Admin APIs will be permanently shut down. Access to this feature will no longer be available
 description: |
   Contains the data that describes an Identity Aware Proxy owned client.
 


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
iap: Updated deprecation dates for `google_iap_client` and `google_iap_brand`
```
