### PR TITLE
apigee: make  field required on google_apigee_env_keystore

### DIFF
--- a/mmv1/products/apigee/EnvKeystore.yaml
+++ b/mmv1/products/apigee/EnvKeystore.yaml
@@ -61,6 +61,7 @@ parameters:
     type: String
     description: |
       The name of the newly created keystore.
+    required: true
     immutable: true
 properties:
   - name: 'aliases'


### PR DESCRIPTION
## Description

`google_apigee_env_keystore` had `name` marked as Optional in the YAML schema, but the Apigee API requires it — omitting it returns `400: keystore ID must be set`. This change marks `name` as `required: true`.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/23084

## Tests

```
--- PASS: TestAccApigeeEnvKeystore_apigeeEnvironmentKeystoreTestExample (1241.91s)
PASS
```

```release-note:breaking-change
apigee: fixed `google_apigee_env_keystore` to require the `name` field which is mandatory in the Apigee API
```