### PR TITLE
[SecurityScanner] Add ignore_http_status_errors to google_security_scanner_scan_config

### DIFF
--- a/mmv1/products/securityscanner/ScanConfig.yaml
+++ b/mmv1/products/securityscanner/ScanConfig.yaml
@@ -36,6 +36,12 @@ examples:
     vars:
       address_name: scan-basic-static-ip
       scan_config_name: terraform-scan-config
+  - name: scan_config_ignore_http_status_errors
+    primary_resource_id: scan-config
+    min_version: beta
+    vars:
+      address_name: scan-ignore-http-ip
+      scan_config_name: terraform-scan-config
 properties:
   - name: name
     type: String
@@ -189,3 +195,6 @@ properties:
     enum_values:
       - ENABLED
       - DISABLED
+  - name: ignoreHttpStatusErrors
+    type: Boolean
+    description: Whether to keep scanning even if most requests return HTTP error codes.

--- a/mmv1/templates/terraform/examples/scan_config_ignore_http_status_errors.tf.tmpl
+++ b/mmv1/templates/terraform/examples/scan_config_ignore_http_status_errors.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_address" "scanner_static_ip" {
+  provider = google-beta
+  name     = "{{index $.Vars "address_name"}}"
+}
+
+resource "google_security_scanner_scan_config" "{{$.PrimaryResourceId}}" {
+  provider                  = google-beta
+  display_name              = "{{index $.Vars "scan_config_name"}}"
+  starting_urls             = ["http://${google_compute_address.scanner_static_ip.address}"]
+  target_platforms          = ["COMPUTE"]
+  ignore_http_status_errors = true
+}


### PR DESCRIPTION
Added `ignore_http_status_errors` field to the `google_security_scanner_scan_config` resource.

```release-note:enhancement
securityscanner: added `ignore_http_status_errors` field to `google_security_scanner_scan_config` resource (beta)
```