### PR TITLE
feat(firestore): Support for skip wait on Firestore index resource.

### DIFF
--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -51,6 +51,7 @@ custom_code:
   constants: 'templates/terraform/constants/firestore_index.go.tmpl'
   encoder: 'templates/terraform/encoders/index.go.tmpl'
   custom_import: 'templates/terraform/custom_import/index_self_link_as_name_set_project.go.tmpl'
+  custom_create: 'templates/terraform/custom_create/firestore_index.go.tmpl'
 error_retry_predicates:
 
   - 'transport_tpg.FirestoreIndex409Retry'
@@ -98,7 +99,22 @@ examples:
       database_id: 'database-id-unique'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_skip_wait'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id-skip-wait'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'skip_wait'
+virtual_fields:
+  - name: "skip_wait"
+    type: Boolean
+    default_value: false
+    description: "Whether to skip waiting for the index to be created."
+    ignore_read: true
 parameters:
+# Firestore uses a custom create function. Any new fields must be explicitly handled there.
 properties:
   - name: 'name'
     type: String

--- a/mmv1/templates/terraform/custom_create/firestore_index.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/firestore_index.go.tmpl
@@ -1,0 +1,145 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+obj := make(map[string]interface{})
+databaseProp, err := expandFirestoreIndexDatabase(d.Get("database"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("database"); !tpgresource.IsEmptyValue(reflect.ValueOf(databaseProp)) && (ok || !reflect.DeepEqual(v, databaseProp)) {
+	obj["database"] = databaseProp
+}
+collectionProp, err := expandFirestoreIndexCollection(d.Get("collection"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("collection"); !tpgresource.IsEmptyValue(reflect.ValueOf(collectionProp)) && (ok || !reflect.DeepEqual(v, collectionProp)) {
+	obj["collection"] = collectionProp
+}
+queryScopeProp, err := expandFirestoreIndexQueryScope(d.Get("query_scope"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("query_scope"); !tpgresource.IsEmptyValue(reflect.ValueOf(queryScopeProp)) && (ok || !reflect.DeepEqual(v, queryScopeProp)) {
+	obj["queryScope"] = queryScopeProp
+}
+apiScopeProp, err := expandFirestoreIndexApiScope(d.Get("api_scope"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("api_scope"); !tpgresource.IsEmptyValue(reflect.ValueOf(apiScopeProp)) && (ok || !reflect.DeepEqual(v, apiScopeProp)) {
+	obj["apiScope"] = apiScopeProp
+}
+densityProp, err := expandFirestoreIndexDensity(d.Get("density"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("density"); !tpgresource.IsEmptyValue(reflect.ValueOf(densityProp)) && (ok || !reflect.DeepEqual(v, densityProp)) {
+	obj["density"] = densityProp
+}
+multikeyProp, err := expandFirestoreIndexMultikey(d.Get("multikey"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("multikey"); !tpgresource.IsEmptyValue(reflect.ValueOf(multikeyProp)) && (ok || !reflect.DeepEqual(v, multikeyProp)) {
+	obj["multikey"] = multikeyProp
+}
+uniqueProp, err := expandFirestoreIndexUnique(d.Get("unique"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("unique"); !tpgresource.IsEmptyValue(reflect.ValueOf(uniqueProp)) && (ok || !reflect.DeepEqual(v, uniqueProp)) {
+	obj["unique"] = uniqueProp
+}
+fieldsProp, err := expandFirestoreIndexFields(d.Get("fields"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("fields"); !tpgresource.IsEmptyValue(reflect.ValueOf(fieldsProp)) && (ok || !reflect.DeepEqual(v, fieldsProp)) {
+	obj["fields"] = fieldsProp
+}
+
+obj, err = resourceFirestoreIndexEncoder(d, meta, obj)
+if err != nil {
+	return err
+}
+
+url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}FirestoreBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/databases/{{"{{"}}database{{"}}"}}/collectionGroups/{{"{{"}}collection{{"}}"}}/indexes")
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Creating new Index: %#v", obj)
+billingProject := ""
+
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return fmt.Errorf("Error fetching project for Index: %s", err)
+}
+billingProject = project
+
+// err == nil indicates that the billing_project value was found
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+headers := make(http.Header)
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:               config,
+	Method:               "POST",
+	Project:              billingProject,
+	RawURL:               url,
+	UserAgent:            userAgent,
+	Body:                 obj,
+	Timeout:              d.Timeout(schema.TimeoutCreate),
+	Headers:              headers,
+	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.FirestoreIndex409Retry},
+})
+if err != nil {
+	return fmt.Errorf("Error creating Index: %s", err)
+}
+
+// Store the ID now
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+if d.Get("skip_wait").(bool) {
+	// If skip_wait, the LRO will not be complete so the response will not be populated.
+	// Extract the index name from the metadata field.
+	metadata, ok := res["metadata"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Error constructing id from result.")
+	}
+	index, ok := metadata["index"].(string)
+	if !ok {
+		return fmt.Errorf("Error constructing id from result.")
+	}
+	if err := d.Set("name", flattenFirestoreIndexName(index, d, config)); err != nil {
+		return err
+	}
+} else {
+	// Use the resource in the operation response to populate
+	// identity fields and d.Id() before read
+	var opRes map[string]interface{}
+	err = FirestoreOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Creating Index", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		// The resource didn't actually create
+		d.SetId("")
+
+		return fmt.Errorf("Error waiting to create Index: %s", err)
+	}
+
+	if err := d.Set("name", flattenFirestoreIndexName(opRes["name"], d, config)); err != nil {
+		return err
+	}
+}
+
+// This may have caused the ID to update - update it if so.
+id, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+log.Printf("[DEBUG] Finished creating Index %q: %#v", d.Id(), res)
+
+return resourceFirestoreIndexRead(d, meta)

--- a/mmv1/templates/terraform/examples/firestore_index_skip_wait.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_skip_wait.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_firestore_database" "database" {
+  project     = "{{index $.TestEnvVars "project_id"}}"
+  name        = "{{index $.Vars "database_id"}}"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+}
+
+resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
+  project    = "{{index $.TestEnvVars "project_id"}}"
+  database   = google_firestore_database.database.name
+  collection = "atestcollection"
+
+  fields {
+    field_path = "name"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "description"
+    order      = "DESCENDING"
+  }
+
+  skip_wait = true
+}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -94,7 +94,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
     return &schema.Resource{
         Create: resource{{ $.ResourceName -}}Create,
         Read: resource{{ $.ResourceName -}}Read,
-{{- if or $.Updatable $.RootLabels }}
+{{- if or (or $.Updatable $.RootLabels) $.VirtualFields }}
         Update: resource{{ $.ResourceName -}}Update,
 {{- end}}
         Delete: resource{{ $.ResourceName -}}Delete,
@@ -108,7 +108,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout({{ $.Timeouts.InsertMinutes -}} * time.Minute),
-{{- if or $.Updatable $.RootLabels }}
+{{- if or (or $.Updatable $.RootLabels) $.VirtualFields }}
             Update: schema.DefaultTimeout({{ $.Timeouts.UpdateMinutes -}} * time.Minute),
 {{- end}}
             Delete: schema.DefaultTimeout({{ $.Timeouts.DeleteMinutes -}} * time.Minute),
@@ -1041,9 +1041,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
     return resource{{ $.ResourceName -}}Read(d, meta)
 {{-      end }}{{/*if CustomUpdate*/}}
 }
-{{  else if $.RootLabels -}}{{/*if not immutable*/}}
+{{  else if or $.RootLabels $.VirtualFields -}}{{/*if not immutable*/}}
 func resource{{ $.ResourceName -}}Update(d *schema.ResourceData, meta interface{}) error {
-    // Only the root field "labels" and "terraform_labels" are mutable
+    // Only the root field "labels", "terraform_labels", and virtual fields are mutable
     return resource{{ $.ResourceName -}}Read(d, meta)
 }
 


### PR DESCRIPTION
Add `skip_wait` field to `google_firestore_index` resource

This field allows users to skip waiting for the long-running operation to complete during index creation. This is useful for creating multiple indexes in parallel or when usage patterns do not require immediate index readiness.

Also adds support for updating virtual fields on otherwise immutable resources.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13422

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `skip_wait` field to `google_firestore_index` resource, skipping the wait for index creation
```
