### PR TITLE
Made singleton generation support PUT-based singletons

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -58,7 +58,7 @@ type Product struct {
 	CaiAssetService string `yaml:"cai_asset_service,omitempty"`
 
 	// CaiResourceType of resources that already have an AssetType constant defined in the product.
-	ResourcesWithCaiAssetType map[string]struct{}
+	ResourcesWithCaiAssetType map[string]struct{} `yaml:"-"`
 
 	// A function reference designed for the rare case where you
 	// need to use retries in operation calls. Used for the service api

--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -203,6 +203,8 @@ func findResources(doc *openapi3.T) map[string]*resource {
 		}
 		if name, op := buildOperation(key, pathValue.Patch, "Update"); op != nil {
 			getDefault(name).update = op
+		} else if name, op := buildOperation(key, pathValue.Put, "Update"); op != nil {
+			getDefault(name).update = op
 		}
 	}
 
@@ -293,6 +295,11 @@ func buildSingleton(resourceName string, in *resource, root *openapi3.T) api.Res
 	resourcePath := in.update.path
 
 	op := root.Paths.Find(resourcePath).Patch
+	verb := "PATCH"
+	if op == nil {
+		op = root.Paths.Find(resourcePath).Put
+		verb = "PUT"
+	}
 	parsedObjects := parseOpenApi(resourcePath, resourceName, op)
 
 	parameters := parsedObjects[0].([]*api.Type)
@@ -308,9 +315,9 @@ func buildSingleton(resourceName string, in *resource, root *openapi3.T) api.Res
 	resource.SelfLink = selfLink
 	resource.CreateUrl = fmt.Sprintf("%s=?updateMask=*", baseUrl)
 
-	resource.CreateVerb = "PATCH"
+	resource.CreateVerb = verb
 
-	resource.UpdateVerb = "PATCH"
+	resource.UpdateVerb = verb
 	resource.UpdateMask = true
 	if in.update.async {
 		resource.AutogenAsync = true

--- a/mmv1/products/vectorsearch/product.yaml
+++ b/mmv1/products/vectorsearch/product.yaml
@@ -21,4 +21,3 @@ versions:
     name: ga
   - base_url: https://vectorsearch.googleapis.com/v1beta/
     name: beta
-resourceswithcaiassettype: {}


### PR DESCRIPTION
also omitted resourcewithcaiassettype from yaml, since it's purely used at runtime to track which assets have already been defined in generated code.

Ran into this working on support for firebase RuntimeConfig, which is a PUT-based singleton; these changes allowed me to generate it.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
