### PR TITLE
apigee: remove immutable from google_apigee_security_action to allow in-place updates

### DIFF
--- a/mmv1/products/apigee/SecurityAction.yaml
+++ b/mmv1/products/apigee/SecurityAction.yaml
@@ -26,7 +26,8 @@ docs:
 base_url: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions'
 self_link: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}'
 create_url: 'organizations/{{org_id}}/environments/{{env_id}}/securityActions?securityActionId={{security_action_id}}'
-immutable: true
+update_verb: 'PATCH'
+update_mask: true
 import_format:
   - 'organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}'
 examples:


### PR DESCRIPTION
## Summary

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23966

The `google_apigee_security_action` resource was marked `immutable: true` at the resource level in the MMv1 YAML, which caused every field change to destroy and recreate the resource even though the Apigee API supports PATCH updates.

This PR removes the resource-level `immutable: true` and replaces it with `update_verb: 'PATCH'` and `update_mask: true`, enabling in-place updates for mutable fields (`state`, `description`, `condition_config`, `allow`, `deny`, `flag`, `api_proxies`). The URL parameter fields (`org_id`, `env_id`, `security_action_id`) retain their individual `immutable: true` annotations.

## Test evidence

`TestAccApigeeSecurityAction_apigeeSecurityActionFull` passed locally (3388s):
```
--- PASS: TestAccApigeeSecurityAction_apigeeSecurityActionFull (3387.86s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	3388.720s
```

```release-note:bug
apigee: fixed `google_apigee_security_action` to support in-place updates instead of always destroying and recreating the resource
```