### PR TITLE
`fix`: set `zonal-redundancy-disable` to `true` for `TestAccCloudRunService_cloudRunServiceGpuExample`

### DIFF
--- a/mmv1/templates/terraform/examples/cloud_run_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloud_run_service_gpu.tf.tmpl
@@ -13,6 +13,7 @@ resource "google_cloud_run_service" "{{$.PrimaryResourceId}}" {
       annotations = {
         "autoscaling.knative.dev/maxScale": "1"
         "run.googleapis.com/cpu-throttling": "false"
+        "run.googleapis.com/gpu-zonal-redundancy-disabled" = "true"
       }
     }
     spec {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21999

Setting `gpu-zonal-redundancy-disable = true` should resolve our quota issues since by default google deploys across multiple regions. More info [here](https://docs.cloud.google.com/run/docs/configuring/services/gpu#zonal-redundancy)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
