### PR TITLE
Add resource manager tags to Storage Pool

### DIFF
--- a/mmv1/products/compute/StoragePool.yaml
+++ b/mmv1/products/compute/StoragePool.yaml
@@ -29,7 +29,7 @@ update_verb: "PATCH"
 update_mask: false
 autogen_async: true
 async:
-  type: 'OpAsync'
+  type: "OpAsync"
   operation:
     base_url: "{{op_id}}"
 iam_policy:
@@ -45,14 +45,14 @@ examples:
     vars:
       storage_pool_name: "storage-pool-basic"
     ignore_read_extra:
-      - 'deletion_protection'
+      - "deletion_protection"
     exclude_test: true
   - name: "compute_storage_pool_full"
     primary_resource_id: "test-storage-pool-full"
     vars:
       storage_pool_name: "storage-pool-full"
     ignore_read_extra:
-      - 'deletion_protection'
+      - "deletion_protection"
     exclude_test: true
 parameters:
   - name: "zone"
@@ -194,9 +194,9 @@ properties:
       * `hyperdisk-throughput`
     required: true
     immutable: true
-    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
-    resource: 'StoragePoolType'
-    imports: 'selfLink'
+    custom_expand: "templates/terraform/custom_expand/resourceref_with_validation.go.tmpl"
+    resource: "StoragePoolType"
+    imports: "selfLink"
   - name: "status"
     type: NestedObject
     description: |
@@ -279,6 +279,26 @@ properties:
     type: KeyValueLabels
     description: |
       Labels to apply to this storage pool. These can be later modified by the setLabels method.
+  - name: "params"
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: "resourceManagerTags"
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the storage pool. Tag keys and values have the
+          same definition as resource manager tags. Keys and values can be either in numeric format,
+          such as tagKeys/{tag_key_id} and tagValues/{tag_value_id} or in namespaced format such as
+          {org_id|projectId}/{tag_key_short_name} and {tag_value_short_name}. The field is ignored when empty.
+          The field is immutable and causes resource replacement when mutated. This field is only
+          set at create time and modifying this field after creation will trigger recreation.
+          To apply tags to an existing resource, see the google_tags_tag_binding resource.
+        api_name: "resourceManagerTags"
+        ignore_read: true
+        immutable: true
 virtual_fields:
   - name: "deletion_protection"
     type: Boolean

--- a/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_storage_pool_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -219,4 +220,86 @@ func testAccCheckComputeStoragePoolDestroyProducer(t *testing.T) func(s *terrafo
 
 		return nil
 	}
+}
+
+func TestAccComputeStoragePool_resourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeStoragePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeStoragePool_resourceManagerTags(context),
+			},
+			{
+				ResourceName:            "google_compute_storage_pool.test-storage-pool-with-resource-manager-tags",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "zone", "params"},
+			},
+		},
+	})
+}
+
+func testAccComputeStoragePool_resourceManagerTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "tag_key" {
+  parent      = "projects/%{project_id}"
+  short_name  = "storage-pool-tag-%{random_suffix}"
+  description = "Tag key for storage pool acceptance tests"
+}
+
+resource "google_tags_tag_value" "tag_value_1" {
+  parent      = google_tags_tag_key.tag_key.id
+  short_name  = "value-one-%{random_suffix}"
+  description = "First tag value for storage pool acceptance tests"
+}
+
+resource "google_tags_tag_value" "tag_value_2" {
+  parent      = google_tags_tag_key.tag_key.id
+  short_name  = "value-two-%{random_suffix}"
+  description = "Second tag value for storage pool acceptance tests"
+
+  # Serialize value creation for stable VCR recordings.
+  depends_on = [google_tags_tag_value.tag_value_1]
+}
+
+resource "google_compute_storage_pool" "test-storage-pool-with-resource-manager-tags" {
+  name = "tf-test-storage-pool-rmt%{random_suffix}"
+
+  description = "Hyperdisk Balanced storage pool with resource manager tags"
+
+  capacity_provisioning_type    = "STANDARD"
+  pool_provisioned_capacity_gb  = "10240"
+  performance_provisioning_type = "STANDARD"
+  pool_provisioned_iops         = "10000"
+  pool_provisioned_throughput   = "1024"
+
+  storage_pool_type = data.google_compute_storage_pool_types.balanced.self_link
+
+  zone = "us-central1-a"
+
+  deletion_protection = false
+
+  params {
+    resource_manager_tags = {
+      (google_tags_tag_key.tag_key.id) = google_tags_tag_value.tag_value_1.id
+    }
+  }
+}
+
+data "google_project" "project" {}
+
+data "google_compute_storage_pool_types" "balanced" {
+  zone = "us-central1-a"
+	storage_pool_type = "hyperdisk-balanced"
+}
+`, context)
 }


### PR DESCRIPTION
Added resource manager tags support to Storage Pool.

```release-note:enhancement
compute: add `params.resourceManagerTags` field to the `google_compute_storage_pool`
```