### PR TITLE
fix the panic when the  list value is nil during tfplan2cai

### DIFF
--- a/mmv1/templates/terraform/expand_property_method.go.tmpl
+++ b/mmv1/templates/terraform/expand_property_method.go.tmpl
@@ -88,11 +88,9 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
   v = v.(*schema.Set).List()
       {{- end }}
       {{- if or $.NestedProperties (and ($.IsA "NestedObject") $.AllowEmptyObject) }}
-        {{- if hasPrefix $.ResourceMetadata.Compiler "terraformgoogleconversion"}}
-          if v == nil {
-            return nil, nil
-          }
-        {{- end }}
+  if v == nil {
+    return nil, nil
+  }
   l := v.([]interface{})
         {{- if $.IsA "Array" }}
   req := make([]interface{}, 0, len(l))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

One customer team gets the panic error when upgrading TGC to 6.49.0.

```
panic: interface conversion: interface {} is nil, not []interface {} [recovered]
        panic: interface conversion: interface {} is nil, not []interface {}

goroutine 63 [running]:
testing.tRunner.func1.2({0x44f2300, 0xc00102f3e0})
        /usr/lib/go-1.24/src/testing/testing.go:1734 +0x21c
testing.tRunner.func1()
        /usr/lib/go-1.24/src/testing/testing.go:1737 +0x35e
panic({0x44f2300?, 0xc00102f3e0?})
        /usr/lib/go-1.24/src/runtime/panic.go:792 +0x132
github.com/GoogleCloudPlatform/terraform-google-conversion/v6/tfplan2cai/converters/google/resources/services/compute.expandComputeNetworkParams({0x0?, 0x0?}, {0x4e96d04?, 0x25?}, 0xc000b97da0?)
        /usr/local/google/home/yngliu/go/pkg/mod/github.com/!google!cloud!platform/terraform-google-conversion/v6@v6.49.0/tfplan2cai/converters/google/resources/services/compute/compute_network.go:210 +0x2c6
github.com/GoogleCloudPlatform/terraform-google-conversion/v6/tfplan2cai/converters/google/resources/services/compute.GetComputeNetworkApiObject({0x5681f20, 0xc00102f2f0}, 0xc000fa2588)
        /usr/local/google/home/yngliu/go/pkg/mod/github.com/!google!cloud!platform/terraform-google-conversion/v6@v6.49.0/tfplan2cai/converters/google/resources/services/compute/compute_network.go:113 +0xd25
github.com/GoogleCloudPlatform/terraform-google-conversion/v6/tfplan2cai/converters/google/resources/services/compute.GetComputeNetworkCaiObject({0x5681f20, 0xc00102f2f0}, 0xc000fa2588)
        
```

After debugging and checking with their team, they are using an terraform provider version older than 6.49.0, which doesn't have `params` field in `google_compute_network` resource. The value of `d.Get("params")` is nil.

In our test, the provider has `params` field in `google_compute_network` resource. The value of `d.Get("params")` is empty []interface {}{}

Even the olde version of terraform provider is used, the panic should not occur.

This change is adding the nil check to the template `mmv1/templates/terraform/expand_property_method.go.tmpl` to avoid the panic.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
