### PR TITLE
Revert "`resourceIdentityGeneration`: use nil check instead of error when calling `identity()`"

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -722,7 +722,9 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     {{ $.CustomTemplate $.CustomCode.CustomIdentityRead true -}}
 {{- else }}
 	identity, err := d.Identity()
-    if err != nil && identity != nil {
+	if err != nil {
+		return fmt.Errorf("Error getting identity: %s", err)
+	}
     {{- range $p := $.IdentityProperties }}
     if v, ok := identity.GetOk("{{ underscore $p.Name}}"); ok && v != "" {
         err = identity.Set("{{ underscore $p.Name}}", d.Get("{{ underscore $p.Name}}").(string))
@@ -731,9 +733,6 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
             }     
     }
     {{- end }}
-    } else {
-        fmt.Printf("[DEBUG] identity not set: %s", err)
-    }
 {{- end }}
 {{  end -}}
     return nil

--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -26,8 +26,8 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 			return fmt.Errorf("Import is not supported. Invalid regex formats.")
 		}
 		identity, err := d.Identity()
-		if identity == nil {
-			fmt.Printf("[DEBUG] identity not set: %s", err)
+		if err != nil {
+			return err
 		}
 		if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
 			log.Printf("[DEBUG] matching ID %s to regex %s.", d.Id(), idFormat)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#15170