### PR TITLE
docs: fix grammar error in service_account (ref hashicorp/terraform-provider-google#26532)

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/service_account.html.markdown
@@ -41,7 +41,7 @@ resource "kubernetes_secret" "google-application-credentials" {
 
 The following arguments are supported:
 
-* `account_id` - (Required) The Google service account ID. This be one of:
+* `account_id` - (Required) The Google service account ID. This must be one of:
 
     * The name of the service account within the project (e.g. `my-service`)
 


### PR DESCRIPTION
## Description
This PR fixes a small grammar error ("This be one of" -> "This must be one of") in the google_service_account data source documentation.

This fix was originally submitted to the provider repository (hashicorp/terraform-provider-google#26936) but is being moved here to the source generator (Magic Modules) per maintainer feedback from @melinath.

## Related Issue
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26532

## References
- Original PR: hashicorp/terraform-provider-google#26936
- Internal Google tracking: b/495459471

## Release Note

```release-note:none
docs: fix grammar in google_service_account data source documentation
```