### PR TITLE
Promoting  `enable_emergent_maintenance` to  GA and setting to optional as this is not required 

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -367,9 +367,7 @@ properties:
     type: Boolean
     description: |
       Indicates if this group of VMs have emergent maintenance enabled.
-    immutable: true
     ignore_read: true
-    min_version: 'beta'
   - name: 'reservationBlockCount'
     type: Integer
     description: |


### PR DESCRIPTION
This is supported in the update and does not require a recreation in gcloud

https://docs.cloud.google.com/compute/docs/reference/rest/v1/reservations/update




```release-note:enhancement
compute: added `enable_emergent_maintenance` to `resource_compute_reservation` (GA)
```