### PR TITLE
Migrated Compute instance network interface to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_network_interface_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_network_interface_helpers.go.tmpl
@@ -3,31 +3,41 @@ package compute
 import (
 	"fmt"
 
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-func computeInstanceDeleteAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface *compute.NetworkInterface, project, zone, userAgent, instanceName string) error {
+func computeInstanceDeleteAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface map[string]interface{}, project, zone, userAgent, instanceName string) error {
 	// Delete any accessConfig that currently exists in instNetworkInterface
-	for _, ac := range instNetworkInterface.AccessConfigs {
-		url, err := transport_tpg.AddQueryParams(
-			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/deleteAccessConfig", config.ComputeBasePath, project, zone, instanceName),
-			map[string]string{
-				"accessConfig":     ac.Name,
-				"networkInterface": instNetworkInterface.Name,
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("Error constructing deleteAccessConfig URL: %s", err)
+	rawAccessConfigs, ok := instNetworkInterface["accessConfigs"].([]interface{})
+	if !ok {
+		return nil // No access configs to delete
+	}
+
+	for _, rawAc := range rawAccessConfigs {
+		ac, ok := rawAc.(map[string]interface{})
+		if !ok {
+			continue
 		}
+		acName := ac["name"].(string)
+		nicName := instNetworkInterface["name"].(string)
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/deleteAccessConfig")
+		if err != nil {
+			return fmt.Errorf("error replacing vars for DeleteAccessConfig URL: %w", err)
+		}
+
+		params := map[string]string{
+			"accessConfig":     acName,
+			"networkInterface": nicName,
+		}
+		url, err = transport_tpg.AddQueryParams(url, params)
+		if err != nil {
+			return fmt.Errorf("error adding query params for DeleteAccessConfig: %w", err)
+		}
+
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -36,60 +46,77 @@ func computeInstanceDeleteAccessConfigs(d *schema.ResourceData, config *transpor
 			UserAgent: userAgent,
 		})
 		if err != nil {
-			return fmt.Errorf("Error deleting old access_config: %s", err)
+			return fmt.Errorf("error deleting old access_config %q: %w", acName, err)
 		}
+
 		err = ComputeOperationWaitTime(config, res, project, "old access_config to delete", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for old access_config %q deletion: %w", acName, err)
 		}
 	}
 	return nil
 }
 
-func computeInstanceAddAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface *compute.NetworkInterface, accessConfigs []*compute.AccessConfig, project, zone, userAgent, instanceName string) error {
+func computeInstanceAddAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface map[string]interface{}, accessConfigs []interface{}, project, zone, userAgent, instanceName string) error {
+	nicName := instNetworkInterface["name"].(string)
+
 	// Create new ones
-	for _, ac := range accessConfigs {
-		url, err := transport_tpg.AddQueryParams(
-			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addAccessConfig", config.ComputeBasePath, project, zone, instanceName),
-			map[string]string{
-				"networkInterface": instNetworkInterface.Name,
-			},
-		)
-		if err != nil {
-			return fmt.Errorf("Error constructing addAccessConfig URL: %s", err)
+	for _, rawAc := range accessConfigs {
+		ac, ok := rawAc.(map[string]interface{})
+		if !ok {
+			continue
 		}
-		acBody, err := tpgresource.ConvertToMap(ac)
+		acName, _ := ac["name"].(string)
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/addAccessConfig")
 		if err != nil {
-			return fmt.Errorf("Error converting access config: %s", err)
+			return fmt.Errorf("error replacing vars for AddAccessConfig URL: %w", err)
 		}
+
+		params := map[string]string{
+			"networkInterface": nicName,
+		}
+		url, err = transport_tpg.AddQueryParams(url, params)
+		if err != nil {
+			return fmt.Errorf("error adding query params for AddAccessConfig: %w", err)
+		}
+
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
 			Project:   project,
 			RawURL:    url,
 			UserAgent: userAgent,
-			Body:      acBody,
+			Body:      ac,
 		})
 		if err != nil {
-			return fmt.Errorf("Error adding new access_config: %s", err)
+			return fmt.Errorf("error adding new access_config %q: %w", acName, err)
 		}
+
 		err = ComputeOperationWaitTime(config, res, project, "new access_config to add", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for new access_config %q addition: %w", acName, err)
 		}
 	}
 	return nil
 }
 
-func computeInstanceCreateUpdateWhileStoppedCall(d *schema.ResourceData, config *transport_tpg.Config, networkInterfacePatchObj *compute.NetworkInterface, accessConfigs []*compute.AccessConfig, accessConfigsHaveChanged bool, index int, project, zone, userAgent, instanceName string) func(inst *compute.Instance) error {
+func computeInstanceCreateUpdateWhileStoppedCall(d *schema.ResourceData, config *transport_tpg.Config, networkInterfacePatchObj map[string]interface{}, accessConfigs []interface{}, accessConfigsHaveChanged bool, index int, project, zone, userAgent, instanceName string) func(inst map[string]interface{}) error {
 
 	// Access configs' ip changes when the instance stops invalidating our fingerprint
 	// expect caller to re-validate instance before calling patch this is why we expect
 	// instance to be passed in
-	return func(instance *compute.Instance) error {
+	return func(instance map[string]interface{}) error {
+		rawNics, ok := instance["networkInterfaces"].([]interface{})
+		if !ok || len(rawNics) <= index {
+			return fmt.Errorf("error updating network interface: instance has no network interface at index %d", index)
+		}
+		instNetworkInterface, ok := rawNics[index].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("error updating network interface: invalid network interface type at index %d", index)
+		}
 
-		instNetworkInterface := instance.NetworkInterfaces[index]
-		networkInterfacePatchObj.Fingerprint = instNetworkInterface.Fingerprint
+		networkInterfacePatchObj["fingerprint"] = instNetworkInterface["fingerprint"]
 
 		// Access config can run into some issues since we can't tell the difference between
 		// the users declared intent (config within their hcl file) and what we have inferred from the
@@ -103,33 +130,35 @@ func computeInstanceCreateUpdateWhileStoppedCall(d *schema.ResourceData, config 
 			}
 		}
 
-		url, err := transport_tpg.AddQueryParams(
-			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instanceName),
-			map[string]string{
-				"networkInterface": instNetworkInterface.Name,
-			},
-		)
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
 		if err != nil {
-			return errwrap.Wrapf("Error constructing updateNetworkInterface URL: {{"{{"}}err{{"}}"}}", err)
+			return fmt.Errorf("error replacing vars for UpdateNetworkInterface URL: %w", err)
 		}
-		patchBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+
+		nicName := instNetworkInterface["name"].(string)
+		params := map[string]string{
+			"networkInterface": nicName,
+		}
+		url, err = transport_tpg.AddQueryParams(url, params)
 		if err != nil {
-			return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			return fmt.Errorf("error adding query params for UpdateNetworkInterface: %w", err)
 		}
+
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "PATCH",
 			Project:   project,
 			RawURL:    url,
 			UserAgent: userAgent,
-			Body:      patchBody,
+			Body:      networkInterfacePatchObj,
 		})
 		if err != nil {
 			return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 		}
+
 		err = ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for network interface update: %w", err)
 		}
 
 		if accessConfigsHaveChanged {
@@ -151,7 +180,12 @@ func computeInstanceAddSecurityPolicy(d *schema.ResourceData, config *transport_
 		if sp != "" {
 			sBody["securityPolicy"] = sp
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setSecurityPolicy", config.ComputeBasePath, project, zone, instanceName)
+		
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setSecurityPolicy")
+		if err != nil {
+			return fmt.Errorf("error replacing vars for SetSecurityPolicy URL: %w", err)
+		}
+
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -161,11 +195,12 @@ func computeInstanceAddSecurityPolicy(d *schema.ResourceData, config *transport_
 			Body:      sBody,
 		})
 		if err != nil {
-			return fmt.Errorf("Error adding security policy: %s", err)
+			return fmt.Errorf("error adding security policy for policy %q: %w", sp, err)
 		}
+		
 		err = ComputeOperationWaitTime(config, res, project, "security_policy to add", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
-			return err
+			return fmt.Errorf("error waiting for security policy addition: %w", err)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/compute_instance_network_interface_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_network_interface_helpers.go.tmpl
@@ -6,9 +6,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-{{- if ne $.TargetVersionName "ga" }}
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-{{- end }}
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/compute/v1"
@@ -20,14 +18,29 @@ import (
 func computeInstanceDeleteAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface *compute.NetworkInterface, project, zone, userAgent, instanceName string) error {
 	// Delete any accessConfig that currently exists in instNetworkInterface
 	for _, ac := range instNetworkInterface.AccessConfigs {
-		op, err := config.NewComputeClient(userAgent).Instances.DeleteAccessConfig(
-			project, zone, instanceName, ac.Name, instNetworkInterface.Name).Do()
+		url, err := transport_tpg.AddQueryParams(
+			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/deleteAccessConfig", config.ComputeBasePath, project, zone, instanceName),
+			map[string]string{
+				"accessConfig":     ac.Name,
+				"networkInterface": instNetworkInterface.Name,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("Error constructing deleteAccessConfig URL: %s", err)
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error deleting old access_config: %s", err)
 		}
-		opErr := ComputeOperationWaitTime(config, op, project, "old access_config to delete", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if opErr != nil {
-			return opErr
+		err = ComputeOperationWaitTime(config, res, project, "old access_config to delete", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -36,13 +49,33 @@ func computeInstanceDeleteAccessConfigs(d *schema.ResourceData, config *transpor
 func computeInstanceAddAccessConfigs(d *schema.ResourceData, config *transport_tpg.Config, instNetworkInterface *compute.NetworkInterface, accessConfigs []*compute.AccessConfig, project, zone, userAgent, instanceName string) error {
 	// Create new ones
 	for _, ac := range accessConfigs {
-		op, err := config.NewComputeClient(userAgent).Instances.AddAccessConfig(project, zone, instanceName, instNetworkInterface.Name, ac).Do()
+		url, err := transport_tpg.AddQueryParams(
+			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addAccessConfig", config.ComputeBasePath, project, zone, instanceName),
+			map[string]string{
+				"networkInterface": instNetworkInterface.Name,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("Error constructing addAccessConfig URL: %s", err)
+		}
+		acBody, err := tpgresource.ConvertToMap(ac)
+		if err != nil {
+			return fmt.Errorf("Error converting access config: %s", err)
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      acBody,
+		})
 		if err != nil {
 			return fmt.Errorf("Error adding new access_config: %s", err)
 		}
-		opErr := ComputeOperationWaitTime(config, op, project, "new access_config to add", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if opErr != nil {
-			return opErr
+		err = ComputeOperationWaitTime(config, res, project, "new access_config to add", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
 		}
 	}
 	return nil
@@ -70,13 +103,33 @@ func computeInstanceCreateUpdateWhileStoppedCall(d *schema.ResourceData, config 
 			}
 		}
 
-		op, err := config.NewComputeClient(userAgent).Instances.UpdateNetworkInterface(project, zone, instanceName, instNetworkInterface.Name, networkInterfacePatchObj).Do()
+		url, err := transport_tpg.AddQueryParams(
+			fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instanceName),
+			map[string]string{
+				"networkInterface": instNetworkInterface.Name,
+			},
+		)
+		if err != nil {
+			return errwrap.Wrapf("Error constructing updateNetworkInterface URL: {{"{{"}}err{{"}}"}}", err)
+		}
+		patchBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+		if err != nil {
+			return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "PATCH",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      patchBody,
+		})
 		if err != nil {
 			return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 		}
-		opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if opErr != nil {
-			return opErr
+		err = ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
 		}
 
 		if accessConfigsHaveChanged {
@@ -92,17 +145,27 @@ func computeInstanceCreateUpdateWhileStoppedCall(d *schema.ResourceData, config 
 {{ if ne $.TargetVersionName `ga` -}}
 func computeInstanceAddSecurityPolicy(d *schema.ResourceData, config *transport_tpg.Config, securityPolicyWithNics map[string][]string, project, zone, userAgent, instanceName string) error {
 	for sp, nics := range securityPolicyWithNics {
-		req := &compute.InstancesSetSecurityPolicyRequest{
-			NetworkInterfaces: nics,
-			SecurityPolicy:    sp,
+		sBody := map[string]interface{}{
+			"networkInterfaces": nics,
 		}
-		op, err := config.NewComputeClient(userAgent).Instances.SetSecurityPolicy(project, zone, instanceName, req).Do()
+		if sp != "" {
+			sBody["securityPolicy"] = sp
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setSecurityPolicy", config.ComputeBasePath, project, zone, instanceName)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      sBody,
+		})
 		if err != nil {
 			return fmt.Errorf("Error adding security policy: %s", err)
 		}
-		opErr := ComputeOperationWaitTime(config, op, project, "security_policy to add", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if opErr != nil {
-			return opErr
+		err = ComputeOperationWaitTime(config, res, project, "security_policy to add", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2632,7 +2632,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 	{{- end }}
 
-	var updatesToNIWhileStopped []func(inst *compute.Instance) error
+	var updatesToNIWhileStopped []func(inst map[string]interface{}) error
 	for i := 0; i < len(networkInterfaces); i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
 		networkInterface := networkInterfaces[i]
@@ -2681,13 +2681,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			// necessary, and also add before removing.
 
 			// Delete current access configs
-			err := computeInstanceDeleteAccessConfigs(d, config, instNetworkInterface, project, zone, userAgent, instance.Name)
+			instNiMap, err := tpgresource.ConvertToMap(instNetworkInterface)
+			if err != nil {
+				return fmt.Errorf("Error converting network interface to map: %w", err)
+			}
+			err = computeInstanceDeleteAccessConfigs(d, config, instNiMap, project, zone, userAgent, instance.Name)
 			if err != nil {
 				return err
 			}
 
 			// Create new ones
-			err = computeInstanceAddAccessConfigs(d, config, instNetworkInterface, networkInterface.AccessConfigs, project, zone, userAgent, instance.Name)
+			acMaps := make([]interface{}, len(networkInterface.AccessConfigs))
+			for j, ac := range networkInterface.AccessConfigs {
+				acMap, err := tpgresource.ConvertToMap(ac)
+				if err != nil {
+					return fmt.Errorf("Error converting access config to map: %w", err)
+				}
+				acMaps[j] = acMap
+			}
+			err = computeInstanceAddAccessConfigs(d, config, instNiMap, acMaps, project, zone, userAgent, instance.Name)
 			if err != nil {
 				return err
 			}
@@ -2839,7 +2851,20 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			// configs if we notice the configuration (user intent) changes.
 			accessConfigsHaveChanged := d.HasChange(prefix + ".access_config")
 
-			updateCall := computeInstanceCreateUpdateWhileStoppedCall(d, config, networkInterfacePatchObj, networkInterface.AccessConfigs, accessConfigsHaveChanged, i, project, zone, userAgent, instance.Name)
+			acMaps := make([]interface{}, len(networkInterface.AccessConfigs))
+			for j, ac := range networkInterface.AccessConfigs {
+				acMap, err := tpgresource.ConvertToMap(ac)
+				if err != nil {
+					return fmt.Errorf("Error converting access config to map: %w", err)
+				}
+				acMaps[j] = acMap
+			}
+			niPatchMap, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return fmt.Errorf("Error converting network interface patch object to map: %w", err)
+			}
+
+			updateCall := computeInstanceCreateUpdateWhileStoppedCall(d, config, niPatchMap, acMaps, accessConfigsHaveChanged, i, project, zone, userAgent, instance.Name)
 			updatesToNIWhileStopped = append(updatesToNIWhileStopped, updateCall)
 		}
 	}
@@ -3252,7 +3277,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 		}
 		for _, patch := range updatesToNIWhileStopped {
-			err := patch(instance)
+			instanceMap, err := tpgresource.ConvertToMap(instance)
+			if err != nil {
+				return fmt.Errorf("Error converting instance to map: %w", err)
+			}
+			err = patch(instanceMap)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `compute_instance_network_interface_helpers` resource to use direct HTTP rather than a client library
```
