### PR TITLE
fix(26336): google_gke_hub_feature_membership import with membership location

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -748,8 +748,6 @@ FeatureMembership can be imported using any of these accepted formats:
 * `{{project}}/{{location}}/{{feature}}/{{membership}}`
 * `{{location}}/{{feature}}/{{membership}}`
 
-When the `membership_location` is omitted from the import ID, it will default to `global`.
-
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import FeatureMembership using one of the formats above. For example:
 
 ```tf

--- a/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/gke_hub_feature_membership.html.markdown
@@ -741,15 +741,20 @@ This resource provides the following
 
 FeatureMembership can be imported using any of these accepted formats:
 
+* `projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}/membershipLocation/{{membership_location}}`
+* `{{project}}/{{location}}/{{feature}}/{{membership}}/{{membership_location}}`
+* `{{location}}/{{feature}}/{{membership}}/{{membership_location}}`
 * `projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}`
 * `{{project}}/{{location}}/{{feature}}/{{membership}}`
 * `{{location}}/{{feature}}/{{membership}}`
+
+When the `membership_location` is omitted from the import ID, it will default to `global`.
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import FeatureMembership using one of the formats above. For example:
 
 ```tf
 import {
-  id = "projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}"
+  id = "projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}/membershipLocation/{{membership_location}}"
   to = google_gke_hub_feature_membership.default
 }
 ```
@@ -757,6 +762,9 @@ import {
 When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), FeatureMembership can be imported using one of the formats above. For example:
 
 ```
+$ terraform import google_gke_hub_feature_membership.default projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}/membershipLocation/{{membership_location}}
+$ terraform import google_gke_hub_feature_membership.default {{project}}/{{location}}/{{feature}}/{{membership}}/{{membership_location}}
+$ terraform import google_gke_hub_feature_membership.default {{location}}/{{feature}}/{{membership}}/{{membership_location}}
 $ terraform import google_gke_hub_feature_membership.default projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}
 $ terraform import google_gke_hub_feature_membership.default {{project}}/{{location}}/{{feature}}/{{membership}}
 $ terraform import google_gke_hub_feature_membership.default {{location}}/{{feature}}/{{membership}}

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -14,6 +14,15 @@
 - type: CUSTOM_ID
   details:
     id: 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}'
+- type: IMPORT_FORMAT
+  details:
+    formats:
+      - 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}/membershipLocation/{{membership_location}}'
+      - '{{project}}/{{location}}/{{feature}}/{{membership}}/{{membership_location}}'
+      - '{{location}}/{{feature}}/{{membership}}/{{membership_location}}'
+      - 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}'
+      - '{{project}}/{{location}}/{{feature}}/{{membership}}'
+      - '{{location}}/{{feature}}/{{membership}}'
 - type: MUTEX
   details:
     mutex: '{{project}}/{{location}}/{{feature}}'

--- a/tpgtools/overrides/gkehub/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/feature_membership.yaml
@@ -14,6 +14,15 @@
 - type: CUSTOM_ID
   details:
     id: 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}'
+- type: IMPORT_FORMAT
+  details:
+    formats:
+      - 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}/membershipLocation/{{membership_location}}'
+      - '{{project}}/{{location}}/{{feature}}/{{membership}}/{{membership_location}}'
+      - '{{location}}/{{feature}}/{{membership}}/{{membership_location}}'
+      - 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}'
+      - '{{project}}/{{location}}/{{feature}}/{{membership}}'
+      - '{{location}}/{{feature}}/{{membership}}'
 - type: MUTEX
   details:
     mutex: '{{project}}/{{location}}/{{feature}}'


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26336

Allows importing `google_gke_hub_feature_membership` for memberships that have a non-global membership location.

```sh
# GA
> make provider VERSION=ga OUTPUT_PATH="/Users/locutus/code/terraform-provider-google"

# Beta
> make provider VERSION=beta OUTPUT_PATH="/Users/locutus/code/terraform-provider-google-beta"

> cat ~/.terraformrc
provider_installation {
  dev_overrides {
    "hashicorp/google"      = "/Users/locutus/code/terraform-provider-google"
    "hashicorp/google-beta"  = "/Users/locutus/code/terraform-provider-google-beta"
  }

  direct {}
}
```


<details>
<summary>New import example:</summary>

```
> terraform state show 'module.container_clusters["my-cluster"].google_gke_hub_feature_membership.acm[0]'
# module.container_clusters["my-cluster"].google_gke_hub_feature_membership.acm[0]:
resource "google_gke_hub_feature_membership" "acm" {
    feature             = "configmanagement"
    id                  = "projects/my-project/locations/global/features/configmanagement/membershipId/my-cluster"
    location            = "global"
    membership          = "my-cluster"
    membership_location = "us-east4"  // NOTE regional membership
    project             = "my-project"

    configmanagement {
        management = null
        version    = "1.23.2"

        config_sync {
            enabled                           = true
            metrics_gcp_service_account_email = null
            prevent_drift                     = true
            source_format                     = "unstructured"
            stop_syncing                      = false

            git {
                gcp_service_account_email = null
                https_proxy               = null
                policy_dir                = "configs/env/dev/my-cluster"
                secret_type               = "ssh"
                sync_branch               = "main"
                sync_repo                 = "git@github.com:[REDACTED]"
                sync_rev                  = null
                sync_wait_secs            = null
            }
        }
    }
}
```

```
> terraform state rm 'module.container_clusters["my-cluster"].google_gke_hub_feature_membership.acm[0]'
Removed module.container_clusters["my-cluster"].google_gke_hub_feature_membership.acm[0]
Successfully removed 1 resource instance(s).
```

```
terraform import 'module.container_clusters["my-cluster"].google_gke_hub_feature_membership.acm[0]' 'global/configmanagement/my-cluster/us-east4'

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```
</details>

<details>
<summary>Import regression example:</summary>

```
> terraform state show 'google_gke_hub_feature_membership.gke_hub_feature_membership_26336'
# google_gke_hub_feature_membership.gke_hub_feature_membership_26336:
resource "google_gke_hub_feature_membership" "gke_hub_feature_membership_26336" {
    feature             = "configmanagement"
    id                  = "projects/my-project/locations/global/features/configmanagement/membershipId/gke-hub-membership-26336"
    location            = "global"
    membership          = "gke-hub-membership-26336"
    membership_location = null
    project             = "my-project"

    configmanagement {
        management = null
        version    = "1.23.2"

        config_sync {
            enabled                           = true
            metrics_gcp_service_account_email = null
            prevent_drift                     = false
            source_format                     = null
            stop_syncing                      = false

            oci {
                gcp_service_account_email = "service-account-26336-2@my-project.iam.gserviceaccount.com"
                policy_dir                = "config-connector"
                secret_type               = "gcpserviceaccount"
                sync_repo                 = "us-central1-docker.pkg.dev/sample-project/config-repo/config-sync-gke:latest"
                sync_wait_secs            = "20"
            }
        }
    }
}
```

```
> terraform state rm 'google_gke_hub_feature_membership.gke_hub_feature_membership_26336'
Removed google_gke_hub_feature_membership.gke_hub_feature_membership_26336
Successfully removed 1 resource instance(s).
```

```
terraform import 'google_gke_hub_feature_membership.gke_hub_feature_membership_26336' 'global/configmanagement/gke-hub-membership-26336'

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```
</details>

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
google_gke_hub_feature_membership: allow specifying membership region in import.
```