### PR TITLE
Container nil check for filter field

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -6366,11 +6366,13 @@ func expandNotificationConfig(configured interface{}) *container.NotificationCon
 				},
 			}
 
-			if vv, ok := pubsub["filter"]; ok && len(vv.([]interface{})) > 0 {
+			if vv, ok := pubsub["filter"]; ok && len(vv.([]interface{})) > 0 && vv.([]interface{})[0] != nil {
 				filter := vv.([]interface{})[0].(map[string]interface{})
-				eventType := filter["event_type"].([]interface{})
-				nc.Pubsub.Filter = &container.Filter{
-					EventType: tpgresource.ConvertStringArr(eventType),
+				if eventTypeVal, ok := filter["event_type"]; ok && eventTypeVal != nil {
+					eventType := eventTypeVal.([]interface{})
+					nc.Pubsub.Filter = &container.Filter{
+						EventType: tpgresource.ConvertStringArr(eventType),
+					}
 				}
 			}
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -412,6 +412,15 @@ func TestAccContainerCluster_withFilteredNotificationConfig(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
+			{
+				Config: testAccContainerCluster_withEmptyFilteredNotificationConfig(clusterName, newTopic, networkName, subnetworkName),
+			},
+			{
+				ResourceName:      "google_container_cluster.filtered_notification_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
 		},
 	})
 }
@@ -8086,6 +8095,35 @@ resource "google_container_cluster" "filtered_notification_config" {
 	  topic   = google_pubsub_topic.%s.id
 	  filter {
 		event_type = ["UPGRADE_AVAILABLE_EVENT"]
+	  }
+	}
+  }
+  network    = "%s"
+  subnetwork = "%s"
+
+  deletion_protection = false
+}
+`, topic, topic, clusterName, topic, networkName, subnetworkName)
+}
+
+func testAccContainerCluster_withEmptyFilteredNotificationConfig(clusterName, topic, networkName, subnetworkName string) string {
+
+	return fmt.Sprintf(`
+
+resource "google_pubsub_topic" "%s" {
+  name = "%s"
+}
+
+resource "google_container_cluster" "filtered_notification_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 3
+  notification_config {
+	pubsub {
+	  enabled = true
+	  topic   = google_pubsub_topic.%s.id
+	  filter {
+		event_type = []
 	  }
 	}
   }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -404,7 +404,7 @@ func TestAccContainerCluster_withFilteredNotificationConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_disableFilteredNotificationConfig(clusterName, newTopic, networkName, subnetworkName),
+				Config: testAccContainerCluster_withEmptyFilteredNotificationConfig(clusterName, newTopic, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.filtered_notification_config",
@@ -413,7 +413,7 @@ func TestAccContainerCluster_withFilteredNotificationConfig(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccContainerCluster_withEmptyFilteredNotificationConfig(clusterName, newTopic, networkName, subnetworkName),
+				Config: testAccContainerCluster_disableFilteredNotificationConfig(clusterName, newTopic, networkName, subnetworkName),
 			},
 			{
 				ResourceName:      "google_container_cluster.filtered_notification_config",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->


```
resource "google_container_cluster" "cluster" {
  # ...
  notification_config {
    pubsub {
      enabled = true
      topic   = "projects/my-project/topics/gke-updates"
      filter {
        event_type = []
      }
    }
  }
}
```
Instead of returning an empty map representation like `map[string]interface{}{"event_type": []interface{}{}}`, the Terraform Plugin SDKv2 effectively strips the empty fields. Because no explicit data remains to compose a map, the SDK inserts `nil` natively at index 0.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
