### PR TITLE
Add google_apigee_datastore resource

### DIFF
--- a/mmv1/products/apigee/Datastore.yaml
+++ b/mmv1/products/apigee/Datastore.yaml
@@ -1,0 +1,131 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Datastore'
+description: |
+  An analytics datastore for an Apigee organization. Datastores configure
+  export destinations for Apigee Analytics data, supporting either Google
+  Cloud Storage (GCS) or BigQuery as targets.
+references:
+  guides:
+    'Export analytics data': 'https://cloud.google.com/apigee/docs/api-platform/analytics/analytics-export'
+  api: 'https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.analytics.datastores'
+docs:
+base_url: '{{org_id}}/analytics/datastores'
+self_link: '{{org_id}}/analytics/datastores/{{name}}'
+update_url: '{{org_id}}/analytics/datastores/{{name}}'
+update_verb: 'PUT'
+update_mask: false
+delete_url: '{{org_id}}/analytics/datastores/{{name}}'
+import_format:
+  - '{{org_id}}/analytics/datastores/{{name}}'
+  - '{{org_id}}/{{name}}'
+timeouts:
+  insert_minutes: 1
+  update_minutes: 1
+  delete_minutes: 1
+custom_code:
+  decoder: 'templates/terraform/decoders/apigee_datastore.go.tmpl'
+  custom_import: 'templates/terraform/custom_import/apigee_datastore.go.tmpl'
+exclude_sweeper: true
+examples:
+  - name: 'apigee_datastore_basic'
+    vars:
+      display_name: 'my_datastore'
+      bucket_name: 'my-analytics-bucket'
+    exclude_test: true
+  - name: 'apigee_datastore_basic_test'
+    primary_resource_id: 'apigee_datastore'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
+parameters:
+  - name: 'orgId'
+    type: String
+    description: |
+      The Apigee Organization associated with the Apigee datastore,
+      in the format `organizations/{{org_name}}`.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The server-assigned UUID identifier for the datastore. Extracted
+      from the `self` field in the API response.
+    output: true
+  - name: 'self'
+    type: String
+    description: |
+      The resource link for the datastore, including the full API path.
+    output: true
+    api_name: 'self'
+  - name: 'displayName'
+    type: String
+    description: |
+      The display name for the datastore.
+    required: true
+  - name: 'org'
+    type: String
+    description: |
+      The Apigee organization name.
+    output: true
+  - name: 'targetType'
+    type: String
+    description: |
+      The type of target for the datastore. Must be `gcs` for Google
+      Cloud Storage or `bigquery` for BigQuery.
+    required: true
+    immutable: true
+  - name: 'createTime'
+    type: String
+    description: |
+      The time at which the datastore was created in milliseconds since the epoch.
+    output: true
+  - name: 'lastUpdateTime'
+    type: String
+    description: |
+      The time at which the datastore was last updated in milliseconds since the epoch.
+    output: true
+  - name: 'datastoreConfig'
+    type: NestedObject
+    description: |
+      Configuration of the datastore target.
+    required: true
+    properties:
+      - name: 'projectId'
+        type: String
+        description: |
+          The GCP project ID that the datastore target resides in.
+        required: true
+      - name: 'bucketName'
+        type: String
+        description: |
+          The name of the Cloud Storage bucket. Required for `gcs` target type.
+      - name: 'path'
+        type: String
+        description: |
+          The path within the Cloud Storage bucket. Used for `gcs` target type.
+      - name: 'datasetName'
+        type: String
+        description: |
+          The name of the BigQuery dataset. Required for `bigquery` target type.
+      - name: 'tablePrefix'
+        type: String
+        description: |
+          The prefix for BigQuery table names. Used for `bigquery` target type.

--- a/mmv1/products/apigee/Datastore.yaml
+++ b/mmv1/products/apigee/Datastore.yaml
@@ -53,6 +53,19 @@ examples:
     exclude_docs: true
     skip_vcr: true
     external_providers: ["time"]
+  - name: 'apigee_datastore_bigquery'
+    vars:
+      display_name: 'my_bigquery_datastore'
+      dataset_id: 'my_analytics_dataset'
+    exclude_test: true
+  - name: 'apigee_datastore_bigquery_test'
+    primary_resource_id: 'apigee_datastore'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    skip_vcr: true
+    external_providers: ["time"]
 parameters:
   - name: 'orgId'
     type: String

--- a/mmv1/products/apigee/Datastore.yaml
+++ b/mmv1/products/apigee/Datastore.yaml
@@ -38,10 +38,11 @@ timeouts:
 custom_code:
   decoder: 'templates/terraform/decoders/apigee_datastore.go.tmpl'
   custom_import: 'templates/terraform/custom_import/apigee_datastore.go.tmpl'
-exclude_sweeper: true
 examples:
   - name: 'apigee_datastore_basic'
     vars:
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
       display_name: 'my_datastore'
       bucket_name: 'my-analytics-bucket'
     exclude_test: true
@@ -54,6 +55,8 @@ examples:
     external_providers: ["time"]
   - name: 'apigee_datastore_bigquery'
     vars:
+      network_name: 'apigee-network'
+      range_name: 'apigee-range'
       display_name: 'my_bigquery_datastore'
       dataset_id: 'my_analytics_dataset'
     exclude_test: true

--- a/mmv1/products/apigee/Datastore.yaml
+++ b/mmv1/products/apigee/Datastore.yaml
@@ -51,7 +51,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    skip_vcr: true
     external_providers: ["time"]
   - name: 'apigee_datastore_bigquery'
     vars:
@@ -64,7 +63,6 @@ examples:
       org_id: 'ORG_ID'
       billing_account: 'BILLING_ACCT'
     exclude_docs: true
-    skip_vcr: true
     external_providers: ["time"]
 parameters:
   - name: 'orgId'

--- a/mmv1/templates/terraform/custom_import/apigee_datastore.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/apigee_datastore.go.tmpl
@@ -1,0 +1,42 @@
+config := meta.(*transport_tpg.Config)
+
+// current import_formats cannot import fields with forward slashes in their value
+if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("name").(string), "/")
+if len(nameParts) == 5 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/analytics/datastores/{{"{{"}}name{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("name", nameParts[4]); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
+	}
+} else if len(nameParts) == 3 {
+	// `organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}`
+	orgId := fmt.Sprintf("organizations/%s", nameParts[1])
+	if err := d.Set("org_id", orgId); err != nil {
+		return nil, fmt.Errorf("Error setting org_id: %s", err)
+	}
+	if err := d.Set("name", nameParts[2]); err != nil {
+		return nil, fmt.Errorf("Error setting name: %s", err)
+	}
+} else {
+	return nil, fmt.Errorf(
+		"Saw %s when the name is expected to have shape %s or %s",
+		d.Get("name"),
+		"organizations/{{"{{"}}org_name{{"}}"}}/analytics/datastores/{{"{{"}}name{{"}}"}}",
+		"organizations/{{"{{"}}org_name{{"}}"}}/{{"{{"}}name{{"}}"}}")
+}
+
+// Replace import id for the resource id
+id, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}org_id{{"}}"}}/analytics/datastores/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return nil, fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/decoders/apigee_datastore.go.tmpl
+++ b/mmv1/templates/terraform/decoders/apigee_datastore.go.tmpl
@@ -1,0 +1,17 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+if selfLink, ok := res["self"].(string); ok && selfLink != "" {
+	parts := strings.Split(selfLink, "/")
+	res["name"] = parts[len(parts)-1]
+}
+return res, nil

--- a/mmv1/templates/terraform/examples/apigee_datastore_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_basic.tf.tmpl
@@ -1,0 +1,43 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_storage_bucket" "analytics_bucket" {
+  name     = "{{index $.Vars "bucket_name"}}"
+  location = "US"
+}
+
+resource "google_apigee_datastore" "apigee_datastore" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "{{index $.Vars "display_name"}}"
+  target_type  = "gcs"
+
+  datastore_config {
+    project_id  = data.google_client_config.current.project
+    bucket_name = google_storage_bucket.analytics_bucket.name
+    path        = "/analytics"
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_datastore_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_basic.tf.tmpl
@@ -1,11 +1,11 @@
 data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
-  name = "apigee-network"
+  name = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/apigee_datastore_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_basic_test.tf.tmpl
@@ -1,0 +1,85 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_storage_bucket" "analytics_bucket" {
+  name     = "tf-test-apigee-analytics%{random_suffix}"
+  location = "US"
+  project  = google_project.project.project_id
+}
+
+resource "google_apigee_datastore" "{{$.PrimaryResourceId}}" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf_test%{random_suffix}"
+  target_type  = "gcs"
+
+  datastore_config {
+    project_id  = google_project.project.project_id
+    bucket_name = google_storage_bucket.analytics_bucket.name
+    path        = "/analytics"
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_datastore_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_basic_test.tf.tmpl
@@ -29,6 +29,12 @@ resource "google_project_service" "servicenetworking" {
   depends_on = [google_project_service.compute]
 }
 
+resource "google_project_service" "storage" {
+  project = google_project.project.project_id
+  service = "storage.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
 resource "time_sleep" "wait_300_seconds" {
   create_duration = "300s"
   depends_on = [google_project_service.servicenetworking]
@@ -67,9 +73,11 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_storage_bucket" "analytics_bucket" {
-  name     = "tf-test-apigee-analytics%{random_suffix}"
-  location = "US"
-  project  = google_project.project.project_id
+  name                        = "tf-test-apigee-analytics%{random_suffix}"
+  location                    = "US"
+  project                     = google_project.project.project_id
+  uniform_bucket_level_access = true
+  depends_on                  = [google_project_service.storage]
 }
 
 resource "google_apigee_datastore" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/apigee_datastore_bigquery.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_bigquery.tf.tmpl
@@ -1,0 +1,43 @@
+data "google_client_config" "current" {}
+
+resource "google_compute_network" "apigee_network" {
+  name = "apigee-network"
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = data.google_client_config.current.project
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [google_service_networking_connection.apigee_vpc_connection]
+}
+
+resource "google_bigquery_dataset" "analytics_dataset" {
+  dataset_id = "{{index $.Vars "dataset_id"}}"
+  location   = "US"
+}
+
+resource "google_apigee_datastore" "apigee_datastore" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "{{index $.Vars "display_name"}}"
+  target_type  = "bigquery"
+
+  datastore_config {
+    project_id   = data.google_client_config.current.project
+    dataset_name = google_bigquery_dataset.analytics_dataset.dataset_id
+    table_prefix = "apigee_"
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_datastore_bigquery.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_bigquery.tf.tmpl
@@ -1,11 +1,11 @@
 data "google_client_config" "current" {}
 
 resource "google_compute_network" "apigee_network" {
-  name = "apigee-network"
+  name = "{{index $.Vars "network_name"}}"
 }
 
 resource "google_compute_global_address" "apigee_range" {
-  name          = "apigee-range"
+  name          = "{{index $.Vars "range_name"}}"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16

--- a/mmv1/templates/terraform/examples/apigee_datastore_bigquery_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_bigquery_test.tf.tmpl
@@ -1,0 +1,85 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_bigquery_dataset" "analytics_dataset" {
+  dataset_id = "tf_test_apigee_analytics%{random_suffix}"
+  location   = "US"
+  project    = google_project.project.project_id
+}
+
+resource "google_apigee_datastore" "{{$.PrimaryResourceId}}" {
+  org_id       = google_apigee_organization.apigee_org.id
+  display_name = "tf_test_bq%{random_suffix}"
+  target_type  = "bigquery"
+
+  datastore_config {
+    project_id   = google_project.project.project_id
+    dataset_name = google_bigquery_dataset.analytics_dataset.dataset_id
+    table_prefix = "apigee_"
+  }
+}

--- a/mmv1/templates/terraform/examples/apigee_datastore_bigquery_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_datastore_bigquery_test.tf.tmpl
@@ -29,9 +29,15 @@ resource "google_project_service" "servicenetworking" {
   depends_on = [google_project_service.compute]
 }
 
+resource "google_project_service" "bigquery" {
+  project = google_project.project.project_id
+  service = "bigquery.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
 resource "time_sleep" "wait_300_seconds" {
   create_duration = "300s"
-  depends_on = [google_project_service.servicenetworking]
+  depends_on = [google_project_service.bigquery]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -70,6 +76,7 @@ resource "google_bigquery_dataset" "analytics_dataset" {
   dataset_id = "tf_test_apigee_analytics%{random_suffix}"
   location   = "US"
   project    = google_project.project.project_id
+  depends_on = [google_project_service.bigquery]
 }
 
 resource "google_apigee_datastore" "{{$.PrimaryResourceId}}" {


### PR DESCRIPTION
New resource `google_apigee_datastore` for managing Apigee Analytics data export destinations via the `organizations.analytics.datastores` API.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/24772

Datastores define where Apigee exports analytics data -- either a Cloud Storage bucket or a BigQuery dataset. This resource supports both target types with all configuration fields from the API.

Tested all CRUD operations + import against a live Apigee evaluation org:
- Create (1s)
- Read with no drift
- Update in-place (display name, GCS path)
- Import by full resource path (5-segment: `organizations/{org}/analytics/datastores/{uuid}`)
- Delete

Key implementation details:
- The API returns a `self` field (not `name`) containing the full resource path with a server-assigned UUID. A custom decoder extracts the UUID from the last path segment of `self` and sets it as `name` for URL template resolution.
- Uses `PUT` with no update mask (same pattern as `DeveloperApp`, `CustomReport`).
- The API normalizes the GCS `path` field with a leading `/` -- the example reflects this.
- `targetType` is immutable (cannot switch between `gcs` and `bigquery` after creation).

### Operational note on lifecycle management

Analytics datastores are often used in rotation patterns -- e.g., pointing exports to date-partitioned GCS paths or rotating BigQuery table prefixes on a schedule. When managing datastores that receive frequent config updates from external automation (export schedulers, rotation scripts), users may want to use Terraform lifecycle meta-arguments to avoid drift:

```hcl
resource "google_apigee_datastore" "analytics_export" {
  org_id       = google_apigee_organization.org.id
  display_name = "analytics-export"
  target_type  = "gcs"

  datastore_config {
    project_id  = "my-project"
    bucket_name = "my-analytics-bucket"
    path        = "/exports/current"
  }

  # If an external process rotates the export path on a schedule,
  # ignore changes to avoid Terraform reverting the rotation.
  lifecycle {
    ignore_changes = [datastore_config[0].path]
  }
}
```

For datastores that are fully Terraform-managed with no external rotation, no special lifecycle configuration is needed.

Related to [PR #16954](https://github.com/GoogleCloudPlatform/magic-modules/pull/16954) (`google_apigee_data_collector`) and [PR #16955](https://github.com/GoogleCloudPlatform/magic-modules/pull/16955) (`google_apigee_custom_report`).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_apigee_datastore`
```