### PR TITLE
datastream: add support for `mongodb_source_config` in `google_datastream_stream`

### DIFF
--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -240,6 +240,13 @@ examples:
       source_connection_profile_id: 'source-profile'
       destination_connection_profile_id: 'destination-profile'
     exclude_test: true
+  - name: 'datastream_stream_mongodb'
+    primary_resource_id: 'default'
+    vars:
+      stream_id: 'mdb-stream'
+      source_connection_profile_id: 'source-profile'
+      destination_connection_profile_id: 'destination-profile'
+    exclude_test: true
 virtual_fields:
   - name: 'desired_state'
     description: |

--- a/mmv1/templates/terraform/examples/datastream_stream_mongodb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_stream_mongodb.tf.tmpl
@@ -1,0 +1,49 @@
+resource "google_datastream_stream" "default" {
+    display_name = "MongoDB to BigQuery"
+    location     = "us-central1"
+    stream_id    = "{{index $.Vars "stream_id"}}"
+
+    source_config {
+        source_connection_profile = "{{index $.Vars "source_connection_profile_id"}}"
+        mongodb_source_config {
+            max_concurrent_backfill_tasks = 20
+            include_objects {
+                databases = [
+                    {
+                        database = "retail",
+                        collections = [
+                            {
+                                collection = "inventory",
+                                fields = [
+                                    {
+                                        field = "item_id"
+                                    },
+                                    {
+                                        field = "price"
+                                    },
+                                    {
+                                        field = "quantity"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+
+    destination_config {
+        destination_connection_profile = "{{index $.Vars "destination_connection_profile_id"}}"
+        bigquery_destination_config {
+            data_freshness = "900s"
+            source_hierarchy_datasets {
+                dataset_template {
+                    location = "us-central1"
+                }
+            }
+        }
+    }
+
+    backfill_none {}
+}


### PR DESCRIPTION
Partly closes https://github.com/hashicorp/terraform-provider-google/issues/24391

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
datastream: add support for `mongodb_source_config` in `google_datastream_stream`
```

