### PR TITLE
Add the health-check-disabled field to Service resource

### DIFF
--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -340,6 +340,7 @@ properties:
                     See https://cloud.google.com/sdk/gcloud/reference/run/deploy#--vpc-egress.
                   - `run.googleapis.com/gpu-zonal-redundancy-disabled` sets
                     [GPU zonal redundancy](https://cloud.google.com/run/docs/configuring/services/gpu-zonal-redundancy) for the Revision.
+                  - `run.googleapis.com/health-check-disabled` disabled health checking containers during deployment.
                 default_from_api: true
                 diff_suppress_func: 'cloudrunTemplateAnnotationDiffSuppress'
               - name: 'name'

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -993,6 +993,9 @@ properties:
       - name: 'gpuZonalRedundancyDisabled'
         type: Boolean
         description: True if GPU zonal redundancy is disabled on this revision.
+      - name: 'healthCheckDisabled'
+        type: Boolean
+        description: Disables health checking containers during deployment.
   - name: 'traffic'
     type: Array
     description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -359,7 +359,6 @@ properties:
     type: Boolean
     description: |-
       Disables public resolution of the default URI of this service.
-    min_version: 'beta'
   - name: 'template'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/cloudrunv2_service_limits.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_limits.tf.tmpl
@@ -5,6 +5,7 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   ingress = "INGRESS_TRAFFIC_ALL"
 
   template {
+    health_check_disabled = true
     containers {
       image = "us-docker.pkg.dev/cloudrun/container/hello"
       resources {

--- a/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrun/resource_cloud_run_service_test.go.tmpl
@@ -1228,6 +1228,11 @@ resource "google_cloud_run_service" "default" {
   location = "us-central1"
 
   template {
+    metadata {
+      annotations = {
+        "run.googleapis.com/health-check-disabled": "true"
+      }
+    }
     spec {
       containers {
         image = "us-docker.pkg.dev/cloudrun/container/hello"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1143,9 +1143,6 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 
-
-{{ if ne $.TargetVersionName `ga` -}}
-
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithDefaultUriDisabled(t *testing.T) {
   t.Parallel()
   context := map[string]interface{} {
@@ -1209,8 +1206,6 @@ resource "google_cloud_run_v2_service" "default" {
 
 `, context)
 }
-
-{{ end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccCloudRunV2Service_cloudrunv2ServiceMeshUpdate(t *testing.T) {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1197,6 +1197,7 @@ resource "google_cloud_run_v2_service" "default" {
   }
   default_uri_disabled = true
   template {
+    health_check_disabled = true
     containers {
       name = "container-1"
       image = "us-docker.pkg.dev/cloudrun/container/hello"

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1163,7 +1163,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceWithDefaultUriDisabled(t *testing
         ResourceName: "google_cloud_run_v2_service.default",
         ImportState: true,
         ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "deletion_protection"},
       },
       {
         Config: testAccCloudRunV2Service_cloudrunv2ServiceWithNoMinInstances(context),
@@ -1172,7 +1172,7 @@ func TestAccCloudRunV2Service_cloudrunv2ServiceWithDefaultUriDisabled(t *testing
         ResourceName: "google_cloud_run_v2_service.default",
         ImportState: true,
         ImportStateVerify: true,
-        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "deletion_protection"},
       },
 
     }, 
@@ -1186,7 +1186,6 @@ resource "google_cloud_run_v2_service" "default" {
   description = "description creating"
   location = "us-central1"
   deletion_protection = false
-  launch_stage = "BETA"
   annotations = {
     generated-by = "magic-modules"
   }
@@ -1205,11 +1204,6 @@ resource "google_cloud_run_v2_service" "default" {
       name = "container-1"
       image = "us-docker.pkg.dev/cloudrun/container/hello"
     }
-  }
-  lifecycle {
-    ignore_changes = [
-      launch_stage,
-    ]
   }
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrun: added `run.googleapis.com/health-check-disabled` annotation to `google_cloud_run_service` resource test and examples.

cloudrunv2: added `health-check-disabled` field to `google_cloud_run_v2_service` resource.
```
