### PR TITLE
Fix permadiff in `google_identity_platform_config`

### DIFF
--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -5,9 +5,9 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   
   original := v.(map[string]interface{})
 
+  // return nil if api returned empty object
   if len(original) == 0 {
-    // return nil if api returned empty object
-    return nil;
+    return nil
   }
 
   transformed := make(map[string]interface{})

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -1,20 +1,25 @@
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-  transformed := make(map[string]interface{})
-
   if v == nil {
     return nil
+  }
+  
+  original := v.(map[string]interface{})
+
+  if len(original) == 0 {
+    // return nil if api returned empty object
+    return nil;
+  }
+
+  transformed := make(map[string]interface{})
+
+  if original["allowTenants"] == nil {
+    transformed["allow_tenants"] = false
   } else {
-    original := v.(map[string]interface{})
+    transformed["allow_tenants"] = original["allowTenants"]
+  }
 
-    if original["allowTenants"] == nil {
-      transformed["allow_tenants"] = false
-    } else {
-      transformed["allow_tenants"] = original["allowTenants"]
-    }
-
-    if original["defaultTenantLocation"] != nil {
-      transformed["default_tenant_location"] = original["defaultTenantLocation"]
-    }
+  if original["defaultTenantLocation"] != nil {
+    transformed["default_tenant_location"] = original["defaultTenantLocation"]
   }
 
   return []interface{}{transformed}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/22432, Fixes https://github.com/hashicorp/terraform-provider-google/issues/22430

This PR adds check for empty response object from the server for multiTenant and returns nil if it is empty to prevent permadiff that is causing the tests to break. Server sends multiTenant as empty in default case


```release-note:bug
identityplatform: Fix permadiff in `google_identity_platform_config`
```
