### PR TITLE
fix(apihub): custom decoder to resolve permadiff

### DIFF
--- a/mmv1/products/apihub/Plugin.yaml
+++ b/mmv1/products/apihub/Plugin.yaml
@@ -31,6 +31,8 @@ examples:
     external_providers: ["time"]
 autogen_async: true
 autogen_status: UGx1Z2lu
+custom_code:
+  decoder: 'templates/terraform/decoders/apihub_plugin_auth_config_template.go.tmpl'
 parameters:
   - name: location
     type: String

--- a/mmv1/templates/terraform/decoders/apihub_plugin_auth_config_template.go.tmpl
+++ b/mmv1/templates/terraform/decoders/apihub_plugin_auth_config_template.go.tmpl
@@ -1,0 +1,24 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+if configTemplate, ok := res["configTemplate"].(map[string]interface{}); ok {
+	if authConfig, ok := configTemplate["authConfigTemplate"].(map[string]interface{}); ok {
+		supportedAuthTypes, exists := authConfig["supportedAuthTypes"]
+		if !exists || supportedAuthTypes == nil {
+			delete(configTemplate, "authConfigTemplate")
+		} else if authTypes, ok := supportedAuthTypes.([]interface{}); ok && len(authTypes) == 0 {
+			delete(configTemplate, "authConfigTemplate")
+		}
+	}
+}
+
+return res, nil


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/24355

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
apihub: fix permadiff on `supported_auth_types`
```
