### PR TITLE
Add SENSITIVITY_UNKNOWN enum value to actions.tag_resources.tag_conditions.sensitivity_score.score in DiscoveryConfig

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -256,6 +256,7 @@ properties:
                           - 'SENSITIVITY_LOW'
                           - 'SENSITIVITY_MODERATE'
                           - 'SENSITIVITY_HIGH'
+                          - 'SENSITIVITY_UNKNOWN'
             - name: 'profileGenerationsToTag'
               type: Array
               description: The profile generations for which the tag should be attached to resources. If you attach a tag to only new profiles, then if the sensitivity score of a profile subsequently changes, its tag doesn't change. By default, this field includes only new profiles. To include both new and updated profiles for tagging, this field should explicitly include both `PROFILE_GENERATION_NEW` and `PROFILE_GENERATION_UPDATE`.

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_test.go
@@ -621,7 +621,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 }
 
 resource "google_pubsub_topic" "basic" {
-	name = "test-topic"
+	name = "tf-test-topic-%{random_suffix}"
 }
 
 resource "google_project_iam_member" "tag_role" {
@@ -676,6 +676,14 @@ resource "google_data_loss_prevention_discovery_config" "basic" {
                     score = "SENSITIVITY_HIGH"
                 }
             }
+			tag_conditions {
+                tag {
+                    namespaced_value = "%{project}/tf_test_environment%{random_suffix}/tf_test_prod%{random_suffix}"
+                }
+                sensitivity_score {
+                    score = "SENSITIVITY_UNKNOWN"
+                }
+            }	
             profile_generations_to_tag = ["PROFILE_GENERATION_NEW", "PROFILE_GENERATION_UPDATE"]
             lower_data_risk_to_low = true
         }
@@ -705,7 +713,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 }
 
 resource "google_pubsub_topic" "basic" {
-	name = "test-topic"
+	name = "tf-test-topic-%{random_suffix}"
 }
 
 resource "google_data_loss_prevention_discovery_config" "basic" {


### PR DESCRIPTION
Also add test and add random suffix to some other test resources.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dlp: added `SENSITIVITY_UNKNOWN` as possible enum value for `actions.tag_resources.tag_conditions.sensitivity_score.score` in `google_data_loss_prevention_discovery_config` resource
```
