### PR TITLE
compute: resolve permadiff for `display_name` in `google_compute_organization_security_policy`

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -61,6 +61,7 @@ properties:
       User-provided name of the organization security policy. The name should be unique in the organization in which the security policy is created. This should only be used when SecurityPolicyType is FIREWALL.
     min_version: 'beta'
     immutable: true
+    diff_suppress_func: 'tpgresource.EmptyStringOrNilDiffSuppress'
   - name: 'description'
     type: String
     description: |

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress.go
@@ -22,6 +22,11 @@ func EmptyOrFalseSuppressBoolean(k, old, new string, d *schema.ResourceData) boo
 	return (o == nil && !n.(bool))
 }
 
+func EmptyStringOrNilDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(k)
+	return (o == nil || o == "") && (n != nil && n != "")
+}
+
 func CaseDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.ToUpper(old) == strings.ToUpper(new)
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/24412

Was able to reproduce the permadiff via the config provided in the issue. Added a general function because I think this logic can be reused, in fact I already re-use the same logic in my other PR https://github.com/GoogleCloudPlatform/magic-modules/pull/15254. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: resolve permadiff for `display_name` in `google_compute_organization_security_policy`
```

Manual tests (no diff with new build, while having a reproduced diff with latest provider version):

<details>

```console
~/projects/personal/terraform_test_suite                                                                                         v3.13.2 (ae-adh-dbt) 󱇶 rituals took 24s
❯ TF_CLI_CONFIG_FILE="$(pwd)/tf-dev-override.tfrc" terraform apply

╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/google in /Users/ramon/go/bin
│  - hashicorp/google-beta in /Users/ramon/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
google_folder.folder_24412: Refreshing state... [id=folders/360679475693]
google_compute_organization_security_policy.c_org_sec_policy_24412: Refreshing state... [id=locations/global/securityPolicies/978663178349]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

~/projects/personal/terraform_test_suite                                                                                          v3.13.2 (ae-adh-dbt) 󱇶 rituals took 3s
➜ terraform apply
google_folder.folder_24412: Refreshing state... [id=folders/360679475693]
google_compute_organization_security_policy.c_org_sec_policy_24412: Refreshing state... [id=locations/global/securityPolicies/978663178349]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # google_compute_organization_security_policy.c_org_sec_policy_24412 must be replaced
-/+ resource "google_compute_organization_security_policy" "c_org_sec_policy_24412" {
      + display_name = "c-org-sec-policy-24412" # forces replacement
      ~ fingerprint  = "MfWEetyNlRo=" -> (known after apply)
      ~ id           = "locations/global/securityPolicies/978663178349" -> (known after apply)
      ~ policy_id    = "978663178349" -> (known after apply)
        # (4 unchanged attributes hidden)
    }

```

</details>
