### PR TITLE
apigee: fix org_id doubled prefix in google_apigee_sharedflow

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -20,6 +21,14 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
+
+// apigeeSharedflowNormalizeOrgId strips the "organizations/" prefix from org_id
+// if present. This allows users to pass either google_apigee_organization.id
+// (which returns "organizations/<project-id>") or a bare project ID.
+func apigeeSharedflowNormalizeOrgId(v interface{}) string {
+	s := v.(string)
+	return strings.TrimPrefix(s, "organizations/")
+}
 
 func ResourceApigeeSharedFlow() *schema.Resource {
 	return &schema.Resource{
@@ -62,6 +71,13 @@ func ResourceApigeeSharedFlow() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization name associated with the Apigee instance.`,
+				// Normalize org_id by stripping the "organizations/" prefix. Users may
+				// pass google_apigee_organization.id which returns "organizations/<project-id>",
+				// which would otherwise be doubled in the URL.
+				StateFunc: apigeeSharedflowNormalizeOrgId,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return apigeeSharedflowNormalizeOrgId(old) == apigeeSharedflowNormalizeOrgId(new)
+				},
 			},
 			"latest_revision_id": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Description

Fixes a bug where using `google_apigee_organization.id` as `org_id` in `google_apigee_sharedflow` caused a doubled `organizations/` prefix in the API URL, resulting in 404 errors.

`google_apigee_organization.id` returns `"organizations/<project-id>"`. The resource URL template is `organizations/{{org_id}}/sharedflows`, so when the full value is substituted it becomes `organizations/organizations/<project-id>/sharedflows`.

**Fix:** Added a `StateFunc` and `DiffSuppressFunc` to the `org_id` field that strip the `organizations/` prefix if present, so both bare project IDs and fully-qualified organization IDs work correctly.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/25876

## Tests

`TestAccApigeeSharedFlow_apigeeSharedflowTestExample` passed locally (1138s):

```
--- PASS: TestAccApigeeSharedFlow_apigeeSharedflowTestExample (1138.23s)
PASS
```

```release-note:bug
apigee: fixed `google_apigee_sharedflow` `org_id` accepting `organizations/` prefix to prevent doubled prefix in API URL
```