### PR TITLE
Migrated data_source_google_compute_addresses.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_addresses.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_addresses.go.tmpl
@@ -11,11 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-{{- if eq $.TargetVersionName "ga" }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func DataSourceGoogleComputeAddresses() *schema.Resource {
@@ -135,34 +130,96 @@ func dataSourceGoogleComputeAddressesRead(context context.Context, d *schema.Res
 
 	allAddresses := make([]map[string]interface{}, 0)
 
-	client := config.NewComputeClient(userAgent).Addresses
-	if region, has_region := d.GetOk("region"); has_region {
-		request := client.List(project, region.(string))
-		if filter, has_filter := d.GetOk("filter"); has_filter {
-			request = request.Filter(filter.(string))
-		}
-		err = request.Pages(context, func(addresses *compute.AddressList) error {
-			for _, address := range addresses.Items {
-				allAddresses = append(allAddresses, generateTfAddress(address))
+	filter, hasFilter := d.GetOk("filter")
+
+	if region, hasRegion := d.GetOk("region"); hasRegion {
+		baseURL := fmt.Sprintf("%sprojects/%s/regions/%s/addresses", config.ComputeBasePath, project, region.(string))
+		pageToken := ""
+		for {
+			params := map[string]string{}
+			if hasFilter {
+				params["filter"] = filter.(string)
 			}
-			return nil
-		})
-	} else {
-		request := client.AggregatedList(project)
-		if filter, has_filter := d.GetOk("filter"); has_filter {
-			request = request.Filter(filter.(string))
-		}
-		err = request.Pages(context, func(addresses *compute.AddressAggregatedList) error {
-			for _, items := range addresses.Items {
-				for _, address := range items.Addresses {
+			if pageToken != "" {
+				params["pageToken"] = pageToken
+			}
+			url, err := transport_tpg.AddQueryParams(baseURL, params)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if items, ok := resp["items"].([]interface{}); ok {
+				for _, item := range items {
+					address, ok := item.(map[string]interface{})
+					if !ok {
+						continue
+					}
 					allAddresses = append(allAddresses, generateTfAddress(address))
 				}
 			}
-			return nil
-		})
-	}
-	if err != nil {
-		return diag.FromErr(err)
+			pageToken, _ = resp["nextPageToken"].(string)
+			if pageToken == "" {
+				break
+			}
+		}
+	} else {
+		baseURL := fmt.Sprintf("%sprojects/%s/aggregated/addresses", config.ComputeBasePath, project)
+		pageToken := ""
+		for {
+			params := map[string]string{}
+			if hasFilter {
+				params["filter"] = filter.(string)
+			}
+			if pageToken != "" {
+				params["pageToken"] = pageToken
+			}
+			url, err := transport_tpg.AddQueryParams(baseURL, params)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+			})
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if items, ok := resp["items"].(map[string]interface{}); ok {
+				for _, scopeVal := range items {
+					scopeData, ok := scopeVal.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					addresses, ok := scopeData["addresses"].([]interface{})
+					if !ok {
+						continue
+					}
+					for _, item := range addresses {
+						address, ok := item.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						allAddresses = append(allAddresses, generateTfAddress(address))
+					}
+				}
+			}
+			pageToken, _ = resp["nextPageToken"].(string)
+			if pageToken == "" {
+				break
+			}
+		}
 	}
 
 	if err := d.Set("addresses", allAddresses); err != nil {
@@ -176,20 +233,23 @@ func dataSourceGoogleComputeAddressesRead(context context.Context, d *schema.Res
 	return nil
 }
 
-func generateTfAddress(address *compute.Address) map[string]interface{} {
-	return map[string]interface{}{
-		"name":           address.Name,
-		"address":        address.Address,
-		"address_type":   address.AddressType,
-		"description":    address.Description,
-		"prefix_length":  address.PrefixLength,
-		"region":         regionFromUrl(address.Region),
-		"status":         address.Status,
-		"self_link":      address.SelfLink,
-{{- if ne $.TargetVersionName "ga" }}
-		"labels":       address.Labels,
-{{- end }}
+func generateTfAddress(address map[string]interface{}) map[string]interface{} {
+	region, _ := address["region"].(string)
+	prefixLength, _ := address["prefixLength"].(float64)
+	result := map[string]interface{}{
+		"name":          address["name"],
+		"address":       address["address"],
+		"address_type":  address["addressType"],
+		"description":   address["description"],
+		"prefix_length": int(prefixLength),
+		"region":        regionFromUrl(region),
+		"status":        address["status"],
+		"self_link":     address["selfLink"],
 	}
+{{- if ne $.TargetVersionName "ga" }}
+	result["labels"] = address["labels"]
+{{- end }}
+	return result
 }
 
 func computeId(project string, d *schema.ResourceData) string {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `data_source_google_compute_addresses.go.tmpl` data source to use direct HTTP rather then a client library
```
