### PR TITLE
Fix perma-diff in google_service_networking_connection for reserved_peering_ranges ordering

### DIFF
--- a/.changelog/16191.txt
+++ b/.changelog/16191.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+servicenetworking: fixed perma-diff issue in `google_service_networking_connection` when `reserved_peering_ranges` order changes
+```

--- a/.changelog/16191.txt
+++ b/.changelog/16191.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-servicenetworking: fixed perma-diff issue in `google_service_networking_connection` when `reserved_peering_ranges` order changes
-```

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -231,10 +231,13 @@ func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error setting peering: %s", err)
 	}
 
-	ranges := connection.ReservedPeeringRanges
-	if err := d.Set("reserved_peering_ranges", ranges); err != nil {
+	// removed the intermediate `ranges` variable — it was a
+	// leftover from when sort.Strings() lived here. The DiffSuppressFunc
+	// already handles ordering, so we write the API response directly to state.
+	if err := d.Set("reserved_peering_ranges", connection.ReservedPeeringRanges); err != nil {
 		return fmt.Errorf("Error setting reserved_peering_ranges: %s", err)
 	}
+
 	return nil
 }
 
@@ -438,7 +441,6 @@ func RetrieveServiceNetworkingNetworkName(d *schema.ResourceData, config *transp
 
 	// return the network name formatting unique to this API
 	return fmt.Sprintf("projects/%v/global/networks/%v", project.ProjectNumber, networkName), nil
-
 }
 
 const parentServicePattern = "^services/.+$"

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -465,25 +465,23 @@ func init() {
 }
 
 func stringListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// Extract the root field name from k (e.g., "reserved_peering_ranges.0" -> "reserved_peering_ranges")
-	// DiffSuppressFunc is called for each element and for the count, so we need to handle both
-	rootKey := k
-	if idx := strings.Index(k, "."); idx != -1 {
-		rootKey = k[:idx]
-	}
+	// The key (k) can be "reserved_peering_ranges", "reserved_peering_ranges.#", or "reserved_peering_ranges.0", etc.
+	// We want to check the *entire* list equality whenever any part of it is questioned.
+	root := "reserved_peering_ranges"
 
-	// Only process once when k equals the root field name or when it's the count (e.g., "reserved_peering_ranges.#")
-	if k != rootKey && !strings.HasSuffix(k, ".#") {
+	// If this key doesn't belong to our field, ignore it.
+	if k != root && !strings.HasPrefix(k, root+".") {
 		return false
 	}
 
-	o, n := d.GetChange(rootKey)
+	// Get the full list values (Old and New) from the resource data
+	o, n := d.GetChange(root)
 
 	// Cast to generic lists
 	oldList, ok1 := o.([]interface{})
 	newList, ok2 := n.([]interface{})
 
-	// If casting fails or lengths differ, don't suppress the diff
+	// If casting fails or lengths differ, we definitely have a change, so don't suppress.
 	if !ok1 || !ok2 || len(oldList) != len(newList) {
 		return false
 	}
@@ -499,8 +497,10 @@ func stringListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 		newStrs[i] = fmt.Sprintf("%v", v)
 	}
 
+	// Sort both lists to compare content regardless of order
 	sort.Strings(oldStrs)
 	sort.Strings(newStrs)
 
+	// If the sorted lists are identical, return true to SUPPRESS the diff.
 	return reflect.DeepEqual(oldStrs, newStrs)
 }

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -230,7 +230,10 @@ func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interf
 	if err := d.Set("peering", connection.Peering); err != nil {
 		return fmt.Errorf("Error setting peering: %s", err)
 	}
-	if err := d.Set("reserved_peering_ranges", connection.ReservedPeeringRanges); err != nil {
+	
+	ranges := connection.ReservedPeeringRanges
+	sort.Strings(ranges)
+	if err := d.Set("reserved_peering_ranges", ranges); err != nil {
 		return fmt.Errorf("Error setting reserved_peering_ranges: %s", err)
 	}
 	return nil

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -230,7 +230,7 @@ func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interf
 	if err := d.Set("peering", connection.Peering); err != nil {
 		return fmt.Errorf("Error setting peering: %s", err)
 	}
-	
+
 	ranges := connection.ReservedPeeringRanges
 	sort.Strings(ranges)
 	if err := d.Set("reserved_peering_ranges", ranges); err != nil {

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -464,29 +464,24 @@ func init() {
 	}.Register()
 }
 
+// stringListDiffSuppress suppresses diffs for TypeList fields where the
+// order of elements does not matter. It derives the root key from k by
+// stripping the element index suffix.
 func stringListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// The key (k) can be "reserved_peering_ranges", "reserved_peering_ranges.#", or "reserved_peering_ranges.0", etc.
-	// We want to check the *entire* list equality whenever any part of it is questioned.
-	root := "reserved_peering_ranges"
-
-	// If this key doesn't belong to our field, ignore it.
-	if k != root && !strings.HasPrefix(k, root+".") {
-		return false
+	root := k
+	if idx := strings.IndexByte(k, '.'); idx != -1 {
+		root = k[:idx]
 	}
 
-	// Get the full list values (Old and New) from the resource data
 	o, n := d.GetChange(root)
 
-	// Cast to generic lists
 	oldList, ok1 := o.([]interface{})
 	newList, ok2 := n.([]interface{})
 
-	// If casting fails or lengths differ, we definitely have a change, so don't suppress.
 	if !ok1 || !ok2 || len(oldList) != len(newList) {
 		return false
 	}
 
-	// Convert to string slices for sorting
 	oldStrs := make([]string, len(oldList))
 	for i, v := range oldList {
 		oldStrs[i] = fmt.Sprintf("%v", v)
@@ -497,10 +492,8 @@ func stringListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 		newStrs[i] = fmt.Sprintf("%v", v)
 	}
 
-	// Sort both lists to compare content regardless of order
 	sort.Strings(oldStrs)
 	sort.Strings(newStrs)
 
-	// If the sorted lists are identical, return true to SUPPRESS the diff.
 	return reflect.DeepEqual(oldStrs, newStrs)
 }

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -62,10 +64,11 @@ func ResourceServiceNetworkingConnection() *schema.Resource {
 				Description: `Provider peering service that is managing peering connectivity for a service provider organization. For Google services that support this functionality it is 'servicenetworking.googleapis.com'.`,
 			},
 			"reserved_peering_ranges": {
-				Type:        schema.TypeList,
-				Required:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Description: `Named IP address range(s) of PEERING type reserved for this service provider. Note that invoking this method with a different range when connection is already established will not reallocate already provisioned service producer subnetworks.`,
+				Type:             schema.TypeList,
+				Required:         true,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: stringListDiffSuppress,
+				Description:      `Named IP address range(s) of PEERING type reserved for this service provider. Note that invoking this method with a different range when connection is already established will not reallocate already provisioned service producer subnetworks.`,
 			},
 			"deletion_policy": {
 				Type:         schema.TypeString,
@@ -456,4 +459,45 @@ func init() {
 		Type:        registry.SchemaTypeResource,
 		Schema:      ResourceServiceNetworkingConnection(),
 	}.Register()
+}
+
+func stringListDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Extract the root field name from k (e.g., "reserved_peering_ranges.0" -> "reserved_peering_ranges")
+	// DiffSuppressFunc is called for each element and for the count, so we need to handle both
+	rootKey := k
+	if idx := strings.Index(k, "."); idx != -1 {
+		rootKey = k[:idx]
+	}
+
+	// Only process once when k equals the root field name or when it's the count (e.g., "reserved_peering_ranges.#")
+	if k != rootKey && !strings.HasSuffix(k, ".#") {
+		return false
+	}
+
+	o, n := d.GetChange(rootKey)
+
+	// Cast to generic lists
+	oldList, ok1 := o.([]interface{})
+	newList, ok2 := n.([]interface{})
+
+	// If casting fails or lengths differ, don't suppress the diff
+	if !ok1 || !ok2 || len(oldList) != len(newList) {
+		return false
+	}
+
+	// Convert to string slices for sorting
+	oldStrs := make([]string, len(oldList))
+	for i, v := range oldList {
+		oldStrs[i] = fmt.Sprintf("%v", v)
+	}
+
+	newStrs := make([]string, len(newList))
+	for i, v := range newList {
+		newStrs[i] = fmt.Sprintf("%v", v)
+	}
+
+	sort.Strings(oldStrs)
+	sort.Strings(newStrs)
+
+	return reflect.DeepEqual(oldStrs, newStrs)
 }

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection.go
@@ -232,7 +232,6 @@ func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interf
 	}
 
 	ranges := connection.ReservedPeeringRanges
-	sort.Strings(ranges)
 	if err := d.Set("reserved_peering_ranges", ranges); err != nil {
 		return fmt.Errorf("Error setting reserved_peering_ranges: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
@@ -373,7 +373,9 @@ resource "google_project_service" "servicenetworking" {
 }
 
 resource "google_compute_network" "servicenet" {
-  name = "%s"
+  name       = "%s"
+  # FIX: Create this inside the new project
+  project    = google_project.project.project_id
   depends_on = [google_project_service.servicenetworking]
 }
 
@@ -382,8 +384,10 @@ resource "google_compute_global_address" "r1" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
+  # FIX: Create this inside the new project
+  project       = google_project.project.project_id
   network       = google_compute_network.servicenet.self_link
-  depends_on = [google_project_service.servicenetworking]
+  depends_on    = [google_project_service.servicenetworking]
 }
 
 resource "google_compute_global_address" "r2" {
@@ -391,8 +395,10 @@ resource "google_compute_global_address" "r2" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
+  # FIX: Create this inside the new project
+  project       = google_project.project.project_id
   network       = google_compute_network.servicenet.self_link
-  depends_on = [google_project_service.servicenetworking]
+  depends_on    = [google_project_service.servicenetworking]
 }
 
 resource "google_service_networking_connection" "foobar" {

--- a/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
+++ b/mmv1/third_party/terraform/services/servicenetworking/resource_service_networking_connection_test.go
@@ -312,27 +312,21 @@ resource "google_service_networking_connection" "foobar" {
 `, addressRangeName, addressRangeName, org_id, billing_account, networkName, addressRangeName, serviceName)
 }
 
-// MODIFIED BY FLOW AI: Fixed test to use default project instead of creating a new one
 func TestAccServiceNetworkingConnection_reorder(t *testing.T) {
 	t.Parallel()
 
-	// Shortened prefix to fit within 30 char limit for Project Name
-	// "tf-test-snc-" (12 chars) + 10 random = 22 chars
 	network := fmt.Sprintf("tf-test-snc-%s", acctest.RandString(t, 10))
 	range1 := fmt.Sprintf("tf-test-range1-%s", acctest.RandString(t, 10))
 	range2 := fmt.Sprintf("tf-test-range2-%s", acctest.RandString(t, 10))
 
 	service := "servicenetworking.googleapis.com"
-	// MODIFIED: Removed org_id and billing_account retrieval as they are not needed for default project
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testServiceNetworkingConnectionDestroy(t, service, network),
 		Steps: []resource.TestStep{
-			// Step 1: Create with Order [Range1, Range2]
 			{
-				// MODIFIED: Removed org_id and billing_account arguments
 				Config: testAccServiceNetworkingConnectionOrder(network, range1, range2, service, "forward"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_service_networking_connection.foobar", "reserved_peering_ranges.#", "2"),
@@ -343,10 +337,7 @@ func TestAccServiceNetworkingConnection_reorder(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Step 2: Update with Order [Range2, Range1]
-			// We expect an Empty Plan. If the bug exists, this step fails with "Plan not empty".
 			{
-				// MODIFIED: Removed org_id and billing_account arguments
 				Config:   testAccServiceNetworkingConnectionOrder(network, range1, range2, service, "reverse"),
 				PlanOnly: true,
 			},
@@ -361,12 +352,8 @@ func testAccServiceNetworkingConnectionOrder(networkName, r1, r2, serviceName, o
 	}
 
 	return fmt.Sprintf(`
-# MODIFIED: Removed google_project and google_project_service resources.
-# The test now relies on the default provider project which already has APIs enabled.
-
 resource "google_compute_network" "servicenet" {
-  name       = "%s"
-  # MODIFIED: Removed project = google_project.project.project_id
+  name = "%s"
 }
 
 resource "google_compute_global_address" "r1" {
@@ -374,7 +361,6 @@ resource "google_compute_global_address" "r1" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  # MODIFIED: Removed project = ...
   network       = google_compute_network.servicenet.self_link
 }
 
@@ -383,7 +369,6 @@ resource "google_compute_global_address" "r2" {
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  # MODIFIED: Removed project = ...
   network       = google_compute_network.servicenet.self_link
 }
 
@@ -391,7 +376,6 @@ resource "google_service_networking_connection" "foobar" {
   network                 = google_compute_network.servicenet.self_link
   service                 = "%s"
   reserved_peering_ranges = %s
-  # MODIFIED: Removed depends_on for google_project_service
   depends_on = [google_compute_global_address.r1, google_compute_global_address.r2]
 }
 `, networkName, r1, r2, serviceName, ranges)


### PR DESCRIPTION
## Description
Fixes PR #20398 (https://github.com/hashicorp/terraform-provider-google/issues/20398)
Replaces PR #16191 with clean commit history
Reopening PR #16259 

This PR resolves a perma-diff issue in `google_service_networking_connection` where the order of `reserved_peering_ranges` caused Terraform to detect changes during every plan, even if the set of ranges remained identical.

## Changes
- **Schema Change**: Added a `DiffSuppressFunc` to `reserved_peering_ranges` in `resource_service_networking_connection.go` to ignore ordering differences between config and state.
- **Helper Function**: Added `stringListDiffSuppress` to handle the unordered comparison of the string list.
- **Test**: Added `TestAccServiceNetworkingConnection_reorder` to `resource_service_networking_connection_test.go` to verify that changing the order of ranges does not trigger an update.

## Breaking Change Note
This change utilizes `DiffSuppressFunc` on the existing `TypeList` schema rather than converting to `TypeSet`.

**Impact**: None. This is not a breaking change. Existing state files remain compatible as the schema type has not changed.

## Verification
Test added: `TestAccServiceNetworkingConnection_reorder` to verify order changes don't trigger updates.

```release-note:bug
servicenetworking: fixed a permadiff issue of `reserved_peering_ranges` in `google_service_networking_connection`
````