### PR TITLE
compute: add supporte to maxSession in backend_service resource

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -161,6 +161,11 @@ examples:
     min_version: 'beta'
     vars:
       backend_service_name: 'backend-service'
+  - name: 'backend_service_max_session_basic'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    vars:
+      backend_service_name: 'backend-service-max-session'
 parameters:
 properties:
   - name: 'affinityCookieTtlSec'
@@ -201,6 +206,24 @@ properties:
             - 'CONNECTION'
             - 'CUSTOM_METRICS'
             - 'IN_FLIGHT'
+        - name: 'maxSession'
+          type: Integer
+          description: |
+            Defines a maximum number of long-lived sessions.
+            Not available if backend's balancing mode is RATE or CONNECTION
+          min_version: 'beta'
+        - name: 'maxSessionPerEndpoint'
+          type: Integer
+          description: |
+            Defines a maximum number of endpoint per sessions.
+            Not available if backend's balancing mode is RATE or CONNECTION
+          min_version: 'beta'
+        - name: 'maxSessionPerInstance'
+          type: Integer
+          description: |
+            Defines a maximum number of instance sessions.
+            Not available if backend's balancing mode is RATE or CONNECTION
+          min_version: 'beta'
         - name: 'capacityScaler'
           type: Double
           description: |

--- a/mmv1/templates/terraform/examples/backend_service_max_session_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/backend_service_max_session_basic.tf.tmpl
@@ -1,0 +1,92 @@
+resource "google_compute_network" "custom" {
+  provider              = google-beta
+  name                    = "custom-vpc%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "{{$.PrimaryResourceId}}" {
+  provider      = google-beta
+  name          = "custom-subnet%{random_suffix}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.custom.id
+}
+
+resource "google_compute_region_instance_template" "foobar_template" {
+  provider     = google-beta
+  name_prefix  = "foobar-template-"
+  machine_type = "e2-medium"
+  region       = "us-central1" 
+
+  disk {
+    source_image = "debian-cloud/debian-11"
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network    = google_compute_network.custom.id
+    subnetwork = google_compute_subnetwork.default.id
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "foobar" {
+  provider           = google-beta
+  name               = "foobar-mig"
+  base_instance_name = "foobar-app"
+  region             = "us-central1"
+
+  version {
+    instance_template = google_compute_region_instance_template.foobar_template.id
+    name              = "primary"
+  }
+
+  target_size = 2 
+
+  named_port {
+    name = "http"
+    port = 80
+  }
+
+  distribution_policy_zones = ["us-central1-a", "us-central1-b", "us-central1-c"]
+
+  update_policy {
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    max_surge_fixed       = 3
+    max_unavailable_fixed = 0
+  }
+}
+
+resource "google_compute_health_check" "{{$.PrimaryResourceId}}"{
+  provider           = google-beta
+  name               = "tf-test-health-check"
+  check_interval_sec = 5
+  timeout_sec        = 5
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  provider              = google-beta
+  name                  = "{{index $.Vars "backend_service_name"}}"
+  description           = "Hello World 1234"
+  port_name             = "http"
+  protocol              = "TCP"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  health_checks = [google_compute_health_check.default.id]
+  connection_draining_timeout_sec = 300 
+
+  backend {
+    group          = google_compute_region_instance_group_manager.foobar.instance_group
+    balancing_mode = "CONNECTION"
+    max_connections_per_instance = 100
+    max_session_per_instance = 100
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Hello folks,

This Pr is to create a support to maxSession,maxSessionPerEndpoint and maxSessionPerInstance field in a backend_service resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `maxSession`, `maxSessionPerEndpoint`, `maxSessionPerInstance` on `google_compute_backend_service` resource
```
