### PR TITLE
apigee: fix org_id doubled prefix in google_apigee_sharedflow_deployment

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -3,6 +3,7 @@ package apigee
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -39,6 +40,16 @@ func ResourceApigeeSharedFlowDeployment() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization associated with the Apigee instance`,
+				// Normalize org_id by stripping the "organizations/" prefix. Users may
+				// pass google_apigee_organization.id which returns "organizations/<project-id>",
+				// which would otherwise be doubled in the URL or cause a diff after import
+				// (since the import regex strips the prefix from the captured group).
+				StateFunc: func(v interface{}) string {
+					return strings.TrimPrefix(v.(string), "organizations/")
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.TrimPrefix(old, "organizations/") == strings.TrimPrefix(new, "organizations/")
+				},
 			},
 			"revision": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
## Description

Fixes a bug where importing `google_apigee_sharedflow_deployment` would trigger an unwanted destroy+recreate cycle when `org_id` uses a `google_apigee_organization.id` reference.

**Root cause:** `google_apigee_organization.id` returns `"organizations/<project-id>"`. The import regex captures only `<project-id>` into `org_id`. After import, the state has `org_id = "project-id"` but the config has `org_id = "organizations/project-id"`. This diff triggers ForceNew → destroy → undeploy → 400 error if dependent API proxies are attached:

```
Error: googleapi: Error 400: generic::failed_precondition: undeployment validations failed
Shared flow cannot be removed. It is a dependency of deployment ...
```

**Fix:** Added a `StateFunc` and `DiffSuppressFunc` to the `org_id` field that strip the `organizations/` prefix if present, so both bare project IDs and fully-qualified organization IDs normalize to the same value and no spurious diff is produced.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/25852

## Tests

`TestAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample` passed locally (1323s), including `ImportStateVerify` steps:

```
--- PASS: TestAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample (1323.60s)
PASS
```

```release-note:bug
apigee: fixed `google_apigee_sharedflow_deployment` `org_id` to prevent ForceNew destroy on import when using `organizations/` prefix
```