### PR TITLE
Make flex autotiering fields GA

### DIFF
--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -200,7 +200,6 @@ properties:
     description: |
       Total hot tier capacity for the Storage Pool. It is applicable only to Flex service level.
       It should be less than the minimum storage pool size and cannot be more than the current storage pool size. It cannot be decreased once set.
-    min_version: 'beta'
   - name: 'enableHotTierAutoResize'
     type: Boolean
     send_empty_value: true
@@ -208,7 +207,6 @@ properties:
     description: |
       Flag indicating that the hot-tier threshold will be auto-increased by 10% of the hot-tier when it hits 100%. Default is true.
       The increment will kick in only if the new size after increment is still less than or equal to storage pool size.
-    min_version: 'beta'
   - name: 'qosType'
     type: Enum
     description: |
@@ -223,4 +221,14 @@ properties:
     type: Double
     description: |
       Available throughput of the storage pool (in MiB/s).
+    output: true
+  - name: 'coldTierSizeUsedGib'
+    type: String
+    description: |
+      Total cold tier data rounded down to the nearest GiB used by the storage pool.
+    output: true
+  - name: 'hotTierSizeUsedGib'
+    type: String
+    description: |
+      Total hot tier data rounded down to the nearest GiB used by the storage pool.
     output: true

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -368,6 +368,11 @@ properties:
           description: |
               Protocol to mount with.
           output: true
+        - name: 'ipAddress'
+          type: String
+          description: |
+              IP Address.
+          output: true
   - name: 'snapshotPolicy'
     type: NestedObject
     description: |-
@@ -542,7 +547,6 @@ properties:
         description: |
           Optional. Flag indicating that the hot tier bypass mode is enabled. Default is false.
           Only applicable to Flex service level.
-        min_version: 'beta'
   - name: 'hybridReplicationParameters'
     type: NestedObject
     description: |-
@@ -586,3 +590,8 @@ properties:
     description: |
       Optional. Custom Performance Total Throughput of the pool (in MiB/s).
     default_from_api: true
+  - name: 'hotTierSizeUsedGib'
+    type: String
+    description: |
+      Total hot tier data rounded down to the nearest GiB used by the volume. This field is only used for flex Service Level
+    output: true

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_storage_pool_test.go
@@ -181,7 +181,6 @@ resource "google_netapp_storage_pool" "test_pool" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_update(t *testing.T) {
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-2", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
@@ -190,7 +189,7 @@ func TestAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_update(t *tes
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckNetappStoragePoolDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
@@ -229,14 +228,12 @@ func TestAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_update(t *tes
 }
 
 func testAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_full(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 data "google_compute_network" "default" {
-  provider = google-beta
   name = "%{network_name}"
 }
 
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-south1-a"
   service_level = "FLEX"
@@ -261,14 +258,12 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 
 func testAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_update(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 data "google_compute_network" "default" {
-  provider = google-beta
   name = "%{network_name}"
 }
 
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-south1-a"
   service_level = "FLEX"
@@ -293,14 +288,12 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 
 func testAccNetappStoragePool_flexAutoTierStoragePoolCreateExample_update_2(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 data "google_compute_network" "default" {
-  provider = google-beta
   name = "%{network_name}"
 }
 
 resource "google_netapp_storage_pool" "test_pool" {
-  provider = google-beta
   name = "tf-test-pool%{random_suffix}"
   location = "us-south1-a"
   service_level = "FLEX"
@@ -322,7 +315,6 @@ resource "google_netapp_storage_pool" "test_pool" {
 }
 `, context)
 }
-{{ end }}
 
 func TestAccNetappStoragePool_FlexRegionalStoragePoolCreateExample_update(t *testing.T) {
 	context := map[string]interface{}{

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_volume_test.go.tmpl
@@ -760,7 +760,6 @@ data "google_compute_network" "default" {
 `, context)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappVolume_flexAutoTierNetappVolume_update(t *testing.T) {
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
@@ -769,7 +768,7 @@ func TestAccNetappVolume_flexAutoTierNetappVolume_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckNetappVolumeDestroyProducer(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
@@ -800,7 +799,6 @@ func TestAccNetappVolume_flexAutoTierNetappVolume_update(t *testing.T) {
 func testAccNetappVolume_flexAutoTierVolume_default(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "default" {
-    provider = google-beta
     name = "tf-test-pool%{random_suffix}"
     location = "us-south1-a"
     service_level = "FLEX"
@@ -814,7 +812,6 @@ resource "google_netapp_storage_pool" "default" {
     enable_hot_tier_auto_resize = true
 }
 resource "google_netapp_volume" "test_volume" {
-    provider = google-beta
     location = "us-south1-a"
     name = "tf-test-volume%{random_suffix}"
     capacity_gib = "100"
@@ -828,7 +825,6 @@ resource "google_netapp_volume" "test_volume" {
     }
 }
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
@@ -837,7 +833,6 @@ data "google_compute_network" "default" {
 func testAccNetappVolume_flexAutoTierVolume_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_netapp_storage_pool" "default" {
-    provider = google-beta
     name = "tf-test-pool%{random_suffix}"
     location = "us-south1-a"
     service_level = "FLEX"
@@ -851,7 +846,6 @@ resource "google_netapp_storage_pool" "default" {
     enable_hot_tier_auto_resize = true
 }
 resource "google_netapp_volume" "test_volume" {
-    provider = google-beta
     location = "us-south1-a"
     name = "tf-test-volume%{random_suffix}"
     capacity_gib = "100"
@@ -865,12 +859,12 @@ resource "google_netapp_volume" "test_volume" {
     }
 }
 data "google_compute_network" "default" {
-    provider = google-beta
     name = "%{network_name}"
 }
 `, context)
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
 func TestAccNetappVolume_volumeExportPolicyWithSquashMode(t *testing.T) {
 	context := map[string]interface{}{
 		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),


### PR DESCRIPTION
```release-note:enhancement
netapp: promoted `hot_tier_size_gib`, `enable_hot_tier_auto_resize` fields of `google_netapp_storage_pool` resource to GA and added `cold_tier_size_used_gib` and `hot_tier_size_used_gib` fields to `google_netapp_storage_pool`
```
```release-note:enhancement
netapp: promoted `hot_tier_bypass_mode_enabled` field of `google_netapp_volume` resource to GA and added `hot_tier_size_used_gib` fields to `google_netapp_volume`
```