### PR TITLE
`ephemeral`: ability to assert values + update ephemeral resource acctests

### DIFF
--- a/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
@@ -16,7 +16,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -197,6 +199,14 @@ func ProtoV5ProviderBetaFactories(t *testing.T) map[string]func() (tfprotov5.Pro
 			return provider(), err
 		},
 {{- end }}
+	}
+}
+
+// ProtoV6ProviderFactories returns a provider server for that currently
+// only contains an echo provider for testing usage of ephemeral values
+func ProtoV6ProviderFactories(t *testing.T) map[string]func() (tfprotov6.ProviderServer, error) {
+	return map[string]func() (tfprotov6.ProviderServer, error){
+		"echo": echoprovider.NewProviderServer(),
 	}
 }
 

--- a/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
@@ -210,6 +210,20 @@ func ProtoV6ProviderFactories(t *testing.T) map[string]func() (tfprotov6.Provide
 	}
 }
 
+var EchoResourceName string = "echo.test"
+
+// EchoResourceConfig returns some HCL that configures the echo provider with a reference to an ephemeral value (e.g. an ephemeral resource)
+// and provisions an echo resource that surfaces that ephemeral data in a non-ephemeral way, for testing purposes.
+// See: https://github.com/hashicorp/terraform-plugin-testing/pull/389
+func EchoResourceConfig(ephemeralReference string) string {
+	return fmt.Sprintf(`
+provider "echo" {
+  data = %s
+}
+resource "echo" "test" {}
+`, ephemeralReference)
+}
+
 // This is a Printf sibling (Nprintf; Named Printf), which handles strings like
 // Nprintf("Hello %{target}!", map[string]interface{}{"target":"world"}) == "Hello world!".
 // This is particularly useful for generated tests, where we don't want to use Printf,

--- a/mmv1/third_party/terraform/fwvalidators/framework_validators.go
+++ b/mmv1/third_party/terraform/fwvalidators/framework_validators.go
@@ -55,21 +55,21 @@ func CredentialsValidator() validator.String {
 }
 
 // Non Negative Duration Validator
-type nonnegativeBoundedDuration struct {
+type nonnegativedurationValidator struct {
 }
 
 // Description describes the validation in plain text formatting.
-func (v nonnegativeBoundedDuration) Description(_ context.Context) string {
+func (v nonnegativedurationValidator) Description(_ context.Context) string {
 	return "value expected to be a string representing a non-negative duration"
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.
-func (v nonnegativeBoundedDuration) MarkdownDescription(ctx context.Context) string {
+func (v nonnegativedurationValidator) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
 // ValidateString performs the validation.
-func (v nonnegativeBoundedDuration) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+func (v nonnegativedurationValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
@@ -86,8 +86,8 @@ func (v nonnegativeBoundedDuration) ValidateString(ctx context.Context, request 
 	}
 }
 
-func NonNegativeBoundedDuration() validator.String {
-	return nonnegativeBoundedDuration{}
+func NonNegativeDurationValidator() validator.String {
+	return nonnegativedurationValidator{}
 }
 
 // Non Empty String Validator

--- a/mmv1/third_party/terraform/fwvalidators/framework_validators.go
+++ b/mmv1/third_party/terraform/fwvalidators/framework_validators.go
@@ -55,21 +55,21 @@ func CredentialsValidator() validator.String {
 }
 
 // Non Negative Duration Validator
-type nonnegativedurationValidator struct {
+type nonnegativeBoundedDuration struct {
 }
 
 // Description describes the validation in plain text formatting.
-func (v nonnegativedurationValidator) Description(_ context.Context) string {
+func (v nonnegativeBoundedDuration) Description(_ context.Context) string {
 	return "value expected to be a string representing a non-negative duration"
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.
-func (v nonnegativedurationValidator) MarkdownDescription(ctx context.Context) string {
+func (v nonnegativeBoundedDuration) MarkdownDescription(ctx context.Context) string {
 	return v.Description(ctx)
 }
 
 // ValidateString performs the validation.
-func (v nonnegativedurationValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+func (v nonnegativeBoundedDuration) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
 	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
 		return
 	}
@@ -86,8 +86,8 @@ func (v nonnegativedurationValidator) ValidateString(ctx context.Context, reques
 	}
 }
 
-func NonNegativeDurationValidator() validator.String {
-	return nonnegativedurationValidator{}
+func NonNegativeBoundedDuration() validator.String {
+	return nonnegativeBoundedDuration{}
 }
 
 // Non Empty String Validator

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_access_token_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_access_token_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-var echoResourceName string = "echo.test"
 var defaultMaxLifetime string = "3600s"
 
 func TestAccEphemeralServiceAccountToken_basic(t *testing.T) {
@@ -33,11 +32,11 @@ func TestAccEphemeralServiceAccountToken_basic(t *testing.T) {
 				Config: testAccEphemeralServiceAccountToken_basic(context),
 				Check: resource.ComposeTestCheckFunc(
 					// Assert exact values
-					resource.TestCheckResourceAttr(echoResourceName, "data.target_service_account", context["target_service_account"].(string)),
-					resource.TestCheckResourceAttr(echoResourceName, "data.scopes.0", context["scope_1"].(string)),
-					resource.TestCheckResourceAttr(echoResourceName, "data.lifetime", defaultMaxLifetime),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.target_service_account", context["target_service_account"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.scopes.0", context["scope_1"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.lifetime", defaultMaxLifetime),
 					// Assert set
-					resource.TestCheckResourceAttrSet(echoResourceName, "data.access_token"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.access_token"),
 				),
 			},
 		},
@@ -69,10 +68,10 @@ func TestAccEphemeralServiceAccountToken_withDelegates(t *testing.T) {
 				Config: testAccEphemeralServiceAccountToken_withDelegates(context),
 				Check: resource.ComposeTestCheckFunc(
 					// Assert exact values
-					resource.TestCheckResourceAttr(echoResourceName, "data.delegates.0", context["delegate_1"].(string)),
-					resource.TestCheckResourceAttr(echoResourceName, "data.delegates.1", context["delegate_2"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.delegates.0", context["delegate_1"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.delegates.1", context["delegate_2"].(string)),
 					// Assert set
-					resource.TestCheckResourceAttrSet(echoResourceName, "data.access_token"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.access_token"),
 				),
 			},
 		},
@@ -101,9 +100,9 @@ func TestAccEphemeralServiceAccountToken_withCustomLifetime(t *testing.T) {
 				Config: testAccEphemeralServiceAccountToken_withCustomLifetime(context),
 				Check: resource.ComposeTestCheckFunc(
 					// Assert exact values
-					resource.TestCheckResourceAttr(echoResourceName, "data.lifetime", context["lifetime"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.lifetime", context["lifetime"].(string)),
 					// Assert set
-					resource.TestCheckResourceAttrSet(echoResourceName, "data.access_token"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.access_token"),
 				),
 			},
 		},
@@ -111,11 +110,7 @@ func TestAccEphemeralServiceAccountToken_withCustomLifetime(t *testing.T) {
 }
 
 func testAccEphemeralServiceAccountToken_basic(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-provider "echo" {
-  data = %{ephemeral_reference}
-}
-resource "echo" "test" {}
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 
 ephemeral "google_service_account_access_token" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"
@@ -125,11 +120,7 @@ ephemeral "google_service_account_access_token" "%{ephemeral_resource_name}" {
 }
 
 func testAccEphemeralServiceAccountToken_withDelegates(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-provider "echo" {
-  data = %{ephemeral_reference}
-}
-resource "echo" "test" {}
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 
 ephemeral "google_service_account_access_token" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"
@@ -143,11 +134,7 @@ ephemeral "google_service_account_access_token" "%{ephemeral_resource_name}" {
 }
 
 func testAccEphemeralServiceAccountToken_withCustomLifetime(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-provider "echo" {
-  data = %{ephemeral_reference}
-}
-resource "echo" "test" {}
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 
 ephemeral "google_service_account_access_token" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_id_token_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_id_token_test.go
@@ -18,9 +18,6 @@ func TestAccEphemeralServiceAccountIdToken_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountIdToken_basic(targetServiceAccountEmail),
@@ -40,9 +37,6 @@ func TestAccEphemeralServiceAccountIdToken_withDelegates(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountIdToken_withDelegates(delegateServiceAccountEmailOne, delegateServiceAccountEmailTwo, targetServiceAccountEmail),
@@ -80,9 +74,6 @@ func TestAccEphemeralServiceAccountIdToken_withIncludeEmail(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountIdToken_withIncludeEmail(targetServiceAccountEmail),

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_jwt_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_jwt_test.go
@@ -16,6 +16,7 @@ func TestAccEphemeralServiceAccountJwt_basic(t *testing.T) {
 
 	context := map[string]interface{}{
 		"ephemeral_resource_name": "jwt",
+		"ephemeral_reference":     "ephemeral.google_service_account_jwt.jwt",
 		"target_service_account":  targetServiceAccountEmail,
 		"sub":                     targetServiceAccountEmail,
 	}
@@ -23,9 +24,18 @@ func TestAccEphemeralServiceAccountJwt_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountJwt_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Assert exact values
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.target_service_account", context["target_service_account"].(string)),
+					// Assert set
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.jwt"),
+					// Assert unset
+					resource.TestCheckNoResourceAttr(acctest.EchoResourceName, "data.expires_in"),
+				),
 			},
 		},
 	})
@@ -41,6 +51,7 @@ func TestAccEphemeralServiceAccountJwt_withDelegates(t *testing.T) {
 
 	context := map[string]interface{}{
 		"ephemeral_resource_name": "jwt",
+		"ephemeral_reference":     "ephemeral.google_service_account_jwt.jwt",
 		"target_service_account":  targetServiceAccountEmail,
 		"delegate_1":              delegateServiceAccountEmailOne,
 		"delegate_2":              delegateServiceAccountEmailTwo,
@@ -50,9 +61,17 @@ func TestAccEphemeralServiceAccountJwt_withDelegates(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountJwt_withDelegates(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Assert exact values
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.delegates.0", context["delegate_1"].(string)),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.delegates.1", context["delegate_2"].(string)),
+					// Assert set
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.jwt"),
+				),
 			},
 		},
 	})
@@ -66,6 +85,7 @@ func TestAccEphemeralServiceAccountJwt_withExpiresIn(t *testing.T) {
 
 	context := map[string]interface{}{
 		"ephemeral_resource_name": "jwt",
+		"ephemeral_reference":     "ephemeral.google_service_account_jwt.jwt",
 		"target_service_account":  targetServiceAccountEmail,
 		"sub":                     targetServiceAccountEmail,
 		"expires_in":              "3600",
@@ -74,16 +94,23 @@ func TestAccEphemeralServiceAccountJwt_withExpiresIn(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountJwt_withExpiresIn(context),
+				Check: resource.ComposeTestCheckFunc(
+					// Assert exact values
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.expires_in", context["expires_in"].(string)),
+					// Assert set
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.jwt"),
+				),
 			},
 		},
 	})
 }
 
 func testAccEphemeralServiceAccountJwt_basic(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"
   payload               = jsonencode({
@@ -95,7 +122,7 @@ ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
 }
 
 func testAccEphemeralServiceAccountJwt_withDelegates(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"
   delegates = [
@@ -111,7 +138,7 @@ ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
 }
 
 func testAccEphemeralServiceAccountJwt_withExpiresIn(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+	return acctest.EchoResourceConfig(context["ephemeral_reference"].(string)) + acctest.Nprintf(`
 ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
   target_service_account = "%{target_service_account}"
   expires_in            = %{expires_in}

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_jwt_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_jwt_test.go
@@ -1,7 +1,6 @@
 package resourcemanager_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -15,12 +14,18 @@ func TestAccEphemeralServiceAccountJwt_basic(t *testing.T) {
 	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
 	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "jwt-basic", serviceAccount)
 
+	context := map[string]interface{}{
+		"ephemeral_resource_name": "jwt",
+		"target_service_account":  targetServiceAccountEmail,
+		"sub":                     targetServiceAccountEmail,
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralServiceAccountJwt_basic(targetServiceAccountEmail),
+				Config: testAccEphemeralServiceAccountJwt_basic(context),
 			},
 		},
 	})
@@ -34,12 +39,20 @@ func TestAccEphemeralServiceAccountJwt_withDelegates(t *testing.T) {
 	delegateServiceAccountEmailTwo := acctest.BootstrapServiceAccount(t, "jwt-delegate2", delegateServiceAccountEmailOne) // SA_3
 	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "jwt-target", delegateServiceAccountEmailTwo)         // SA_4
 
+	context := map[string]interface{}{
+		"ephemeral_resource_name": "jwt",
+		"target_service_account":  targetServiceAccountEmail,
+		"delegate_1":              delegateServiceAccountEmailOne,
+		"delegate_2":              delegateServiceAccountEmailTwo,
+		"sub":                     targetServiceAccountEmail,
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralServiceAccountJwt_withDelegates(delegateServiceAccountEmailOne, delegateServiceAccountEmailTwo, targetServiceAccountEmail),
+				Config: testAccEphemeralServiceAccountJwt_withDelegates(context),
 			},
 		},
 	})
@@ -51,56 +64,61 @@ func TestAccEphemeralServiceAccountJwt_withExpiresIn(t *testing.T) {
 	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
 	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "expiry", serviceAccount)
 
+	context := map[string]interface{}{
+		"ephemeral_resource_name": "jwt",
+		"target_service_account":  targetServiceAccountEmail,
+		"sub":                     targetServiceAccountEmail,
+		"expires_in":              "3600",
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralServiceAccountJwt_withExpiresIn(targetServiceAccountEmail),
+				Config: testAccEphemeralServiceAccountJwt_withExpiresIn(context),
 			},
 		},
 	})
 }
 
-func testAccEphemeralServiceAccountJwt_basic(serviceAccountEmail string) string {
-	return fmt.Sprintf(`
-ephemeral "google_service_account_jwt" "jwt" {
-  target_service_account = "%s"
+func testAccEphemeralServiceAccountJwt_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
+  target_service_account = "%{target_service_account}"
   payload               = jsonencode({
-    "sub": "%[1]s",
+    "sub": "%{sub}",
     "aud": "https://example.com"
   })
 }
-`, serviceAccountEmail)
+`, context)
 }
 
-func testAccEphemeralServiceAccountJwt_withDelegates(delegateServiceAccountEmailOne, delegateServiceAccountEmailTwo, targetServiceAccountEmail string) string {
-	return fmt.Sprintf(`
-ephemeral "google_service_account_jwt" "jwt" {
-  target_service_account = "%s"
+func testAccEphemeralServiceAccountJwt_withDelegates(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
+  target_service_account = "%{target_service_account}"
   delegates = [
-    "%s",
-    "%s",
+    "%{delegate_1}",
+    "%{delegate_2}",
   ]
   payload               = jsonencode({
-    "sub": "%[1]s",
+    "sub": "%{sub}",
     "aud": "https://example.com"
   })
 }
-# The delegation chain is:
-# SA_1 (initialServiceAccountEmail) -> SA_2 (delegateServiceAccountEmailOne) -> SA_3 (delegateServiceAccountEmailTwo) -> SA_4 (targetServiceAccountEmail)
-`, targetServiceAccountEmail, delegateServiceAccountEmailOne, delegateServiceAccountEmailTwo)
+`, context)
 }
 
-func testAccEphemeralServiceAccountJwt_withExpiresIn(serviceAccountEmail string) string {
-	return fmt.Sprintf(`
-ephemeral "google_service_account_jwt" "jwt" {
-  target_service_account = "%s"
-  expires_in            = 3600
+func testAccEphemeralServiceAccountJwt_withExpiresIn(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+ephemeral "google_service_account_jwt" "%{ephemeral_resource_name}" {
+  target_service_account = "%{target_service_account}"
+  expires_in            = %{expires_in}
   payload               = jsonencode({
-    "sub": "%[1]s",
+    "sub": "%{sub}",
     "aud": "https://example.com"
   })
 }
-`, serviceAccountEmail)
+`, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Now that plugin-testing has been bumped to `1.14.1` we can include more testing around ephemeral resources.

This is comes from a PR that was opened initially when ephemeral resources was worked on but was not merged due to being pinned on `1.5.1` for plugin-testing at the time:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/12383

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
