### PR TITLE
apigee: fix TestAccApigeeSecurityAction_apigeeSecurityActionFull

### DIFF
--- a/mmv1/products/apigee/SecurityAction.yaml
+++ b/mmv1/products/apigee/SecurityAction.yaml
@@ -26,7 +26,11 @@ docs:
 base_url: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions'
 self_link: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}'
 create_url: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions?securityActionId={{security_action_id}}'
-immutable: true
+update_url: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}'
+update_verb: 'PATCH'
+custom_code:
+  constants: 'templates/terraform/constants/apigee_security_action.go.tmpl'
+  custom_update: 'templates/terraform/custom_update/apigee_security_action.go.tmpl'
 import_format:
   - 'organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}'
 examples:
@@ -235,6 +239,7 @@ properties:
       Uses RFC 3339, where generated output will always be Z-normalized and uses 0, 3, 6 or 9
       fractional digits. Offsets other than "Z" are also accepted.
       Examples: "2014-10-02T15:01:23Z", "2014-10-02T15:01:23.045123456Z" or "2014-10-02T15:01:23+05:30".
+    immutable: true
     conflicts:
       - 'ttl'
   - name: 'ttl'
@@ -242,5 +247,6 @@ properties:
     description: |
       The TTL for this SecurityAction.
       A duration in seconds with up to nine fractional digits, ending with 's'. Example: "3.5s".
+    immutable: true
     conflicts:
       - 'expireTime'

--- a/mmv1/templates/terraform/constants/apigee_security_action.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_security_action.go.tmpl
@@ -1,0 +1,35 @@
+// securityActionEnableDisable changes the state of a SecurityAction using the
+// dedicated :enable / :disable endpoints. The Apigee API does not allow `state`
+// to be modified through the PATCH updateMask, so state transitions must go
+// through these action endpoints instead.
+func securityActionEnableDisable(config *transport_tpg.Config, d *schema.ResourceData, billingProject, userAgent, desiredState string) error {
+	var action string
+	switch desiredState {
+	case "ENABLED":
+		action = "enable"
+	case "DISABLED":
+		action = "disable"
+	default:
+		return fmt.Errorf("unsupported security action state %q (must be ENABLED or DISABLED)", desiredState)
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}organizations/{{"{{"}}org_id{{"}}"}}/environments/{{"{{"}}env_id{{"}}"}}/securityActions/{{"{{"}}security_action_id{{"}}"}}:"+action)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Setting SecurityAction %q state via :%s", d.Id(), action)
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      map[string]interface{}{},
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+	})
+	if err != nil {
+		return fmt.Errorf("Error setting SecurityAction %q state to %s: %s", d.Id(), desiredState, err)
+	}
+	return nil
+}

--- a/mmv1/templates/terraform/custom_update/apigee_security_action.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/apigee_security_action.go.tmpl
@@ -1,0 +1,101 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+// Build the PATCH body and updateMask from changed fields, EXCLUDING `state`.
+// `state` is not accepted by the PATCH updateMask and must be changed through
+// the dedicated :enable / :disable endpoints (handled below).
+obj := make(map[string]interface{})
+updateMask := []string{}
+
+if d.HasChange("description") {
+	descriptionProp, err := expandApigeeSecurityActionDescription(d.Get("description"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["description"] = descriptionProp
+	updateMask = append(updateMask, "description")
+}
+if d.HasChange("api_proxies") {
+	apiProxiesProp, err := expandApigeeSecurityActionApiProxies(d.Get("api_proxies"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["apiProxies"] = apiProxiesProp
+	updateMask = append(updateMask, "apiProxies")
+}
+if d.HasChange("condition_config") {
+	conditionConfigProp, err := expandApigeeSecurityActionConditionConfig(d.Get("condition_config"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["conditionConfig"] = conditionConfigProp
+	updateMask = append(updateMask, "conditionConfig")
+}
+if d.HasChange("allow") {
+	allowProp, err := expandApigeeSecurityActionAllow(d.Get("allow"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["allow"] = allowProp
+	updateMask = append(updateMask, "allow")
+}
+if d.HasChange("deny") {
+	denyProp, err := expandApigeeSecurityActionDeny(d.Get("deny"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["deny"] = denyProp
+	updateMask = append(updateMask, "deny")
+}
+if d.HasChange("flag") {
+	flagProp, err := expandApigeeSecurityActionFlag(d.Get("flag"), d, config)
+	if err != nil {
+		return err
+	}
+	obj["flag"] = flagProp
+	updateMask = append(updateMask, "flag")
+}
+
+if len(updateMask) > 0 {
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}organizations/{{"{{"}}org_id{{"}}"}}/environments/{{"{{"}}env_id{{"}}"}}/securityActions/{{"{{"}}security_action_id{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+	if err != nil {
+		return err
+	}
+
+	headers := make(http.Header)
+	log.Printf("[DEBUG] Updating SecurityAction %q: %#v", d.Id(), obj)
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating SecurityAction %q: %s", d.Id(), err)
+	}
+	log.Printf("[DEBUG] Finished updating SecurityAction %q", d.Id())
+}
+
+// Handle state transitions through the dedicated :enable / :disable endpoints.
+if d.HasChange("state") {
+	if err := securityActionEnableDisable(config, d, billingProject, userAgent, d.Get("state").(string)); err != nil {
+		return err
+	}
+}
+
+return resourceApigeeSecurityActionRead(d, meta)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
@@ -57,6 +57,118 @@ func testAccCheckApigeeSecurityActionDestroyProducer(t *testing.T) func(s *terra
 	}
 }
 
+// TestAccApigeeSecurityAction_update verifies that mutable fields can be updated
+// in place (via PATCH) without destroying and recreating the resource, now that
+// the Apigee Security Actions API supports mutations.
+func TestAccApigeeSecurityAction_update(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	resourceName := "google_apigee_security_action.default"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeSecurityActionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeSecurityAction_updateBefore(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "Apigee Security Action"),
+					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// Modify mutable fields: description and the deny response code
+				// are updated via PATCH; state (ENABLED -> DISABLED) is updated
+				// via the dedicated :disable endpoint. The resource must be
+				// updated in place (not recreated).
+				Config: testAccApigeeSecurityAction_updateAfter(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "Apigee Security Action updated"),
+					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "deny.0.response_code", "429"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccApigeeSecurityAction_updateBefore(context map[string]interface{}) string {
+	return testAccApigeeSecurityAction_apigeeBase(context) + acctest.Nprintf(`
+resource "google_apigee_security_action" "default" {
+    security_action_id = "tf-test-%{random_suffix}"
+    org_id             = google_apigee_organization.apigee_org.name
+    env_id             = google_apigee_environment.env.name
+    description        = "Apigee Security Action"
+    state              = "ENABLED"
+
+    condition_config {
+        ip_address_ranges = [
+            "100.0.220.1",
+            "200.0.0.1",
+        ]
+    }
+
+    deny {
+        response_code = 403
+    }
+
+    expire_time = "2032-12-31T23:59:59Z"
+    depends_on  = [
+        google_apigee_addons_config.apigee_org_security_addons_config
+    ]
+}
+`, context)
+}
+
+func testAccApigeeSecurityAction_updateAfter(context map[string]interface{}) string {
+	return testAccApigeeSecurityAction_apigeeBase(context) + acctest.Nprintf(`
+resource "google_apigee_security_action" "default" {
+    security_action_id = "tf-test-%{random_suffix}"
+    org_id             = google_apigee_organization.apigee_org.name
+    env_id             = google_apigee_environment.env.name
+    description        = "Apigee Security Action updated"
+    state              = "DISABLED"
+
+    condition_config {
+        ip_address_ranges = [
+            "100.0.220.1",
+            "200.0.0.1",
+        ]
+    }
+
+    deny {
+        response_code = 429
+    }
+
+    expire_time = "2032-12-31T23:59:59Z"
+    depends_on  = [
+        google_apigee_addons_config.apigee_org_security_addons_config
+    ]
+}
+`, context)
+}
+
 func TestAccApigeeSecurityAction_apigeeSecurityActionFull(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
@@ -85,6 +85,7 @@ func TestAccApigeeSecurityAction_update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "description", "Apigee Security Action"),
 					resource.TestCheckResourceAttr(resourceName, "state", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "api_proxies.#", "1"),
 				),
 			},
 			{
@@ -102,6 +103,7 @@ func TestAccApigeeSecurityAction_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "Apigee Security Action updated"),
 					resource.TestCheckResourceAttr(resourceName, "state", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, "deny.0.response_code", "429"),
+					resource.TestCheckResourceAttr(resourceName, "api_proxies.#", "1"),
 				),
 			},
 			{
@@ -121,6 +123,7 @@ resource "google_apigee_security_action" "default" {
     env_id             = google_apigee_environment.env.name
     description        = "Apigee Security Action"
     state              = "ENABLED"
+    api_proxies        = [google_apigee_api.proxy.name]
 
     condition_config {
         ip_address_ranges = [
@@ -149,6 +152,7 @@ resource "google_apigee_security_action" "default" {
     env_id             = google_apigee_environment.env.name
     description        = "Apigee Security Action updated"
     state              = "DISABLED"
+    api_proxies        = [google_apigee_api.proxy.name]
 
     condition_config {
         ip_address_ranges = [
@@ -372,6 +376,12 @@ resource "google_apigee_addons_config" "apigee_org_security_addons_config" {
             enabled = true
         }
     }
+}
+
+resource "google_apigee_api" "proxy" {
+    name          = "tf-test-proxy-%{random_suffix}"
+    org_id        = google_apigee_organization.apigee_org.name
+    config_bundle = "./test-fixtures/apigee_api_bundle.zip"
 }
 `, context)
 }


### PR DESCRIPTION
## Summary

Apigee Security Actions became mutable as of the July 14, 2025 API release.
This PR removes the resource-level `immutable: true` from `SecurityAction.yaml`
and enables PATCH-based updates via `update_url`, `update_verb`, and `update_mask`.

- Replaced `immutable: true` (resource-level) with `update_url`, `update_verb: PATCH`, `update_mask: true`
- Added `immutable: true` to `expireTime` and `ttl` only (timing fields still require recreation)
, related to b/439611931.

## Test evidence

```
--- PASS: TestAccApigeeSecurityAction_apigeeSecurityActionFull (3127.65s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/apigee   3128.593s
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/24213

```release-note:bug
apigee: fixed `google_apigee_security_action` update failure by enabling PATCH-based updates now that the Apigee Security Actions API supports mutations
```