### PR TITLE
WIP: compute: Add `protection_tier` and `enable_emergent_maintenance` fields to `compute_future_reservation`

### DIFF
--- a/mmv1/products/compute/FutureReservation.yaml
+++ b/mmv1/products/compute/FutureReservation.yaml
@@ -192,6 +192,15 @@ properties:
     type: String
     description: |
       Name prefix for the reservations to be created at the time of delivery. The name prefix must comply with RFC1035. Maximum allowed length for name prefix is 20. Automatically created reservations name format will be -date-####.
+  - name: 'protectionTier'
+    type: Enum
+    description: |
+      Protection tier for the workload.
+    enum_values:
+      - 'STANDARD'
+      - 'CAPACITY_OPTIMIZED'
+    default_from_api: true
+    immutable: true
   - name: 'status'
     type: NestedObject
     description: |
@@ -428,6 +437,11 @@ properties:
     type: Boolean
     description: |
       Indicates whether the auto-created reservation can be consumed by VMs with affinity for "any" reservation. If the field is set, then only VMs that target the reservation by name can consume from the delivered reservation.
+  - name: 'enableEmergentMaintenance'
+    type: Boolean
+    description: |
+      Indicates if this group of VMs have emergent maintenance enabled.
+    immutable: true
   - name: 'reservationName'
     type: String
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_future_reservation_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_future_reservation_test.go.tmpl
@@ -17,8 +17,8 @@ func TestAccComputeFutureReservation_update(t *testing.T) {
 	context := map[string]interface{}{
 		"random_suffix": acctest.RandString(t, 10),
 		"project":       envvar.GetTestProjectFromEnv(),
-		"end_time":        time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.Now().Location()).AddDate(0, 0, 10).Format(time.RFC3339),
-		"start_time":      time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.Now().Location()).AddDate(0, 0, 1).Format(time.RFC3339),
+		"end_time":      time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 10).Format(time.RFC3339),
+		"start_time":    time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1).Format(time.RFC3339),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -47,6 +47,33 @@ func TestAccComputeFutureReservation_update(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"auto_delete_auto_created_reservations"},
+			},
+		},
+	})
+}
+
+func TestAccComputeFutureReservation_maintenance_protection(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"project":       envvar.GetTestProjectFromEnv(),
+		"end_time":      time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 10).Format(time.RFC3339),
+		"start_time":    time.Date(time.Now().Year(), 12, 31, 0, 0, 0, 0, time.UTC).AddDate(0, 0, 1).Format(time.RFC3339),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFutureReservation_maintenance_protection(context),
+			},
+			{
+				ResourceName:            "google_compute_future_reservation.gce_future_reservation",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auto_delete_auto_created_reservations", "enable_emergent_maintenance"},
 			},
 		},
 	})
@@ -91,6 +118,33 @@ resource "google_compute_future_reservation" "gce_future_reservation" {
     start_time = "%{start_time}"
     end_time   = "%{end_time}"
   }
+  specific_sku_properties {
+    total_count = "1"
+    instance_properties {
+      machine_type = "e2-standard-2"
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeFutureReservation_maintenance_protection(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_future_reservation" "gce_future_reservation" {
+  provider = google-beta
+  name     = "tf-test-fr%{random_suffix}"
+  name_prefix = "fr-%{random_suffix}"
+  project  = "%{project}"
+  planning_status = "DRAFT"
+  auto_delete_auto_created_reservations = true
+  enable_emergent_maintenance = true
+  protection_tier = "CAPACITY_OPTIMIZED"
+  description      = "test future reservation"
+  time_window {
+    start_time = "%{start_time}"
+    end_time   = "%{end_time}"
+  }
+
   specific_sku_properties {
     total_count = "1"
     instance_properties {


### PR DESCRIPTION
This patch adds `protection_tier` and `enable_emergent_maintenance` to the `google_compute_future_reservation` resource.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `protection_tier` field to `google_compute_future_reservation` resource
```
```release-note:enhancement
compute: added `enable_emergent_maintenance` field to `google_compute_future_reservation` resource
```
