### PR TITLE
[Security Scanner] Add static_ip_scan field to google_security_scanner_scan_config

### DIFF
--- a/mmv1/products/securityscanner/ScanConfig.yaml
+++ b/mmv1/products/securityscanner/ScanConfig.yaml
@@ -36,6 +36,12 @@ examples:
     vars:
       address_name: scan-basic-static-ip
       scan_config_name: terraform-scan-config
+  - name: scan_config_static_ip
+    primary_resource_id: scan-config
+    min_version: beta
+    vars:
+      address_name: scan-static-ip
+      scan_config_name: terraform-scan-config-static
 properties:
   - name: name
     type: String
@@ -189,3 +195,6 @@ properties:
     enum_values:
       - ENABLED
       - DISABLED
+  - name: staticIpScan
+    type: Boolean
+    description: Whether the scan configuration has enabled static IP address scan feature. If enabled, the scanner will access applications from static IP addresses.

--- a/mmv1/templates/terraform/examples/scan_config_static_ip.tf.tmpl
+++ b/mmv1/templates/terraform/examples/scan_config_static_ip.tf.tmpl
@@ -1,0 +1,12 @@
+resource "google_compute_address" "scanner_static_ip" {
+  provider = google-beta
+  name     = "{{index $.Vars "address_name"}}"
+}
+
+resource "google_security_scanner_scan_config" "{{$.PrimaryResourceId}}" {
+  provider         = google-beta
+  display_name     = "{{index $.Vars "scan_config_name"}}"
+  starting_urls    = ["http://${google_compute_address.scanner_static_ip.address}"]
+  target_platforms = ["COMPUTE"]
+  static_ip_scan   = true
+}


### PR DESCRIPTION
Added the `static_ip_scan` field to the `google_security_scanner_scan_config` resource. 

This new field allows users to enable the static IP address scan feature. If enabled, the scanner will access applications from static IP addresses. A corresponding acceptance test has also been added to ensure the new field is properly applied and destroyed.

```release-note:enhancement
securityscanner: added `static_ip_scan` field to `google_security_scanner_scan_config` resource (beta)
```