### PR TITLE
apigee: fix import format docs for google_apigee_addons_config (org not name)

### DIFF
--- a/mmv1/products/apigee/AddonsConfig.yaml
+++ b/mmv1/products/apigee/AddonsConfig.yaml
@@ -27,6 +27,9 @@ update_url: 'organizations/{{org}}:setAddons'
 update_verb: 'POST'
 delete_url: 'organizations/{{org}}:setAddons'
 delete_verb: 'POST'
+import_format:
+  - 'organizations/{{org}}'
+  - '{{org}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -41,8 +44,6 @@ async:
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_addons.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/apigee_addons_override.go.tmpl'
-  custom_identity:
-    - 'org'
 examples:
   - name: 'apigee_addons_basic'
     exclude_test: true


### PR DESCRIPTION
## Summary

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/14607

The generated documentation for `google_apigee_addons_config` showed `{{name}}` as the import identifier field, but the actual field is named `{{org}}`. This caused the import instructions in the docs to be incorrect.

**Root cause:** `AddonsConfig.yaml` had no `import_format` section. Without it, the code generator fell back to a default that used `{{name}}`, which is not a field on this resource. The correct field is `{{org}}`.

**Fix:** Added `import_format` to `AddonsConfig.yaml` explicitly specifying `organizations/{{org}}` and `{{org}}`.

## Test evidence

`TestAccApigeeAddonsConfig_apigeeAddonsTestExample` passed locally (1377s):
```
--- PASS: TestAccApigeeAddonsConfig_apigeeAddonsTestExample (1377.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/apigee	1378.010s
```

```release-note:bug
apigee: fixed `google_apigee_addons_config` import documentation to use correct field name `org` instead of `name`
```