### PR TITLE
Add sweeper that covers org-scope resources for dlp.

### DIFF
--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_sweeper.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_discovery_config_sweeper.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/sweeper"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -12,6 +13,7 @@ import (
 
 func init() {
 	sweeper.AddTestSweepersLegacy("DataLossPreventionDiscoveryConfig", testSweepDataLossPreventionDiscoveryConfig)
+	sweeper.AddTestSweepersLegacy("DataLossPreventionDiscoveryConfigOrgScope", testSweepDataLossPreventionDiscoveryConfigOrgScope)
 }
 
 // At the time of writing, the CI only passes us-central1 as the region
@@ -93,6 +95,100 @@ func testSweepDataLossPreventionDiscoveryConfig(region string) error {
 			Config:    config,
 			Method:    "DELETE",
 			Project:   config.Project,
+			RawURL:    deleteUrl,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+	return nil
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepDataLossPreventionDiscoveryConfigOrgScope(region string) error {
+	resourceName := "DataLossPreventionDiscoveryConfig"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for org-scope %s", resourceName)
+
+	config, err := sweeper.SharedConfigForRegion(region)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	err = config.LoadAndValidate(context.Background())
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	// Setup variables to replace in list template
+	testOrg := envvar.GetTestOrgFromEnv(nil)
+	if testOrg == "" {
+		log.Printf("test org not set for test environment, skip sweep")
+		return nil
+	}
+	d := &tpgresource.ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"org":      testOrg,
+			"region":   region,
+			"location": region,
+			"zone":     "-",
+		},
+	}
+
+	listTemplate := strings.Split("https://dlp.googleapis.com/v2/organizations/{{org}}/locations/{{location}}/discoveryConfigs", "?")[0]
+	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    listUrl,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["discoveryConfigs"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["name"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		// Note that we do not check for a sweepable prefix here.
+		// We can have at most 1 DiscoveryConfig for a storage type in the same project/location, so ensure we delete everything.
+		name := tpgresource.GetResourceNameFromSelfLink(obj["name"].(string))
+
+		deleteTemplate := "https://dlp.googleapis.com/v2/organizations/{{org}}/locations/{{location}}/discoveryConfigs/{{name}}"
+		deleteUrl, err := tpgresource.ReplaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
 			RawURL:    deleteUrl,
 			UserAgent: config.UserAgent,
 		})


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR:

- Adds a new sweeper to remove DiscoveryConfigs that are org-scope. Previously, we added a custom sweeper but this only covered project-scope DiscoveryConfigs. 
- Was tested locally
  - Created org-scope discovery config (https://screenshot.googleplex.com/UsVta6L4MzqGk25)
  - Ran sweepers locally (https://paste.googleplex.com/4906054144098304)
  - Confirmed discovery config was deleted (https://screenshot.googleplex.com/7xNgdHLukfjnE73)
  
  
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
