### PR TITLE
Add resource_policies to google_compute_reservation

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -397,6 +397,13 @@ properties:
     description: |
       Reserved for future use.
     output: true
+  - name: 'resourcePolicies'
+    type: KeyValuePairs
+    description: |
+      Resource policies to attach to this reservation. Each map entry uses a
+      user-defined key; the value is the full or partial URL of the resource policy
+      (for example, a group placement policy). Used to associate placement policy
+      with the reservation.
   - name: 'resourceStatus'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -152,6 +152,9 @@ properties:
       When set to true, only VMs that target this reservation by name can
       consume this reservation. Otherwise, it can be consumed by VMs with
       affinity for any reservation. Defaults to false.
+
+      If you set `resource_policies` to attach a compact placement policy, the
+      API requires this field to be `true`.
     immutable: true
     # Not a hard API default, but this should help avoid a unset/true/false
     # trinary.
@@ -402,8 +405,21 @@ properties:
     description: |
       Resource policies to attach to this reservation. Each map entry uses a
       user-defined key; the value is the full or partial URL of the resource policy
-      (for example, a group placement policy). Used to associate placement policy
-      with the reservation.
+      (for example, a group placement policy for compact placement).
+
+      **Compact placement** is the only supported policy type for reservations.
+      You cannot use **spread** placement policies, **shared** reservations, or
+      reservations **tied to commitments**. A given compact placement policy can
+      only be attached to **one** reservation at a time. You cannot use a compact
+      policy whose **maximum distance** is `1` with a reservation. For
+      `group_placement_policy` on the resource policy, do not set `vm_count` for use
+      with a reservation; the API requires an incremental compact policy for
+      reservations and rejects vm_count-scoped group placement in that case.
+
+      Set `specific_reservation_required` to `true` when using this field for
+      compact placement. For details, see
+      [About reservations](https://cloud.google.com/compute/docs/instances/reservations-overview)
+      and [Restrictions for compact placement policies](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions_for_compact_placement_policies).
   - name: 'resourceStatus'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -303,6 +303,11 @@ properties:
           Number of VMs in this placement group. Google does not recommend that you use this field
           unless you use a compact policy and you want your policy to work only if it contains this
           exact number of VMs.
+
+          Do not set this when the policy is attached to a
+          `google_compute_reservation`: reservations only support incremental
+          compact placement, and the API errors if the group placement policy is
+          vm_count-scoped in that context.
       - name: availabilityDomainCount
         type: Integer
         description: |
@@ -321,6 +326,10 @@ properties:
         type: Integer
         description: |
           Specifies the number of max logical switches.
+
+          A value of `1` is not valid on a `google_compute_reservation` that
+          references this policy; other values follow the
+          [compact placement restrictions for reservations](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions_for_compact_placement_policies).
         min_version: beta
         conflicts:
           - group_placement_policy.0.gpu_topology

--- a/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/reservation.go.tmpl
@@ -151,4 +151,16 @@
 		}
 	}
 
+	// Include other PATCH fields from the expanded update body (this encoder only
+	// handles share settings and specific reservation count).
+	for k, v := range obj {
+		if _, exists := newObj[k]; exists {
+			continue
+		}
+		if k == "specificReservation" && newObj["specificSkuCount"] != nil {
+			continue
+		}
+		newObj[k] = v
+	}
+
 	return newObj, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
@@ -136,8 +136,8 @@ func testAccComputeReservation_resourcePolicies(reservationName, policyName stri
 resource "google_compute_resource_policy" "placement" {
   name   = "%s"
   region = "us-central1"
+  // Compact policy for reservation must not set vm_count (API: incremental only).
   group_placement_policy {
-    vm_count    = 2
     collocation = "COLLOCATED"
   }
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
@@ -10,6 +10,38 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
+func TestAccComputeReservation_resourcePolicies(t *testing.T) {
+	t.Parallel()
+
+	rand := acctest.RandString(t, 10)
+	reservationName := fmt.Sprintf("tf-test-res-%s", rand)
+	policyName := fmt.Sprintf("tf-test-pol-%s", rand)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeReservationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeReservation_resourcePolicies(reservationName, policyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"google_compute_reservation.reservation",
+						"resource_policies.policy1",
+						regexp.MustCompile(`resourcePolicies/`),
+					),
+				),
+			},
+			{
+				ResourceName:            "google_compute_reservation.reservation",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"resource_policies"},
+			},
+		},
+	})
+}
+
 func TestAccComputeReservation_update(t *testing.T) {
 	t.Parallel()
 
@@ -97,6 +129,38 @@ func TestAccComputeReservation_deleteAfterDuration(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccComputeReservation_resourcePolicies(reservationName, policyName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "placement" {
+  name   = "%s"
+  region = "us-central1"
+  group_placement_policy {
+    vm_count    = 2
+    collocation = "COLLOCATED"
+  }
+}
+
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  resource_policies = {
+    policy1 = google_compute_resource_policy.placement.self_link
+  }
+
+  specific_reservation {
+    count = 2
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+
+  depends_on = [google_compute_resource_policy.placement]
+}
+`, policyName, reservationName)
 }
 
 func testAccComputeReservation_basic(reservationName, count string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
@@ -150,6 +150,8 @@ resource "google_compute_reservation" "reservation" {
     policy1 = google_compute_resource_policy.placement.self_link
   }
 
+  specific_reservation_required = true
+
   specific_reservation {
     count = 2
     instance_properties {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_reservation_test.go
@@ -25,6 +25,9 @@ func TestAccComputeReservation_resourcePolicies(t *testing.T) {
 			{
 				Config: testAccComputeReservation_resourcePolicies(reservationName, policyName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_compute_reservation.reservation", "specific_reservation_required", "true",
+					),
 					resource.TestMatchResourceAttr(
 						"google_compute_reservation.reservation",
 						"resource_policies.policy1",
@@ -136,7 +139,8 @@ func testAccComputeReservation_resourcePolicies(reservationName, policyName stri
 resource "google_compute_resource_policy" "placement" {
   name   = "%s"
   region = "us-central1"
-  // Compact policy for reservation must not set vm_count (API: incremental only).
+  // Incremental compact placement only: do not set vm_count (see resource_policies
+  // on google_compute_reservation in the provider docs).
   group_placement_policy {
     collocation = "COLLOCATED"
   }


### PR DESCRIPTION
## Summary

Adds support for the Compute Engine `resourcePolicies` field on reservations as the Terraform argument `resource_policies` (a map of user-defined keys to resource policy URLs), for use cases such as group placement policies.

## Implementation

- **Reservation.yaml**: New `resourcePolicies` property (`KeyValuePairs`).
- **reservation.go.tmpl**: After building the custom update payload for shared-reservation settings and resize (`specificSkuCount`), merge any remaining keys from the expanded update body so other PATCH fields (including `resourcePolicies`) are not dropped.

## References

- [REST Resource: reservations](https://cloud.google.com/compute/docs/reference/rest/v1/reservations)
- [reservations.update](https://cloud.google.com/compute/docs/reference/rest/v1/reservations/update)

```release-note:enhancement
compute: added `resource_policies` field to `google_compute_reservation` resource
```