### PR TITLE
Deprecate auto scaling for WorkerPools.

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -282,20 +282,19 @@ properties:
     properties:
       - name: 'scalingMode'
         ignore_read: true
-        type: Enum
+        type: String
         description: |
-          The scaling mode for the worker pool. It defaults to MANUAL.
-        enum_values:
-          - 'AUTOMATIC'
-          - 'MANUAL'
+          The scaling mode for the worker pool. Currently only MANUAL is supported.
       - name: 'minInstanceCount'
         type: Integer
         description: |
           The minimum count of instances distributed among revisions based on the specified instance split percentages.
+        deprecation_message: '`minInstanceCount` is deprecated as WorkerPool does not support auto scaling and will be removed in a future major release.'
       - name: 'maxInstanceCount'
         type: Integer
         description: |
           The maximum count of instances distributed among revisions based on the specified instance split percentages.
+        deprecation_message: '`maxInstanceCount` is deprecated as WorkerPool does not support auto scaling and will be removed in a future major release.'
       - name: 'manualInstanceCount'
         type: Integer
         description: |

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_worker_pool_test.go
@@ -522,6 +522,7 @@ resource "google_cloud_run_v2_worker_pool" "default" {
   client_version = "client-version-1"
   launch_stage = "BETA"
   scaling {
+    scaling_mode = "MANUAL"
     manual_instance_count = 2
   }
   template {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:deprecation
Deprecating `scalingMode` , `minInstance` ,  `maxInstance` for WorkerPool.
```
