### PR TITLE
fix: resolve oauth2_client_id permadiff in backend services

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -891,6 +891,7 @@ properties:
         description: |
           OAuth2 Client ID for IAP
         send_empty_value: true
+        diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress(" ")'
       - name: 'oauth2ClientSecret'
         type: String
         description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -901,6 +901,7 @@ properties:
         description: |
           OAuth2 Client ID for IAP
         send_empty_value: true
+        diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress(" ")'
       - name: 'oauth2ClientSecret'
         type: String
         description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -3436,3 +3436,44 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, tagKey, tagValue, checkName)
 }
+
+func TestAccComputeBackendService_iapOauthClientIdPermadiff(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": tpgresource.RandString(t, 10),
+	}
+
+	tpgresource.VCRTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: tpgresource.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Explicitly set to a single space (simulating API state)
+				Config: testAccComputeBackendService_iapOauthClientId(context, " "),
+			},
+			{
+				// Step 2: Remove it from config (set to empty)
+				// With the fix, this should NOT trigger an update.
+				Config: testAccComputeBackendService_iapOauthClientId(context, ""),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testAccComputeBackendService_iapOauthClientId(context map[string]interface{}, clientId string) string {
+	context["client_id"] = clientId
+	return tpgresource.Nprintf(`
+resource "google_compute_backend_service" "myservice" {
+  name = "tf-test-iap-diff-%{random_suffix}"
+  iap {
+    enabled = true
+    oauth2_client_id = "%{client_id}"
+    oauth2_client_secret = "my-secret"
+  }
+  load_balancing_scheme = "EXTERNAL"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -3441,12 +3441,12 @@ func TestAccComputeBackendService_iapOauthClientIdPermadiff(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": tpgresource.RandString(t, 10),
+		"random_suffix": acctest.RandString(t, 10),
 	}
 
-	tpgresource.VCRTest(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: tpgresource.ProtoV5ProviderFactories(t),
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -3465,7 +3465,7 @@ func TestAccComputeBackendService_iapOauthClientIdPermadiff(t *testing.T) {
 
 func testAccComputeBackendService_iapOauthClientId(context map[string]interface{}, clientId string) string {
 	context["client_id"] = clientId
-	return tpgresource.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_compute_backend_service" "myservice" {
   name = "tf-test-iap-diff-%{random_suffix}"
   iap {

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -252,3 +252,71 @@ func TestBase64DiffSuppress(t *testing.T) {
 		}
 	}
 }
+
+func TestEmptyOrDefaultStringSuppress_IAP(t *testing.T) {
+	// The fix we added: tpgresource.EmptyOrDefaultStringSuppress(" ")
+	suppressor := EmptyOrDefaultStringSuppress(" ")
+
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"API returns space, config is empty": {
+			Old:                " ",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"API returns space, config is null": {
+			Old:                " ",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"Config has space, API returns empty": {
+			Old:                "",
+			New:                " ",
+			ExpectDiffSuppress: true,
+		},
+		"Actual Client ID change (Should NOT suppress)": {
+			Old:                " ",
+			New:                "actual-id",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if suppressor("iap.0.oauth2_client_id", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("failed case %s: Old='%s', New='%s', expected suppress=%t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
+func TestEmptyOrDefaultStringSuppress_IAP(t *testing.T) {
+	suppressor := EmptyOrDefaultStringSuppress(" ")
+
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"API returns space, config is empty": {
+			Old:                " ",
+			New:                "",
+			ExpectDiffSuppress: true,
+		},
+		"Config is empty, API returns space": {
+			Old:                "",
+			New:                " ",
+			ExpectDiffSuppress: true,
+		},
+		"Actual Client ID change (Should NOT suppress)": {
+			Old:                " ",
+			New:                "actual-id",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if suppressor("iap.0.oauth2_client_id", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("failed case %s: Old='%s', New='%s', expected suppress=%t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -290,33 +290,3 @@ func TestEmptyOrDefaultStringSuppress_IAP(t *testing.T) {
 	}
 }
 
-func TestEmptyOrDefaultStringSuppress_IAP(t *testing.T) {
-	suppressor := EmptyOrDefaultStringSuppress(" ")
-
-	cases := map[string]struct {
-		Old, New           string
-		ExpectDiffSuppress bool
-	}{
-		"API returns space, config is empty": {
-			Old:                " ",
-			New:                "",
-			ExpectDiffSuppress: true,
-		},
-		"Config is empty, API returns space": {
-			Old:                "",
-			New:                " ",
-			ExpectDiffSuppress: true,
-		},
-		"Actual Client ID change (Should NOT suppress)": {
-			Old:                " ",
-			New:                "actual-id",
-			ExpectDiffSuppress: false,
-		},
-	}
-
-	for tn, tc := range cases {
-		if suppressor("iap.0.oauth2_client_id", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
-			t.Errorf("failed case %s: Old='%s', New='%s', expected suppress=%t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
-		}
-	}
-}

--- a/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
+++ b/mmv1/third_party/terraform/tpgresource/common_diff_suppress_test.go
@@ -289,4 +289,3 @@ func TestEmptyOrDefaultStringSuppress_IAP(t *testing.T) {
 		}
 	}
 }
-


### PR DESCRIPTION
Resolve permadiff for field iap.oauth2_client_id when API returns a single space.

Fixes b/488425726
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25374

```release-note:bug
compute: fixed permadiff for `iap.oauth2_client_id` in `google_compute_backend_service` and `google_compute_region_backend_service` when the API returns a single space
```