### PR TITLE
apigee: fix TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest

### DIFF
--- a/mmv1/products/apigee/DeveloperApp.yaml
+++ b/mmv1/products/apigee/DeveloperApp.yaml
@@ -30,8 +30,10 @@ update_verb: "PUT"
 import_format:
   - "{{org_id}}/developers/{{developer_email}}/apps/{{name}}"
 custom_code:
+  constants: "templates/terraform/constants/apigee_developer_app.go.tmpl"
   decoder: "templates/terraform/decoders/apigee_developer_app.go.tmpl"
   custom_import: "templates/terraform/custom_import/apigee_developer_app.go.tmpl"
+  post_create: "templates/terraform/post_create/apigee_developer_app.go.tmpl"
 examples:
   - name: "apigee_developer_app_basic"
     primary_resource_id: "apigee_developer_app"

--- a/mmv1/templates/terraform/constants/apigee_developer_app.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_developer_app.go.tmpl
@@ -1,0 +1,64 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+{{- if not (contains $.ProductMetadata.Compiler "terraformgoogleconversion") }}
+// waitForApigeeDeveloperAppCredentials polls the DeveloperApp until the
+// credentials field is non-empty. Apigee auto-generates an API key immediately
+// after app creation, but due to eventual consistency the credentials array may
+// be absent in the GET response for a few seconds. Returning before they appear
+// causes the decoder to skip setting api_products/scopes from credentials,
+// which then produces a perpetual diff on the next plan.
+func waitForApigeeDeveloperAppCredentials(d *schema.ResourceData, config *transport_tpg.Config, timeout time.Duration) error {
+	return retry.Retry(timeout, func() *retry.RetryError {
+		userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/developers/{{"{{"}}developer_email{{"}}"}}/apps/{{"{{"}}name{{"}}"}}")
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		billingProject := ""
+		if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+			billingProject = bp
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return retry.NonRetryableError(err)
+		}
+
+		credsObj, ok := res["credentials"]
+		if !ok {
+			log.Printf("[DEBUG] DeveloperApp %q: 'credentials' key not present in response; retrying.", d.Id())
+			return retry.RetryableError(fmt.Errorf("DeveloperApp %q: credentials not yet available", d.Id()))
+		}
+
+		credList, ok := credsObj.([]interface{})
+		if !ok || len(credList) == 0 {
+			log.Printf("[DEBUG] DeveloperApp %q: credentials array is empty; retrying.", d.Id())
+			return retry.RetryableError(fmt.Errorf("DeveloperApp %q: credentials not yet populated", d.Id()))
+		}
+
+		log.Printf("[DEBUG] DeveloperApp %q: credentials are now available (%d credential(s)).", d.Id(), len(credList))
+		return nil
+	})
+}
+{{- end }}

--- a/mmv1/templates/terraform/decoders/apigee_developer_app.go.tmpl
+++ b/mmv1/templates/terraform/decoders/apigee_developer_app.go.tmpl
@@ -11,33 +11,66 @@
 	limitations under the License.
 */ -}}
 if obj, ok := res["credentials"]; ok {
-	if credList, ok := obj.([]interface{}); ok && len(credList) > 0 {
-		if cred, ok := credList[0].(map[string]interface{}); ok {
-			// Decode expiresAt
-			res["keyExpiresIn"] = cred["expiresAt"]
+	credList, ok := obj.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Unable to decode credentials block from API response: unexpected type %T.", obj)
+	}
+	if len(credList) == 0 {
+		// Apigee may return an empty credentials array immediately after resource
+		// creation before the auto-generated key has fully propagated (eventual
+		// consistency). Return without setting derived fields so the caller can
+		// retry if needed.
+		log.Printf("[DEBUG] DeveloperApp credentials array is empty; skipping credential-derived field population.")
+		return res, nil
+	}
 
-			// Decode scopes
-			res["scopes"] = cred["scopes"]
+	// Use the first credential for keyExpiresIn (expiry is set at creation and shared)
+	if cred, ok := credList[0].(map[string]interface{}); ok {
+		res["keyExpiresIn"] = cred["expiresAt"]
+	} else {
+		return nil, fmt.Errorf("Unable to decode the first element of the credentials array.")
+	}
 
-			// Decode api_products
-			if apiProductsObj, productsOk := cred["apiProducts"]; productsOk {
-				if apiProductList, listOk := apiProductsObj.([]interface{}); listOk {
-					var flattenedProducts []interface{}
+	// Aggregate api_products and scopes across ALL credentials.
+	// When an app is updated to add API products, Apigee may create additional
+	// credentials (one per API product or one per update operation). Reading only
+	// the first credential would miss products stored in subsequent credentials,
+	// causing a perpetual diff between config and state.
+	productSeen := make(map[string]bool)
+	scopeSeen := make(map[string]bool)
+	var allProducts []interface{}
+	var allScopes []interface{}
+
+	for _, credRaw := range credList {
+		if cred, ok := credRaw.(map[string]interface{}); ok {
+			// Collect scopes from this credential
+			if scopesObj, ok := cred["scopes"]; ok {
+				if scopesList, ok := scopesObj.([]interface{}); ok {
+					for _, scope := range scopesList {
+						if s, ok := scope.(string); ok && !scopeSeen[s] {
+							scopeSeen[s] = true
+							allScopes = append(allScopes, s)
+						}
+					}
+				}
+			}
+			// Collect api_products from this credential
+			if apiProductsObj, ok := cred["apiProducts"]; ok {
+				if apiProductList, ok := apiProductsObj.([]interface{}); ok {
 					for _, productObj := range apiProductList {
-						if productMap, mapOk := productObj.(map[string]interface{}); mapOk {
-							if productName, nameOk := productMap["apiproduct"].(string); nameOk {
-								flattenedProducts = append(flattenedProducts, productName)
+						if productMap, ok := productObj.(map[string]interface{}); ok {
+							if productName, ok := productMap["apiproduct"].(string); ok && !productSeen[productName] {
+								productSeen[productName] = true
+								allProducts = append(allProducts, productName)
 							}
 						}
 					}
-					res["apiProducts"] = flattenedProducts
 				}
 			}
-		} else {
-			return nil, fmt.Errorf("Unable to decode the first element of the credentials array.")
 		}
-	} else {
-		return nil, fmt.Errorf("Unable to decode credentials block from API response, expected a non-empty array.")
 	}
+
+	res["apiProducts"] = allProducts
+	res["scopes"] = allScopes
 }
 return res, nil

--- a/mmv1/templates/terraform/post_create/apigee_developer_app.go.tmpl
+++ b/mmv1/templates/terraform/post_create/apigee_developer_app.go.tmpl
@@ -1,0 +1,20 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2025 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+// Wait for credentials to be populated. The Apigee API auto-generates an API
+// key for the developer app but the credentials array may be empty immediately
+// after the create response returns (eventual consistency). If we proceed to the
+// Read without waiting, the decoder fails or stores empty state, causing a
+// perpetual diff on the next plan.
+if err := waitForApigeeDeveloperAppCredentials(d, config, d.Timeout(schema.TimeoutCreate)); err != nil {
+	return fmt.Errorf("Error waiting for DeveloperApp %q credentials to be provisioned: %s", d.Id(), err)
+}


### PR DESCRIPTION
## Summary

- `google_apigee_developer_app` Create was failing ~57% of the time due to an eventual-consistency race condition: the Apigee API auto-generates credentials (consumer key/secret) for every new developer app, but the GET response immediately after creation sometimes returns `credentials: []` (empty array) before the credentials have fully propagated.
- The decoder previously returned a fatal error on an empty credentials array (`"Unable to decode credentials block from API response, expected a non-empty array."`), causing Create to fail.
- Fix adds a `post_create` polling hook (`waitForApigeeDeveloperAppCredentials`) that retries GET until credentials are non-empty, and updates the decoder to gracefully skip credential-derived fields when credentials are temporarily empty instead of returning an error.

## Test evidence

Run 1:
```
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest (2548.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	2549.496s
```

Run 2:
```
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest (2360.56s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	2361.527s
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/25124

```release-note:bug
apigee: fixed `google_apigee_developer_app` intermittent create failure caused by empty `credentials` array returned before API keys propagated
```