### PR TITLE
Port import support for GCR, Dataproc, and Endpoints

### DIFF
--- a/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
+++ b/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry.go
@@ -17,6 +17,9 @@ func ResourceContainerRegistry() *schema.Resource {
 		Create:             resourceContainerRegistryCreate,
 		Read:               resourceContainerRegistryRead,
 		Delete:             resourceContainerRegistryDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceContainerRegistryImport,
+		},
 
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
@@ -129,4 +132,34 @@ func resourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) err
 func resourceContainerRegistryDelete(d *schema.ResourceData, meta interface{}) error {
 	// Don't delete the backing bucket as this is not a supported GCR action
 	return nil
+}
+
+func resourceContainerRegistryImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"^(?P<location>[a-zA-Z]+)\\.artifacts\\.(?P<project>[^/]+)\\.appspot\\.com$",
+		"^artifacts\\.(?P<project>[^/]+)\\.appspot\\.com$",
+		"^(?P<project>[^/]+)/(?P<location>[a-zA-Z]+)$",
+		"^(?P<project>[^/]+)$",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	location := d.Get("location").(string)
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+
+	name := ""
+	if location != "" {
+		name = fmt.Sprintf("%s.artifacts.%s.appspot.com", strings.ToLower(location), project)
+	} else {
+		name = fmt.Sprintf("artifacts.%s.appspot.com", project)
+	}
+	d.SetId(name)
+
+	d.Set("location", strings.ToUpper(location))
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry_test.go
+++ b/mmv1/third_party/terraform/services/containeranalysis/resource_container_registry_test.go
@@ -18,6 +18,11 @@ func TestAccContainerRegistry_basic(t *testing.T) {
 			{
 				Config: testAccContainerRegistry_basic(),
 			},
+			{
+				ResourceName:      "google_container_registry.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -189,6 +189,9 @@ func ResourceDataprocCluster() *schema.Resource {
 		Read:   resourceDataprocClusterRead,
 		Update: resourceDataprocClusterUpdate,
 		Delete: resourceDataprocClusterDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDataprocClusterImport,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(45 * time.Minute),
@@ -3921,4 +3924,24 @@ func parseDataprocImageVersion(version string) (*dataprocImageVersion, error) {
 		subminor: matches[3],
 		osName:   matches[4],
 	}, nil
+}
+
+func resourceDataprocClusterImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/clusters/(?P<name>[^/]+)",
+		"(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)",
+		"(?P<name>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	// We populate the id using the format Dataproc currently uses
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/regions/{{region}}/clusters/{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -100,6 +100,12 @@ func TestAccDataprocCluster_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.preemptible_worker_config.0.instance_names.#", "0"),
 				),
 			},
+			{
+				ResourceName:            "google_dataproc_cluster.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels", "graceful_decommission_timeout"},
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
@@ -24,6 +24,9 @@ func ResourceEndpointsService() *schema.Resource {
 		Read:   resourceEndpointsServiceRead,
 		Delete: resourceEndpointsServiceDelete,
 		Update: resourceEndpointsServiceUpdate,
+		Importer: &schema.ResourceImporter{
+			State: resourceEndpointsServiceImport,
+		},
 
 		// Migrates protoc_output -> protoc_output_base64.
 		SchemaVersion: 1,
@@ -435,4 +438,16 @@ func flattenServiceManagementEndpoints(endpoints []*servicemanagement.Endpoint) 
 		}
 	}
 	return flattened
+}
+
+func resourceEndpointsServiceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*transport_tpg.Config)
+	if err := tpgresource.ParseImportId([]string{
+		"(?P<service_name>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	d.SetId(d.Get("service_name").(string))
+	return []*schema.ResourceData{d}, nil
 }

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
@@ -37,6 +37,12 @@ func TestAccEndpointsService_basic(t *testing.T) {
 				Config: testAccEndpointsService_basic(serviceId, envvar.GetTestProjectFromEnv(), "3"),
 				Check:  testAccCheckEndpointExistsByName(t, serviceId),
 			},
+			{
+				ResourceName:            "google_endpoints_service.endpoints_service",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"openapi_config", "grpc_config", "protoc_output_base64", "project"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
containeranalysis: added import support for `google_container_registry` 
```
```release-note:enhancement
dataproc: added import support for `google_dataproc_cluster`
```
```release-note:enhancement
servicemanagement: added import support for `google_endpoints_service`
```
