### PR TITLE
Update org KAJ policy config tests to use target org

### DIFF
--- a/mmv1/products/kms/OrganizationKajPolicyConfig.yaml
+++ b/mmv1/products/kms/OrganizationKajPolicyConfig.yaml
@@ -55,7 +55,7 @@ examples:
     primary_resource_id: "example"
     min_version: 'beta'
     test_env_vars:
-      org_id: 'ORG_ID'
+      org_id: 'ORG_TARGET'
 parameters:
   - name: 'organization'
     type: String

--- a/mmv1/third_party/terraform/services/kms/resource_kms_organization_kaj_policy_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_organization_kaj_policy_config_test.go.tmpl
@@ -15,7 +15,7 @@ func TestAccKMSOrganizationKajPolicyConfig_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_id":        envvar.GetTestOrgTargetFromEnv(t),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -74,6 +74,9 @@ resource "google_kms_organization_kaj_policy_config" "example" {
 	provider 				= google-beta
 	organization 				= "%{org_id}"
 	default_key_access_justification_policy {
+		allowed_access_reasons = [
+			"CUSTOMER_INITIATED_ACCESS",
+		]
 	}
 }
 `, context)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
fixes https://github.com/hashicorp/terraform-provider-google/issues/24528
Use org2 for the OrganizationKajPolicyConfig tests introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/15219, so the tests in the primary org are not affected.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
