### PR TITLE
Modify override merging to ignore blocks with an incompatible version

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -282,9 +282,20 @@ func (p Product) Lineage() string {
 	return p.Name
 }
 
-func Merge(self, otherObj reflect.Value) {
-
+func Merge(self, otherObj reflect.Value, version string) {
 	selfObj := reflect.Indirect(self)
+
+	// Skip merge if otherObj targets a higher version than what is being generated
+	for i := 0; i < otherObj.NumField(); i++ {
+		if otherObj.Type().Field(i).Name == "MinVersion" {
+			for j := slices.Index(product.ORDER, version) + 1; j < len(product.ORDER); j++ {
+				if otherObj.Field(i).String() == product.ORDER[j] {
+					return
+				}
+			}
+		}
+	}
+
 	for i := 0; i < selfObj.NumField(); i++ {
 
 		// skip if the override is the "empty" value
@@ -295,14 +306,14 @@ func Merge(self, otherObj reflect.Value) {
 		}
 
 		if selfObj.Field(i).Kind() == reflect.Slice {
-			DeepMerge(selfObj.Field(i), otherObj.Field(i))
+			DeepMerge(selfObj.Field(i), otherObj.Field(i), version)
 		} else {
 			selfObj.Field(i).Set(otherObj.Field(i))
 		}
 	}
 }
 
-func DeepMerge(arr1, arr2 reflect.Value) {
+func DeepMerge(arr1, arr2 reflect.Value, version string) {
 	if arr1.Len() == 0 {
 		arr1.Set(arr2)
 		return
@@ -341,7 +352,7 @@ func DeepMerge(arr1, arr2 reflect.Value) {
 			}
 		}
 		if otherVal.IsValid() {
-			Merge(currentVal, otherVal)
+			Merge(currentVal, otherVal, version)
 		}
 	}
 

--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -195,7 +195,7 @@ func GenerateProduct(version, providerName, productName, outputPath string, prod
 			overrideApiProduct := &api.Product{}
 			api.Compile(productOverridePath, overrideApiProduct, overrideDirectory)
 
-			api.Merge(reflect.ValueOf(productApi), reflect.ValueOf(*overrideApiProduct))
+			api.Merge(reflect.ValueOf(productApi), reflect.ValueOf(*overrideApiProduct), version)
 		} else {
 			api.Compile(productOverridePath, productApi, overrideDirectory)
 		}
@@ -265,7 +265,7 @@ func GenerateProduct(version, providerName, productName, outputPath string, prod
 				api.Compile(baseResourcePath, resource, overrideDirectory)
 				overrideResource := &api.Resource{}
 				api.Compile(overrideYamlPath, overrideResource, overrideDirectory)
-				api.Merge(reflect.ValueOf(resource), reflect.ValueOf(*overrideResource))
+				api.Merge(reflect.ValueOf(resource), reflect.ValueOf(*overrideResource), version)
 				resource.SourceYamlFile = baseResourcePath
 			} else {
 				api.Compile(overrideYamlPath, resource, overrideDirectory)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This changes how the override merging works for mmv1 generation.

Previously, mmv1 yaml objects were (mostly) overridden naively, with the set of "override" fields essentially replacing the original set of fields. The problem with this is that overrides can then only change behavior through mmv1 mechanisms.

This PR changes the merge behavior to ignore (or prune) entire "override" objects if they target a version that is not compatible with the provider version being built. This allows overrides to exclude behavior with a higher degree of control by using `min_version` tags.

See https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/53590 for how this change impacts EAP (no diff).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
