### PR TITLE
Add google_apigee_data_collector resource

### DIFF
--- a/mmv1/products/apigee/DataCollector.yaml
+++ b/mmv1/products/apigee/DataCollector.yaml
@@ -1,0 +1,105 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'DataCollector'
+description: |
+  A `DataCollector` collects and stores data from the runtime for use in
+  Analytics custom reports or API monetization. Data collectors are scoped
+  to an Apigee organization.
+references:
+  guides:
+    'Creating a data collector': 'https://cloud.google.com/apigee/docs/api-platform/analytics/custom-reports'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.datacollectors'
+docs:
+base_url: '{{org_id}}/datacollectors'
+self_link: '{{org_id}}/datacollectors/{{data_collector_id}}'
+create_url: '{{org_id}}/datacollectors?dataCollectorId={{data_collector_id}}'
+update_url: '{{org_id}}/datacollectors/{{data_collector_id}}'
+update_verb: 'PATCH'
+update_mask: true
+delete_url: '{{org_id}}/datacollectors/{{data_collector_id}}'
+import_format:
+  - '{{org_id}}/datacollectors/{{data_collector_id}}'
+  - '{{org_id}}/{{data_collector_id}}'
+timeouts:
+  insert_minutes: 1
+  update_minutes: 1
+  delete_minutes: 1
+custom_code:
+  custom_import: 'templates/terraform/custom_import/apigee_data_collector.go.tmpl'
+exclude_sweeper: true
+examples:
+  - name: 'apigee_data_collector_basic'
+    vars:
+      data_collector_id: 'dc_my_data_collector'
+    exclude_test: true
+  - name: 'apigee_data_collector_basic_test'
+    primary_resource_id: 'apigee_data_collector'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
+parameters:
+  - name: 'orgId'
+    type: String
+    description: |
+      The Apigee Organization associated with the Apigee data collector,
+      in the format `organizations/{{org_name}}`.
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'dataCollectorId'
+    type: String
+    description: |
+      The ID for the data collector. Must begin with `dc_`.
+    url_param_only: true
+    required: true
+    immutable: true
+    validation:
+      regex: '^dc_[a-zA-Z0-9_]+$'
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The resource name of the data collector, in the format
+      `organizations/{{org_name}}/datacollectors/{{data_collector_id}}`.
+    output: true
+  - name: 'description'
+    type: String
+    description: |
+      A description of the data collector.
+  - name: 'type'
+    type: Enum
+    description: |
+      The type of data this data collector will collect.
+    required: true
+    immutable: true
+    enum_values:
+      - 'BOOLEAN'
+      - 'DATETIME'
+      - 'FLOAT'
+      - 'INTEGER'
+      - 'STRING'
+  - name: 'createdAt'
+    type: String
+    description: |
+      The time at which the data collector was created in milliseconds since the epoch.
+    output: true
+  - name: 'lastModifiedAt'
+    type: String
+    description: |
+      The time at which the data collector was last modified in milliseconds since the epoch.
+    output: true

--- a/mmv1/products/apigee/DataCollector.yaml
+++ b/mmv1/products/apigee/DataCollector.yaml
@@ -50,7 +50,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    skip_vcr: true
     external_providers: ["time"]
 parameters:
   - name: 'orgId'

--- a/mmv1/products/apigee/DataCollector.yaml
+++ b/mmv1/products/apigee/DataCollector.yaml
@@ -38,10 +38,11 @@ timeouts:
   delete_minutes: 1
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_data_collector.go.tmpl'
-exclude_sweeper: true
 examples:
   - name: 'apigee_data_collector_basic'
     vars:
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
       data_collector_id: 'dc_my_data_collector'
     exclude_test: true
   - name: 'apigee_data_collector_basic_test'

--- a/mmv1/templates/terraform/custom_import/apigee_data_collector.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/apigee_data_collector.go.tmpl
@@ -1,0 +1,42 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{"(?P<data_collector_id>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("data_collector_id").(string), "/")
+if len(nameParts) == 4 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/datacollectors/{{"{{"}}data_collector_id{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("data_collector_id", nameParts[3]); err != nil {
+		return nil, fmt.Errorf("Error setting data_collector_id: %s", err)
+	}
+} else if len(nameParts) == 3 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}data_collector_id{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("data_collector_id", nameParts[2]); err != nil {
+		return nil, fmt.Errorf("Error setting data_collector_id: %s", err)
+	}
+} else {
+	return nil, fmt.Errorf(
+		"Saw %s when the name is expected to have shape %s or %s",
+		d.Get("data_collector_id"),
+		"organizations/{{"{{"}}org_name{{"}}"}}/datacollectors/{{"{{"}}data_collector_id{{"}}"}}",
+		"organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}data_collector_id{{"}}"}}")
+}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}org_id{{"}}"}}/datacollectors/{{"{{"}}data_collector_id{{"}}"}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/apigee_data_collector_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_data_collector_basic.tf.tmpl
@@ -1,0 +1,33 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_apigee_data_collector" "apigee_data_collector" {
+  org_id            = google_apigee_organization.apigee_org.id
+  data_collector_id = "{{index $.Vars "data_collector_id"}}"
+  description       = "A data collector for custom analytics"
+  type              = "INTEGER"
+}

--- a/mmv1/templates/terraform/examples/apigee_data_collector_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_data_collector_basic.tf.tmpl
@@ -1,11 +1,11 @@
 data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
-  name = "apigee-network"
+  name = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/apigee_data_collector_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_data_collector_basic_test.tf.tmpl
@@ -1,0 +1,74 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_data_collector" "{{$.PrimaryResourceId}}" {
+  org_id            = google_apigee_organization.apigee_org.id
+  data_collector_id = "dc_tf_test%{random_suffix}"
+  description       = "A test data collector"
+  type              = "INTEGER"
+}


### PR DESCRIPTION
Adds the `google_apigee_data_collector` resource to the Google provider, enabling Terraform management of Apigee DataCollectors for custom analytics and API monetization.

This is a rewrite of #11655, which was opened under the old Ruby generator format. As noted by @rileykarson in that PR, the generator has since moved to Go with generic YAML types. This PR follows the current conventions.

## Resource Details

- **API**: `apigee.googleapis.com/v1/organizations/{org}/datacollectors`
- **Operations**: Create, Read, Update (PATCH with updateMask), Delete, Import
- **Fields**:
  - `org_id` (required, immutable) - Apigee organization
  - `data_collector_id` (required, immutable) - Must begin with `dc_`, validated via regex
  - `type` (required, immutable) - Enum: INTEGER, FLOAT, STRING, BOOLEAN, DATETIME
  - `description` (optional, mutable) - Only updatable field
  - `name`, `created_at`, `last_modified_at` (computed, output-only)

## Testing

Built the provider locally and tested all CRUD operations against a real Apigee eval organization:

| Operation | Result |
|-----------|--------|
| Create | 2 data collectors (INTEGER, STRING types) created successfully |
| Read | No drift on re-plan |
| Update | Description updated via PATCH |
| Import | Full path format (`organizations/{org}/datacollectors/{id}`) works |
| Delete | Clean destruction with correct dependency ordering |

## Files

- `mmv1/products/apigee/DataCollector.yaml` - Resource definition
- `mmv1/templates/terraform/custom_import/apigee_data_collector.go.tmpl` - Import logic for org-scoped resources
- `mmv1/templates/terraform/examples/apigee_data_collector_basic.tf.tmpl` - Docs example
- `mmv1/templates/terraform/examples/apigee_data_collector_basic_test.tf.tmpl` - Acceptance test example

Modeled on existing Apigee resources (`AppGroup`, `Envgroup`) for consistency.

```release-note:new-resource
`google_apigee_data_collector`
```