### PR TITLE
Adding IAM support for hubs in terraform

### DIFF
--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -38,11 +38,11 @@ async:
 custom_code:
 legacy_long_form_project: true
 iam_policy:
-  parent_resource_attribute: 'name'
+  parent_resource_attribute: 'hub'
   method_name_separator: ':'
   fetch_iam_policy_verb: 'GET'
   import_format:
-    - 'projects/{{project}}/locations/global/hubs/{{name}}'
+    - 'projects/{{project}}/locations/global/hubs/{{hub}}'
   allowed_iam_role: 'roles/networkconnectivity.hubViewer'
 examples:
   - name: 'network_connectivity_hub_basic'

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -42,7 +42,7 @@ iam_policy:
   method_name_separator: ':'
   fetch_iam_policy_verb: 'GET'
   import_format:
-    - 'projects/{{project}}/locations/global/hubs/{{hub}}'
+    - 'projects/{{project}}/locations/global/hubs/{{name}}'
   allowed_iam_role: 'roles/networkconnectivity.hubViewer'
 examples:
   - name: 'network_connectivity_hub_basic'

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -38,7 +38,7 @@ async:
 custom_code:
 legacy_long_form_project: true
 iam_policy:
-  parent_resource_attribute: 'name'
+  parent_resource_attribute: 'hub'
   method_name_separator: ':'
   fetch_iam_policy_verb: 'GET'
   import_format:

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -37,6 +37,13 @@ async:
     resource_inside_response: false
 custom_code:
 legacy_long_form_project: true
+iam_policy:
+  parent_resource_attribute: 'name'
+  method_name_separator: ':'
+  fetch_iam_policy_verb: 'GET'
+  import_format:
+    - 'projects/{{project}}/locations/global/hubs/{{hub}}'
+  allowed_iam_role: 'roles/networkconnectivity.hubViewer'
 examples:
   - name: 'network_connectivity_hub_basic'
     primary_resource_id: 'primary'

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -76,6 +76,8 @@ properties:
     immutable: true
     default_from_api: true
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+    custom_expand: 'templates/terraform/custom_expand/resource_from_self_link.go.tmpl'
   - name: 'createTime'
     type: String
     description: Output only. The time the hub was created.

--- a/mmv1/products/networkconnectivity/Hub.yaml
+++ b/mmv1/products/networkconnectivity/Hub.yaml
@@ -38,11 +38,12 @@ async:
 custom_code:
 legacy_long_form_project: true
 iam_policy:
-  parent_resource_attribute: 'hub'
+  parent_resource_attribute: 'name'
   method_name_separator: ':'
   fetch_iam_policy_verb: 'GET'
   import_format:
-    - 'projects/{{project}}/locations/global/hubs/{{hub}}'
+    - 'projects/{{project}}/locations/global/hubs/{{name}}'
+    - '{{name}}'
   allowed_iam_role: 'roles/networkconnectivity.hubViewer'
 examples:
   - name: 'network_connectivity_hub_basic'


### PR DESCRIPTION
Added IAM support for the network_connectivity_hub resource

Justification for configurational values:

Justification of Configuration Values
- method_name_separator: ':': The NCC API uses the standard colon separator for custom IAM methods, such as `.../hubs/{hub_id}:getIamPolicy` ([ Network Connectivity A...](https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest?content_ref=resource+projects+locations+global+hubs+getiampolicy)).
- fetch_iam_policy_verb: 'GET': The Network Connectivity API specifically defines getIamPolicy as a GET request in its service configuration ([ Network Connectivity A...](https://docs.cloud.google.com/network-connectivity/docs/reference/networkconnectivity/rest?content_ref=resource+projects+locations+global+hubs+getiampolicy)).
- import_format: This must match the parent resource's self_link 



**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
networkconnectivity: added support for IAM conditions to `google_network_connectivity_hub` resource
```
