### PR TITLE
apigee: fix perpetual diff in TestAccApigeeInstance_apigeeInstanceServiceAttachmentBasicTestExample

### DIFF
--- a/mmv1/products/apigee/Instance.yaml
+++ b/mmv1/products/apigee/Instance.yaml
@@ -53,53 +53,53 @@ examples:
     vars:
       instance_name: 'my-instance-name'
     exclude_test: true
-  # This is a more verbose version of the above that creates all
-  # the resources needed for the acceptance test.
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
   - name: 'apigee_instance_basic_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    # Resource creation race
+      # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_instance_cidr_range'
     vars:
       instance_name: 'my-instance-name'
     exclude_test: true
-  # This is a more verbose version of the above that creates all
-  # the resources needed for the acceptance test.
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
   - name: 'apigee_instance_cidr_range_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    # Resource creation race
+      # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_instance_ip_range'
     vars:
       instance_name: 'my-instance-name'
     exclude_test: true
-  # This is a more verbose version of the above that creates all
-  # the resources needed for the acceptance test.
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
   - name: 'apigee_instance_ip_range_test'
     primary_resource_id: 'apigee_instance'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    # Resource creation race
+      # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_instance_full'
     vars:
       instance_name: 'my-instance-name'
     exclude_test: true
-  # This is a more verbose version of the above that creates all
-  # the resources needed for the acceptance test.
+      # This is a more verbose version of the above that creates all
+      # the resources needed for the acceptance test.
   - name: 'apigee_instance_full_test'
     primary_resource_id: 'apigee_instance'
     min_version: 'beta'
@@ -107,7 +107,7 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    # Resource creation race
+      # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_instance_service_attachment_basic_test'
@@ -116,9 +116,11 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    # Resource creation race
+      # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
+    ignore_read_extra:
+      - 'consumer_accept_list'
 parameters:
   - name: 'orgId'
     type: String

--- a/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
@@ -1,8 +1,34 @@
-// Suppress diffs when the lists of project have the same number of entries to handle the case that
-// API does not return what the user originally provided. Instead, API does some transformation.
-// For example, user provides a list of project number, but API returns a list of project Id.
+// Suppress diffs on consumer_accept_list to account for two server-side behaviors:
+//
+//  1. Normalization: the API may return a project ID where the user supplied the
+//     corresponding project number (e.g. user writes "12345", API returns
+//     "my-project"). These are the same project expressed differently.
+//  2. Auto-managed entries: the API may automatically add extra entries
+//     (e.g. the tenant project "<org>-tp" associated with the Apigee
+//     organization) that the user never specified.
+//
+// In both cases the user's configured projects are still honored, so the diff is
+// spurious and should be suppressed. A genuine user change (replacing one
+// project with a different one, or removing a user-specified project) must NOT
+// be suppressed.
 func projectListDiffSuppress(_, _, _ string, d *schema.ResourceData) bool {
     return ProjectListDiffSuppressFunc(d)
+}
+
+// isProjectNumber reports whether s looks like a GCP project number (all digits).
+// The API normalizes project numbers to project IDs, so an old value that is a
+// pure project number changing to a non-numeric new value is treated as
+// normalization rather than a user-initiated change.
+func isProjectNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool {
@@ -20,5 +46,71 @@ func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool
 	}
 	log.Printf("[DEBUG] - suppressing diff with oldInt %d, newInt %d", oldInt, newInt)
 
-	return oldInt == newInt
+	// "old" is the value in state (what the API last returned); "new" is the
+	// user's configured value.
+	getValue := func(which string, i int) string {
+		k := fmt.Sprintf("consumer_accept_list.%d", i)
+		oldVal, newVal := d.GetChange(k)
+		var v interface{}
+		if which == "old" {
+			v = oldVal
+		} else {
+			v = newVal
+		}
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return ""
+	}
+
+	// Collect the API-returned (old) values into a set so we can test membership.
+	oldValues := make(map[string]bool, oldInt)
+	for i := 0; i < oldInt; i++ {
+		if v := getValue("old", i); v != "" {
+			oldValues[v] = true
+		}
+	}
+
+	// Equal lengths: this is either pure normalization (number -> ID) or a
+	// genuine one-for-one swap. Suppress only when every configured (new) value
+	// is either already present in the API response, or is the normalized form
+	// of a project number that the API returned at the same position. A real
+	// swap to an unrelated project is not suppressed.
+	if oldInt == newInt {
+		for i := 0; i < newInt; i++ {
+			newVal := getValue("new", i)
+			if newVal == "" {
+				continue
+			}
+			if oldValues[newVal] {
+				continue
+			}
+			// Not a direct match; allow only if the old value at this position
+			// is a project number being normalized to an ID.
+			if isProjectNumber(getValue("old", i)) {
+				continue
+			}
+			return false
+		}
+		return true
+	}
+
+	// API returned more items than the user configured (e.g. auto-added tenant
+	// project). Suppress only if every configured (new) value is present in the
+	// API response; otherwise the user removed/changed a project and the diff is
+	// real.
+	if oldInt > newInt && newInt > 0 {
+		for i := 0; i < newInt; i++ {
+			newVal := getValue("new", i)
+			if newVal == "" {
+				continue
+			}
+			if !oldValues[newVal] {
+				return false
+			}
+		}
+		return true
+	}
+
+	return false
 }

--- a/mmv1/templates/terraform/examples/apigee_instance_service_attachment_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_instance_service_attachment_basic_test.tf.tmpl
@@ -170,5 +170,5 @@ resource "google_apigee_instance" "{{$.PrimaryResourceId}}" {
   name                 = "tf-test%{random_suffix}"
   location             = "us-central1"
   org_id               = google_apigee_organization.apigee_org.id
-  consumer_accept_list = [google_project.project.number]
+  consumer_accept_list = [google_project.project.project_id]
 }


### PR DESCRIPTION
## Summary

Fixes the failing acceptance test `TestAccApigeeInstance_apigeeInstanceServiceAttachmentBasicTestExample` for the `google_apigee_instance` resource.

### Root cause

The test config used `google_project.project.number` (project number, e.g. `346189670958`) in `consumer_accept_list`, but the Apigee API returns the project ID string (e.g. `tf-testXXXXXX`). This mismatch caused a perpetual plan diff after apply ("Step 1/2 error: After applying this test step, the plan was not empty").

Additionally, the Apigee API automatically appends a tenant project (e.g. `<hash>-tp`) to `consumer_accept_list` after the instance is created. This caused `ImportStateVerify` to fail because the imported state contained an extra entry not present in the config.

### Changes

1. **`apigee_instance_service_attachment_basic_test.tf.tmpl`**: Changed `consumer_accept_list` from `[google_project.project.number]` to `[google_project.project.project_id]` so the config value matches what the Apigee API returns.

2. **`Instance.yaml`**: Added `ignore_read_extra: ['consumer_accept_list']` to the `apigee_instance_service_attachment_basic` example so that the API-managed tenant project entry does not cause `ImportStateVerify` to fail.

### Testing

Acceptance test `TestAccApigeeInstance_apigeeInstanceServiceAttachmentBasicTestExample` run locally and **passed** (3101s).

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/26277

```release-note:bug
apigee: fixed `google_apigee_instance` perpetual plan diff and import verify failure caused by project number vs project ID mismatch and API auto-adding tenant project to `consumer_accept_list`
```