### PR TITLE
`serviceAccountKey`: add `Close()` in ephemeral to support `private_data` attribute

### DIFF
--- a/mmv1/third_party/terraform/go.mod
+++ b/mmv1/third_party/terraform/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-mux v0.23.1

--- a/mmv1/third_party/terraform/go.mod
+++ b/mmv1/third_party/terraform/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/hashicorp/terraform-json v0.27.2
 	github.com/hashicorp/terraform-plugin-framework v1.17.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
-	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-mux v0.22.0

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -194,8 +194,8 @@ github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9ipl
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0 h1:I/N0g/eLZ1ZkLZXUQ0oRSXa8YG/EF0CEuQP1wXdrzKw=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0/go.mod h1:t339KhmxnaF4SzdpxmqW8HnQBHVGYazwtfxU0qCs4eE=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/mmv1/third_party/terraform/go.sum
+++ b/mmv1/third_party/terraform/go.sum
@@ -194,8 +194,8 @@ github.com/hashicorp/terraform-plugin-framework v1.17.0 h1:JdX50CFrYcYFY31gkmitA
 github.com/hashicorp/terraform-plugin-framework v1.17.0/go.mod h1:4OUXKdHNosX+ys6rLgVlgklfxN3WHR5VHSOABeS/BM0=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0 h1:I/N0g/eLZ1ZkLZXUQ0oRSXa8YG/EF0CEuQP1wXdrzKw=
 github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0/go.mod h1:t339KhmxnaF4SzdpxmqW8HnQBHVGYazwtfxU0qCs4eE=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
-github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.30.0 h1:VmEiD0n/ewxbvV5VI/bYwNtlSEAXtHaZlSnyUUuQK6k=
 github.com/hashicorp/terraform-plugin-go v0.30.0/go.mod h1:8d523ORAW8OHgA9e8JKg0ezL3XUO84H0A25o4NY/jRo=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -1,17 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package resourcemanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/ephemeralvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
+	"google.golang.org/api/iam/v1"
 )
 
 var _ ephemeral.EphemeralResource = &googleEphemeralServiceAccountKey{}
@@ -29,19 +38,45 @@ func (p *googleEphemeralServiceAccountKey) Metadata(ctx context.Context, req eph
 }
 
 type ephemeralServiceAccountKeyModel struct {
-	Name          types.String `tfsdk:"name"`
-	PublicKeyType types.String `tfsdk:"public_key_type"`
-	KeyAlgorithm  types.String `tfsdk:"key_algorithm"`
-	PublicKey     types.String `tfsdk:"public_key"`
+	FetchKey         types.Bool   `tfsdk:"fetch_key"`
+	ServiceAccountId types.String `tfsdk:"service_account_id"`
+	Name             types.String `tfsdk:"name"`
+	PublicKeyType    types.String `tfsdk:"public_key_type"`
+	KeyAlgorithm     types.String `tfsdk:"key_algorithm"`
+	PublicKeyData    types.String `tfsdk:"public_key_data"`
+	PrivateKey       types.String `tfsdk:"private_key"`
+	PrivateKeyType   types.String `tfsdk:"private_key_type"`
+}
+
+func (p *googleEphemeralServiceAccountKey) ConfigValidators(ctx context.Context) []ephemeral.ConfigValidator {
+	return []ephemeral.ConfigValidator{
+		ephemeralvalidator.Conflicting(
+			path.MatchRoot("public_key_data"),
+			path.MatchRoot("private_key_type"),
+		),
+		ephemeralvalidator.Conflicting(
+			path.MatchRoot("public_key_data"),
+			path.MatchRoot("key_algorithm"),
+		),
+		ephemeralvalidator.AtLeastOneOf(
+			path.MatchRoot("service_account_id"),
+			path.MatchRoot("name"),
+		),
+	}
 }
 
 func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Get an ephemeral service account public key.",
 		Attributes: map[string]schema.Attribute{
+			"service_account_id": schema.StringAttribute{
+				Description: `The ID of the parent service account of the key. This can be a string in the format {ACCOUNT} or projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}, where {ACCOUNT} is the email address or unique id of the service account. If the {ACCOUNT} syntax is used, the project will be inferred from the provider's configuration.`,
+				Optional:    true,
+			},
 			"name": schema.StringAttribute{
 				Description: "The name of the service account key. This must have format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}` is the email address or unique id of the service account.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(verify.ServiceAccountKeyNameRegex),
@@ -51,6 +86,7 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 			"public_key_type": schema.StringAttribute{
 				Description: "The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.",
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"TYPE_X509_PEM_FILE",
@@ -60,11 +96,26 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 			},
 			"key_algorithm": schema.StringAttribute{
 				Description: "The algorithm used to generate the key.",
+				Optional:    true,
 				Computed:    true,
 			},
-			"public_key": schema.StringAttribute{
+			"public_key_data": schema.StringAttribute{
 				Description: "The public key, base64 encoded.",
+				Optional:    true,
+			},
+			"private_key": schema.StringAttribute{
+				Description: "The private key, base64 encoded.",
+				Optional:    true,
 				Computed:    true,
+			},
+			"private_key_type": schema.StringAttribute{
+				Description: "The type of the private key.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"fetch_key": schema.BoolAttribute{
+				Description: "Whether to fetch the public key.",
+				Optional:    true,
 			},
 		},
 	}
@@ -87,40 +138,153 @@ func (p *googleEphemeralServiceAccountKey) Configure(ctx context.Context, req ep
 	p.providerConfig = pd
 }
 
+type ServiceAccountKeyPrivateData struct {
+	Name       string `json:"name"`
+	FetchedKey bool   `json:"fetched_key"`
+}
+
+var createdServiceAccountKey bool
+
 func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
-	var data ephemeralServiceAccountKeyModel
-
+	var data = ephemeralServiceAccountKeyModel{}
+	var err error
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-
-	keyName := data.Name.ValueString()
-
-	// Validate name
-	r := regexp.MustCompile(verify.ServiceAccountKeyNameRegex)
-	if !r.MatchString(keyName) {
-		resp.Diagnostics.AddError(
-			"Invalid key name",
-			fmt.Sprintf("Invalid key name %q does not match regexp %q", keyName, verify.ServiceAccountKeyNameRegex),
-		)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	publicKeyType := data.PublicKeyType.ValueString()
-	if publicKeyType == "" {
-		publicKeyType = "TYPE_X509_PEM_FILE"
+	var serviceAccountKey *iam.ServiceAccountKey
+	var saName string
+	if data.ServiceAccountId.ValueString() != "" {
+		saName = data.ServiceAccountId.ValueString()
+	} else {
+		saName = data.Name.ValueString()
 	}
 
-	sak, err := p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Get(keyName).PublicKeyType(publicKeyType).Do()
+	var publicKeyType string
+	if data.PublicKeyType.ValueString() == "" {
+		publicKeyType = "TYPE_X509_PEM_FILE"
+	} else {
+		publicKeyType = data.PublicKeyType.ValueString()
+	}
+
+	saName, err = tpgresource.ServiceAccountFQN(saName, nil, p.providerConfig)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error retrieving Service Account Key",
-			fmt.Sprintf("Error retrieving Service Account Key %q: %s", keyName, err),
+			"Error getting service account name",
+			fmt.Sprintf("Error getting service account name: %s", err),
 		)
 		return
 	}
 
-	data.Name = types.StringValue(sak.Name)
-	data.KeyAlgorithm = types.StringValue(sak.KeyAlgorithm)
-	data.PublicKey = types.StringValue(sak.PublicKeyData)
+	createdServiceAccountKey = false
+	if !data.FetchKey.ValueBool() {
+		if data.PublicKeyData.ValueString() != "" {
+			ru := &iam.UploadServiceAccountKeyRequest{
+				PublicKeyData: data.PublicKeyData.ValueString(),
+			}
+			serviceAccountKey, err = p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Upload(saName, ru).Do()
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error creating service account key [Upload]",
+					fmt.Sprintf("%s: %s", saName, err),
+				)
+				return
+			}
+			createdServiceAccountKey = true
+		} else {
+			var keyAlgorithm, privateKeyType string
+			if data.PrivateKeyType.ValueString() == "" {
+				privateKeyType = "TYPE_GOOGLE_CREDENTIALS_FILE"
+			} else {
+				privateKeyType = data.PrivateKeyType.ValueString()
+			}
+			if data.KeyAlgorithm.ValueString() == "" {
+				keyAlgorithm = "KEY_ALG_RSA_2048"
+			} else {
+				keyAlgorithm = data.KeyAlgorithm.ValueString()
+			}
+			rc := &iam.CreateServiceAccountKeyRequest{
+				KeyAlgorithm:   keyAlgorithm,
+				PrivateKeyType: privateKeyType,
+			}
+			serviceAccountKey, err = p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Create(saName, rc).Do()
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error creating service account key [Create]",
+					fmt.Sprintf("%s: %s", saName, err),
+				)
+				return
+			}
+			createdServiceAccountKey = true
+		}
+
+		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
+		err = ServiceAccountKeyWaitTime(p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
+			)
+			return
+		}
+
+		marshalledName, _ := json.Marshal(ServiceAccountKeyPrivateData{Name: serviceAccountKey.Name})
+
+		resp.Private.SetKey(ctx, "name", marshalledName)
+
+		data.Name = types.StringValue(serviceAccountKey.Name)
+		data.KeyAlgorithm = types.StringValue(serviceAccountKey.KeyAlgorithm)
+		data.PrivateKey = types.StringValue(serviceAccountKey.PrivateKeyData)
+		data.PrivateKeyType = types.StringValue(serviceAccountKey.PrivateKeyType)
+	}
+	data.PublicKeyType = types.StringValue(publicKeyType)
+	if serviceAccountKey != nil {
+		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
+		err = ServiceAccountKeyWaitTime(p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
+			)
+			return
+		}
+	} else {
+		err = ServiceAccountKeyWaitTime(p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, saName, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", saName, err),
+			)
+			return
+		}
+	}
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}
+
+func (p *googleEphemeralServiceAccountKey) Close(ctx context.Context, req ephemeral.CloseRequest, resp *ephemeral.CloseResponse) {
+	if !createdServiceAccountKey {
+		return
+	}
+	dataBytes, diags := req.Private.GetKey(ctx, "name")
+	if diags.HasError() {
+		resp.Diagnostics.AddError(
+			"Error getting name data",
+			fmt.Sprintf("Error getting name data: %s", diags.Errors()),
+		)
+		return
+	}
+	var data ServiceAccountKeyPrivateData
+	json.Unmarshal(dataBytes, &data)
+	if data.Name != "" {
+		log.Printf("[DEBUG] Deleting Service Account Key %q\n", data.Name)
+		_, err := p.providerConfig.NewIamClient(p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Delete(data.Name).Do()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error deleting Service Account Key",
+				fmt.Sprintf("Error deleting Service Account Key %q: %s", data.Name, err.Error()),
+			)
+			return
+		}
+	}
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 package resourcemanager
 

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -149,35 +149,29 @@ func (p *googleEphemeralServiceAccountKey) Configure(ctx context.Context, req ep
 }
 
 type ServiceAccountKeyPrivateData struct {
-	Name       string `json:"name"`
-	FetchedKey bool   `json:"fetched_key"`
+	Name string `json:"name"`
 }
 
-var createdServiceAccountKey bool
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
-	var data = ephemeralServiceAccountKeyModel{}
-	var err error
+	var data ephemeralServiceAccountKeyModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	var serviceAccountKey *iam.ServiceAccountKey
-	var saName string
-	if data.ServiceAccountId.ValueString() != "" {
-		saName = data.ServiceAccountId.ValueString()
-	} else {
-		saName = data.Name.ValueString()
-	}
 
-	var publicKeyType string
-	if data.PublicKeyType.ValueString() == "" {
-		publicKeyType = "TYPE_X509_PEM_FILE"
-	} else {
-		publicKeyType = data.PublicKeyType.ValueString()
-	}
+	saName := firstNonEmpty(data.ServiceAccountId.ValueString(), data.Name.ValueString())
+	publicKeyType := firstNonEmpty(data.PublicKeyType.ValueString(), "TYPE_X509_PEM_FILE")
 
-	saName, err = tpgresource.ServiceAccountFQN(saName, nil, p.providerConfig)
+	saName, err := tpgresource.ServiceAccountFQN(saName, nil, p.providerConfig)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error getting service account name",
@@ -186,13 +180,14 @@ func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemer
 		return
 	}
 
-	createdServiceAccountKey = false
+	keys := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys
+
+	var serviceAccountKey *iam.ServiceAccountKey
 	if !data.FetchKey.ValueBool() {
 		if data.PublicKeyData.ValueString() != "" {
-			ru := &iam.UploadServiceAccountKeyRequest{
+			serviceAccountKey, err = keys.Upload(saName, &iam.UploadServiceAccountKeyRequest{
 				PublicKeyData: data.PublicKeyData.ValueString(),
-			}
-			serviceAccountKey, err = iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Upload(saName, ru).Do()
+			}).Do()
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Error creating service account key [Upload]",
@@ -200,24 +195,11 @@ func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemer
 				)
 				return
 			}
-			createdServiceAccountKey = true
 		} else {
-			var keyAlgorithm, privateKeyType string
-			if data.PrivateKeyType.ValueString() == "" {
-				privateKeyType = "TYPE_GOOGLE_CREDENTIALS_FILE"
-			} else {
-				privateKeyType = data.PrivateKeyType.ValueString()
-			}
-			if data.KeyAlgorithm.ValueString() == "" {
-				keyAlgorithm = "KEY_ALG_RSA_2048"
-			} else {
-				keyAlgorithm = data.KeyAlgorithm.ValueString()
-			}
-			rc := &iam.CreateServiceAccountKeyRequest{
-				KeyAlgorithm:   keyAlgorithm,
-				PrivateKeyType: privateKeyType,
-			}
-			serviceAccountKey, err = iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Create(saName, rc).Do()
+			serviceAccountKey, err = keys.Create(saName, &iam.CreateServiceAccountKeyRequest{
+				KeyAlgorithm:   firstNonEmpty(data.KeyAlgorithm.ValueString(), "KEY_ALG_RSA_2048"),
+				PrivateKeyType: firstNonEmpty(data.PrivateKeyType.ValueString(), "TYPE_GOOGLE_CREDENTIALS_FILE"),
+			}).Do()
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Error creating service account key [Create]",
@@ -225,21 +207,9 @@ func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemer
 				)
 				return
 			}
-			createdServiceAccountKey = true
-		}
-
-		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
-		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error retrieving Service Account Key",
-				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
-			)
-			return
 		}
 
 		marshalledName, _ := json.Marshal(ServiceAccountKeyPrivateData{Name: serviceAccountKey.Name})
-
 		resp.Private.SetKey(ctx, "name", marshalledName)
 
 		data.Name = types.StringValue(serviceAccountKey.Name)
@@ -248,34 +218,24 @@ func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemer
 		data.PrivateKeyType = types.StringValue(serviceAccountKey.PrivateKeyType)
 	}
 	data.PublicKeyType = types.StringValue(publicKeyType)
+
+	nameToWait := saName
 	if serviceAccountKey != nil {
-		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
-		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error retrieving Service Account Key",
-				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
-			)
-			return
-		}
-	} else {
-		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, saName, publicKeyType, "Retrieving Service account key", 4*time.Minute)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error retrieving Service Account Key",
-				fmt.Sprintf("Error retrieving Service Account Key %q: %s", saName, err),
-			)
-			return
-		}
+		nameToWait = serviceAccountKey.Name
+	}
+	log.Printf("[DEBUG] Retrieving Service Account Key %q\n", nameToWait)
+	if err := ServiceAccountKeyWaitTime(keys, nameToWait, publicKeyType, "Retrieving Service account key", 4*time.Minute); err != nil {
+		resp.Diagnostics.AddError(
+			"Error retrieving Service Account Key",
+			fmt.Sprintf("Error retrieving Service Account Key %q: %s", nameToWait, err),
+		)
+		return
 	}
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
 }
 
 func (p *googleEphemeralServiceAccountKey) Close(ctx context.Context, req ephemeral.CloseRequest, resp *ephemeral.CloseResponse) {
-	if !createdServiceAccountKey {
-		return
-	}
 	dataBytes, diags := req.Private.GetKey(ctx, "name")
 	if diags.HasError() {
 		resp.Diagnostics.AddError(
@@ -284,17 +244,25 @@ func (p *googleEphemeralServiceAccountKey) Close(ctx context.Context, req epheme
 		)
 		return
 	}
+	if len(dataBytes) == 0 {
+		return
+	}
 	var data ServiceAccountKeyPrivateData
-	json.Unmarshal(dataBytes, &data)
-	if data.Name != "" {
-		log.Printf("[DEBUG] Deleting Service Account Key %q\n", data.Name)
-		_, err := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Delete(data.Name).Do()
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error deleting Service Account Key",
-				fmt.Sprintf("Error deleting Service Account Key %q: %s", data.Name, err.Error()),
-			)
-			return
-		}
+	if err := json.Unmarshal(dataBytes, &data); err != nil {
+		resp.Diagnostics.AddError(
+			"Error decoding ephemeral private data",
+			fmt.Sprintf("Error decoding ephemeral private data: %s", err),
+		)
+		return
+	}
+
+	log.Printf("[DEBUG] Deleting Service Account Key %q\n", data.Name)
+	keys := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys
+	if _, err := keys.Delete(data.Name).Do(); err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting Service Account Key",
+			fmt.Sprintf("Error deleting Service Account Key %q: %s", data.Name, err.Error()),
+		)
+		return
 	}
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -1,19 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
 package resourcemanager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"log"
 	"regexp"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/ephemeralvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/services/iambeta"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
+	"google.golang.org/api/iam/v1"
 )
 
 var _ ephemeral.EphemeralResource = &googleEphemeralServiceAccountKey{}
@@ -39,19 +48,45 @@ func (p *googleEphemeralServiceAccountKey) Metadata(ctx context.Context, req eph
 }
 
 type ephemeralServiceAccountKeyModel struct {
-	Name          types.String `tfsdk:"name"`
-	PublicKeyType types.String `tfsdk:"public_key_type"`
-	KeyAlgorithm  types.String `tfsdk:"key_algorithm"`
-	PublicKey     types.String `tfsdk:"public_key"`
+	FetchKey         types.Bool   `tfsdk:"fetch_key"`
+	ServiceAccountId types.String `tfsdk:"service_account_id"`
+	Name             types.String `tfsdk:"name"`
+	PublicKeyType    types.String `tfsdk:"public_key_type"`
+	KeyAlgorithm     types.String `tfsdk:"key_algorithm"`
+	PublicKeyData    types.String `tfsdk:"public_key_data"`
+	PrivateKey       types.String `tfsdk:"private_key"`
+	PrivateKeyType   types.String `tfsdk:"private_key_type"`
+}
+
+func (p *googleEphemeralServiceAccountKey) ConfigValidators(ctx context.Context) []ephemeral.ConfigValidator {
+	return []ephemeral.ConfigValidator{
+		ephemeralvalidator.Conflicting(
+			path.MatchRoot("public_key_data"),
+			path.MatchRoot("private_key_type"),
+		),
+		ephemeralvalidator.Conflicting(
+			path.MatchRoot("public_key_data"),
+			path.MatchRoot("key_algorithm"),
+		),
+		ephemeralvalidator.AtLeastOneOf(
+			path.MatchRoot("service_account_id"),
+			path.MatchRoot("name"),
+		),
+	}
 }
 
 func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephemeral.SchemaRequest, resp *ephemeral.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Description: "Get an ephemeral service account public key.",
 		Attributes: map[string]schema.Attribute{
+			"service_account_id": schema.StringAttribute{
+				Description: `The ID of the parent service account of the key. This can be a string in the format {ACCOUNT} or projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}, where {ACCOUNT} is the email address or unique id of the service account. If the {ACCOUNT} syntax is used, the project will be inferred from the provider's configuration.`,
+				Optional:    true,
+			},
 			"name": schema.StringAttribute{
 				Description: "The name of the service account key. This must have format `projects/{PROJECT_ID}/serviceAccounts/{ACCOUNT}/keys/{KEYID}`, where `{ACCOUNT}` is the email address or unique id of the service account.",
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(verify.ServiceAccountKeyNameRegex),
@@ -61,6 +96,7 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 			"public_key_type": schema.StringAttribute{
 				Description: "The output format of the public key requested. TYPE_X509_PEM_FILE is the default output format.",
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"TYPE_X509_PEM_FILE",
@@ -70,11 +106,26 @@ func (p *googleEphemeralServiceAccountKey) Schema(ctx context.Context, req ephem
 			},
 			"key_algorithm": schema.StringAttribute{
 				Description: "The algorithm used to generate the key.",
+				Optional:    true,
 				Computed:    true,
 			},
-			"public_key": schema.StringAttribute{
+			"public_key_data": schema.StringAttribute{
 				Description: "The public key, base64 encoded.",
+				Optional:    true,
+			},
+			"private_key": schema.StringAttribute{
+				Description: "The private key, base64 encoded.",
+				Optional:    true,
 				Computed:    true,
+			},
+			"private_key_type": schema.StringAttribute{
+				Description: "The type of the private key.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"fetch_key": schema.BoolAttribute{
+				Description: "Whether to fetch the public key.",
+				Optional:    true,
 			},
 		},
 	}
@@ -97,40 +148,153 @@ func (p *googleEphemeralServiceAccountKey) Configure(ctx context.Context, req ep
 	p.providerConfig = pd
 }
 
+type ServiceAccountKeyPrivateData struct {
+	Name       string `json:"name"`
+	FetchedKey bool   `json:"fetched_key"`
+}
+
+var createdServiceAccountKey bool
+
 func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
-	var data ephemeralServiceAccountKeyModel
-
+	var data = ephemeralServiceAccountKeyModel{}
+	var err error
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-
-	keyName := data.Name.ValueString()
-
-	// Validate name
-	r := regexp.MustCompile(verify.ServiceAccountKeyNameRegex)
-	if !r.MatchString(keyName) {
-		resp.Diagnostics.AddError(
-			"Invalid key name",
-			fmt.Sprintf("Invalid key name %q does not match regexp %q", keyName, verify.ServiceAccountKeyNameRegex),
-		)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	publicKeyType := data.PublicKeyType.ValueString()
-	if publicKeyType == "" {
-		publicKeyType = "TYPE_X509_PEM_FILE"
+	var serviceAccountKey *iam.ServiceAccountKey
+	var saName string
+	if data.ServiceAccountId.ValueString() != "" {
+		saName = data.ServiceAccountId.ValueString()
+	} else {
+		saName = data.Name.ValueString()
 	}
 
-	sak, err := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Get(keyName).PublicKeyType(publicKeyType).Do()
+	var publicKeyType string
+	if data.PublicKeyType.ValueString() == "" {
+		publicKeyType = "TYPE_X509_PEM_FILE"
+	} else {
+		publicKeyType = data.PublicKeyType.ValueString()
+	}
+
+	saName, err = tpgresource.ServiceAccountFQN(saName, nil, p.providerConfig)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error retrieving Service Account Key",
-			fmt.Sprintf("Error retrieving Service Account Key %q: %s", keyName, err),
+			"Error getting service account name",
+			fmt.Sprintf("Error getting service account name: %s", err),
 		)
 		return
 	}
 
-	data.Name = types.StringValue(sak.Name)
-	data.KeyAlgorithm = types.StringValue(sak.KeyAlgorithm)
-	data.PublicKey = types.StringValue(sak.PublicKeyData)
+	createdServiceAccountKey = false
+	if !data.FetchKey.ValueBool() {
+		if data.PublicKeyData.ValueString() != "" {
+			ru := &iam.UploadServiceAccountKeyRequest{
+				PublicKeyData: data.PublicKeyData.ValueString(),
+			}
+			serviceAccountKey, err = iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Upload(saName, ru).Do()
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error creating service account key [Upload]",
+					fmt.Sprintf("%s: %s", saName, err),
+				)
+				return
+			}
+			createdServiceAccountKey = true
+		} else {
+			var keyAlgorithm, privateKeyType string
+			if data.PrivateKeyType.ValueString() == "" {
+				privateKeyType = "TYPE_GOOGLE_CREDENTIALS_FILE"
+			} else {
+				privateKeyType = data.PrivateKeyType.ValueString()
+			}
+			if data.KeyAlgorithm.ValueString() == "" {
+				keyAlgorithm = "KEY_ALG_RSA_2048"
+			} else {
+				keyAlgorithm = data.KeyAlgorithm.ValueString()
+			}
+			rc := &iam.CreateServiceAccountKeyRequest{
+				KeyAlgorithm:   keyAlgorithm,
+				PrivateKeyType: privateKeyType,
+			}
+			serviceAccountKey, err = iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Create(saName, rc).Do()
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error creating service account key [Create]",
+					fmt.Sprintf("%s: %s", saName, err),
+				)
+				return
+			}
+			createdServiceAccountKey = true
+		}
+
+		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
+		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
+			)
+			return
+		}
+
+		marshalledName, _ := json.Marshal(ServiceAccountKeyPrivateData{Name: serviceAccountKey.Name})
+
+		resp.Private.SetKey(ctx, "name", marshalledName)
+
+		data.Name = types.StringValue(serviceAccountKey.Name)
+		data.KeyAlgorithm = types.StringValue(serviceAccountKey.KeyAlgorithm)
+		data.PrivateKey = types.StringValue(serviceAccountKey.PrivateKeyData)
+		data.PrivateKeyType = types.StringValue(serviceAccountKey.PrivateKeyType)
+	}
+	data.PublicKeyType = types.StringValue(publicKeyType)
+	if serviceAccountKey != nil {
+		log.Printf("[DEBUG] Retrieving Service Account Key %q\n", serviceAccountKey.Name)
+		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, serviceAccountKey.Name, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", serviceAccountKey.Name, err),
+			)
+			return
+		}
+	} else {
+		err = ServiceAccountKeyWaitTime(iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys, saName, publicKeyType, "Retrieving Service account key", 4*time.Minute)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error retrieving Service Account Key",
+				fmt.Sprintf("Error retrieving Service Account Key %q: %s", saName, err),
+			)
+			return
+		}
+	}
 
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
+}
+
+func (p *googleEphemeralServiceAccountKey) Close(ctx context.Context, req ephemeral.CloseRequest, resp *ephemeral.CloseResponse) {
+	if !createdServiceAccountKey {
+		return
+	}
+	dataBytes, diags := req.Private.GetKey(ctx, "name")
+	if diags.HasError() {
+		resp.Diagnostics.AddError(
+			"Error getting name data",
+			fmt.Sprintf("Error getting name data: %s", diags.Errors()),
+		)
+		return
+	}
+	var data ServiceAccountKeyPrivateData
+	json.Unmarshal(dataBytes, &data)
+	if data.Name != "" {
+		log.Printf("[DEBUG] Deleting Service Account Key %q\n", data.Name)
+		_, err := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys.Delete(data.Name).Do()
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error deleting Service Account Key",
+				fmt.Sprintf("Error deleting Service Account Key %q: %s", data.Name, err.Error()),
+			)
+			return
+		}
+	}
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
@@ -9,45 +9,141 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
-func TestAccEphemeralServiceAccountKey_basic(t *testing.T) {
+func TestAccEphemeralServiceAccountKey_create(t *testing.T) {
 	t.Parallel()
 
-	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
-	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "key-basic", serviceAccount)
+	accountID := "a" + acctest.RandString(t, 10)
+	displayName := "Terraform Test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccEphemeralServiceAccountKey_setup(targetServiceAccountEmail),
+				Config: testAccEphemeralServiceAccountKey_create_setup(accountID, displayName),
 			},
 			{
-				Config: testAccEphemeralServiceAccountKey_basic(targetServiceAccountEmail),
+				Config: testAccEphemeralServiceAccountKey_create(accountID, displayName),
 			},
 		},
 	})
 }
 
-func testAccEphemeralServiceAccountKey_setup(serviceAccount string) string {
+func testAccEphemeralServiceAccountKey_create_setup(accountID, displayName string) string {
 	return fmt.Sprintf(`
-resource "google_service_account_key" "key" {
-  service_account_id = "%s"
-  public_key_type = "TYPE_X509_PEM_FILE"
-}
-`, serviceAccount)
+resource "google_service_account" "service_account" {
+	account_id   = "%s"
+	display_name = "%s"
 }
 
-func testAccEphemeralServiceAccountKey_basic(serviceAccount string) string {
+`, accountID, displayName)
+}
+
+func testAccEphemeralServiceAccountKey_create(accountID, displayName string) string {
 	return fmt.Sprintf(`
-resource "google_service_account_key" "key" {
-  service_account_id = "%s"
-  public_key_type = "TYPE_X509_PEM_FILE"
+resource "google_service_account" "service_account" {
+	account_id   = "%s"
+	display_name = "%s"
 }
 
 ephemeral "google_service_account_key" "key" {
-  name            = google_service_account_key.key.name
+  service_account_id = google_service_account.service_account.email
   public_key_type = "TYPE_X509_PEM_FILE"
 }
-`, serviceAccount)
+`, accountID, displayName)
+}
+
+func TestAccEphemeralServiceAccountKey_upload(t *testing.T) {
+	t.Parallel()
+
+	accountID := "b" + acctest.RandString(t, 10)
+	displayName := "Terraform Test Two"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralServiceAccountKey_upload_setup(accountID, displayName),
+			},
+			{
+				Config: testAccEphemeralServiceAccountKey_upload(accountID, displayName),
+			},
+		},
+	})
+}
+
+func testAccEphemeralServiceAccountKey_upload_setup(accountID, displayName string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "service_account" {
+	account_id   = "%s"
+	display_name = "%s"
+}
+resource "time_sleep" "wait_30_seconds" {
+  create_duration = "30s"
+  depends_on = [google_service_account.service_account]
+}
+`, accountID, displayName)
+}
+
+func testAccEphemeralServiceAccountKey_upload(accountID, displayName string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "service_account" {
+	account_id   = "%s"
+	display_name = "%s"
+}
+resource "time_sleep" "wait_30_seconds" {
+  create_duration = "30s"
+  depends_on = [google_service_account.service_account]
+}
+
+ephemeral "google_service_account_key" "key" {
+  service_account_id = google_service_account.service_account.email
+  public_key_data    = filebase64("test-fixtures/public_key.pem")
+}
+`, accountID, displayName)
+}
+
+func TestAccEphemeralServiceAccountKey_fetch(t *testing.T) {
+	t.Parallel()
+
+	serviceAccount := envvar.GetTestServiceAccountFromEnv(t)
+	targetServiceAccountEmail := acctest.BootstrapServiceAccount(t, "key-basic", serviceAccount)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEphemeralServiceAccountKey_fetch_setup(targetServiceAccountEmail),
+			},
+			{
+				Config: testAccEphemeralServiceAccountKey_fetch(targetServiceAccountEmail),
+			},
+		},
+	})
+}
+
+func testAccEphemeralServiceAccountKey_fetch_setup(accountID string) string {
+	return fmt.Sprintf(`
+resource "google_service_account_key" "acceptance" {
+  service_account_id = "%s"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}
+`, accountID)
+}
+
+func testAccEphemeralServiceAccountKey_fetch(accountID string) string {
+	return fmt.Sprintf(`
+resource "google_service_account_key" "acceptance" {
+  service_account_id = "%s"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+}
+
+ephemeral "google_service_account_key" "key" {
+  name = google_service_account_key.acceptance.name
+  fetch_key = true
+}
+`, accountID)
 }

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
@@ -66,6 +66,9 @@ func TestAccEphemeralServiceAccountKey_upload(t *testing.T) {
 
 	accountID := "b" + acctest.RandString(t, 10)
 	displayName := "Terraform Test Two"
+	project := envvar.GetTestProjectFromEnv()
+	expectedServiceAccountEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountID, project)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -80,8 +83,9 @@ func TestAccEphemeralServiceAccountKey_upload(t *testing.T) {
 			{
 				Config: testAccEphemeralServiceAccountKey_upload(accountID, displayName),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.service_account_id", expectedServiceAccountEmail),
 					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.public_key_type", "TYPE_X509_PEM_FILE"),
-					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.private_key"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.name"),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key_test.go
@@ -14,16 +14,24 @@ func TestAccEphemeralServiceAccountKey_create(t *testing.T) {
 
 	accountID := "a" + acctest.RandString(t, 10)
 	displayName := "Terraform Test"
+	project := envvar.GetTestProjectFromEnv()
+	expectedServiceAccountEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountID, project)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountKey_create_setup(accountID, displayName),
 			},
 			{
 				Config: testAccEphemeralServiceAccountKey_create(accountID, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.service_account_id", expectedServiceAccountEmail),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.public_key_type", "TYPE_X509_PEM_FILE"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.private_key"),
+				),
 			},
 		},
 	})
@@ -40,7 +48,7 @@ resource "google_service_account" "service_account" {
 }
 
 func testAccEphemeralServiceAccountKey_create(accountID, displayName string) string {
-	return fmt.Sprintf(`
+	return acctest.EchoResourceConfig("ephemeral.google_service_account_key.key") + fmt.Sprintf(`
 resource "google_service_account" "service_account" {
 	account_id   = "%s"
 	display_name = "%s"
@@ -61,6 +69,7 @@ func TestAccEphemeralServiceAccountKey_upload(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
@@ -70,6 +79,10 @@ func TestAccEphemeralServiceAccountKey_upload(t *testing.T) {
 			},
 			{
 				Config: testAccEphemeralServiceAccountKey_upload(accountID, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.public_key_type", "TYPE_X509_PEM_FILE"),
+					resource.TestCheckResourceAttrSet(acctest.EchoResourceName, "data.private_key"),
+				),
 			},
 		},
 	})
@@ -89,7 +102,7 @@ resource "time_sleep" "wait_30_seconds" {
 }
 
 func testAccEphemeralServiceAccountKey_upload(accountID, displayName string) string {
-	return fmt.Sprintf(`
+	return acctest.EchoResourceConfig("ephemeral.google_service_account_key.key") + fmt.Sprintf(`
 resource "google_service_account" "service_account" {
 	account_id   = "%s"
 	display_name = "%s"
@@ -114,12 +127,18 @@ func TestAccEphemeralServiceAccountKey_fetch(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEphemeralServiceAccountKey_fetch_setup(targetServiceAccountEmail),
 			},
 			{
 				Config: testAccEphemeralServiceAccountKey_fetch(targetServiceAccountEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(acctest.EchoResourceName, "data.name", "google_service_account_key.acceptance", "name"),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.fetch_key", "true"),
+					resource.TestCheckResourceAttr(acctest.EchoResourceName, "data.public_key_type", "TYPE_X509_PEM_FILE"),
+				),
 			},
 		},
 	})
@@ -135,7 +154,7 @@ resource "google_service_account_key" "acceptance" {
 }
 
 func testAccEphemeralServiceAccountKey_fetch(accountID string) string {
-	return fmt.Sprintf(`
+	return acctest.EchoResourceConfig("ephemeral.google_service_account_key.key") + fmt.Sprintf(`
 resource "google_service_account_key" "acceptance" {
   service_account_id = "%s"
   public_key_type    = "TYPE_X509_PEM_FILE"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

The new `Close()` method that wasn't introducded on the initial implementation of `ephemeral_service_account_key` allows for clean-up in the case where a new service-account-key is being created. any other case such as `fetch` or `upload` results in the cleanup of service_account_key to be passed since we only perform clean-ups when sensitive information is being used (we now are able to include the `private_key` attribute because of this)

Refer to [Hashicorp Docs - Ephemeral/Close() method](https://developer.hashicorp.com/terraform/plugin/framework/ephemeral-resources/close) for more info

# Local Test Runs

## TestAccEphemeralServiceAccountKey_create
```hcl
󰀵 mau  …/terraform-provider-google   main $✘!?⇕   v1.26.1   10:35   envchain GCLOUD make testacc TEST=./google/services/resourcemanager TESTARGS='-run=TestAccEphemeralServiceAccountKey_create'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/resourcemanager -v -run=TestAccEphemeralServiceAccountKey_create -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccEphemeralServiceAccountKey_create
=== PAUSE TestAccEphemeralServiceAccountKey_create
=== CONT  TestAccEphemeralServiceAccountKey_create
--- PASS: TestAccEphemeralServiceAccountKey_create (41.01s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/resourcemanager  42.532s
```
## TestAccEphemeralServiceAccountKey_upload
```hcl
󰀵 mau  …/terraform-provider-google   main $✘!?⇕   v1.26.1   11:35   envchain GCLOUD make testacc TEST=./google/services/resourcemanager TESTARGS='-run=TestAccEphemeralServiceAccountKey_upload'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/resourcemanager -v -run=TestAccEphemeralServiceAccountKey_upload -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccEphemeralServiceAccountKey_upload
=== PAUSE TestAccEphemeralServiceAccountKey_upload
=== CONT  TestAccEphemeralServiceAccountKey_upload
--- PASS: TestAccEphemeralServiceAccountKey_upload (83.25s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/resourcemanager  84.823s
```

## TestAccEphemeralServiceAccountKey_fetch
```hcl
󰀵 mau  …/terraform-provider-google   main $   v1.26.1   10:59   envchain GCLOUD make testacc TEST=./google/services/resourcemanager TESTARGS='-run=TestAccEphemeralServiceAccountKey_fetch' 
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/resourcemanager -v -run=TestAccEphemeralServiceAccountKey_fetch -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccEphemeralServiceAccountKey_fetch
=== PAUSE TestAccEphemeralServiceAccountKey_fetch
=== CONT  TestAccEphemeralServiceAccountKey_fetch
2026/04/16 11:03:49 [INFO] Authenticating using configured Google JSON 'credentials'...
2026/04/16 11:03:49 [INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]
2026/04/16 11:03:49 [INFO] Authenticating using configured Google JSON 'credentials'...
2026/04/16 11:03:49 [INFO]   -- Scopes: [https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email]
2026/04/16 11:03:49 [DEBUG] Waiting for state to become: [success]
2026/04/16 11:03:50 [INFO] Terraform is using this identity: mauricio-alvarezleon@hc-terraform-testing.iam.gserviceaccount.com
2026/04/16 11:03:50 [DEBUG] Verifying projects/hc-terraform-testing/serviceAccounts/tf-bootstrap-sa-key-basic@hc-terraform-testing.iam.gserviceaccount.com as bootstrapped service account.
2026/04/16 11:03:50 [INFO] Instantiating Google Cloud IAM client for path https://iam.googleapis.com/
2026/04/16 11:03:50 [DEBUG] Setting service account permissions.
2026/04/16 11:03:50 [INFO] Instantiating Google Cloud IAM client for path https://iam.googleapis.com/
--- PASS: TestAccEphemeralServiceAccountKey_fetch (31.74s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/resourcemanager  33.341s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
resourcemanager: add `private_key` and `private_key_type` fields to ephemeral `google_service_account_key` resource
```
