### PR TITLE
apigee: added `deletion_protection` to `google_apigee_instance`

### DIFF
--- a/mmv1/products/apigee/Instance.yaml
+++ b/mmv1/products/apigee/Instance.yaml
@@ -44,6 +44,7 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/apigee_instance.go.tmpl'
   custom_import: 'templates/terraform/custom_import/apigee_instance.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/apigee_instance.go.tmpl'
 error_retry_predicates:
   - 'transport_tpg.IsApigeeRetryableError'
 exclude_sweeper: true
@@ -226,3 +227,9 @@ properties:
           The statusCode is the only expected/supported filter field. (Ex: statusCode)
           The filter will parse it to the Common Expression Language semantics for expression
           evaluation to build the filter condition. (Ex: "filter": statusCode >= 200 && statusCode < 300 )
+virtual_fields:
+  - name: 'deletionProtection'
+    type: Boolean
+    description: "Optional. If set to true deletion of the instance will fail."
+    # TODO: change to `true` in the next major release (8.0.0)
+    # default_value: true

--- a/mmv1/templates/terraform/pre_delete/apigee_instance.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/apigee_instance.go.tmpl
@@ -1,0 +1,3 @@
+if d.Get("deletion_protection").(bool) {
+  return fmt.Errorf("cannot destroy instance without setting deletion_protection=false and running `terraform apply`")
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/24422

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
apigee: added `deletion_protection` to `google_apigee_instance`
```

There was no `deletionProtection` field available in the API, so I figured a virtual field  in combination with a `pre_delete` hook seemed like a logical solution to me. Default value is `false` for now to prevent a breaking change.

I did some manual testing:

<details>

**Config used:**
```terraform
data "google_client_config" "current" {}

resource "google_compute_network" "apigee_network" {
  name = "apigee-network"
}

resource "google_compute_global_address" "apigee_range" {
  name          = "apigee-range"
  purpose       = "VPC_PEERING"
  address_type  = "INTERNAL"
  prefix_length = 16
  network       = google_compute_network.apigee_network.id
}

resource "google_service_networking_connection" "apigee_vpc_connection" {
  network                 = google_compute_network.apigee_network.id
  service                 = "servicenetworking.googleapis.com"
  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
}

resource "google_apigee_organization" "apigee_org" {
  analytics_region   = "us-central1"
  project_id         = data.google_client_config.current.project
  authorized_network = google_compute_network.apigee_network.id
  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
}

resource "google_apigee_instance" "apigee_instance" {
  name                = "my-instance-name"
  location            = "us-central1"
  org_id              = google_apigee_organization.apigee_org.id
  deletion_protection = true
}
```

(also did full apply/destroy cycle without `deletion_protection` set and that still works as intended)

Ran:

```

```
google_apigee_instance.apigee_instance: Destroying... [id=organizations/apigee-test-ramon/instances/my-instance-name]
╷
│ Error: cannot destroy instance without setting deletion_protection=false and running `terraform apply`
│
│
╵
```


</details>
