### PR TITLE
Add `trustDefaultSharedCa` to IAM Workload Identity Pool

### DIFF
--- a/mmv1/products/iambeta/WorkloadIdentityPool.yaml
+++ b/mmv1/products/iambeta/WorkloadIdentityPool.yaml
@@ -277,6 +277,15 @@ properties:
                       PEM certificate of the PKI used for validation. Must only contain one ca
                       certificate(either root or intermediate cert).
                     required: true
+            - name: 'trustDefaultSharedCa'
+              type: Boolean
+              description: |
+                If set to True, the trust bundle will include the private ca managed identity regional root
+                public certificates.
+
+
+                ~> **Note** `trust_default_shared_ca` is only supported for managed identity trust domain
+                resource.
   - name: 'attestationRules'
     is_missing_in_cai: true
     type: Array

--- a/mmv1/templates/terraform/examples/iam_workload_identity_pool_full_trust_domain_mode.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iam_workload_identity_pool_full_trust_domain_mode.tf.tmpl
@@ -15,7 +15,8 @@ resource "google_iam_workload_identity_pool" "{{$.PrimaryResourceId}}" {
   }
   inline_trust_config {
     additional_trust_bundles {
-      trust_domain = "example.com"
+      trust_domain            = "example.com"
+      trust_default_shared_ca = false      
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_1.pem")
       }
@@ -24,7 +25,8 @@ resource "google_iam_workload_identity_pool" "{{$.PrimaryResourceId}}" {
       }
     }
     additional_trust_bundles {
-      trust_domain = "example.net"
+      trust_domain            = "example.net"
+      trust_default_shared_ca = false
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_3.pem")
       }

--- a/mmv1/templates/terraform/examples/iam_workload_identity_pool_full_trust_domain_mode_with_default_shared_ca.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iam_workload_identity_pool_full_trust_domain_mode_with_default_shared_ca.tf.tmpl
@@ -12,7 +12,8 @@ resource "google_iam_workload_identity_pool" "{{$.PrimaryResourceId}}" {
   }
   inline_trust_config {
     additional_trust_bundles {
-      trust_domain = "example.com"
+      trust_domain            = "example.com"
+      trust_default_shared_ca = true
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_1.pem")
       }
@@ -21,7 +22,8 @@ resource "google_iam_workload_identity_pool" "{{$.PrimaryResourceId}}" {
       }
     }
     additional_trust_bundles {
-      trust_domain = "example.net"
+      trust_domain            = "example.net"
+      trust_default_shared_ca = true
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_3.pem")
       }

--- a/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go
+++ b/mmv1/third_party/terraform/services/iambeta/resource_iam_workload_identity_pool_test.go
@@ -159,7 +159,8 @@ resource "google_iam_workload_identity_pool" "my_pool" {
   }
   inline_trust_config {
     additional_trust_bundles {
-      trust_domain = "ca-pool-foo.global.project-foo.workload.id.goog"
+      trust_domain            = "ca-pool-foo.global.project-foo.workload.id.goog"
+      trust_default_shared_ca = false
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_1.pem")
       }
@@ -168,7 +169,8 @@ resource "google_iam_workload_identity_pool" "my_pool" {
       }
     }
     additional_trust_bundles {
-      trust_domain = "ca-pool-bar.global.project-bar.workload.id.goog"
+      trust_domain            = "ca-pool-bar.global.project-bar.workload.id.goog"
+      trust_default_shared_ca = false
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_3.pem")
       }
@@ -203,7 +205,8 @@ resource "google_iam_workload_identity_pool" "my_pool" {
   }
   inline_trust_config {
     additional_trust_bundles {
-      trust_domain = "ca-pool-baz.global.project-baz.workload.id.goog"
+      trust_domain            = "ca-pool-baz.global.project-baz.workload.id.goog"
+	  trust_default_shared_ca = false
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_updated.pem")
       }
@@ -238,7 +241,8 @@ resource "google_iam_workload_identity_pool" "my_pool" {
   }
   inline_trust_config {
     additional_trust_bundles {
-      trust_domain = "ca-pool-baz.global.project-baz.workload.id.goog"
+      trust_domain            = "ca-pool-baz.global.project-baz.workload.id.goog"
+	  trust_default_shared_ca = true
       trust_anchors {
         pem_certificate = file("test-fixtures/trust_anchor_updated.pem")
       }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID

Add `trustDefaultSharedCa` to IAM Workload Identity Pool

This change adds the boolean option `trustDefaultSharedCa` to the resource `google_iam_workload_identity_pool`. The document example can be found in https://docs.cloud.google.com/iam/docs/create-managed-workload-identities-gke#create-trust-config.
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
iambeta: added `trust_default_shared_ca` field to `google_iam_workload_identity_pool` resource
```
