### PR TITLE
Add variable_substition commands

### DIFF
--- a/mmv1/api/resource/examples.go
+++ b/mmv1/api/resource/examples.go
@@ -351,15 +351,16 @@ func (e *Examples) ExecuteTemplate(baseDir string) (string, error) {
 	}
 
 	fileContentString := string(templateContent)
+	processedContent := google.ProcessNoSubstitution(fileContentString)
 
 	// Check that any variables in Vars or TestEnvVars used in the example are defined via YAML
 	envVarRegex := regexp.MustCompile(`{{index \$\.TestEnvVars "([a-zA-Z_]*)"}}`)
-	validateRegexForContents(envVarRegex, fileContentString, e.ConfigPath, "test_env_vars", e.TestEnvVars)
+	validateRegexForContents(envVarRegex, processedContent, e.ConfigPath, "test_env_vars", e.TestEnvVars)
 	varRegex := regexp.MustCompile(`{{index \$\.Vars "([a-zA-Z_]*)"}}`)
-	validateRegexForContents(varRegex, fileContentString, e.ConfigPath, "vars", e.Vars)
+	validateRegexForContents(varRegex, processedContent, e.ConfigPath, "vars", e.Vars)
 
 	templateFileName := filepath.Base(e.ConfigPath)
-	tmpl, err := template.New(templateFileName).Funcs(google.TemplateFunctions).Parse(fileContentString)
+	tmpl, err := template.New(templateFileName).Funcs(google.TemplateFunctions).Parse(processedContent)
 	if err != nil {
 		return "", err
 	}

--- a/mmv1/api/resource/step.go
+++ b/mmv1/api/resource/step.go
@@ -234,18 +234,19 @@ func (s *Step) ExecuteTemplate() string {
 	}
 
 	fileContentString := string(templateContent)
+	processedContent := google.ProcessNoSubstitution(fileContentString)
 
 	// Check that any variables in PrefixedVars, Vars or TestEnvVars used in the step are defined via YAML
 	envVarRegex := regexp.MustCompile(`{{index \$\.TestEnvVars "([a-zA-Z_]*)"}}`)
-	validateRegexForContents(envVarRegex, fileContentString, s.ConfigPath, "test_env_vars", s.TestEnvVars)
+	validateRegexForContents(envVarRegex, processedContent, s.ConfigPath, "test_env_vars", s.TestEnvVars)
 	varRegex := regexp.MustCompile(`{{index \$\.Vars "([a-zA-Z_]*)"}}`)
-	validateRegexForContents(varRegex, fileContentString, s.ConfigPath, "vars", s.Vars)
+	validateRegexForContents(varRegex, processedContent, s.ConfigPath, "vars", s.Vars)
 	prefixedVarRegex := regexp.MustCompile(`{{index \$\.PrefixedVars "([a-zA-Z_]*)"}}`)
-	validateRegexForContents(prefixedVarRegex, fileContentString, s.ConfigPath, "prefixed_vars", s.PrefixedVars)
+	validateRegexForContents(prefixedVarRegex, processedContent, s.ConfigPath, "prefixed_vars", s.PrefixedVars)
 
 	templateFileName := filepath.Base(s.ConfigPath)
 
-	tmpl, err := template.New(templateFileName).Funcs(google.TemplateFunctions).Parse(fileContentString)
+	tmpl, err := template.New(templateFileName).Funcs(google.TemplateFunctions).Parse(processedContent)
 	if err != nil {
 		glog.Exit(err)
 	}

--- a/mmv1/provider/template_data.go
+++ b/mmv1/provider/template_data.go
@@ -323,14 +323,31 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 		funcMap[k] = v
 	}
 
-	tmpl, err := template.New(templateFileName).Funcs(funcMap).ParseFiles(templates...)
-	if err != nil {
-		glog.Exit(fmt.Sprintf("error parsing %s for filepath %s ", templateFileName, filePath), err)
+	tmpl := template.New(templateFileName).Funcs(funcMap)
+	var err error // Declare err here
+	for _, tplFile := range templates {
+		content, err_read := os.ReadFile(tplFile) // Use err_read for new var
+		if err_read != nil {
+			glog.Exit(fmt.Sprintf("error reading %s for filepath %s: %v", tplFile, filePath, err_read))
+		}
+
+		name := filepath.Base(tplFile)
+		var tpl *template.Template
+		if name == tmpl.Name() {
+			tpl = tmpl
+		} else {
+			tpl = tmpl.New(name)
+		}
+
+		_, err = tpl.Parse(google.ProcessNoSubstitution(string(content))) // Assign to declared err
+		if err != nil {
+			glog.Exit(fmt.Sprintf("error parsing %s for filepath %s: %v", tplFile, filePath, err))
+		}
 	}
 
 	contents := bytes.Buffer{}
-	if err = tmpl.ExecuteTemplate(&contents, templateFileName, input); err != nil {
-		glog.Exit(fmt.Sprintf("error executing %s for filepath %s ", templateFileName, filePath), err)
+	if err = tmpl.ExecuteTemplate(&contents, templateFileName, input); err != nil { // Assign to declared err
+		glog.Exit(fmt.Sprintf("error executing %s for filepath %s: %v", templateFileName, filePath, err))
 	}
 
 	sourceByte := contents.Bytes()
@@ -339,7 +356,8 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 	}
 
 	if goFormat {
-		formattedByte, err := format.Source(sourceByte)
+		var formattedByte []byte
+		formattedByte, err = format.Source(sourceByte) // Assign to declared err
 		if err != nil {
 			glog.Error(fmt.Errorf("error formatting %s: %s", filePath, err))
 		} else {
@@ -347,7 +365,7 @@ func (td *TemplateData) GenerateFile(filePath, templatePath string, input any, g
 		}
 	}
 
-	err = os.WriteFile(filePath, sourceByte, 0644)
+	err = os.WriteFile(filePath, sourceByte, 0644) // Assign to declared err
 	if err != nil {
 		glog.Exit(err)
 	}

--- a/mmv1/templates/terraform/custom_update/firewall_policy_association_update.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/firewall_policy_association_update.go.tmpl
@@ -25,10 +25,12 @@ userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 		obj["firewallPolicy"] = firewallPolicyProp
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}locations/global/firewallPolicies/{{"{{"}}firewall_policy{{"}}"}}/addAssociation?replaceExistingAssociation=true")
+  // begin:no_variable_substitution
+	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}/locations/global/firewallPolicies/{{firewall_policy}}/addAssociation?replaceExistingAssociation=true")
 	if err != nil {
 		return err
 	}
+  // end:no_variable_substitution
 
 	log.Printf("[DEBUG] Updating FirewallPolicyAssociation %q: %#v", d.Id(), obj)
 	headers := make(http.Header)


### PR DESCRIPTION
Long time no see!

I'm helping out with some Terraform work and noticed that there's some places that we have to do some strange template work to override the {{ }} for variable substitition.

I've added two new comments: `// begin:no_variable_substitition` and `// end:no_variable_subsitition`. Anything inside of these tags should not have their {{ }} tags altered.

This should be a no-op as-is.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
