### PR TITLE
Fix panic in firebasehosting_custom_domain CheckDestroy test step"

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/firebasehosting_custom_domain_soft_delete.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/firebasehosting_custom_domain_soft_delete.go.tmpl
@@ -18,6 +18,7 @@ resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
     RawURL:    url,
     UserAgent: config.UserAgent,
 })
-if err == nil && resp["deleteTime"].(string) == "" {
+deleteTime, ok := resp["deleteTime"].(string)
+if err == nil && (!ok || deleteTime == "") {
     return fmt.Errorf("FirebaseHostingCustomDomain still exists at %s", url)
 }


### PR DESCRIPTION
We recently started running into a panic with this line trying to access `deleteTime`. This changes this check to be more graceful, avoiding said panic.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:REPLACEME

```
