### PR TITLE
Migrated compute operation to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/templates/terraform/pre_delete/detach_disk.tmpl
+++ b/mmv1/templates/terraform/pre_delete/detach_disk.tmpl
@@ -148,9 +148,13 @@ if v, ok := readRes["users"].([]interface{}); ok {
 			userAgent, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
 			var opErr ComputeOperationError
-			if errors.As(err, &opErr) && len(opErr.Errors) == 1 && opErr.Errors[0].Code == "RESOURCE_NOT_FOUND" {
-				log.Printf("[WARN] instance %q was deleted while awaiting detach", call.instance)
-				continue
+			if errors.As(err, &opErr) {
+				if rawErrors, _ := opErr["errors"].([]interface{}); len(rawErrors) == 1 {
+					if errMap, _ := rawErrors[0].(map[string]interface{}); errMap["code"] == "RESOURCE_NOT_FOUND" {
+						log.Printf("[WARN] instance %q was deleted while awaiting detach", call.instance)
+						continue
+					}
+				}
 			}
 			return err
 		}

--- a/mmv1/third_party/terraform/services/compute/compute_operation.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_operation.go.tmpl
@@ -1,31 +1,26 @@
+{{- /* As a template for version handling */ -}}
 package compute
 
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-  "io"
+	"io"
 	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 type ComputeOperationWaiter struct {
-	Service *compute.Service
-	Op      *compute.Operation
-	Context context.Context
-	Project string
-	Parent  string
+	Config    *transport_tpg.Config
+	UserAgent string
+	Op        map[string]interface{}
+	Context   context.Context
+	Project   string
+	Parent    string
 }
 
 func (w *ComputeOperationWaiter) State() string {
@@ -33,21 +28,32 @@ func (w *ComputeOperationWaiter) State() string {
 		return "<nil>"
 	}
 
-	return w.Op.Status
+	status, _ := w.Op["status"].(string)
+	return status
 }
 
 func (w *ComputeOperationWaiter) Error() error {
-	if w != nil && w.Op != nil && w.Op.Error != nil {
-		return ComputeOperationError(*w.Op.Error)
+	if w != nil && w.Op != nil {
+		if opErr, ok := w.Op["error"]; ok && opErr != nil {
+			errMap, ok := opErr.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("operation error: %v", opErr)
+			}
+			return ComputeOperationError(errMap)
+		}
 	}
 	return nil
 }
 
 func (w *ComputeOperationWaiter) IsRetryable(err error) bool {
 	if oe, ok := err.(ComputeOperationError); ok {
-		for _, e := range oe.Errors {
-			if e.Code == "RESOURCE_NOT_READY" {
-				return true
+		if rawErrors, ok := oe["errors"].([]interface{}); ok {
+			for _, rawErr := range rawErrors {
+				if errMap, ok := rawErr.(map[string]interface{}); ok {
+					if code, _ := errMap["code"].(string); code == "RESOURCE_NOT_READY" {
+						return true
+					}
+				}
 			}
 		}
 	}
@@ -56,7 +62,7 @@ func (w *ComputeOperationWaiter) IsRetryable(err error) bool {
 
 func (w *ComputeOperationWaiter) SetOp(op interface{}) error {
 	var ok bool
-	w.Op, ok = op.(*compute.Operation)
+	w.Op, ok = op.(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("Unable to set operation. Bad type!")
 	}
@@ -76,16 +82,26 @@ func (w *ComputeOperationWaiter) QueryOp() (interface{}, error) {
 			// default must be here to keep the previous case from blocking
 		}
 	}
-	if w.Op.Zone != "" {
-		zone := tpgresource.GetResourceNameFromSelfLink(w.Op.Zone)
-		return w.Service.ZoneOperations.Get(w.Project, zone, w.Op.Name).Do()
-	} else if w.Op.Region != "" {
-		region := tpgresource.GetResourceNameFromSelfLink(w.Op.Region)
-		return w.Service.RegionOperations.Get(w.Project, region, w.Op.Name).Do()
+	opName, _ := w.Op["name"].(string)
+	var url string
+	if zone, ok := w.Op["zone"].(string); ok && zone != "" {
+		zoneName := tpgresource.GetResourceNameFromSelfLink(zone)
+		url = fmt.Sprintf("%sprojects/%s/zones/%s/operations/%s", w.Config.ComputeBasePath, w.Project, zoneName, opName)
+	} else if region, ok := w.Op["region"].(string); ok && region != "" {
+		regionName := tpgresource.GetResourceNameFromSelfLink(region)
+		url = fmt.Sprintf("%sprojects/%s/regions/%s/operations/%s", w.Config.ComputeBasePath, w.Project, regionName, opName)
 	} else if w.Parent != "" {
-		return w.Service.GlobalOrganizationOperations.Get(w.Op.Name).ParentId(w.Parent).Do()
+		url = fmt.Sprintf("%slocations/global/operations/%s?parentId=%s", w.Config.ComputeBasePath, opName, w.Parent)
+	} else {
+		url = fmt.Sprintf("%sprojects/%s/global/operations/%s", w.Config.ComputeBasePath, w.Project, opName)
 	}
-	return w.Service.GlobalOperations.Get(w.Project, w.Op.Name).Do()
+	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    w.Config,
+		Method:    "GET",
+		Project:   w.Project,
+		RawURL:    url,
+		UserAgent: w.UserAgent,
+	})
 }
 
 func (w *ComputeOperationWaiter) OpName() string {
@@ -93,7 +109,8 @@ func (w *ComputeOperationWaiter) OpName() string {
 		return "<nil> Compute Op"
 	}
 
-	return w.Op.Name
+	name, _ := w.Op["name"].(string)
+	return name
 }
 
 func (w *ComputeOperationWaiter) PendingStates() []string {
@@ -105,17 +122,17 @@ func (w *ComputeOperationWaiter) TargetStates() []string {
 }
 
 func ComputeOperationWaitTime(config *transport_tpg.Config, res interface{}, project, activity, userAgent string, timeout time.Duration) error {
-	op := &compute.Operation{}
-	err := tpgresource.Convert(res, op)
+	op, err := tpgresource.ConvertToMap(res)
 	if err != nil {
 		return err
 	}
 
 	w := &ComputeOperationWaiter{
-		Service: config.NewComputeClient(userAgent),
-		Context: config.Context,
-		Op:      op,
-		Project: project,
+		Config:    config,
+		UserAgent: userAgent,
+		Context:   config.Context,
+		Op:        op,
+		Project:   project,
 	}
 
 	if err := w.SetOp(op); err != nil {
@@ -125,16 +142,16 @@ func ComputeOperationWaitTime(config *transport_tpg.Config, res interface{}, pro
 }
 
 func ComputeOrgOperationWaitTimeWithResponse(config *transport_tpg.Config, res interface{}, response *map[string]interface{}, parent, activity, userAgent string, timeout time.Duration) error {
-	op := &compute.Operation{}
-	err := tpgresource.Convert(res, op)
+	op, err := tpgresource.ConvertToMap(res)
 	if err != nil {
 		return err
 	}
 
 	w := &ComputeOperationWaiter{
-		Service: config.NewComputeClient(userAgent),
-		Op:      op,
-		Parent:  parent,
+		Config:    config,
+		UserAgent: userAgent,
+		Op:        op,
+		Parent:    parent,
 	}
 
 	if err := w.SetOp(op); err != nil {
@@ -143,21 +160,22 @@ func ComputeOrgOperationWaitTimeWithResponse(config *transport_tpg.Config, res i
 	if err := tpgresource.OperationWait(w, activity, timeout, config.PollInterval); err != nil {
 		return err
 	}
-	e, err := json.Marshal(w.Op)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(e, response)
+	*response = w.Op
+	return nil
 }
 
-// ComputeOperationError wraps compute.OperationError and implements the
+// ComputeOperationError wraps the error part of an operation response and implements the
 // error interface so it can be returned.
-type ComputeOperationError compute.OperationError
+type ComputeOperationError map[string]interface{}
 
 func (e ComputeOperationError) Error() string {
 	buf := bytes.NewBuffer(nil)
-	for _, err := range e.Errors {
-		writeOperationError(buf, err)
+	if rawErrors, ok := e["errors"].([]interface{}); ok {
+		for _, rawErr := range rawErrors {
+			if errMap, ok := rawErr.(map[string]interface{}); ok {
+				writeOperationError(buf, errMap)
+			}
+		}
 	}
 
 	return buf.String()
@@ -165,55 +183,80 @@ func (e ComputeOperationError) Error() string {
 
 const errMsgSep = "\n\n"
 
-func writeOperationError(w io.StringWriter, opError *compute.OperationErrorErrors) {
-	w.WriteString(opError.Message + "\n")
+func writeOperationError(w io.StringWriter, opError map[string]interface{}) {
+	if msg, ok := opError["message"].(string); ok {
+		w.WriteString(msg + "\n")
+	}
 
-	var lm *compute.LocalizedMessage
-	var link *compute.HelpLink
+	code, _ := opError["code"].(string)
 
-        for _, ed := range opError.ErrorDetails {
-                if opError.Code == "QUOTA_EXCEEDED" && ed.QuotaInfo != nil {
-			w.WriteString("\tmetric name = " + ed.QuotaInfo.MetricName + "\n")
-			w.WriteString("\tlimit name = " + ed.QuotaInfo.LimitName + "\n")
-			if ed.QuotaInfo.Limit != 0 {
-				w.WriteString("\tlimit = " + fmt.Sprint(ed.QuotaInfo.Limit) + "\n")
+	var lmMessage string
+	var linkDescription, linkURL string
+
+	if rawDetails, ok := opError["errorDetails"].([]interface{}); ok {
+		for _, rawDetail := range rawDetails {
+			detail, ok := rawDetail.(map[string]interface{})
+			if !ok {
+				continue
 			}
-			if ed.QuotaInfo.FutureLimit != 0 {
-				w.WriteString("\tfuture limit = " + fmt.Sprint(ed.QuotaInfo.FutureLimit) + "\n")
-				w.WriteString("\trollout status = in progress\n")
+			if code == "QUOTA_EXCEEDED" {
+				if quotaInfo, ok := detail["quotaInfo"].(map[string]interface{}); ok {
+					if v, ok := quotaInfo["metricName"].(string); ok {
+						w.WriteString("\tmetric name = " + v + "\n")
+					}
+					if v, ok := quotaInfo["limitName"].(string); ok {
+						w.WriteString("\tlimit name = " + v + "\n")
+					}
+					if v, ok := quotaInfo["limit"].(float64); ok && v != 0 {
+						w.WriteString("\tlimit = " + fmt.Sprint(v) + "\n")
+					}
+					if v, ok := quotaInfo["futureLimit"].(float64); ok && v != 0 {
+						w.WriteString("\tfuture limit = " + fmt.Sprint(v) + "\n")
+						w.WriteString("\trollout status = in progress\n")
+					}
+					if dims, ok := quotaInfo["dimensions"]; ok && dims != nil {
+						w.WriteString("\tdimensions = " + fmt.Sprint(dims) + "\n")
+					}
+					break
+				}
 			}
-			if ed.QuotaInfo.Dimensions != nil {
-				w.WriteString("\tdimensions = " + fmt.Sprint(ed.QuotaInfo.Dimensions) + "\n")
+			if lmMessage == "" {
+				if lm, ok := detail["localizedMessage"].(map[string]interface{}); ok {
+					if msg, ok := lm["message"].(string); ok {
+						lmMessage = msg
+					}
+				}
 			}
-			break
-		}
-		if lm == nil && ed.LocalizedMessage != nil {
-			lm = ed.LocalizedMessage
-		}
 
-		if link == nil && ed.Help != nil && len(ed.Help.Links) > 0 {
-			link = ed.Help.Links[0]
-		}
+			if linkURL == "" {
+				if help, ok := detail["help"].(map[string]interface{}); ok {
+					if links, ok := help["links"].([]interface{}); ok && len(links) > 0 {
+						if link, ok := links[0].(map[string]interface{}); ok {
+							linkDescription, _ = link["description"].(string)
+							linkURL, _ = link["url"].(string)
+						}
+					}
+				}
+			}
 
-		if lm != nil && link != nil {
-			break
+			if lmMessage != "" && linkURL != "" {
+				break
+			}
 		}
 	}
 
-	if lm != nil && lm.Message != "" {
+	if lmMessage != "" {
 		w.WriteString(errMsgSep)
-		w.WriteString(lm.Message + "\n")
+		w.WriteString(lmMessage + "\n")
 	}
 
-	if link != nil {
+	if linkURL != "" {
 		w.WriteString(errMsgSep)
 
-		if link.Description != "" {
-			w.WriteString(link.Description + "\n")
+		if linkDescription != "" {
+			w.WriteString(linkDescription + "\n")
 		}
 
-		if link.Url != "" {
-			w.WriteString(link.Url + "\n")
-		}
+		w.WriteString(linkURL + "\n")
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/compute_operation_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_operation_test.go.tmpl
@@ -1,23 +1,18 @@
+{{- /* This file has no version-specific content */ -}}
 package compute
 
 import (
 	"fmt"
 	"strings"
 	"testing"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 const (
 	topLevelMsg             = "Top-level message."
 	localizedMsgTmpl        = "LocalizedMessage%d message"
 	helpLinkDescriptionTmpl = "Help%dLink%d Description"
-        helpLinkUrlTmpl         = "https://help%d.com/link%d"
-        quotaExceededMsg        = "Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1."
+	helpLinkUrlTmpl         = "https://help%d.com/link%d"
+	quotaExceededMsg        = "Quota DISKS_TOTAL_GB exceeded.  Limit: 1100.0 in region us-central1."
 	quotaExceededCode       = "QUOTA_EXCEEDED"
 	quotaMetricName         = "compute.googleapis.com/disks_total_storage"
 	quotaLimitName          = "DISKS-TOTAL-GB-per-project-region"
@@ -25,62 +20,72 @@ const (
 
 var locales = []string{"en-US", "es-US", "es-ES", "es-MX", "de-DE"}
 
-func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) compute.OperationError {
-	opError := &compute.OperationErrorErrors{Message: topLevelMsg}
-	opErrorErrors := []*compute.OperationErrorErrors{opError}
+func buildOperationError(numLocalizedMsg int, numHelpWithLinks []int) map[string]interface{} {
+	errorDetails := []interface{}{}
 
 	for n := 1; n <= numLocalizedMsg; n++ {
-		opError.ErrorDetails = append(opError.ErrorDetails,
-			&compute.OperationErrorErrorsErrorDetails{
-				LocalizedMessage: &compute.LocalizedMessage{
-					Locale:  locales[n-1%len(locales)],
-					Message: formatLocalizedMsg(n),
-				},
-			})
+		errorDetails = append(errorDetails, map[string]interface{}{
+			"localizedMessage": map[string]interface{}{
+				"locale":  locales[n-1%len(locales)],
+				"message": formatLocalizedMsg(n),
+			},
+		})
 	}
 
 	for i := 0; i < len(numHelpWithLinks); i++ {
-		errorDetail := &compute.OperationErrorErrorsErrorDetails{
-			Help: &compute.Help{},
-		}
-
+		links := []interface{}{}
 		for nLinks := 1; nLinks <= numHelpWithLinks[i]; nLinks++ {
 			desc, url := formatLink(i+1, nLinks)
-			errorDetail.Help.Links = append(errorDetail.Help.Links, &compute.HelpLink{
-				Description: desc,
-				Url:         url,
+			links = append(links, map[string]interface{}{
+				"description": desc,
+				"url":         url,
 			})
 		}
-
-		opError.ErrorDetails = append(opError.ErrorDetails, errorDetail)
+		errorDetails = append(errorDetails, map[string]interface{}{
+			"help": map[string]interface{}{
+				"links": links,
+			},
+		})
 	}
 
-	return compute.OperationError{Errors: opErrorErrors}
-
+	return map[string]interface{}{
+		"errors": []interface{}{
+			map[string]interface{}{
+				"message":      topLevelMsg,
+				"errorDetails": errorDetails,
+			},
+		},
+	}
 }
 
-func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool, withFutureLimit bool) compute.OperationError {
-	opError := &compute.OperationErrorErrors{Message: quotaExceededMsg, Code: quotaExceededCode}
-	opErrorErrors := []*compute.OperationErrorErrors{opError}
-	if withDetails {
-		quotaInfo := &compute.QuotaExceededInfo{
-			MetricName: quotaMetricName,
-			LimitName:  quotaLimitName,
-			Limit:      1100,
-		}
-		if withFutureLimit {
-			quotaInfo.FutureLimit = 2200
-		}
-		if withDimensions {
-			quotaInfo.Dimensions = map[string]string{"region": "us-central1"}
-		}
-		opError.ErrorDetails = append(opError.ErrorDetails,
-			&compute.OperationErrorErrorsErrorDetails{
-				QuotaInfo: quotaInfo,
-			})
+func buildOperationErrorQuotaExceeded(withDetails bool, withDimensions bool, withFutureLimit bool) map[string]interface{} {
+	opError := map[string]interface{}{
+		"message": quotaExceededMsg,
+		"code":    quotaExceededCode,
 	}
 
-	return compute.OperationError{Errors: opErrorErrors}
+	if withDetails {
+		quotaInfo := map[string]interface{}{
+			"metricName": quotaMetricName,
+			"limitName":  quotaLimitName,
+			"limit":      float64(1100),
+		}
+		if withFutureLimit {
+			quotaInfo["futureLimit"] = float64(2200)
+		}
+		if withDimensions {
+			quotaInfo["dimensions"] = map[string]interface{}{"region": "us-central1"}
+		}
+		opError["errorDetails"] = []interface{}{
+			map[string]interface{}{
+				"quotaInfo": quotaInfo,
+			},
+		}
+	}
+
+	return map[string]interface{}{
+		"errors": []interface{}{opError},
+	}
 }
 
 func omitAlways(numLocalizedMsg int, numHelpWithLinks []int) []string {
@@ -120,7 +125,7 @@ func formatLink(helpNum, linkNum int) (string, string) {
 func TestComputeOperationError_Error(t *testing.T) {
 	testCases := []struct {
 		name           string
-		input          compute.OperationError
+		input          map[string]interface{}
 		expectContains []string
 		expectOmits    []string
 	}{
@@ -209,8 +214,8 @@ func TestComputeOperationError_Error(t *testing.T) {
 				"https://help1.com/link1",
 			},
 			expectOmits: append(omitAlways(2, []int{1}), []string{}...),
-                },
-                {
+		},
+		{
 			name:  "QuotaMessageOnly",
 			input: buildOperationErrorQuotaExceeded(false, false, false),
 			expectContains: []string{

--- a/mmv1/third_party/terraform/services/deploymentmanager/deployment_manager_operation.go.tmpl
+++ b/mmv1/third_party/terraform/services/deploymentmanager/deployment_manager_operation.go.tmpl
@@ -1,3 +1,4 @@
+{{- /* This file has no version-specific content */ -}}
 package deploymentmanager
 
 import (
@@ -8,12 +9,6 @@ import (
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 type DeploymentManagerOperationWaiter struct {
@@ -29,39 +24,30 @@ func (w *DeploymentManagerOperationWaiter) IsRetryable(error) bool {
 }
 
 func (w *DeploymentManagerOperationWaiter) QueryOp() (interface{}, error) {
-	if w == nil || w.Op == nil || w.Op.SelfLink == "" {
+	if w == nil || w.Op == nil || w.OperationUrl == "" {
 		return nil, fmt.Errorf("cannot query unset/nil operation")
 	}
 
-	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config: w.Config,
-		Method: "GET",
-		Project: w.Project,
-		RawURL: w.Op.SelfLink,
+	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    w.Config,
+		Method:    "GET",
+		Project:   w.Project,
+		RawURL:    w.OperationUrl,
 		UserAgent: w.UserAgent,
 	})
-	if err != nil {
-		return nil, err
-	}
-	op := &compute.Operation{}
-	if err := tpgresource.Convert(resp, op); err != nil {
-		return nil, fmt.Errorf("could not convert response to operation: %v", err)
-	}
-	return op, nil
 }
 
-
 func DeploymentManagerOperationWaitTime(config *transport_tpg.Config, resp interface{}, project, activity, userAgent string, timeout time.Duration) error {
-	op := &compute.Operation{}
-	err := tpgresource.Convert(resp, op)
+	op, err := tpgresource.ConvertToMap(resp)
 	if err != nil {
 		return err
 	}
 
+	selfLink, _ := op["selfLink"].(string)
 	w := &DeploymentManagerOperationWaiter{
 		Config:       config,
 		UserAgent:    userAgent,
-		OperationUrl: op.SelfLink,
+		OperationUrl: selfLink,
 		ComputeOperationWaiter: tpgcompute.ComputeOperationWaiter{
 			Project: project,
 		},
@@ -74,22 +60,43 @@ func DeploymentManagerOperationWaitTime(config *transport_tpg.Config, resp inter
 }
 
 func (w *DeploymentManagerOperationWaiter) Error() error {
-	if w != nil && w.Op != nil && w.Op.Error != nil {
-		return DeploymentManagerOperationError{
-			HTTPStatusCode: w.Op.HttpErrorStatusCode,
-			HTTPMessage:    w.Op.HttpErrorMessage,
-			OperationError: *w.Op.Error,
+	if w != nil && w.Op != nil {
+		if opErr, ok := w.Op["error"]; ok && opErr != nil {
+			errObj, ok := opErr.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("operation error: %v", opErr)
+			}
+
+			httpStatusCode, _ := w.Op["httpErrorStatusCode"].(float64)
+			httpMessage, _ := w.Op["httpErrorMessage"].(string)
+
+			var errorMessages []string
+			if rawErrors, ok := errObj["errors"].([]interface{}); ok {
+				for _, rawErr := range rawErrors {
+					if errMap, ok := rawErr.(map[string]interface{}); ok {
+						if msg, ok := errMap["message"].(string); ok {
+							errorMessages = append(errorMessages, msg)
+						}
+					}
+				}
+			}
+
+			return DeploymentManagerOperationError{
+				HTTPStatusCode: int64(httpStatusCode),
+				HTTPMessage:    httpMessage,
+				Errors:         errorMessages,
+			}
 		}
 	}
 	return nil
 }
 
-// DeploymentManagerOperationError wraps information from the compute.Operation
+// DeploymentManagerOperationError wraps information from an operation response
 // in an implementation of Error.
 type DeploymentManagerOperationError struct {
 	HTTPStatusCode int64
 	HTTPMessage    string
-	compute.OperationError
+	Errors         []string
 }
 
 func (e DeploymentManagerOperationError) Error() string {
@@ -97,8 +104,8 @@ func (e DeploymentManagerOperationError) Error() string {
 	buf.WriteString("Deployment Manager returned errors for this operation, likely due to invalid configuration.")
 	buf.WriteString(fmt.Sprintf("Operation failed with HTTP error %d: %s.", e.HTTPStatusCode, e.HTTPMessage))
 	buf.WriteString("Errors returned: \n")
-	for _, err := range e.Errors {
-		buf.WriteString(err.Message + "\n")
+	for _, msg := range e.Errors {
+		buf.WriteString(msg + "\n")
 	}
 	return buf.String()
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `compute-operation` resource to use direct HTTP rather then a client library
```
