### PR TITLE
Add exclude_from_gen_ai_features field to Datastore

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -419,6 +419,11 @@ properties:
                   required: false
                   item_type:
                     type: String
+  - name: 'excludeFromGenAiFeatures'
+    type: 'Boolean'
+    description: |
+      If set true, the DataStore will not be used for Generative AI features.
+    required: false
   - name: 'createTime'
     type: Time
     description: |

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -86,6 +86,10 @@ examples:
     primary_resource_id: 'advanced_site_search_config'
     vars:
       data_store_id: 'data-store-id'
+  - name: 'discoveryengine_datastore_exclude_from_gen_ai_features'
+    primary_resource_id: 'exclude_from_gen_ai_features'
+    vars:
+      data_store_id: 'data-store-id'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_exclude_from_gen_ai_features.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_exclude_from_gen_ai_features.tf.tmpl
@@ -1,4 +1,4 @@
-resource "google_discovery_engine_data_store" "basic" {
+resource "google_discovery_engine_data_store" "exclude_from_gen_ai_features" {
   location                     = "global"
   data_store_id                = "{{index $.Vars "data_store_id"}}"
   display_name                 = "tf-test-structured-datastore"

--- a/mmv1/templates/terraform/examples/discoveryengine_datastore_exclude_from_gen_ai_features.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_datastore_exclude_from_gen_ai_features.tf.tmpl
@@ -1,0 +1,11 @@
+resource "google_discovery_engine_data_store" "basic" {
+  location                     = "global"
+  data_store_id                = "{{index $.Vars "data_store_id"}}"
+  display_name                 = "tf-test-structured-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "NO_CONTENT"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = false
+  exclude_from_gen_ai_features = true
+}


### PR DESCRIPTION
google_discovery_engine_data_store.

This PR adds `exclude_from_gen_ai_features` as a valid field to the `google_discovery_engine_data_store` resource.
FIxes b/483792089

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
discoveryengine: added `exclude_from_gen_ai_features` field to `google_discovery_engine_data_store` resource
```
