### PR TITLE
Add data source for Network Management Connectivity Tests

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl
@@ -301,6 +301,7 @@ var handwrittenDatasources = map[string]*schema.Resource{
 	"google_vmwareengine_vcenter_credentials":          vmwareengine.DataSourceVmwareengineVcenterCredentials(),
 	"google_compute_region_backend_service":            compute.DataSourceGoogleComputeRegionBackendService(),
 	"google_network_management_connectivity_test_run":  networkmanagement.DataSourceGoogleNetworkManagementTestRun(),
+	"google_network_management_connectivity_tests":  	networkmanagement.DataSourceGoogleNetworkManagementConnectivityTests(),
 	// ####### END handwritten datasources ###########
 }
 

--- a/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_tests.go
+++ b/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_tests.go
@@ -1,0 +1,164 @@
+package networkmanagement
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleNetworkManagementConnectivityTests() *schema.Resource {
+	testSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceNetworkManagementConnectivityTest().Schema)
+	return &schema.Resource{
+		Read: dataSourceGoogleNetworkManagementConnectivityTests,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"filter": {
+				Type:        schema.TypeString,
+				Description: `Lists the ConnectivityTests that match the filter expression. A filter expression filters the resources listed in the response.`,
+				Optional:    true,
+			},
+			"connectivity_tests": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: testSchema,
+				},
+			},
+		},
+		UseJSONNumber: true,
+	}
+}
+
+func dataSourceGoogleNetworkManagementConnectivityTests(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{NetworkManagementBasePath}}projects/{{project}}/locations/global/connectivityTests")
+	if err != nil {
+		return err
+	}
+
+	filter, has_filter := d.GetOk("filter")
+
+	if has_filter {
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
+		if err != nil {
+			return err
+		}
+	}
+
+	billingProject := ""
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for Connectivity Tests: %s", err)
+	}
+	billingProject = project
+
+	// err == nil indicates that the billing_project value was found
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	// To handle pagination locally
+	allTests := make([]interface{}, 0)
+	token := ""
+	for paginate := true; paginate; {
+		if token != "" {
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"pageToken": token})
+			if err != nil {
+				return err
+			}
+		}
+		tests, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("NetworkManagementConnectivityTests %q", d.Id()))
+		}
+		testsInterface := tests["resources"]
+		if testsInterface == nil {
+			break
+		}
+		allTests = append(allTests, testsInterface.([]interface{})...)
+		tokenInterface := tests["nextPageToken"]
+		if tokenInterface == nil {
+			paginate = false
+		} else {
+			paginate = true
+			token = tokenInterface.(string)
+		}
+	}
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %s", err)
+	}
+
+	if err := d.Set("filter", filter); err != nil {
+		return fmt.Errorf("error setting filter: %s", err)
+	}
+
+	if err := d.Set("connectivity_tests", flattenNetworkManagementConnectivityTests(allTests, d, config)); err != nil {
+		return fmt.Errorf("error setting connectivity tests: %s", err)
+	}
+
+	// Store the ID now
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/global/connectivityTests")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	if has_filter {
+		id += "/filter=" + filter.(string)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func flattenNetworkManagementConnectivityTests(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"name":                   flattenNetworkManagementConnectivityTestName(original["name"], d, config),
+			"description":            flattenNetworkManagementConnectivityTestDescription(original["description"], d, config),
+			"source":                 flattenNetworkManagementConnectivityTestSource(original["source"], d, config),
+			"destination":            flattenNetworkManagementConnectivityTestDestination(original["destination"], d, config),
+			"protocol":               flattenNetworkManagementConnectivityTestProtocol(original["protocol"], d, config),
+			"related_projects":       flattenNetworkManagementConnectivityTestRelatedProjects(original["relatedProjects"], d, config),
+			"labels":                 flattenNetworkManagementConnectivityTestLabels(original["labels"], d, config),
+			"round_trip":             flattenNetworkManagementConnectivityTestRoundTrip(original["roundTrip"], d, config),
+			"bypass_firewall_checks": flattenNetworkManagementConnectivityTestBypassFirewallChecks(original["bypassFirewallChecks"], d, config),
+			"terraform_labels":       flattenNetworkManagementConnectivityTestTerraformLabels(original["labels"], d, config),
+			"effective_labels":       flattenNetworkManagementConnectivityTestEffectiveLabels(original["labels"], d, config),
+			"project":                getDataFromName(original["name"], 1),
+		})
+	}
+	return transformed
+}
+
+func getDataFromName(v interface{}, part int) string {
+	name := v.(string)
+	split := strings.Split(name, "/")
+	return split[part]
+}

--- a/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_tests_test.go
+++ b/mmv1/third_party/terraform/services/networkmanagement/data_source_network_management_connectivity_tests_test.go
@@ -1,0 +1,266 @@
+package networkmanagement_test
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccNetworkManagementConnectivityTests_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkManagementConnectivityTestDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkManagementConnectivityTests_withoutFilter(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkListDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_network_management_connectivity_tests.conn-tests",
+						"google_network_management_connectivity_test.conn-test-1",
+						map[string]struct{}{
+							"id":                 {},
+							"project":            {},
+							"terraform_labels.%": {},
+							"terraform_labels.goog-terraform-provisioned": {},
+						},
+					),
+				),
+			},
+			{
+				Config: testAccNetworkManagementConnectivityTests_withFilter(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkListDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_network_management_connectivity_tests.conn-tests",
+						"google_network_management_connectivity_test.conn-test-2",
+						map[string]struct{}{
+							"id":                 {},
+							"project":            {},
+							"terraform_labels.%": {},
+							"terraform_labels.goog-terraform-provisioned": {},
+						},
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkManagementConnectivityTests_withoutFilter(context map[string]interface{}) string {
+	connTestCfg := acctest.Nprintf(`
+data "google_network_management_connectivity_tests" "conn-tests" {
+  depends_on = [
+  	google_network_management_connectivity_test.conn-test-1,
+  	google_network_management_connectivity_test.conn-test-2
+  ]
+}
+
+
+`, context)
+	return fmt.Sprintf("%s\n\n%s\n\n", connTestCfg, testAccNetworkManagementConnectivityTests_baseResources(context))
+}
+
+func testAccNetworkManagementConnectivityTests_withFilter(context map[string]interface{}) string {
+	connTestCfg := acctest.Nprintf(`
+data "google_network_management_connectivity_tests" "conn-tests" {
+  filter = "description:%{random_suffix}"
+  depends_on = [
+  	google_network_management_connectivity_test.conn-test-1,
+  	google_network_management_connectivity_test.conn-test-2
+  ]
+}
+
+
+`, context)
+	return fmt.Sprintf("%s\n\n%s\n\n", connTestCfg, testAccNetworkManagementConnectivityTests_baseResources(context))
+}
+
+func testAccNetworkManagementConnectivityTests_baseResources(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_network_management_connectivity_test" "conn-test-1" {
+  name = "tf-test-conntest%{random_suffix}"
+  source {
+      ip_address = google_compute_address.source-addr.address
+      project_id = google_compute_address.source-addr.project
+      network = google_compute_network.vpc.id
+      network_type = "GCP_NETWORK"
+  }
+
+  destination {
+      ip_address = google_compute_address.dest-addr.address
+      project_id = google_compute_address.dest-addr.project
+      network = google_compute_network.vpc.id
+  }
+
+  protocol = "UDP"
+}
+
+resource "google_network_management_connectivity_test" "conn-test-2" {
+  name        = "tf-test-conntest-swap%{random_suffix}"
+  description = "%{random_suffix}"
+  source {
+      ip_address = google_compute_address.dest-addr.address
+      project_id = google_compute_address.dest-addr.project
+      network = google_compute_network.vpc.id
+      network_type = "GCP_NETWORK"
+  }
+
+  destination {
+      ip_address = google_compute_address.source-addr.address
+      project_id = google_compute_address.source-addr.project
+      network = google_compute_network.vpc.id
+  }
+
+  protocol = "TCP"
+}
+
+resource "google_compute_network" "vpc" {
+  name = "connectivity-vpc%{random_suffix}"
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "connectivity-vpc-subnet%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.vpc.id
+}
+
+resource "google_compute_address" "source-addr" {
+  name         = "src-addr%{random_suffix}"
+  subnetwork   = google_compute_subnetwork.subnet.id
+  address_type = "INTERNAL"
+  address      = "10.0.42.42"
+  region       = "us-central1"
+}
+
+resource "google_compute_address" "dest-addr" {
+  name         = "dest-addr%{random_suffix}"
+  subnetwork   = google_compute_subnetwork.subnet.id
+  address_type = "INTERNAL"
+  address      = "10.0.43.43"
+  region       = "us-central1"
+}`, context)
+}
+
+func checkListDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourceName string, ignoreFields map[string]struct{}) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", dataSourceName)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName)
+		}
+
+		dsAttr := ds.Primary.Attributes
+		rsAttr := rs.Primary.Attributes
+
+		err := checkFieldsMatchForDataSourceStateAndResourceState(dsAttr, rsAttr, ignoreFields)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func checkFieldsMatchForDataSourceStateAndResourceState(dsAttr, rsAttr map[string]string, ignoreFields map[string]struct{}) error {
+	totalTests, err := strconv.Atoi(dsAttr["connectivity_tests.#"])
+	if err != nil {
+		return errors.New("Couldn't convert length of connectivity_tests list to integer")
+	}
+	index := "-1"
+	for i := 0; i < totalTests; i++ {
+		if dsAttr["connectivity_tests."+strconv.Itoa(i)+".name"] == rsAttr["name"] {
+			index = strconv.Itoa(i)
+			break
+		}
+	}
+
+	if index == "-1" {
+		return fmt.Errorf("The newly created connectivity test (%s) is not found in the data source", rsAttr["name"])
+	}
+
+	errMsg := ""
+	// Data sources are often derived from resources, so iterate over the resource fields to
+	// make sure all fields are accounted for in the data source.
+	// If a field exists in the data source but not in the resource, its expected value should
+	// be checked separately.
+	for k := range rsAttr {
+		if _, ok := ignoreFields[k]; ok {
+			continue
+		}
+		if k == "%" {
+			continue
+		}
+		if dsAttr["connectivity_tests."+index+"."+k] != rsAttr[k] {
+			// ignore data sources where an empty list is being compared against a null list.
+			if k[len(k)-1:] == "#" && (dsAttr["connectivity_tests."+index+"."+k] == "" || dsAttr["connectivity_tests."+index+"."+k] == "0") && (rsAttr[k] == "" || rsAttr[k] == "0") {
+				continue
+			}
+			errMsg += fmt.Sprintf("%s is %s; want %s\n", k, dsAttr["connectivity_tests."+index+"."+k], rsAttr[k])
+		}
+	}
+
+	if errMsg != "" {
+		return errors.New(errMsg)
+	}
+
+	return nil
+}
+
+// This function checks state match for resourceName and asserts the absence of resourceName2 in data source
+func checkListDataSourceStateMatchesResourceStateWithIgnoresForAppliedFilter(dataSourceName, resourceName, resourceName2 string, ignoreFields map[string]struct{}) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", dataSourceName)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName)
+		}
+
+		rs2, ok := s.RootModule().Resources[resourceName2]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName2)
+		}
+
+		dsAttr := ds.Primary.Attributes
+		rsAttr := rs.Primary.Attributes
+		rsAttr2 := rs2.Primary.Attributes
+
+		err := checkFieldsMatchForDataSourceStateAndResourceState(dsAttr, rsAttr, ignoreFields)
+		if err != nil {
+			return err
+		}
+		err = checkResourceAbsentInDataSourceAfterFilterApplied(dsAttr, rsAttr2)
+		return err
+	}
+}
+
+func checkResourceAbsentInDataSourceAfterFilterApplied(dsAttr, rsAttr map[string]string) error {
+	totalTests, err := strconv.Atoi(dsAttr["connectivity_tests.#"])
+	if err != nil {
+		return errors.New("Couldn't convert length of connectivity tests list to integer")
+	}
+	for i := 0; i < totalTests; i++ {
+		if dsAttr["connectivity_tests."+strconv.Itoa(i)+".name"] == rsAttr["name"] {
+			return errors.New("The resource is present in the data source even after the filter is applied")
+		}
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/website/docs/d/network_management_connectivity_tests.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/network_management_connectivity_tests.html.markdown
@@ -1,0 +1,165 @@
+---
+subcategory: "Network Management"
+description: |-
+  A connectivity test is a static analysis of your resource configurations
+  that enables you to evaluate connectivity to and from Google Cloud
+  resources in your Virtual Private Cloud (VPC) network.
+---
+
+# google_network_management_connectivity_tests
+
+A connectivity test is a static analysis of your resource configurations
+that enables you to evaluate connectivity to and from Google Cloud
+resources in your Virtual Private Cloud (VPC) network. This data source allows
+you to list connectivity tests in a project.
+
+To get more information about connectivity tests, see:
+
+* [API documentation](https://cloud.google.com/network-intelligence-center/docs/reference/networkmanagement/rest/v1/projects.locations.global.connectivityTests/rerun)
+* How-to Guides
+    * [Official Documentation](https://cloud.google.com/network-intelligence-center/docs)
+
+## Example Usage
+
+```hcl
+data "google_network_management_connectivity_tests" "tests" {
+  filter = "name:my-tests"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Optional) The ID of the project.
+
+* `filter` - (Optional) Lists the ConnectivityTests that match the [filter expression](https://cloud.google.com/network-intelligence-center/docs/reference/networkmanagement/rest/v1/projects.locations.global.connectivityTests/list#query-parameters). A filter expression filters the resources listed in the response.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `connectivity_tests` - A list of connectivity tests in the selected project matching the filter. Structure is [defined below](#nested_connectivity_tests).
+
+<a name="nested_connectivity_tests"></a>The `connectivity_tests` block supports:
+
+* `name` -
+  Unique name for the connectivity test.
+
+* `source` -
+  Source specification of the Connectivity Test.
+  Structure is [documented below](#nested_source).
+
+* `destination` -
+  Destination specification of the Connectivity Test.
+  Structure is [documented below](#nested_destination).
+
+* `description` -
+  The user-supplied description of the Connectivity Test.
+
+* `protocol` -
+  IP Protocol of the test. 
+
+* `related_projects` -
+  Other projects that may be relevant for reachability analysis.
+
+* `labels` -
+  Resource labels to represent user-provided metadata.
+
+* `round_trip` -
+  Whether run analysis for the return path from destination to source.
+
+* `bypass_firewall_checks` -
+  Whether the analysis should skip firewall checking. 
+
+* `project` - The ID of the project in which the resource belongs.
+
+<a name="nested_source"></a>The `source` block supports:
+
+* `ip_address` -
+  The IP address of the endpoint.
+
+* `port` -
+  The IP protocol port of the endpoint. 
+
+* `instance` -
+  A Compute Engine instance URI.
+
+* `gke_master_cluster` -
+  A cluster URI for Google Kubernetes Engine cluster control plane.
+
+* `cloud_sql_instance` -
+  A Cloud SQL instance URI.
+
+* `cloud_function` -
+  A Cloud Function.
+  Structure is [documented below](#nested_source_cloud_function).
+
+* `app_engine_version` -
+  An App Engine service version.
+  Structure is [documented below](#nested_source_app_engine_version).
+
+* `cloud_run_revision` -
+  A Cloud Run revision.
+  Structure is [documented below](#nested_source_cloud_run_revision).
+
+* `network` -
+  A VPC network URI.
+
+* `network_type` -
+  Type of the network where the endpoint is located.
+
+* `project_id` -
+  Project ID where the endpoint is located.
+
+<a name="nested_source_cloud_function"></a>The `cloud_function` block supports:
+
+* `uri` -
+  A Cloud Function name.
+
+<a name="nested_source_app_engine_version"></a>The `app_engine_version` block supports:
+
+* `uri` -
+  An App Engine service version name.
+
+<a name="nested_source_cloud_run_revision"></a>The `cloud_run_revision` block supports:
+
+* `uri` -
+  A Cloud Run revision URI.
+
+<a name="nested_destination"></a>The `destination` block supports:
+
+* `ip_address` -
+  The IP address of the endpoint.
+
+* `port` -
+  The IP protocol port of the endpoint.
+
+* `instance` -
+  A Compute Engine instance URI.
+
+* `forwarding_rule` -
+  Forwarding rule URI. Forwarding rules are frontends for load balancers,
+  PSC endpoints, and Protocol Forwarding.
+
+* `gke_master_cluster` -
+  A cluster URI for Google Kubernetes Engine cluster control plane.
+
+* `fqdn` -
+  A DNS endpoint of Google Kubernetes Engine cluster control plane.
+
+* `cloud_sql_instance` -
+  A Cloud SQL instance URI.
+
+* `redis_instance` -
+  A Redis Instance URI.
+
+* `redis_cluster` -
+  A Redis Cluster URI.
+
+* `network` -
+  A VPC network URI.
+
+* `project_id` -
+  Project ID where the endpoint is located.
+

--- a/mmv1/third_party/terraform/website/docs/d/network_management_connectivity_tests.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/network_management_connectivity_tests.html.markdown
@@ -23,7 +23,7 @@ To get more information about connectivity tests, see:
 
 ```hcl
 data "google_network_management_connectivity_tests" "tests" {
-  filter = "name:my-tests"
+  filter = "name:projects/project-id/locations/global/connectivityTests/my-tests"
 }
 ```
 


### PR DESCRIPTION
Add data source for listing connectivity tests.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_network_management_connectivity_tests`
```
