### PR TITLE
feat(apihub): Add support for API Hub Attributes

### DIFF
--- a/mmv1/products/apihub/Attribute.yaml
+++ b/mmv1/products/apihub/Attribute.yaml
@@ -1,0 +1,174 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Attribute
+description: |-
+  An attribute in the API Hub. An attribute is a name value pair which can be attached to different
+  resources in the API hub based on the scope of the attribute. Attributes can either be pre-defined
+  by the API Hub or created by users.
+references:
+  guides:
+    "Create and manage API Hub attributes": "https://cloud.google.com/apigee/docs/api-hub/manage-attributes"
+  api: "https://cloud.google.com/apigee/docs/reference/apis/apihub/rest/v1/projects.locations.attributes"
+base_url: projects/{{project}}/locations/{{location}}/attributes
+self_link: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+create_url: projects/{{project}}/locations/{{location}}/attributes?attributeId={{attribute_id}}
+update_verb: "PATCH"
+update_mask: true
+id_format: projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/attributes/{{attribute_id}}
+custom_code:
+  pre_create: templates/terraform/pre_create/apihub_attribute.go.tmpl
+examples:
+  - name: apihub_attribute_basic
+    primary_resource_id: attribute
+    vars:
+      attribute_id: "test-attribute"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    test_vars_overrides:
+      "attribute_id": '"tf-test-attribute-" + acctest.RandString(t, 10)'
+    # Skip test as it requires API Hub instance to be created first
+    exclude_test: true
+  - name: apihub_attribute_full
+    primary_resource_id: attribute
+    vars:
+      attribute_id: "test-attribute-full"
+    test_env_vars:
+      project_id: PROJECT_NAME
+    test_vars_overrides:
+      "attribute_id": '"tf-test-attribute-full-" + acctest.RandString(t, 10)'
+    # Skip test as it requires API Hub instance to be created first
+    exclude_test: true
+parameters:
+  - name: location
+    type: String
+    description: |-
+      The location of the API Hub instance. This field is used to identify the
+      location of the API Hub instance in which to create the attribute.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: attributeId
+    type: String
+    description: |-
+      Optional. The ID to use for the attribute, which will become the final component
+      of the attribute's resource name. This field is optional.
+
+      * If provided, the same will be used. The service will throw an error if
+      the specified id is already used by another attribute resource in the API hub.
+      * If not provided, a system generated id will be used.
+
+      This value should be 4-500 characters, and valid characters are /[a-z][A-Z][0-9]-_/.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: |-
+      Identifier. The name of the attribute in the API Hub.
+      Format: projects/{project}/locations/{location}/attributes/{attribute}
+    output: true
+  - name: displayName
+    type: String
+    description: Required. The display name of the attribute.
+    required: true
+  - name: description
+    type: String
+    description: Optional. The description of the attribute.
+  - name: definitionType
+    type: Enum
+    description: Output only. The definition type of the attribute.
+    output: true
+    enum_values:
+      - "DEFINITION_TYPE_UNSPECIFIED"
+      - "SYSTEM_DEFINED"
+      - "USER_DEFINED"
+  - name: scope
+    type: Enum
+    description: |-
+      Required. The scope of the attribute. It represents the resource in the
+      API Hub to which the attribute can be linked.
+    required: true
+    enum_values:
+      - "SCOPE_UNSPECIFIED"
+      - "API"
+      - "VERSION"
+      - "SPEC"
+      - "API_OPERATION"
+      - "DEPLOYMENT"
+      - "DEPENDENCY"
+      - "DEFINITION"
+      - "EXTERNAL_API"
+      - "PLUGIN"
+  - name: dataType
+    type: Enum
+    description: Required. The type of the data of the attribute.
+    required: true
+    enum_values:
+      - "DATA_TYPE_UNSPECIFIED"
+      - "ENUM"
+      - "JSON"
+      - "STRING"
+      - "URI"
+  - name: allowedValues
+    type: Array
+    description: |-
+      Optional. The list of allowed values when the attribute value is of type enum.
+      This is required when the dataType of the attribute is ENUM. The maximum number
+      of allowed values of an attribute will be 1000.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: id
+          type: String
+          description: The ID of the allowed value.
+          required: true
+        - name: displayName
+          type: String
+          description: The display name of the allowed value.
+          required: true
+        - name: description
+          type: String
+          description: Optional. The description of the allowed value.
+        - name: immutable
+          type: Boolean
+          default_value: false
+          description: |-
+            Optional. When set to true, the allowed value cannot be updated or deleted
+            by the user. It can only be true for System defined attributes.
+  - name: cardinality
+    type: Integer
+    description: |-
+      Optional. The maximum number of values that the attribute can have when
+      associated with an API Hub resource. Cardinality 1 would represent a
+      single-valued attribute. It must not be less than 1 or greater than 20.
+      If not specified, the cardinality would be set to 1 by default and
+      represent a single-valued attribute.
+    default_from_api: true
+  - name: mandatory
+    type: Boolean
+    description: |-
+      Output only. When mandatory is true, the attribute is mandatory for the
+      resource specified in the scope. Only System defined attributes can be mandatory.
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. The time at which the attribute was created.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. The time at which the attribute was last updated.
+    output: true

--- a/mmv1/templates/terraform/examples/apihub_attribute_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_basic.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_apihub_attribute" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  display_name = "Test Attribute"
+  scope        = "API"
+  data_type    = "STRING"
+}

--- a/mmv1/templates/terraform/examples/apihub_attribute_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apihub_attribute_full.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_apihub_attribute" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  attribute_id = "{{index $.Vars "attribute_id"}}"
+  display_name = "Test Attribute Full"
+  description  = "A comprehensive test attribute with all fields"
+  scope        = "API"
+  data_type    = "ENUM"
+  cardinality  = 3
+  
+  allowed_values {
+    id           = "production"
+    display_name = "Production"
+    description  = "Production environment"
+  }
+  
+  allowed_values {
+    id           = "staging"
+    display_name = "Staging"
+    description  = "Staging environment"
+  }
+  
+  allowed_values {
+    id           = "development"
+    display_name = "Development"
+    description  = "Development environment"
+  }
+}

--- a/mmv1/templates/terraform/pre_create/apihub_attribute.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/apihub_attribute.go.tmpl
@@ -1,0 +1,27 @@
+// Check if the attribute already exists (system-defined attributes)
+// System-defined attributes cannot be created, only updated
+attributeId := d.Get("attribute_id").(string)
+location := d.Get("location").(string)
+proj := config.Project
+
+// Build the GET URL (without the attributeId query parameter)
+getUrl := fmt.Sprintf("https://apihub.googleapis.com/v1/projects/%s/locations/%s/attributes/%s", proj, location, attributeId)
+getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	RawURL:    getUrl,
+	UserAgent: userAgent,
+	Timeout:   d.Timeout(schema.TimeoutRead),
+})
+if err == nil {
+	// Attribute exists, check if it's system-defined
+	if defType, ok := getRes["definitionType"].(string); ok && defType == "SYSTEM_DEFINED" {
+		return fmt.Errorf("Cannot create system-defined attribute '%s'. System-defined attributes are pre-configured and cannot be created through Terraform. To manage their allowed values, use `google_apihub_attribute_allowed_values` instead.", attributeId)
+	}
+	// If it's user-defined but already exists, return an error
+	return fmt.Errorf("Attribute '%s' already exists", attributeId)
+}
+// If we get a 404, the attribute doesn't exist and we can proceed with creation
+if !transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+	return fmt.Errorf("Error checking if attribute exists: %v", err)
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24372
- Add google_apihub_attribute resource
- Add pre_create hook to stop creation for system-defined attributes earlier

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_apihub_attribute`
```
