### PR TITLE
feat: Add skip_wait option to async operations.

### DIFF
--- a/mmv1/api/async.go
+++ b/mmv1/api/async.go
@@ -34,6 +34,9 @@ type Async struct {
 	// The list of methods where operations are used.
 	Actions []string `yaml:"actions,omitempty"`
 
+	// If true, the system will allow the user to skip waiting for the operation result.
+	AllowSkipWait bool `yaml:"allow_skip_wait,omitempty"`
+
 	OpAsync   `yaml:",inline"`
 	PollAsync `yaml:",inline"`
 }

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -935,6 +935,24 @@ func (r *Resource) AddExtraFields(props []*Type, parent *Type) []*Type {
 	return props
 }
 
+func (r *Resource) AddExtraVirtualFields(virtualFields []*Type, parent *Type) []*Type {
+	if parent == nil && r.Async != nil && r.Async.AllowSkipWait {
+		virtualFields = append(virtualFields, buildSkipWaitField())
+	}
+	return virtualFields
+}
+
+func buildSkipWaitField() *Type {
+	options := []func(*Type){
+		propertyWithType("Boolean"),
+		propertyWithIgnoreWrite(true),
+		propertyWithImmutable(false),
+		propertyWithClientSide(true),
+		propertyWithDescription("If true, the asynchronous operation will not be awaited."),
+	}
+	return NewProperty("skip_wait", "skip_wait", options)
+}
+
 func (r *Resource) addLabelsFields(props []*Type, parent *Type, labels *Type) []*Type {
 	if parent == nil || parent.FlattenObject {
 		if r.ExcludeAttributionLabel {

--- a/mmv1/api/resource/custom_code.go
+++ b/mmv1/api/resource/custom_code.go
@@ -140,6 +140,11 @@ type CustomCode struct {
 
 	ValidateRawResourceConfigFuncs string `yaml:"raw_resource_config_validation,omitempty"`
 
+	// This code is run for async operations when skip_wait is enabled and opted-in by
+	// the terraform user. This decoder is required for parsing the resource out of a
+	// in-progress operation response.
+	SkipWaitDecoder string `yaml:"skip_wait_decoder,omitempty"`
+
 	// ====================
 	// TGC Encoders & Decoders
 	// ====================

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -727,4 +727,50 @@ func TestResourceAddExtraFields(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Async SkipWait adds skip_wait field", func(t *testing.T) {
+		t.Parallel()
+
+		resource := createTestResource("testresource")
+		resource.Async = &Async{
+			AllowSkipWait: true,
+		}
+
+		props := []*Type{}
+		result := resource.AddExtraVirtualFields(props, nil)
+
+		if len(result) != 1 {
+			t.Errorf("Expected 1 property after adding skip_wait field, got %d", len(result))
+		}
+
+		skipWait := result[0]
+		if skipWait.Name != "skip_wait" {
+			t.Errorf("Expected property name to be skip_wait, got %s", skipWait.Name)
+		}
+		if skipWait.Type != "Boolean" {
+			t.Errorf("Expected property type to be Boolean, got %s", skipWait.Type)
+		}
+		if !skipWait.IgnoreWrite {
+			t.Error("Expected skip_wait to have IgnoreWrite=true")
+		}
+		if skipWait.Immutable {
+			t.Error("Expected skip_wait to have Immutable=false")
+		}
+	})
+
+	t.Run("Async without SkipWait does not add skip_wait field", func(t *testing.T) {
+		t.Parallel()
+
+		resource := createTestResource("testresource")
+		resource.Async = &Async{
+			AllowSkipWait: false,
+		}
+
+		props := []*Type{}
+		result := resource.AddExtraVirtualFields(props, nil)
+
+		if len(result) != 0 {
+			t.Errorf("Expected 0 properties, got %d", len(result))
+		}
+	})
 }

--- a/mmv1/loader/loader.go
+++ b/mmv1/loader/loader.go
@@ -326,6 +326,7 @@ func (l *Loader) AddExtraFields() error {
 	for _, product := range l.Products {
 		for _, resource := range product.Objects {
 			resource.Properties = resource.AddExtraFields(resource.PropertiesWithExcluded(), nil)
+			resource.VirtualFields = resource.AddExtraVirtualFields(resource.VirtualFields, nil)
 			// SetDefault after AddExtraFields to ensure relevant metadata is available for the newly generated fields
 			resource.SetDefault(product)
 		}

--- a/mmv1/products/firestore/Index.yaml
+++ b/mmv1/products/firestore/Index.yaml
@@ -47,10 +47,12 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
+  allow_skip_wait: true
 custom_code:
   constants: 'templates/terraform/constants/firestore_index.go.tmpl'
   encoder: 'templates/terraform/encoders/index.go.tmpl'
   custom_import: 'templates/terraform/custom_import/index_self_link_as_name_set_project.go.tmpl'
+  skip_wait_decoder: 'templates/terraform/decoders/firestore_index_skip_wait.go.tmpl'
 error_retry_predicates:
 
   - 'transport_tpg.FirestoreIndex409Retry'
@@ -98,6 +100,14 @@ examples:
       database_id: 'database-id-unique'
     test_env_vars:
       project_id: 'PROJECT_NAME'
+  - name: 'firestore_index_skip_wait'
+    primary_resource_id: 'my-index'
+    vars:
+      database_id: 'database-id-skip-wait'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    ignore_read_extra:
+      - 'skip_wait'
 parameters:
 properties:
   - name: 'name'

--- a/mmv1/templates/terraform/decoders/firestore_index_skip_wait.go.tmpl
+++ b/mmv1/templates/terraform/decoders/firestore_index_skip_wait.go.tmpl
@@ -1,0 +1,11 @@
+// If skip_wait, the LRO will not be complete so the response will not be populated.
+// Extract the index name from the metadata field.
+metadata, ok := res["metadata"].(map[string]interface{})
+if !ok {
+	return nil, fmt.Errorf("Error constructing id from result.")
+}
+index, ok := metadata["index"].(string)
+if !ok {
+	return nil, fmt.Errorf("Error constructing id from result.")
+}
+return map[string]interface{}{"name": index}, nil

--- a/mmv1/templates/terraform/examples/firestore_index_skip_wait.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firestore_index_skip_wait.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_firestore_database" "database" {
+  project     = "{{index $.TestEnvVars "project_id"}}"
+  name        = "{{index $.Vars "database_id"}}"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+}
+
+resource "google_firestore_index" "{{$.PrimaryResourceId}}" {
+  project    = "{{index $.TestEnvVars "project_id"}}"
+  database   = google_firestore_database.database.name
+  collection = "atestcollection"
+
+  fields {
+    field_path = "name"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "description"
+    order      = "DESCENDING"
+  }
+
+  skip_wait = true
+}

--- a/mmv1/templates/terraform/operation.go.tmpl
+++ b/mmv1/templates/terraform/operation.go.tmpl
@@ -117,7 +117,7 @@ func {{ camelize $.ProductMetadata.Name "upper" }}OperationWaitTimeWithResponse(
       return err
   }
   if err := tpgresource.OperationWait(w, activity, timeout, config.PollInterval); err != nil {
-      return err
+    return err
   }
   rawResponse := []byte(w.CommonOperationWaiter.Op.Response)
   if len(rawResponse) == 0 {

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -94,7 +94,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
     return &schema.Resource{
         Create: resource{{ $.ResourceName -}}Create,
         Read: resource{{ $.ResourceName -}}Read,
-{{- if or $.Updatable $.RootLabels }}
+{{- if or (or $.Updatable $.RootLabels) $.VirtualFields }}
         Update: resource{{ $.ResourceName -}}Update,
 {{- end}}
         Delete: resource{{ $.ResourceName -}}Delete,
@@ -108,7 +108,7 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout({{ $.Timeouts.InsertMinutes -}} * time.Minute),
-{{- if or $.Updatable $.RootLabels }}
+{{- if or (or $.Updatable $.RootLabels) $.VirtualFields }}
             Update: schema.DefaultTimeout({{ $.Timeouts.UpdateMinutes -}} * time.Minute),
 {{- end}}
             Delete: schema.DefaultTimeout({{ $.Timeouts.DeleteMinutes -}} * time.Minute),
@@ -1041,9 +1041,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
     return resource{{ $.ResourceName -}}Read(d, meta)
 {{-      end }}{{/*if CustomUpdate*/}}
 }
-{{  else if $.RootLabels -}}{{/*if not immutable*/}}
+{{  else if or $.RootLabels $.VirtualFields -}}{{/*if not immutable*/}}
 func resource{{ $.ResourceName -}}Update(d *schema.ResourceData, meta interface{}) error {
-    // Only the root field "labels" and "terraform_labels" are mutable
+    // Only the root field "labels", "terraform_labels", and virtual fields are mutable
     return resource{{ $.ResourceName -}}Read(d, meta)
 }
 

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -345,9 +345,22 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     // Use the resource in the operation response to populate
     // identity fields and d.Id() before read
     var opRes map[string]interface{}
-    err = {{ $.ClientNamePascal -}}OperationWaitTimeWithResponse(
-    config, res, &opRes, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Creating {{ $.Name -}}", userAgent,
-        d.Timeout(schema.TimeoutCreate))
+{{      if $.GetAsync.AllowSkipWait -}}
+    if d.Get("skip_wait").(bool) {
+{{        if $.CustomCode.SkipWaitDecoder -}}
+        opRes, err =  resource{{ $.ResourceName -}}SkipWaitDecoder(d, meta, res)
+        if err != nil {
+            return fmt.Errorf("Error decoding response from operation: %s", err)
+        }
+{{- end}}
+    } else {
+{{      end -}}
+        err = {{ $.ClientNamePascal -}}OperationWaitTimeWithResponse(
+            config, res, &opRes, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Creating {{ $.Name -}}", userAgent,
+            d.Timeout(schema.TimeoutCreate))
+{{      if $.GetAsync.AllowSkipWait -}}
+    }
+{{      end -}}
     if err != nil {
 {{if $.CustomCode.PostCreateFailure -}}
         resource{{ $.ResourceName -}}PostCreateFailure(d, meta)
@@ -420,6 +433,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     d.SetId(id)
 
 {{        else -}}
+{{          if $.GetAsync.AllowSkipWait -}}
+    if !d.Get("skip_wait").(bool) {
+{{          end -}}
     err = {{ $.ClientNamePascal -}}OperationWaitTime(
     config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Creating {{ $.Name -}}", userAgent,
         d.Timeout(schema.TimeoutCreate))
@@ -434,6 +450,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- end}}
         return fmt.Errorf("Error waiting to create {{ $.Name -}}: %s", err)
     }
+{{           if $.GetAsync.AllowSkipWait -}}
+    }
+{{           end -}}
 
 {{        end  -}}
 {{      end -}}{{/*if ($.GetAsync.IsA "OpAsync")*/}}
@@ -853,6 +872,9 @@ if len(updateMask) > 0 {
 
 {{              if and ($.GetAsync) ($.GetAsync.Allow "update") -}}
 {{                  if $.GetAsync.IsA "OpAsync" -}}
+{{                      if $.GetAsync.AllowSkipWait -}}
+    if !d.Get("skip_wait").(bool) {
+{{                      end -}}
     err = {{ $.ClientNamePascal -}}OperationWaitTime(
         config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Updating {{ $.Name -}}", userAgent,
         d.Timeout(schema.TimeoutUpdate))
@@ -860,6 +882,9 @@ if len(updateMask) > 0 {
     if err != nil {
         return err
     }
+{{-                      if $.GetAsync.AllowSkipWait -}}
+    }
+{{-                      end -}}
 {{-             if not $.FieldSpecificUpdateMethods }}
 {{""}}
 {{-             end}}
@@ -1012,12 +1037,18 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
 
 {{                  if and ($.GetAsync) ($.GetAsync.Allow "update") -}}
 {{                      if $.GetAsync.IsA "OpAsync" -}}
-	    err = {{ $.ClientNamePascal -}}OperationWaitTime(
-	        config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Updating {{ $.Name -}}", userAgent,
-	        d.Timeout(schema.TimeoutUpdate))
-	    if err != nil {
-	        return err
-	    }
+{{                          if $.GetAsync.AllowSkipWait -}}
+     if !d.Get("skip_wait").(bool) {
+{{                          end -}}
+        err = {{ $.ClientNamePascal -}}OperationWaitTime(
+            config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Updating {{ $.Name -}}", userAgent,
+            d.Timeout(schema.TimeoutUpdate))
+        if err != nil {
+            return err
+        }
+{{-                          if $.GetAsync.AllowSkipWait -}}
+    }
+{{-                          end -}}
 {{-                      else if $.GetAsync.IsA "PollAsync" -}}
 	    err = transport_tpg.PollingWaitTime(resource{{ $.ResourceName -}}PollRead(d, meta), {{ $.GetAsync.CheckResponseFuncExistence -}}, "Updating {{ $.Name -}}", d.Timeout(schema.TimeoutUpdate), {{ $.GetAsync.TargetOccurrences -}})
 	    if err != nil {
@@ -1157,6 +1188,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
             {{- end }}
     }
         {{- else }}
+{{          if $.GetAsync.AllowSkipWait -}}
+    if !d.Get("skip_wait").(bool) {
+{{          end -}}
     err = {{ $.ClientNamePascal }}OperationWaitTime(
         config, res, {{if or $.HasProject $.GetAsync.IncludeProject -}} {{if $.LegacyLongFormProject -}}tpgresource.GetResourceNameFromSelfLink(project){{ else }}project{{ end }}, {{ end -}} "Deleting {{ $.Name -}}", userAgent,
         d.Timeout(schema.TimeoutDelete))
@@ -1164,6 +1198,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
         return err
     }
+{{-           if $.GetAsync.AllowSkipWait -}}
+    }
+{{-           end -}}
     {{- end }}
 {{- end }}
 {{- if $.CustomCode.PostDelete }}
@@ -1307,5 +1344,10 @@ func resource{{ $.ResourceName -}}PostCreateSetComputedFields(d *schema.Resource
     {{-   end }}{{/* prop is potentially computed */}}
     {{- end }}{{/* range */}}
     return nil
+}
+{{- end }}
+{{- if $.CustomCode.SkipWaitDecoder }}
+func resource{{ $.ResourceName -}}SkipWaitDecoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
+    {{ customTemplate $ $.CustomCode.SkipWaitDecoder false -}}
 }
 {{- end }}


### PR DESCRIPTION
This allows users to skip waiting for the long-running operation to complete during index creation. This is useful for creating resources in parallel, when usage patterns do not require immediate resource readiness, and especially when resource creation can take hours.

Resource providers may provide a custom decoder to extract the resource from the in-progress operation.

See Firestore Index.yaml for an example of usage.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/13422

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firestore: added `skip_wait` field to `google_firestore_index` resource, skipping the wait for index creation
```
