### PR TITLE
Add Terraform support for Data table Row for v1 endpoint

### DIFF
--- a/mmv1/products/chronicle/DataTableRow.yaml
+++ b/mmv1/products/chronicle/DataTableRow.yaml
@@ -24,16 +24,14 @@ import_format:
 update_verb: PATCH
 update_mask: true
 
-min_version: 'beta'
 references:
   guides:
     'Google SecOps Guides': 'https://cloud.google.com/chronicle/docs/secops/secops-overview'
-  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.dataTables.dataTableRows'
+  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.dataTables.dataTableRows'
 examples:
   - name: 'chronicle_data_table_row_basic'
     config_path: 'templates/terraform/examples/chronicle_data_table_row_basic.tf.tmpl'
     primary_resource_id: 'example_row'
-    min_version: 'beta'
     test_env_vars:
       instance_id: 'CHRONICLE_ID'
     vars:

--- a/mmv1/templates/terraform/examples/chronicle_data_table_row_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_data_table_row_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_chronicle_data_table" "example_dt" {
-  provider       = google-beta
   location       = "us"
   instance = "{{index $.TestEnvVars "instance_id"}}"
   data_table_id  = "{{index $.Vars "data_table_id"}}"
@@ -17,7 +16,6 @@ resource "google_chronicle_data_table" "example_dt" {
 }
 
 resource "google_chronicle_data_table_row" "example_row" {
-  provider       = google-beta
   location       = "us"
   instance       = "{{index $.TestEnvVars "instance_id"}}"
   data_table_id  = google_chronicle_data_table.example_dt.data_table_id

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_deletion_policy_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_deletion_policy_test.go
@@ -1,7 +1,5 @@
 package chronicle_test
 
-{{- if ne $.TargetVersionName "ga" }}
-
 import (
 	"fmt"
 	"regexp"
@@ -23,7 +21,7 @@ func TestAccChronicleDataTable_DeletionPolicy_DefaultFail(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccChronicleDataTable_DefaultDeletion(context),
@@ -33,16 +31,16 @@ func TestAccChronicleDataTable_DeletionPolicy_DefaultFail(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccChronicleDataTable_DefaultDeletion_TableOnly(context),
-                ExpectError: regexp.MustCompile("Unable to delete table as table is non empty"),
+				Config:      testAccChronicleDataTable_DefaultDeletion_TableOnly(context),
+				ExpectError: regexp.MustCompile("Unable to delete table as table is non empty"),
 			},
 			{
-                Config: testAccChronicleDataTable_DefaultDeletion_RowOnly(context),
-                Check: resource.ComposeTestCheckFunc(
-                    checkResourceDestroyed("google_chronicle_data_table_row.default_fail_row"),
-                    resource.TestCheckResourceAttrSet("google_chronicle_data_table.test_delete_default_fail", "id"),
-                ),
-            },
+				Config: testAccChronicleDataTable_DefaultDeletion_RowOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkResourceDestroyed("google_chronicle_data_table_row.default_fail_row"),
+					resource.TestCheckResourceAttrSet("google_chronicle_data_table.test_delete_default_fail", "id"),
+				),
+			},
 		},
 	})
 }
@@ -57,7 +55,7 @@ func TestAccChronicleDataTable_DeletionPolicy_Force(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			// Step 1: Create table and a row, with Deletion policy FORCE.
 			{
@@ -83,7 +81,6 @@ func TestAccChronicleDataTable_DeletionPolicy_Force(t *testing.T) {
 func testAccChronicleDataTable_DefaultDeletion(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "test_delete_default_fail" {
-  provider       = google-beta
   location       = "us"
   instance       = "%{instance_id}"
   data_table_id  = "tf_test_def_fail_%{random_suffix}"
@@ -98,7 +95,6 @@ resource "google_chronicle_data_table" "test_delete_default_fail" {
 }
 
 resource "google_chronicle_data_table_row" "default_fail_row" {
-  provider       = google-beta
   location       = google_chronicle_data_table.test_delete_default_fail.location
   instance       = google_chronicle_data_table.test_delete_default_fail.instance
   data_table_id  = google_chronicle_data_table.test_delete_default_fail.data_table_id
@@ -111,7 +107,6 @@ resource "google_chronicle_data_table_row" "default_fail_row" {
 func testAccChronicleDataTable_ForceDeletion(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "test_delete_force" {
-  provider         = google-beta
   location         = "us"
   instance         = "%{instance_id}"
   data_table_id    = "tf_test_force_%{random_suffix}"
@@ -126,7 +121,6 @@ resource "google_chronicle_data_table" "test_delete_force" {
 }
 
 resource "google_chronicle_data_table_row" "force_row" {
-  provider      = google-beta
   location      = google_chronicle_data_table.test_delete_force.location
   instance      = google_chronicle_data_table.test_delete_force.instance
   data_table_id = google_chronicle_data_table.test_delete_force.data_table_id
@@ -139,7 +133,6 @@ resource "google_chronicle_data_table_row" "force_row" {
 func testAccChronicleDataTable_DefaultDeletion_TableOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table_row" "default_fail_row" {
-  provider       = google-beta
   location       = "us" # Assuming 'us'
   instance       = "%{instance_id}"
   data_table_id  = "tf_test_def_fail_%{random_suffix}" # Needs to match the created table ID
@@ -149,9 +142,8 @@ resource "google_chronicle_data_table_row" "default_fail_row" {
 }
 
 func testAccChronicleDataTable_DefaultDeletion_RowOnly(context map[string]interface{}) string {
-        return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "test_delete_default_fail" {
-  provider       = google-beta
   location       = "us"
   instance       = "%{instance_id}"
   data_table_id  = "tf_test_def_fail_%{random_suffix}"
@@ -171,7 +163,6 @@ resource "google_chronicle_data_table" "test_delete_default_fail" {
 func testAccChronicleDataTable_ForceDeletion_TableOnly(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table_row" "force_row" {
-  provider      = google-beta
   location      = "us" # Assuming 'us'
   instance      = "%{instance_id}"
   data_table_id = "tf_test_force_%{random_suffix}" # Needs to match the created table ID
@@ -190,5 +181,3 @@ func checkResourceDestroyed(name string) resource.TestCheckFunc {
 		return nil
 	}
 }
-
-{{- end }}

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_row_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_data_table_row_test.go
@@ -1,7 +1,5 @@
 package chronicle_test
 
-{{- if ne $.TargetVersionName "ga" }}
-
 import (
 	"testing"
 
@@ -16,17 +14,17 @@ func TestAccChronicleDataTableRow_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"instance_id":   envvar.GetTestChronicleInstanceIdFromEnv(t),
-		"random_suffix": acctest.RandString(t, 10),
-		"ttl_initial":  "24h",
-		"ttl_updated":  "48h",
+		"instance_id":    envvar.GetTestChronicleInstanceIdFromEnv(t),
+		"random_suffix":  acctest.RandString(t, 10),
+		"ttl_initial":    "24h",
+		"ttl_updated":    "48h",
 		"values_initial": `["testuser1", "192.168.1.1/32"]`,
 		"values_updated": `["testuser2", "192.168.1.2/32"]`,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:          func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			// Step 1: Create initial row
 			{
@@ -113,7 +111,6 @@ func TestAccChronicleDataTableRow_update(t *testing.T) {
 func testAccChronicleDataTableRow_basic(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "example_dt" {
-  provider       = google-beta
   location       = "us"
   instance = "%{instance_id}"
   data_table_id  = "tf_test_terraform_test%{random_suffix}"
@@ -132,7 +129,6 @@ resource "google_chronicle_data_table" "example_dt" {
 }
 
 resource "google_chronicle_data_table_row" "example_row" {
-  provider       = google-beta
   # Explicitly provide the URL parameters.
   location       = "us"
   instance       = "%{instance_id}"
@@ -152,7 +148,6 @@ output "data_table_row_name" {
 func testAccChronicleDataTableRow_ttlUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "example_dt" {
-  provider        = google-beta
   location        = "us"
   instance        = "%{instance_id}"
   data_table_id   = "tf_test_terraform_test%{random_suffix}"
@@ -171,7 +166,6 @@ resource "google_chronicle_data_table" "example_dt" {
 }
 
 resource "google_chronicle_data_table_row" "example_row" {
-  provider         = google-beta
   location         = "us"
   instance         = "%{instance_id}"
   data_table_id    = google_chronicle_data_table.example_dt.data_table_id
@@ -186,7 +180,6 @@ resource "google_chronicle_data_table_row" "example_row" {
 func testAccChronicleDataTableRow_valuesReplace(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "example_dt" {
-  provider        = google-beta
   location        = "us"
   instance        = "%{instance_id}"
   data_table_id   = "tf_test_terraform_test%{random_suffix}"
@@ -205,7 +198,6 @@ resource "google_chronicle_data_table" "example_dt" {
 }
 
 resource "google_chronicle_data_table_row" "example_row" {
-  provider         = google-beta
   location         = "us"
   instance         = "%{instance_id}"
   data_table_id    = google_chronicle_data_table.example_dt.data_table_id
@@ -220,7 +212,6 @@ resource "google_chronicle_data_table_row" "example_row" {
 func testAccChronicleDataTableRow_bothReplace(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_chronicle_data_table" "example_dt" {
-  provider        = google-beta
   location        = "us"
   instance        = "%{instance_id}"
   data_table_id   = "tf_test_terraform_test%{random_suffix}"
@@ -239,7 +230,6 @@ resource "google_chronicle_data_table" "example_dt" {
 }
 
 resource "google_chronicle_data_table_row" "example_row" {
-  provider         = google-beta
   location         = "us"
   instance         = "%{instance_id}"
   data_table_id    = google_chronicle_data_table.example_dt.data_table_id
@@ -249,5 +239,3 @@ resource "google_chronicle_data_table_row" "example_row" {
 }
 `, context)
 }
-
-{{- end }}


### PR DESCRIPTION
This commit introduces Terraform resources for the Google Chronicle Data Table Row v1 API, including:

*   `google_chronicle_data_table_row`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26930


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_chronicle_datatable_row` (ga)
```

