### PR TITLE
Update Test Generation: convert examples before generating providers

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,13 +61,16 @@ ifneq ($(SKIP_CLEAN),)
   endif
 endif
 
-terraform build provider: validate_environment clean-provider mmv1 tpgtools
+TEMP_DIR := $(shell mktemp -d)
+export TEMP_DIR
+
+terraform build provider: validate_environment clean-provider mmv1 tpgtools clean-temp
 	@echo "Provider generation process finished for $(VERSION) in $(OUTPUT_PATH)"
 
 
-mmv1:
+mmv1: prepare-temp
 	@echo "Executing mmv1 build for $(OUTPUT_PATH)"; 
-	@cd mmv1;\
+	@cd $(TEMP_DIR)/mmv1;\
 		if [ "$(VERSION)" = "ga" ]; then \
 			go run . --output $(OUTPUT_PATH) --version ga --no-docs $(mmv1_compile) \
 			&& go run . --output $(OUTPUT_PATH) --version beta --no-code $(mmv1_compile); \
@@ -75,9 +78,9 @@ mmv1:
 			go run . --output $(OUTPUT_PATH) --version $(VERSION) $(mmv1_compile); \
 		fi
 
-tpgtools: serialize
+tpgtools: prepare-temp serialize
 	@echo "Executing tpgtools build for $(OUTPUT_PATH)";
-	@cd tpgtools;\
+	@cd $(TEMP_DIR)/tpgtools;\
 		go run . --output $(OUTPUT_PATH) --version $(VERSION) $(tpgtools_compile); \
 		rm serialization.go
 
@@ -137,7 +140,7 @@ test:
 		go test ./...
 
 serialize:
-	cd tpgtools;\
+	cd $(TEMP_DIR)/tpgtools;\
 		cp -f serialization.go.base serialization.go &&\
 		go run . $(serialize_compile) --mode "serialization" > temp.serial &&\
 		mv -f temp.serial serialization.go
@@ -175,4 +178,36 @@ check_safe_build:
 doctor:
 	./scripts/doctor
 
-.PHONY: mmv1 tpgtools test clean-provider validate_environment serialize doctor
+
+prepare-temp:
+
+	@echo "Setting up temporary workspace for conversion at $(TEMP_DIR)..."
+	@rm -rf $(TEMP_DIR)
+	@mkdir -p $(TEMP_DIR)/mmv1 $(TEMP_DIR)/tpgtools $(TEMP_DIR)/tools
+	@echo "Copying files to $(TEMP_DIR)..."
+	@cp -R ./mmv1/. $(TEMP_DIR)/mmv1/
+	@cp -R ./tpgtools/. $(TEMP_DIR)/tpgtools/
+	@cp -R ./tools/. $(TEMP_DIR)/tools/
+	@echo "Building resource template converter in temp..."
+	cd $(TEMP_DIR)/tools/resource-template-converter && go env -w GO111MODULE=on && go mod tidy && go build -v -o $(TEMP_DIR)/tools/convert-resource-template . && echo "BUILD SUCCEEDED" || (echo "BUILD FAILED"; exit 1)
+	@echo "Build finished, running converter..."
+	@ls -la $(TEMP_DIR)/tools/convert-resource-template
+	@$(TEMP_DIR)/tools/convert-resource-template convert-resource-template $(TEMP_DIR)
+	@echo "Temporary workspace setup complete."
+
+test-convert:
+	@echo $(TEMP_DIR)
+
+clean-temp:
+	@echo "Cleaning up temporary workspace $(TEMP_DIR)..."
+	@rm -rf $(TEMP_DIR)
+
+convert-templates:
+	@echo "Checking and running resource template converter..."
+	@if [ ! -f ./convert-resource-template ]; then \
+		echo "Building convert-resource-template tool..."; \
+		(cd tools/resource-template-converter && go build -o ../../convert-resource-template); \
+	fi
+	@./convert-resource-template convert-resource-template .
+
+.PHONY: mmv1 tpgtools test clean-provider validate_environment serialize doctor convert-templates prepare-temp clean-temp


### PR DESCRIPTION
This updates the generation command to convert all examples to samples before generation. This switches us over to the new sample generator backend. Must be merged after https://github.com/GoogleCloudPlatform/magic-modules/pull/16470.

Merging of this PR indicates the initial launch of update test generation.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
