### PR TITLE
Change field `name` from url_param_only to ignore_read in ReservationGr…

### DIFF
--- a/mmv1/products/bigqueryreservation/ReservationGroup.yaml
+++ b/mmv1/products/bigqueryreservation/ReservationGroup.yaml
@@ -42,5 +42,5 @@ properties:
     description: |
       The name of the reservation group. This field must only contain alphanumeric characters or dash.
     immutable: true
-    url_param_only: true
+    ignore_read: true
     diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName


### PR DESCRIPTION
…oup.

This is following https://yaqs.corp.google.com/eng/q/4010639086615265280 to fix the issue in https://buganizer.corp.google.com/issues/70296790#comment58.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
bigqueryreservation: ensure the field `name` is properly detected as having an API equivalent for `google_bigqueryreservation_reservation_group `.
```
