### PR TITLE
[ServiceUsage] Add `unit` field to `google_service_usage_consumer_quota_override`

### DIFF
--- a/mmv1/products/serviceusage/ConsumerQuotaOverride.yaml
+++ b/mmv1/products/serviceusage/ConsumerQuotaOverride.yaml
@@ -57,42 +57,51 @@ examples:
     min_version: beta
     vars:
       project_id: quota
+    test_env_vars:
+      org_id: ORG_ID
     test_vars_overrides:
       # for backward compatible
       project_id: '"quota" + randomSuffix'
-    test_env_vars:
-      org_id: ORG_ID
   - name: consumer_quota_override_zero_value
     primary_resource_id: override
     min_version: beta
     exclude_docs: true
     vars:
       project_id: quota
+    test_env_vars:
+      org_id: ORG_ID
     test_vars_overrides:
       # for backward compatible
       project_id: '"quota" + randomSuffix'
-    test_env_vars:
-      org_id: ORG_ID
   - name: region_consumer_quota_override
     primary_resource_id: override
     min_version: beta
     vars:
       project_id: quota
+    test_env_vars:
+      org_id: ORG_ID
     test_vars_overrides:
       # for backward compatible
       project_id: '"quota" + randomSuffix'
-    test_env_vars:
-      org_id: ORG_ID
   - name: consumer_quota_override_custom_dimension
     primary_resource_id: override
     min_version: beta
     vars:
       project_id: quota
+    test_env_vars:
+      org_id: ORG_ID
     test_vars_overrides:
       # for backward compatible
       project_id: '"quota" + randomSuffix'
+  - name: consumer_quota_override_unit
+    primary_resource_id: override
+    min_version: beta
+    vars:
+      project_id: quota
     test_env_vars:
       org_id: ORG_ID
+    test_vars_overrides:
+      project_id: '"quota" + randomSuffix'
 parameters:
   - name: name
     type: String
@@ -150,3 +159,6 @@ properties:
       If this map is nonempty, then this override applies only to specific values for dimensions defined in the limit unit.
     immutable: true
     min_version: beta
+  - name: unit
+    type: String
+    description: 'The limit unit of the limit to which this override applies. An example unit would be: `1/{project}/{region}` Note that `{project}` and `{region}` are not placeholders in this example; the literal characters `{` and `}` occur in the string.'

--- a/mmv1/templates/terraform/examples/consumer_quota_override_unit.tf.tmpl
+++ b/mmv1/templates/terraform/examples/consumer_quota_override_unit.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_project" "my_project" {
+  provider        = google-beta
+  name            = "tf-test-project"
+  project_id      = "{{index $.Vars "project_id"}}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_service_usage_consumer_quota_override" "override" {
+  provider       = google-beta
+  dimensions = {
+    region = "us-central1"
+  }
+  project        = google_project.my_project.project_id
+  service        = "compute.googleapis.com"
+  metric         = urlencode("compute.googleapis.com/n2_cpus")
+  limit          = urlencode("/project/region")
+  unit           = "1/{project}/{region}"
+  override_value = "8"
+  force          = true
+}


### PR DESCRIPTION
Adds the `unit` field to the `google_service_usage_consumer_quota_override` resource.

```release-note:enhancement
serviceusage: added `unit` field to `google_service_usage_consumer_quota_override` resource (beta)
```