### PR TITLE
Add Model Armor config example for Discovery Engine Assistant

### DIFF
--- a/mmv1/products/discoveryengine/Assistant.yaml
+++ b/mmv1/products/discoveryengine/Assistant.yaml
@@ -36,6 +36,12 @@ examples:
       data_store_id: 'example-data-store-id'
       engine_id: 'example-engine-id'
       template_id: 'example-template-id'
+  - name: 'discoveryengine_assistant_with_model_armor'
+    primary_resource_id: 'with-model-armor'
+    vars:
+      data_store_id: 'example-data-store-id'
+      engine_id: 'example-engine-id'
+      template_id: 'ma-template-id'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/Assistant.yaml
+++ b/mmv1/products/discoveryengine/Assistant.yaml
@@ -42,6 +42,9 @@ examples:
       data_store_id: 'example-data-store-id'
       engine_id: 'example-engine-id'
       template_id: 'ma-template-id'
+      ma_location: 'europe-west1'
+    test_vars_overrides:
+      ma_location: '"europe-west1"'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/Assistant.yaml
+++ b/mmv1/products/discoveryengine/Assistant.yaml
@@ -42,9 +42,9 @@ examples:
       data_store_id: 'example-data-store-id'
       engine_id: 'example-engine-id'
       template_id: 'ma-template-id'
-      ma_location: 'us-central1'
+      ma_location: 'eu'
     test_vars_overrides:
-      ma_location: '"us-central1"'
+      ma_location: '"eu"'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/Assistant.yaml
+++ b/mmv1/products/discoveryengine/Assistant.yaml
@@ -42,9 +42,9 @@ examples:
       data_store_id: 'example-data-store-id'
       engine_id: 'example-engine-id'
       template_id: 'ma-template-id'
-      ma_location: 'europe-west1'
+      ma_location: 'us-central1'
     test_vars_overrides:
-      ma_location: '"europe-west1"'
+      ma_location: '"us-central1"'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/Assistant.yaml
+++ b/mmv1/products/discoveryengine/Assistant.yaml
@@ -42,9 +42,9 @@ examples:
       data_store_id: 'example-data-store-id'
       engine_id: 'example-engine-id'
       template_id: 'ma-template-id'
-      ma_location: 'eu'
+      ma_location: 'us'
     test_vars_overrides:
-      ma_location: '"eu"'
+      ma_location: '"us"'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "with_armor" {
-  location                    = "global"
+  location                    = "eu"
   data_store_id               = "{{index $.Vars "data_store_id"}}"
   display_name                = "tf-test-structured-datastore"
   industry_vertical           = "GENERIC"
@@ -9,7 +9,7 @@ resource "google_discovery_engine_data_store" "with_armor" {
 }
 
 resource "google_discovery_engine_search_engine" "with_armor" {
-  location      = "global"
+  location      = "eu"
   collection_id = "default_collection"
   engine_id     = "{{index $.Vars "engine_id"}}"
   display_name  = "Example Search Engine"
@@ -43,7 +43,7 @@ resource "google_model_armor_template" "prompt_shield" {
 }
 
 resource "google_discovery_engine_assistant" "{{$.PrimaryResourceId}}" {
-  location      = "global"
+  location      = "eu"
   collection_id = "default_collection"
   engine_id     = google_discovery_engine_search_engine.with_armor.engine_id
   assistant_id  = "default_assistant"

--- a/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "with_armor" {
-  location                    = "eu"
+  location                    = "us"
   data_store_id               = "{{index $.Vars "data_store_id"}}"
   display_name                = "tf-test-structured-datastore"
   industry_vertical           = "GENERIC"
@@ -9,7 +9,7 @@ resource "google_discovery_engine_data_store" "with_armor" {
 }
 
 resource "google_discovery_engine_search_engine" "with_armor" {
-  location      = "eu"
+  location      = "us"
   collection_id = "default_collection"
   engine_id     = "{{index $.Vars "engine_id"}}"
   display_name  = "Example Search Engine"
@@ -43,7 +43,7 @@ resource "google_model_armor_template" "prompt_shield" {
 }
 
 resource "google_discovery_engine_assistant" "{{$.PrimaryResourceId}}" {
-  location      = "eu"
+  location      = "us"
   collection_id = "default_collection"
   engine_id     = google_discovery_engine_search_engine.with_armor.engine_id
   assistant_id  = "default_assistant"

--- a/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "with_armor" {
-  location                    = "global"
+  location                    = "eu"
   data_store_id               = "{{index $.Vars "data_store_id"}}"
   display_name                = "tf-test-structured-datastore"
   industry_vertical           = "GENERIC"
@@ -9,7 +9,7 @@ resource "google_discovery_engine_data_store" "with_armor" {
 }
 
 resource "google_discovery_engine_search_engine" "with_armor" {
-  location      = "global"
+  location      = "eu"
   collection_id = "default_collection"
   engine_id     = "{{index $.Vars "engine_id"}}"
   display_name  = "Example Search Engine"
@@ -19,7 +19,7 @@ resource "google_discovery_engine_search_engine" "with_armor" {
 }
 
 resource "google_model_armor_template" "prompt_shield" {
-  location    = "global"
+  location    = "{{index $.Vars "ma_location"}}"
   template_id = "{{index $.Vars "template_id"}}"
   filter_config {
     rai_settings {
@@ -43,7 +43,7 @@ resource "google_model_armor_template" "prompt_shield" {
 }
 
 resource "google_discovery_engine_assistant" "{{$.PrimaryResourceId}}" {
-  location      = "global"
+  location      = "eu"
   collection_id = "default_collection"
   engine_id     = google_discovery_engine_search_engine.with_armor.engine_id
   assistant_id  = "default_assistant"

--- a/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "with_armor" {
-  location                    = "eu"
+  location                    = "global"
   data_store_id               = "{{index $.Vars "data_store_id"}}"
   display_name                = "tf-test-structured-datastore"
   industry_vertical           = "GENERIC"
@@ -9,7 +9,7 @@ resource "google_discovery_engine_data_store" "with_armor" {
 }
 
 resource "google_discovery_engine_search_engine" "with_armor" {
-  location      = "eu"
+  location      = "global"
   collection_id = "default_collection"
   engine_id     = "{{index $.Vars "engine_id"}}"
   display_name  = "Example Search Engine"
@@ -43,7 +43,7 @@ resource "google_model_armor_template" "prompt_shield" {
 }
 
 resource "google_discovery_engine_assistant" "{{$.PrimaryResourceId}}" {
-  location      = "eu"
+  location      = "global"
   collection_id = "default_collection"
   engine_id     = google_discovery_engine_search_engine.with_armor.engine_id
   assistant_id  = "default_assistant"

--- a/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_assistant_with_model_armor.tf.tmpl
@@ -1,0 +1,71 @@
+resource "google_discovery_engine_data_store" "with_armor" {
+  location                    = "global"
+  data_store_id               = "{{index $.Vars "data_store_id"}}"
+  display_name                = "tf-test-structured-datastore"
+  industry_vertical           = "GENERIC"
+  content_config              = "NO_CONTENT"
+  solution_types              = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search = false
+}
+
+resource "google_discovery_engine_search_engine" "with_armor" {
+  location      = "global"
+  collection_id = "default_collection"
+  engine_id     = "{{index $.Vars "engine_id"}}"
+  display_name  = "Example Search Engine"
+  data_store_ids = [google_discovery_engine_data_store.with_armor.data_store_id]
+  search_engine_config {
+  }
+}
+
+resource "google_model_armor_template" "prompt_shield" {
+  location    = "global"
+  template_id = "{{index $.Vars "template_id"}}"
+  filter_config {
+    rai_settings {
+      rai_filters {
+        filter_type      = "HATE_SPEECH"
+        confidence_level = "MEDIUM_AND_ABOVE"
+      }
+      rai_filters {
+        filter_type      = "DANGEROUS"
+        confidence_level = "HIGH"
+      }
+    }
+    pi_and_jailbreak_filter_settings {
+      filter_enforcement = "ENABLED"
+      confidence_level   = "MEDIUM_AND_ABOVE"
+    }
+    malicious_uri_filter_settings {
+      filter_enforcement = "ENABLED"
+    }
+  }
+}
+
+resource "google_discovery_engine_assistant" "{{$.PrimaryResourceId}}" {
+  location      = "global"
+  collection_id = "default_collection"
+  engine_id     = google_discovery_engine_search_engine.with_armor.engine_id
+  assistant_id  = "default_assistant"
+  display_name  = "Assistant with Model Armor"
+  description   = "Gemini Enterprise assistant protected by Model Armor"
+  generation_config {
+    system_instruction {
+      additional_system_instruction = "You are a helpful assistant."
+    }
+    default_language = "en"
+  }
+  customer_policy {
+    banned_phrases {
+      phrase            = "confidential"
+      match_type        = "WORD_BOUNDARY_STRING_MATCH"
+      ignore_diacritics = true
+    }
+    model_armor_config {
+      user_prompt_template = google_model_armor_template.prompt_shield.id
+      response_template    = google_model_armor_template.prompt_shield.id
+      failure_mode         = "FAIL_OPEN"
+    }
+  }
+  web_grounding_type = "WEB_GROUNDING_TYPE_GOOGLE_SEARCH"
+}


### PR DESCRIPTION
The existing example only covers banned_phrases in customer_policy. This adds a second example demonstrating model_armor_config integration, which configures user prompt and response sanitization templates.

This helps users who need to integrate Model Armor with Gemini Enterprise (Discovery Engine) via Terraform.

Related: https://github.com/hashicorp/terraform-provider-google/issues/26316

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
discoveryengine: added example with `model_armor_config` in `customer_policy` for `google_discovery_engine_assistant`
```