### PR TITLE
Reorder pubsub acceptance test functions

### DIFF
--- a/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/resource_pubsub_topic_test.go
@@ -210,6 +210,136 @@ func TestAccPubsubTopic_cloudStorageIngestionUpdate(t *testing.T) {
 	})
 }
 
+func TestAccPubsubTopic_azureEventHubsIngestionUpdate(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubTopic_updateWithAzureEventHubsIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubTopic_updateWithUpdatedAzureEventHubsIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPubsubTopic_awsMskIngestionUpdate(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubTopic_updateWithAwsMskIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubTopic_updateWithUpdatedAwsMskIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPubsubTopic_confluentCloudIngestionUpdate(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPubsubTopic_updateWithConfluentCloudIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPubsubTopic_updateWithUpdatedConfluentCloudIngestionSettings(topic),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccPubsubTopic_javascriptUdfUpdate(t *testing.T) {
+	t.Parallel()
+
+	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
+
+	functionName := "my_func"
+	code := "function my_func(message, metadata) {return null;}"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
+		Steps: []resource.TestStep{
+			// Initial transform
+			{
+				Config: testAccPubsubTopic_javascriptUdfSettings(topic, functionName, code),
+			},
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Destroy transform
+			{
+				ResourceName:      "google_pubsub_topic.foo",
+				ImportStateId:     topic,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccPubsubTopic_update(topic, key, value string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {
@@ -372,38 +502,6 @@ resource "google_pubsub_topic" "foo" {
 `, topic)
 }
 
-func TestAccPubsubTopic_azureEventHubsIngestionUpdate(t *testing.T) {
-	t.Parallel()
-
-	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPubsubTopic_updateWithAzureEventHubsIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccPubsubTopic_updateWithUpdatedAzureEventHubsIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccPubsubTopic_updateWithAzureEventHubsIngestionSettings(topic string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {
@@ -446,38 +544,6 @@ resource "google_pubsub_topic" "foo" {
 `, topic)
 }
 
-func TestAccPubsubTopic_awsMskIngestionUpdate(t *testing.T) {
-	t.Parallel()
-
-	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPubsubTopic_updateWithAwsMskIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccPubsubTopic_updateWithUpdatedAwsMskIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccPubsubTopic_updateWithAwsMskIngestionSettings(topic string) string {
 	return fmt.Sprintf(`
 resource "google_pubsub_topic" "foo" {
@@ -512,38 +578,6 @@ resource "google_pubsub_topic" "foo" {
   }
 }
 `, topic)
-}
-
-func TestAccPubsubTopic_confluentCloudIngestionUpdate(t *testing.T) {
-	t.Parallel()
-
-	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPubsubTopic_updateWithConfluentCloudIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccPubsubTopic_updateWithUpdatedConfluentCloudIngestionSettings(topic),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
 }
 
 func testAccPubsubTopic_updateWithConfluentCloudIngestionSettings(topic string) string {
@@ -582,39 +616,6 @@ resource "google_pubsub_topic" "foo" {
   }
 }
 `, topic)
-}
-func TestAccPubsubTopic_javascriptUdfUpdate(t *testing.T) {
-	t.Parallel()
-
-	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(t, 10))
-
-	functionName := "my_func"
-	code := "function my_func(message, metadata) {return null;}"
-
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckPubsubTopicDestroyProducer(t),
-		Steps: []resource.TestStep{
-			// Initial transform
-			{
-				Config: testAccPubsubTopic_javascriptUdfSettings(topic, functionName, code),
-			},
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Destroy transform
-			{
-				ResourceName:      "google_pubsub_topic.foo",
-				ImportStateId:     topic,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
 }
 
 func testAccPubsubTopic_javascriptUdfSettings(topic, functionName, code string) string {


### PR DESCRIPTION
Consistently order pubsub acceptance tests' test functions before template functions.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
