### PR TITLE
Migrate data_source_google_compute_instance_template.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_template.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance_template.go
@@ -2,18 +2,13 @@ package compute
 
 import (
 	"fmt"
+	neturl "net/url"
 	"sort"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func DataSourceGoogleComputeInstanceTemplate() *schema.Resource {
@@ -36,8 +31,8 @@ func DataSourceGoogleComputeInstanceTemplate() *schema.Resource {
 	// Set 'Optional' schema elements
 	tpgresource.AddOptionalFieldsToSchema(dsSchema, "name", "filter", "most_recent", "project", "self_link_unique")
 
-	mutuallyExclusive:= []string{"name", "filter", "self_link_unique"}
-	for _, n:= range mutuallyExclusive {
+	mutuallyExclusive := []string{"name", "filter", "self_link_unique"}
+	for _, n := range mutuallyExclusive {
 		dsSchema[n].ExactlyOneOf = mutuallyExclusive
 	}
 
@@ -59,27 +54,47 @@ func datasourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interfac
 		return retrieveInstance(d, meta, project, v.(string))
 	}
 	if v, ok := d.GetOk("filter"); ok {
-		userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 		if err != nil {
 			return err
 		}
 
-		templates, err := config.NewComputeClient(userAgent).InstanceTemplates.List(project).Filter(v.(string)).Do()
+		params := neturl.Values{}
+		params.Set("filter", v.(string))
+		listUrl := fmt.Sprintf("%sprojects/%s/global/instanceTemplates?%s", config.ComputeBasePath, project, params.Encode())
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    listUrl,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("error retrieving list of instance templates: %s", err)
 		}
 
+		var items []map[string]interface{}
+		if rawItems, ok := res["items"].([]interface{}); ok {
+			for _, rawItem := range rawItems {
+				item, ok := rawItem.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				items = append(items, item)
+			}
+		}
+
 		mostRecent := d.Get("most_recent").(bool)
 		if mostRecent {
-			sort.Sort(ByCreationTimestamp(templates.Items))
+			sort.Sort(ByCreationTimestamp(items))
 		}
 
-		count := len(templates.Items)
+		count := len(items)
 		if count == 1 || count > 1 && mostRecent {
-			return retrieveInstance(d, meta, project, templates.Items[0].Name)
+			return retrieveInstance(d, meta, project, items[0]["name"].(string))
 		}
 
-		return fmt.Errorf("your filter has returned %d instance template(s). Please refine your filter or set most_recent to return exactly one instance template", len(templates.Items))
+		return fmt.Errorf("your filter has returned %d instance template(s). Please refine your filter or set most_recent to return exactly one instance template", len(items))
 	}
 	if v, ok := d.GetOk("self_link_unique"); ok {
 		return retrieveInstanceFromUniqueId(d, meta, project, v.(string))
@@ -108,12 +123,14 @@ func retrieveInstanceFromUniqueId(d *schema.ResourceData, meta interface{}, proj
 	return tpgresource.SetDataSourceLabels(d)
 }
 
-// ByCreationTimestamp implements sort.Interface for []*InstanceTemplate based on
+// ByCreationTimestamp implements sort.Interface for []map[string]interface{} based on
 // the CreationTimestamp field.
-type ByCreationTimestamp []*compute.InstanceTemplate
+type ByCreationTimestamp []map[string]interface{}
 
 func (a ByCreationTimestamp) Len() int      { return len(a) }
 func (a ByCreationTimestamp) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ByCreationTimestamp) Less(i, j int) bool {
-	return a[i].CreationTimestamp > a[j].CreationTimestamp
+	ti, _ := a[i]["creationTimestamp"].(string)
+	tj, _ := a[j]["creationTimestamp"].(string)
+	return ti > tj
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_template.go.tmpl
@@ -1,7 +1,6 @@
 package compute
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 
@@ -9,12 +8,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func DataSourceGoogleComputeRegionInstanceTemplate() *schema.Resource {
@@ -89,19 +82,15 @@ func datasourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta in
 			return fmt.Errorf("error retrieving list of region instance templates: %s", err)
 		}
 
-		instanceTemplates := templates["items"]
-
-		instanceTemplatesList, err := json.Marshal(instanceTemplates)
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-
-		var items []*compute.InstanceTemplate
-
-		if err := json.Unmarshal(instanceTemplatesList, &items); err != nil {
-			fmt.Println(err)
-			return err
+		var items []map[string]interface{}
+		if rawItems, ok := templates["items"].([]interface{}); ok {
+			for _, rawItem := range rawItems {
+				item, ok := rawItem.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				items = append(items, item)
+			}
 		}
 
 		mostRecent := d.Get("most_recent").(bool)
@@ -111,7 +100,7 @@ func datasourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta in
 
 		count := len(items)
 		if count == 1 || count > 1 && mostRecent {
-			return retrieveInstances(d, meta, project, region, items[0].Name)
+			return retrieveInstances(d, meta, project, region, items[0]["name"].(string))
 		}
 
 		return fmt.Errorf("your filter has returned %d region instance template(s). Please refine your filter or set most_recent to return exactly one region instance template", len(items))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `data_source_google_compute_instance_template` datasource to use direct HTTP rather then a client library
```
