### PR TITLE
Added tests for block cross region backup create and update.

### DIFF
--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -523,3 +523,176 @@ resource "google_netapp_backup" "test_backup" {
 }
 `, context)
 }
+func TestAccNetappBackup_NetappCrossRegionBackup(t *testing.T) {
+  context := map[string]interface{}{
+    "network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
+    "random_suffix": acctest.RandString(t, 10),
+  }
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckNetappBackupDestroyProducer(t),
+    ExternalProviders: map[string]resource.ExternalProvider{
+      "time": {},
+    },
+    Steps: []resource.TestStep{
+      {
+        Config: testAccNetappBackup_CrossRegionBackup(context),
+      },
+      {
+        ResourceName:            "google_netapp_backup.test_backup",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+      },
+      {
+        Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
+      },
+      {
+        ResourceName:            "google_netapp_backup.test_backup",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+      }
+    },
+  })
+}
+
+func testAccNetappBackup_CrossRegionBackup(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+resource "google_netapp_storage_pool" "default" {
+  name          = "tf-test-backup-pool%{random_suffix}"               
+  location      = "us-central1"
+  service_level = "FLEX"
+  type          = "UNIFIED"
+  capacity_gib  = "2048"
+  network       = data.google_compute_network.default.id
+  zone          = "us-central1-a"
+  replica_zone = "us-central1-b"
+}
+
+resource "time_sleep" "wait_3_minutes" {
+  depends_on      = [google_netapp_storage_pool.default]
+  create_duration = "3m"
+}
+
+resource "google_netapp_volume" "default" {
+  name            = "tf-test-backup-volume%{random_suffix}"
+  location        = google_netapp_storage_pool.default.location
+  capacity_gib    = "100"
+  share_name      = "tf-test-backup-volume%{random_suffix}"
+  storage_pool    = google_netapp_storage_pool.default.name
+  protocols       = ["ISCSI"]
+  deletion_policy = "FORCE"
+  backup_config {
+    backup_vault = google_netapp_backup_vault.default.id
+  }
+}
+
+resource "google_netapp_backup_vault" "default" {
+  name              = "tf-test-backup-vault%{random_suffix}"
+  location          = google_netapp_storage_pool.default.location
+  backup_vault_type = "CROSS_REGION"  
+  backup_region     = "us-east4"
+}
+
+resource "google_netapp_volume_snapshot" "default" {
+  depends_on  = [google_netapp_volume.default]
+  location    = google_netapp_volume.default.location
+  volume_name = google_netapp_volume.default.name
+  description = "This is a test description"
+  name        = "testvolumesnap%{random_suffix}"
+  labels = {
+    key   = "test"
+    value = "snapshot"
+  }
+}
+
+resource "google_netapp_backup" "test_backup" {
+  name            = "tf-test-test-backup%{random_suffix}"
+  description     = "This is a test cross region backup"
+  source_volume   = google_netapp_volume.default.id
+  location        = google_netapp_backup_vault.default.location
+  vault_name      = google_netapp_backup_vault.default.name
+  source_snapshot = google_netapp_volume_snapshot.default.id
+  labels = {
+    key   = "test"
+    value = "backup"
+  }
+}
+`, context)
+}
+
+func testAccNetappBackup_CrossRegionBackupUpdate(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+data "google_compute_network" "default" {
+  name = "%{network_name}"
+}
+
+resource "google_netapp_storage_pool" "default" {
+  name          = "tf-test-backup-pool%{random_suffix}"               
+  location      = "us-central1"
+  service_level = "FLEX"
+  type          = "UNIFIED"
+  capacity_gib  = "2048"
+  network       = data.google_compute_network.default.id
+  zone          = "us-central1-a"
+  replica_zone = "us-central1-b"
+}
+
+resource "time_sleep" "wait_3_minutes" {
+  depends_on      = [google_netapp_storage_pool.default]
+  create_duration = "3m"
+}
+
+resource "google_netapp_volume" "default" {
+  name            = "tf-test-backup-volume%{random_suffix}"
+  location        = google_netapp_storage_pool.default.location
+  capacity_gib    = "100"
+  share_name      = "tf-test-backup-volume%{random_suffix}"
+  storage_pool    = google_netapp_storage_pool.default.name
+  protocols       = ["ISCSI"]
+  deletion_policy = "FORCE"
+  backup_config {
+    backup_vault = google_netapp_backup_vault.default.id
+  }
+}
+
+resource "google_netapp_backup_vault" "default" {
+  name              = "tf-test-backup-vault%{random_suffix}"
+  location          = google_netapp_storage_pool.default.location
+  backup_vault_type = "CROSS_REGION"  
+  backup_region     = "us-east4"
+}
+
+resource "google_netapp_volume_snapshot" "default" {
+  depends_on  = [google_netapp_volume.default]
+  location    = google_netapp_volume.default.location
+  volume_name = google_netapp_volume.default.name
+  description = "This is a test description"
+  name        = "testvolumesnap%{random_suffix}"
+  labels = {
+    key   = "test"
+    value = "snapshot"
+  }
+}
+
+resource "google_netapp_backup" "test_backup" {
+  name            = "tf-test-test-backup%{random_suffix}"
+  description     = "This is a test cross region backup updated"
+  source_volume   = google_netapp_volume.default.id
+  location        = google_netapp_backup_vault.default.location
+  vault_name      = google_netapp_backup_vault.default.name
+  source_snapshot = google_netapp_volume_snapshot.default.id
+  labels = {
+    key   = "test_update"
+    value = "backup_update"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -547,7 +547,12 @@ func TestAccNetappBackup_NetappCrossRegionBackup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
 			},
 			{
-				Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
+        Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_netapp_backup.test_backup", plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
 				ResourceName:            "google_netapp_backup.test_backup",

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -554,7 +554,7 @@ func TestAccNetappBackup_NetappCrossRegionBackup(t *testing.T) {
         ImportState:             true,
         ImportStateVerify:       true,
         ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
-      }
+      },
     },
   })
 }

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -524,43 +524,43 @@ resource "google_netapp_backup" "test_backup" {
 `, context)
 }
 func TestAccNetappBackup_NetappCrossRegionBackup(t *testing.T) {
-  context := map[string]interface{}{
-    "network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
-    "random_suffix": acctest.RandString(t, 10),
-  }
+	context := map[string]interface{}{
+		"network_name":  acctest.BootstrapSharedServiceNetworkingConnection(t, "gcnv-network-config-3", acctest.ServiceNetworkWithParentService("netapp.servicenetworking.goog")),
+		"random_suffix": acctest.RandString(t, 10),
+	}
 
-  acctest.VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy:             testAccCheckNetappBackupDestroyProducer(t),
-    ExternalProviders: map[string]resource.ExternalProvider{
-      "time": {},
-    },
-    Steps: []resource.TestStep{
-      {
-        Config: testAccNetappBackup_CrossRegionBackup(context),
-      },
-      {
-        ResourceName:            "google_netapp_backup.test_backup",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
-      },
-      {
-        Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
-      },
-      {
-        ResourceName:            "google_netapp_backup.test_backup",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
-      },
-    },
-  })
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetappBackupDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetappBackup_CrossRegionBackup(context),
+			},
+			{
+				ResourceName:            "google_netapp_backup.test_backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+			},
+			{
+				Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
+			},
+			{
+				ResourceName:            "google_netapp_backup.test_backup",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
+			},
+		},
+	})
 }
 
 func testAccNetappBackup_CrossRegionBackup(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 data "google_compute_network" "default" {
   name = "%{network_name}"
 }
@@ -629,7 +629,7 @@ resource "google_netapp_backup" "test_backup" {
 }
 
 func testAccNetappBackup_CrossRegionBackupUpdate(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 data "google_compute_network" "default" {
   name = "%{network_name}"
 }

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNetappBackup_NetappBackupFull_update(t *testing.T) {

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccNetappBackup_NetappBackupFull_update(t *testing.T) {

--- a/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
+++ b/mmv1/third_party/terraform/services/netapp/resource_netapp_backup_test.go
@@ -547,7 +547,7 @@ func TestAccNetappBackup_NetappCrossRegionBackup(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels", "vault_name"},
 			},
 			{
-        Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
+				Config: testAccNetappBackup_CrossRegionBackupUpdate(context),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_netapp_backup.test_backup", plancheck.ResourceActionUpdate),


### PR DESCRIPTION
```release-note:note
note:This change introduces a new test case (testAccNetappBackup_NetappCrossRegionBackup) to verify cross region backup creation functionality for NetApp Unified Block Flex service level.
```
