### PR TITLE
fix(apigee): fix resource name conflict in environment patch update test

### DIFF
--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -7,11 +7,17 @@ resource "google_project" "project" {
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on      = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -38,12 +44,17 @@ resource "google_project_service" "kms" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "time_sleep" "wait_for_services" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.kms]
+}
+
 resource "google_compute_network" "apigee_network" {
   provider = google-beta
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -72,7 +83,7 @@ resource "google_kms_key_ring" "apigee_keyring" {
   name       = "apigee-keyring"
   location   = "us-central1"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key" "apigee_key" {
@@ -87,7 +98,7 @@ resource "google_project_service_identity" "apigee_sa" {
 
   project    = google_project.project.project_id
   service    = google_project_service.apigee.service
-  depends_on = [google_project_service.apigee, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -97,6 +108,11 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+}
+
+resource "time_sleep" "wait_for_iam" {
+  create_duration = "120s"
+  depends_on      = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -110,8 +126,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+    time_sleep.wait_for_iam,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -5,12 +5,6 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
-  deletion_policy = "DELETE"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-  depends_on = [google_project.project]
 }
 
 resource "google_project_service" "apigee" {
@@ -18,36 +12,30 @@ resource "google_project_service" "apigee" {
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
-  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "compute.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
   depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "servicenetworking.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
   depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "cloudkms.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "cloudkms.googleapis.com"
   depends_on = [google_project_service.servicenetworking]
-}
-
-resource "time_sleep" "wait_300_seconds" {
-  create_duration = "300s"
-  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -55,7 +43,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_300_seconds]
+  depends_on = [google_project_service.compute, google_project_service.kms]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -90,15 +78,16 @@ resource "google_kms_key_ring" "apigee_keyring" {
 resource "google_kms_crypto_key" "apigee_key" {
   provider = google-beta
 
-  name            = "apigee-key"
-  key_ring        = google_kms_key_ring.apigee_keyring.id
+  name     = "apigee-key"
+  key_ring = google_kms_key_ring.apigee_keyring.id
 }
 
 resource "google_project_service_identity" "apigee_sa" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = google_project_service.apigee.service
+  project    = google_project.project.project_id
+  service    = google_project_service.apigee.service
+  depends_on = [google_project_service.apigee, google_project_service.kms]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -107,7 +96,7 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  member = google_project_service_identity.apigee_sa.member
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -5,6 +5,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -13,21 +13,16 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
-	randomSuffix := acctest.RandString(t, 10)
-
-  context := map[string]interface{}{
-    "billing_account": envvar.GetTestBillingAccountFromEnv(t),
-    "org_id":          envvar.GetTestOrgFromEnv(t),
-    "random_suffix":   randomSuffix,
-  }
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckApigeeEnvironmentDestroyProducer(t),
+		CheckDestroy:             testAccCheckApigeeEnvironmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExample(context),
@@ -62,17 +57,11 @@ resource "google_project" "project" {
   billing_account = "%{billing_account}"
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-  depends_on = [google_project.project]
-}
-
 resource "google_project_service" "apigee" {
   provider = google-beta
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
-  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -80,7 +69,6 @@ resource "google_project_service" "compute" {
 
   project = google_project.project.project_id
   service = "compute.googleapis.com"
-  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
@@ -88,7 +76,6 @@ resource "google_project_service" "servicenetworking" {
 
   project = google_project.project.project_id
   service = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
@@ -96,12 +83,6 @@ resource "google_project_service" "kms" {
 
   project = google_project.project.project_id
   service = "cloudkms.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
-
-resource "time_sleep" "wait_300_seconds" {
-  create_duration = "300s"
-  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -109,7 +90,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_300_seconds]
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_compute_global_address" "apigee_range" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -52,7 +52,7 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 }
 
 func testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(context map[string]interface{}) string {
-        return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_project" "project" {
   provider = google-beta
 
@@ -63,11 +63,17 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -75,6 +81,7 @@ resource "google_project_service" "compute" {
 
   project = google_project.project.project_id
   service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
@@ -82,6 +89,7 @@ resource "google_project_service" "servicenetworking" {
 
   project = google_project.project.project_id
   service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
@@ -89,11 +97,12 @@ resource "google_project_service" "kms" {
 
   project = google_project.project.project_id
   service = "cloudkms.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
 }
 
 resource "time_sleep" "wait_300_seconds" {
   create_duration = "300s"
-  depends_on = [google_project_service.compute]
+  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -107,7 +116,7 @@ resource "google_compute_network" "apigee_network" {
 resource "google_compute_global_address" "apigee_range" {
   provider = google-beta
 
-  name          = "tf-test-apigee-range%{random_suffix}"
+  name          = "apigee-range"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -175,11 +184,11 @@ resource "google_apigee_organization" "apigee_org" {
 resource "google_apigee_environment" "apigee_environment" {
   provider = google-beta
 
-  org_id       = google_apigee_organization.apigee_org.id
-  name         = "tf-test%{random_suffix}"
-  description  = "Apigee Environment"
-  display_name = "tf-test%{random_suffix}"
-  type         = "INTERMEDIATE"
+  org_id            = google_apigee_organization.apigee_org.id
+  name              = "tf-test%{random_suffix}"
+  description       = "Apigee Environment"
+  display_name      = "tf-test%{random_suffix}"
+  type              = "INTERMEDIATE"
   forward_proxy_uri = "http://test:456"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -22,7 +22,10 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckApigeeEnvironmentDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeEnvironmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExample(context),
@@ -57,11 +60,17 @@ resource "google_project" "project" {
   billing_account = "%{billing_account}"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on      = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -88,12 +97,17 @@ resource "google_project_service" "kms" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "time_sleep" "wait_for_services" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.kms]
+}
+
 resource "google_compute_network" "apigee_network" {
   provider = google-beta
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -122,7 +136,7 @@ resource "google_kms_key_ring" "apigee_keyring" {
   name       = "apigee-keyring"
   location   = "us-central1"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key" "apigee_key" {
@@ -137,7 +151,7 @@ resource "google_project_service_identity" "apigee_sa" {
 
   project    = google_project.project.project_id
   service    = google_project_service.apigee.service
-  depends_on = [google_project_service.apigee, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -147,6 +161,11 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+}
+
+resource "time_sleep" "wait_for_iam" {
+  create_duration = "120s"
+  depends_on      = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -160,8 +179,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+    time_sleep.wait_for_iam,
   ]
 }
 

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -67,22 +67,25 @@ resource "google_project_service" "apigee" {
 resource "google_project_service" "compute" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "compute.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "servicenetworking.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "cloudkms.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "cloudkms.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -90,7 +93,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
+  depends_on = [google_project_service.compute, google_project_service.kms]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -125,15 +128,16 @@ resource "google_kms_key_ring" "apigee_keyring" {
 resource "google_kms_crypto_key" "apigee_key" {
   provider = google-beta
 
-  name            = "apigee-key"
-  key_ring        = google_kms_key_ring.apigee_keyring.id
+  name     = "apigee-key"
+  key_ring = google_kms_key_ring.apigee_keyring.id
 }
 
 resource "google_project_service_identity" "apigee_sa" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = google_project_service.apigee.service
+  project    = google_project.project.project_id
+  service    = google_project_service.apigee.service
+  depends_on = [google_project_service.apigee, google_project_service.kms]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -60,7 +60,6 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
-  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -161,7 +161,7 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  member = google_project_service_identity.apigee_sa.member
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -58,6 +58,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {


### PR DESCRIPTION
## Summary

Fixes `TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate` (b/397799471).

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/21510

### Root Cause

The test was failing due to a **Service Account propagation race**: `google_project_service_identity` returns an SA email immediately from the API, but the SA does not actually exist in GCP yet. Using `depends_on` chains alone is insufficient — the KMS IAM binding for `apigee_sa_keyuser` would silently succeed, but the Apigee organization creation would then fail with "Service account not found".

Additionally, the create config in the generated test had duplicate resource blocks from a prior edit session that caused Terraform to error with "Duplicate resource" errors.

### Fix

- Added three `time_sleep` resources to both the create and update configs to ensure identical structure across test steps:
  - `time_sleep.wait_60_seconds` (60s after project creation, before enabling APIs)
  - `time_sleep.wait_for_services` (300s after all services enabled, before KMS/network/SA)
  - `time_sleep.wait_for_iam` (120s after KMS IAM binding, before org creation)
- Added `ExternalProviders: map[string]resource.ExternalProvider{"time": {}}` to both test cases
- Set `external_providers: ["time"]` in `Environment.yaml` for the example
- Removed duplicate resource declarations from the generated test file that were left from a stale sync

### Test Evidence

```
--- PASS: TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate (1401.48s)
PASS
ok      github.com/hashicorp/terraform-provider-google-beta/google-beta/services/apigee  1402.035s
```

(Run 9, completed successfully)

```release-note:bug
apigee: fixed `google_apigee_environment` update test failure due to service account propagation race by adding time_sleep waits before KMS IAM binding and organization creation
```