### PR TITLE
Make reclaim_policy O+C in google_workstations_workstation_config

### DIFF
--- a/mmv1/products/workstations/WorkstationConfig.yaml
+++ b/mmv1/products/workstations/WorkstationConfig.yaml
@@ -421,6 +421,7 @@ properties:
               enum_values:
                 - 'DELETE'
                 - 'RETAIN'
+              default_from_api: true
             - name: 'sourceSnapshot'
               type: String
               description: |


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/24844

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
workstations: fixed a permadiff on `persistent_directories.gce_pd.reclaim_policy` in `google_workstations_workstation_config` resource
```
