### PR TITLE
Feature gap: Add `maxInFlightRequests*` and `trafficDuration` to `BackendService` and `RegionBackendService`

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -311,6 +311,39 @@ properties:
             Used when balancingMode is UTILIZATION. This ratio defines the
             CPU utilization target for the group. Valid range is [0.0, 1.0].
           default_from_api: true
+        - name: 'maxInFlightRequests'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for the whole NEG
+            or instance group. Not available if backend's balancingMode is RATE
+            or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerInstance'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single VM.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerEndpoint'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single endpoint.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'trafficDuration'
+          type: Enum
+          description: |
+            This field specifies how long a connection should be kept alive for:
+            - LONG: Most of the requests are expected to take more than multiple
+              seconds to finish.
+            - SHORT: Most requests are expected to finish with a sub-second latency.
+          enum_values:
+            - 'LONG'
+            - 'SHORT'
+          min_version: 'beta'
         - name: 'customMetrics'
           type: Array
           description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -317,6 +317,39 @@ properties:
             Used when balancingMode is UTILIZATION. This ratio defines the
             CPU utilization target for the group. Valid range is [0.0, 1.0].
             Cannot be set for INTERNAL backend services.
+        - name: 'maxInFlightRequests'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for the whole NEG
+            or instance group. Not available if backend's balancingMode is RATE
+            or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerInstance'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single VM.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'maxInFlightRequestsPerEndpoint'
+          type: Integer
+          description: |
+            Defines a maximum number of in-flight requests for a single endpoint.
+            Not available if backend's balancingMode is RATE or CONNECTION.
+          default_from_api: true
+          min_version: 'beta'
+        - name: 'trafficDuration'
+          type: Enum
+          description: |
+            This field specifies how long a connection should be kept alive for:
+            - LONG: Most of the requests are expected to take more than multiple
+              seconds to finish.
+            - SHORT: Most requests are expected to finish with a sub-second latency.
+          enum_values:
+            - 'LONG'
+            - 'SHORT'
+          min_version: 'beta'
         - name: 'customMetrics'
           type: Array
           description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -989,6 +989,147 @@ func TestAccComputeBackendService_trafficDirectorUpdateFull(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeBackendService_withMaxInFlightRequests(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequests(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequests(
+					serviceName, igName, itName, checkName, 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeBackendService_withMaxInFlightRequestsPerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	service := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	instance := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	neg := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	network := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	check := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequestsPerEndpoint(
+					service, instance, neg, network, check, 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequestsPerEndpoint(
+					service, instance, neg, network, check, 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeBackendService_withMaxInFlightRequestsPerInstance(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequestsPerInstance(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withMaxInFlightRequestsPerInstance(
+					serviceName, igName, itName, checkName, 20),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeBackendService_withTrafficDuration(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withTrafficDuration(
+					serviceName, igName, itName, checkName, "LONG"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withTrafficDuration(
+					serviceName, igName, itName, checkName, "SHORT"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 {{- end }}
 
 func TestAccComputeBackendService_withPrivateOriginAuth(t *testing.T) {
@@ -3000,6 +3141,278 @@ resource "google_compute_health_check" "default" {
   }
 }
 `, namePrefix, spillover, ratio, namePrefix, namePrefix, namePrefix, namePrefix)
+}
+
+func testAccComputeBackendService_withMaxInFlightRequests(
+	serviceName, igName, itName, checkName string, maxInFlightRequests int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group                        = google_compute_instance_group_manager.foobar.instance_group
+	balancing_mode        		 = "UTILIZATION"
+    max_in_flight_requests       = %v
+	traffic_duration              = "LONG"
+  }
+
+  health_checks = [google_compute_health_check.default.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name = "%s"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, maxInFlightRequests, igName, itName, checkName)
+}
+
+func testAccComputeBackendService_withMaxInFlightRequestsPerInstance(
+	serviceName, igName, itName, checkName string, maxInFlightRequestsPerInstance int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_instance_group_manager.foobar.instance_group
+    max_in_flight_requests_per_instance = %v
+	traffic_duration = "LONG"
+  }
+
+  health_checks = [google_compute_health_check.default.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name = "%s"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, maxInFlightRequestsPerInstance, igName, itName, checkName)
+}
+
+func testAccComputeBackendService_withMaxInFlightRequestsPerEndpoint(
+	service, instance, neg, network, check string, maxInFlightRequestsPerEndpoint int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  # WEIGHTED_ROUND_ROBIN and CUSTOM_METRICS require EXTERNAL_MANAGED.
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  locality_lb_policy    = "WEIGHTED_ROUND_ROBIN"
+  custom_metrics {
+    name    = "orca.application_utilization"
+    # At least one metric should be not dry_run.
+    dry_run = false
+  }
+
+  backend {
+    group          = google_compute_network_endpoint_group.lb-neg.self_link
+    balancing_mode = "CUSTOM_METRICS"
+    custom_metrics {
+      name    = "orca.cpu_utilization"
+      dry_run = true
+	  max_utilization = 0.9
+    }
+    custom_metrics {
+      name    = "orca.named_metrics.foo"
+      max_utilization = 0.9
+      # At least one metric should be not dry_run.
+      dry_run = false
+    }
+    traffic_duration = "LONG"
+    max_in_flight_requests_per_endpoint = %v
+  }
+
+  health_checks = [google_compute_health_check.default.self_link]
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "endpoint-instance" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.default.self_link
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+}
+
+resource "google_compute_network_endpoint_group" "lb-neg" {
+  name         = "%s"
+  network      = google_compute_network.default.self_link
+  subnetwork   = google_compute_subnetwork.default.self_link
+  default_port = "90"
+  zone         = "us-central1-a"
+}
+
+resource "google_compute_network_endpoint" "lb-endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.lb-neg.name
+
+  instance   = google_compute_instance.endpoint-instance.name
+  port       = google_compute_network_endpoint_group.lb-neg.default_port
+  ip_address = google_compute_instance.endpoint-instance.network_interface[0].network_ip
+}
+
+resource "google_compute_network" "default" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.self_link
+}
+
+resource "google_compute_health_check" "default" {
+  name = "%s"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, service, maxInFlightRequestsPerEndpoint, instance, neg, network, network, check)
+}
+
+func testAccComputeBackendService_withTrafficDuration(serviceName, igName, itName, checkName, duration string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  port_name   = "http"
+  protocol    = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group = google_compute_instance_group_manager.foobar.instance_group
+    traffic_duration = "%s"
+  }
+
+  health_checks = [google_compute_health_check.default.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name = "%s"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, duration, igName, itName, checkName)
 }
 {{- end }}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -401,6 +401,148 @@ func TestAccComputeRegionBackendService_subsettingUpdate(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComputeRegionBackendService_withMaxInFlightRequests(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequests(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequests(
+					serviceName, igName, itName, checkName, 20),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionBackendService_withMaxInFlightRequestsPerInstance(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequestsPerInstance(
+					serviceName, igName, itName, checkName, 10),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequestsPerInstance(
+					serviceName, igName, itName, checkName, 20),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionBackendService_withMaxInFlightRequestsPerEndpoint(t *testing.T) {
+	t.Parallel()
+
+	randSuffix := acctest.RandString(t, 10)
+	service := fmt.Sprintf("tf-test-%s", randSuffix)
+	instance := fmt.Sprintf("tf-test-%s", randSuffix)
+	neg := fmt.Sprintf("tf-test-%s", randSuffix)
+	network := fmt.Sprintf("tf-test-%s", randSuffix)
+	check := fmt.Sprintf("tf-test-%s", randSuffix)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequestsPerEndpoint(
+					service, instance, neg, network, check, 5),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_withMaxInFlightRequestsPerEndpoint(
+					service, instance, neg, network, check, 10),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRegionBackendService_withTrafficDuration(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	igName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	itName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withTrafficDuration(
+					serviceName, igName, itName, checkName, "LONG"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_withTrafficDuration(
+					serviceName, igName, itName, checkName, "SHORT"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.lipsum",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 {{- end }}
 
 func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
@@ -1740,6 +1882,289 @@ resource "google_compute_region_security_policy" "policy" {
   type        = "CLOUD_ARMOR"
 }
 `, serviceName, polLink, polName)
+}
+
+func testAccComputeRegionBackendService_withMaxInFlightRequests(
+	serviceName, igName, itName, checkName string, maxInFlight int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_backend_service" "lipsum" {
+  name                  = "%s"
+  description           = "Hello World 1234"
+  port_name             = "http"
+  protocol              = "TCP"
+  region                = "us-central1"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group                  = google_compute_instance_group_manager.foobar.instance_group
+    balancing_mode         = "UTILIZATION"
+    traffic_duration       = "LONG"
+    capacity_scaler        = 1.0
+    max_in_flight_requests = %d
+  }
+
+  health_checks = [google_compute_region_health_check.hc1.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, maxInFlight, igName, itName, checkName)
+}
+
+func testAccComputeRegionBackendService_withMaxInFlightRequestsPerInstance(
+	serviceName, igName, itName, checkName string, maxPerInstance int64) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_backend_service" "lipsum" {
+  name                  = "%s"
+  description           = "Hello World 1234"
+  port_name             = "http"
+  protocol              = "TCP"
+  region                = "us-central1"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group             = google_compute_instance_group_manager.foobar.instance_group
+    traffic_duration  = "LONG"
+    capacity_scaler   = 1.0
+    max_in_flight_requests_per_instance = %d
+  }
+
+  health_checks = [google_compute_region_health_check.hc1.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, maxPerInstance, igName, itName, checkName)
+}
+
+func testAccComputeRegionBackendService_withMaxInFlightRequestsPerEndpoint(
+	service, instance, neg, network, check string, maxPerEndpoint int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "lipsum" {
+  name                  = "%s"
+  description           = "Hello World 1234"
+  region                = "us-central1"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  locality_lb_policy    = "WEIGHTED_ROUND_ROBIN"
+  custom_metrics {
+    name    = "orca.application_utilization"
+    # At least one metric should be not dry_run.
+    dry_run = false
+  }
+
+  backend {
+    group            = google_compute_network_endpoint_group.lb-neg.self_link
+    traffic_duration = "LONG"
+    capacity_scaler  = 1.0
+    balancing_mode = "CUSTOM_METRICS"
+    custom_metrics {
+      name    = "orca.cpu_utilization"
+      dry_run = true
+	    max_utilization = 0.9
+    }
+    custom_metrics {
+      name    = "orca.named_metrics.foo"
+      max_utilization = 0.9
+      # At least one metric should be not dry_run.
+      dry_run = false
+    }
+    max_in_flight_requests_per_endpoint = %d
+  }
+
+  health_checks = [google_compute_region_health_check.hc1.self_link]
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "endpoint-instance" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.default.self_link
+    access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+}
+
+resource "google_compute_network_endpoint_group" "lb-neg" {
+  name         = "%s"
+  network      = google_compute_network.default.self_link
+  subnetwork   = google_compute_subnetwork.default.self_link
+  default_port = "90"
+  zone         = "us-central1-a"
+}
+
+resource "google_compute_network_endpoint" "lb-endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.lb-neg.name
+  instance               = google_compute_instance.endpoint-instance.name
+  port                   = google_compute_network_endpoint_group.lb-neg.default_port
+  ip_address             = google_compute_instance.endpoint-instance.network_interface[0].network_ip
+}
+
+resource "google_compute_network" "default" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.default.self_link
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, service, maxPerEndpoint, instance, neg, network, network, check)
+}
+
+func testAccComputeRegionBackendService_withTrafficDuration(
+	serviceName, igName, itName, checkName, duration string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_backend_service" "lipsum" {
+  name                  = "%s"
+  description           = "Hello World 1234"
+  port_name             = "http"
+  protocol              = "TCP"
+  region                = "us-central1"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+
+  backend {
+    group            = google_compute_instance_group_manager.foobar.instance_group
+    traffic_duration = "%s"
+    capacity_scaler  = 1.0
+  }
+
+  health_checks = [google_compute_region_health_check.hc1.self_link]
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name = "%s"
+  version {
+    instance_template = google_compute_instance_template.foobar.self_link
+    name              = "primary"
+  }
+  base_instance_name = "tf-test-foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+
+  network_interface {
+    network = "default"
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_region_health_check" "hc1" {
+  name   = "%s"
+  region = "us-central1"
+  tcp_health_check {
+    port = "110"
+  }
+}
+`, serviceName, duration, igName, itName, checkName)
 }
 {{- end }}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR contain changes for `BackendService` and `RegionBackendService` and provides support for below fields for beta provider:
```
- backends.maxInFlightRequests
- backends.maxInFlightRequestsPerInstance
- backends.maxInFlightRequestsPerEndpoint
- backends.trafficDuration
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `backend.0.max_in_flight_requests`, `backend.0.max_in_flight_requests_per_instance`, `backend.0.max_in_flight_requests_per_endpoint` and `backend.0.traffic_duration` fields to `google_compute_backend_service` resource (beta)
```
