### PR TITLE
compute: add resource_manager_tags to MachineImage

### DIFF
--- a/mmv1/products/compute/MachineImage.yaml
+++ b/mmv1/products/compute/MachineImage.yaml
@@ -58,6 +58,18 @@ examples:
       key_name: '"key" + randomSuffix'
       # for backward compatible
       keyring_name: '"keyring" + randomSuffix'
+  - name: machine_image_resource_manager_tags
+    primary_resource_id: image
+    vars:
+      image_name: my-image
+      vm_name: my-vm
+      tag_key: tagkey
+      tag_value: tagvalue
+      org_id: '123456789'
+    test_vars_overrides:
+      'tag_key': '"tf-test-key-" + acctest.RandString(t, 10)'
+      'tag_value': '"tf-test-value-" + acctest.RandString(t, 10)'
+      'org_id': 'envvar.GetTestOrgFromEnv(t)'
 properties:
   - name: name
     type: String
@@ -125,3 +137,23 @@ properties:
           The service account used for the encryption request for the given KMS key.
           If absent, the Compute Engine Service Agent service account is used.
         min_version: beta
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    min_version: beta
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload.
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the machine image. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456. The field is ignored when empty.
+          The field is immutable and causes resource replacement when mutated. This field is only
+          set at create time and modifying this field after creation will trigger recreation.
+          To apply tags to an existing resource, see the `google_tags_tag_value` resource.
+        api_name: resourceManagerTags
+        min_version: beta
+        ignore_read: true

--- a/mmv1/products/compute/MachineImage.yaml
+++ b/mmv1/products/compute/MachineImage.yaml
@@ -65,11 +65,9 @@ examples:
       vm_name: my-vm
       tag_key: tagkey
       tag_value: tagvalue
-      org_id: '123456789'
     test_vars_overrides:
       'tag_key': '"tf-test-key-" + acctest.RandString(t, 10)'
       'tag_value': '"tf-test-value-" + acctest.RandString(t, 10)'
-      'org_id': 'envvar.GetTestOrgFromEnv(t)'
 properties:
   - name: name
     type: String

--- a/mmv1/products/compute/MachineImage.yaml
+++ b/mmv1/products/compute/MachineImage.yaml
@@ -150,10 +150,7 @@ properties:
         description: |
           Resource manager tags to be bound to the machine image. Tag keys and values have the
           same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
-          and values are in the format tagValues/456. The field is ignored when empty.
-          The field is immutable and causes resource replacement when mutated. This field is only
-          set at create time and modifying this field after creation will trigger recreation.
-          To apply tags to an existing resource, see the `google_tags_tag_value` resource.
+          and values are in the format tagValues/456.
         api_name: resourceManagerTags
         min_version: beta
         ignore_read: true

--- a/mmv1/templates/terraform/examples/machine_image_resource_manager_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/machine_image_resource_manager_tags.tf.tmpl
@@ -1,0 +1,36 @@
+resource "google_tags_tag_key" "tag_key1" {
+  parent     = "organizations/{{index $.Vars "org_id"}}"
+  short_name = "{{index $.Vars "tag_key"}}"
+}
+
+resource "google_tags_tag_value" "tag_value1" {
+  parent     = google_tags_tag_key.tag_key1.id
+  short_name = "{{index $.Vars "tag_value"}}"
+}
+
+resource "google_compute_instance" "vm" {
+  provider     = google-beta
+  name         = "{{index $.Vars "vm_name"}}"
+  machine_type = "e2-medium"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_machine_image" "{{$.PrimaryResourceId}}" {
+  provider        = google-beta
+  name            = "{{index $.Vars "image_name"}}"
+  source_instance = google_compute_instance.vm.self_link
+  params {
+    resource_manager_tags = {
+      (google_tags_tag_key.tag_key1.id) = (google_tags_tag_value.tag_value1.id)
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/machine_image_resource_manager_tags.tf.tmpl
+++ b/mmv1/templates/terraform/examples/machine_image_resource_manager_tags.tf.tmpl
@@ -1,9 +1,15 @@
+data "google_project" "project" {
+  provider = google-beta
+}
+
 resource "google_tags_tag_key" "tag_key1" {
-  parent     = "organizations/{{index $.Vars "org_id"}}"
+  provider   = google-beta
+  parent     = "projects/${data.google_project.project.number}"
   short_name = "{{index $.Vars "tag_key"}}"
 }
 
 resource "google_tags_tag_value" "tag_value1" {
+  provider   = google-beta
   parent     = google_tags_tag_key.tag_key1.id
   short_name = "{{index $.Vars "tag_value"}}"
 }


### PR DESCRIPTION
   Add input-only, force-new `params.resource_manager_tags` map field to
   google_compute_machine_image, matching the pattern used by Disk,
   BackendService and VpnGateway. Tags are passed under `params` and
   ignored on read (persisted by the API but not returned), consistent with
   the behavior documented at go/gce-tf-tags-support.

   Add a new generated acceptance test example
   `machine_image_resource_manager_tags` that bootstraps
   `google_tags_tag_key` / `google_tags_tag_value` resources and binds them
   to the machine image at creation time

```release-note:enhancement
compute: added `resource_manager_tags` field to `google_compute_machine_image` resource
```
