### PR TITLE
dataproc: support `accelerators` in `preemptible_worker_config`

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -1308,6 +1308,13 @@ func ResourceDataprocCluster() *schema.Resource {
 											},
 										},
 									},
+									"accelerators": {
+										Type:        schema.TypeSet,
+										Optional:    true,
+										ForceNew:    true,
+										Elem:        acceleratorsSchema(),
+										Description: `The Compute Engine accelerator configuration for these instances.`,
+									},
 								},
 							},
 						},
@@ -2597,6 +2604,9 @@ func expandPreemptibleInstanceGroupConfig(cfg map[string]interface{}) *dataproc.
 	if p, ok := cfg["preemptibility"]; ok {
 		icg.Preemptibility = p.(string)
 	}
+	if ac, ok := cfg["accelerators"]; ok {
+		icg.Accelerators = expandAccelerators(ac.(*schema.Set).List())
+	}
 	return icg
 }
 
@@ -3425,6 +3435,9 @@ func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc
 			if icg.InstanceFlexibilityPolicy.ProvisioningModelMix != nil {
 				instanceFlexibilityPolicy["provisioning_model_mix"] = flattenProvisioningModelMix(icg.InstanceFlexibilityPolicy.ProvisioningModelMix)
 			}
+		}
+		if len(icg.Accelerators) > 0 {
+			data["accelerators"] = flattenAccelerators(icg.Accelerators)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -165,7 +165,7 @@ func TestAccDataprocCluster_withAccelerators(t *testing.T) {
 				Config: testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.accelerated_cluster", &cluster),
-					testAccCheckDataprocClusterAccelerator(&cluster, project, 1, 1),
+					testAccCheckDataprocClusterAccelerator(&cluster, project, 1, 1, 1),
 					resource.TestCheckResourceAttr("google_dataproc_cluster.accelerated_cluster", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "false"),
 				),
 			},
@@ -191,7 +191,7 @@ func testAccCheckDataprocAuxiliaryNodeGroupAccelerator(cluster *dataproc.Cluster
 	}
 }
 
-func testAccCheckDataprocClusterAccelerator(cluster *dataproc.Cluster, project string, masterCount int, workerCount int) resource.TestCheckFunc {
+func testAccCheckDataprocClusterAccelerator(cluster *dataproc.Cluster, project string, masterCount, workerCount, secondaryWorkerCount int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		expectedUri := fmt.Sprintf("projects/%s/zones/.*/acceleratorTypes/nvidia-tesla-t4", project)
 		r := regexp.MustCompile(expectedUri)
@@ -222,6 +222,20 @@ func testAccCheckDataprocClusterAccelerator(cluster *dataproc.Cluster, project s
 		matches = r.FindStringSubmatch(worker[0].AcceleratorTypeUri)
 		if len(matches) != 1 {
 			return fmt.Errorf("Saw %s worker accelerator type instead of %s", worker[0].AcceleratorTypeUri, expectedUri)
+		}
+
+		secondaryWorkerConfig := cluster.Config.SecondaryWorkerConfig.Accelerators
+		if len(secondaryWorkerConfig) != 0 {
+			return fmt.Errorf("Saw %d secondary worker accelerator types instead of 0", len(secondaryWorkerConfig))
+		}
+
+		if int(secondaryWorkerConfig[0].AcceleratorCount) != secondaryWorkerCount {
+			return fmt.Errorf("Saw %d secondary worker accelerators instead of %d", int(secondaryWorkerConfig[0].AcceleratorCount), secondaryWorkerCount)
+		}
+
+		matches = r.FindStringSubmatch(secondaryWorkerConfig[0].AcceleratorTypeUri)
+		if len(matches) != 1 {
+			return fmt.Errorf("Saw %s secondary worker accelerator type instead of %s", secondaryWorkerConfig[0].AcceleratorTypeUri, expectedUri)
 		}
 
 		return nil
@@ -1792,9 +1806,16 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
         accelerator_count = "1"
       }
     }
+
+		preemptible_worker_config {
+		  accelerators {
+				accelerator_type  = "%s"
+				accelerator_count = "1"
+			}
+		}
   }
 }
-`, rnd, subnetworkName, zone, acceleratorType, acceleratorType)
+`, rnd, subnetworkName, zone, acceleratorType, acceleratorType, acceleratorType)
 }
 
 func testAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(rnd string) string {

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -1807,12 +1807,14 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
       }
     }
 
-		preemptible_worker_config {
-		  accelerators {
-				accelerator_type  = "%s"
-				accelerator_count = "1"
-			}
-		}
+    preemptible_worker_config {
+      num_instances = "1"
+
+      accelerators {
+        accelerator_type  = "%s"
+        accelerator_count = "1"
+      }
+    }
   }
 }
 `, rnd, subnetworkName, zone, acceleratorType, acceleratorType, acceleratorType)

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -682,6 +682,12 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
       * `standard_capacity_base` - (Optional) The base capacity that will always use Standard VMs to avoid risk of more preemption than the minimum capacity you need. Dataproc will create only standard VMs until it reaches standardCapacityBase, then it will start using standardCapacityPercentAboveBase to mix Spot with Standard VMs. eg. If 15 instances are requested and standardCapacityBase is 5, Dataproc will create 5 standard VMs and then start mixing spot and standard VMs for remaining 10 instances.
 
       * `standard_capacity_percent_above_base` - (Optional) The percentage of target capacity that should use Standard VM. The remaining percentage will use Spot VMs. The percentage applies only to the capacity above standardCapacityBase. eg. If 15 instances are requested and standardCapacityBase is 5 and standardCapacityPercentAboveBase is 30, Dataproc will create 5 standard VMs and then start mixing spot and standard VMs for remaining 10 instances. The mix will be 30% standard and 70% spot.
+
+* `accelerators` (Optional) The Compute Engine accelerator (GPU) configuration for these instances. Can be specified multiple times.
+
+    * `accelerator_type` - (Required) The short name of the accelerator type to expose to this instance. For example, `nvidia-tesla-k80`.
+
+    * `accelerator_count` - (Required) The number of the accelerator cards of this type exposed to this instance. Often restricted to one of `1`, `2`, `4`, or `8`.
 - - -
 
 <a name="nested_software_config"></a>The `cluster_config.software_config` block supports:


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/21946

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataproc: support `accelerators` in `preemptible_worker_config`
```

Good to keep this in mind while reviewing:
```
NOTE : preemptible_worker_config is an alias for the api's [secondaryWorkerConfig](https://cloud.google.com/dataproc/docs/reference/rest/v1/ClusterConfig#InstanceGroupConfig). The name doesn't necessarily mean it is preemptible and is named as such for legacy/compatibility reasons.
```