### PR TITLE
update machine type in TestAccComputeRegionInstanceTemplate_AdvancedMachineFeatures

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -3646,7 +3646,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_instance_template" "foobar" {
   name         = "tf-test-instance-template-%s"
   region       = "us-central1"
-  machine_type = "c2-standard-2"
+  machine_type = "n2-standard-2"
 
   disk {
     source_image = data.google_compute_image.my_image.self_link


### PR DESCRIPTION
…achineFeatures

This will resolve issue `Invalid value for field 'resource.properties.machineType': 'c2-standard-2'. Instance properties must provide existing machine type., invalid`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
