### PR TITLE
Update dataproc_batch_pyspark example to use gs:// format

### DIFF
--- a/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
@@ -18,11 +18,11 @@ resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
       jar_file_uris        = ["file:///usr/lib/spark/examples/jars/spark-examples.jar"]
       python_file_uris     = ["gs://dataproc-examples/pyspark/hello-world/hello-world.py"]
       archive_uris         = [
-        "https://storage.googleapis.com/terraform-batches/animals.txt.tar.gz#unpacked",
-        "https://storage.googleapis.com/terraform-batches/animals.txt.jar",
-        "https://storage.googleapis.com/terraform-batches/animals.txt"
+        "gs://storage.googleapis.com/terraform-batches/animals.txt.tar.gz#unpacked",
+        "gs://storage.googleapis.com/terraform-batches/animals.txt.jar",
+        "gs://storage.googleapis.com/terraform-batches/animals.txt"
       ]
-      file_uris            = ["https://storage.googleapis.com/terraform-batches/people.txt"]
+      file_uris            = ["gs://storage.googleapis.com/terraform-batches/people.txt"]
     }
 }
 

--- a/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
@@ -13,7 +13,7 @@ resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
     }
 
     pyspark_batch {
-      main_python_file_uri = "https://storage.googleapis.com/terraform-batches/test_util.py"
+      main_python_file_uri = "gs://storage.googleapis.com/terraform-batches/test_util.py"
       args                 = ["10"]
       jar_file_uris        = ["file:///usr/lib/spark/examples/jars/spark-examples.jar"]
       python_file_uris     = ["gs://dataproc-examples/pyspark/hello-world/hello-world.py"]

--- a/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataproc_batch_pyspark.tf.tmpl
@@ -13,16 +13,15 @@ resource "google_dataproc_batch" "{{$.PrimaryResourceId}}" {
     }
 
     pyspark_batch {
-      main_python_file_uri = "gs://storage.googleapis.com/terraform-batches/test_util.py"
+      main_python_file_uri = "gs://terraform-batches/test_util.py"
       args                 = ["10"]
       jar_file_uris        = ["file:///usr/lib/spark/examples/jars/spark-examples.jar"]
       python_file_uris     = ["gs://dataproc-examples/pyspark/hello-world/hello-world.py"]
       archive_uris         = [
-        "gs://storage.googleapis.com/terraform-batches/animals.txt.tar.gz#unpacked",
-        "gs://storage.googleapis.com/terraform-batches/animals.txt.jar",
-        "gs://storage.googleapis.com/terraform-batches/animals.txt"
+        "gs://terraform-batches/animals.txt.tar.gz#unpacked",
+        "gs://terraform-batches/animals.txt.jar",
+        "gs://terraform-batches/animals.txt"
       ]
-      file_uris            = ["gs://storage.googleapis.com/terraform-batches/people.txt"]
+      file_uris            = ["gs://terraform-batches/people.txt"]
     }
 }
-


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
