### PR TITLE
feat(bigqueryconnection): add `configuration` block to `google_bigquery_connection`

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -153,6 +153,20 @@ examples:
     ignore_read_extra:
       # password removed
       - 'cloud_sql.0.credential'
+  - name: 'bigquery_connection_connector_configuration'
+    primary_resource_id: 'connection'
+    vars:
+      connection_id: 'my-connection'
+      username: 'user'
+      password: 'password'
+    test_vars_overrides:
+      username: '"user" + randomSuffix'
+    ignore_read_extra:
+      # password removed
+      - 'configuration.0.authentication.0.username_password.0.password'
+    external_providers: ["random", "time"]
+    # Random provider
+    skip_vcr: true
 parameters:
 properties:
   - name: 'name'
@@ -209,6 +223,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'instanceId'
         type: String
@@ -261,6 +276,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'accessRole'
         type: NestedObject
@@ -295,6 +311,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'application'
         type: String
@@ -340,6 +357,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'database'
         type: String
@@ -397,6 +415,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'serviceAccountId'
         type: String
@@ -416,6 +435,7 @@ properties:
       - 'cloud_spanner'
       - 'cloud_resource'
       - 'spark'
+      - 'configuration'
     properties:
       - name: 'serviceAccountId'
         type: String
@@ -436,3 +456,94 @@ properties:
           - name: 'dataprocCluster'
             type: String
             description: Resource name of an existing Dataproc Cluster to act as a Spark History Server for the connection if the form of projects/[projectId]/regions/[region]/clusters/[cluster_name].
+  - name: 'configuration'
+    type: NestedObject
+    description: |
+      Connector configuration. This is a generic configuration that is used to connect to
+      external data sources such as AlloyDB, MySQL, and PostgreSQL using the BigQuery
+      Connector framework.
+    exactly_one_of:
+      - 'cloud_sql'
+      - 'aws'
+      - 'azure'
+      - 'cloud_spanner'
+      - 'cloud_resource'
+      - 'spark'
+      - 'configuration'
+    properties:
+      - name: 'connectorId'
+        type: String
+        description: |
+          The ID of the connector. Possible values include `google-alloydb`, `google-cloudsql-mysql`,
+          `google-cloudsql-postgres`, and other connector IDs supported by the BigQuery Connector framework.
+        required: true
+        immutable: true
+      - name: 'endpoint'
+        type: NestedObject
+        description: Endpoint configuration for the connector.
+        properties:
+          - name: 'hostPort'
+            type: String
+            description: |
+              Host and port in the format of `host:port` for the connector endpoint.
+      - name: 'authentication'
+        type: NestedObject
+        description: Authentication configuration for the connector.
+        properties:
+          - name: 'usernamePassword'
+            type: NestedObject
+            description: Username/password authentication configuration.
+            custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_configuration_authentication_flatten.go.tmpl'
+            properties:
+              - name: 'username'
+                type: String
+                description: Username for the connector.
+                required: true
+              - name: 'password'
+                type: NestedObject
+                description: Password configuration for the connector.
+                required: true
+                properties:
+                  - name: 'plaintext'
+                    type: String
+                    description: The plaintext password.
+                    required: true
+                    sensitive: true
+                  - name: 'secretType'
+                    type: String
+                    description: |
+                      Output only. The type of the secret.
+                    output: true
+          - name: 'serviceAccount'
+            type: String
+            description: |
+              Output only. The service account used for authenticating with the connector.
+            output: true
+      - name: 'network'
+        type: NestedObject
+        description: Network configuration for the connector.
+        properties:
+          - name: 'privateServiceConnect'
+            type: NestedObject
+            description: Private Service Connect configuration for the connector.
+            properties:
+              - name: 'networkAttachment'
+                type: String
+                description: |
+                  The resource name of a network attachment in the format of
+                  `projects/{project}/regions/{region}/networkAttachments/{networkAttachment}`.
+                required: true
+      - name: 'asset'
+        type: NestedObject
+        description: Asset configuration for the connector.
+        required: true
+        properties:
+          - name: 'database'
+            type: String
+            description: The name of the database.
+          - name: 'googleCloudResource'
+            type: String
+            description: |
+              The full resource name of the Google Cloud resource.
+              For AlloyDB, this is in the format of
+              `//alloydb.googleapis.com/projects/{project}/locations/{region}/clusters/{cluster}/instances/{instance}`.

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -162,7 +162,8 @@ examples:
     test_vars_overrides:
       username: '"user" + randomSuffix'
     ignore_read_extra:
-      # password removed
+      # username and password are not returned by the API
+      - 'configuration.0.authentication.0.username_password.0.username'
       - 'configuration.0.authentication.0.username_password.0.password'
     external_providers: ["random", "time"]
     # Random provider

--- a/mmv1/templates/terraform/custom_flatten/bigquery_connection_configuration_authentication_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/bigquery_connection_configuration_authentication_flatten.go.tmpl
@@ -1,0 +1,24 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"username": d.Get("configuration.0.authentication.0.username_password.0.username"),
+			"password": []interface{}{
+				map[string]interface{}{
+					"plaintext": d.Get("configuration.0.authentication.0.username_password.0.password.0.plaintext"),
+				},
+			},
+		},
+	}
+}

--- a/mmv1/templates/terraform/examples/bigquery_connection_connector_configuration.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_connector_configuration.tf.tmpl
@@ -9,6 +9,8 @@ resource "google_alloydb_cluster" "default" {
     password = "alloydb-cluster-password"
   }
 
+  deletion_protection = false
+
   lifecycle {
     ignore_changes = [initial_user]
   }
@@ -22,10 +24,26 @@ resource "google_alloydb_instance" "default" {
   machine_config {
     cpu_count = 2
   }
+
+  depends_on = [google_service_networking_connection.vpc_connection]
 }
 
 resource "google_compute_network" "default" {
   name = "alloydb-network-${local.name_suffix}"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          = "alloydb-ip-${local.name_suffix}"
+  address_type  = "INTERNAL"
+  purpose       = "VPC_PEERING"
+  prefix_length = 16
+  network       = google_compute_network.default.id
+}
+
+resource "google_service_networking_connection" "vpc_connection" {
+  network                 = google_compute_network.default.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
 }
 
 locals {

--- a/mmv1/templates/terraform/examples/bigquery_connection_connector_configuration.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_connection_connector_configuration.tf.tmpl
@@ -1,0 +1,56 @@
+resource "google_alloydb_cluster" "default" {
+  cluster_id = "alloydb-cluster-${local.name_suffix}"
+  location   = "us-central1"
+  network_config {
+    network = google_compute_network.default.id
+  }
+
+  initial_user {
+    password = "alloydb-cluster-password"
+  }
+
+  lifecycle {
+    ignore_changes = [initial_user]
+  }
+}
+
+resource "google_alloydb_instance" "default" {
+  cluster       = google_alloydb_cluster.default.name
+  instance_id   = "alloydb-instance-${local.name_suffix}"
+  instance_type = "PRIMARY"
+
+  machine_config {
+    cpu_count = 2
+  }
+}
+
+resource "google_compute_network" "default" {
+  name = "alloydb-network-${local.name_suffix}"
+}
+
+locals {
+  name_suffix = "{{index $.Vars "connection_id"}}"
+}
+
+resource "google_bigquery_connection" "{{$.PrimaryResourceId}}" {
+  connection_id = "{{index $.Vars "connection_id"}}"
+  location      = "us-central1"
+  friendly_name = "alloydb connection"
+  description   = "AlloyDB connection using connector configuration"
+
+  configuration {
+    connector_id = "google-alloydb"
+    asset {
+      database              = "postgres"
+      google_cloud_resource = "//alloydb.googleapis.com/${google_alloydb_instance.default.id}"
+    }
+    authentication {
+      username_password {
+        username = "{{index $.Vars "username"}}"
+        password {
+          plaintext = "{{index $.Vars "password"}}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for the `configuration` block (ConnectorConfiguration) to the `google_bigquery_connection` resource. This enables users to create BigQuery connections using the new Connector framework, which supports AlloyDB, Cloud SQL (MySQL/PostgreSQL), and other connector types.

### Background

The BigQuery Connection API v1 supports AlloyDB connections via the `ConnectorConfiguration` framework (with `connector_id: "google-alloydb"`), which is a fully typed schema in the [Discovery API](https://bigqueryconnection.googleapis.com/$discovery/rest?version=v1). However, the Terraform provider currently only supports the legacy connection types (`cloud_sql`, `aws`, `azure`, `cloud_spanner`, `cloud_resource`, `spark`) and does not support the newer `configuration` field.

### Changes

- Added `configuration` block to `google_bigquery_connection` resource in `Connection.yaml`
  - `connector_id` (required, immutable) - e.g., `google-alloydb`
  - `endpoint` - host/port configuration
  - `authentication` - username/password or service account
  - `network` - Private Service Connect configuration
  - `asset` (required) - database and Google Cloud resource reference
- Added `configuration` to `exactly_one_of` constraint for all existing connection types
- Added custom flatten template for authentication (password is redacted by the API on read)
- Added example/test for AlloyDB connection using `configuration` block

### Example Usage

```hcl
resource "google_bigquery_connection" "alloydb" {
  connection_id = "my-alloydb-connection"
  location      = "us-central1"

  configuration {
    connector_id = "google-alloydb"
    asset {
      database              = "mydb"
      google_cloud_resource = "//alloydb.googleapis.com/projects/my-project/locations/us-central1/clusters/my-cluster/instances/my-instance"
    }
    authentication {
      username_password {
        username = "user"
        password {
          plaintext = "password"
        }
      }
    }
  }
}
```

## Release Note

```release-note:enhancement
bigqueryconnection: added `configuration` block to `google_bigquery_connection` resource to support AlloyDB and other connector types via the BigQuery Connector framework
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/18663