### PR TITLE
`resourceIdentity`: remove productName character check

### DIFF
--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
@@ -102,15 +102,12 @@ func TestAcc{{ $e.TestSlug $.Res.ProductMetadata.Name $.Res.Name }}(t *testing.T
 			},
 	{{- end }}
 	{{- if eq $i 0 }}
-	{{- if lt (index $.Res.ProductMetadata.ApiName 0) 'a' }}
-
 			{
 				ResourceName:       "{{ $.Res.TerraformName }}.{{ $e.PrimaryResourceId }}",
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 				ImportStateKind:    resource.ImportBlockWithResourceIdentity,
 			},
-	{{- end }}
 	{{- end }}
 		},
 	})


### PR DESCRIPTION
originally we made the update to the test template in order to speed of the testing of VCR tests by separating it based on product name character. After running through them all in individual PRs we can now remove the conditional that prevents all the tests from being ran:

- https://github.com/GoogleCloudPlatform/magic-modules/pull/15074
- https://github.com/GoogleCloudPlatform/magic-modules/pull/15021
- https://github.com/GoogleCloudPlatform/magic-modules/pull/15020
- https://github.com/GoogleCloudPlatform/magic-modules/pull/15019

The original PR that introduced the test template with no operation can be found here:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/14993

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
