### PR TITLE
added default_from_api: true for squashMode, hasRootAccess & accessType

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -218,6 +218,7 @@ properties:
       - 'QOS_TYPE_UNSPECIFIED'
       - 'AUTO'
       - 'MANUAL'
+    default_from_api: true
   - name: 'availableThroughputMibps'
     type: Double
     description: |

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -151,6 +151,7 @@ properties:
               type: String
               description: |-
                  If enabled, the root user (UID = 0) of the specified clients doesn't get mapped to nobody (UID = 65534). This is also known as no_root_squash.
+              default_from_api: true
             - name: 'accessType'
               type: Enum
               description: |
@@ -159,6 +160,7 @@ properties:
                 - 'READ_ONLY'
                 - 'READ_WRITE'
                 - 'READ_NONE'
+              default_from_api: true
             - name: 'nfsv3'
               type: Boolean
               description: |
@@ -199,6 +201,7 @@ properties:
                 - 'NO_ROOT_SQUASH'
                 - 'ROOT_SQUASH'
                 - 'ALL_SQUASH'
+              default_from_api: true
             - name: 'anonUid'
               type: Integer
               description: |-

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -160,7 +160,6 @@ properties:
                 - 'READ_ONLY'
                 - 'READ_WRITE'
                 - 'READ_NONE'
-              default_from_api: true
             - name: 'nfsv3'
               type: Boolean
               description: |

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
@@ -1038,6 +1038,24 @@ func TestAccNetappVolume_volumeExportPolicyWithSquashMode(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
 			},
+            {
+				Config: testAccNetappVolume_volumeExportPolicyWithoutSquashMode(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
+            {
+				Config: testAccNetappVolume_volumeExportPolicyWithoutSquashModeUpdate(context),
+			},
+			{
+				ResourceName:            "google_netapp_volume.test_volume",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"restore_parameters", "location", "name", "deletion_policy", "labels", "terraform_labels"},
+			},
 		},
 	})
 }
@@ -1312,6 +1330,82 @@ func testAccNetappVolume_volumeExportPolicyWithSquashMode_rootSquash_readNoneAcc
               nfsv3                 = true
               nfsv4                 = false
               squash_mode     = "ROOT_SQUASH"
+          }
+      }
+  }
+
+  data "google_compute_network" "default" {
+      provider = google-beta
+      name = "%{network_name}"
+  }
+  `, context)
+}
+
+func testAccNetappVolume_volumeExportPolicyWithoutSquashMode(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_netapp_storage_pool" "default" {
+      provider = google-beta
+      name = "tf-test-pool%{random_suffix}"
+      location = "northamerica-northeast1"
+      service_level = "PREMIUM"
+      capacity_gib = "2048"
+      network = data.google_compute_network.default.id
+  }
+    resource "time_sleep" "wait_3_minutes" {
+        depends_on = [google_netapp_storage_pool.default]
+        create_duration = "3m"
+    }
+  resource "google_netapp_volume" "test_volume" {
+      provider = google-beta
+      location = "northamerica-northeast1"
+      name = "tf-test-test-volume%{random_suffix}"
+      capacity_gib = "100"
+      share_name = "tf-test-test-volume%{random_suffix}"
+      storage_pool = google_netapp_storage_pool.default.name
+      protocols = ["NFSV3"]
+      export_policy {
+          rules {
+              access_type     = "READ_NONE"
+              allowed_clients = "0.0.0.0/0"
+              nfsv3                 = true
+          }
+      }
+  }
+
+  data "google_compute_network" "default" {
+      provider = google-beta
+      name = "%{network_name}"
+  }
+  `, context)
+}
+
+func testAccNetappVolume_volumeExportPolicyWithoutSquashModeUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_netapp_storage_pool" "default" {
+      provider = google-beta
+      name = "tf-test-pool%{random_suffix}"
+      location = "northamerica-northeast1"
+      service_level = "PREMIUM"
+      capacity_gib = "2048"
+      network = data.google_compute_network.default.id
+  }
+    resource "time_sleep" "wait_3_minutes" {
+        depends_on = [google_netapp_storage_pool.default]
+        create_duration = "3m"
+    }
+  resource "google_netapp_volume" "test_volume" {
+      provider = google-beta
+      location = "northamerica-northeast1"
+      name = "tf-test-test-volume%{random_suffix}"
+      capacity_gib = "200"
+      share_name = "tf-test-test-volume%{random_suffix}"
+      storage_pool = google_netapp_storage_pool.default.name
+      protocols = ["NFSV3"]
+      export_policy {
+          rules {
+              access_type     = "READ_NONE"
+              allowed_clients = "0.0.0.0/0"
+              nfsv3                 = true
           }
       }
   }


### PR DESCRIPTION
```release-note: bug
netapp: fixed incorrect default value handling in `google_netapp_volume` for `export_policy.rules` attributes `has_root_access` and `squash_mode`. When not specified, these fields will now take on the API default value with no diff.
```
