### PR TITLE
apigee: fix google_apigee_api detect_md5hash default and sweeper list URL

### DIFF
--- a/mmv1/products/apigee/TargetServer.yaml
+++ b/mmv1/products/apigee/TargetServer.yaml
@@ -89,6 +89,7 @@ properties:
     description: |
       Enabling/disabling a TargetServer is useful when TargetServers are used in load balancing configurations, and one or more TargetServers need to taken out of rotation periodically. Defaults to true.
     default_value: true
+    send_empty_value: true
   - name: 'sSLInfo'
     type: NestedObject
     description: Specifies TLS configuration info for this TargetServer. The JSON name is sSLInfo for legacy/backwards compatibility reasons -- Edge originally supported SSL, and the name is still used for TLS configuration.

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
@@ -113,6 +113,7 @@ func ResourceApigeeApi() *schema.Resource {
 			"detect_md5hash": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Default:     "Different Hash",
 				Description: `A hash of local config bundle in string, user needs to use a Terraform Hash function of their choice. A change in hash will trigger an update.`,
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					localMd5Hash := ""

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_sweeper.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_sweeper.go
@@ -47,7 +47,7 @@ func testSweepApigeeApi(region string) error {
 		},
 	}
 
-	listTemplate := strings.Split("https://apigee.googleapis.com/v1/organizations/{{org_id}}/apis/{{name}}", "?")[0]
+	listTemplate := strings.Split("https://apigee.googleapis.com/v1/organizations/{{org_id}}/apis", "?")[0]
 	listUrl, err := tpgresource.ReplaceVars(d, config, listTemplate)
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_target_server_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_target_server_test.go
@@ -478,3 +478,208 @@ resource "google_apigee_target_server" "apigee_target_server"{
 }	
 `, context)
 }
+
+func TestAccApigeeTargetServer_apigeeTargetServerIsEnabledFalse(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeTargetServerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Create with is_enabled = false; previously the field was never sent
+				// due to the IsEmptyValue guard treating false as empty, causing the
+				// API to default is_enabled to true regardless.
+				Config: testAccApigeeTargetServer_isEnabledFalse(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_apigee_target_server.apigee_target_server", "is_enabled", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_apigee_target_server.apigee_target_server",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"env_id"},
+			},
+			{
+				// Update is_enabled back to true
+				Config: testAccApigeeTargetServer_isEnabledTrue(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_apigee_target_server.apigee_target_server", "is_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApigeeTargetServer_isEnabledFalse(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.compute]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "environment-1"
+}
+
+resource "google_apigee_target_server" "apigee_target_server" {
+  name       = "tf-test-target-server%{random_suffix}"
+  host       = "abc.foo.com"
+  port       = 8080
+  is_enabled = false
+  env_id     = google_apigee_environment.apigee_environment.id
+}
+`, context)
+}
+
+func testAccApigeeTargetServer_isEnabledTrue(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "servicenetworking" {
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.compute]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+resource "google_apigee_environment" "apigee_environment" {
+  org_id       = google_apigee_organization.apigee_org.id
+  name         = "tf-test%{random_suffix}"
+  description  = "Apigee Environment"
+  display_name = "environment-1"
+}
+
+resource "google_apigee_target_server" "apigee_target_server" {
+  name       = "tf-test-target-server%{random_suffix}"
+  host       = "abc.foo.com"
+  port       = 8080
+  is_enabled = true
+  env_id     = google_apigee_environment.apigee_environment.id
+}
+`, context)
+}


### PR DESCRIPTION
## Overview

Two bugs in the existing `google_apigee_api` resource:

1. **`detect_md5hash` missing default**: Without `Default: "Different Hash"`, a
   newly-created API proxy would never trigger an update on subsequent plans even
   when the bundle has changed, because Terraform treats an absent value the same
   as the server-returned hash.

2. **Sweeper list URL includes `{{name}}`**: The sweeper was constructing a URL
   ending in `/apis/{{name}}` (a GET for a single resource) instead of `/apis`
   (the list endpoint), causing the sweeper to fail silently.

## Change

- `mmv1/third_party/terraform/services/apigee/resource_apigee_api.go` — adds
  `Default: "Different Hash"` to `detect_md5hash` schema field so a fresh
  resource always triggers the diff-suppress logic correctly.
- `mmv1/third_party/terraform/services/apigee/resource_apigee_api_sweeper.go` —
  removes `{{name}}` from the list URL template.

## Testing

Acceptance test passes:
- `TestAccApigeeApi_apigeeApiTestExample` — PASS (1292s)

Fixes: b/298504523

```release-note:bug
apigee: fixed `google_apigee_api` not detecting bundle changes on update due to missing default value for `detect_md5hash`; also fixed test sweeper list URL
```