### PR TITLE
feat(datastream): add deletion_policy to google_datastream_private_connection

### DIFF
--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -54,6 +54,13 @@ examples:
       network_name: 'my-network'
     ignore_read_extra:
       - 'deletion_policy'
+  - name: 'datastream_private_connection_force_delete'
+    primary_resource_id: 'default'
+    vars:
+      private_connection_id: 'my-connection'
+      network_name: 'my-network'
+    ignore_read_extra:
+      - 'deletion_policy'
   - name: 'datastream_private_connection_psc_interface'
     primary_resource_id: 'default'
     test_env_vars:

--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -52,6 +52,8 @@ examples:
     vars:
       private_connection_id: 'my-connection'
       network_name: 'my-network'
+    ignore_read_extra:
+      - 'deletion_policy'
   - name: 'datastream_private_connection_psc_interface'
     primary_resource_id: 'default'
     test_env_vars:
@@ -64,6 +66,15 @@ examples:
       network_attachment_name: 'my-network-attachment'
       network_name: 'my-network'
       subnetwork_name: 'my-subnetwork'
+virtual_fields:
+  - name: 'deletion_policy'
+    description: |
+      The deletion policy for the private connection. Setting `FORCE` will also delete any child
+      routes that belong to this private connection. Setting `DEFAULT` will fail the delete if
+      child routes exist. Defaults to `FORCE` for backwards compatibility.
+      Possible values: `DEFAULT`, `FORCE`.
+    type: String
+    default_value: "FORCE"
 parameters:
   - name: 'privateConnectionId'
     type: String

--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -66,6 +66,8 @@ examples:
       network_attachment_name: 'my-network-attachment'
       network_name: 'my-network'
       subnetwork_name: 'my-subnetwork'
+    ignore_read_extra:
+      - 'deletion_policy'
 virtual_fields:
   - name: 'deletion_policy'
     description: |

--- a/mmv1/templates/terraform/examples/datastream_private_connection_force_delete.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_force_delete.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
+	display_name          = "Connection profile"
+	location              = "us-central1"
+	private_connection_id = "{{index $.Vars "private_connection_id"}}"
+	deletion_policy       = "FORCE"
+
+	labels = {
+		key = "value"
+	}
+
+	vpc_peering_config {
+		vpc = google_compute_network.default.id
+		subnet = "10.0.0.0/29"
+	}
+}
+
+resource "google_compute_network" "default" {
+  name = "{{index $.Vars "network_name"}}"
+}

--- a/mmv1/templates/terraform/pre_delete/private_connection.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/private_connection.go.tmpl
@@ -1,5 +1,7 @@
-// Add force=true query param to force deletion of private connection sub resources like Routes
-url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": strconv.FormatBool(true)})
-if err != nil {
-return err
+// Add force=true query param if deletion_policy is FORCE to delete child routes
+if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "FORCE" {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"force": strconv.FormatBool(true)})
+	if err != nil {
+		return err
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/13054

Currently, `google_datastream_private_connection` always sends `force=true` when deleting, which was introduced in #11394. This means child routes (managed outside Terraform) are always deleted without user control.

This PR adds a `deletion_policy` virtual field (`FORCE` / `DEFAULT`) so users can control this behavior:

- `FORCE` (default): sends `force=true`, deleting child routes — preserves current behavior for backwards compatibility
- `DEFAULT`: omits the `force` param, failing if child routes exist

Changes:
- Add `deletion_policy` virtual field to `PrivateConnection.yaml` with default `FORCE`
- Update `pre_delete` template to conditionally set `force` based on `deletion_policy`
- Add example with explicit `deletion_policy = "FORCE"`
- Add `ignore_read_extra` for `deletion_policy` to existing examples

Reference: https://googlecloudplatform.github.io/magic-modules/best-practices/deletion-behaviors/

```release-note:enhancement
google_datastream_private_connection: added `deletion_policy` field to control whether child routes are force-deleted
```