### PR TITLE
Remove TestAccContainerCluster_withIdentityServiceConfig

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -4315,57 +4315,6 @@ func TestAccContainerCluster_withWorkloadIdentityConfigAutopilot(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withIdentityServiceConfig(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	networkName := acctest.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := acctest.BootstrapSubnet(t, "gke-cluster", networkName)
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:     func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:        "google_container_cluster.primary",
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccContainerCluster_withIdentityServiceConfigEnabled(clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:        "google_container_cluster.primary",
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccContainerCluster_withIdentityServiceConfigUpdated(clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:        "google_container_cluster.primary",
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-			{
-				Config: testAccContainerCluster_basic(clusterName, networkName, subnetworkName),
-			},
-			{
-				ResourceName:        "google_container_cluster.primary",
-				ImportState:         true,
-				ImportStateVerify:   true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withSecretManagerConfig(t *testing.T) {
 	t.Parallel()
 
@@ -11763,38 +11712,6 @@ resource "google_container_cluster" "primary" {
   subnetwork    = "%s"
 }
 `, clusterName, gatewayApiChannel, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_withIdentityServiceConfigEnabled(name, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  identity_service_config {
-    enabled = true
-  }
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
-}
-`, name, networkName, subnetworkName)
-}
-
-func testAccContainerCluster_withIdentityServiceConfigUpdated(name, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "primary" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  identity_service_config {
-    enabled = false
-  }
-  deletion_protection = false
-  network    = "%s"
-  subnetwork    = "%s"
-}
-`, name, networkName, subnetworkName)
 }
 
 func testAccContainerCluster_withSecretManagerConfigEnabled(projectID, name, networkName, subnetworkName string) string {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24129. This is failing in nightly/VCR with:

```
Identity Service for GKE is no longer supported for new organizations. For OIDC support, please use Workforce Identity Federation. See https://cloud.google.com/iam/docs/workforce-identity-federation.
```

That seems unrecoverable for our test environment given we'd need to be allowlisted. The change apparently went through July 1 per https://cloud.google.com/kubernetes-engine/docs/how-to/oidc#external-idp-authentication-methods, but we started failing August 21 or 22.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
