### PR TITLE
mark is_action_configured as input

### DIFF
--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -261,7 +261,6 @@ properties:
         description: |
           Whether the action connector is fully configured. Set by the system
           after the action configuration is validated.
-        output: true
       - name: 'createBapConnection'
         type: Boolean
         description: |

--- a/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_with_actions.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_with_actions.tf.tmpl
@@ -45,6 +45,7 @@ resource "google_discovery_engine_data_connector" "jira-with-actions" {
       auth_type                = "OAUTH"
     }
     create_bap_connection      = true
+    is_action_configured = true
   }
   bap_config {
     supported_connector_modes = ["ACTIONS"]

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
@@ -121,6 +121,7 @@ resource "google_discovery_engine_data_connector" "servicenow-basic" {
       auth_type     = "OAUTH"
     }
     create_bap_connection = true
+    is_action_configured = true
   }
   bap_config {
     supported_connector_modes = ["ACTIONS"]
@@ -203,6 +204,7 @@ resource "google_discovery_engine_data_connector" "servicenow-basic" {
       client_secret = "unused"
       auth_type     = "OAUTH"
     }
+    is_action_configured = true
     create_bap_connection = true
   }
   bap_config {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
discoveryengine: updated `action_config.is_action_configured ` as an input field in `google_discovery_engine_data_connector` resource
```
