### PR TITLE
feat(apihub): Add support for API Hub Attributes

### DIFF
--- a/mmv1/products/apihub/Attribute.yaml
+++ b/mmv1/products/apihub/Attribute.yaml
@@ -1,0 +1,173 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Attribute
+description: |-
+  An attribute in the API Hub. An attribute is a name value pair which can be attached to different
+  resources in the API hub based on the scope of the attribute. Attributes can either be pre-defined
+  by the API Hub or created by users.
+references:
+  guides:
+    "Create and manage API Hub attributes": "https://cloud.google.com/apigee/docs/api-hub/manage-attributes"
+  api: "https://cloud.google.com/apigee/docs/reference/apis/apihub/rest/v1/projects.locations.attributes"
+base_url: projects/{{project}}/locations/{{location}}/attributes
+self_link: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+create_url: projects/{{project}}/locations/{{location}}/attributes?attributeId={{attribute_id}}
+update_verb: "PATCH"
+update_mask: true
+id_format: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+custom_code:
+  pre_create: templates/terraform/pre_create/apihub_attribute.go.tmpl
+examples:
+  - name: apihub_attribute_basic
+    primary_resource_id: attribute
+    vars:
+      attribute_id: "test-attribute"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    test_vars_overrides:
+      "attribute_id": '"tf-test-attribute-" + acctest.RandString(t, 10)'
+    # Skip test as it requires API Hub instance to be created first
+    exclude_test: true
+  - name: apihub_attribute_full
+    primary_resource_id: attribute
+    vars:
+      attribute_id: "test-attribute-full"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    test_vars_overrides:
+      "attribute_id": '"tf-test-attribute-full-" + acctest.RandString(t, 10)'
+    # Skip test as it requires API Hub instance to be created first
+    exclude_test: true
+parameters:
+  - name: location
+    type: String
+    description: |-
+      The location of the API Hub instance. This field is used to identify the
+      location of the API Hub instance in which to create the attribute.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: attributeId
+    type: String
+    description: |-
+      Optional. The ID to use for the attribute, which will become the final component
+      of the attribute's resource name. This field is optional.
+
+      * If provided, the same will be used. The service will throw an error if
+      the specified id is already used by another attribute resource in the API hub.
+      * If not provided, a system generated id will be used.
+
+      This value should be 4-500 characters, and valid characters are /[a-z][A-Z][0-9]-_/.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. The name of the attribute in the API Hub.
+      Format: projects/{project}/locations/{location}/attributes/{attribute}
+    output: true
+  - name: displayName
+    type: String
+    description: Required. The display name of the attribute.
+    required: true
+  - name: description
+    type: String
+    description: Optional. The description of the attribute.
+  - name: definitionType
+    type: Enum
+    description: Output only. The definition type of the attribute.
+    output: true
+    enum_values:
+      - "DEFINITION_TYPE_UNSPECIFIED"
+      - "SYSTEM_DEFINED"
+      - "USER_DEFINED"
+  - name: scope
+    type: Enum
+    description: |-
+      Required. The scope of the attribute. It represents the resource in the
+      API Hub to which the attribute can be linked.
+    required: true
+    enum_values:
+      - "SCOPE_UNSPECIFIED"
+      - "API"
+      - "VERSION"
+      - "SPEC"
+      - "API_OPERATION"
+      - "DEPLOYMENT"
+      - "DEPENDENCY"
+      - "DEFINITION"
+      - "EXTERNAL_API"
+      - "PLUGIN"
+  - name: dataType
+    type: Enum
+    description: Required. The type of the data of the attribute.
+    required: true
+    enum_values:
+      - "DATA_TYPE_UNSPECIFIED"
+      - "ENUM"
+      - "JSON"
+      - "STRING"
+      - "URI"
+  - name: allowedValues
+    type: Array
+    description: |-
+      Optional. The list of allowed values when the attribute value is of type enum.
+      This is required when the dataType of the attribute is ENUM. The maximum number
+      of allowed values of an attribute will be 1000.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: id
+          type: String
+          description: The ID of the allowed value.
+          required: true
+        - name: displayName
+          type: String
+          description: The display name of the allowed value.
+          required: true
+        - name: description
+          type: String
+          description: Optional. The description of the allowed value.
+        - name: immutable
+          type: Boolean
+          description: |-
+            Optional. When set to true, the allowed value cannot be updated or deleted
+            by the user. It can only be true for System defined attributes.
+  - name: cardinality
+    type: Integer
+    description: |-
+      Optional. The maximum number of values that the attribute can have when
+      associated with an API Hub resource. Cardinality 1 would represent a
+      single-valued attribute. It must not be less than 1 or greater than 20.
+      If not specified, the cardinality would be set to 1 by default and
+      represent a single-valued attribute.
+    default_from_api: true
+  - name: mandatory
+    type: Boolean
+    description: |-
+      Output only. When mandatory is true, the attribute is mandatory for the
+      resource specified in the scope. Only System defined attributes can be mandatory.
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. The time at which the attribute was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. The time at which the attribute was last updated.
+    output: true

--- a/mmv1/products/apihub/Attribute.yaml
+++ b/mmv1/products/apihub/Attribute.yaml
@@ -145,6 +145,7 @@ properties:
           description: Optional. The description of the allowed value.
         - name: immutable
           type: Boolean
+          default_value: false
           description: |-
             Optional. When set to true, the allowed value cannot be updated or deleted
             by the user. It can only be true for System defined attributes.

--- a/mmv1/products/apihub/AttributeAllowedValues.yaml
+++ b/mmv1/products/apihub/AttributeAllowedValues.yaml
@@ -1,0 +1,108 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AttributeAllowedValues
+description: |-
+  Manages the allowed values of attributes in the API Hub. This resource can manage allowed values
+  for both system-defined and user-defined attributes of ENUM type. For system-defined attributes,
+  immutable values are automatically preserved and cannot be modified or removed.
+references:
+  guides:
+    "Manage attributes": "https://cloud.google.com/apigee/docs/api-hub/manage-attributes"
+  api: "https://cloud.google.com/apigee/docs/reference/apis/apihub/rest/v1/projects.locations.attributes"
+base_url: projects/{{project}}/locations/{{location}}/attributes
+self_link: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+update_url: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+update_verb: "PATCH"
+update_mask: true
+id_format: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+custom_code:
+  constants: templates/terraform/constants/apihub_attribute_allowed_values.go.tmpl
+  custom_create: templates/terraform/custom_create/apihub_attribute_allowed_values.go.tmpl
+  custom_delete: templates/terraform/custom_delete/apihub_attribute_allowed_values.go.tmpl
+  pre_update: templates/terraform/pre_update/apihub_attribute_allowed_values.go.tmpl
+examples:
+  - name: apihub_attribute_allowed_values_user_defined
+    primary_resource_id: user_attribute_allowed_values
+    vars:
+      attribute_id: "environment"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    test_vars_overrides:
+      "attribute_id": '"tf-test-attr-values-" + acctest.RandString(t, 10)'
+    # Skip test as it requires API Hub instance
+    exclude_test: true
+  - name: apihub_attribute_allowed_values_system_defined
+    primary_resource_id: system_attribute_allowed_values
+    vars:
+      attribute_id: "system-lifecycle-stage"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    # Skip test as it requires API Hub instance and system attributes to exist
+    exclude_test: true
+parameters:
+  - name: location
+    type: String
+    description: |-
+      The location of the API Hub instance where the system attribute exists.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: attributeId
+    type: String
+    api_name: name
+    description: |-
+      The ID of the attribute. This can be either a system-defined attribute
+      (e.g., "system-lifecycle-stage") or a user-defined attribute.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: allowedValues
+    type: Array
+    description: |-
+      The allowed values for the attribute. This is a list of allowed values
+      that can be used for the attribute. For system-defined attributes, some
+      values may be immutable and cannot be removed.
+    required: true
+    custom_flatten: templates/terraform/custom_flatten/apihub_attribute_allowed_values_allowed_values.go.tmpl
+    update_mask_fields:
+      - "allowed_values"
+    item_type:
+      type: NestedObject
+      properties:
+        - name: id
+          type: String
+          description: |-
+            Required. The ID of the allowed value. This should be unique within the
+            attribute. If this is an immutable value from the system, it cannot be
+            modified or removed.
+          required: true
+        - name: displayName
+          type: String
+          description: |-
+            Required. The display name of the allowed value. This can be updated
+            for mutable values.
+          required: true
+        - name: description
+          type: String
+          description: Optional. The description of the allowed value.
+        - name: immutable
+          type: Boolean
+          default_value: false
+          description: |-
+            Output only. Whether the allowed value is immutable. Immutable values
+            cannot be modified or removed and will be automatically preserved during updates.

--- a/mmv1/templates/terraform/constants/apihub_attribute_allowed_values.go.tmpl
+++ b/mmv1/templates/terraform/constants/apihub_attribute_allowed_values.go.tmpl
@@ -1,0 +1,75 @@
+{{- /*
+	Helper function to consolidate allowed values for API Hub attributes.
+	This function merges existing immutable values with desired values,
+	handling both system-defined and user-defined attributes.
+*/ -}}
+func consolidateAllowedValues(d *schema.ResourceData, currentAttribute map[string]interface{}, desiredAllowedValues []interface{}) []interface{} {
+	// Check if it's system-defined
+	isSystemDefined := false
+	if defType, ok := currentAttribute["definitionType"].(string); ok && defType == "SYSTEM_DEFINED" {
+		isSystemDefined = true
+	}
+	
+	// Get current allowed_values from the API
+	currentAllowedValues := []interface{}{}
+	if av, ok := currentAttribute["allowedValues"]; ok && av != nil {
+		currentAllowedValues = av.([]interface{})
+	}
+	
+	// Build a map of desired values by ID for easy lookup
+	desiredMap := make(map[string]interface{})
+	for _, val := range desiredAllowedValues {
+		if valMap, ok := val.(map[string]interface{}); ok {
+			if id, ok := valMap["id"].(string); ok {
+				desiredMap[id] = val
+			}
+		}
+	}
+	
+	// Merge values based on attribute type
+	mergedValues := []interface{}{}
+	if isSystemDefined {
+		// For system-defined attributes, preserve immutable values
+		for _, currentVal := range currentAllowedValues {
+			if currentValMap, ok := currentVal.(map[string]interface{}); ok {
+				currentId, _ := currentValMap["id"].(string)
+				
+				// Check if this value is immutable
+				isImmutable := false
+				if immutableVal, ok := currentValMap["immutable"]; ok {
+					if immutableBool, ok := immutableVal.(bool); ok && immutableBool {
+						isImmutable = true
+					}
+				}
+				
+				if isImmutable {
+					// Always include immutable values
+					mergedValues = append(mergedValues, currentVal)
+				} else if desiredVal, exists := desiredMap[currentId]; exists {
+					// Include the desired version of mutable values
+					mergedValues = append(mergedValues, desiredVal)
+					delete(desiredMap, currentId)
+				} else if !d.HasChange("allowed_values") {
+					// If allowed_values hasn't changed, keep existing values
+					mergedValues = append(mergedValues, currentVal)
+				}
+			}
+		}
+	} else {
+		// For user-defined attributes
+		if d.HasChange("allowed_values") {
+			// Use desired values directly when changed
+			mergedValues = desiredAllowedValues
+		} else {
+			// Keep existing values when not changed
+			mergedValues = currentAllowedValues
+		}
+	}
+	
+	// Add any new values
+	for _, val := range desiredMap {
+		mergedValues = append(mergedValues, val)
+	}
+	
+	return mergedValues
+}

--- a/mmv1/templates/terraform/custom_create/apihub_attribute_allowed_values.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/apihub_attribute_allowed_values.go.tmpl
@@ -1,0 +1,86 @@
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	// This resource manages allowed values for existing attributes (both system and user-defined)
+	// It performs an update operation during "create"
+	attributeId := d.Get("attribute_id").(string)
+	location := d.Get("location").(string)
+	project := config.Project
+	
+	billingProject := ""
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	// First, check if the attribute exists
+	checkUrl := fmt.Sprintf("https://apihub.googleapis.com/v1/projects/%s/locations/%s/attributes/%s", project, location, attributeId)
+	checkRes, checkErr := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    checkUrl,
+		UserAgent: userAgent,
+		Timeout:   d.Timeout(schema.TimeoutRead),
+	})
+
+	if checkErr != nil {
+		if transport_tpg.IsGoogleApiErrorWithCode(checkErr, 404) {
+			return fmt.Errorf("Attribute '%s' does not exist in location '%s'. The attribute must exist before its allowed values can be managed.", attributeId, location)
+		}
+		return fmt.Errorf("Error checking attribute: %v", checkErr)
+	}
+
+	// Check if it's an ENUM type (only ENUM types have allowed values)
+	dataType, _ := checkRes["dataType"].(string)
+	if dataType != "ENUM" && dataType != "STRING" && dataType != "INT64" && dataType != "BOOL" {
+		return fmt.Errorf("System attribute '%s' is of type '%s'. Only ENUM, STRING, INT64 and BOOL type attributes can have allowed values managed.", attributeId, dataType)
+	}
+
+	// Get the allowed values from the request
+	allowedValuesProp, err := expandApihubAttributeAllowedValuesAllowedValues(d.Get("allowed_values"), d, config)
+	if err != nil {
+		return err
+	}
+	
+	// Convert allowedValuesProp to []interface{} if it's not nil
+	desiredAllowedValues := []interface{}{}
+	if allowedValuesProp != nil {
+		desiredAllowedValues = allowedValuesProp.([]interface{})
+	}
+	
+	// Build the update object with allowed values
+	obj := make(map[string]interface{})
+	
+	// Use shared function to consolidate allowed values
+	mergedValues := consolidateAllowedValues(d, checkRes, desiredAllowedValues)
+	obj["allowedValues"] = mergedValues
+	
+	// Perform the update
+	updateUrl := checkUrl
+	updateMask := "allowed_values"
+	updateUrl = fmt.Sprintf("%s?updateMask=%s", updateUrl, updateMask)
+	
+	log.Printf("[DEBUG] Managing system attribute values for '%s': %#v", attributeId, obj)
+	
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    updateUrl,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
+	if err != nil {
+		return fmt.Errorf("Error managing system attribute values for '%s': %s", attributeId, err)
+	}
+	
+	// Set the ID for the resource
+	id := fmt.Sprintf("projects/%s/locations/%s/attributes/%s", project, location, attributeId)
+	d.SetId(id)
+	
+	log.Printf("[DEBUG] Finished managing system attribute values for '%s': %#v", attributeId, res)
+	
+	return resourceApihubAttributeAllowedValuesRead(d, meta)

--- a/mmv1/templates/terraform/custom_delete/apihub_attribute_allowed_values.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/apihub_attribute_allowed_values.go.tmpl
@@ -1,0 +1,11 @@
+	// Delete is suppose to be an update to clear the allowed_values for the attribute
+	// However, the API does not allow empty allowed_values and there's no way to clear it without deleting the attribute.
+	// Potential improvement on API side to allow empty allowed_values so that empty attributes can be reset to initial state.
+	// `exclude_delete` can be set but creating this hook in case the suggested API change is implemented.
+	
+	// This resource performs a no-op for delete - the resource is simply removed from Terraform state
+	// userAgent is required by Magic Modules but not used since we're not making API calls
+	_ = userAgent
+	log.Printf("[DEBUG] System attribute values resource '%s' removed from Terraform state. System attributes continue to exist in API Hub.", d.Id())
+	d.SetId("")
+	return nil

--- a/mmv1/templates/terraform/custom_flatten/apihub_attribute_allowed_values_allowed_values.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/apihub_attribute_allowed_values_allowed_values.go.tmpl
@@ -1,0 +1,104 @@
+func flattenApihubAttributeAllowedValuesAllowedValues(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	
+	l := v.([]interface{})
+	if len(l) == 0 {
+		return l
+	}
+	
+	// Get configured values from user's Terraform config
+	rawConfigValue := d.Get("allowed_values")
+	configValue, _ := rawConfigValue.([]interface{})
+	
+	// Build a map of configured IDs for quick lookup
+	configuredIds := make(map[string]bool)
+	for _, v := range configValue {
+		if m, ok := v.(map[string]interface{}); ok {
+			if id, ok := m["id"].(string); ok {
+				configuredIds[id] = true
+			}
+		}
+	}
+	
+	// Filter values based on mutability and configuration
+	result := make([]interface{}, 0)
+	
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		
+		original := raw.(map[string]interface{})
+		
+		// Get the ID of this value
+		valueId := ""
+		if id, ok := original["id"].(string); ok {
+			valueId = id
+		}
+		
+		// Check if this value is immutable
+		isImmutable := false
+		if immutableVal, ok := original["immutable"]; ok {
+			if immutableBool, ok := immutableVal.(bool); ok && immutableBool {
+				isImmutable = true
+			}
+		}
+		
+		// Include value if:
+		// 1. It's mutable (always include mutable values), OR
+		// 2. It's immutable but configured by the user (to prevent diffs)
+		if !isImmutable || configuredIds[valueId] {
+			// Transform the value for state
+			transformed := make(map[string]interface{})
+			
+			if val, ok := original["id"]; ok {
+				transformed["id"] = val
+			}
+			if val, ok := original["displayName"]; ok {
+				transformed["display_name"] = val
+			}
+			if val, ok := original["description"]; ok {
+				transformed["description"] = val
+			}
+			// Don't include immutable field in state
+			
+			result = append(result, transformed)
+		}
+	}
+	
+	// Sort the result to match the order in user's configuration
+	// This prevents diffs from different ordering
+	if len(configValue) > 0 && len(result) > 0 {
+		// Convert to []map[string]interface{} for SortMapsByConfigOrder
+		configMaps := make([]map[string]interface{}, 0, len(configValue))
+		for _, v := range configValue {
+			if m, ok := v.(map[string]interface{}); ok {
+				configMaps = append(configMaps, m)
+			}
+		}
+		
+		resultMaps := make([]map[string]interface{}, 0, len(result))
+		for _, v := range result {
+			if m, ok := v.(map[string]interface{}); ok {
+				resultMaps = append(resultMaps, m)
+			}
+		}
+		
+		sortedMaps, err := tpgresource.SortMapsByConfigOrder(configMaps, resultMaps, "id")
+		if err != nil {
+			log.Printf("[DEBUG] Could not sort allowed values by config order: %s", err)
+			return result
+		}
+		
+		// Convert back to []interface{}
+		sortedResult := make([]interface{}, len(sortedMaps))
+		for i, m := range sortedMaps {
+			sortedResult[i] = m
+		}
+		return sortedResult
+	}
+	
+	return result
+}

--- a/mmv1/templates/terraform/examples/apihub_attribute_allowed_values_system_defined.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_allowed_values_system_defined.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_apihub_attribute_allowed_values" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  
+  # Manage allowed values for the system-defined attribute
+  # The resource automatically fetches existing values and preserves immutable ones
+  allowed_values {
+    id           = "dev"
+    display_name = "Development"
+    description  = "Development environment"
+  }
+  
+  allowed_values {
+    id           = "test"
+    display_name = "Testing"
+    description  = "Testing environment"
+  }
+  
+  allowed_values {
+    id           = "staging"
+    display_name = "Staging"
+    description  = "Staging environment"
+  }
+  
+  allowed_values {
+    id           = "prod"
+    display_name = "Production"
+    description  = "Production environment"
+  }
+}

--- a/mmv1/templates/terraform/examples/apihub_attribute_allowed_values_user_defined.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_allowed_values_user_defined.tf.tmpl
@@ -1,0 +1,23 @@
+resource "google_apihub_attribute_allowed_values" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  
+  # Manage allowed values for a user-defined attribute
+  allowed_values {
+    id           = "dev"
+    display_name = "Development"
+    description  = "Development environment"
+  }
+  
+  allowed_values {
+    id           = "test"
+    display_name = "Testing"
+    description  = "Testing environment"
+  }
+  
+  allowed_values {
+    id           = "prod"
+    display_name = "Production"
+    description  = "Production environment"
+  }
+}

--- a/mmv1/templates/terraform/examples/apihub_attribute_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_apihub_attribute" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  display_name = "Test Attribute"
+  scope        = "API"
+  data_type    = "STRING"
+}

--- a/mmv1/templates/terraform/examples/apihub_attribute_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_full.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_apihub_attribute" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  display_name = "Test Attribute Full"
+  description  = "A comprehensive test attribute with all fields"
+  scope        = "API"
+  data_type    = "ENUM"
+  cardinality  = 3
+  
+  allowed_values {
+    id           = "production"
+    display_name = "Production"
+    description  = "Production environment"
+  }
+  
+  allowed_values {
+    id           = "staging"
+    display_name = "Staging"
+    description  = "Staging environment"
+  }
+  
+  allowed_values {
+    id           = "development"
+    display_name = "Development"
+    description  = "Development environment"
+  }
+}

--- a/mmv1/templates/terraform/pre_create/apihub_attribute.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/apihub_attribute.go.tmpl
@@ -1,0 +1,27 @@
+// Check if the attribute already exists (system-defined attributes)
+// System-defined attributes cannot be created, only updated
+attributeId := d.Get("attribute_id").(string)
+location := d.Get("location").(string)
+proj := config.Project
+
+// Build the GET URL (without the attributeId query parameter)
+getUrl := fmt.Sprintf("https://apihub.googleapis.com/v1/projects/%s/locations/%s/attributes/%s", proj, location, attributeId)
+getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+	Timeout:   d.Timeout(schema.TimeoutRead),
+})
+if err == nil {
+	// Attribute exists, check if it's system-defined
+	if defType, ok := getRes["definitionType"].(string); ok && defType == "SYSTEM_DEFINED" {
+		return fmt.Errorf("Cannot create system-defined attribute '%s'. System-defined attributes are pre-configured and cannot be created through Terraform. To manage their allowed values, use `google_apihub_attribute_allowed_values` instead.", attributeId)
+	}
+	// If it's user-defined but already exists, return an error
+	return fmt.Errorf("Attribute '%s' already exists", attributeId)
+}
+// If we get a 404, the attribute doesn't exist and we can proceed with creation
+if !transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+	return fmt.Errorf("Error checking if attribute exists: %v", err)
+}

--- a/mmv1/templates/terraform/pre_update/apihub_attribute_allowed_values.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/apihub_attribute_allowed_values.go.tmpl
@@ -1,0 +1,46 @@
+// Get the current attribute to check its type and handle allowed_values properly
+// Remove the updateMask query parameter from the URL for GET request
+getUrl := url
+if idx := strings.Index(getUrl, "?"); idx != -1 {
+	getUrl = getUrl[:idx]
+}
+getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+	Timeout:   d.Timeout(schema.TimeoutRead),
+})
+if err != nil {
+	return fmt.Errorf("Error fetching system attribute for update: %v", err)
+}
+
+// Check data type - ENUM attributes require allowed_values
+dataType := ""
+if dt, ok := getRes["dataType"].(string); ok {
+	dataType = dt
+}
+
+// For ENUM attributes, allowed_values must always be included (even if empty)
+if dataType == "ENUM" {
+	// Get the desired allowed_values from Terraform config (may be nil/empty)
+	desiredAllowedValues := []interface{}{}
+	if av, ok := obj["allowedValues"]; ok && av != nil {
+		desiredAllowedValues = av.([]interface{})
+	}
+	
+	// Use shared function to consolidate allowed values
+	mergedValues := consolidateAllowedValues(d, getRes, desiredAllowedValues)
+	
+	// Always include allowed_values for ENUM attributes (even if empty)
+	// This ensures an empty array is sent when clearing all values
+	obj["allowedValues"] = mergedValues
+}
+
+// Only allowed_values should be updated for system attributes
+// Clear any other fields that might have been included
+for key := range obj {
+	if key != "allowedValues" {
+		delete(obj, key)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24372

- Add google_apihub_attribute resource
- Add a virtual resource google_apihub_attribute_allowed_values to manage allowed values only
- Customized create/update/delete behaviours to support CRUD for virtual resource google_apihub_attribute_allowed_values
- Tested locally as unit tests depend on API Hub instance provision

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_apihub_attribute`
```
```release-note:new-resource
`google_apihub_attribute_allowed_values`
```
