### PR TITLE
add round-trip marshalling in mapHashId - fixes artifactRegistry tests

### DIFF
--- a/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
+++ b/mmv1/templates/terraform/constants/artifact_registry_repository.go.tmpl
@@ -80,9 +80,22 @@ func durationDiffSuppress(k, oldr, newr string, d *schema.ResourceData) bool {
 }
 
 func mapHashID(v any) int {
-	replaceNestedValue(v, []string{"condition", "older_than"}, expandDuration)
-	replaceNestedValue(v, []string{"condition", "newer_than"}, expandDuration)
-	return schema.HashString(fmt.Sprintf("%v", v))
+	// v's dynamic type can differ between config and state, so we need to marshal and unmarshal to ensure consistent key order.
+	b, err := json.Marshal(v)
+	if err != nil {
+		return schema.HashString(fmt.Sprintf("%v", v))
+	}
+	var c any
+	if err := json.Unmarshal(b, &c); err != nil {
+		return schema.HashString(fmt.Sprintf("%v", v))
+	}
+	m, ok := c.(map[string]any)
+	if !ok {
+		return schema.HashString(fmt.Sprintf("%v", v))
+	}
+	replaceNestedValue(m, []string{"condition", "older_than"}, expandDuration)
+	replaceNestedValue(m, []string{"condition", "newer_than"}, expandDuration)
+	return schema.HashString(fmt.Sprintf("%v", m))
 }
 
 func expandDuration(v any) (any, bool) {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Resolves https://github.com/hashicorp/terraform-provider-google/issues/26873
Resolves https://github.com/hashicorp/terraform-provider-google/issues/26871

The round-trip marshalling resolves inconsistencyies between hashing when comparing between config and state. Both can differ in go types resulting in hash mismatch. The round-trip allows for a more stable hash set for each element in `conditions`

## Fixes the following failing tests found in VCR

```hcl
=== RUN   TestAccArtifactRegistryRepository_cleanup
=== PAUSE TestAccArtifactRegistryRepository_cleanup
=== CONT  TestAccArtifactRegistryRepository_cleanup
    resource_artifact_registry_repository_test.go:162: Step 1/4 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # google_artifact_registry_repository.test will be updated in-place
          ~ resource "google_artifact_registry_repository" "test" {
                id                     = "projects/ci-test-project-188019/locations/us-central1/repositories/tf-test-8878528727292003803"
                name                   = "tf-test-8878528727292003803"
                # (13 unchanged attributes hidden)
        
              - cleanup_policies {
                  - action = "DELETE" -> null
                  - id     = "delete" -> null
        
                  - condition {
                      - older_than            = "7d" -> null
                      - package_name_prefixes = [] -> null
                      - tag_prefixes          = [] -> null
                      - tag_state             = "ANY" -> null
                      - version_name_prefixes = [] -> null
                        # (1 unchanged attribute hidden)
                    }
                }
              + cleanup_policies {
                  + action = "DELETE"
                  + id     = "delete"
        
                  + condition {
                      + older_than            = "604800s"
                      + package_name_prefixes = []
                      + tag_prefixes          = []
                      + tag_state             = "ANY"
                      + version_name_prefixes = []
                        # (1 unchanged attribute hidden)
                    }
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccArtifactRegistryRepository_cleanup (19.02s)
```
```hcl
=== RUN   TestAccArtifactRegistryRepository_cleanup
=== PAUSE TestAccArtifactRegistryRepository_cleanup
=== CONT  TestAccArtifactRegistryRepository_cleanup
    resource_artifact_registry_repository_test.go:162: Step 1/4 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # google_artifact_registry_repository.test will be updated in-place
          ~ resource "google_artifact_registry_repository" "test" {
                id                     = "projects/ci-test-project-188019/locations/us-central1/repositories/tf-test-8878528727292003803"
                name                   = "tf-test-8878528727292003803"
                # (13 unchanged attributes hidden)
        
              - cleanup_policies {
                  - action = "DELETE" -> null
                  - id     = "delete" -> null
        
                  - condition {
                      - older_than            = "7d" -> null
                      - package_name_prefixes = [] -> null
                      - tag_prefixes          = [] -> null
                      - tag_state             = "ANY" -> null
                      - version_name_prefixes = [] -> null
                        # (1 unchanged attribute hidden)
                    }
                }
              + cleanup_policies {
                  + action = "DELETE"
                  + id     = "delete"
        
                  + condition {
                      + older_than            = "604800s"
                      + package_name_prefixes = []
                      + tag_prefixes          = []
                      + tag_state             = "ANY"
                      + version_name_prefixes = []
                        # (1 unchanged attribute hidden)
                    }
                }
        
                # (1 unchanged block hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccArtifactRegistryRepository_cleanup (19.02s)
```

## Passing after applying round-trip marshalling

```hcl
󰀵 mau  …/terraform-provider-google   main $   v1.26.1   16:58   envchain GCLOUD make testacc TEST=./google/services/artifactregistry TESTARGS='-run=TestAccArtifactRegistryRepository_cleanup'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/artifactregistry -v -run=TestAccArtifactRegistryRepository_cleanup -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccArtifactRegistryRepository_cleanup
=== PAUSE TestAccArtifactRegistryRepository_cleanup
=== CONT  TestAccArtifactRegistryRepository_cleanup
--- PASS: TestAccArtifactRegistryRepository_cleanup (36.50s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/artifactregistry 37.976s
```
```hcl
󰀵 mau  …/terraform-provider-google   main $   v1.26.1   17:10   envchain GCLOUD make testacc TEST=./google/services/artifactregistry TESTARGS='-run=TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/artifactregistry -v -run=TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample
=== PAUSE TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample
=== CONT  TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample
--- PASS: TestAccArtifactRegistryRepository_artifactRegistryRepositoryCleanupExample (29.39s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/artifactregistry 30.859s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
