### PR TITLE
apigee: support uppercase characters in the product name

### DIFF
--- a/mmv1/products/apigee/ApiProduct.yaml
+++ b/mmv1/products/apigee/ApiProduct.yaml
@@ -82,7 +82,7 @@ properties:
     required: true
     immutable: true
     validation:
-      regex: '^[a-z][a-z0-9._\-$ %]*$'
+      regex: '^[a-zA-Z][a-zA-Z0-9._\-$ %]*$'
 
   - name: "displayName"
     type: String

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_product_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_product_update_test.go
@@ -358,7 +358,7 @@ resource "google_apigee_developer" "apigee_developer" {
 }
 resource "google_apigee_api_product" "apigee_api_product" {
   org_id        = google_apigee_organization.apigee_org.id
-  name              = "tf-test%{random_suffix}"
+  name              = "tf-TEST%{random_suffix}"
   display_name  = "My full API Product"
 
   approval_type = "auto"


### PR DESCRIPTION
closes: https://github.com/hashicorp/terraform-provider-google/issues/25231

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
apigee: support uppercase characters in the product name
```
