### PR TITLE
fix(alloydb): allow hours=0 in maintenance window start time

### DIFF
--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -652,18 +652,22 @@ properties:
                   description: |
                     Hours of day in 24 hour format. Should be from 0 to 23.
                   required: true
+                  send_empty_value: true
                 - name: 'minutes'
                   type: Integer
                   description: |
                     Minutes of hour of day. Currently, only the value 0 is supported.
+                  send_empty_value: true
                 - name: 'seconds'
                   type: Integer
                   description: |
                     Seconds of minutes of the time. Currently, only the value 0 is supported.
+                  send_empty_value: true
                 - name: 'nanos'
                   type: Integer
                   description: |
                     Fractions of seconds in nanoseconds. Currently, only the value 0 is supported.
+                  send_empty_value: true
   - name: 'subscriptionType'
     type: Enum
     description: |


### PR DESCRIPTION
## Description

Setting `hours = 0` in `maintenance_update_policy.maintenance_windows.start_time` fails with
`"time must be specified"` error because Terraform treats the Go int zero value as "unset" and
omits it from the API request.

This PR adds `send_empty_value: true` to the `hours`, `minutes`, `seconds`, and `nanos` fields
in the `maintenanceWindows.startTime` block, so that zero values are correctly included in API
requests.

### Root cause

In Go, `int(0)` is the zero value for integers. Without `send_empty_value: true`, the generated
Terraform code skips zero values in the expand function, causing the API to receive an empty
`start_time` object `{}` instead of `{"hours": 0, "minutes": 0, "seconds": 0, "nanos": 0}`.

### Changes

- Added `send_empty_value: true` to `hours`, `minutes`, `seconds`, and `nanos` fields in
  `maintenanceUpdatePolicy.maintenanceWindows.startTime` in `Cluster.yaml`

## Release Note

```release-note:bug
alloydb: fixed `google_alloydb_cluster` so that `maintenance_update_policy.maintenance_windows.start_time.hours` can be set to `0` (midnight)
```

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/24388