### PR TITLE
Add resource manager tags to Image

### DIFF
--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -186,6 +186,26 @@ properties:
     description: Labels to apply to this Image.
     update_url: 'projects/{{project}}/global/images/{{name}}/setLabels'
     update_verb: 'POST'
+  - name: "params"
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload.
+    properties:
+      - name: "resourceManagerTags"
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the image. Tag keys and values have the
+          same definition as resource manager tags. Keys and values can be either in numeric format,
+          such as tagKeys/{tag_key_id} and tagValues/{tag_value_id} or in namespaced format such as
+          {org_id|projectId}/{tag_key_short_name} and {tag_value_short_name}. The field is ignored when empty.
+          The field is immutable and causes resource replacement when mutated. This field is only
+          set at create time and modifying this field after creation will trigger recreation.
+          To apply tags to an existing resource, see the google_tags_tag_binding resource.
+        api_name: "resourceManagerTags"
+        ignore_read: true
+        immutable: true
   - name: 'labelFingerprint'
     type: Fingerprint
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -1111,4 +1112,69 @@ resource "google_compute_image" "image" {
   ]
 }
 `, kmsRingName, kmsKeyName, suffix, suffix)
+}
+
+func TestAccComputeImage_resourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"project_id":    envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeImageDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeImage_resourceManagerTags(context),
+			},
+			{
+				ResourceName:            "google_compute_image.image_with_resource_manager_tags",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"params", "raw_disk"},
+			},
+		},
+	})
+}
+
+func testAccComputeImage_resourceManagerTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_tags_tag_key" "tag_key" {
+  parent      = "projects/%{project_id}"
+  short_name  = "image-tag-%{random_suffix}"
+  description = "Tag key for image acceptance tests"
+}
+
+resource "google_tags_tag_value" "tag_value_1" {
+  parent      = google_tags_tag_key.tag_key.id
+  short_name  = "value-one-%{random_suffix}"
+  description = "First tag value for image acceptance tests"
+}
+
+resource "google_tags_tag_value" "tag_value_2" {
+  parent      = google_tags_tag_key.tag_key.id
+  short_name  = "value-two-%{random_suffix}"
+  description = "Second tag value for image acceptance tests"
+
+  # Serialize value creation for stable VCR recordings.
+  depends_on = [google_tags_tag_value.tag_value_1]
+}
+data "google_compute_image" "debian" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+resource "google_compute_image" "image_with_resource_manager_tags" {
+  name = "tf-test-image-rmt%{random_suffix}"
+  source_image = data.google_compute_image.debian.self_link
+
+  params {
+    resource_manager_tags = {
+      (google_tags_tag_key.tag_key.id) = google_tags_tag_value.tag_value_1.id
+    }
+  }
+}
+`, context)
 }


### PR DESCRIPTION
Added resource manager tags support to Image.

```release-note:enhancement
compute: added `params.resourceManagerTags` field to `google_compute_image`
```
