### PR TITLE
Support resource_manager_tags for Interconnect

### DIFF
--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -63,6 +63,12 @@ examples:
       address_name: 'test-address'
       router_name: 'test-router'
       network_name: 'test-network'
+  - name: 'compute_interconnect_attachment_tags'
+    primary_resource_id: 'interconnect-attachment-with-tags'
+    vars:
+      interconnect_attachment_name: 'interconnect-attachment-with-tags'
+      router_name: 'router-1'
+      network_name: 'network-1'
   - name: 'compute_interconnect_attachment_custom_ranges'
     primary_resource_id: 'custom-ranges-interconnect-attachment'
     vars:
@@ -160,6 +166,21 @@ properties:
       identifier of an PARTNER attachment used to initiate provisioning with
       a selected partner. Of the form "XXXXX/region/domain"
     output: true
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+     Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the interconnect attachment. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true
   - name: 'partnerAsn'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/compute_interconnect_attachment_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_interconnect_attachment_tags.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_compute_interconnect_attachment" "{{$.PrimaryResourceId}}" {
+  name                     = "{{index $.Vars "interconnect_attachment_name"}}"
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.foobar.id
+  mtu                      = 1500
+  labels                   = { mykey = "myvalue" }
+  resource_manager_tags = {
+    "tagKeys/123" = "tagValues/456"
+  }
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "{{index $.Vars "router_name"}}"
+  network = google_compute_network.foobar.name
+  bgp {
+    asn = 16550
+  }
+}
+
+resource "google_compute_network" "foobar" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}


### PR DESCRIPTION
GCI tagging at creation Hz - b/374259120
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `params` field to `google_compute_interconnect_attachment` resource
```