### PR TITLE
Suppress Retry Transport debug logs

### DIFF
--- a/mmv1/third_party/terraform/transport/retry_transport.go
+++ b/mmv1/third_party/terraform/transport/retry_transport.go
@@ -105,7 +105,6 @@ func (t *retryTransport) RoundTrip(req *http.Request) (resp *http.Response, resp
 		log.Printf("[WARN] Retry Transport: Consuming original request body failed: %v", err)
 	}
 
-	log.Printf("[DEBUG] Retry Transport: starting RoundTrip retry loop")
 Retry:
 	for {
 		// RoundTrip contract says request body can/will be consumed, so we need to
@@ -113,31 +112,44 @@ Retry:
 		// If we can't copy the request, we run as a single request.
 		newRequest, copyErr := copyHttpRequest(req)
 		if copyErr != nil {
-			log.Printf("[WARN] Retry Transport: Unable to copy request body: %v.", copyErr)
-			log.Printf("[WARN] Retry Transport: Running request as non-retryable")
+			log.Printf("[DEBUG] Retry Transport: Unable to copy request body: %v.", copyErr)
+			log.Printf("[DEBUG] Retry Transport: Running request as non-retryable")
 			resp, respErr = t.internal.RoundTrip(req)
 			break Retry
 		}
 
-		log.Printf("[DEBUG] Retry Transport: request attempt %d", attempts)
+		// Silent informational logs on first attempt, log on subsequent attempts
+		if attempts > 0 {
+			if attempts == 1 {
+				log.Printf("[DEBUG] Retry Transport: Initial request failed. Beginning retries.")
+			}
+
+			log.Printf("[DEBUG] Retry Transport: request attempt %d", attempts)
+		}
 		// Do the wrapped Roundtrip. This is one request in the retry loop.
 		resp, respErr = t.internal.RoundTrip(newRequest)
 		attempts++
 
 		retryErr := t.checkForRetryableError(resp, respErr)
 		if retryErr == nil {
-			log.Printf("[DEBUG] Retry Transport: Stopping retries, last request was successful")
+			if attempts > 0 {
+				log.Printf("[DEBUG] Retry Transport: Stopping retries, last request was successful")
+			}
 			break Retry
 		}
 		if !retryErr.Retryable {
-			log.Printf("[DEBUG] Retry Transport: Stopping retries, last request failed with non-retryable error: %s", retryErr.Err)
+			if attempts > 0 {
+				log.Printf("[DEBUG] Retry Transport: Stopping retries, last request failed with non-retryable error: %s", retryErr.Err)
+			}
 			break Retry
 		}
 
 		log.Printf("[DEBUG] Retry Transport: Waiting %s before trying request again", backoff)
 		select {
 		case <-ctx.Done():
-			log.Printf("[DEBUG] Retry Transport: Stopping retries, context done: %v", ctx.Err())
+			if attempts > 0 {
+				log.Printf("[DEBUG] Retry Transport: Stopping retries, context done: %v", ctx.Err())
+			}
 			break Retry
 		case <-time.After(backoff):
 			log.Printf("[DEBUG] Retry Transport: Finished waiting %s before next retry", backoff)
@@ -149,7 +161,10 @@ Retry:
 			continue
 		}
 	}
-	log.Printf("[DEBUG] Retry Transport: Returning after %d attempts", attempts)
+	if attempts > 0 {
+		log.Printf("[DEBUG] Retry Transport: Returning after %d attempts", attempts)
+	}
+
 	return resp, respErr
 }
 


### PR DESCRIPTION
It logs 4 lines on every request even though it's only triggered in rare cases (typically when requests fail to a server 500) as most failures are post-LRO. Suppress all logging until the second attempt.

Also change some [WARN] logs to [DEBUG]. Terraform used to eat non-[DEBUG] log and I don't think it still does, but we don't set any other log level in practice.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
```
