### PR TITLE
Updated documentation for export_policies and import_policies fields

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -515,12 +515,20 @@ The following arguments are supported:
   IPv4 address of the BGP interface outside Google Cloud Platform.
 
 *  `export_policies` -
+<<<<<<< Updated upstream
   (Optional, [Beta](../guides/provider_versions.html.markdown)) 
+=======
+  (Optional) 
+>>>>>>> Stashed changes
   routers.list of export policies applied to this peer, in the order they must be evaluated. 
   The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_EXPORT type.
 
 *  `import_policies` -
+<<<<<<< Updated upstream
   (Optional, [Beta](../guides/provider_versions.html.markdown)) 
+=======
+  (Optional) 
+>>>>>>> Stashed changes
   routers.list of import policies applied to this peer, in the order they must be evaluated. 
   The name must correspond to an existing policy that has ROUTE_POLICY_TYPE_IMPORT type.
 


### PR DESCRIPTION
Updated documentation for export_policies and import_policies field in google_compute_router_peer resource. The fields was GA'd a while back but the documentation still carried 'Beta' tag.

```release-note:note
compute: Removed the 'Beta' tag from the export_policies and import_policies field in resource 'google_compute_router_peer'
```
