### PR TITLE
Add deletion_protection field to Pub/Sub topic and subscription

### DIFF
--- a/mmv1/products/pubsub/Subscription.yaml
+++ b/mmv1/products/pubsub/Subscription.yaml
@@ -45,6 +45,7 @@ custom_code:
   constants: 'templates/terraform/constants/subscription.go.tmpl'
   encoder: 'templates/terraform/encoders/no_send_name.go.tmpl'
   update_encoder: 'templates/terraform/update_encoder/pubsub_subscription.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/pubsub_subscription.go.tmpl'
 tgc_ignore_terraform_encoder: true
 examples:
   - name: 'pubsub_subscription_push'
@@ -52,6 +53,8 @@ examples:
     vars:
       topic_name: 'example-topic'
       subscription_name: 'example-subscription'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'pubsub_subscription_pull'
     primary_resource_id: 'example'
     vars:
@@ -583,3 +586,11 @@ properties:
           description: |
             Controls whether or not to use this transform. If not set or `false`,
             the transform will be applied to messages. Default: `true`.
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the subscription. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the subscription will fail.
+    type: Boolean
+    default_value: false

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -52,6 +52,7 @@ iam_policy:
 custom_code:
   encoder: 'templates/terraform/encoders/no_send_name.go.tmpl'
   update_encoder: 'templates/terraform/update_encoder/pubsub_topic.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/pubsub_topic.go.tmpl'
 tgc_ignore_terraform_encoder: true
 error_retry_predicates:
   - 'transport_tpg.PubsubTopicProjectNotReady'
@@ -62,6 +63,8 @@ examples:
     primary_resource_name: 'fmt.Sprintf("tf-test-example-topic%s", context["random_suffix"])'
     vars:
       topic_name: 'example-topic'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'pubsub_topic_cmek'
     primary_resource_id: 'example'
     vars:
@@ -508,3 +511,11 @@ properties:
           description: |
             Controls whether or not to use this transform. If not set or `false`,
             the transform will be applied to messages. Default: `true`.
+virtual_fields:
+  - name: 'deletion_protection'
+    description: |
+      Whether Terraform will be prevented from destroying the topic. Defaults to false.
+      When the field is set to true in Terraform state, a `terraform apply`
+      or `terraform destroy` that would delete the topic will fail.
+    type: Boolean
+    default_value: false

--- a/mmv1/templates/terraform/examples/pubsub_subscription_push.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_subscription_push.tf.tmpl
@@ -19,4 +19,6 @@ resource "google_pubsub_subscription" "{{$.PrimaryResourceId}}" {
       x-goog-version = "v1"
     }
   }
+
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/examples/pubsub_topic_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/pubsub_topic_basic.tf.tmpl
@@ -6,4 +6,6 @@ resource "google_pubsub_topic" "{{$.PrimaryResourceId}}" {
   }
 
   message_retention_duration = "86600s"
+
+  deletion_protection = false
 }

--- a/mmv1/templates/terraform/pre_delete/pubsub_subscription.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/pubsub_subscription.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy pubsub subscription without setting deletion_protection=false and running `terraform apply`")
+}

--- a/mmv1/templates/terraform/pre_delete/pubsub_topic.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/pubsub_topic.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+    return fmt.Errorf("cannot destroy pubsub topic without setting deletion_protection=false and running `terraform apply`")
+}


### PR DESCRIPTION
Add deletion_protection field to make deletion actions require an explicit intent
Part of b/443114698

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
pubsub: added `deletion_protection` field to `google_pubsub_topic` and `google_pubsub_subscription` resources to make deleting them require an explicit intent. These resources now cannot be destroyed unless `deletion_protection = false` is set for the resource.
```
