### PR TITLE
Allow setting google_bigquery_dataset.default_collation to empty string

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -41,6 +41,8 @@ include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/bigquery_dataset.go.tmpl'
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
+custom_diff:
+  - 'customCollationDiff'
 # exluding resource_identity due to dataset_id field
 exclude_identity_generation: true
 exclude_sweeper: true
@@ -447,6 +449,8 @@ properties:
       - 'und:ci': undetermined locale, case insensitive.
       - '': empty string. Default to case-sensitive behavior.
     default_from_api: true
+    send_empty_value: true
+    custom_expand: 'templates/terraform/custom_expand/bigquery_dataset_default_collation.go.tmpl'
   - name: 'storageBillingModel'
     type: String
     description: |

--- a/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
@@ -30,6 +30,26 @@ func validateDefaultTableExpirationMs(v interface{}, k string) (ws []string, err
     return
 }
 
+func customCollationDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// 1. Check if the configuration is explicitly set to an empty string.
+	// We use GetRawConfig to see what the user actually wrote,
+	// before the SDK "fills in" computed values.
+	conf := d.GetRawConfig()
+	if !conf.IsNull() && conf.GetAttr("default_collation").IsKnown() && !conf.GetAttr("default_collation").IsNull() {
+		val := conf.GetAttr("default_collation").AsString()
+
+		// 2. If config is "", but the state (old value) is NOT "", force an update.
+		old, _ := d.GetChange("default_collation")
+		if old != "" && val == "" {
+			// THIS is what goes inside the block:
+			if err := d.SetNew("default_collation", ""); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 {{- if ne $.ProductMetadata.Compiler "terraformgoogleconversion-codegen" }}
 // bigqueryDatasetAccessHash is a custom hash function for the access block.
 // It normalizes

--- a/mmv1/templates/terraform/custom_expand/bigquery_dataset_default_collation.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/bigquery_dataset_default_collation.go.tmpl
@@ -1,0 +1,9 @@
+func expandBigQueryDatasetDefaultCollation(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if rd, ok := d.(*schema.ResourceData); ok {
+		conf := rd.GetRawConfig()
+		if !conf.IsNull() && conf.GetAttr("default_collation").IsKnown() && !conf.GetAttr("default_collation").IsNull() {
+			return conf.GetAttr("default_collation").AsString(), nil
+		}
+	}
+	return v, nil
+}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_dataset_test.go
@@ -565,6 +565,44 @@ func TestAccBigQueryDataset_externalCatalogDatasetOptions_update(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDataset_collationUpdate(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryDatasetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDataset_defaultCollation(datasetID, "und:ci"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_dataset.test", "default_collation", "und:ci"),
+				),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccBigQueryDataset_defaultCollation(datasetID, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_dataset.test", "default_collation", ""),
+				),
+			},
+			{
+				ResourceName:            "google_bigquery_dataset.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
 func testAccAddTable(t *testing.T, datasetID string, tableID string) resource.TestCheckFunc {
 	// Not actually a check, but adds a table independently of terraform
 	return func(s *terraform.State) error {
@@ -1067,4 +1105,16 @@ resource "google_bigquery_dataset" "dataset" {
   }
 }
 `, context)
+}
+
+func testAccBigQueryDataset_defaultCollation(datasetID, collation string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id        = "%s"
+  friendly_name     = "foo"
+  description       = "This is a foo description"
+  location          = "US"
+  default_collation = "%s"
+}
+`, datasetID, collation)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26875.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
bigquery: fixed inability to set `default_collation` to empty string in `google_bigquery_dataset`
```
