### PR TITLE
Remove post merge VCR step from downstream push

### DIFF
--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -185,33 +185,6 @@ steps:
         - $COMMIT_SHA
 
     - name: 'gcr.io/graphite-docker-images/go-plus'
-      id: magician-check-vcr-cassettes
-      waitFor: ["vcr-merge"]
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv:
-        - "GITHUB_TOKEN_DOWNSTREAMS"
-        - "GOOGLE_BILLING_ACCOUNT"
-        - "GOOGLE_CHRONICLE_INSTANCE_ID"
-        - "GOOGLE_CUST_ID"
-        - "GOOGLE_IDENTITY_USER"
-        - "GOOGLE_MASTER_BILLING_ACCOUNT"
-        - "GOOGLE_ORG"
-        - "GOOGLE_ORG_2"
-        - "GOOGLE_ORG_DOMAIN"
-        - "GOOGLE_PROJECT"
-        - "GOOGLE_PROJECT_NUMBER"
-        - "GOOGLE_SERVICE_ACCOUNT"
-        - "SA_KEY"
-        - "GOOGLE_PUBLIC_AVERTISED_PREFIX_DESCRIPTION"
-        - "GOOGLE_VMWAREENGINE_PROJECT"
-      env:
-        - "COMMIT_SHA=$COMMIT_SHA"
-        - "GOOGLE_REGION=us-central1"
-        - "GOOGLE_ZONE=us-central1-a"
-      args:
-        - "check-cassettes"
-
-    - name: 'gcr.io/graphite-docker-images/go-plus'
       id: magician-delete-branches
       waitFor: ["vcr-merge"]
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'


### PR DESCRIPTION
Remove post-merge VCR run - we use nightly-VCR to update cassettes


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
