### PR TITLE
discoveryengine: document google_drive as supported data_source and add example

### DIFF
--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -58,6 +58,11 @@ examples:
     primary_resource_id: 'jira-with-actions'
     vars:
       collection_id: 'collection-id'
+  - name: 'discoveryengine_dataconnector_google_drive'
+    primary_resource_id: 'google-drive'
+    vars:
+      collection_id: 'collection-id'
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String
@@ -108,7 +113,12 @@ properties:
     type: String
     description: |
       The name of the data source.
-      Supported values: `salesforce`, `jira`, `confluence`, `bigquery`.
+      Supported values include `salesforce`, `jira`, `confluence`, `bigquery`,
+      `google_drive`, and more. For the full list of supported data sources, see
+      the [connectors documentation](https://cloud.google.com/agentspace/docs/introduction-to-connectors-and-data-stores).
+      Note: Google first-party connectors like `google_drive` require
+      ACL configuration (`google_discovery_engine_acl_config`) before
+      creating the data connector.
     required: true
     immutable: true
   - name: 'dataSourceVersion'
@@ -157,8 +167,9 @@ properties:
           description: |
             The name of the entity. Supported values by data source:
             * Salesforce: `Lead`, `Opportunity`, `Contact`, `Account`, `Case`, `Contract`, `Campaign`
-            * Jira: project, issue, attachment, comment, worklog
+            * Jira: `project`, `issue`, `attachment`, `comment`, `worklog`
             * Confluence: `Content`, `Space`
+            * Google Drive: `google_drive`
         - name: 'keyPropertyMappings'
           type: KeyValuePairs
           diff_suppress_func: 'DataConnectorEntitiesFieldsDiffSuppress'

--- a/mmv1/templates/terraform/examples/discoveryengine_dataconnector_google_drive.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_dataconnector_google_drive.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_discovery_engine_data_connector" "google-drive" {
+  location                = "global"
+  collection_id           = "{{index $.Vars "collection_id"}}"
+  collection_display_name = "Google Drive"
+  data_source             = "google_drive"
+  refresh_interval        = "0s"
+  entities {
+    entity_name = "google_drive"
+    params      = jsonencode({
+      included_shared_drive_ids = ["SHARED_DRIVE_ID"]
+    })
+  }
+  connector_modes = ["FEDERATED"]
+}


### PR DESCRIPTION
## Description

The `data_source` field on `google_discovery_engine_data_connector` currently documents only 4 supported values (`salesforce`, `jira`, `confluence`, `bigquery`), but the API supports many more connectors including Google first-party ones like Google Drive.

This PR makes a focused update to document `google_drive` support, which we've tested and verified end-to-end.

### Changes

1. **`data_source` description** - Added `google_drive` to the list and linked to the [full connectors documentation](https://cloud.google.com/agentspace/docs/introduction-to-connectors-and-data-stores) for the complete list of supported data sources
2. **ACL prerequisite note** - Added a note that Google first-party connectors like `google_drive` require `google_discovery_engine_acl_config` before creating the data connector
3. **`entity_name` description** - Added `google_drive` entity name for Google Drive, and backtick-formatted the Jira entity names for consistency
4. **New example** - Google Drive connector in `FEDERATED` mode with shared drive filtering via `included_shared_drive_ids`

### Testing

Tested and verified working with Google Drive data connectors in `FEDERATED` mode in a production GCP environment (`terraform apply` + `terraform destroy`). The example uses `exclude_test: true` since it requires real Google Workspace integration.

```release-note:enhancement
discoveryengine: updated `data_source` documentation on `google_discovery_engine_data_connector` to include `google_drive` and added Google Drive example
```