### PR TITLE
Keep base yaml source file location when overrides are used

### DIFF
--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -266,6 +266,7 @@ func GenerateProduct(version, providerName, productName, outputPath string, prod
 				overrideResource := &api.Resource{}
 				api.Compile(overrideYamlPath, overrideResource, overrideDirectory)
 				api.Merge(reflect.ValueOf(resource), reflect.ValueOf(*overrideResource))
+				resource.SourceYamlFile = baseResourcePath
 			} else {
 				api.Compile(overrideYamlPath, resource, overrideDirectory)
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

See EAP Diff at https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/terraform-next/+/53490

TLDR: We were losing the path to the source yaml file when overrides were used, and it creates a nosier diff when we try to compare across providers.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
