### PR TITLE
new-resource: `google_vertex_ai_cache_config`

### DIFF
--- a/mmv1/products/vertexai/CacheConfig.yaml
+++ b/mmv1/products/vertexai/CacheConfig.yaml
@@ -1,0 +1,56 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'CacheConfig'
+description: |-
+  Config of GenAI caching features. This is a singleton resource.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/Shared.Types/CacheConfig'
+  api: 'https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/projects/updateCacheConfig'
+docs:
+import_format:
+  - 'projects/{{project}}/cacheConfig'
+base_url: 'projects/{{project}}/cacheConfig'
+self_link: 'projects/{{project}}/cacheConfig'
+examples:
+  - name: 'vertex_ai_cache_config'
+    primary_resource_id: 'cache_config'
+    test_env_vars:
+      project: 'PROJECT_NAME'
+create_verb: 'PATCH'
+update_verb: 'PATCH'
+exclude_delete: true
+async:
+  actions: ['create', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Identifier. name of the cache config. Format: - `projects/{project}/cacheConfig`.
+    output: true
+  - name: 'disableCache'
+    type: Boolean
+    description: |
+      If set to true, disables GenAI caching. Otherwise caching is enabled.
+    required: true

--- a/mmv1/products/vertexai/CacheConfig.yaml
+++ b/mmv1/products/vertexai/CacheConfig.yaml
@@ -39,10 +39,6 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
-timeouts:
-  insert_minutes: 20
-  update_minutes: 20
-  delete_minutes: 20
 properties:
   - name: 'name'
     type: String

--- a/mmv1/templates/terraform/examples/vertex_ai_cache_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_cache_config.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_vertex_ai_cache_config" "{{$.PrimaryResourceId}}" {
+  project       = "{{index $.TestEnvVars "project"}}"
+  disable_cache = true
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/22968

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_vertex_ai_cache_config`
```
