### PR TITLE
Add terraform support for self service update in Memcached

### DIFF
--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -334,3 +334,19 @@ properties:
     ignore_read: true
     item_type:
       type: String
+  - name: 'maintenance_version'
+    type: String
+    description: |
+      The version of the maintenance running on the instance.
+  - name: 'effective_maintenance_version'
+    type: String
+    description: |
+      The maintenance version that the instance is planned to be upgraded to.
+    output: true
+  - name: 'available_maintenance_versions'
+    type: Array
+    description: |
+      The versions of available maintenance for the instance.
+    output: true
+    item_type:
+      type: String

--- a/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
+++ b/mmv1/third_party/terraform/services/memcache/resource_memcache_instance_test.go
@@ -37,6 +37,10 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 				ResourceName:      "google_memcache_instance.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					// Check if effective_maintenance_version is present and not empty
+					testAccMemcacheInstance_checkMaintenanceVersionIsNotEmpty("effective_maintenance_version"),
+				),
 			},
 		},
 	})
@@ -161,4 +165,25 @@ data "google_compute_network" "memcache_network" {
   name = "%s"
 }
 `, name, region, deletionProtection, network)
+}
+
+// Helper function to check if a maintenance version attribute is not empty.
+func testAccMemcacheInstance_checkMaintenanceVersionIsNotEmpty(attr string) resource.TestCheckFunc {
+	return func(s *resource.State) error {
+		rs, ok := s.RootResourceStateMode.Resources["google_memcache_instance.test"]
+		if !ok {
+			return fmt.Errorf("root resource not found")
+		}
+
+		attrValue, ok := rs.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("attribute %s not found", attr)
+		}
+		if attrValue == "" {
+			return fmt.Errorf("attribute %s is empty", attr)
+		}
+		// Optional: Add more specific checks if needed, e.g., format validation.
+		// For now, just checking for presence and non-empty is sufficient per the request.
+		return nil
+	}
 }


### PR DESCRIPTION
Added support for self service update in UpdateAPI for Memcached

```release-note:enhancement
memcache: Add maintenance_version, available_maintenance_versions and effective_maintenance_version for self service update feature.
```
