### PR TITLE
fix crash in ServicePerimeterResource

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
@@ -87,6 +87,7 @@ parameters:
     type: ResourceRef
     description: |
       The name of the Service Perimeter to add this resource to.
+      Format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}
     url_param_only: true
     required: true
     immutable: true

--- a/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeterResource.yaml
@@ -87,7 +87,7 @@ parameters:
     type: ResourceRef
     description: |
       The name of the Service Perimeter to add this resource to.
-      Format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}
+      Format: accessPolicies/{accessPolicy}/servicePerimeters/{servicePerimeter}
     url_param_only: true
     required: true
     immutable: true

--- a/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
+++ b/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
@@ -7,7 +7,7 @@ perimeterName := d.Get("perimeter_name").(string)
 
 parts := strings.Split(perimeterName, "/")
 if len(parts) < 2 {
-	return nil, fmt.Errorf("invalid perimeter_name format: %s. Expected format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}", perimeterName)
+	return nil, fmt.Errorf("invalid perimeter_name format: %s. Expected format: accessPolicies/{accessPolicy}/servicePerimeters/{servicePerimeter}", perimeterName)
 }
 
 if err := d.Set("access_policy_id", fmt.Sprintf("accessPolicies/%s", parts[1])); err != nil {

--- a/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
+++ b/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
@@ -2,7 +2,16 @@
 
 // The is logic is inside the encoder since the access_policy_id field is part of
 // the mutex lock and encoders run before the lock is set.
-parts := strings.Split(d.Get("perimeter_name").(string), "/")
-d.Set("access_policy_id", fmt.Sprintf("accessPolicies/%s", parts[1]))
+
+perimeterName := d.Get("perimeter_name").(string)
+
+parts := strings.Split(perimeterName, "/")
+if len(parts) < 2 {
+	retirn nil, fmt.Errorf("invalid perimeter_name format: %s. Expected format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}", perimeterName)
+}
+
+if err := d.Set("access_policy_id", fmt.Sprintf("accessPolicies/%s", parts[1])); err != nil {
+	return nil, fmt.Errorf("error setting access_policy_id: %s", err)
+}
 
 return obj, nil

--- a/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
+++ b/mmv1/templates/terraform/encoders/access_context_manager_service_perimeter_resource.go.tmpl
@@ -7,7 +7,7 @@ perimeterName := d.Get("perimeter_name").(string)
 
 parts := strings.Split(perimeterName, "/")
 if len(parts) < 2 {
-	retirn nil, fmt.Errorf("invalid perimeter_name format: %s. Expected format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}", perimeterName)
+	return nil, fmt.Errorf("invalid perimeter_name format: %s. Expected format: accessPolicies/{access_policy}/servicePerimeters/{servicePerimeter}", perimeterName)
 }
 
 if err := d.Set("access_policy_id", fmt.Sprintf("accessPolicies/%s", parts[1])); err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24682

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
accesscontextmanager: fixed a crash in `google_access_context_manager_service_perimeter_resource` when `perimeter_name` was provided in an invalid format.
```
