### PR TITLE
cloudidentity: Add dynamic group support to google_cloud_identity_group

### DIFF
--- a/mmv1/products/cloudidentity/Group.yaml
+++ b/mmv1/products/cloudidentity/Group.yaml
@@ -58,6 +58,15 @@ examples:
       cust_id: 'CUST_ID'
     # Has a handwritten test due to CloudIdentityGroup-related tests needing to run synchronously
     exclude_test: true
+  - name: 'cloud_identity_groups_dynamic'
+    primary_resource_id: 'cloud_identity_group_dynamic'
+    vars:
+      id_group: 'my-dynamic-group'
+    test_env_vars:
+      org_domain: 'ORG_DOMAIN'
+      cust_id: 'CUST_ID'
+    # Has a handwritten test due to CloudIdentityGroup-related tests needing to run synchronously
+    exclude_test: true
 parameters:
   - name: 'initialGroupConfig'
     type: Enum
@@ -188,3 +197,58 @@ properties:
 
       Identity-mapped groups for Cloud Search have a label with a key of system/groups/external and an empty value.
     required: true
+  - name: 'dynamicGroupMetadata'
+    type: NestedObject
+    description: |
+      Dynamic group metadata. When set, the group's membership is
+      determined dynamically based on a CEL query rather than being
+      explicitly managed. Dynamic groups have a label with a key of
+      cloudidentity.googleapis.com/groups.dynamic which is automatically
+      added by the API.
+    default_from_api: true
+    update_mask_fields:
+      - 'dynamicGroupMetadata.queries'
+    properties:
+      - name: 'queries'
+        type: Array
+        description: |
+          Memberships will be the union of all queries. Only one query is
+          supported currently.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'query'
+              type: String
+              description: |
+                The query string. Must be a CEL expression.
+                Example: `user.organizations.exists(org, org.department=='Engineering')`
+              required: true
+            - name: 'resourceType'
+              type: Enum
+              description: |
+                The resource type that the query is applied to.
+              default_value: "USER"
+              enum_values:
+                - 'USER'
+      - name: 'status'
+        type: NestedObject
+        description: |
+          The current status of the dynamic group.
+        output: true
+        properties:
+          - name: 'status'
+            type: Enum
+            description: |
+              Status of the dynamic group.
+            output: true
+            enum_values:
+              - 'UP_TO_DATE'
+              - 'COMPUTING_MEMBERSHIPS'
+              - 'STATUS_UNSPECIFIED'
+          - name: 'statusTime'
+            type: String
+            description: |
+              The latest time at which the dynamic group is guaranteed
+              to be in the given status. A timestamp in RFC3339 UTC
+              "Zulu" format.
+            output: true

--- a/mmv1/templates/terraform/examples/cloud_identity_groups_dynamic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloud_identity_groups_dynamic.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_cloud_identity_group" "{{$.PrimaryResourceId}}" {
+  display_name         = "{{index $.Vars "id_group"}}"
+  initial_group_config = "EMPTY"
+
+  parent = "customers/{{index $.TestEnvVars "cust_id"}}"
+
+  group_key {
+  	id = "{{index $.Vars "id_group"}}@{{index $.TestEnvVars "org_domain"}}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+
+  dynamic_group_metadata {
+    queries {
+      query         = "user.organizations.exists(org, org.department=='Engineering')"
+      resource_type = "USER"
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudidentity/resource_cloud_identity_group_test.go.tmpl
@@ -35,6 +35,8 @@ func TestAccCloudIdentityGroup(t *testing.T) {
 		"data_source_membership_basic":            testAccDataSourceCloudIdentityGroupMemberships_basicTest,
 		"data_source_transitive_membership_basic": testAccDataSourceCloudIdentityGroupTransitiveMemberships_basicTest,
 		"data_source_group_lookup":                testAccDataSourceCloudIdentityGroupLookup_basicTest,
+		"dynamic":                                 testAccCloudIdentityGroup_dynamicTest,
+		"dynamic_update":                          testAccCloudIdentityGroup_dynamicUpdateTest,
 	}
 
 	for name, tc := range testCases {
@@ -134,6 +136,124 @@ resource "google_cloud_identity_group" "cloud_identity_group_basic" {
 
   labels = {
     "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}
+`, context)
+}
+
+func testAccCloudIdentityGroup_dynamicTest(t *testing.T) {
+	context := map[string]interface{}{
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"cust_id":       envvar.GetTestCustIdFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudIdentityGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudIdentityGroup_dynamic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_identity_group.cloud_identity_group_dynamic",
+						"dynamic_group_metadata.0.queries.0.query",
+						"user.organizations.exists(org, org.department=='Engineering')"),
+					resource.TestCheckResourceAttr("google_cloud_identity_group.cloud_identity_group_dynamic",
+						"dynamic_group_metadata.0.queries.0.resource_type", "USER"),
+				),
+			},
+			{
+				ResourceName:            "google_cloud_identity_group.cloud_identity_group_dynamic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"initial_group_config"},
+			},
+		},
+	})
+}
+
+func testAccCloudIdentityGroup_dynamic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_identity_group" "cloud_identity_group_dynamic" {
+  display_name         = "tf-test-my-dynamic-group%{random_suffix}"
+  initial_group_config = "EMPTY"
+
+  parent = "customers/%{cust_id}"
+
+  group_key {
+    id = "tf-test-my-dynamic-group%{random_suffix}@%{org_domain}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+
+  dynamic_group_metadata {
+    queries {
+      query         = "user.organizations.exists(org, org.department=='Engineering')"
+      resource_type = "USER"
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudIdentityGroup_dynamicUpdateTest(t *testing.T) {
+	context := map[string]interface{}{
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"cust_id":       envvar.GetTestCustIdFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCloudIdentityGroupDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudIdentityGroup_dynamic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_identity_group.cloud_identity_group_dynamic",
+						"dynamic_group_metadata.0.queries.0.query",
+						"user.organizations.exists(org, org.department=='Engineering')"),
+				),
+			},
+			{
+				Config: testAccCloudIdentityGroup_dynamicUpdated(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_cloud_identity_group.cloud_identity_group_dynamic",
+						"dynamic_group_metadata.0.queries.0.query",
+						"user.locations.exists(loc, loc.buildingId=='NYC-01')"),
+					resource.TestCheckResourceAttr("google_cloud_identity_group.cloud_identity_group_dynamic",
+						"display_name", fmt.Sprintf("tf-test-my-dynamic-group%s-updated", context["random_suffix"])),
+				),
+			},
+		},
+	})
+}
+
+func testAccCloudIdentityGroup_dynamicUpdated(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_cloud_identity_group" "cloud_identity_group_dynamic" {
+  display_name         = "tf-test-my-dynamic-group%{random_suffix}-updated"
+  initial_group_config = "EMPTY"
+
+  parent = "customers/%{cust_id}"
+
+  group_key {
+    id = "tf-test-my-dynamic-group%{random_suffix}@%{org_domain}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+
+  dynamic_group_metadata {
+    queries {
+      query         = "user.locations.exists(loc, loc.buildingId=='NYC-01')"
+      resource_type = "USER"
+    }
   }
 }
 `, context)


### PR DESCRIPTION
## Summary

- Adds `dynamic_group_metadata` block to `google_cloud_identity_group`, enabling CEL query-based automatic membership (e.g., `user.organizations.exists(org, org.department=='Engineering')`)
- Uses `update_mask_fields` to send `dynamicGroupMetadata.queries` on updates, matching the Cloud Identity API's expected field path
- Includes documentation example and acceptance tests for create, import, and update flows

## Motivation

This replaces the need for community forked `terraform-provider-googleworkspace` to manage dynamic groups. Since the Cloud Identity API already supports `dynamicGroupMetadata` on the same `groups/{group_id}` endpoint, extending the existing resource is the correct approach rather than creating a separate resource.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudidentity: added `dynamic_group_metadata` field to `google_cloud_identity_group` resource
```
