### PR TITLE
fix `google_bigquery_table` schema check with row_access_policy 

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -450,6 +450,11 @@ func resourceBigQueryTableSchemaCustomizeDiffFunc(d tpgresource.TerraformResourc
 			// same as above
 			log.Printf("[DEBUG] unable to unmarshal json customized diff - %v", err)
 		}
+
+		// no is schema changeable check needed, if new schema is old schema
+		if reflect.DeepEqual(old, new) {
+			return nil
+		}
 		_, isExternalTable := d.GetOk("external_data_configuration")
 		isChangeable, err := resourceBigQueryTableSchemaIsChangeable(old, new, isExternalTable, true, hasRowAccessPolicyFunc)
 		if err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/24414

A plan will also fail if `row_access_policy` is enabled and no change is done in the table's schema.
I believe func `resourceBigQueryTableSchemaIsChangeable` is not necessary to call, if there is no change at all.

**Release Note Template for Downstream PRs (will be copied)**


```release-note:bug
bigquery: fixed the issue where `google_bigquery_table` detected an incorrect `schema` diff on tables with row access policies when the schema was unchanged.
```
