### PR TITLE
`resourceIdentityGeneration`: use nil check instead of error when calling `identity()`

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -732,7 +732,7 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     }
     {{- end }}
     } else {
-        fmt.Printf("identity not set: %s", err)
+        fmt.Printf("[DEBUG] identity not set: %s", err)
     }
 {{- end }}
 {{  end -}}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -722,7 +722,7 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     {{ $.CustomTemplate $.CustomCode.CustomIdentityRead true -}}
 {{- else }}
 	identity, err := d.Identity()
-    if identity != nil {
+    if err != nil && identity != nil {
     {{- range $p := $.IdentityProperties }}
     if v, ok := identity.GetOk("{{ underscore $p.Name}}"); ok && v != "" {
         err = identity.Set("{{ underscore $p.Name}}", d.Get("{{ underscore $p.Name}}").(string))

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -722,9 +722,7 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     {{ $.CustomTemplate $.CustomCode.CustomIdentityRead true -}}
 {{- else }}
 	identity, err := d.Identity()
-	if err != nil {
-		return fmt.Errorf("Error getting identity: %s", err)
-	}
+    if identity != nil {
     {{- range $p := $.IdentityProperties }}
     if v, ok := identity.GetOk("{{ underscore $p.Name}}"); ok && v != "" {
         err = identity.Set("{{ underscore $p.Name}}", d.Get("{{ underscore $p.Name}}").(string))
@@ -733,6 +731,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
             }     
     }
     {{- end }}
+    } else {
+        fmt.Printf("identity not set: %s", err)
+    }
 {{- end }}
 {{  end -}}
     return nil

--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -25,10 +25,7 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 			log.Printf("[DEBUG] Could not compile %s.", idFormat)
 			return fmt.Errorf("Import is not supported. Invalid regex formats.")
 		}
-		identity, err := d.Identity()
-		if err != nil {
-			return err
-		}
+		identity, _ := d.Identity()
 		if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
 			log.Printf("[DEBUG] matching ID %s to regex %s.", d.Id(), idFormat)
 			// Starting at index 1, the first match is the full string.

--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -25,7 +25,10 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 			log.Printf("[DEBUG] Could not compile %s.", idFormat)
 			return fmt.Errorf("Import is not supported. Invalid regex formats.")
 		}
-		identity, _ := d.Identity()
+		identity, err := d.Identity()
+		if identity == nil {
+			fmt.Printf("[DEBUG] identity not set: %s", err)
+		}
 		if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
 			log.Printf("[DEBUG] matching ID %s to regex %s.", d.Id(), idFormat)
 			// Starting at index 1, the first match is the full string.


### PR DESCRIPTION
after running tests, we ran into missing identity() errors being shown due to

- handwritten resources not having the identity schema but utilizing the identity in `importStateUpgrade`
- using `identity()` in data sources

this PR makes it so that we do a nil check of the identityData type and prevent the use of identtiy setting and getting in the event that identityData is nil

first discussed here:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/15074

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
