### PR TITLE
feat(bigtable): Add support for tags on  instances

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance.go
@@ -224,6 +224,14 @@ func ResourceBigtableInstance() *schema.Resource {
 				ForceNew:    true,
 				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
 			},
+
+			"tags": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: `A map of Resource Manager Tags. Keys can be either the numeric tag key ID (tagKeys/123) or the namespaced name (project/tag-key). Values can be the numeric tag value ID (tagValues/456) or the namespaced value (project/tag-key/tag-value). The field is ignored when empty.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -255,6 +263,10 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 
 	if _, ok := d.GetOk("effective_labels"); ok {
 		conf.Labels = tpgresource.ExpandEffectiveLabels(d)
+	}
+
+	if _, ok := d.GetOk("tags"); ok {
+		conf.Tags = tpgresource.ExpandStringMap(d, "tags")
 	}
 
 	switch d.Get("instance_type").(string) {

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_meta.yaml
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_meta.yaml
@@ -26,5 +26,6 @@ fields:
   - api_field: 'labels'
   - api_field: 'name'
   - field: 'project'
+  - api_field: 'tags'
   - field: 'terraform_labels'
     provider_only: true

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -1296,12 +1296,12 @@ data "google_project" "project" {
 
 resource "google_tags_tag_key" "key" {
   parent     = "projects/${data.google_project.project.project_id}"
-  short_name = "key"
+  short_name = "key-%s"
 }
 
 resource "google_tags_tag_value" "value" {
   parent     = "tagKeys/${google_tags_tag_key.key.name}"
-  short_name = "value"
+  short_name = "value-%s"
 }
 
 resource "google_bigtable_instance" "instance" {
@@ -1320,5 +1320,5 @@ resource "google_bigtable_instance" "instance" {
     google_tags_tag_value.value
   ]
 }
-`, pid, instanceName, instanceName)
+`, pid, instanceName, instanceName, instanceName, instanceName)
 }

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -627,6 +627,7 @@ func TestAccBigtableInstance_tags(t *testing.T) {
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	pid := envvar.GetTestProjectFromEnv()
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -638,13 +639,13 @@ func TestAccBigtableInstance_tags(t *testing.T) {
 				ExpectError: regexp.MustCompile("config is invalid: Too few cluster blocks: Should have at least 1 \"cluster\" block"),
 			},
 			{
-				Config: testAccBigtableInstance_tags(instanceName, map[string]string{"tagKeys/123": "tagValue/456"}),
+				Config: testAccBigtableInstance_tags(pid, instanceName),
 			},
 			{
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "tags"}, // we don't read tags back
+				ImportStateVerifyIgnore: []string{"instance_type", "deletion_protection", "tags"}, // we don't read tags back
 			},
 		},
 	})
@@ -1287,8 +1288,22 @@ resource "time_offset" "week-in-future" {
 `
 }
 
-func testAccBigtableInstance_tags(instanceName string, tags map[string]string) string {
-	l := fmt.Sprintf(`
+func testAccBigtableInstance_tags(pid, instanceName string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_tags_tag_key" "key" {
+  parent     = "projects/${data.google_project.project.project_id}"
+  short_name = "key"
+}
+
+resource "google_tags_tag_value" "value" {
+  parent     = "tagKeys/${google_tags_tag_key.key.name}"
+  short_name = "value"
+}
+
 resource "google_bigtable_instance" "instance" {
   name = "%s"
   cluster {
@@ -1297,14 +1312,13 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 1
     storage_type = "HDD"
   }
-deletion_protection = false
-  tags = {`, instanceName, instanceName)
-
-	r := ""
-	for key, value := range tags {
-		r += fmt.Sprintf("%q = %q\n", key, value)
-	}
-
-	r += fmt.Sprintf("}\n")
-	return l + r
+  deletion_protection = false
+  tags = {
+	"${google_tags_tag_key.key.id}" = "${google_tags_tag_value.value.id}"
+  }
+  depends_on = [
+    google_tags_tag_value.value
+  ]
+}
+`, pid, instanceName, instanceName)
 }

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_instance_test.go
@@ -621,6 +621,35 @@ func TestAccBigtableInstance_createWithNodeScalingFactorThenUpdateViaForceNew(t 
 	})
 }
 
+func TestAccBigtableInstance_tags(t *testing.T) {
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigtableInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBigtableInstance_invalid(instanceName),
+				ExpectError: regexp.MustCompile("config is invalid: Too few cluster blocks: Should have at least 1 \"cluster\" block"),
+			},
+			{
+				Config: testAccBigtableInstance_tags(instanceName, map[string]string{"tagKeys/123": "tagValue/456"}),
+			},
+			{
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "tags"}, // we don't read tags back
+			},
+		},
+	})
+}
+
 func TestAccBigtableInstance_createWithNodeScalingFactorThenFailFromDeletionProtection(t *testing.T) {
 	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	acctest.SkipIfVcr(t)
@@ -1256,4 +1285,26 @@ resource "time_offset" "week-in-future" {
   offset_days = 7
 }
 `
+}
+
+func testAccBigtableInstance_tags(instanceName string, tags map[string]string) string {
+	l := fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s-a"
+    zone         = "us-central1-a"
+    num_nodes    = 1
+    storage_type = "HDD"
+  }
+deletion_protection = false
+  tags = {`, instanceName, instanceName)
+
+	r := ""
+	for key, value := range tags {
+		r += fmt.Sprintf("%q = %q\n", key, value)
+	}
+
+	r += fmt.Sprintf("}\n")
+	return l + r
 }

--- a/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -114,6 +114,8 @@ to default to the backend value. See [structure below](#nested_cluster).
 * `effective_labels` -
   All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
 
+* `tags` - (Optional) A set of key/value label pairs to assign to the resource. Tags must follow the requirements at [create and manage tags](https://docs.cloud.google.com/resource-manager/docs/tags/tags-creating-and-managing).
+
 -----
 
 <a name="nested_cluster"></a>The `cluster` block supports the following arguments:


### PR DESCRIPTION
This PR adds support for the new `tags` field to the bigtable instance resource. This allows users to specify key/value tag pairs on bigtable instances at creation.

Bigtable tags public docs: https://docs.cloud.google.com/bigtable/docs/tags

```release-note:enhancement
bigtable: added support for `tags` to `google_bigtable_instance`
```
