### PR TITLE
Fix Identity Platform config plan-not-empty failure

### DIFF
--- a/mmv1/products/identityplatform/Config.yaml
+++ b/mmv1/products/identityplatform/Config.yaml
@@ -386,6 +386,7 @@ properties:
         type: Boolean
         description: |
           Whether this project can have tenants or not.
+        default_from_api: true
       - name: 'defaultTenantLocation'
         type: String
         description: |

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -6,7 +6,9 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   } else {
     original := v.(map[string]interface{})
 
-    if original["allowTenants"] != nil {
+    if original["allowTenants"] == nil {
+      transformed["allow_tenants"] = false
+    } else {
       transformed["allow_tenants"] = original["allowTenants"]
     }
 

--- a/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/identity_platform_config_multi_tenant.go.tmpl
@@ -6,9 +6,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
   } else {
     original := v.(map[string]interface{})
 
-    if original["allowTenants"] == nil {
-      transformed["allow_tenants"] = false
-    } else {
+    if original["allowTenants"] != nil {
       transformed["allow_tenants"] = original["allowTenants"]
     }
 

--- a/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
+++ b/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
@@ -193,13 +193,12 @@ resource "google_identity_platform_config" "basic" {
 }
 
 func TestAccIdentityPlatformConfig_multiTenantUnset(t *testing.T) {
-	acctest.SkipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":           envvar.GetTestOrgFromEnv(t),
-		"billing_acct":     envvar.GetTestBillingAccountFromEnv(t),
-		"random_suffix":    acctest.RandString(t, 10),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"billing_acct":  envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
+++ b/mmv1/third_party/terraform/services/identityplatform/resource_identity_platform_config_test.go
@@ -191,3 +191,75 @@ resource "google_identity_platform_config" "basic" {
 }
 `, context)
 }
+
+func TestAccIdentityPlatformConfig_multiTenantUnset(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":           envvar.GetTestOrgFromEnv(t),
+		"billing_acct":     envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":    acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityPlatformConfig_multiTenantEnabled(context),
+			},
+			{
+				Config: testAccIdentityPlatformConfig_multiTenantOmitted(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_identity_platform_config.basic", "multi_tenant.0.allow_tenants", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityPlatformConfig_multiTenantEnabled(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "basic" {
+  project_id = "tf-test-my-project%{random_suffix}"
+  name       = "tf-test-my-project%{random_suffix}"
+  org_id     = "%{org_id}"
+  billing_account =  "%{billing_acct}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "identitytoolkit" {
+  project = google_project.basic.project_id
+  service = "identitytoolkit.googleapis.com"
+}
+
+resource "google_identity_platform_config" "basic" {
+  project = google_project.basic.project_id
+  multi_tenant {
+    allow_tenants = true
+  }
+}
+`, context)
+}
+
+func testAccIdentityPlatformConfig_multiTenantOmitted(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "basic" {
+  project_id = "tf-test-my-project%{random_suffix}"
+  name       = "tf-test-my-project%{random_suffix}"
+  org_id     = "%{org_id}"
+  billing_account =  "%{billing_acct}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "identitytoolkit" {
+  project = google_project.basic.project_id
+  service = "identitytoolkit.googleapis.com"
+}
+
+resource "google_identity_platform_config" "basic" {
+  project = google_project.basic.project_id
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
identityplatform: fixed plan-not-empty diff for `allow_tenants` in `google_identity_platform_config` when omitted from configuration
```
