### PR TITLE
tgc-revival: ignore tags and sensitive properties in tests

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -2202,6 +2202,11 @@ func (r Resource) TGCTestIgnorePropertiesToStrings(e resource.Examples) []string
 			props = append(props, google.Underscore(tp.Name))
 		} else if tp.IsMissingInCai {
 			props = append(props, tp.MetadataLineage())
+		} else if tp.IgnoreRead {
+			if tp.Sensitive || tp.Name == "tags" {
+				// TODO: handle tags conversion, which are separate Cai assets with resources.
+				props = append(props, tp.MetadataLineage())
+			}
 		}
 	}
 	props = append(props, e.TGCTestIgnoreExtra...)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Ignore sensitive properties and `tags` with `ignore_read: true` in tgc integration tests.

The current failed test in https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/ will be fixed.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
