### PR TITLE
feat(alloydb): Add trackClientAddress field to AlloyDB observability config

### DIFF
--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -311,6 +311,12 @@ properties:
         include_empty_value_in_cai: true  # Default value is false in CAI asset
         send_empty_value: true
         default_from_api: true
+      - name: 'trackClientAddress'
+        type: Boolean
+        description: 'Track client address for an instance. If not set, default value is "off".'
+        include_empty_value_in_cai: true  # Default value is false in CAI asset
+        send_empty_value: true
+        default_from_api: true
       - name: 'assistiveExperiencesEnabled'
         type: Boolean
         description: 'Whether assistive experiences are enabled for this AlloyDB instance.'

--- a/mmv1/templates/terraform/custom_expand/alloydb_instance_observability_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/alloydb_instance_observability_config.go.tmpl
@@ -59,6 +59,13 @@ func expandAlloydbInstanceObservabilityConfig(v interface{}, d tpgresource.Terra
 		transformed["trackActiveQueries"] = transformedTrackActiveQueries
 	}
 
+	transformedTrackClientAddress, err := expandAlloydbInstanceObservabilityConfigTrackClientAddress(original["track_client_address"], d, config)
+	if err != nil {
+		return nil, err
+	} else if transformedTrackClientAddress != nil {
+		transformed["trackClientAddress"] = transformedTrackClientAddress
+	}
+
 	transformedAssistiveExperiencesEnabled, err := expandAlloydbInstanceObservabilityConfigAssistiveExperiencesEnabled(original["assistive_experiences_enabled"], d, config)
 	if err != nil {
 		return nil, err
@@ -99,6 +106,10 @@ func expandAlloydbInstanceObservabilityConfigQueryPlansPerMinute(v interface{}, 
 }
 
 func expandAlloydbInstanceObservabilityConfigTrackActiveQueries(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandAlloydbInstanceObservabilityConfigTrackClientAddress(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/alloydb/resource_alloydb_instance_test.go.tmpl
@@ -1595,6 +1595,7 @@ func TestAccAlloydbInstance_ObservabilityConfig_Update(t *testing.T) {
 		"record_application_tags":       true,
 		"query_plans_per_minute":        10,
 		"track_active_queries":          true,
+		"track_client_address":          true,
 		"assistive_experiences_enabled": false,
 	}
 
@@ -1614,6 +1615,7 @@ func TestAccAlloydbInstance_ObservabilityConfig_Update(t *testing.T) {
 		"record_application_tags":       false,
 		"query_plans_per_minute":        5,
 		"track_active_queries":          false,
+		"track_client_address":          false,
 		"assistive_experiences_enabled": false,
 	}
 
@@ -1698,6 +1700,7 @@ resource "google_alloydb_instance" "default" {
     record_application_tags        = %{record_application_tags}
     query_plans_per_minute         = %{query_plans_per_minute}
     track_active_queries           = %{track_active_queries}
+    track_client_address           = %{track_client_address}
     assistive_experiences_enabled  = %{assistive_experiences_enabled}
   }
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Adds the trackClientAddress field to observability_config in google_alloydb_instance.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
alloydb: added `track_client_address` field to `google_alloydb_instance` resource
```