### PR TITLE
Migrated compute machine types datasource to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_machine_types.go.tmpl
@@ -3,17 +3,14 @@ package compute
 import (
 	"context"
 	"fmt"
+	neturl "net/url"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-{{- if eq $.TargetVersionName "ga" }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func DataSourceGoogleComputeMachineTypes() *schema.Resource {
@@ -170,15 +167,31 @@ func dataSourceGoogleComputeMachineTypesRead(ctx context.Context, d *schema.Reso
 	token := ""
 
 	for paginate := true; paginate; {
-		resp, err := config.NewComputeClient(userAgent).MachineTypes.List(project, zone).Context(ctx).Filter(filter).PageToken(token).Do()
+		params := neturl.Values{}
+		if filter != "" {
+			params.Set("filter", filter)
+		}
+		if token != "" {
+			params.Set("pageToken", token)
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/machineTypes", config.ComputeBasePath, project, zone)
+		if len(params) > 0 {
+			url = fmt.Sprintf("%s?%s", url, params.Encode())
+		}
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("Error retrieving machine types: %w", err))
-
 		}
-		pageMachineTypes := flattenDatasourceGoogleComputeMachineTypesList(ctx, resp.Items)
+		pageMachineTypes := flattenDatasourceGoogleComputeMachineTypesListV2(resp["items"])
 		machineTypes = append(machineTypes, pageMachineTypes...)
 
-		token = resp.NextPageToken
+		token, _ = resp["nextPageToken"].(string)
 		paginate = token != ""
 	}
 
@@ -199,49 +212,65 @@ func dataSourceGoogleComputeMachineTypesRead(ctx context.Context, d *schema.Reso
 	return diag.Diagnostics{}
 }
 
-func flattenDatasourceGoogleComputeMachineTypesList(ctx context.Context, v []*compute.MachineType) []map[string]interface{} {
-	if v == nil {
+func flattenDatasourceGoogleComputeMachineTypesListV2(v interface{}) []map[string]interface{} {
+	items, ok := v.([]interface{})
+	if !ok || items == nil {
 		return make([]map[string]interface{}, 0)
 	}
 
-	machineTypes := make([]map[string]interface{}, 0, len(v))
-	for _, mt := range v {
-		accelerators := make([]map[string]interface{}, len(mt.Accelerators))
-		for i, a := range mt.Accelerators {
-			accelerators[i] = map[string]interface{}{
-				"guest_accelerator_type":  a.GuestAcceleratorType,
-				"guest_accelerator_count": a.GuestAcceleratorCount,
+	machineTypes := make([]map[string]interface{}, 0, len(items))
+	for _, raw := range items {
+		mt, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var accelerators []map[string]interface{}
+		if rawAccels, ok := mt["accelerators"].([]interface{}); ok {
+			accelerators = make([]map[string]interface{}, 0, len(rawAccels))
+			for _, rawAccel := range rawAccels {
+				a, ok := rawAccel.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				accelerators = append(accelerators, map[string]interface{}{
+					"guest_accelerator_type":  a["guestAcceleratorType"],
+					"guest_accelerator_count": a["guestAcceleratorCount"],
+				})
 			}
 		}
 		{{- if ne $.TargetVersionName "ga" }}
 		var localSSDs []map[string]interface{}
-		if bls := mt.BundledLocalSsds; bls != nil {
+		if bls, ok := mt["bundledLocalSsds"].(map[string]interface{}); ok {
 			localSSDs = []map[string]interface{}{
 				{
-					"default_interface": bls.DefaultInterface,
-					"partition_count":   bls.PartitionCount,
+					"default_interface": bls["defaultInterface"],
+					"partition_count":   bls["partitionCount"],
 				},
 			}
 		}
 		{{- end }}
+		var maxPersistentDisksSizeGb int64
+		if s, ok := mt["maximumPersistentDisksSizeGb"].(string); ok {
+			maxPersistentDisksSizeGb, _ = strconv.ParseInt(s, 10, 64)
+		}
 		machineType := map[string]interface{}{
-			"name":                             mt.Name,
-			"guest_cpus":                       mt.GuestCpus,
-			"memory_mb":                        mt.MemoryMb,
+			"name":                             mt["name"],
+			"guest_cpus":                       mt["guestCpus"],
+			"memory_mb":                        mt["memoryMb"],
 			{{- if ne $.TargetVersionName "ga" }}
 			"bundled_local_ssds":               localSSDs,
 			{{- end }}
-			"maximum_persistent_disks":         mt.MaximumPersistentDisks,
-			"maximum_persistent_disks_size_gb": mt.MaximumPersistentDisksSizeGb,
-			"description":                      mt.Description,
-			"is_shared_cpus":                   mt.IsSharedCpu,
+			"maximum_persistent_disks":         mt["maximumPersistentDisks"],
+			"maximum_persistent_disks_size_gb": maxPersistentDisksSizeGb,
+			"description":                      mt["description"],
+			"is_shared_cpus":                   mt["isSharedCpu"],
 			"accelerators":                     accelerators,
-			"self_link":                        mt.SelfLink,
+			"self_link":                        mt["selfLink"],
 		}
-		if dep := mt.Deprecated; dep != nil {
+		if dep, ok := mt["deprecated"].(map[string]interface{}); ok {
 			d := map[string]interface{}{
-				"replacement": dep.Replacement,
-				"state":       dep.State,
+				"replacement": dep["replacement"],
+				"state":       dep["state"],
 			}
 			machineType["deprecated"] = []map[string]interface{}{d}
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `data_source_google_compute_machine_types` datasource to use direct HTTP rather than a client library
```
