### PR TITLE
[Dataform] Add release_compilation_result to google_dataform_repository_release_config

### DIFF
--- a/mmv1/products/dataform/RepositoryReleaseConfig.yaml
+++ b/mmv1/products/dataform/RepositoryReleaseConfig.yaml
@@ -50,6 +50,17 @@ examples:
       secret_name: my_secret
     test_vars_overrides:
       git_repository_name: '"my/repository" + randomSuffix'
+  - name: dataform_repository_release_config_with_compilation_result
+    primary_resource_id: release
+    min_version: beta
+    vars:
+      data: secret-data
+      dataform_repository_name: dataform_repository
+      git_repository_name: my/repository
+      release_name: my_release
+      secret_name: my_secret
+    test_vars_overrides:
+      git_repository_name: '"my/repository" + randomSuffix'
 parameters:
   - name: region
     type: String
@@ -163,3 +174,6 @@ properties:
   - name: disabled
     type: Boolean
     description: Disables automatic creation of compilation results.
+  - name: releaseCompilationResult
+    type: String
+    description: The name of the currently released compilation result for this release config. This value is updated when a compilation result is automatically created from this release config (using cron_schedule), or when this resource is updated by API call (perhaps to roll back to an earlier release). The compilation result must have been created using this release config. Must be in the format `projects/*/locations/*/repositories/*/compilationResults/*`.

--- a/mmv1/templates/terraform/examples/dataform_repository_release_config_with_compilation_result.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository_release_config_with_compilation_result.tf.tmpl
@@ -1,0 +1,53 @@
+resource "google_sourcerepo_repository" "git_repository" {
+  provider = google-beta
+  name     = "{{index $.Vars "git_repository_name"}}"
+}
+
+resource "google_secret_manager_secret" "secret" {
+  provider  = google-beta
+  secret_id = "{{index $.Vars "secret_name"}}"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  provider = google-beta
+  secret   = google_secret_manager_secret.secret.id
+
+  secret_data = "{{index $.Vars "data"}}"
+}
+
+resource "google_dataform_repository" "repository" {
+  provider = google-beta
+  name     = "{{index $.Vars "dataform_repository_name"}}"
+  region   = "us-central1"
+
+  git_remote_settings {
+      url = google_sourcerepo_repository.git_repository.url
+      default_branch = "main"
+      authentication_token_secret_version = google_secret_manager_secret_version.secret_version.id
+  }
+
+  workspace_compilation_overrides {
+    default_database = "database"
+    schema_suffix = "_suffix"
+    table_prefix = "prefix_"
+  }
+}
+
+resource "google_dataform_repository_release_config" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  project    = google_dataform_repository.repository.project
+  region     = google_dataform_repository.repository.region
+  repository = google_dataform_repository.repository.name
+
+  name          = "{{index $.Vars "release_name"}}"
+  git_commitish = "main"
+  cron_schedule = "0 7 * * *"
+  time_zone     = "America/New_York"
+
+  release_compilation_result = "projects/${google_dataform_repository.repository.project}/locations/${google_dataform_repository.repository.region}/repositories/${google_dataform_repository.repository.name}/compilationResults/123456789a"
+}


### PR DESCRIPTION
Added the `release_compilation_result` field to the `google_dataform_repository_release_config` resource.

```release-note:enhancement
dataform: added `release_compilation_result` field to `google_dataform_repository_release_config` resource
```