### PR TITLE
Add Schema for DocumentAI

### DIFF
--- a/mmv1/products/documentai/Schema.yaml
+++ b/mmv1/products/documentai/Schema.yaml
@@ -1,0 +1,77 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Schema'
+description: |
+  A Schema is a collection of SchemaVersions that defines the structure and layout of document data. 
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/document-ai/docs/overview'
+  api: 'https://cloud.google.com/document-ai/docs/reference/rest/v1/projects.locations.schemas'
+docs:
+base_url: 'projects/{{project}}/locations/{{location}}/schemas'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+custom_code:
+sweeper:
+  url_substitutions:
+    - region: "us"
+    - region: "eu"
+examples:
+  - name: 'documentai_schema_basic'
+    primary_resource_id: 'schema'
+    vars:
+      location: 'us'
+      display_name: 'test-schema'
+  - name: 'documentai_schema_basic_eu'
+    primary_resource_id: 'schema'
+    vars:
+      location: 'eu'
+      display_name: 'test-schema'
+    exclude_docs: true
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The location of the resource.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The resource name of the Schema.
+    output: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+  - name: 'displayName'
+    type: String
+    description: |
+      The user-defined name of the Schema.
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      The Google Cloud labels for the Schema.
+  - name: 'createTime'
+    type: Time
+    description: |
+      The time when the Schema was created.
+    output: true
+  - name: 'updateTime'
+    type: Time
+    description: |
+      The time when the Schema was last updated.
+    output: true

--- a/mmv1/products/documentai/Schema.yaml
+++ b/mmv1/products/documentai/Schema.yaml
@@ -14,7 +14,7 @@
 ---
 name: 'Schema'
 description: |
-  A Schema is a collection of SchemaVersions that defines the structure and layout of document data. 
+  A Schema is a collection of SchemaVersions that defines the structure and layout of document data.
 references:
   guides:
     'Official Documentation': 'https://cloud.google.com/document-ai/docs/overview'

--- a/mmv1/products/pubsub/Topic.yaml
+++ b/mmv1/products/pubsub/Topic.yaml
@@ -291,7 +291,7 @@ properties:
               - 'avro_format'
               - 'pubsub_avro_format'
             properties:
- # Meant to be an empty object with no properties.
+              # Meant to be an empty object with no properties.
               []
           - name: 'pubsubAvroFormat'
             type: NestedObject
@@ -307,7 +307,7 @@ properties:
               - 'avro_format'
               - 'pubsub_avro_format'
             properties:
- # Meant to be an empty object with no properties.
+              # Meant to be an empty object with no properties.
               []
           - name: 'minimumObjectCreateTime'
             type: String

--- a/mmv1/templates/terraform/examples/documentai_processor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/documentai_processor.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_document_ai_processor" "{{$.PrimaryResourceId}}" {
-  location = "us"
+  location     = "us"
   display_name = "{{index $.Vars "processor_name"}}"
-  type = "OCR_PROCESSOR"
+  type         = "OCR_PROCESSOR"
 }

--- a/mmv1/templates/terraform/examples/documentai_schema_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/documentai_schema_basic.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_document_ai_schema" "{{$.PrimaryResourceId}}" {
+  location     = "{{index $.Vars "location"}}"
+  display_name = "{{index $.Vars "display_name"}}"
+}

--- a/mmv1/templates/terraform/examples/documentai_schema_basic_eu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/documentai_schema_basic_eu.tf.tmpl
@@ -1,0 +1,4 @@
+resource "google_document_ai_schema" "{{$.PrimaryResourceId}}" {
+  location     = "{{index $.Vars "location"}}"
+  display_name = "{{index $.Vars "display_name"}}"
+}


### PR DESCRIPTION
## Description

This PR adds support for the Document AI Schema resource, enabling users to manage Document AI schemas through Terraform.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/25831

## Changes

- Added `mmv1/products/documentai/Schema.yaml` resource definition
- Implemented support for creating, reading, updating, and deleting Document AI schemas
- Added basic example configuration


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
**New Resource:** `google_document_ai_schema`
```