### PR TITLE
'Compute' Enable reading of `shareSettings` for Reservation resource and datasource

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -165,7 +165,6 @@ properties:
     type: NestedObject
     description: |
       The share setting for reservations.
-    ignore_read: true
     default_from_api: true
     properties:
       - name: 'shareType'


### PR DESCRIPTION
fix for https://github.com/hashicorp/terraform-provider-google/issues/18248

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
`compute`: Fixed an issue where `share_settings` was not populated on read for `google_compute_reservation` resource and `data` source (fixes #18248).
```
