### PR TITLE
Revert "Add activity journal feature for google_storage_insights_dataset_config"

### DIFF
--- a/mmv1/products/storageinsights/DatasetConfig.yaml
+++ b/mmv1/products/storageinsights/DatasetConfig.yaml
@@ -119,10 +119,6 @@ properties:
     description: |
       Number of days of history that must be retained.
     required: true
-  - name: 'activityDataRetentionPeriodDays'
-    type: Integer
-    description: |
-      Number of days of activity data that must be retained. If not specified, retentionPeriodDays will be used. Set to 0 to turn off the activity data.
   - name: 'link'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/storage_insights_dataset_config_excludes.tf.tmpl
+++ b/mmv1/templates/terraform/examples/storage_insights_dataset_config_excludes.tf.tmpl
@@ -2,7 +2,6 @@ resource "google_storage_insights_dataset_config" "{{$.PrimaryResourceId}}" {
     location = "us-central1"
     dataset_config_id = "{{$.Vars.dataset_config_id}}"
     retention_period_days = 1
-    activity_data_retention_period_days = 2
     organization_scope = true
     identity {
         type = "IDENTITY_TYPE_PER_PROJECT"

--- a/mmv1/templates/terraform/pre_update/storage_insights_dataset_config.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/storage_insights_dataset_config.go.tmpl
@@ -8,10 +8,6 @@ if d.HasChange("retention_period_days") {
 	updateMask = append(updateMask, "retentionPeriodDays")
 }
 
-if d.HasChange("activity_data_retention_period_days") {
-	updateMask = append(updateMask, "activityDataRetentionPeriodDays")
-}
-
 if d.HasChange("description") {
 	updateMask = append(updateMask, "description")
 }

--- a/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_dataset_config_test.go
+++ b/mmv1/third_party/terraform/services/storageinsights/resource_storage_insights_dataset_config_test.go
@@ -220,7 +220,6 @@ resource "google_storage_insights_dataset_config" "config" {
   location = "us-central1"
   dataset_config_id = "tf_test_my_config%{random_suffix}"
   retention_period_days = 1
-  activity_data_retention_period_days = 2
   source_folders {
     folder_numbers = ["123", "456"]
   }
@@ -237,7 +236,6 @@ resource "google_storage_insights_dataset_config" "config" {
   location = "us-central1"
   dataset_config_id = "tf_test_my_config%{random_suffix}"
   retention_period_days = 1
-  activity_data_retention_period_days = 0
   organization_scope = true
   identity {
     type = "IDENTITY_TYPE_PER_CONFIG"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#15202

```release-note:breaking-change
storageinsights: removed `activity_data_retention_period_days` field from `google_storage_insights_dataset_config` resource due to a delayed launch. It will be readded when the feature launches.
```