### PR TITLE
apigee: add analytics_config to google_apigee_addons_config

### DIFF
--- a/mmv1/products/apigee/AddonsConfig.yaml
+++ b/mmv1/products/apigee/AddonsConfig.yaml
@@ -120,3 +120,17 @@ properties:
               Time at which the Connectors Platform add-on expires in milliseconds since epoch.
               If unspecified, the add-on will never expire.
             output: true
+      - name: 'analyticsConfig'
+        type: NestedObject
+        description: Configuration for the Analytics add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Analytics add-on is enabled.
+          - name: 'expiresAt'
+            type: String
+            description:
+              Time at which the Analytics add-on expires in milliseconds since epoch.
+              If unspecified, the add-on will never expire.
+            output: true


### PR DESCRIPTION
## Description

Adds the `analyticsConfig` nested object to the `AddonsConfig` resource YAML, exposing the Analytics add-on toggle (`enabled` + `expires_at`) in the `google_apigee_addons_config` resource.

## Fixes

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17667

## Test Evidence

```
--- PASS: TestAccApigeeAddonsConfig_apigeeAddonsTestExample (1346.02s)
PASS
ok  github.com/hashicorp/terraform-provider-google/google/services/apigee  1346.872s
```

```release-note:bug
apigee: added `analytics_config` block to `google_apigee_addons_config` resource
```