### PR TITLE
Add actions.save_findings.output_config.storage_path field to google_data_loss_prevention_job_trigger.

### DIFF
--- a/mmv1/products/dlp/JobTrigger.yaml
+++ b/mmv1/products/dlp/JobTrigger.yaml
@@ -729,7 +729,7 @@ properties:
                   send_empty_value: true
                   allow_empty_object: true
                   properties:
- # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#SurrogateType
+                    # Meant to be an empty object with no properties - see here : https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#SurrogateType
                     []
       - name: 'storageConfig'
         type: NestedObject
@@ -1085,7 +1085,6 @@ properties:
                       type: NestedObject
                       description: |
                         Information on the location of the target BigQuery Table.
-                      required: true
                       properties:
                         - name: 'projectId'
                           type: String
@@ -1102,6 +1101,22 @@ properties:
                           description: |
                             Name of the table. If is not set a new one will be generated for you with the following format:
                             `dlp_googleapis_yyyy_mm_dd_[dlp_job_id]`. Pacific timezone will be used for generating the date details.
+                    - name: 'storagePath'
+                      type: NestedObject
+                      description: |
+                        Store findings in an existing Cloud Storage bucket. Files will be generated with the job ID and file part number
+                        as the filename, and will contain findings in textproto format as SaveToGcsFindingsOutput. The file name will use
+                        the naming convention <job_id>-<shard_number>, for example: my-job-id-2.
+
+                        Supported for InspectJobs. The bucket must not be the same as the bucket being inspected. If storing findings to
+                        Cloud Storage, the output schema field should not be set. If set, it will be ignored.
+                      properties:
+                        - name: 'path'
+                          type: String
+                          description: |
+                            A URL representing a file or path (no wildcards) in Cloud Storage.
+                            Example: `gs://[BUCKET_NAME]/dictionary.txt`
+                          required: true
                     - name: 'outputSchema'
                       type: Enum
                       description: |

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_job_trigger_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_job_trigger_test.go
@@ -513,6 +513,41 @@ func TestAccDataLossPreventionJobTrigger_dlpJobTriggerCreateWithTimespanConfigBi
 	})
 }
 
+func TestAccDataLossPreventionJobTrigger_dlpJobTriggerSaveToCloudStorage(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project":       envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionJobTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionJobTrigger_inspectUpdateSaveToCloudStorage(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+			{
+				Config: testAccDataLossPreventionJobTrigger_inspectUpdateSaveToCloudStorageUpdate(context),
+			},
+			{
+				ResourceName:            "google_data_loss_prevention_job_trigger.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"parent"},
+			},
+		},
+	})
+}
+
 func testAccDataLossPreventionJobTrigger_dlpJobTriggerBasic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_data_loss_prevention_job_trigger" "basic" {
@@ -2821,6 +2856,80 @@ resource "google_data_loss_prevention_job_trigger" "bigquery_row_limit_timespan"
 						dataset_id = "output"
 					}
 				}
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_inspectUpdateSaveToCloudStorage(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					storage_path {
+						path = "gs://mybucket/save-path/"
+					}
+				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+				file_types = ["POWERPOINT", "EXCEL", "CSV", "TSV"]
+			}
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionJobTrigger_inspectUpdateSaveToCloudStorageUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_job_trigger" "basic" {
+	parent = "projects/%{project}"
+	description = "Starting description"
+	display_name = "display"
+
+	triggers {
+		schedule {
+			recurrence_period_duration = "86400s"
+		}
+	}
+
+	inspect_job {
+		inspect_template_name = "fake"
+		actions {
+			save_findings {
+				output_config {
+					storage_path {
+						path = "gs://mybucket/save-path-updated/"
+					}
+				}
+			}
+		}
+		storage_config {
+			cloud_storage_options {
+				file_set {
+					url = "gs://mybucket/directory/"
+				}
+				file_types = ["POWERPOINT", "EXCEL", "CSV", "TSV"]
 			}
 		}
 	}


### PR DESCRIPTION
Enables support for saving findings to Cloud Storage.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dlp: added `actions.save_findings.output_config.storage_path` field to `google_data_loss_prevention_job_trigger` resource
```
