### PR TITLE
`resourceIdentity`: change identity debug from `fmt->log`

### DIFF
--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -732,7 +732,7 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     }
     {{- end }}
     } else {
-        fmt.Printf("[DEBUG] identity not set: %s", err)
+        log.Printf("[DEBUG] identity not set: %s", err)
     }
 {{- end }}
 {{  end -}}

--- a/mmv1/third_party/terraform/tpgresource/import.go
+++ b/mmv1/third_party/terraform/tpgresource/import.go
@@ -27,7 +27,7 @@ func ParseImportId(idRegexes []string, d TerraformResourceData, config *transpor
 		}
 		identity, err := d.Identity()
 		if identity == nil {
-			fmt.Printf("[DEBUG] identity not set: %s", err)
+			log.Printf("[DEBUG] identity not set: %s", err)
 		}
 		if fieldValues := re.FindStringSubmatch(d.Id()); fieldValues != nil {
 			log.Printf("[DEBUG] matching ID %s to regex %s.", d.Id(), idFormat)


### PR DESCRIPTION
This change should resolve the VCR errors we see in recording

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
