### PR TITLE
[Dataform] Add builtin_assertion_name_prefix to google_dataform_repository_release_config

### DIFF
--- a/mmv1/products/dataform/RepositoryReleaseConfig.yaml
+++ b/mmv1/products/dataform/RepositoryReleaseConfig.yaml
@@ -36,6 +36,15 @@ examples:
       git_repository_name: my/repository
       release_name: my_release
       secret_name: my_secret
+  - name: dataform_repository_release_config_with_builtin_assertion
+    primary_resource_id: release
+    min_version: beta
+    vars:
+      data: secret-data
+      dataform_repository_name: dataform_repository
+      git_repository_name: my/repository
+      release_name: my_release
+      secret_name: my_secret
 parameters:
   - name: region
     type: String
@@ -112,6 +121,9 @@ properties:
         type: String
         description: Optional. The prefix that should be prepended to all table names.
         min_version: beta
+      - name: builtinAssertionNamePrefix
+        type: String
+        description: The prefix to prepend to built-in assertion names.
   - name: recentScheduledReleaseRecords
     type: Array
     description: Records of the 10 most recent scheduled release attempts, ordered in in descending order of releaseTime. Updated whenever automatic creation of a compilation result is triggered by cronSchedule.

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config_with_builtin_assertion.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config_with_builtin_assertion.tf.tmpl
@@ -1,0 +1,65 @@
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name     = "{{index $.Vars "git_repository_name"}}"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider  = google-beta
+  secret_id = "{{index $.Vars "secret_name"}}"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret   = google_secret_manager_secret.secret.id
+
+  secret_data = "{{index $.Vars "data"}}"
+}
+
+resource "google_dataform_repository" "repository" {
+  provider = google-beta
+  name     = "{{index $.Vars "dataform_repository_name"}}"
+  region   = "us-central1"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+}
+
+resource "google_dataform_repository_release_config" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  project    = google_dataform_repository.repository.project
+  region     = google_dataform_repository.repository.region
+  repository = google_dataform_repository.repository.name
+
+  name          = "{{index $.Vars "release_name"}}"
+  git_commitish = "main"
+  cron_schedule = "0 7 * * *"
+  time_zone     = "America/New_York"
+
+  code_compilation_config {
+    default_database = "gcp-example-project"
+    default_schema   = "example-dataset"
+    default_location = "us-central1"
+    assertion_schema = "example-assertion-dataset"
+    database_suffix  = ""
+    schema_suffix    = ""
+    table_prefix     = ""
+    builtin_assertion_name_prefix = "assertions_"
+    vars = {
+      var1 = "value"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the `code_compilation_config.builtin_assertion_name_prefix` field to the `google_dataform_repository_release_config` resource. This field allows users to specify a prefix to prepend to built-in assertion names.

It also includes the necessary example and acceptance test updates to ensure the field provisions and destroys correctly.

```release-note:enhancement
dataform: added `code_compilation_config.builtin_assertion_name_prefix` field to `google_dataform_repository_release_config` resource
```