### PR TITLE
Fix is_missing_in_cai for versioned properties

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -656,6 +656,17 @@ func (r Resource) AllNestedProperties(props []*Type) []*Type {
 	return nested
 }
 
+func (r Resource) AllNestedPropertiesWithExcluded(props []*Type) []*Type {
+	nested := props
+	for _, prop := range props {
+		if nestedProperties := prop.NestedPropertiesWithExcluded(); !prop.FlattenObject && nestedProperties != nil {
+			nested = google.Concat(nested, r.AllNestedPropertiesWithExcluded(nestedProperties))
+		}
+	}
+
+	return nested
+}
+
 func (r Resource) SensitiveProps() []*Type {
 	props := r.AllNestedProperties(r.RootProperties())
 	return google.Select(props, func(p *Type) bool {
@@ -741,6 +752,21 @@ func (r Resource) RootProperties() []*Type {
 	for _, p := range r.AllUserProperties() {
 		if p.FlattenObject {
 			props = google.Concat(props, p.RootProperties())
+		} else {
+			props = append(props, p)
+		}
+	}
+	return props
+}
+
+// Returns the list of top-level properties once any nested objects with flatten_object
+// set to true have been collapsed, including excluded properties
+func (r Resource) RootPropertiesWithExcluded() []*Type {
+	props := make([]*Type, 0)
+
+	for _, p := range r.AllProperties() {
+		if p.FlattenObject {
+			props = google.Concat(props, p.RootPropertiesWithExcluded())
 		} else {
 			props = append(props, p)
 		}
@@ -2506,7 +2532,7 @@ func (r Resource) TGCTestIgnorePropertiesToStrings() []string {
 	for _, tp := range r.VirtualFields {
 		props = append(props, strings.Join(tp.Lineage(), "."))
 	}
-	for _, tp := range r.AllNestedProperties(r.RootProperties()) {
+	for _, tp := range r.AllNestedPropertiesWithExcluded(r.RootPropertiesWithExcluded()) {
 		if tp.UrlParamOnly {
 			props = append(props, google.Underscore(tp.Name))
 		} else if tp.IsMissingInCai || tp.IgnoreRead || tp.ClientSide || tp.WriteOnlyLegacy {

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -825,6 +825,23 @@ func (t Type) NestedProperties() []*Type {
 	return props
 }
 
+func (t Type) NestedPropertiesWithExcluded() []*Type {
+	props := make([]*Type, 0)
+
+	switch {
+	case t.IsA("Array"):
+		if t.ItemType.IsA("NestedObject") {
+			props = t.ItemType.NestedPropertiesWithExcluded()
+		}
+	case t.IsA("NestedObject"):
+		props = t.Properties
+	case t.IsA("Map"):
+		props = t.ValueType.NestedPropertiesWithExcluded()
+	default:
+	}
+	return props
+}
+
 // Returns write-only properties for this property.
 func (t Type) WriteOnlyProperties() []*Type {
 	props := make([]*Type, 0)
@@ -1128,6 +1145,20 @@ func (t *Type) RootProperties() []*Type {
 	for _, p := range t.UserProperties() {
 		if p.FlattenObject {
 			props = google.Concat(props, p.RootProperties())
+		} else {
+			props = append(props, p)
+		}
+	}
+	return props
+}
+
+// Returns the list of top-level properties once any nested objects with
+// flatten_object set to true have been collapsed, including excluded properties
+func (t *Type) RootPropertiesWithExcluded() []*Type {
+	props := make([]*Type, 0)
+	for _, p := range t.Properties {
+		if p.FlattenObject {
+			props = google.Concat(props, p.RootPropertiesWithExcluded())
 		} else {
 			props = append(props, p)
 		}


### PR DESCRIPTION
This update allows TGCTestIgnorePropertiesToStrings to traverse excluded fields (e.g. min_version: beta) so that even in GA test builds, properties correctly evaluate the is_missing_in_cai flag and get added to the test ignore list.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
