### PR TITLE
Add google_apigee_custom_report resource

### DIFF
--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -1,0 +1,197 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'CustomReport'
+description: |
+  A custom report definition for Apigee Analytics. Custom reports allow you
+  to drill into API metrics and dimensions to understand API performance
+  and usage patterns. Reports are scoped to an Apigee organization.
+references:
+  guides:
+    'Creating a custom report': 'https://cloud.google.com/apigee/docs/api-platform/analytics/create-custom-reports'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.reports'
+docs:
+base_url: '{{org_id}}/reports'
+self_link: '{{org_id}}/reports/{{name}}'
+update_url: '{{org_id}}/reports/{{name}}'
+update_verb: 'PUT'
+update_mask: false
+delete_url: '{{org_id}}/reports/{{name}}'
+import_format:
+  - '{{org_id}}/reports/{{name}}'
+  - '{{org_id}}/{{name}}'
+timeouts:
+  insert_minutes: 1
+  update_minutes: 1
+  delete_minutes: 1
+custom_code:
+  custom_import: 'templates/terraform/custom_import/apigee_custom_report.go.tmpl'
+exclude_sweeper: true
+examples:
+  - name: 'apigee_custom_report_basic'
+    vars:
+      display_name: 'my_custom_report'
+    exclude_test: true
+  - name: 'apigee_custom_report_basic_test'
+    primary_resource_id: 'apigee_custom_report'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
+parameters:
+  - name: 'orgId'
+    type: String
+    description: |
+      The Apigee Organization associated with the Apigee custom report,
+      in the format `organizations/{{org_name}}`.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The internal resource name of the custom report, a UUID assigned
+      by the server on creation. Used as the identifier in the API URL path.
+    output: true
+  - name: 'displayName'
+    type: String
+    description: |
+      The display name for the custom report.
+    required: true
+  - name: 'metrics'
+    type: Array
+    description: |
+      The metrics to include in the custom report. Each metric specifies
+      a name and an optional aggregation function.
+    required: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            The name of the metric. For example, `message_count` or `total_response_time`.
+          required: true
+        - name: 'function'
+          type: String
+          description: |
+            The aggregation function to apply to the metric.
+            Common values include `avg`, `min`, `max`, `sum`, and `rate`.
+  - name: 'dimensions'
+    type: Array
+    description: |
+      The dimensions to group the report by. For example, `apiproxy` or `target_host`.
+    item_type:
+      type: String
+  - name: 'filter'
+    type: String
+    description: |
+      A filter expression to apply to the report data. For example,
+      `(apiproxy eq 'my-proxy')`.
+  - name: 'timeUnit'
+    type: String
+    description: |
+      The time unit for aggregating report data. Valid values include
+      `minute`, `hour`, `day`, `week`, and `month`.
+  - name: 'sortByCols'
+    type: Array
+    description: |
+      The columns to sort the report results by.
+    item_type:
+      type: String
+  - name: 'sortOrder'
+    type: String
+    description: |
+      The sort order for the report results. For example, `ASC` or `DESC`.
+  - name: 'fromTime'
+    type: String
+    description: |
+      The start time for the report data. Typically a timestamp string.
+  - name: 'toTime'
+    type: String
+    description: |
+      The end time for the report data. Typically a timestamp string.
+  - name: 'topk'
+    type: String
+    description: |
+      The number of top results to return. Used for top-k queries.
+  - name: 'limit'
+    type: String
+    description: |
+      The maximum number of rows to return in the report.
+  - name: 'offset'
+    type: String
+    description: |
+      The offset for paginating through report results.
+  - name: 'chartType'
+    type: String
+    description: |
+      The chart type for displaying the report. For example, `line` or `column`.
+  - name: 'tags'
+    type: Array
+    description: |
+      Tags associated with the custom report.
+    item_type:
+      type: String
+  - name: 'comments'
+    type: Array
+    description: |
+      Comments associated with the custom report.
+    item_type:
+      type: String
+  - name: 'properties'
+    type: Array
+    description: |
+      Key-value properties associated with the report.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'property'
+          type: String
+          description: |
+            The property name.
+        - name: 'value'
+          type: Array
+          description: |
+            The property values.
+          item_type:
+            type: String
+  - name: 'organization'
+    type: String
+    description: |
+      The Apigee organization name.
+    output: true
+  - name: 'environment'
+    type: String
+    description: |
+      The Apigee environment name.
+    output: true
+  - name: 'createdAt'
+    type: String
+    description: |
+      The time at which the custom report was created in milliseconds since the epoch.
+    output: true
+  - name: 'lastModifiedAt'
+    type: String
+    description: |
+      The time at which the custom report was last modified in milliseconds since the epoch.
+    output: true
+  - name: 'lastViewedAt'
+    type: String
+    description: |
+      The time at which the custom report was last viewed in milliseconds since the epoch.
+    output: true

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google Inc.
+# Copyright 2026 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -45,6 +45,11 @@ examples:
     exclude_test: true
   - name: 'apigee_custom_report_basic_test'
     primary_resource_id: 'apigee_custom_report'
+    vars:
+      project_id: 'my-project'
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
+      display_name: 'my_custom_report'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
@@ -57,6 +62,11 @@ examples:
     exclude_test: true
   - name: 'apigee_custom_report_full_test'
     primary_resource_id: 'apigee_custom_report'
+    vars:
+      project_id: 'my-project'
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
+      display_name: 'my_detailed_report'
     test_env_vars:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -51,6 +51,18 @@ examples:
     exclude_docs: true
     skip_vcr: true
     external_providers: ["time"]
+  - name: 'apigee_custom_report_full'
+    vars:
+      display_name: 'my_detailed_report'
+    exclude_test: true
+  - name: 'apigee_custom_report_full_test'
+    primary_resource_id: 'apigee_custom_report'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
 parameters:
   - name: 'orgId'
     type: String

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -142,31 +142,6 @@ properties:
     type: String
     description: |
       The sort order for the report results. For example, `ASC` or `DESC`.
-  - name: 'fromTime'
-    type: String
-    description: |
-      The start time for the report data. Typically a timestamp string.
-    ignore_read: true
-  - name: 'toTime'
-    type: String
-    description: |
-      The end time for the report data. Typically a timestamp string.
-    ignore_read: true
-  - name: 'topk'
-    type: String
-    description: |
-      The number of top results to return. Used for top-k queries.
-    ignore_read: true
-  - name: 'limit'
-    type: String
-    description: |
-      The maximum number of rows to return in the report.
-    ignore_read: true
-  - name: 'offset'
-    type: String
-    description: |
-      The offset for paginating through report results.
-    ignore_read: true
   - name: 'chartType'
     type: String
     description: |
@@ -175,13 +150,6 @@ properties:
     type: Array
     description: |
       Tags associated with the custom report.
-    item_type:
-      type: String
-  - name: 'comments'
-    type: Array
-    description: |
-      Comments associated with the custom report.
-    ignore_read: true
     item_type:
       type: String
   - name: 'properties'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -54,7 +54,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_custom_report_full'
     vars:
@@ -71,7 +70,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    skip_vcr: true
     external_providers: ["time"]
 parameters:
   - name: 'orgId'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -37,16 +37,17 @@ timeouts:
   delete_minutes: 1
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_custom_report.go.tmpl'
-exclude_sweeper: true
 examples:
   - name: 'apigee_custom_report_basic'
     vars:
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
       display_name: 'my_custom_report'
     exclude_test: true
   - name: 'apigee_custom_report_basic_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -57,12 +58,14 @@ examples:
     external_providers: ["time"]
   - name: 'apigee_custom_report_full'
     vars:
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
       display_name: 'my_detailed_report'
     exclude_test: true
   - name: 'apigee_custom_report_full_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -47,7 +47,6 @@ examples:
   - name: 'apigee_custom_report_basic_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -65,7 +64,6 @@ examples:
   - name: 'apigee_custom_report_full_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -40,6 +40,7 @@ custom_code:
 examples:
   - name: 'apigee_custom_report_basic'
     vars:
+      project_id: 'my-project'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -47,6 +48,7 @@ examples:
   - name: 'apigee_custom_report_basic_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
+      project_id: 'my-project'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -57,6 +59,7 @@ examples:
     external_providers: ["time"]
   - name: 'apigee_custom_report_full'
     vars:
+      project_id: 'my-project'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'
@@ -64,6 +67,7 @@ examples:
   - name: 'apigee_custom_report_full_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
+      project_id: 'my-project'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -188,9 +188,18 @@ properties:
         - name: 'value'
           type: Array
           description: |
-            The property values.
+            The property values. Each value is an Attribute object with a name and value.
           item_type:
-            type: String
+            type: NestedObject
+            properties:
+              - name: 'name'
+                type: String
+                description: |
+                  The attribute name.
+              - name: 'value'
+                type: String
+                description: |
+                  The attribute value.
   - name: 'organization'
     type: String
     description: |

--- a/mmv1/products/apigee/CustomReport.yaml
+++ b/mmv1/products/apigee/CustomReport.yaml
@@ -40,7 +40,7 @@ custom_code:
 examples:
   - name: 'apigee_custom_report_basic'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -48,7 +48,7 @@ examples:
   - name: 'apigee_custom_report_basic_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_custom_report'
@@ -59,7 +59,7 @@ examples:
     external_providers: ["time"]
   - name: 'apigee_custom_report_full'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'
@@ -67,7 +67,7 @@ examples:
   - name: 'apigee_custom_report_full_test'
     primary_resource_id: 'apigee_custom_report'
     vars:
-      project_id: 'my-project'
+      project_id: 'proj'
       network_name: 'apigee-network'
       range_name: 'apigee-range'
       display_name: 'my_detailed_report'
@@ -146,22 +146,27 @@ properties:
     type: String
     description: |
       The start time for the report data. Typically a timestamp string.
+    ignore_read: true
   - name: 'toTime'
     type: String
     description: |
       The end time for the report data. Typically a timestamp string.
+    ignore_read: true
   - name: 'topk'
     type: String
     description: |
       The number of top results to return. Used for top-k queries.
+    ignore_read: true
   - name: 'limit'
     type: String
     description: |
       The maximum number of rows to return in the report.
+    ignore_read: true
   - name: 'offset'
     type: String
     description: |
       The offset for paginating through report results.
+    ignore_read: true
   - name: 'chartType'
     type: String
     description: |
@@ -176,6 +181,7 @@ properties:
     type: Array
     description: |
       Comments associated with the custom report.
+    ignore_read: true
     item_type:
       type: String
   - name: 'properties'

--- a/mmv1/templates/terraform/custom_import/apigee_custom_report.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/apigee_custom_report.go.tmpl
@@ -1,0 +1,42 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("name").(string), "/")
+if len(nameParts) == 4 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/reports/{{"{{"}}name{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("name", nameParts[3]); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
+	}
+} else if len(nameParts) == 3 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("name", nameParts[2]); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
+	}
+} else {
+	return nil, fmt.Errorf(
+		"Saw %s when the name is expected to have shape %s or %s",
+		d.Get("name"),
+		"organizations/{{"{{"}}org_name{{"}}"}}/reports/{{"{{"}}name{{"}}"}}",
+		"organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}")
+}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}org_id{{"}}"}}/reports/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/custom_import/apigee_custom_report.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/apigee_custom_report.go.tmpl
@@ -1,35 +1,10 @@
 config := meta.(*transport_tpg.Config)
 
-// current import_formats cannot import fields with forward slashes in their value
-if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+if err := tpgresource.ParseImportId([]string{
+	"^(?P<org_id>.+)/reports/(?P<name>[^/]+)$",
+	"^(?P<org_id>.+)/(?P<name>[^/]+)$",
+}, d, config); err != nil {
 	return nil, err
-}
-
-nameParts := strings.Split(d.Get("name").(string), "/")
-if len(nameParts) == 4 {
-	// `organizations/{{"{{"}}org_name{{"}}"}}/reports/{{"{{"}}name{{"}}"}}`
-	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
-	if err := d.Set("org_id", orgId); err != nil {
-		return nil, fmt.Errorf("Error setting org_id: %s", err)
-	}
-	if err := d.Set("name", nameParts[3]); err != nil {
-		return nil, fmt.Errorf("Error setting name: %s", err)
-	}
-} else if len(nameParts) == 3 {
-	// `organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}`
-	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
-	if err := d.Set("org_id", orgId); err != nil {
-		return nil, fmt.Errorf("Error setting org_id: %s", err)
-	}
-	if err := d.Set("name", nameParts[2]); err != nil {
-		return nil, fmt.Errorf("Error setting name: %s", err)
-	}
-} else {
-	return nil, fmt.Errorf(
-		"Saw %s when the name is expected to have shape %s or %s",
-		d.Get("name"),
-		"organizations/{{"{{"}}org_name{{"}}"}}/reports/{{"{{"}}name{{"}}"}}",
-		"organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}")
 }
 
 // Replace import id for the resource id

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic.tf.tmpl
@@ -1,0 +1,38 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_apigee_custom_report" "apigee_custom_report" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "{{index $.Vars "display_name"}}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  dimensions = ["apiproxy"]
+}

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic.tf.tmpl
@@ -1,11 +1,11 @@
 data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
-  name = "apigee-network"
+  name = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "{{index $.Vars "project_id"}}%{random_suffix}"
+  name            = "{{index $.Vars "project_id"}}%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"
@@ -35,13 +35,13 @@ resource "time_sleep" "wait_300_seconds" {
 }
 
 resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
+  name       = "{{index $.Vars "network_name"}}"
   project    = google_project.project.project_id
   depends_on = [time_sleep.wait_300_seconds]
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -68,7 +68,7 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
   org_id       = google_apigee_organization.apigee_org.id
-  display_name = "tf_test%{random_suffix}"
+  display_name = "{{index $.Vars "display_name"}}%{random_suffix}"
 
   metrics {
     name     = "message_count"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
@@ -1,0 +1,79 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf_test%{random_suffix}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  dimensions = ["apiproxy"]
+}

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "{{index $.Vars "project_id"}}"
+  name            = "{{index $.Vars "project_id"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_basic_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "{{index $.Vars "project_id"}}%{random_suffix}"
-  name            = "{{index $.Vars "project_id"}}%{random_suffix}"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
@@ -1,0 +1,60 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_apigee_custom_report" "apigee_custom_report" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "{{index $.Vars "display_name"}}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  metrics {
+    name     = "total_response_time"
+    function = "avg"
+  }
+
+  dimensions   = ["apiproxy", "request_verb"]
+  filter       = "(apiproxy eq 'my-proxy')"
+  time_unit    = "hour"
+  sort_by_cols = ["message_count"]
+  sort_order   = "DESC"
+  from_time    = "1609459200000"
+  to_time      = "1640995200000"
+  topk         = "10"
+  limit        = "100"
+  offset       = "0"
+  chart_type   = "line"
+  tags         = ["production", "analytics"]
+  comments     = ["Daily traffic report"]
+
+  properties {
+    property = "ui.chart.showTotal"
+    value    = ["true"]
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
@@ -55,6 +55,9 @@ resource "google_apigee_custom_report" "apigee_custom_report" {
 
   properties {
     property = "ui.chart.showTotal"
-    value    = ["yes"]
+    value {
+      name  = "showTotal"
+      value = "true"
+    }
   }
 }

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
@@ -44,14 +44,8 @@ resource "google_apigee_custom_report" "apigee_custom_report" {
   time_unit    = "hour"
   sort_by_cols = ["message_count"]
   sort_order   = "DESC"
-  from_time    = "1609459200000"
-  to_time      = "1640995200000"
-  topk         = "10"
-  limit        = "100"
-  offset       = "0"
   chart_type   = "line"
   tags         = ["production", "analytics"]
-  comments     = ["Daily traffic report"]
 
   properties {
     property = "ui.chart.showTotal"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
@@ -1,11 +1,11 @@
 data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
-  name = "apigee-network"
+  name = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full.tf.tmpl
@@ -55,6 +55,6 @@ resource "google_apigee_custom_report" "apigee_custom_report" {
 
   properties {
     property = "ui.chart.showTotal"
-    value    = ["true"]
+    value    = ["yes"]
   }
 }

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "{{index $.Vars "project_id"}}%{random_suffix}"
+  name            = "{{index $.Vars "project_id"}}%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"
@@ -35,13 +35,13 @@ resource "time_sleep" "wait_300_seconds" {
 }
 
 resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
+  name       = "{{index $.Vars "network_name"}}"
   project    = google_project.project.project_id
   depends_on = [time_sleep.wait_300_seconds]
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -68,7 +68,7 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
   org_id       = google_apigee_organization.apigee_org.id
-  display_name = "tf_test_full%{random_suffix}"
+  display_name = "{{index $.Vars "display_name"}}%{random_suffix}"
 
   metrics {
     name     = "message_count"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -1,0 +1,101 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf_test_full%{random_suffix}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  metrics {
+    name     = "total_response_time"
+    function = "avg"
+  }
+
+  dimensions   = ["apiproxy", "request_verb"]
+  filter       = "(apiproxy eq 'my-proxy')"
+  time_unit    = "hour"
+  sort_by_cols = ["message_count"]
+  sort_order   = "DESC"
+  from_time    = "1609459200000"
+  to_time      = "1640995200000"
+  topk         = "10"
+  limit        = "100"
+  offset       = "0"
+  chart_type   = "line"
+  tags         = ["production", "analytics"]
+  comments     = ["Daily traffic report"]
+
+  properties {
+    property = "ui.chart.showTotal"
+    value    = ["true"]
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "{{index $.Vars "project_id"}}"
+  name            = "{{index $.Vars "project_id"}}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -96,6 +96,9 @@ resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
 
   properties {
     property = "ui.chart.showTotal"
-    value    = ["yes"]
+    value {
+      name  = "showTotal"
+      value = "true"
+    }
   }
 }

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -96,6 +96,6 @@ resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
 
   properties {
     property = "ui.chart.showTotal"
-    value    = ["true"]
+    value    = ["yes"]
   }
 }

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_project" "project" {
-  project_id      = "{{index $.Vars "project_id"}}%{random_suffix}"
-  name            = "{{index $.Vars "project_id"}}%{random_suffix}"
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
   deletion_policy = "DELETE"

--- a/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_custom_report_full_test.tf.tmpl
@@ -85,14 +85,8 @@ resource "google_apigee_custom_report" "{{$.PrimaryResourceId}}" {
   time_unit    = "hour"
   sort_by_cols = ["message_count"]
   sort_order   = "DESC"
-  from_time    = "1609459200000"
-  to_time      = "1640995200000"
-  topk         = "10"
-  limit        = "100"
-  offset       = "0"
   chart_type   = "line"
   tags         = ["production", "analytics"]
-  comments     = ["Daily traffic report"]
 
   properties {
     property = "ui.chart.showTotal"

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_custom_report_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_custom_report_test.go
@@ -1,0 +1,232 @@
+package apigee_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccApigeeCustomReport_update(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeCustomReportDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeCustomReport_basic(context),
+			},
+			{
+				ResourceName:            "google_apigee_custom_report.apigee_custom_report",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"org_id"},
+			},
+			{
+				Config: testAccApigeeCustomReport_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_apigee_custom_report.apigee_custom_report", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_apigee_custom_report.apigee_custom_report",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"org_id"},
+			},
+		},
+	})
+}
+
+func testAccApigeeCustomReport_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_custom_report" "apigee_custom_report" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf-test-cr%{random_suffix}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  dimensions = ["apiproxy"]
+}
+`, context)
+}
+
+func testAccApigeeCustomReport_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_custom_report" "apigee_custom_report" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf-test-cr-updated%{random_suffix}"
+
+  metrics {
+    name     = "message_count"
+    function = "sum"
+  }
+
+  metrics {
+    name     = "total_response_time"
+    function = "avg"
+  }
+
+  dimensions = ["apiproxy", "request_verb"]
+  filter     = "(apiproxy eq 'my-proxy')"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_custom_report_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_custom_report_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestAccApigeeCustomReport_update(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	randomSuffix := acctest.RandString(t, 10)
@@ -96,13 +95,13 @@ resource "time_sleep" "wait_300_seconds" {
 }
 
 resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
+  name       = "tf-test-apigee-network%{random_suffix}"
   project    = google_project.project.project_id
   depends_on = [time_sleep.wait_300_seconds]
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "tf-test-apigee-range%{random_suffix}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -180,13 +179,13 @@ resource "time_sleep" "wait_300_seconds" {
 }
 
 resource "google_compute_network" "apigee_network" {
-  name       = "apigee-network"
+  name       = "tf-test-apigee-network%{random_suffix}"
   project    = google_project.project.project_id
   depends_on = [time_sleep.wait_300_seconds]
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "tf-test-apigee-range%{random_suffix}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16


### PR DESCRIPTION
New resource `google_apigee_custom_report` for managing Apigee Analytics custom report definitions via the `organizations.reports` API.

Custom reports let users define reusable analytics views with custom metrics, dimensions, filters, and grouping. This resource supports all fields from the API including metrics with aggregation functions, dimensions, time units, sorting, and report properties.

Tested all CRUD operations against a live Apigee evaluation org:
- Create (1s)
- Read with no drift
- Update in-place (display name, metrics, dimensions, time unit)
- Import by full resource path
- Delete

Uses `PUT` with no update mask (same pattern as `DeveloperApp`). The `name` field is a server-assigned UUID used as the path identifier. `displayName` is user-specified and mutable.

Related to [PR #16954](https://github.com/GoogleCloudPlatform/magic-modules/pull/16954) (`google_apigee_data_collector`).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_apigee_custom_report`
```