### PR TITLE
Add Observability TraceScope resource and tests

### DIFF
--- a/mmv1/products/observability/TraceScope.yaml
+++ b/mmv1/products/observability/TraceScope.yaml
@@ -1,0 +1,82 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: TraceScope
+min_version: 'beta'
+description: A trace scope is a collection of resources whose traces are queried together
+base_url: projects/{{project}}/locations/{{location}}/traceScopes
+update_mask: true
+self_link: projects/{{project}}/locations/{{location}}/traceScopes/{{trace_scope_id}}
+create_url: projects/{{project}}/locations/{{location}}/traceScopes?traceScopeId={{trace_scope_id}}
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/traceScopes/{{trace_scope_id}}
+import_format:
+- projects/{{project}}/locations/{{location}}/traceScopes/{{trace_scope_id}}
+examples:
+- name: observability_trace_scope_basic
+  primary_resource_id: observability_trace_scope
+  vars:
+    trace_scope_id: test-scope
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+parameters:
+- name: location
+  type: String
+  description: GCP region the TraceScope is stored in. Only `global` is supported.
+  immutable: true
+  url_param_only: true
+  required: true
+- name: traceScopeId
+  type: String
+  description: A client-assigned identifier for the trace scope.
+  immutable: true
+  url_param_only: true
+  required: true
+properties:
+- name: createTime
+  type: String
+  description: The creation timestamp of the trace scope.
+  output: true
+- name: description
+  type: String
+  description: |-
+    Describes this trace scope.
+
+    The maximum length of the description is 8000 characters.
+- name: name
+  type: String
+  description: |-
+    Identifier. The resource name of the trace scope.
+
+    For example:
+
+    projects/my-project/locations/global/traceScopes/my-trace-scope
+  output: true
+- name: resourceNames
+  type: Array
+  description: |-
+    Names of the projects that are included in this trace scope.
+
+    *  `projects/[PROJECT_ID]`
+
+    A trace scope can include a maximum of 20 projects.
+  required: true
+  item_type:
+    type: String
+- name: updateTime
+  type: String
+  description: The last update timestamp of the trace scope.
+  output: true

--- a/mmv1/products/observability/product.yaml
+++ b/mmv1/products/observability/product.yaml
@@ -1,0 +1,25 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Observability
+display_name: Observability
+scopes:
+- https://www.googleapis.com/auth/cloud-platform
+versions:
+- base_url: https://observability.googleapis.com/v1/
+  name: 'ga'
+- base_url: https://observability.googleapis.com/v1/
+  name: 'beta'
+caibaseurl: ""
+resourceswithcaiassettype: {}

--- a/mmv1/templates/terraform/examples/observability_trace_scope_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/observability_trace_scope_basic.tf.tmpl
@@ -1,0 +1,13 @@
+resource "google_observability_trace_scope" "{{$.PrimaryResourceId}}" {
+    provider         = google-beta
+    trace_scope_id   = "{{index $.Vars "trace_scope_id"}}"
+    location         = "global"
+    resource_names   = [
+        "projects/${data.google_project.project.project_id}",
+    ]
+    description      = "A trace scope configured with Terraform"
+}
+
+data "google_project" "project" {
+    provider         = google-beta
+}

--- a/mmv1/third_party/terraform/services/observability/resource_observability_trace_scope_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/observability/resource_observability_trace_scope_test.go.tmpl
@@ -1,0 +1,86 @@
+package observability_test
+
+import (
+{{ if ne $.TargetVersionName `ga` -}}
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+        "github.com/hashicorp/terraform-plugin-testing/plancheck"
+{{- end }}
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"testing"
+)
+
+func TestAccObservabilityTraceScope_update(t *testing.T) {
+{{ if ne $.TargetVersionName `ga` -}}
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObservabilityTraceScope_basic(context),
+			},
+			{
+				ResourceName:            "google_observability_trace_scope.observability_trace_scope",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "trace_scope_id"},
+			},
+			{
+				Config: testAccObservabilityTraceScope_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_observability_trace_scope.observability_trace_scope", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_observability_trace_scope.observability_trace_scope",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "trace_scope_id"},
+			},
+		},
+	})
+{{- end }}
+}
+
+func testAccObservabilityTraceScope_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_observability_trace_scope" "observability_trace_scope" {
+    provider         = google-beta
+    trace_scope_id   = "tf-test-test-scope%{random_suffix}"
+    location         = "global"
+    resource_names   = [
+        "projects/${data.google_project.project.project_id}",
+    ]
+    description      = "A trace scope configured with Terraform"
+}
+
+data "google_project" "project" {
+    provider         = google-beta
+}
+`, context)
+}
+
+func testAccObservabilityTraceScope_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_observability_trace_scope" "observability_trace_scope" {
+    provider         = google-beta
+    trace_scope_id   = "tf-test-test-scope%{random_suffix}"
+    location         = "global"
+    resource_names   = [
+        "projects/${data.google_project.project.project_id}",
+    ]
+    description      = "A new description"
+}
+
+data "google_project" "project" {
+    provider         = google-beta
+}
+`, context)
+}


### PR DESCRIPTION
Description: Adding a new Observability TraceScope terraform resource to terraform-provider-google-beta. Includes a basic create and basic update acceptance test.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_observability_trace_scope` (beta)
```
