### PR TITLE
Add PSC support to google_vertex_ai_endpoint_with_model_garden_deployment

### DIFF
--- a/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
+++ b/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
@@ -95,6 +95,14 @@ examples:
     ignore_read_extra:
       - "project"
     exclude_test: true  # handwritten test required since resource does not support import
+  - name: "vertex_ai_deploy_psc_endpoint_automated"
+    primary_resource_id: "deploy"
+    vars:
+      project: "vertex-ai"
+      publisher_model_name: "publisher_model_name"
+    ignore_read_extra:
+      - "project"
+    exclude_test: true  # handwritten test required since resource does not support import
 parameters:
   - name: location
     type: String

--- a/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
+++ b/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
@@ -864,14 +864,17 @@ properties:
       - name: privateServiceConnectConfig
         type: NestedObject
         description: The configuration for Private Service Connect (PSC).
+        immutable: true
         properties:
           - name: enablePrivateServiceConnect
             type: Boolean
             description: |-
               Required. If true, expose the IndexEndpoint via private service connect.
             required: true
+            immutable: true
           - name: projectAllowlist
             type: Array
+            immutable: true
             description: |-
               A list of Projects from which the forwarding rule will target the service attachment.
             item_type:
@@ -879,14 +882,16 @@ properties:
           - name: pscAutomationConfigs
             type: NestedObject
             description: PSC config that is used to automatically create PSC endpoints in the user projects.
+            immutable: true
             properties:
               - name: projectId
                 type: String
-                description: |-
-                  Required. Project id used to create forwarding rule.
+                immutable: true
+                description: Required. Project id used to create forwarding rule.
                 required: true
               - name: network
                 type: String
+                immutable: true
                 description: |-
                   Required. The full name of the Google Compute Engine network.
                   Format: projects/{project}/global/networks/{network}.

--- a/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
+++ b/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
@@ -87,6 +87,14 @@ examples:
     ignore_read_extra:
       - "project"
     exclude_test: true  # handwritten test required since resource does not support import
+  - name: "vertex_ai_deploy_psc_endpoint"
+    primary_resource_id: "deploy"
+    vars:
+      project: "vertex-ai"
+      publisher_model_name: "publisher_model_name"
+    ignore_read_extra:
+      - "project"
+    exclude_test: true  # handwritten test required since resource does not support import
 parameters:
   - name: location
     type: String
@@ -845,6 +853,66 @@ properties:
           performance and reliability. Note: Once you enabled dedicated endpoint,
           you won't be able to send request to the shared DNS
           {region}-aiplatform.googleapis.com. The limitations will be removed soon.
+      - name: privateServiceConnectConfig
+        type: NestedObject
+        description: The configuration for Private Service Connect (PSC).
+        properties:
+          - name: enablePrivateServiceConnect
+            type: Boolean
+            description: |-
+              Required. If true, expose the IndexEndpoint via private service connect.
+            required: true
+          - name: projectAllowlist
+            type: Array
+            description: |-
+              A list of Projects from which the forwarding rule will target the service attachment.
+            item_type:
+              type: String
+          - name: pscAutomationConfigs
+            type: NestedObject
+            description: PSC config that is used to automatically create PSC endpoints in the user projects.
+            properties:
+              - name: projectId
+                type: String
+                description: |-
+                  Required. Project id used to create forwarding rule.
+                required: true
+              - name: network
+                type: String
+                description: |-
+                  Required. The full name of the Google Compute Engine network.
+                  Format: projects/{project}/global/networks/{network}.
+                required: true
+              - name: ipAddress
+                type: String
+                description: |-
+                  Output only. IP address rule created by the PSC service automation.
+                output: true
+              - name: forwardingRule
+                type: String
+                description: |-
+                  Output only. Forwarding rule created by the PSC service automation.
+                output: true
+              - name: state
+                type: Enum
+                description: |-
+                  Output only. The state of the PSC service automation.
+                output: true
+                enum_values:
+                  - 'PSC_AUTOMATION_STATE_UNSPECIFIED'
+                  - 'PSC_AUTOMATION_STATE_SUCCESSFUL'
+                  - 'PSC_AUTOMATION_STATE_FAILED'
+              - name: errorMessage
+                type: String
+                description: |-
+                  Output only. Error message if the PSC service automation failed.
+                output: true
+          - name: serviceAttachment
+            type: String
+            description: |-
+              Output only. The name of the generated service attachment resource.
+              This is only populated if the endpoint is deployed with PrivateServiceConnect.
+            output: true
   - name: deployConfig
     type: NestedObject
     description: The deploy config to use for the deployment.

--- a/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "{{$.PrimaryResourceId}}" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula =  true
+  }
+
+  endpoint_config {
+    private_service_connect_config {
+      enable_private_service_connect = true
+      project_allowlist              = ["my-project-id"]
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
@@ -11,7 +11,7 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "{{$.PrimaryRe
       enable_private_service_connect = true
       project_allowlist              = [data.google_project.project.id]
 
-      psc_automation_config {
+      psc_automation_configs {
         project_id = data.google_project.project.id
         network    = google_compute_network.network.id
       }

--- a/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_deploy_psc_endpoint_automated.tf.tmpl
@@ -1,0 +1,34 @@
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "{{$.PrimaryResourceId}}" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula =  true
+  }
+
+  endpoint_config {
+    private_service_connect_config {
+      enable_private_service_connect = true
+      project_allowlist              = [data.google_project.project.id]
+
+      psc_automation_config {
+        project_id = data.google_project.project.id
+        network    = google_compute_network.network.id
+      }
+    }
+  }
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "subnetwork"
+  ip_cidr_range = "192.168.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+}
+
+resource "google_compute_network" "network" {
+  name                    = "network"
+  auto_create_subnetworks = false
+}
+
+data "google_project" "project" {}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
@@ -256,7 +256,7 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
       enable_private_service_connect = true
       project_allowlist              = [data.google_project.project.id]
 
-      psc_automation_config {
+      psc_automation_configs {
 		    project_id = data.google_project.project.id
 		    network    = google_compute_network.network.id
 		  }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
@@ -255,11 +255,11 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
     private_service_connect_config {
       enable_private_service_connect = true
       project_allowlist              = [data.google_project.project.id]
-    }
 
-    psc_automation_config {
-      project_id = data.google_project.project.id
-      network    = google_compute_network.network.id
+      psc_automation_config {
+		    project_id = data.google_project.project.id
+		    network    = google_compute_network.network.id
+		  }
     }
   }
 }

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_deploy_test.go
@@ -189,6 +189,97 @@ resource "google_vertex_ai_endpoint_with_model_garden_deployment" "deploy-llama-
 `, context)
 }
 
+func TestAccVertexAIEndpointWithModelGardenDeployment_pscEndpoint(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{"random_suffix": acctest.RandString(t, 10)}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIEndpointWithModelGardenDeployment_pscEndpoint(context),
+			},
+		},
+	})
+}
+
+func testAccVertexAIEndpointWithModelGardenDeployment_pscEndpoint(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula = true
+  }
+
+  endpoint_config {
+    private_service_connect_config {
+      enable_private_service_connect = true
+      project_allowlist              = [data.google_project.project.id]
+    }
+  }
+}
+
+data "google_project" "project" {}
+`, context)
+}
+
+func TestAccVertexAIEndpointWithModelGardenDeployment_pscEndpointAutomated(t *testing.T) {
+	t.Parallel()
+	context := map[string]interface{}{"random_suffix": acctest.RandString(t, 10)}
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIEndpointWithModelGardenDeployment_pscEndpointAutomated(context),
+			},
+		},
+	})
+}
+
+func testAccVertexAIEndpointWithModelGardenDeployment_pscEndpointAutomated(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula = true
+  }
+
+  endpoint_config {
+    private_service_connect_config {
+      enable_private_service_connect = true
+      project_allowlist              = [data.google_project.project.id]
+    }
+
+    psc_automation_config {
+      project_id = data.google_project.project.id
+      network    = google_compute_network.network.id
+    }
+  }
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "subnetwork"
+  ip_cidr_range = "192.168.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.network.id
+}
+
+resource "google_compute_network" "network" {
+  name                    = "network"
+  auto_create_subnetworks = false
+}
+
+data "google_project" "project" {}
+`, context)
+}
+
 func testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for name, rs := range s.RootModule().Resources {


### PR DESCRIPTION
Adds PSC support to `google_vertex_ai_endpoint_with_model_garden_deployment`.

Fixes [hashicorp/terraform-provider-google/issues/24402](https://github.com/hashicorp/terraform-provider-google/issues/24402).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
vertexai: added `endpoint_config.private_service_connect_config` block to `google_vertex_ai_endpoint_with_model_garden_deployment` resource
```
