### PR TITLE
Add bulkInsert routing for compatible google_compute_instance creates

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing.go.tmpl
@@ -1,0 +1,277 @@
+package compute
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
+)
+
+func assertExpectedCreateBackend(usedBulkInsert bool) error {
+	expected := strings.ToLower(strings.TrimSpace(os.Getenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND")))
+	if expected == "" {
+		return nil
+	}
+
+	if expected != "bulk" && expected != "insert" {
+		return fmt.Errorf("invalid GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND value %q; expected 'bulk' or 'insert'", expected)
+	}
+
+	if expected == "bulk" && !usedBulkInsert {
+		return fmt.Errorf("expected google_compute_instance create backend 'bulk' but selected 'insert'")
+	}
+	if expected == "insert" && usedBulkInsert {
+		return fmt.Errorf("expected google_compute_instance create backend 'insert' but selected 'bulk'")
+	}
+
+	return nil
+}
+
+func isBulkInsertCompatible(d *schema.ResourceData) (bool, string) {
+	if v, ok := d.GetOk("deletion_protection"); ok && v.(bool) {
+		return false, "deletion_protection is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("enable_display"); ok && v.(bool) {
+		return false, "enable_display is not supported by bulkInsert"
+	}
+
+	if _, ok := d.GetOk("instance_encryption_key"); ok {
+		return false, "instance_encryption_key is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_raw"); ok && v.(string) != "" {
+		return false, "boot_disk disk_encryption_key_raw (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_rsa"); ok && v.(string) != "" {
+		return false, "boot_disk disk_encryption_key_rsa (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.source_image_encryption_key.0.raw_key"); ok && v.(string) != "" {
+		return false, "boot_disk source_image_encryption_key raw_key (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.source_image_encryption_key.0.rsa_encrypted_key"); ok && v.(string) != "" {
+		return false, "boot_disk source_image_encryption_key rsa_encrypted_key (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.source_snapshot_encryption_key.0.raw_key"); ok && v.(string) != "" {
+		return false, "boot_disk source_snapshot_encryption_key raw_key (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.source_snapshot_encryption_key.0.rsa_encrypted_key"); ok && v.(string) != "" {
+		return false, "boot_disk source_snapshot_encryption_key rsa_encrypted_key (CSEK) is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.snapshot"); ok && v.(string) != "" {
+		return false, "boot_disk initialize_params.snapshot is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.initialize_params.0.resource_policies"); ok && len(v.([]interface{})) > 0 {
+		return false, "boot_disk initialize_params.resource_policies is not supported by bulkInsert"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.source"); ok && v.(string) != "" && strings.Contains(v.(string), "/zones/") {
+		return false, "boot_disk source must be a regional disk for bulkInsert (zonal disk self_links are rejected)"
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.force_attach"); ok && v.(bool) {
+		return false, "boot_disk force_attach is not supported by bulkInsert"
+	}
+
+	attachedDisksCount := d.Get("attached_disk.#").(int)
+	for i := 0; i < attachedDisksCount; i++ {
+		if v, ok := d.GetOk(fmt.Sprintf("attached_disk.%d.disk_encryption_key_raw", i)); ok && v.(string) != "" {
+			return false, fmt.Sprintf("attached_disk.%d disk_encryption_key_raw (CSEK) is not supported by bulkInsert", i)
+		}
+		if v, ok := d.GetOk(fmt.Sprintf("attached_disk.%d.disk_encryption_key_rsa", i)); ok && v.(string) != "" {
+			return false, fmt.Sprintf("attached_disk.%d disk_encryption_key_rsa (CSEK) is not supported by bulkInsert", i)
+		}
+		if mode := d.Get(fmt.Sprintf("attached_disk.%d.mode", i)).(string); mode != "READ_ONLY" {
+			return false, fmt.Sprintf("attached_disk.%d must use mode READ_ONLY for bulkInsert (got %q)", i, mode)
+		}
+		if src := d.Get(fmt.Sprintf("attached_disk.%d.source", i)).(string); src != "" && strings.Contains(src, "/zones/") {
+			return false, fmt.Sprintf("attached_disk.%d source must be a regional disk for bulkInsert (zonal disk self_links are rejected)", i)
+		}
+	}
+
+	networkInterfacesCount := d.Get("network_interface.#").(int)
+	for i := 0; i < networkInterfacesCount; i++ {
+		if v, ok := d.GetOk(fmt.Sprintf("network_interface.%d.network_ip", i)); ok && v.(string) != "" {
+			return false, fmt.Sprintf("network_interface.%d network_ip is not supported by bulkInsert", i)
+		}
+		if v, ok := d.GetOk(fmt.Sprintf("network_interface.%d.alias_ip_range", i)); ok && len(v.([]interface{})) > 0 {
+			return false, fmt.Sprintf("network_interface.%d alias_ip_range is not supported by bulkInsert", i)
+		}
+		if v, ok := d.GetOk(fmt.Sprintf("network_interface.%d.igmp_query", i)); ok && v.(string) != "" && v.(string) != "IGMP_QUERY_DISABLED" {
+			return false, fmt.Sprintf("network_interface.%d igmp_query %q is not supported by bulkInsert", i, v.(string))
+		}
+
+		accessConfigCount := d.Get(fmt.Sprintf("network_interface.%d.access_config.#", i)).(int)
+		for j := 0; j < accessConfigCount; j++ {
+			if v, ok := d.GetOk(fmt.Sprintf("network_interface.%d.access_config.%d.nat_ip", i, j)); ok && v.(string) != "" {
+				return false, fmt.Sprintf("network_interface.%d.access_config.%d nat_ip is not supported by bulkInsert", i, j)
+			}
+			if v, ok := d.GetOk(fmt.Sprintf("network_interface.%d.access_config.%d.public_ptr_domain_name", i, j)); ok && v.(string) != "" {
+				return false, fmt.Sprintf("network_interface.%d.access_config.%d public_ptr_domain_name is not supported by bulkInsert", i, j)
+			}
+		}
+	}
+
+	return true, ""
+}
+
+func instanceToInstanceProperties(instance *compute.Instance) *compute.InstanceProperties {
+	props := &compute.InstanceProperties{
+		CanIpForward:               instance.CanIpForward,
+		Description:                instance.Description,
+		MachineType:                tpgresource.GetResourceNameFromSelfLink(instance.MachineType),
+		Disks:                      sanitizeBulkInsertDisks(instance.Disks),
+		Metadata:                   instance.Metadata,
+		NetworkInterfaces:          instance.NetworkInterfaces,
+		NetworkPerformanceConfig:   instance.NetworkPerformanceConfig,
+		Tags:                       instance.Tags,
+		Labels:                     instance.Labels,
+		ServiceAccounts:            instance.ServiceAccounts,
+		GuestAccelerators:          sanitizeBulkInsertGuestAccelerators(instance.GuestAccelerators),
+		MinCpuPlatform:             instance.MinCpuPlatform,
+		Scheduling:                 instance.Scheduling,
+		ConfidentialInstanceConfig: instance.ConfidentialInstanceConfig,
+		AdvancedMachineFeatures:    instance.AdvancedMachineFeatures,
+		ShieldedInstanceConfig:     instance.ShieldedInstanceConfig,
+		ResourcePolicies:           sanitizeBulkInsertResourcePolicies(instance.ResourcePolicies),
+		ReservationAffinity:        instance.ReservationAffinity,
+		KeyRevocationActionType:    instance.KeyRevocationActionType,
+		PrivateIpv6GoogleAccess:    instance.PrivateIpv6GoogleAccess,
+		ForceSendFields:            []string{"CanIpForward"},
+	}
+
+	if instance.Params != nil && len(instance.Params.ResourceManagerTags) > 0 {
+		props.ResourceManagerTags = instance.Params.ResourceManagerTags
+	}
+
+	return props
+}
+
+func createInstanceViaBulkInsert(d *schema.ResourceData, config *transport_tpg.Config, instance *compute.Instance, project, zone, userAgent string) (map[string]interface{}, error) {
+	instanceProperties := instanceToInstanceProperties(instance)
+
+	perInstanceProps := map[string]compute.BulkInsertInstanceResourcePerInstanceProperties{
+		instance.Name: {},
+	}
+
+	if instance.Hostname != "" {
+		perInstanceProps[instance.Name] = compute.BulkInsertInstanceResourcePerInstanceProperties{
+			Hostname: instance.Hostname,
+		}
+	}
+
+	bulkReq := &compute.BulkInsertInstanceResource{
+		Count:                 1,
+		PerInstanceProperties: perInstanceProps,
+		InstanceProperties:    instanceProperties,
+	}
+
+	body, err := json.Marshal(bulkReq)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling bulk insert request: %s", err)
+	}
+
+	var bodyMap map[string]interface{}
+	if err := json.Unmarshal(body, &bodyMap); err != nil {
+		return nil, fmt.Errorf("error converting bulk insert request to map: %s", err)
+	}
+
+	requestURL := fmt.Sprintf("%sprojects/%s/zones/%s/instances/bulkInsert", config.ComputeBasePath, project, zone)
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    requestURL,
+		UserAgent: userAgent,
+		Body:      bodyMap,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error creating instance via bulkInsert: %s", err)
+	}
+
+	return res, nil
+}
+
+func sanitizeBulkInsertDisks(disks []*compute.AttachedDisk) []*compute.AttachedDisk {
+	sanitized := make([]*compute.AttachedDisk, len(disks))
+	for i, disk := range disks {
+		diskCopy := *disk
+		if diskCopy.DiskEncryptionKey != nil {
+			keyCopy := *diskCopy.DiskEncryptionKey
+			keyCopy.RawKey = ""
+			keyCopy.RsaEncryptedKey = ""
+			diskCopy.DiskEncryptionKey = &keyCopy
+		}
+		if diskCopy.InitializeParams != nil && diskCopy.InitializeParams.SourceImageEncryptionKey != nil {
+			keyCopy := *diskCopy.InitializeParams.SourceImageEncryptionKey
+			keyCopy.RawKey = ""
+			keyCopy.RsaEncryptedKey = ""
+			diskCopy.InitializeParams.SourceImageEncryptionKey = &keyCopy
+		}
+		if diskCopy.InitializeParams != nil && diskCopy.InitializeParams.SourceSnapshotEncryptionKey != nil {
+			keyCopy := *diskCopy.InitializeParams.SourceSnapshotEncryptionKey
+			keyCopy.RawKey = ""
+			keyCopy.RsaEncryptedKey = ""
+			diskCopy.InitializeParams.SourceSnapshotEncryptionKey = &keyCopy
+		}
+		if diskCopy.InitializeParams != nil && diskCopy.InitializeParams.DiskType != "" {
+			diskCopy.InitializeParams.DiskType = tpgresource.GetResourceNameFromSelfLink(diskCopy.InitializeParams.DiskType)
+		}
+		sanitized[i] = &diskCopy
+	}
+	return sanitized
+}
+
+func sanitizeBulkInsertGuestAccelerators(accels []*compute.AcceleratorConfig) []*compute.AcceleratorConfig {
+	if len(accels) == 0 {
+		return accels
+	}
+	out := make([]*compute.AcceleratorConfig, len(accels))
+	for i, a := range accels {
+		if a == nil {
+			continue
+		}
+		cp := *a
+		cp.AcceleratorType = tpgresource.GetResourceNameFromSelfLink(a.AcceleratorType)
+		if cp.AcceleratorType == "" {
+			cp.AcceleratorType = a.AcceleratorType
+		}
+		out[i] = &cp
+	}
+	return out
+}
+
+func sanitizeBulkInsertResourcePolicies(policies []string) []string {
+	if len(policies) == 0 {
+		return policies
+	}
+	out := make([]string, len(policies))
+	for i, p := range policies {
+		name := tpgresource.GetResourceNameFromSelfLink(p)
+		if name == "" {
+			name = p
+		}
+		out[i] = name
+	}
+	return out
+}

--- a/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing_internal_test.go.tmpl
@@ -1,0 +1,398 @@
+package compute
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
+)
+
+func TestIsBulkInsertCompatible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		raw            map[string]interface{}
+		wantCompatible bool
+		wantReasonLike string
+	}{
+		{
+			name:           "basic compatible",
+			raw:            baseBulkInsertTestResourceData(),
+			wantCompatible: true,
+		},
+		{
+			name: "enable_display incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["enable_display"] = true
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "enable_display",
+		},
+		{
+			name: "boot disk csek incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["boot_disk"] = []interface{}{
+					map[string]interface{}{
+						"initialize_params": []interface{}{
+							map[string]interface{}{
+								"image": "debian-cloud/debian-11",
+							},
+						},
+						"disk_encryption_key_raw": "c2VjcmV0Cg==",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "disk_encryption_key_raw",
+		},
+		{
+			name: "instance encryption key incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["instance_encryption_key"] = []interface{}{
+					map[string]interface{}{
+						"kms_key_self_link": "projects/p/locations/global/keyRings/r/cryptoKeys/k",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "instance_encryption_key",
+		},
+		{
+			name: "boot disk snapshot incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["boot_disk"] = []interface{}{
+					map[string]interface{}{
+						"initialize_params": []interface{}{
+							map[string]interface{}{
+								"snapshot": "projects/p/global/snapshots/snap-1",
+							},
+						},
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "initialize_params.snapshot",
+		},
+		{
+			name: "boot disk resource policies incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["boot_disk"] = []interface{}{
+					map[string]interface{}{
+						"initialize_params": []interface{}{
+							map[string]interface{}{
+								"image":             "debian-cloud/debian-11",
+								"resource_policies": []interface{}{"projects/p/regions/us-central1/resourcePolicies/policy-1"},
+							},
+						},
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "resource_policies",
+		},
+		{
+			name: "boot disk zonal source incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["boot_disk"] = []interface{}{
+					map[string]interface{}{
+						"source": "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/disks/d1",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "regional disk",
+		},
+		{
+			name: "boot disk force attach incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["boot_disk"] = []interface{}{
+					map[string]interface{}{
+						"initialize_params": []interface{}{
+							map[string]interface{}{
+								"image": "debian-cloud/debian-11",
+							},
+						},
+						"force_attach": true,
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "force_attach",
+		},
+		{
+			name: "attached disk read write incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["attached_disk"] = []interface{}{
+					map[string]interface{}{
+						"source": "projects/p/regions/us-central1/disks/reg-disk",
+						"mode":   "READ_WRITE",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "READ_ONLY",
+		},
+		{
+			name: "attached zonal disk incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["attached_disk"] = []interface{}{
+					map[string]interface{}{
+						"source": "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a/disks/d1",
+						"mode":   "READ_ONLY",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "regional disk",
+		},
+		{
+			name: "network ip incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["network_interface"] = []interface{}{
+					map[string]interface{}{
+						"network":    "default",
+						"network_ip": "10.0.0.5",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "network_ip",
+		},
+		{
+			name: "nat ip incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["network_interface"] = []interface{}{
+					map[string]interface{}{
+						"network": "default",
+						"access_config": []interface{}{
+							map[string]interface{}{
+								"nat_ip": "34.0.0.5",
+							},
+						},
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "nat_ip",
+		},
+		{
+			name: "public ptr domain incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["network_interface"] = []interface{}{
+					map[string]interface{}{
+						"network": "default",
+						"access_config": []interface{}{
+							map[string]interface{}{
+								"public_ptr_domain_name": "vm.example.com.",
+							},
+						},
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "public_ptr_domain_name",
+		},
+		{
+			name: "alias ip range incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["network_interface"] = []interface{}{
+					map[string]interface{}{
+						"network": "default",
+						"alias_ip_range": []interface{}{
+							map[string]interface{}{
+								"ip_cidr_range": "10.1.0.0/24",
+							},
+						},
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "alias_ip_range",
+		},
+		{
+			name: "igmp query incompatible",
+			raw: func() map[string]interface{} {
+				rd := baseBulkInsertTestResourceData()
+				rd["network_interface"] = []interface{}{
+					map[string]interface{}{
+						"network":    "default",
+						"igmp_query": "IGMP_QUERY_V2",
+					},
+				}
+				return rd
+			}(),
+			wantCompatible: false,
+			wantReasonLike: "igmp_query",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := schema.TestResourceDataRaw(t, ResourceComputeInstance().Schema, tc.raw)
+			gotCompatible, gotReason := isBulkInsertCompatible(d)
+			if gotCompatible != tc.wantCompatible {
+				t.Fatalf("got compatible=%t, want %t (reason=%q)", gotCompatible, tc.wantCompatible, gotReason)
+			}
+			if tc.wantReasonLike != "" && !strings.Contains(gotReason, tc.wantReasonLike) {
+				t.Fatalf("got reason %q, expected to contain %q", gotReason, tc.wantReasonLike)
+			}
+		})
+	}
+}
+
+func TestInstanceToInstancePropertiesSanitizes(t *testing.T) {
+	t.Parallel()
+
+	instance := &compute.Instance{
+		Name:        "vm-1",
+		CanIpForward: true,
+		MachineType: "https://www.googleapis.com/compute/v1/projects/test-p/zones/us-central1-a/machineTypes/e2-medium",
+		Disks: []*compute.AttachedDisk{
+			{
+				Source: "/projects/test-p/regions/us-central1/disks/disk-1",
+				DiskEncryptionKey: &compute.CustomerEncryptionKey{
+					RawKey:         "raw",
+					RsaEncryptedKey: "rsa",
+				},
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					DiskType: "https://www.googleapis.com/compute/v1/projects/test-p/zones/us-central1-a/diskTypes/pd-ssd",
+					SourceImageEncryptionKey: &compute.CustomerEncryptionKey{
+						RawKey:         "img-raw",
+						RsaEncryptedKey: "img-rsa",
+					},
+					SourceSnapshotEncryptionKey: &compute.CustomerEncryptionKey{
+						RawKey:         "snap-raw",
+						RsaEncryptedKey: "snap-rsa",
+					},
+				},
+			},
+		},
+		GuestAccelerators: []*compute.AcceleratorConfig{
+			{
+				AcceleratorType:  "https://www.googleapis.com/compute/v1/projects/test-p/zones/us-central1-a/acceleratorTypes/nvidia-tesla-t4",
+				AcceleratorCount: 1,
+			},
+		},
+		ResourcePolicies: []string{
+			"https://www.googleapis.com/compute/v1/projects/test-p/regions/us-central1/resourcePolicies/policy-a",
+		},
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{Network: "global/networks/default"},
+		},
+		Params: &compute.InstanceParams{
+			ResourceManagerTags: map[string]string{
+				"tagKeys/111": "tagValues/222",
+			},
+		},
+	}
+
+	props := instanceToInstanceProperties(instance)
+	if props.MachineType != "e2-medium" {
+		t.Fatalf("got machine type %q, want %q", props.MachineType, "e2-medium")
+	}
+	if props.Disks[0].DiskEncryptionKey.RawKey != "" || props.Disks[0].DiskEncryptionKey.RsaEncryptedKey != "" {
+		t.Fatalf("expected disk encryption key raw/rsa to be stripped, got %+v", props.Disks[0].DiskEncryptionKey)
+	}
+	if props.Disks[0].InitializeParams.DiskType != "pd-ssd" {
+		t.Fatalf("got disk type %q, want %q", props.Disks[0].InitializeParams.DiskType, "pd-ssd")
+	}
+	if props.GuestAccelerators[0].AcceleratorType != "nvidia-tesla-t4" {
+		t.Fatalf("got accelerator type %q, want %q", props.GuestAccelerators[0].AcceleratorType, "nvidia-tesla-t4")
+	}
+	if len(props.ResourcePolicies) != 1 || props.ResourcePolicies[0] != "policy-a" {
+		t.Fatalf("unexpected resource policies: %#v", props.ResourcePolicies)
+	}
+	if props.ResourceManagerTags["tagKeys/111"] != "tagValues/222" {
+		t.Fatalf("resource manager tags were not copied: %#v", props.ResourceManagerTags)
+	}
+
+}
+
+func TestAssertExpectedCreateBackend(t *testing.T) {
+	tests := []struct {
+		name           string
+		expected       string
+		usedBulkInsert bool
+		wantErr        bool
+	}{
+		{name: "unset no-op", expected: "", usedBulkInsert: true, wantErr: false},
+		{name: "bulk expected bulk selected", expected: "bulk", usedBulkInsert: true, wantErr: false},
+		{name: "bulk expected insert selected", expected: "bulk", usedBulkInsert: false, wantErr: true},
+		{name: "insert expected insert selected", expected: "insert", usedBulkInsert: false, wantErr: false},
+		{name: "insert expected bulk selected", expected: "insert", usedBulkInsert: true, wantErr: true},
+		{name: "invalid expected value", expected: "whatever", usedBulkInsert: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expected != "" {
+				t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", tc.expected)
+			}
+			err := assertExpectedCreateBackend(tc.usedBulkInsert)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil error but got %v", err)
+			}
+		})
+	}
+}
+
+func baseBulkInsertTestResourceData() map[string]interface{} {
+	return map[string]interface{}{
+		"name":         "vm-test",
+		"machine_type": "e2-medium",
+		"zone":         "us-central1-a",
+		"boot_disk": []interface{}{
+			map[string]interface{}{
+				"initialize_params": []interface{}{
+					map[string]interface{}{
+						"image": "debian-cloud/debian-11",
+					},
+				},
+			},
+		},
+		"network_interface": []interface{}{
+			map[string]interface{}{
+				"network": "default",
+			},
+		},
+	}
+}

--- a/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_bulk_insert_routing_test.go.tmpl
@@ -1,0 +1,661 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
+)
+
+func TestAccComputeInstance_bulkInsertBasic(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertBasic(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasInstanceId(&instance, "google_compute_instance.foobar"),
+					testAccCheckComputeInstanceTag(&instance, "foo"),
+					testAccCheckComputeInstanceLabel(&instance, "my_key", "my_value"),
+					testAccCheckComputeInstanceMetadata(&instance, "foo", "bar"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "current_status", "RUNNING"),
+					resource.TestCheckResourceAttrSet("google_compute_instance.foobar", "creation_timestamp"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{
+				"labels.%", "labels.my_key", "labels.my_other_key",
+				"terraform_labels", "terraform_labels.%",
+				"metadata.foo",
+			}),
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertDefaultsToBulkInsert(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertBasic(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "current_status", "RUNNING"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertFallbackDeletionProtection(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "insert")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertDeletionProtection(instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "deletion_protection", "true"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_bulkInsertDeletionProtection(instanceName, false),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertWithScheduling(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertSpot(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.provisioning_model", "SPOT"),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "scheduling.0.preemptible", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertWithAttachedDisk(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	diskName := fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertAttachedDiskReadOnly(instanceName, diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceDisk(&instance, instanceName, true, true),
+					testAccCheckComputeInstanceDisk(&instance, diskName, false, false),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertWithServiceAccount(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	saAccountID := fmt.Sprintf("tf-bi-sa-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertServiceAccount(instanceName, saAccountID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttrPair(
+						"google_compute_instance.foobar", "service_account.0.email",
+						"google_service_account.bulk_insert_test", "email"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertUpdate(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "bulk")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertBasic(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceLabel(&instance, "my_key", "my_value"),
+				),
+			},
+			{
+				Config: testAccComputeInstance_bulkInsertUpdatedLabels(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceLabel(&instance, "my_key", "updated_value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertFallbackEnableDisplay(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "insert")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertEnableDisplay(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.foobar", "enable_display", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertFallbackBootDiskCSEK(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "insert")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertBootDiskCSEK(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttrSet("google_compute_instance.foobar", "instance_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertFallbackBootDiskSnapshot(t *testing.T) {
+	var instance compute.Instance
+	snapshotName := fmt.Sprintf("tf-test-snap-%s", acctest.RandString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "insert")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertBootDiskSnapshot(instanceName, snapshotName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttrSet("google_compute_instance.foobar", "instance_id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_bulkInsertFallbackInstanceEncryptionKey(t *testing.T) {
+	var instance compute.Instance
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	saAccountID := fmt.Sprintf("tf-bikms-%s", acctest.RandString(t, 10))
+
+	// Per-test KMS resources avoid BootstrapKMSKey's shared crypto key, which may be
+	// absent or destroyed in some test projects.
+	context := map[string]interface{}{
+		"instance_name": instanceName,
+		"sa_account_id": saAccountID,
+		"key_ring":      fmt.Sprintf("tf-bulk-kr-%s", acctest.RandString(t, 10)),
+		"crypto_key":    fmt.Sprintf("tf-bulk-ck-%s", acctest.RandString(t, 10)),
+	}
+
+	t.Setenv("GOOGLE_COMPUTE_EXPECT_CREATE_BACKEND", "insert")
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bulkInsertInstanceEncryptionKey(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					resource.TestCheckResourceAttrSet("google_compute_instance.foobar", "instance_encryption_key.0.kms_key_self_link"),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeInstance_bulkInsertBasic(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+  tags         = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  labels = {
+    my_key       = "my_value"
+    my_other_key = "my_other_value"
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_bulkInsertUpdatedLabels(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+  tags         = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+
+  labels = {
+    my_key       = "updated_value"
+    my_other_key = "my_other_value"
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_bulkInsertDeletionProtection(instance string, deletionProtection bool) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name                = "%s"
+  machine_type        = "e2-medium"
+  zone                = "us-central1-a"
+  deletion_protection = %t
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, instance, deletionProtection)
+}
+
+func testAccComputeInstance_bulkInsertSpot(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    preemptible                 = true
+    automatic_restart           = false
+    provisioning_model          = "SPOT"
+    instance_termination_action = "STOP"
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_bulkInsertAttachedDiskReadOnly(instance, disk string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "seed" {
+  name  = "%[1]s-seed"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = data.google_compute_image.my_image.self_link
+}
+
+resource "google_compute_snapshot" "snap" {
+  name        = "%[1]s-snap"
+  source_disk = google_compute_disk.seed.name
+  zone        = "us-central1-a"
+}
+
+resource "google_compute_region_disk" "foobar" {
+  name          = "%[1]s"
+  snapshot      = google_compute_snapshot.snap.self_link
+  type          = "pd-ssd"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%[2]s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  attached_disk {
+    source = google_compute_region_disk.foobar.self_link
+    mode   = "READ_ONLY"
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, disk, instance)
+}
+
+func testAccComputeInstance_bulkInsertServiceAccount(instance, saAccountID string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_service_account" "bulk_insert_test" {
+  account_id   = "%s"
+  display_name = "Terraform bulkInsert routing test"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    email  = google_service_account.bulk_insert_test.email
+    scopes = [
+      "userinfo-email",
+      "compute-ro",
+      "storage-ro",
+    ]
+  }
+}
+`, saAccountID, instance)
+}
+
+func testAccComputeInstance_bulkInsertEnableDisplay(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+
+  enable_display = true
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_bulkInsertBootDiskSnapshot(instance, snapshot string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_disk" "seed" {
+  name  = "%[2]s-seed"
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+  image = data.google_compute_image.my_image.self_link
+}
+
+resource "google_compute_snapshot" "boot" {
+  name        = "%[2]s"
+  source_disk = google_compute_disk.seed.name
+  zone        = "us-central1-a"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%[1]s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      snapshot = google_compute_snapshot.boot.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, instance, snapshot)
+}
+
+func testAccComputeInstance_bulkInsertBootDiskCSEK(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    disk_encryption_key_raw = "xKfPzQ6x9YxNQ6Qv0s2C8rM0oWQG2f2WzNf8aQ4kJpM="
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, instance)
+}
+
+func testAccComputeInstance_bulkInsertInstanceEncryptionKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_kms_key_ring" "bulk_insert_kms" {
+	name     = "%{key_ring}"
+	location = "global"
+}
+
+resource "google_kms_crypto_key" "bulk_insert_kms" {
+	name     = "%{crypto_key}"
+	key_ring = google_kms_key_ring.bulk_insert_kms.id
+}
+
+resource "google_service_account" "kms_actor" {
+	account_id   = "%{sa_account_id}"
+	display_name = "Terraform bulkInsert routing CMEK test"
+}
+
+resource "google_kms_crypto_key_iam_member" "kms_actor" {
+	crypto_key_id = google_kms_crypto_key.bulk_insert_kms.id
+	role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+	member        = "serviceAccount:${google_service_account.kms_actor.email}"
+}
+
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%{instance_name}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.self_link
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	instance_encryption_key {
+		kms_key_self_link       = google_kms_crypto_key.bulk_insert_kms.id
+		kms_key_service_account = google_service_account.kms_actor.email
+	}
+
+	depends_on = [google_kms_crypto_key_iam_member.kms_actor]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1771,7 +1771,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 
 	for i := 0; i < attachedDisksCount; i++ {
 		diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-		disk, err := expandAttachedDisk(diskConfig, d, config)
+		disk, err := expandAttachedDisk(diskConfig, d, config, i)
 		if err != nil {
 			return nil, err
 		}
@@ -1966,17 +1966,36 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	}
 	{{- end }}
 
-	log.Printf("[INFO] Requesting instance creation")
-	op, err := config.NewComputeClient(userAgent).Instances.Insert(project, zone.Name, instance).Do()
-	if err != nil {
-		return fmt.Errorf("Error creating instance: %s", err)
+	bulkCompatible, incompatReason := isBulkInsertCompatible(d)
+	usedBulkInsert := bulkCompatible
+	var opRes interface{}
+
+	if err := assertExpectedCreateBackend(usedBulkInsert); err != nil {
+		return err
+	}
+
+	if usedBulkInsert {
+		log.Printf("[INFO] Creating instance %s via bulkInsert (bulk-compatible config)", instance.Name)
+		res, err := createInstanceViaBulkInsert(d, config, instance, project, zone.Name, userAgent)
+		if err != nil {
+			return err
+		}
+		opRes = res
+	} else {
+		log.Printf("[INFO] Instance %s not bulk-compatible (%s), falling back to classic insert", instance.Name, incompatReason)
+		log.Printf("[INFO] Requesting instance creation")
+		op, err := config.NewComputeClient(userAgent).Instances.Insert(project, zone.Name, instance).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating instance: %s", err)
+		}
+		opRes = op
 	}
 
 	// Store the ID now
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := ComputeOperationWaitTime(config, op, project, "instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
+	waitErr := ComputeOperationWaitTime(config, opRes, project, "instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -2874,9 +2893,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// Since changing any field within the disk needs to detach+reattach it,
 		// keep track of the hash of the full disk.
 		oDisks := map[uint64]string{}
-		for _, disk := range o.([]interface{}) {
+		for i, disk := range o.([]interface{}) {
 			diskConfig := disk.(map[string]interface{})
-			computeDisk, err := expandAttachedDisk(diskConfig, d, config)
+			computeDisk, err := expandAttachedDisk(diskConfig, d, config, i)
 			if err != nil {
 				return err
 			}
@@ -2895,9 +2914,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// If a disk with a certain hash is only in the new config, it should be attached.
 		nDisks := map[uint64]struct{}{}
 		var attach []*compute.AttachedDisk
-		for _, disk := range n.([]interface{}) {
+		for i, disk := range n.([]interface{}) {
 			diskConfig := disk.(map[string]interface{})
-			computeDisk, err := expandAttachedDisk(diskConfig, d, config)
+			computeDisk, err := expandAttachedDisk(diskConfig, d, config, i)
 			if err != nil {
 				return err
 			}
@@ -3315,7 +3334,7 @@ func startInstanceOperation(d *schema.ResourceData, config *transport_tpg.Config
 	return op, err
 }
 
-func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceData, meta interface{}) (*compute.AttachedDisk, error) {
+func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceData, meta interface{}, attachedDiskIndex int) (*compute.AttachedDisk, error) {
 	config := meta.(*transport_tpg.Config)
 
 	s := diskConfig["source"].(string)
@@ -3338,9 +3357,7 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 		Source: sourceLink,
 	}
 
-	if v, ok := diskConfig["mode"]; ok {
-		disk.Mode = v.(string)
-	}
+	disk.Mode = d.Get(fmt.Sprintf("attached_disk.%d.mode", attachedDiskIndex)).(string)
 
 	if v, ok := diskConfig["device_name"]; ok {
 		disk.DeviceName = v.(string)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
@@ -286,7 +286,7 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 	if attachedDisksCount > 0 {
 		for i := 0; i < attachedDisksCount; i++ {
 			diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-			disk, err := expandAttachedDisk(diskConfig, d, config)
+			disk, err := expandAttachedDisk(diskConfig, d, config, i)
 			if err != nil {
 				return nil, err
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
@@ -27,6 +27,7 @@ func TestAccComputeInstanceFromMachineImage_basic(t *testing.T) {
 	var instance compute.Instance
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	generatedInstanceName := fmt.Sprintf("tf-test-generated-%s", acctest.RandString(t, 10))
+	saAccountID := fmt.Sprintf("tf-machimg-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_machine_image.foobar"
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -35,7 +36,7 @@ func TestAccComputeInstanceFromMachineImage_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeInstanceFromMachineImageDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceFromMachineImage_basic(instanceName, generatedInstanceName),
+				Config: testAccComputeInstanceFromMachineImage_basic(instanceName, generatedInstanceName, saAccountID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExists(t, resourceName, &instance),
 
@@ -394,8 +395,14 @@ func testAccCheckComputeInstanceFromMachineImageDestroyProducer(t *testing.T) fu
 	}
 }
 
-func testAccComputeInstanceFromMachineImage_basic(instance, newInstance string) string {
+func testAccComputeInstanceFromMachineImage_basic(instance, newInstance, saAccountID string) string {
 	return fmt.Sprintf(`
+resource "google_service_account" "machimg" {
+  provider     = google-beta
+  account_id   = "%s"
+  display_name = "Terraform acc test machine image basic"
+}
+
 resource "google_compute_instance" "vm" {
   provider     = google-beta
 
@@ -410,6 +417,11 @@ resource "google_compute_instance" "vm" {
 
   network_interface {
     network = "default"
+  }
+
+  service_account {
+    email  = google_service_account.machimg.email
+    scopes = ["cloud-platform"]
   }
 
   metadata = {
@@ -436,6 +448,11 @@ resource "google_compute_instance_from_machine_image" "foobar" {
 
   source_machine_image = google_compute_machine_image.foobar.self_link
 
+  service_account {
+    email  = google_service_account.machimg.email
+    scopes = ["cloud-platform"]
+  }
+
   // Overrides
   can_ip_forward = false
   labels = {
@@ -445,7 +462,7 @@ resource "google_compute_instance_from_machine_image" "foobar" {
     automatic_restart = false
   }
 }
-`, instance, instance, newInstance)
+`, saAccountID, instance, instance, newInstance)
 }
 
 func testAccComputeInstanceFromMachineImage_ConfidentialInstanceConfigEnable(instance string, newInstance string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
@@ -294,7 +294,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 	if attachedDisksCount > 0 {
 		for i := 0; i < attachedDisksCount; i++ {
 			diskConfig := d.Get(fmt.Sprintf("attached_disk.%d", i)).(map[string]interface{})
-			disk, err := expandAttachedDisk(diskConfig, d, config)
+			disk, err := expandAttachedDisk(diskConfig, d, config, i)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Routes `google_compute_instance` create through `instances.bulkInsert` when the configuration is compatible, and falls back to classic `instances.insert` otherwise.

This PR adds a dedicated routing helper, compatibility checks for unsupported bulkInsert cases, backend-selection assertions in acceptance tests, and a small attached-disk expansion fix that now reads disk mode by block index.

The compatibility gate currently falls back to classic insert for known unsupported cases such as:
- `deletion_protection`
- `enable_display`
- `instance_encryption_key`
- boot/attached disk CSEK paths
- boot disk snapshot / zonal source / force attach / initialize params resource policies
- custom NIC IPs, alias IP ranges, custom NAT IPs, PTR settings, and IGMP query

```release-note:enhancement
compute: `google_compute_instance` now uses `instances.bulkInsert` for compatible creates and falls back to `instances.insert` for unsupported configurations.
```