### PR TITLE
Fix: Include user_service_account_mapping in Dataproc update mask

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -3011,6 +3011,17 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		updMask = append(updMask, "config.lifecycle_config.auto_stop_time")
 	}
 
+	if d.HasChange("cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping") {
+		if icfg, ok := configOptions(d, "cluster_config.0.security_config.0.identity_config"); ok {
+			if cluster.Config.SecurityConfig == nil {
+				cluster.Config.SecurityConfig = &dataproc.SecurityConfig{}
+			}
+			cluster.Config.SecurityConfig.IdentityConfig = expandIdentityConfig(icfg)
+
+			updMask = append(updMask, "config.security_config.identity_config.user_service_account_mapping")
+		}
+	}
+
 	if len(updMask) > 0 {
 		gracefulDecommissionTimeout := d.Get("graceful_decommission_timeout").(string)
 


### PR DESCRIPTION
Updated the `resourceDataprocClusterUpdate` function to explicitly include `user_service_account_mapping` in the update mask. This ensures that changes to the identity config are correctly detected and propagated to the Dataproc API during a Terraform apply.

```release-note:bug
dataproc: fixed an issue where changes to `user_service_account_mapping` in the `google_dataproc_cluster` resource were not propagated during updates.
```
