### PR TITLE
Migrated compute_attached_disk to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/acctest/vcr_utils.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -264,8 +265,13 @@ func HandleVCRConfiguration(ctx context.Context, testName string, rndTripper htt
 // NewVcrMatcherFunc returns a function used for matching HTTP requests with data recorded in VCR cassettes
 func NewVcrMatcherFunc(ctx context.Context) func(r *http.Request, i cassette.Request) bool {
 	return func(r *http.Request, i cassette.Request) bool {
-		// Default matcher compares method and URL only
-		if !cassette.DefaultMatcher(r, i) {
+		// Compare method and URL, normalizing standard Google API query
+		// params (alt, prettyPrint) so that cassettes recorded via the
+		// typed client match requests made via transport_tpg.SendRequest.
+		if r.Method != i.Method {
+			return false
+		}
+		if stripStandardQueryParams(r.URL.String()) != stripStandardQueryParams(i.URL) {
 			return false
 		}
 		if r.Body == nil {
@@ -304,6 +310,22 @@ func NewVcrMatcherFunc(ctx context.Context) func(r *http.Request, i cassette.Req
 		}
 		return false
 	}
+}
+
+// stripStandardQueryParams removes standard Google API query parameters
+// (alt, prettyPrint) from a URL string. This allows VCR cassettes recorded
+// via the typed API client to match requests made via transport_tpg.SendRequest,
+// which may include a different set of these decorative parameters.
+func stripStandardQueryParams(rawurl string) string {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return rawurl
+	}
+	q := u.Query()
+	q.Del("alt")
+	q.Del("prettyPrint")
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // MuxedProviders configures the providers, thus, if we want the providers to be configured

--- a/mmv1/third_party/terraform/acctest/vcr_utils_test.go
+++ b/mmv1/third_party/terraform/acctest/vcr_utils_test.go
@@ -52,6 +52,38 @@ func TestNewVcrMatcherFunc_canDetectMatches(t *testing.T) {
 				body:   "{\"field\":\"value\"}",
 			},
 		},
+		"matches GET requests when SendRequest adds alt=json but cassette has alt=json&prettyPrint=false": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance",
+				query:  "alt=json",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance",
+				query:  "alt=json&prettyPrint=false",
+			},
+		},
+		"matches GET requests when both have alt and prettyPrint in different order": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance",
+				query:  "prettyPrint=false&alt=json",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance",
+				query:  "alt=json&prettyPrint=false",
+			},
+		},
 		"matches POST requests with matching but re-ordered bodies, but only if Content-Type contains 'application/json'": {
 			httpRequest: requestDescription{
 				scheme: "https",
@@ -174,6 +206,22 @@ func TestNewVcrMatcherFunc_canDetectMismatches(t *testing.T) {
 				host:   "example.com",
 				path:   "foobar",
 				body:   "{\"field\":\"value is MNLOP\"}",
+			},
+		},
+		"requests with different non-standard query params do not match": {
+			httpRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance/detachDisk",
+				query:  "deviceName=disk-1&alt=json",
+			},
+			cassetteRequest: requestDescription{
+				scheme: "https",
+				method: "GET",
+				host:   "compute.googleapis.com",
+				path:   "compute/v1/projects/my-project/zones/us-central1-a/instances/my-instance/detachDisk",
+				query:  "deviceName=disk-2&alt=json&prettyPrint=false",
 			},
 		},
 		"POST requests with matching but re-ordered bodies aren't matching if Content-Type header is not 'application/json'": {
@@ -320,14 +368,16 @@ type requestDescription struct {
 	host    string
 	path    string
 	body    string
+	query   string
 	headers map[string]string
 }
 
 func prepareHttpRequest(d requestDescription) *http.Request {
 	url := &url.URL{
-		Scheme: d.scheme,
-		Host:   d.host,
-		Path:   d.path,
+		Scheme:   d.scheme,
+		Host:     d.host,
+		Path:     d.path,
+		RawQuery: d.query,
 	}
 
 	req := &http.Request{
@@ -353,6 +403,9 @@ func prepareHttpRequest(d requestDescription) *http.Request {
 
 func prepareCassetteRequest(d requestDescription) cassette.Request {
 	fullUrl := fmt.Sprintf("%s://%s/%s", d.scheme, d.host, d.path)
+	if d.query != "" {
+		fullUrl = fmt.Sprintf("%s?%s", fullUrl, d.query)
+	}
 
 	req := cassette.Request{
 		Method: d.method,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.tmpl
@@ -15,11 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceComputeAttachedDisk() *schema.Resource {
@@ -124,21 +119,34 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 		diskSrc = rv.RelativeLink()
 	}
 
-	attachedDisk := compute.AttachedDisk{
-		Source:     diskSrc,
-		Mode:       d.Get("mode").(string),
-		DeviceName: d.Get("device_name").(string),
-                Interface:  d.Get("interface").(string),
+	obj := map[string]interface{}{
+		"source":     diskSrc,
+		"mode":       d.Get("mode").(string),
 	}
+	if v := d.Get("device_name").(string); v != "" {
+        obj["deviceName"] = v
+    }
+    if v := d.Get("interface").(string); v != "" {
+    	obj["interface"] = v
+    }
 
-	op, err := config.NewComputeClient(userAgent).Instances.AttachDisk(zv.Project, zv.Zone, zv.Name, &attachedDisk).Do()
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/attachDisk", config.ComputeBasePath, zv.Project, zv.Zone, zv.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   zv.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
 	if err != nil {
 		return err
 	}
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", zv.Project, zv.Zone, zv.Name, diskName))
 
-	waitErr := ComputeOperationWaitTime(config, op, zv.Project,
+	waitErr := ComputeOperationWaitTime(config, res, zv.Project,
 		"disk to attach", userAgent, d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		d.SetId("")
@@ -168,36 +176,43 @@ func resourceAttachedDiskRead(d *schema.ResourceData, meta interface{}) error {
 
 	diskName := tpgresource.GetResourceNameFromSelfLink(d.Get("disk").(string))
 
-	instance, err := config.NewComputeClient(userAgent).Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s", config.ComputeBasePath, zv.Project, zv.Zone, zv.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   zv.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("AttachedDisk %q", d.Id()))
 	}
 
 	// Iterate through the instance's attached disks as this is the only way to
 	// confirm the disk is actually attached
-	ad := FindDiskByName(instance.Disks, diskName)
+	ad := findDiskByName(res["disks"], diskName)
 	if ad == nil {
 		log.Printf("[WARN] Referenced disk wasn't found attached to this compute instance. Removing from state.")
 		d.SetId("")
 		return nil
 	}
 
-	if err := d.Set("device_name", ad.DeviceName); err != nil {
+	if err := d.Set("device_name", ad["deviceName"]); err != nil {
 		return fmt.Errorf("Error setting device_name: %s", err)
 	}
-	if err := d.Set("mode", ad.Mode); err != nil {
+	if err := d.Set("mode", ad["mode"]); err != nil {
 		return fmt.Errorf("Error setting mode: %s", err)
-        }
+	}
 
 	// Force the referenced resources to a self-link in state because it's more specific then name.
-	instancePath, err := tpgresource.GetRelativePath(instance.SelfLink)
+	instancePath, err := tpgresource.GetRelativePath(res["selfLink"].(string))
 	if err != nil {
 		return err
 	}
 	if err := d.Set("instance", instancePath); err != nil {
 		return fmt.Errorf("Error setting instance: %s", err)
 	}
-	diskPath, err := tpgresource.GetRelativePath(ad.Source)
+	diskPath, err := tpgresource.GetRelativePath(ad["source"].(string))
 	if err != nil {
 		return err
 	}
@@ -222,24 +237,45 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 
 	diskName := tpgresource.GetResourceNameFromSelfLink(d.Get("disk").(string))
 
-	instance, err := config.NewComputeClient(userAgent).Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
+	getUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s", config.ComputeBasePath, zv.Project, zv.Zone, zv.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   zv.Project,
+		RawURL:    getUrl,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return err
 	}
 
 	// Confirm the disk is still attached before making the call to detach it. If the disk isn't listed as an attached
 	// disk on the compute instance then return as though the delete call succeed since this is the desired state.
-	ad := FindDiskByName(instance.Disks, diskName)
+	ad := findDiskByName(res["disks"], diskName)
 	if ad == nil {
 		return nil
 	}
 
-	op, err := config.NewComputeClient(userAgent).Instances.DetachDisk(zv.Project, zv.Zone, zv.Name, ad.DeviceName).Do()
+	deviceName := ad["deviceName"].(string)
+	detachUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/detachDisk", config.ComputeBasePath, zv.Project, zv.Zone, zv.Name)
+	detachUrl, err = transport_tpg.AddQueryParams(detachUrl, map[string]string{"deviceName": deviceName})
 	if err != nil {
 		return err
 	}
 
-	waitErr := ComputeOperationWaitTime(config, op, zv.Project,
+	res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   zv.Project,
+		RawURL:    detachUrl,
+		UserAgent: userAgent,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+	})
+	if err != nil {
+		return err
+	}
+
+	waitErr := ComputeOperationWaitTime(config, res, zv.Project,
 		fmt.Sprintf("Detaching disk from %s", zv.Name), userAgent, d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
@@ -274,6 +310,24 @@ func FindDiskByName(disks []*compute.AttachedDisk, id string) *compute.AttachedD
 		}
 	}
 
+	return nil
+}
+
+func findDiskByName(disksRaw interface{}, id string) map[string]interface{} {
+	disks, ok := disksRaw.([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, diskRaw := range disks {
+		disk, ok := diskRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		source, _ := disk["source"].(string)
+		if tpgresource.CompareSelfLinkOrResourceName("", source, id, nil) {
+			return disk
+		}
+	}
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk.go.tmpl
@@ -303,16 +303,6 @@ func resourceAttachedDiskImport(d *schema.ResourceData, meta interface{}) ([]*sc
 	return []*schema.ResourceData{d}, nil
 }
 
-func FindDiskByName(disks []*compute.AttachedDisk, id string) *compute.AttachedDisk {
-	for _, disk := range disks {
-		if tpgresource.CompareSelfLinkOrResourceName("", disk.Source, id, nil) {
-			return disk
-		}
-	}
-
-	return nil
-}
-
 func findDiskByName(disksRaw interface{}, id string) map[string]interface{} {
 	disks, ok := disksRaw.([]interface{})
 	if !ok {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_attached_disk_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/services/compute"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
 func TestAccComputeAttachedDisk_basic(t *testing.T) {
@@ -167,7 +167,13 @@ func testCheckAttachedDiskIsNowDetached(t *testing.T, instanceName, diskName str
 			return err
 		}
 
-		ad := compute.FindDiskByName(instance.Disks, diskName)
+		var ad interface{}
+		for _, disk := range instance.Disks {
+			if tpgresource.CompareSelfLinkOrResourceName("", disk.Source, diskName, nil) {
+				ad = disk
+				break
+			}
+		}
 		if ad != nil {
 			return fmt.Errorf("compute disk is still attached to compute instance")
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_attached_disk` to use direct HTTP rather than a client library
```
