### PR TITLE
apigee: fix TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
@@ -115,7 +115,7 @@ resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
   target                = google_compute_service_attachment.psc_ilb_service_attachment.id
   load_balancing_scheme = "" # need to override EXTERNAL default when target is a service attachment
   network               = "default"
-  ip_address            = google_compute_address.psc_ilb_consumer_address.address
+  ip_address            = google_compute_address.psc_ilb_consumer_address.id
 
   project = google_project.project.project_id
 }
@@ -179,7 +179,7 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
 
   network       = google_compute_network.psc_ilb_network.id
   purpose       =  "PRIVATE_SERVICE_CONNECT"
-  ip_cidr_range = "10.0.1.0/24"
+  ip_cidr_range = "10.0.2.0/24"
 
   project = google_project.project.project_id
 }


### PR DESCRIPTION
## Summary

Fix two issues in the endpoint attachment acceptance test that caused 100% test failure:

1. **IP CIDR range conflict**: `psc_ilb_nat` subnet was configured with `10.0.1.0/24`, the same CIDR as `psc_ilb_producer_subnetwork` (both in `psc_ilb_network`). Fixed by changing `psc_ilb_nat` to use `10.0.2.0/24`.

2. **Invalid `ip_address` format**: The PSC consumer forwarding rule used `.address` (raw IP string e.g. `10.168.0.2`) instead of `.id` (full resource URL). The GCP API now requires a full resource URL for `ip_address` when the target is a service attachment.

## Test evidence

```
--- PASS: TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample (1201.06s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/apigee   1201.962s
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/26276

```release-note:none
apigee: fixed `google_apigee_endpoint_attachment` test failure caused by conflicting subnet CIDR ranges and invalid `ip_address` format in the PSC consumer forwarding rule
```