### PR TITLE
tgc-revival: fix the mismatch for CAI asset types in convert_resource.go

### DIFF
--- a/mmv1/templates/tgc_next/cai2hcl/convert_resource.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/convert_resource.go.tmpl
@@ -42,7 +42,7 @@ func ConvertResource(asset caiasset.Asset) ([]*models.TerraformResourceBlock, er
 		switch asset.Type {
 {{- range $resourceType, $resources := $.ResourcesByCaiResourceType}}
 	{{- if gt (len $resources) 1 }}
-		case {{ $resourceType }}AssetType:
+		case "{{ $resourceType }}":
 		{{- range $i, $object := $resources }}
 			{{- if eq $i 0 }}
 			if strings.Contains(asset.Name, "{{$object.IdentityParam}}") {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The [tests](https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/) failed in TGC after the merging of [PR](https://github.com/GoogleCloudPlatform/magic-modules/pull/15234) .


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
