### PR TITLE
increased `google_lustre_instance` creation timeout

### DIFF
--- a/mmv1/products/lustre/Instance.yaml
+++ b/mmv1/products/lustre/Instance.yaml
@@ -26,6 +26,10 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/instances/{{instance_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/instances/{{instance_id}}
+timeouts:
+  insert_minutes: 40
+  update_minutes: 20
+  delete_minutes: 20
 sweeper:
   url_substitutions:
     - location: "us-central1-a"


### PR DESCRIPTION
Hopefully, this will fix the lustre instance creation timeout issue in TestAccLustreInstanceDatasource_basic

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
lustre: increased creation timeout from 20min to 40min for `google_lustre_instance` resource
```
