### PR TITLE
Add terraform support for gneration scopes

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -698,5 +698,15 @@ properties:
       - 'data_profile_spec'
       - 'data_discovery_spec'
       - 'data_documentation_spec'
-    properties:
-      []
+    properties
+     - name: generation_scopes:
+       type: Array
+       description: Determines the scope of created data documentation scan.
+       item_type: 
+        type: Enum
+        description: Determines the created data documentation scan should create everything, description or queries.
+        enum_values:
+         - GENERATION_SCOPE_UNSPECIFIED
+         - ALL
+         - TABLE_AND_COLUMN_DESCRIPTIONS
+         - SQL_QUERIES


### PR DESCRIPTION
If this PR is for Terraform, I acknowledge that I have:
  -   [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
  -   [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/mmv1/third_party/terraform/tests (for handwritten resources or update tests).
  -   [X] [Generated Terraform providers](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/generate-providers.md), and ran [`make test` and `make lint`](https://googlecloudplatform.github.io/magic-modules/docs/getting-started/run-provider-tests/#run-unit-tests) in the generated providers to ensure it passes unit and linter tests.
  -   [X] [Ran](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/docs/content/docs/getting-started/run-provider-tests.md) relevant acceptance tests using my own Google Cloud project and credentials (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
  -   [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

 Please select one of the following "release-note:enhancement" headings:
  **Release Note Template for Downstream PRs (will be copied)**

dataplex: added `generation_scopes` field to `data_documentation_spec` resource to support the DATA_DOCUMENTATION scan type