### PR TITLE
apigee: fix TestAccApigeeOrganization_apigeeOrganizationCloudBasicDataResidencyTestExample

### DIFF
--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -47,6 +47,7 @@ sweeper:
 custom_code:
   encoder: 'templates/terraform/encoders/apigee_organization.go.tmpl'
   custom_import: 'templates/terraform/custom_import/apigee_organization.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/apigee_organization.go.tmpl'
 examples:
   - name: 'apigee_organization_cloud_basic'
     exclude_test: true

--- a/mmv1/templates/terraform/custom_check_destroy/apigee_organization.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/apigee_organization.go.tmpl
@@ -1,0 +1,40 @@
+config := acctest.GoogleProviderConfig(t)
+
+url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}ApigeeBasePath{{"}}"}}organizations/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+// Apigee Organization deletion is asynchronous. Poll until the org is fully
+// deleted (404) or confirmed to be in a terminal DELETING state.
+deleted := false
+deadline := time.Now().Add(10 * time.Minute)
+for time.Now().Before(deadline) {
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: config.UserAgent,
+	})
+	if err != nil {
+		// 404 (or any error) means the org is gone.
+		deleted = true
+		break
+	}
+	// If the org is in DELETING state, deletion is in progress — acceptable.
+	if state, ok := res["state"].(string); ok && state == "DELETING" {
+		deleted = true
+		break
+	}
+	time.Sleep(30 * time.Second)
+}
+if !deleted {
+	return fmt.Errorf("ApigeeOrganization still exists at %s after waiting", url)
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/hashicorp/terraform-provider-google/issues/22528

The `TestAccApigeeOrganization_apigeeOrganizationCloudBasicDataResidencyTestExample` test was flaky because Apigee Organization deletion is asynchronous. The `CheckDestroy` function ran immediately after `terraform destroy` completed, but the org could still be in `DELETING` state, causing false "resource still exists" failures.

This PR applies the same fix as the sibling PR for b/463028638: override `CheckDestroy` with a custom polling implementation that treats both HTTP 404 and `state == "DELETING"` as successful deletion, polling up to 10 minutes.

**Changes:**
- Added `test_check_destroy` to `mmv1/products/apigee/Organization.yaml`
- Created `mmv1/templates/terraform/custom_check_destroy/apigee_organization.go.tmpl` with async-aware polling logic

## Test evidence

```
--- PASS: TestAccApigeeOrganization_apigeeOrganizationCloudBasicDataResidencyTestExample (916.14s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	916.856s
```

```release-note:bug
apigee: fixed flaky `google_apigee_organization` CheckDestroy caused by async organization deletion in data residency test
```