### PR TITLE
Fix typo in example terraform usage for Workload Identity Service Agent

### DIFF
--- a/mmv1/templates/terraform/examples/workload_identity_service_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/workload_identity_service_agent_basic.tf.tmpl
@@ -2,5 +2,5 @@ data "google_project" "project" {
 }
 
 resource "google_workload_identity_service_agent" "{{$.PrimaryResourceId}}" {
-  parent   = "projects/${data.google_project.project.number}/locations/global/serviceProducers/healthcare.google.apis.com"
+  parent   = "projects/${data.google_project.project.number}/locations/global/serviceProducers/healthcare.googleapis.com"
 }


### PR DESCRIPTION
Fix typo in example terraform usage for Workload Identity Service Agent

```release-note:note
workloadidentity: fixed typo in the healthcare service producer URL in the `google_workload_identity_service_agent` example
```