### PR TITLE
cloudscheduler: fix headers drift when oidc_token/oauth_token is set

### DIFF
--- a/mmv1/templates/terraform/constants/scheduler.tmpl
+++ b/mmv1/templates/terraform/constants/scheduler.tmpl
@@ -68,6 +68,14 @@ func validateHttpHeaders() schema.SchemaValidateFunc {
 			es = append(es, fmt.Errorf("Cannot set the Content-Length header on %s", k))
 			return
 		}
+		// Warn (don't reject) on Authorization: legitimate use cases exist
+		// when no oidc_token / oauth_token is configured, but combining the
+		// two leads to drift because Cloud Scheduler overwrites the value
+		// server-side. The flattener strips Authorization on read in that
+		// case to keep state consistent.
+		if _, ok := headers["Authorization"]; ok {
+			s = append(s, fmt.Sprintf("Setting the Authorization header on %s is discouraged when http_target.oidc_token or http_target.oauth_token is configured; the API will overwrite it.", k))
+		}
 		r := regexp.MustCompile(`(X-Google-|X-AppEngine-).*`)
 		for key := range headers {
 			if r.MatchString(key) {

--- a/mmv1/templates/terraform/custom_flatten/http_headers.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/http_headers.tmpl
@@ -42,5 +42,29 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
       delete(headers, key)
     }
   }
+  // The Cloud Scheduler API injects an `Authorization` header on read whenever
+  // `oidc_token` or `oauth_token` is configured on the http_target, even though
+  // it is not part of the user-supplied `headers` map. Leaving it in state
+  // causes perpetual drift against the configuration. Strip it only when one
+  // of the token blocks is set, so users who legitimately send a literal
+  // `Authorization` header (without token auth) are not affected.
+  //
+  // Note: this template is also used for `app_engine_http_target.headers`,
+  // which has no `oidc_token` / `oauth_token` siblings — the d.Get() lookups
+  // below return zero-valued counts in that case, so the Authorization key is
+  // preserved as-is for App Engine targets.
+  if d != nil {
+    oidcSet := false
+    oauthSet := false
+    if v, ok := d.Get("http_target.0.oidc_token.#").(int); ok && v > 0 {
+      oidcSet = true
+    }
+    if v, ok := d.Get("http_target.0.oauth_token.#").(int); ok && v > 0 {
+      oauthSet = true
+    }
+    if oidcSet || oauthSet {
+      delete(headers, "Authorization")
+    }
+  }
 	return headers
 }

--- a/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_internal_test.go
+++ b/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_internal_test.go
@@ -84,6 +84,22 @@ func TestCloudScheduler_FlattenHttpHeaders(t *testing.T) {
 				"My-Header": "my-header-value",
 			},
 		},
+
+		// Authorization header without oidc_token / oauth_token is preserved.
+		// d here is an empty ResourceData, so the flattener has no token
+		// blocks to detect and must leave the user-supplied value alone.
+		// This protects users who legitimately send a literal Authorization
+		// header from regression.
+		{
+			Input: map[string]interface{}{
+				"Authorization": "Bearer user-managed-value",
+				"My-Header":     "my-header-value",
+			},
+			Output: map[string]interface{}{
+				"Authorization": "Bearer user-managed-value",
+				"My-Header":     "my-header-value",
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -91,6 +107,109 @@ func TestCloudScheduler_FlattenHttpHeaders(t *testing.T) {
 		output := flattenCloudSchedulerJobAppEngineHttpTargetHeaders(c.Input, d, &transport_tpg.Config{})
 		if !reflect.DeepEqual(output, c.Output) {
 			t.Fatalf("Error matching output and expected: %#v vs %#v", output, c.Output)
+		}
+	}
+}
+
+// TestCloudScheduler_FlattenHttpHeaders_AuthorizationStrippedWithOidc verifies
+// the regression fix for headers + oidc_token drift: when an oidc_token block
+// is present on http_target, the Cloud Scheduler API injects an `Authorization`
+// header on read. The flattener must drop it so it does not appear in state
+// and cause a perpetual diff against the user-supplied `headers` map.
+func TestCloudScheduler_FlattenHttpHeaders_AuthorizationStrippedWithOidc(t *testing.T) {
+	cases := map[string]struct {
+		StateOidcCount  int
+		StateOauthCount int
+		Input           map[string]interface{}
+		Output          map[string]interface{}
+	}{
+		"oidc_token set strips Authorization": {
+			StateOidcCount: 1,
+			Input: map[string]interface{}{
+				"Authorization": "Bearer ya29.injected-by-gcp",
+				"My-Header":     "my-header-value",
+			},
+			Output: map[string]interface{}{
+				"My-Header": "my-header-value",
+			},
+		},
+		"oauth_token set strips Authorization": {
+			StateOauthCount: 1,
+			Input: map[string]interface{}{
+				"Authorization": "Bearer ya29.injected-by-gcp",
+				"My-Header":     "my-header-value",
+			},
+			Output: map[string]interface{}{
+				"My-Header": "my-header-value",
+			},
+		},
+		"no token block preserves Authorization": {
+			Input: map[string]interface{}{
+				"Authorization": "Bearer user-managed",
+				"My-Header":     "my-header-value",
+			},
+			Output: map[string]interface{}{
+				"Authorization": "Bearer user-managed",
+				"My-Header":     "my-header-value",
+			},
+		},
+	}
+
+	// Minimal schema mirroring the http_target shape the flattener inspects
+	// via d.Get("http_target.0.oidc_token.#") / oauth_token.
+	schemaMap := map[string]*schema.Schema{
+		"http_target": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"oidc_token": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"service_account_email": {Type: schema.TypeString, Required: true},
+							},
+						},
+					},
+					"oauth_token": {
+						Type:     schema.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"service_account_email": {Type: schema.TypeString, Required: true},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		raw := map[string]interface{}{}
+		if tc.StateOidcCount > 0 || tc.StateOauthCount > 0 {
+			ht := map[string]interface{}{}
+			if tc.StateOidcCount > 0 {
+				ht["oidc_token"] = []interface{}{
+					map[string]interface{}{"service_account_email": "sa@example.iam.gserviceaccount.com"},
+				}
+			}
+			if tc.StateOauthCount > 0 {
+				ht["oauth_token"] = []interface{}{
+					map[string]interface{}{"service_account_email": "sa@example.iam.gserviceaccount.com"},
+				}
+			}
+			raw["http_target"] = []interface{}{ht}
+		}
+
+		d := schema.TestResourceDataRaw(t, schemaMap, raw)
+		output := flattenCloudSchedulerJobHttpTargetHeaders(tc.Input, d, &transport_tpg.Config{})
+		if !reflect.DeepEqual(output, tc.Output) {
+			t.Fatalf("%s: got %#v, want %#v", tn, output, tc.Output)
 		}
 	}
 }


### PR DESCRIPTION
Fixes a perpetual diff on `google_cloud_scheduler_job.http_target.headers` when `oidc_token` or `oauth_token` is configured. The Cloud Scheduler API injects an `Authorization` header server-side in that case, which the existing flattener was not stripping — so the API-injected value landed in state and Terraform repeatedly tried to remove it.

The fix is gated on the presence of one of the token blocks under `http_target`, so:

- Pub/Sub-only jobs (no `http_target` block at all) are unaffected.
- `app_engine_http_target.headers` (which has no `oidc_token`/`oauth_token` siblings) is unaffected.
- Users who set a literal `Authorization` header without token auth keep the existing preservation behaviour.

A validation warning (not an error) is also surfaced when both `Authorization` and a token block are configured, so users see a hint before hitting the drift.

### Tests
- New unit test `TestCloudScheduler_FlattenHttpHeaders_AuthorizationStrippedWithOidc` covers the oidc-set, oauth-set, and no-token cases against the http_target flattener using a populated `*schema.ResourceData`.
- Extended `TestCloudScheduler_FlattenHttpHeaders` with a regression case asserting the App Engine flattener still preserves a literal `Authorization` header (pubsub/app-engine safety guard).

No related upstream issue found in `hashicorp/terraform-provider-google`, so no `Fixes` link.

```release-note:bug
cloudscheduler: fixed perpetual diff on `google_cloud_scheduler_job.http_target.headers` when `oidc_token` or `oauth_token` is set
```