### PR TITLE
feat(netapp): BREAKING CHANGE - Change NetApp Volume peer_ip_addresses to array of strings

### DIFF
--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -566,8 +566,11 @@ properties:
           Required. Name of the user's local source vserver svm to be peered with the destination vserver svm.
       - name: 'peerIpAddresses'
         type: String
+        type: Array
         description: |
           Required. List of node ip addresses to be peered with.
+        item_type:
+          type: String
       - name: 'clusterLocation'
         type: String
         description: |


### PR DESCRIPTION
This PR introduces a **BREAKING CHANGE** to the `google_netapp_volume` resource.

*   **Resource:** `google_netapp_volume`
*   **Service:** NetApp
*   **Field:** `peer_ip_addresses`
*   **Change:** The field type is changed from `String` to `Array of Strings`.

**Reason for Change:**

The current `peer_ip_addresses` field is typed as a single `String`, but the underlying NetApp API expects and returns a list of IP addresses. This change corrects the field type to align with the API specification and expected usage, allowing users to specify multiple peer IP addresses.