### PR TITLE
cloudrunv2: promote mount options for GcsFuse volumes to GA

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -670,7 +670,6 @@ properties:
                         If true, mount this volume as read-only in all mounts. If false, mount this volume as read-write.
                     - name: 'mountOptions'
                       type: Array
-                      min_version: 'beta'
                       description: |
                         A list of flags to pass to the gcsfuse command for configuring this volume.
                         Flags should be passed without leading dashes.

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -929,7 +929,6 @@ properties:
                   description: If true, mount the GCS bucket as read-only
                   required: false
                 - name: 'mountOptions'
-                  min_version: 'beta'
                   type: Array
                   description: |
                     A list of flags to pass to the gcsfuse command for configuring this volume.

--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -593,7 +593,6 @@ properties:
                   description: If true, mount the GCS bucket as read-only
                   required: false
                 - name: 'mountOptions'
-                  min_version: 'beta'
                   type: Array
                   description: |
                     A list of flags to pass to the gcsfuse command for configuring this volume.

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
@@ -388,9 +388,7 @@ func testAccCloudRunV2Job_cloudrunv2JobWithGcsVolume(context map[string]interfac
           gcs {
             bucket = "gcp-public-data-landsat"
             read_only = true
-{{ if ne $.TargetVersionName `ga` -}}
-	mount_options = ["log-severity=info"]
-{{ end }}
+            mount_options = ["log-severity=info"]
           }
         }
       }

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -343,9 +343,7 @@ resource "google_cloud_run_v2_service" "default" {
       gcs {
         bucket = "gcp-public-data-landsat"
         read_only = true
-{{ if ne $.TargetVersionName `ga` -}}
-	mount_options = ["log-severity=info"]
-{{ end }}
+        mount_options = ["log-severity=info"]
       }
     }
     containers {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolFullUpdate(t *testing.T) {
@@ -42,7 +42,6 @@ func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolFullUpdate(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolFull(context map[string]interface{}) string {
 	return acctest.Nprintf(`
@@ -163,7 +162,7 @@ resource "google_service_account" "service_account" {
 }
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolGcsVolume(t *testing.T) {
 	acctest.SkipIfVcr(t)
-  t.Parallel()
+	t.Parallel()
 
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
@@ -182,8 +181,8 @@ func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolGcsVolume(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
-                        },
-              },
+			},
+		},
 	})
 }
 
@@ -261,7 +260,7 @@ func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithDirectVPCUpdate(t *test
 	workerPoolName := fmt.Sprintf("tf-test-cloudrun-worker-pool%s", acctest.RandString(t, 10))
 	context := map[string]interface{}{
 		"service_name": workerPoolName,
-		"project": envvar.GetTestProjectFromEnv(),
+		"project":      envvar.GetTestProjectFromEnv(),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -344,7 +343,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolCustomAudienceUpdate(t *testing.T) {
 	t.Parallel()
 
-  workerPoolName := fmt.Sprintf("tf-test-cloudrun-worker-pool%s", acctest.RandString(t, 10))
+	workerPoolName := fmt.Sprintf("tf-test-cloudrun-worker-pool%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -360,7 +359,7 @@ func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolCustomAudienceUpdate(t *tes
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "launch_stage", "deletion_protection"},
 			},
-      {
+			{
 				Config: testAccCloudRunV2WorkerPool_cloudRunWorkerPoolUpdateWithCustomAudience(workerPoolName, "test_update"),
 			},
 			{
@@ -416,7 +415,6 @@ resource "google_cloud_run_v2_worker_pool" "default" {
 }
 `, workerPoolName, customAudience)
 }
-
 
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolAttributionLabel(t *testing.T) {
 	t.Parallel()
@@ -521,36 +519,35 @@ resource "google_cloud_run_v2_worker_pool" "default" {
 }
 
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualScaling(t *testing.T) {
-  t.Parallel()
-  context := map[string]interface{} {
-    "random_suffix" : acctest.RandString(t, 10),
-  }
-  acctest.VcrTest(t, resource.TestCase {
-    PreCheck: func() { acctest.AccTestPreCheck(t)},
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy: testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
-    Steps: []resource.TestStep{
-       {
-        Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualScaling(context),
-      },
-      {
-        ResourceName: "google_cloud_run_v2_worker_pool.default",
-        ImportState: true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
-      },
-      {
-        Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolUpdateWithManualScaling(context),
-      },
-      {
-        ResourceName: "google_cloud_run_v2_worker_pool.default",
-        ImportState: true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
-      },
-
-    }, 
-  })
+	t.Parallel()
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualScaling(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_worker_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+			},
+			{
+				Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolUpdateWithManualScaling(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_worker_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+			},
+		},
+	})
 }
 
 func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualScaling(context map[string]interface{}) string {
@@ -615,26 +612,26 @@ resource "google_cloud_run_v2_worker_pool" "default" {
 }
 
 func TestAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(t *testing.T) {
-  t.Parallel()
-  context := map[string]interface{} {
-    "random_suffix" : acctest.RandString(t, 10),
-  }
-  acctest.VcrTest(t, resource.TestCase {
-    PreCheck: func() { acctest.AccTestPreCheck(t)},
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy: testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
-    Steps: []resource.TestStep{
-       {
-        Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(context),
-      },
-      {
-        ResourceName: "google_cloud_run_v2_worker_pool.default",
-        ImportState: true,
-        ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
-      },
-    }, 
-  })
+	t.Parallel()
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudRunV2WorkerPoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(context),
+			},
+			{
+				ResourceName:            "google_cloud_run_v2_worker_pool.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+			},
+		},
+	})
 }
 
 func testAccCloudRunV2WorkerPool_cloudrunv2WorkerPoolWithManualInstanceCountZero(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go.tmpl
@@ -219,9 +219,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
       gcs {
         bucket = "gcp-public-data-landsat"
         read_only = true
-{{ if ne $.TargetVersionName `ga` -}}
-	mount_options = ["log-severity=info"]
-{{ end }}
+        mount_options = ["log-severity=info"]
       }
     }
     containers {


### PR DESCRIPTION
Promote mount-options in gcsfuse volumes to GA in all cloudrunv2 resources

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `mount_options` in gcsfuse volumes for `google_cloud_run_v2_service`, `google_cloud_run_v2_job`, and `google_cloud_run_v2_workerpool` resources. (ga)
```
