### PR TITLE
Migrated bucket security policy settings to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/templates/terraform/post_create/compute_backend_bucket_security_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_create/compute_backend_bucket_security_policy.go.tmpl
@@ -5,15 +5,31 @@ if o, n := d.GetChange("edge_security_policy"); o.(string) != n.(string) {
     return errwrap.Wrapf("Error parsing Backend Service security policy: {{"{{"}}err{{"}}"}}", err)
   }
 
-  spr := emptySecurityPolicyReference()
-  spr.SecurityPolicy = pol.RelativeLink()
-  op, err := config.NewComputeClient(userAgent).BackendBuckets.SetEdgeSecurityPolicy(project, obj["name"].(string), spr).Do()
+  sBody := emptySecurityPolicyReference()
+  if link := pol.RelativeLink(); link != "" {
+    sBody["securityPolicy"] = link
+  }
+
+  url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/backendBuckets/{{"{{"}}name{{"}}"}}/setEdgeSecurityPolicy")
+  if err != nil {
+    return err
+  }
+
+  res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+    Config:    config,
+    Method:    "POST",
+    Project:   project,
+    RawURL:    url,
+    UserAgent: userAgent,
+    Body:      sBody,
+    Headers:   headers,
+  })
   if err != nil {
     return errwrap.Wrapf("Error setting Backend Service security policy: {{"{{"}}err{{"}}"}}", err)
   }
   // This uses the create timeout for simplicity, though technically this code appears in both create and update
-  waitErr := ComputeOperationWaitTime(config, op, project, "Setting Backend Service Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
-  if waitErr != nil {
-    return waitErr
+  err = ComputeOperationWaitTime(config, res, project, "Setting Backend Service Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
+  if err != nil {
+    return err
   }
 }

--- a/mmv1/templates/terraform/post_create/compute_backend_service_security_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_create/compute_backend_service_security_policy.go.tmpl
@@ -5,17 +5,9 @@ if o, n := d.GetChange("security_policy"); o.(string) != n.(string) {
     return errwrap.Wrapf("Error parsing Backend Service security policy: {{"{{"}}err{{"}}"}}", err)
   }
 
-  spr := emptySecurityPolicyReference()
-  spr.SecurityPolicy = pol.RelativeLink()
-
-  bodyBytes, err := json.Marshal(spr)
-  if err != nil {
-    return errwrap.Wrapf("Error marshaling security policy reference: {{"{{"}}err{{"}}"}}", err)
-  }
-
-  var sBody map[string]interface{}
-  if err := json.Unmarshal(bodyBytes, &sBody); err != nil {
-    return errwrap.Wrapf("Error unmarshaling security into map: {{"{{"}}err{{"}}"}}", err)
+  sBody := emptySecurityPolicyReference()
+  if link := pol.RelativeLink(); link != "" {
+    sBody["securityPolicy"] = link
   }
 
   securityPolicyPath := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/backendServices/{{"{{"}}name{{"}}"}}/setSecurityPolicy?prettyPrint=false"
@@ -50,16 +42,9 @@ if o, n := d.GetChange("edge_security_policy"); o.(string) != n.(string) {
     return errwrap.Wrapf("Error parsing Backend Service edge security policy: {{"{{"}}err{{"}}"}}", err)
   }
 
-  spr := emptySecurityPolicyReference()
-  spr.SecurityPolicy = pol.RelativeLink()
-  bodyBytes, err := json.Marshal(spr)
-  if err != nil {
-    return errwrap.Wrapf("Error marshaling security policy reference: {{"{{"}}err{{"}}"}}", err)
-  }
-
-  var eBody map[string]interface{}
-  if err := json.Unmarshal(bodyBytes, &eBody); err != nil {
-    return errwrap.Wrapf("Error unmarshaling security into map: {{"{{"}}err{{"}}"}}", err)
+  eBody := emptySecurityPolicyReference()
+  if link := pol.RelativeLink(); link != "" {
+    eBody["securityPolicy"] = link
   }
 
   edgeSecurityPolicyPath := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/backendServices/{{"{{"}}name{{"}}"}}/setEdgeSecurityPolicy?prettyPrint=false"

--- a/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go
+++ b/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go
@@ -1,0 +1,9 @@
+package compute
+
+// emptySecurityPolicyReference returns an empty request body for the
+// setSecurityPolicy / setEdgeSecurityPolicy API calls. Callers should add a
+// "securityPolicy" key only when a non-empty policy URL is provided; omitting
+// the key clears the policy on the resource.
+func emptySecurityPolicyReference() map[string]interface{} {
+	return map[string]interface{}{}
+}

--- a/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go.tmpl
@@ -1,18 +1,5 @@
 package compute
 
-import (
-{{- if eq $.TargetVersionName "ga" }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
-)
-
-// Incredibly hacky way of getting a reference to an SPR of the right type into
-// the generated BackendService code. goimports will always import `compute`, so
-// we need to provide the import manually to be able to switch libraries. Since
-// this is a problem exactly once, just provide a function in a file where we
-// *can* easily pick the imported copy, and return the correct struct.
-func emptySecurityPolicyReference() *compute.SecurityPolicyReference {
-	return &compute.SecurityPolicyReference{}
+func emptySecurityPolicyReference() map[string]interface{} {
+	return map[string]interface{}{}
 }

--- a/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_backend_service_helpers.go.tmpl
@@ -1,5 +1,0 @@
-package compute
-
-func emptySecurityPolicyReference() map[string]interface{} {
-	return map[string]interface{}{}
-}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool.go.tmpl
@@ -271,22 +271,31 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error parsing TargetPool security policy: %s", err)
 		}
 
-		region, err := tpgresource.GetRegion(d, config)
+		sBody := emptySecurityPolicyReference()
+		if link := pol.RelativeLink(); link != "" {
+			sBody["securityPolicy"] = link
+		}
+
+		spUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/targetPools/{{"{{"}}name{{"}}"}}/setSecurityPolicy")
 		if err != nil {
 			return err
 		}
 
-		spr := emptySecurityPolicyReference()
-		spr.SecurityPolicy = pol.RelativeLink()
-
-		op, err := config.NewComputeClient(userAgent).TargetPools.SetSecurityPolicy(project, region, d.Get("name").(string), spr).Do()
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    spUrl,
+			UserAgent: userAgent,
+			Body:      sBody,
+		})
 		if err != nil {
-			return fmt.Errorf("Error setting TargetPool security policy:: %s", err)
+			return fmt.Errorf("Error setting TargetPool security policy: %s", err)
 		}
 
-		waitErr := ComputeOperationWaitTime(config, op, project, "Setting TargetPool Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
-		if waitErr != nil {
-			return waitErr
+		err = ComputeOperationWaitTime(config, res, project, "Setting TargetPool Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return err
 		}
 	}
 	{{- end }}
@@ -435,20 +444,29 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error parsing TargetPool security policy: %s", err)
 		}
 
-		region, err := tpgresource.GetRegion(d, config)
+		sBody := emptySecurityPolicyReference()
+		if link := pol.RelativeLink(); link != "" {
+			sBody["securityPolicy"] = link
+		}
+
+		spUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/targetPools/{{"{{"}}name{{"}}"}}/setSecurityPolicy")
 		if err != nil {
 			return err
 		}
 
-		spr := emptySecurityPolicyReference()
-		spr.SecurityPolicy = pol.RelativeLink()
-
-		op, err := config.NewComputeClient(userAgent).TargetPools.SetSecurityPolicy(project, region, d.Get("name").(string), spr).Do()
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    spUrl,
+			UserAgent: userAgent,
+			Body:      sBody,
+		})
 		if err != nil {
-			return fmt.Errorf("Error updating TargetPool security policy:: %s", err)
+			return fmt.Errorf("Error updating TargetPool security policy: %s", err)
 		}
 
-		waitErr := ComputeOperationWaitTime(config, op, project, "Updating TargetPool Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
+		waitErr := ComputeOperationWaitTime(config, res, project, "Updating TargetPool Security Policy", userAgent, d.Timeout(schema.TimeoutCreate))
 		if waitErr != nil {
 			return waitErr
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `compute_backend_bucket_security_policy` resource to use direct HTTP rather than a client library
```
