### PR TITLE
Remove output_only restriction on OnPremVersion field

### DIFF
--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -298,4 +298,3 @@ properties:
     type: String
     description: |
       Anthos version for the node pool. Defaults to the user cluster version.
-    output: true

--- a/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gkeonprem_vmware_node_pool_full.tf.tmpl
@@ -3,7 +3,7 @@ resource "google_gkeonprem_vmware_cluster" "default-full" {
   location = "us-west1"
   admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
   description = "test cluster"
-  on_prem_version = "1.13.1-gke.35"
+  on_prem_version = "1.33.0-gke.35"
   network_config {
     service_address_cidr_blocks = ["10.96.0.0/12"]
     pod_address_cidr_blocks = ["192.168.0.0/16"]
@@ -40,6 +40,7 @@ resource "google_gkeonprem_vmware_node_pool" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "name"}}"
   location = "us-west1"
   vmware_cluster = google_gkeonprem_vmware_cluster.default-full.name
+  on_prem_version = "1.33.0-gke.35"
   annotations = {}
   config {
     cpus = 4

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
@@ -30,6 +31,11 @@ func TestAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(t *testing.T) {
 			},
 			{
 				Config: testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_gkeonprem_vmware_node_pool.nodepool", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:            "google_gkeonprem_vmware_node_pool.nodepool",

--- a/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go
+++ b/mmv1/third_party/terraform/services/gkeonprem/resource_gkeonprem_vmware_node_pool_test.go
@@ -49,7 +49,7 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
-    on_prem_version = "1.13.1-gke.35"
+    on_prem_version = "1.33.1-gke.35"
     annotations = {}
     network_config {
       service_address_cidr_blocks = ["10.96.0.0/12"]
@@ -89,6 +89,7 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdateStart(context map[string
     name = "tf-test-nodepool-%{random_suffix}"
     location = "us-west1"
     vmware_cluster = google_gkeonprem_vmware_cluster.cluster.name
+    on_prem_version = "1.33.1-gke.35"
     annotations = {
       env = "test"
     }
@@ -134,7 +135,7 @@ func testAccGkeonpremVmwareNodePool_vmwareNodePoolUpdate(context map[string]inte
     location = "us-west1"
     admin_cluster_membership = "projects/870316890899/locations/global/memberships/gkeonprem-terraform-test"
     description = "test cluster"
-    on_prem_version = "1.13.1-gke.35"
+    on_prem_version = "1.33.1-gke.35"
     annotations = {}
     network_config {
       service_address_cidr_blocks = ["10.96.0.0/12"]


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
gkeonprem: made it possible to set the `on_prem_version` field on `google_gkeonprem_vmware_node_pool` (previously output-only)
```
