### PR TITLE
Migrate data_source_google_compute_region_instance_group to use trans…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_instance_group.go
@@ -9,13 +9,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	"google.golang.org/api/googleapi"
-{{- if eq $.TargetVersionName "ga" }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func DataSourceGoogleComputeRegionInstanceGroup() *schema.Resource {
@@ -95,7 +88,7 @@ func DataSourceGoogleComputeRegionInstanceGroup() *schema.Resource {
 
 func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -105,18 +98,30 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 		return err
 	}
 	id := fmt.Sprintf("projects/%s/regions/%s/instanceGroups/%s", project, region, name)
-	instanceGroup, err := NewClient(config, userAgent).RegionInstanceGroups.Get(
-		project, region, name).Do()
+
+	instanceGroupUrl := fmt.Sprintf("%sprojects/%s/regions/%s/instanceGroups/%s", config.ComputeBasePath, project, region, name)
+	instanceGroup, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    instanceGroupUrl,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("Region Instance Group %q", name), id)
 	}
 
-	members, err := NewClient(config, userAgent).RegionInstanceGroups.ListInstances(
-		project, region, name, &compute.RegionInstanceGroupsListInstancesRequest{
-			InstanceState: "ALL",
-		}).Do()
+	listInstancesUrl := fmt.Sprintf("%sprojects/%s/regions/%s/instanceGroups/%s/listInstances", config.ComputeBasePath, project, region, name)
+	members, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    listInstancesUrl,
+		UserAgent: userAgent,
+		Body:      map[string]any{"instanceState": "ALL"},
+	})
 	if err != nil {
-		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+		if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 			// The resource doesn't have any instances, which is okay.
 			if err := d.Set("instances", nil); err != nil {
 				return fmt.Errorf("Error setting instances: %s", err)
@@ -125,12 +130,12 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 			return fmt.Errorf("Error reading RegionInstanceGroup Members: %s", err)
 		}
 	} else {
-		if err := d.Set("instances", flattenInstancesWithNamedPorts(members.Items)); err != nil {
+		if err := d.Set("instances", flattenRegionInstanceGroupInstances(members["items"])); err != nil {
 			return fmt.Errorf("Error setting instances: %s", err)
 		}
 	}
 	d.SetId(id)
-	if err := d.Set("self_link", instanceGroup.SelfLink); err != nil {
+	if err := d.Set("self_link", instanceGroup["selfLink"]); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
 	if err := d.Set("name", name); err != nil {
@@ -145,35 +150,51 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func flattenInstancesWithNamedPorts(insts []*compute.InstanceWithNamedPorts) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(insts))
-	log.Printf("There were %d instances.\n", len(insts))
-	for _, inst := range insts {
-		instMap := make(map[string]interface{})
-		instMap["instance"] = inst.Instance
-		instMap["named_ports"] = flattenNamedPorts(inst.NamedPorts)
-		instMap["status"] = inst.Status
-		result = append(result, instMap)
+func flattenRegionInstanceGroupInstances(insts interface{}) []map[string]interface{} {
+	rawInsts, ok := insts.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(rawInsts))
+	log.Printf("There were %d instances.\n", len(rawInsts))
+	for _, rawInst := range rawInsts {
+		inst, ok := rawInst.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"instance":    inst["instance"],
+			"named_ports": flattenRegionInstanceGroupNamedPorts(inst["namedPorts"]),
+			"status":      inst["status"],
+		})
 	}
 	return result
 }
 
-func flattenNamedPorts(namedPorts []*compute.NamedPort) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(namedPorts))
-	for _, namedPort := range namedPorts {
-		namedPortMap := make(map[string]interface{})
-		namedPortMap["name"] = namedPort.Name
-		namedPortMap["port"] = namedPort.Port
-		result = append(result, namedPortMap)
+func flattenRegionInstanceGroupNamedPorts(namedPorts interface{}) []map[string]interface{} {
+	rawPorts, ok := namedPorts.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(rawPorts))
+	for _, rawPort := range rawPorts {
+		namedPort, ok := rawPort.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		result = append(result, map[string]interface{}{
+			"name": namedPort["name"],
+			"port": namedPort["port"],
+		})
 	}
 	return result
 }
 
 func init() {
 	registry.Schema{
-		Name: "google_compute_region_instance_group",
+		Name:        "google_compute_region_instance_group",
 		ProductName: "compute",
-		Type: registry.SchemaTypeDataSource,
-		Schema: DataSourceGoogleComputeRegionInstanceGroup(),
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceGoogleComputeRegionInstanceGroup(),
 	}.Register()
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
@@ -606,6 +606,17 @@ func resourceComputeInstanceGroupImportState(d *schema.ResourceData, meta interf
 	return []*schema.ResourceData{d}, nil
 }
 
+func flattenNamedPorts(namedPorts []*compute.NamedPort) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(namedPorts))
+	for _, namedPort := range namedPorts {
+		result = append(result, map[string]interface{}{
+			"name": namedPort.Name,
+			"port": namedPort.Port,
+		})
+	}
+	return result
+}
+
 func init() {
 	registry.Schema{
 		Name: "google_compute_instance_group",


### PR DESCRIPTION
…port_tpg.SendRequest

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_region_instance_group` data source to use direct HTTP rather than a client library
```