### PR TITLE
Adding SnapshotRecycleBinPolicy resource for beta

### DIFF
--- a/mmv1/products/compute/OrganizationSnapshotRecycleBinPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSnapshotRecycleBinPolicy.yaml
@@ -1,0 +1,94 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'OrganizationSnapshotRecycleBinPolicy'
+description: |
+  Represents the singleton resource Organization Snapshot Recycle Bin Policy that
+  configures the retention duration for snapshots in the recycle bin at organization
+  level. All projects in that organization will share the same policy. If you 
+  configure the policy at the project level it will be merged with org level policy (if any) 
+  and the snapshots in that project will use that policy.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/disks/organization-snapshot-recycle-bin-policy#snapshot_recycle_bin_policy_how_to_update'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/OrganizationSnapshotRecycleBinPolicy'
+min_version: beta
+examples:
+#  - name: 'snapshot_recycle_bin_policy_basic'
+#    primary_resource_id: 'default'
+#    min_version: 'beta'
+#    exclude_test: true
+#  - name: 'snapshot_recycle_bin_policy_multiple'
+#    primary_resource_id: 'multiple'
+#    min_version: 'beta'
+#    exclude_test: true
+base_url: 'organizations/{{organization}}/global/snapshotRecycleBinPolicy'
+update_url: 'organizations/{{organization}}/global/snapshotRecycleBinPolicy'
+self_link: 'organizations/{{organization}}/global/snapshotRecycleBinPolicy'
+immutable: false
+import_format:
+  - 'organizations/{{organization}}/global/snapshotRecycleBinPolicy/'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+create_verb: 'PATCH'
+update_verb: 'PATCH'
+custom_code:
+  encoder: 'templates/terraform/encoders/compute_snapshot_recycle_bin_policy.go.tmpl'
+  post_create: 'templates/terraform/post_create/compute_organization_snapshot_recycle_bin_policy.go.tmpl'
+  post_update: 'templates/terraform/post_create/compute_organization_snapshot_recycle_bin_policy.go.tmpl'
+# there is only a GET and PATCH endpoint
+exclude_delete: true
+autogen_async: false
+async:
+  actions: []
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+  result:
+    resource_inside_response: true
+parameters:
+  - name: 'organization'
+    type: String
+    description: The organization ID for this request (e.g., "organizations/1234").
+    required: true
+    url_param_only: true
+properties:
+  - name: 'rules'
+    type: Map
+    description: |
+      The rules for the snapshot recycle bin policy. The key name is either 'default'
+      or namespaced name of the tag value which can be in the format:
+      {organization_id}/{tag_key_short_name}/{tag_value_short_name} or
+      {project_id}/{tag_key_short_name}/{tag_value_short_name} or
+      {project_number}/{tag_key_short_name}/{tag_value_short_name}. The default rule is
+      applied if snapshots do not have any of these tags. The value is the rule for the key.
+    key_name: 'name'
+    value_type:
+      type: NestedObject
+      properties:
+        - name: 'standardSnapshots'
+          type: NestedObject
+          description: The rule config for standard snapshots.
+          send_empty_value: true
+          properties:
+            - name: 'retentionDurationDays'
+              type: Integer
+              description: |
+                The retention duration for snapshots in the recycle bin after which the
+                snapshots are automatically deleted from recycle bin.

--- a/mmv1/products/compute/SnapshotRecycleBinPolicy.yaml
+++ b/mmv1/products/compute/SnapshotRecycleBinPolicy.yaml
@@ -33,13 +33,16 @@ examples:
 base_url: 'projects/{{project}}/global/snapshotRecycleBinPolicy'
 update_url: 'projects/{{project}}/global/snapshotRecycleBinPolicy'
 immutable: false
+import_format:
+  - 'projects/{{project}}/global/snapshotRecycleBinPolicy/'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
 create_verb: 'PATCH'
 update_verb: 'PATCH'
-update_mask: true
+custom_code:
+  encoder: 'templates/terraform/encoders/compute_snapshot_recycle_bin_policy.go.tmpl'
 # there is only a GET and PATCH endpoint
 exclude_delete: true
 autogen_async: true
@@ -71,6 +74,7 @@ properties:
       - name: 'standardSnapshots'
         type: NestedObject
         description: The rule config for standard snapshots.
+        send_empty_value: true
         properties:
         - name: 'retentionDurationDays'
           type: Integer

--- a/mmv1/products/compute/SnapshotRecycleBinPolicy.yaml
+++ b/mmv1/products/compute/SnapshotRecycleBinPolicy.yaml
@@ -1,0 +1,79 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'SnapshotRecycleBinPolicy'
+description: |
+  Represents the singleton resource Snapshot Recycle Bin Policy that
+  configures the retention duration for snapshots in the recycle bin.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/disks/snapshot-recycle-bin-policy#snapshot_recycle_bin_policy_how_to_update'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/snapshotRecycleBinPolicy'
+min_version: beta
+examples:
+  - name: 'snapshot_recycle_bin_policy_basic'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    exclude_test: true
+  - name: 'snapshot_recycle_bin_policy_multiple'
+    primary_resource_id: 'multiple'
+    min_version: 'beta'
+    exclude_test: true
+base_url: 'projects/{{project}}/global/snapshotRecycleBinPolicy'
+update_url: 'projects/{{project}}/global/snapshotRecycleBinPolicy'
+immutable: false
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+create_verb: 'PATCH'
+update_verb: 'PATCH'
+update_mask: true
+# there is only a GET and PATCH endpoint
+exclude_delete: true
+autogen_async: true
+async:
+  actions: ['create', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+    timeouts:
+      insert_minutes: 20
+      update_minutes: 20
+  result:
+    resource_inside_response: false
+parameters:
+properties:
+  - name: 'rules'
+    type: Map
+    description: |
+      The rules for the snapshot recycle bin policy. The key name is either 'default'
+      or namespaced name of the tag value which can be in the format:
+      {organization_id}/{tag_key_short_name}/{tag_value_short_name} or
+      {project_id}/{tag_key_short_name}/{tag_value_short_name} or
+      {project_number}/{tag_key_short_name}/{tag_value_short_name}. The default rule is
+      applied if snapshots do not have any of these tags. The value is the rule for the key.
+    key_name: 'name'
+    value_type:
+      type: NestedObject
+      properties:
+      - name: 'standardSnapshots'
+        type: NestedObject
+        description: The rule config for standard snapshots.
+        properties:
+        - name: 'retentionDurationDays'
+          type: Integer
+          description: |
+            The retention duration for snapshots in the recycle bin after which the
+            snapshots are automatically deleted from recycle bin.

--- a/mmv1/templates/terraform/encoders/compute_snapshot_recycle_bin_policy.go.tmpl
+++ b/mmv1/templates/terraform/encoders/compute_snapshot_recycle_bin_policy.go.tmpl
@@ -1,0 +1,20 @@
+// The rules map in SnapshotRecycleBinPolicy is authoritative.
+// When a rule is removed from the Terraform configuration, it should be deleted from the API.
+// Since the API uses PATCH, we must explicitly set removed keys to nil (null in JSON) to delete them.
+
+if rules, ok := obj["rules"].(map[string]interface{}); ok {
+	// Get the old rules from the terraform state to identify deletions
+	oldRulesRaw, ok := d.GetOk("rules")
+	if ok {
+		if oldRules, ok := oldRulesRaw.(map[string]interface{}); ok {
+			for k := range oldRules {
+				if _, ok := rules[k]; !ok {
+					// Rule exists in state but not in new config -> set to nil to delete via PATCH
+					rules[k] = nil
+				}
+			}
+		}
+	}
+}
+
+return obj, nil

--- a/mmv1/templates/terraform/examples/snapshot_recycle_bin_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/snapshot_recycle_bin_policy_basic.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_compute_snapshot_recycle_bin_policy" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  rules {
+    name = "default"
+    standard_snapshots {
+      retention_duration_days = 14
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/snapshot_recycle_bin_policy_multiple.tf.tmpl
+++ b/mmv1/templates/terraform/examples/snapshot_recycle_bin_policy_multiple.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_compute_snapshot_recycle_bin_policy" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  rules {
+    name = "default"
+    standard_snapshots {
+      retention_duration_days = 3
+    }
+  }
+
+  rules {
+    name = "some-project/12345/6789"
+    standard_snapshots {
+      retention_duration_days = 10
+    }
+  }
+}

--- a/mmv1/templates/terraform/post_create/compute_organization_snapshot_recycle_bin_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_create/compute_organization_snapshot_recycle_bin_policy.go.tmpl
@@ -1,0 +1,55 @@
+{{/*
+	res is the operation map[string]interface{} returned by PATCH.
+	We need to poll this operation until it's done.
+*/}}
+opSelfLink, ok := res["selfLink"].(string)
+if !ok {
+	return fmt.Errorf("operation response missing selfLink")
+}
+
+// Ensure we use the correct billing project for the operation status check.
+// Organization operations often require the X-Goog-User-Project header.
+operationBillingProject, err := tpgresource.GetBillingProject(d, config)
+if err != nil {
+	operationBillingProject = config.Project
+}
+
+waitFunc := func() (map[string]interface{}, error) {
+	url := opSelfLink
+	if !strings.HasPrefix(url, "https://") && !strings.HasPrefix(url, "http://") {
+		url = config.ComputeBasePath + url
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   operationBillingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+err = transport_tpg.PollingWaitTime(waitFunc, func(res map[string]interface{}, err error) transport_tpg.PollResult {
+	if err != nil {
+		return transport_tpg.ErrorPollResult(err)
+	}
+	status, ok := res["status"]
+	if !ok {
+		return transport_tpg.ErrorPollResult(fmt.Errorf("operation response missing status"))
+	}
+	if status.(string) == "DONE" {
+		if errorVal, ok := res["error"]; ok && errorVal != nil {
+			return transport_tpg.ErrorPollResult(fmt.Errorf("operation failed: %v", errorVal))
+		}
+		return transport_tpg.SuccessPollResult()
+	}
+	return transport_tpg.PendingStatusPollResult(status.(string))
+}, "Waiting for OrganizationSnapshotRecycleBinPolicy operation", d.Timeout(schema.TimeoutCreate), 1)
+
+if err != nil {
+	return err
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID



-->

### Issue

We are adding terraform support for Snapshot Recycle Bin on Compute Disk. This PR add a snapshot recycle bin policy resource on terraform. The resource will be only enabled for beta. 

For now the testing has been done against an allowlisted alpha staging project. As the feature is not available on beta we cannot at integration tests for it. Integration tests will come in follow up PR.

### Testing

Tested manually against alpha endpoint. 

[logs link](https://paste.googleplex.com/5615501314228224)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME
SnapshotRecycleBinPolicy resource for Disk Recycle Bin feature.

```
