### PR TITLE
[SecurityScanner] Add `risk_level` field to `google_security_scanner_scan_config`

### DIFF
--- a/mmv1/products/securityscanner/ScanConfig.yaml
+++ b/mmv1/products/securityscanner/ScanConfig.yaml
@@ -36,6 +36,12 @@ examples:
     vars:
       address_name: scan-basic-static-ip
       scan_config_name: terraform-scan-config
+  - name: scan_config_risk_level
+    primary_resource_id: scan-config
+    min_version: beta
+    vars:
+      address_name: scan-risk-level-ip
+      scan_config_name: scan-config-risk-level
 properties:
   - name: name
     type: String
@@ -189,3 +195,9 @@ properties:
     enum_values:
       - ENABLED
       - DISABLED
+  - name: riskLevel
+    type: Enum
+    description: The risk level selected for the scan
+    enum_values:
+      - NORMAL
+      - LOW

--- a/mmv1/templates/terraform/examples/scan_config_risk_level.tf.tmpl
+++ b/mmv1/templates/terraform/examples/scan_config_risk_level.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_address" "scanner_static_ip" {
+  provider = google-beta
+  name     = "{{index $.Vars "address_name"}}"
+}
+
+resource "google_security_scanner_scan_config" "{{$.PrimaryResourceId}}" {
+  provider         = google-beta
+  display_name     = "{{index $.Vars "scan_config_name"}}"
+  starting_urls    = ["http://${google_compute_address.scanner_static_ip.address}"]
+  target_platforms = ["COMPUTE"]
+  risk_level       = "NORMAL"
+}


### PR DESCRIPTION
This PR adds the `risk_level` field to the `google_security_scanner_scan_config` resource, which allows users to select the risk level for the scan.

```release-note:enhancement
securityscanner: added `risk_level` field to `google_security_scanner_scan_config` resource (beta)
```