### PR TITLE
Acceptance test for vmware engine network, networkpeering, networkpol…

### DIFF
--- a/mmv1/products/vmwareengine/Network.yaml
+++ b/mmv1/products/vmwareengine/Network.yaml
@@ -152,3 +152,11 @@ properties:
       Checksum that may be sent on update and delete requests to ensure that the user-provided value is up to date befor
       The server computes checksums based on the value of other fields in the request.
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/vmwareengine/NetworkPeering.yaml
+++ b/mmv1/products/vmwareengine/NetworkPeering.yaml
@@ -164,3 +164,11 @@ properties:
       The canonical name of the VMware Engine network in the form:
       projects/{project_number}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
     output: true
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/vmwareengine/NetworkPolicy.yaml
+++ b/mmv1/products/vmwareengine/NetworkPolicy.yaml
@@ -175,3 +175,11 @@ properties:
           - 'UNPROVISIONED'
           - 'RECONCILING'
           - 'ACTIVE'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -434,3 +434,11 @@ properties:
       - 'STANDARD'
       - 'TIME_LIMITED'
       - 'STRETCHED'
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_peering_test.go
@@ -2,11 +2,16 @@ package vmwareengine_test
 
 import (
 	"os"
+	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"strings"
 )
 
 func TestAccVmwareengineNetworkPeering_update(t *testing.T) {
@@ -84,3 +89,174 @@ data "google_vmwareengine_network_peering" "ds" {
 }
 `, context)
 }
+
+func TestAccVmwareengineNetworkPeering_tags(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "vennp-tagkey", map[string]interface{}{})
+	tagValue := acctest.BootstrapSharedTestOrganizationTagValue(t, "vennp-tagvalue", tagKey)
+
+	venSuffix1 := acctest.RandString(t, 10)
+	venSuffix2 := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           org,
+		"tagKey":        tagKey,
+		"tagValue":      tagValue,
+		"ven_suffix1":   venSuffix1,
+		"ven_suffix2":   venSuffix2,
+		"ven_name1":     "tf-test-ven-" + venSuffix1,
+		"ven_name2":     "tf-test-ven-" + venSuffix2,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineNetworkPeeringDestroyProducer(t), // Assuming this exists
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVmwareengineNetworkPeeringTags(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_vmwareengine_network_peering.default", "tags.%"),
+					testAccCheckVmwareengineNetworkPeeringHasTagBindings(t),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_network_peering.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "vmware_engine_network", "peer_network", "tags"},
+			},
+		},
+	})
+}
+
+func testAccVmwareengineNetworkPeeringTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "ven1" {
+  name        = "%{ven_name1}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "Terraform test network 1 for peering"
+}
+
+resource "google_vmwareengine_network" "ven2" {
+  name        = "%{ven_name2}"
+  location    = "global"
+  type        = "STANDARD"
+  description = "Terraform test network 2 for peering"
+}
+
+resource "google_vmwareengine_network_peering" "default" {
+  name                  = "tf-test-ven-peering-%{random_suffix}"
+  vmware_engine_network = google_vmwareengine_network.ven1.id
+  peer_network          = google_vmwareengine_network.ven2.id
+  peer_network_type     = "VMWARE_ENGINE_NETWORK"
+  # description = "Optional description"
+
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
+}
+`, context)
+}
+
+func testAccCheckVmwareengineNetworkPeeringHasTagBindings(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_vmwareengine_network_peering" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			// 1. Get the configured tag key and value from the state.
+			var configuredTagValueNamespacedName string
+			for key, val := range rs.Primary.Attributes {
+				if strings.HasPrefix(key, "tags.") && key != "tags.#" {
+					tagKeyNamespacedName := strings.TrimPrefix(key, "tags.")
+					tagValueShortName := val
+					if tagValueShortName != "" {
+						configuredTagValueNamespacedName = fmt.Sprintf("%s/%s", tagKeyNamespacedName, tagValueShortName)
+						break
+					}
+				}
+			}
+
+			if configuredTagValueNamespacedName == "" {
+				return fmt.Errorf("could not find a configured tag value in the state for resource %s", rs.Primary.ID)
+			}
+			if strings.Contains(configuredTagValueNamespacedName, "%{") {
+				return fmt.Errorf("tag namespaced name contains unsubstituted variables: %q", configuredTagValueNamespacedName)
+			}
+
+			// 2. Describe the tag value to get its full resource name.
+			safeNamespacedName := url.QueryEscape(configuredTagValueNamespacedName)
+			describeTagValueURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagValues/namespaced?name=%s", safeNamespacedName)
+
+			respDescribe, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    describeTagValueURL,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("error describing tag value %q: %v", configuredTagValueNamespacedName, err)
+			}
+			fullTagValueName, ok := respDescribe["name"].(string)
+			if !ok || fullTagValueName == "" {
+				return fmt.Errorf("tag value name not found for %q: %v", configuredTagValueNamespacedName, respDescribe)
+			}
+
+			// 3. Get the tag bindings from the VMware Engine Network Peering.
+			// ID format: projects/{project}/locations/{location}/networkPeerings/{networkPeeringId}
+			// Network Peerings are global for Vmware Engine
+			parentURL := fmt.Sprintf("//vmwareengine.googleapis.com/%s", rs.Primary.ID)
+			listBindingsURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
+
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    listBindingsURL,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("error calling TagBindings API for %s: %v", parentURL, err)
+			}
+
+			tagBindingsVal, exists := resp["tagBindings"]
+			if !exists {
+				tagBindingsVal = []interface{}{}
+			}
+			tagBindings, ok := tagBindingsVal.([]interface{})
+			if !ok {
+				return fmt.Errorf("'tagBindings' is not a slice for %s: %v", rs.Primary.ID, resp)
+			}
+
+			// 4. Perform the comparison.
+			foundMatch := false
+			for _, binding := range tagBindings {
+				bindingMap, ok := binding.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if bindingMap["tagValue"] == fullTagValueName {
+					foundMatch = true
+					break
+				}
+			}
+
+			if !foundMatch {
+				return fmt.Errorf("expected tag value %s (from %q) not found in bindings for %s. Bindings: %v", fullTagValueName, configuredTagValueNamespacedName, rs.Primary.ID, tagBindings)
+			}
+			t.Logf("Successfully found matching tag binding for %s with tagValue %s", rs.Primary.ID, fullTagValueName)
+		}
+		return nil
+	}
+}
+

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_policy_test.go
@@ -2,12 +2,17 @@ package vmwareengine_test
 
 import (
 	"os"
+	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"strings"
 )
 
 func TestAccVmwareengineNetworkPolicy_update(t *testing.T) {
@@ -90,4 +95,186 @@ data "google_vmwareengine_network_policy" "ds" {
   location = "%{region}"
 }
 `, context)
+}
+
+func TestAccVmwareengineNetworkPolicy_tags(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "venp-tagkey", map[string]interface{}{})
+	tagValue := acctest.BootstrapSharedTestOrganizationTagValue(t, "venp-tagvalue", tagKey)
+	// Network Policies are regional. We need a VmwareEngineNetwork to associate with.
+	// Assuming a VEN test setup function or a pre-existing one.
+	venContext := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"location":      "global",
+	}
+	venConfig := testAccVmwareengineNetworkBasic(venContext) // Example helper for VEN
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org":           org,
+		"tagKey":        tagKey,
+		"tagValue":      tagValue,
+		"region":        "me-west1",
+		"ven_name":      "tf-test-ven-" + venContext["random_suffix"].(string),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVmwareengineNetworkPolicyDestroyProducer(t), // Assuming this exists
+		Steps: []resource.TestStep{
+			{
+				Config: venConfig + testAccVmwareengineNetworkPolicyTags(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_vmwareengine_network_policy.default", "tags.%"),
+					testAccCheckVmwareengineNetworkPolicyHasTagBindings(t),
+				),
+			},
+			{
+				ResourceName:            "google_vmwareengine_network_policy.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "location", "vmware_engine_network", "tags"},
+			},
+		},
+	})
+}
+
+// Example basic VEN config helper
+func testAccVmwareengineNetworkBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network" "ven" {
+  name        = "tf-test-ven-%{random_suffix}"
+  location    = "%{location}"
+  type        = "STANDARD"
+  description = "Terraform test network for policy"
+}
+`, context)
+}
+
+func testAccVmwareengineNetworkPolicyTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vmwareengine_network_policy" "default" {
+  name        = "tf-test-ven-policy-%{random_suffix}"
+  location    = "%{region}"
+  vmware_engine_network = google_vmwareengine_network.ven.id
+  edge_services_cidr  = "192.168.1.0/26"  # Required: Provide a valid, non-overlapping CIDR range
+
+  internet_access {
+    enabled = true
+  }
+  external_ip {
+    enabled = true
+  }
+
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
+}
+`, context)
+}
+
+func testAccCheckVmwareengineNetworkPolicyHasTagBindings(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_vmwareengine_network_policy" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+
+			// 1. Get the configured tag key and value from the state.
+			var configuredTagValueNamespacedName string
+			for key, val := range rs.Primary.Attributes {
+				if strings.HasPrefix(key, "tags.") && key != "tags.#" {
+					tagKeyNamespacedName := strings.TrimPrefix(key, "tags.")
+					tagValueShortName := val
+					if tagValueShortName != "" {
+						configuredTagValueNamespacedName = fmt.Sprintf("%s/%s", tagKeyNamespacedName, tagValueShortName)
+						break
+					}
+				}
+			}
+
+			if configuredTagValueNamespacedName == "" {
+				return fmt.Errorf("could not find a configured tag value in the state for resource %s", rs.Primary.ID)
+			}
+			if strings.Contains(configuredTagValueNamespacedName, "%{") {
+				return fmt.Errorf("tag namespaced name contains unsubstituted variables: %q", configuredTagValueNamespacedName)
+			}
+
+			// 2. Describe the tag value to get its full resource name.
+			safeNamespacedName := url.QueryEscape(configuredTagValueNamespacedName)
+			describeTagValueURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagValues/namespaced?name=%s", safeNamespacedName)
+
+			respDescribe, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    describeTagValueURL,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("error describing tag value %q: %v", configuredTagValueNamespacedName, err)
+			}
+			fullTagValueName, ok := respDescribe["name"].(string)
+			if !ok || fullTagValueName == "" {
+				return fmt.Errorf("tag value name not found for %q: %v", configuredTagValueNamespacedName, respDescribe)
+			}
+
+			// 3. Get the tag bindings from the VMware Engine Network Policy.
+			// ID format: projects/{project}/locations/{location}/networkPolicies/{networkPolicyId}
+			parts := strings.Split(rs.Primary.ID, "/")
+			if len(parts) != 6 {
+				return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
+			}
+			location := parts[3] // This will be a region
+
+			parentURL := fmt.Sprintf("//vmwareengine.googleapis.com/%s", rs.Primary.ID)
+			// Network Policy is regional, so TagBindings API is always regional.
+			listBindingsURL := fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", location, url.QueryEscape(parentURL))
+
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    listBindingsURL,
+				UserAgent: config.UserAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("error calling TagBindings API for %s: %v", parentURL, err)
+			}
+
+			tagBindingsVal, exists := resp["tagBindings"]
+			if !exists {
+				tagBindingsVal = []interface{}{}
+			}
+			tagBindings, ok := tagBindingsVal.([]interface{})
+			if !ok {
+				return fmt.Errorf("'tagBindings' is not a slice for %s: %v", rs.Primary.ID, resp)
+			}
+
+			// 4. Perform the comparison.
+			foundMatch := false
+			for _, binding := range tagBindings {
+				bindingMap, ok := binding.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if bindingMap["tagValue"] == fullTagValueName {
+					foundMatch = true
+					break
+				}
+			}
+
+			if !foundMatch {
+				return fmt.Errorf("expected tag value %s (from %q) not found in bindings for %s. Bindings: %v", fullTagValueName, configuredTagValueNamespacedName, rs.Primary.ID, tagBindings)
+			}
+			t.Logf("Successfully found matching tag binding for %s with tagValue %s", rs.Primary.ID, fullTagValueName)
+		}
+		return nil
+	}
 }

--- a/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
+++ b/mmv1/third_party/terraform/services/vmwareengine/resource_vmwareengine_network_test.go
@@ -2,11 +2,16 @@ package vmwareengine_test
 
 import (
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"strings"
 )
 
 func TestAccVmwareengineNetwork_vmwareEngineNetworkUpdate(t *testing.T) {
@@ -82,4 +87,170 @@ resource "time_sleep" "wait_60_seconds" {
   create_duration = "60s"
 }
 `, context)
+}
+
+func TestAccVmwareengineNetwork_tags(t *testing.T) {
+    t.Parallel()
+
+    org := envvar.GetTestOrgFromEnv(t)
+    tagKey := acctest.BootstrapSharedTestOrganizationTagKey(t, "ven-tagkey", map[string]interface{}{})
+    tagValue := acctest.BootstrapSharedTestOrganizationTagValue(t, "ven-tagvalue", tagKey)
+
+    context := map[string]interface{}{
+        "random_suffix": acctest.RandString(t, 10),
+        "org":           org,
+        "tagKey":        tagKey,
+        "tagValue":      tagValue,
+        "location":      "global", // Or a specific region if testing regional VEN
+    }
+
+    acctest.VcrTest(t, resource.TestCase{
+        PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+        CheckDestroy:             testAccCheckVmwareengineNetworkDestroyProducer(t),
+        Steps: []resource.TestStep{
+            {
+                Config: testAccVmwareengineNetworkTags(context),
+                Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttrSet("google_vmwareengine_network.default", "tags.%"),
+                    testAccCheckVmwareengineNetworkHasTagBindings(t),
+                ),
+            },
+            {
+                ResourceName:            "google_vmwareengine_network.default",
+                ImportState:             true,
+                ImportStateVerify:       true,
+                ImportStateVerifyIgnore: []string{"name", "location", "tags"}, // terraform_labels may not apply
+            },
+        },
+    })
+}
+
+func testAccVmwareengineNetworkTags(context map[string]interface{}) string {
+    return acctest.Nprintf(`
+resource "google_vmwareengine_network" "default" {
+  name        = "tf-test-ven-%{random_suffix}"
+  location    = "%{location}"
+  type        = "STANDARD"
+  description = "Terraform test network with tags"
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
+}
+`, context)
+}
+
+func testAccCheckVmwareengineNetworkHasTagBindings(t *testing.T) func(s *terraform.State) error {
+    return func(s *terraform.State) error {
+        for name, rs := range s.RootModule().Resources {
+            if rs.Type != "google_vmwareengine_network" {
+                continue
+            }
+            if strings.HasPrefix(name, "data.") {
+                continue
+            }
+
+            config := acctest.GoogleProviderConfig(t)
+
+            // 1. Get the configured tag key and value from the state.
+            var configuredTagValueNamespacedName string
+            var tagKeyNamespacedName, tagValueShortName string
+            for key, val := range rs.Primary.Attributes {
+                if strings.HasPrefix(key, "tags.") && key != "tags.#" {
+                    tagKeyNamespacedName = strings.TrimPrefix(key, "tags.")
+                    tagValueShortName = val
+                    if tagValueShortName != "" {
+                        configuredTagValueNamespacedName = fmt.Sprintf("%s/%s", tagKeyNamespacedName, tagValueShortName)
+                        break
+                    }
+                }
+            }
+
+            if configuredTagValueNamespacedName == "" {
+                return fmt.Errorf("could not find a configured tag value in the state for resource %s", rs.Primary.ID)
+            }
+             if strings.Contains(configuredTagValueNamespacedName, "%{") {
+                return fmt.Errorf("tag namespaced name contains unsubstituted variables: %q", configuredTagValueNamespacedName)
+            }
+
+            // 2. Describe the tag value to get its full resource name.
+            safeNamespacedName := url.QueryEscape(configuredTagValueNamespacedName)
+            describeTagValueURL := fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagValues/namespaced?name=%s", safeNamespacedName)
+
+            respDescribe, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+                Config:    config,
+                Method:    "GET",
+                RawURL:    describeTagValueURL,
+                UserAgent: config.UserAgent,
+            })
+
+            if err != nil {
+                return fmt.Errorf("error describing tag value using namespaced name %q: %v", configuredTagValueNamespacedName, err)
+            }
+
+            fullTagValueName, ok := respDescribe["name"].(string)
+            if !ok || fullTagValueName == "" {
+                return fmt.Errorf("tag value details (name) not found in response for namespaced name: %q, response: %v", configuredTagValueNamespacedName, respDescribe)
+            }
+
+            // 3. Get the tag bindings from the VMware Engine Network.
+            // ID format: projects/{project}/locations/{location}/vmwareEngineNetworks/{vmwareEngineNetworkId}
+            parts := strings.Split(rs.Primary.ID, "/")
+            if len(parts) != 6 {
+                return fmt.Errorf("invalid resource ID format: %s", rs.Primary.ID)
+            }
+            location := parts[3]
+
+            parentURL := fmt.Sprintf("//vmwareengine.googleapis.com/%s", rs.Primary.ID)
+
+            var listBindingsURL string
+            if location == "global" {
+                listBindingsURL = fmt.Sprintf("https://cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", url.QueryEscape(parentURL))
+            } else {
+                listBindingsURL = fmt.Sprintf("https://%s-cloudresourcemanager.googleapis.com/v3/tagBindings?parent=%s", location, url.QueryEscape(parentURL))
+            }
+
+            resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+                Config:    config,
+                Method:    "GET",
+                RawURL:    listBindingsURL,
+                UserAgent: config.UserAgent,
+            })
+
+            if err != nil {
+                return fmt.Errorf("error calling TagBindings API for %s: %v", parentURL, err)
+            }
+
+            tagBindingsVal, exists := resp["tagBindings"]
+            if !exists {
+                tagBindingsVal = []interface{}{}
+            }
+
+            tagBindings, ok := tagBindingsVal.([]interface{})
+            if !ok {
+                return fmt.Errorf("'tagBindings' is not a slice in response for resource %s. Response: %v", rs.Primary.ID, resp)
+            }
+
+            // 4. Perform the comparison.
+            foundMatch := false
+            for _, binding := range tagBindings {
+                bindingMap, ok := binding.(map[string]interface{})
+                if !ok {
+                    continue
+                }
+                if bindingMap["tagValue"] == fullTagValueName {
+                    foundMatch = true
+                    break
+                }
+            }
+
+            if !foundMatch {
+                return fmt.Errorf("expected tag value %s (from namespaced %q) not found in tag bindings for resource %s. Bindings: %v", fullTagValueName, configuredTagValueNamespacedName, rs.Primary.ID, tagBindings)
+            }
+
+            t.Logf("Successfully found matching tag binding for %s with tagValue %s", rs.Primary.ID, fullTagValueName)
+        }
+
+        return nil
+    }
 }


### PR DESCRIPTION
…icy, privatecloud

```release-note:enhancement
vmwareengine: added `tags` field to the `google_vmwareengine_network`, `google_vmwareengine_network_peering`, `google_vmwareengine_network_policy`, and `google_vmwareengine_private_cloud` resources
```
