### PR TITLE
Tags acceptance test value comparison

### DIFF
--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -522,3 +522,11 @@ properties:
         enum_values:
           - 'LEGACY'
           - 'JSON'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
@@ -3,6 +3,7 @@ package dataprocmetastore_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -164,6 +165,65 @@ resource "google_dataproc_metastore_service" "backup" {
 resource "google_storage_bucket" "bucket" {
   name     = "tf-test-backup%{random_suffix}"
   location = "us-central1"
+}
+`, context)
+}
+
+func TestAccMetastoreService_tags(t *testing.T) {
+	t.Parallel()
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "metastore-service-tagkey", map[string]interface{}{})
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           envvar.GetTestOrgFromEnv(t),
+		"tagKey":        tagKey,
+		"tagValue":      acctest.BootstrapSharedTestOrganizationTagValue(t, "metastore-service-tagvalue", tagKey),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataprocMetastoreServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetastoreServiceTags(context),
+				Check: resource.TestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_dataproc_metastore_service.default", "tags.%"),
+				),
+			},
+			{
+				ResourceName:            "google_dataproc_metastore_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_id", "location", "labels", "terraform_labels", "tags"},
+			},
+		},
+	})
+}
+
+func testAccMetastoreServiceTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dataproc_metastore_service" "default" {
+  service_id   = "tf-test-my-service-%{random_suffix}"
+  location   = "us-central1"
+  port       = 9080
+  tier       = "DEVELOPER"
+
+  maintenance_window {
+    hour_of_day = 2
+    day_of_week = "SUNDAY"
+   }
+
+  hive_metastore_config {
+    version = "2.3.6"
+  }
+
+  labels = {
+    env = "test"
+  }
+  tags = {
+	"%{org}/%{tagKey}" = "%{tagValue}"
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
+++ b/mmv1/third_party/terraform/services/dataprocmetastore/resource_dataproc_metastore_service_test.go
@@ -1,12 +1,16 @@
 package dataprocmetastore_test
 
 import (
+	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"testing"
 
+	metastore "cloud.google.com/go/metastore/apiv1"
+	metastorepb "cloud.google.com/go/metastore/apiv1/metastorepb"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccDataprocMetastoreService_updateAndImport(t *testing.T) {
@@ -171,13 +175,16 @@ resource "google_storage_bucket" "bucket" {
 
 func TestAccMetastoreService_tags(t *testing.T) {
 	t.Parallel()
-	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "metastore-service-tagkey", map[string]interface{}{})
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "metastore-services-tagkey", map[string]interface{}{})
+	tagValue := acctest.BootstrapSharedTestOrganizationTagValue(t, "metastore-services-tagvalue", tagKey)
+
+	testContext := map[string]interface{}{
 		"org":           envvar.GetTestOrgFromEnv(t),
 		"tagKey":        tagKey,
-		"tagValue":      acctest.BootstrapSharedTestOrganizationTagValue(t, "metastore-service-tagvalue", tagKey),
+		"tagValue":      tagValue,
+		"random_suffix": acctest.RandString(t, 10),
 	}
+	resourceName := "google_dataproc_metastore_service.test"
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -185,45 +192,87 @@ func TestAccMetastoreService_tags(t *testing.T) {
 		CheckDestroy:             testAccCheckDataprocMetastoreServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMetastoreServiceTags(context),
-				Check: resource.TestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"google_dataproc_metastore_service.default", "tags.%"),
+				Config: testAccMetastoreServiceTags(testContext),
+				Check: resource.ComposeTestCheckFunc(
+					checkMetastoreServiceTags(resourceName, testContext),
 				),
 			},
 			{
-				ResourceName:            "google_dataproc_metastore_service.default",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"service_id", "location", "labels", "terraform_labels", "tags"},
+				ImportStateVerifyIgnore: []string{"tags"},
 			},
 		},
 	})
 }
 
-func testAccMetastoreServiceTags(context map[string]interface{}) string {
+func testAccMetastoreServiceTags(testContext map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_dataproc_metastore_service" "default" {
-  service_id   = "tf-test-my-service-%{random_suffix}"
-  location   = "us-central1"
-  port       = 9080
-  tier       = "DEVELOPER"
-
-  maintenance_window {
-    hour_of_day = 2
-    day_of_week = "SUNDAY"
-   }
-
-  hive_metastore_config {
-    version = "2.3.6"
-  }
-
-  labels = {
-    env = "test"
-  }
-  tags = {
-	"%{org}/%{tagKey}" = "%{tagValue}"
-  }
+	resource "google_dataproc_metastore_service" "test" {
+	  service_id = "tf-test-service-%{random_suffix}"
+	  location = "us-east1"
+	  tier = "DEVELOPER"
+	  tags = {
+	    "%{org}/%{tagKey}" = "%{tagValue}"
+	  }
+	}`, testContext)
 }
-`, context)
+
+// This function gets the service via the Metastore API and inspects its tags.
+func checkMetastoreServiceTags(resourceName string, testContext map[string]interface{}) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Resource not found: %s", resourceName)
+		}
+
+		// Get resource attributes from state
+		project := rs.Primary.Attributes["project"]
+		location := rs.Primary.Attributes["location"]
+		serviceName := rs.Primary.Attributes["service_id"]
+
+		// Construct the expected full tag key
+		expectedTagKey := fmt.Sprintf("%s/%s", testContext["org"], testContext["tagKey"])
+		expectedTagValue := fmt.Sprintf("%s", testContext["tagValue"])
+
+		// This `ctx` variable is now a `context.Context` object
+		ctx := context.Background()
+
+		// Create a Metastore client
+		metastoreClient, err := metastore.NewDataprocMetastoreClient(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create metastore client: %v", err)
+		}
+		defer metastoreClient.Close()
+
+		// Construct the request to get the service details
+		req := &metastorepb.GetServiceRequest{
+			Name: fmt.Sprintf("projects/%s/locations/%s/services/%s", project, location, serviceName),
+		}
+
+		// Get the Metastore service
+		service, err := metastoreClient.GetService(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to get metastore service '%s': %v", req.Name, err)
+		}
+
+		// Check the service's labels for the expected tag
+		// In the Metastore API, tags are represented as labels.
+		labels := service.GetLabels()
+		if labels == nil {
+			return fmt.Errorf("expected labels not found on service '%s'", req.Name)
+		}
+
+		if actualValue, ok := labels[expectedTagKey]; ok {
+			if actualValue == expectedTagValue {
+				// The tag was found with the correct value. Success!
+				return nil
+			}
+			return fmt.Errorf("tag key '%s' found with incorrect value. Expected: %s, Got: %s", expectedTagKey, expectedTagValue, actualValue)
+		}
+
+		// If we reach here, the tag key was not found.
+		return fmt.Errorf("expected tag key '%s' not found on service '%s'", expectedTagKey, req.Name)
+	}
 }


### PR DESCRIPTION
Add tags field to service resource to allow setting tags on service resources at creation time.
Part of b/365716008

Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
metastore: added `tags` field to `google_dataproc_metastore_service` resource to allow setting tags for services at creation time
```
