### PR TITLE
feat(oracledatabase): `google_oracle_database_autonomous_database` `private_endpoint_ip` should be output

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -195,6 +195,7 @@ properties:
       - name: 'privateEndpointIp'
         type: String
         description: 'The private endpoint IP address for the Autonomous Database. '
+        output: true
         default_from_api: true
       - name: 'privateEndpointLabel'
         type: String


### PR DESCRIPTION
When creating an Oracle autonomous database via terraform, it's often needed to retrieve the endpoint IP so that it can later be used in additional resources. 

This change sets the `output` flag to `true` to enable this. 

```release-note:enhancement
oracledatabase: output `private_endpoint_ip ` field in `google_oracle_database_autonomous_database` resource
```


