### PR TITLE
compute: fix empty boot disk resource_policies guard

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3773,12 +3773,6 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 
 	diskDetails, err := getDisk(disk.Source, d, config)
 
-	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
-	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
-	if v, ok := d.GetOkExists("boot_disk.0.initialize_params.0.resource_policies"); !ok || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
-		diskDetails.ResourcePolicies = nil
-	}
-
 	if err != nil {
 		log.Printf("[WARN] Cannot retrieve boot disk details: %s", err)
 
@@ -3789,6 +3783,13 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			result["initialize_params"] = m
 		}
 	} else {
+		// Resource policies can get autofilled from the API on this field and cause the
+		// instance to recreate. Ignore those API-provided values when the user left the
+		// field unset or explicitly configured an empty list.
+		if v, ok := d.GetOkExists("boot_disk.0.initialize_params.0.resource_policies"); !ok || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
+			diskDetails.ResourcePolicies = nil
+		}
+
 		result["initialize_params"] = []map[string]interface{}{{"{{"}}
 			"type": tpgresource.GetResourceNameFromSelfLink(diskDetails.Type),
 			// If the config specifies a family name that doesn't match the image name, then

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -3774,7 +3775,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 
 	// Resource policies can get autofilled from the API and on this field and this will cause the instance to recreate
 	// This overrides any value set by the API not to cause a diff when the user didn't set this in their config.
-	if d.Get("boot_disk.0.initialize_params.0.resource_policies.0") == nil || d.Get("boot_disk.0.initialize_params.0.resource_policies") == nil {
+	if v, ok := d.GetOkExists("boot_disk.0.initialize_params.0.resource_policies"); !ok || tpgresource.IsEmptyValue(reflect.ValueOf(v)) {
 		diskDetails.ResourcePolicies = nil
 	}
 
@@ -3994,8 +3995,6 @@ func updateDisk(d *schema.ResourceData, config *transport_tpg.Config, userAgent,
 	}
 	return nil
 }
-
-
 func init() {
 	registry.Schema{
 		Name: "google_compute_instance",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_flatten_boot_disk_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_flatten_boot_disk_internal_test.go.tmpl
@@ -98,6 +98,51 @@ func TestComputeInstance_flattenBootDiskResourcePoliciesGuard(t *testing.T) {
 	}
 }
 
+func TestComputeInstance_flattenBootDiskResourcePoliciesGuard_handlesGetDiskError(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, ResourceComputeInstance().Schema, map[string]interface{}{
+		"name":         "test-instance",
+		"machine_type": "e2-medium",
+		"project":      "test-project",
+		"zone":         "us-central1-a",
+		"boot_disk": []interface{}{
+			map[string]interface{}{
+				"initialize_params": []interface{}{
+					map[string]interface{}{
+						"image":             "projects/debian-cloud/global/images/family/debian-11",
+						"resource_policies": []interface{}{},
+					},
+				},
+			},
+		},
+		"network_interface": []interface{}{
+			map[string]interface{}{
+				"network": "default",
+			},
+		},
+	})
+
+	config := testComputeInstanceFlattenBootDiskErrorConfig(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("flattenBootDisk panicked when disk lookup failed: %v", r)
+		}
+	}()
+
+	flattened := flattenBootDisk(d, &compute.AttachedDisk{
+		AutoDelete: true,
+		DeviceName: "test-disk",
+		Mode:       "READ_WRITE",
+		Source:     "projects/test-project/zones/us-central1-a/disks/test-disk",
+	}, config)
+
+	if got, want := flattened[0]["initialize_params"], d.Get("boot_disk.0.initialize_params"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected initialize_params fallback when disk lookup fails: got %#v, want %#v", got, want)
+	}
+}
+
 func testComputeInstanceFlattenBootDiskConfig(t *testing.T, disk *compute.Disk) *transport_tpg.Config {
 	t.Helper()
 
@@ -114,6 +159,29 @@ func testComputeInstanceFlattenBootDiskConfig(t *testing.T, disk *compute.Disk) 
 		if err := json.NewEncoder(w).Encode(disk); err != nil {
 			t.Fatalf("encoding disk response: %v", err)
 		}
+	}))
+
+	t.Cleanup(server.Close)
+
+	return &transport_tpg.Config{
+		Client:          server.Client(),
+		ComputeBasePath: server.URL + "/",
+		Context:         context.Background(),
+		Project:         "test-project",
+		UserAgent:       "test-agent",
+		Zone:            "us-central1-a",
+	}
+}
+
+func testComputeInstanceFlattenBootDiskErrorConfig(t *testing.T) *transport_tpg.Config {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %q", r.Method)
+		}
+
+		http.Error(w, "boom", http.StatusInternalServerError)
 	}))
 
 	t.Cleanup(server.Close)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_internal_test.go.tmpl
@@ -1,0 +1,129 @@
+package compute
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
+)
+
+func TestComputeInstance_flattenBootDiskResourcePoliciesGuard(t *testing.T) {
+	t.Parallel()
+
+	apiResourcePolicies := []string{"policy-a", "policy-b"}
+	diskSource := "projects/test-project/zones/us-central1-a/disks/test-disk"
+
+	cases := map[string]struct {
+		resourcePolicies []interface{}
+		wantPolicies     []string
+	}{
+		"empty list stays unset": {
+			resourcePolicies: []interface{}{},
+			wantPolicies:     nil,
+		},
+		"configured value is preserved": {
+			resourcePolicies: []interface{}{"policy-a"},
+			wantPolicies:     apiResourcePolicies,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, ResourceComputeInstance().Schema, map[string]interface{}{
+				"name":         "test-instance",
+				"machine_type": "e2-medium",
+				"project":      "test-project",
+				"zone":         "us-central1-a",
+				"boot_disk": []interface{}{
+					map[string]interface{}{
+						"initialize_params": []interface{}{
+							map[string]interface{}{
+								"image":             "projects/debian-cloud/global/images/family/debian-11",
+								"resource_policies": tc.resourcePolicies,
+							},
+						},
+					},
+				},
+				"network_interface": []interface{}{
+					map[string]interface{}{
+						"network": "default",
+					},
+				},
+			})
+
+			if len(tc.resourcePolicies) == 0 {
+				if got := d.Get("boot_disk.0.initialize_params.0.resource_policies.0"); got != "" {
+					t.Fatalf("expected empty string for resource_policies.0, got %#v", got)
+				}
+
+				if got := d.Get("boot_disk.0.initialize_params.0.resource_policies"); !reflect.DeepEqual(got, []interface{}{}) {
+					t.Fatalf("expected empty list for resource_policies, got %#v", got)
+				}
+			}
+
+			config := testComputeInstanceFlattenBootDiskConfig(t, &compute.Disk{
+				ResourcePolicies: apiResourcePolicies,
+				Type:             "projects/test-project/zones/us-central1-a/diskTypes/pd-balanced",
+			})
+
+			flattened := flattenBootDisk(d, &compute.AttachedDisk{
+				AutoDelete: true,
+				DeviceName: "test-disk",
+				Mode:       "READ_WRITE",
+				Source:     diskSource,
+			}, config)
+
+			initializeParams, ok := flattened[0]["initialize_params"].([]map[string]interface{})
+			if !ok {
+				t.Fatalf("expected initialize_params to be []map[string]interface{}, got %T", flattened[0]["initialize_params"])
+			}
+
+			gotPolicies := initializeParams[0]["resource_policies"]
+			if !reflect.DeepEqual(gotPolicies, tc.wantPolicies) {
+				t.Fatalf("unexpected flattened resource_policies: got %#v, want %#v", gotPolicies, tc.wantPolicies)
+			}
+		})
+	}
+}
+
+func testComputeInstanceFlattenBootDiskConfig(t *testing.T, disk *compute.Disk) *transport_tpg.Config {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method %q", r.Method)
+		}
+
+		if got, want := r.URL.Path, "/projects/test-project/zones/us-central1-a/disks/test-disk"; got != want {
+			t.Fatalf("unexpected path %q, want %q", got, want)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(disk); err != nil {
+			t.Fatalf("encoding disk response: %v", err)
+		}
+	}))
+
+	t.Cleanup(server.Close)
+
+	return &transport_tpg.Config{
+		Client:          server.Client(),
+		ComputeBasePath: server.URL + "/",
+		Context:         context.Background(),
+		Project:         "test-project",
+		UserAgent:       "test-agent",
+		Zone:            "us-central1-a",
+	}
+}


### PR DESCRIPTION
Context: https://github.com/pulumi/pulumi-gcp/issues/3666

This PR fixes the `google_compute_instance` boot disk `initialize_params.resource_policies` guard in `flattenBootDisk`.

Today that guard only checks for `nil`, but Terraform state can hold this field in an effectively unset shape where:

- `boot_disk.0.initialize_params.0.resource_policies.0 == ""`
- `boot_disk.0.initialize_params.0.resource_policies == []interface{}{}`

When that happens, the guard does not fire and API-populated boot disk resource policies are written back into instance state even though the inline field was not actually configured.

This matters because boot disk resource policies can also be attached out-of-band via `google_compute_disk_resource_policy_attachment`. In that case, refresh can return multiple policies on the boot disk, and those API values should not be flattened back into the inline `boot_disk.initialize_params.resource_policies` field.

This change updates the guard to use the provider's existing `GetOkExists` + `tpgresource.IsEmptyValue(...)` pattern so empty-but-present values are treated as unset.

Tests:
- added an internal regression test for `flattenBootDisk`
- verified the new test fails with the old guard
- verified the new test passes with this fix in both generated `google` and `google-beta` providers

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed `google_compute_instance` boot disk `initialize_params.resource_policies` state handling when the field is unset but empty
```