### PR TITLE
[ServiceUsage] Add admin_override_ancestor to google_service_usage_consumer_quota_override

### DIFF
--- a/mmv1/products/serviceusage/ConsumerQuotaOverride.yaml
+++ b/mmv1/products/serviceusage/ConsumerQuotaOverride.yaml
@@ -81,6 +81,13 @@ examples:
       project_id: quota
     test_env_vars:
       org_id: ORG_ID
+  - name: consumer_quota_override_admin_override
+    primary_resource_id: override
+    min_version: beta
+    vars:
+      project_id: quota
+    test_env_vars:
+      org_id: ORG_ID
 parameters:
   - name: name
     type: String
@@ -138,3 +145,6 @@ properties:
       If this map is nonempty, then this override applies only to specific values for dimensions defined in the limit unit.
     immutable: true
     min_version: beta
+  - name: adminOverrideAncestor
+    type: String
+    description: 'The resource name of the ancestor that requested the override. For example: `organizations/12345` or `folders/67890`. Used by admin overrides only.'

--- a/mmv1/templates/terraform/examples/consumer_quota_override_admin_override.tf.tmpl
+++ b/mmv1/templates/terraform/examples/consumer_quota_override_admin_override.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_project" "my_project" {
+  provider        = google-beta
+  name            = "tf-test-project"
+  project_id      = "{{index $.Vars "project_id"}}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_service_usage_consumer_quota_override" "{{$.PrimaryResourceId}}" {
+  provider                = google-beta
+  project                 = google_project.my_project.project_id
+  service                 = "servicemanagement.googleapis.com"
+  metric                  = urlencode("servicemanagement.googleapis.com/default_requests")
+  limit                   = urlencode("/min/project")
+  override_value          = "95"
+  force                   = true
+  admin_override_ancestor = "organizations/{{index $.TestEnvVars "org_id"}}"
+}


### PR DESCRIPTION
This PR adds the `admin_override_ancestor` field to the `google_service_usage_consumer_quota_override` resource.

It also includes a new acceptance test `consumer_quota_override_admin_override` to verify the creation and destruction of the resource with the new field.

```release-note:enhancement
serviceusage: added `admin_override_ancestor` field to `google_service_usage_consumer_quota_override` resource
```