### PR TITLE
apigee: treat 403 as not-found in google_apigee_organization and google_apigee_envgroup reads

### DIFF
--- a/mmv1/products/apigee/Envgroup.yaml
+++ b/mmv1/products/apigee/Envgroup.yaml
@@ -40,6 +40,7 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
+read_error_transform: 'transformApigeeNotFoundError'
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_environment_group.go.tmpl'
 exclude_sweeper: true

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -44,6 +44,7 @@ async:
     resource_inside_response: true
 sweeper:
   identifier_field: "organization"
+read_error_transform: 'transformApigeeNotFoundError'
 custom_code:
   encoder: 'templates/terraform/encoders/apigee_organization.go.tmpl'
   custom_import: 'templates/terraform/custom_import/apigee_organization.go.tmpl'

--- a/mmv1/third_party/terraform/services/apigee/apigee_utils.go
+++ b/mmv1/third_party/terraform/services/apigee/apigee_utils.go
@@ -3,6 +3,9 @@ package apigee
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -12,6 +15,24 @@ import (
 	"net/http"
 	"time"
 )
+
+// transformApigeeNotFoundError converts a 403 that Apigee returns when a
+// resource does not exist (instead of 404) into a 404 error, so that
+// HandleNotFoundError can correctly remove the resource from state.
+//
+// Apigee deliberately returns 403 to avoid leaking information about whether a
+// resource exists, but for Terraform reads we must treat "may not exist" as
+// "not found".
+func transformApigeeNotFoundError(err error) error {
+	if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok {
+		if gErr.Code == 403 && strings.Contains(gErr.Message, "or it may not exist") {
+			log.Printf("[DEBUG] Treating Apigee 403 as 404 (resource may not exist)")
+			gErr.Code = 404
+		}
+		return gErr
+	}
+	return err
+}
 
 func resourceApigeeNatAddressActivate(config *transport_tpg.Config, d *schema.ResourceData, billingProject string, userAgent string) error {
 	// 1. check prepare for activation


### PR DESCRIPTION
## Description

The Apigee API returns \`403\` (instead of \`404\`) when an organization or envgroup does not exist, to prevent resource enumeration. When a resource is deleted outside of Terraform, subsequent \`terraform plan\` / \`terraform apply\` calls would receive this 403 and treat it as a fatal authorization error rather than a \"not found\" signal, preventing Terraform from detecting drift and recreating the resource.

This change adds a \`transformApigeeNotFoundError\` helper to \`apigee_utils.go\` (following the same pattern used by \`cloud_identity\`, \`sql\`, and other services) and wires it in via \`read_error_transform\` in \`Organization.yaml\` and \`Envgroup.yaml\`.

The transform converts a 403 that contains the Apigee-specific message "or it may not exist" to a 404, which \`HandleNotFoundError\` then handles gracefully.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/17103

## Tests

The acceptance test for envgroup (\`TestAccApigeeEnvgroup_apigeeEnvironmentGroupBasicTestExample\`) requires provisioning a full Apigee organization (~30-60 min) and cannot reliably be run locally within CI time limits. The fix follows an established pattern used across the codebase.

Build verified:
\`\`\`
go build ./google/services/apigee/...  # exits 0
\`\`\`

```release-note:bug
apigee: fixed `google_apigee_organization` and `google_apigee_envgroup` to handle 403 responses as not-found during read, allowing Terraform to detect and recreate resources deleted outside of Terraform
```