### PR TITLE
Migrated resource compute disk test to use transport_tgp.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_disk_test.go.tmpl
@@ -2,6 +2,7 @@ package compute_test
 
 import (
 	"fmt"
+	neturl "net/url"
 	"os"
 	"testing"
 	"time"
@@ -13,12 +14,6 @@ import (
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func TestDiskImageDiffSuppress(t *testing.T) {
@@ -347,17 +342,37 @@ func TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames(t *testing.T) 
 		page := 0
 		maxPages := 10
 		for paginate := true; paginate && page < maxPages; {
-			resp, err := config.NewComputeClient(config.UserAgent).Images.List(publicImageProject).Filter("deprecated.replacement ne .*images.*").PageToken(token).Do()
+			params := neturl.Values{}
+			params.Set("filter", "deprecated.replacement ne .*images.*")
+			if token != "" {
+				params.Set("pageToken", token)
+			}
+			listURL := fmt.Sprintf("%sprojects/%s/global/images?%s", config.ComputeBasePath, publicImageProject, params.Encode())
+			resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   publicImageProject,
+				RawURL:    listURL,
+				UserAgent: config.UserAgent,
+			})
 			if err != nil {
 				t.Fatalf("Can't list public images for project %q", publicImageProject)
 			}
 
-			for _, image := range resp.Items {
-				if !tpgcompute.DiskImageDiffSuppress("image", image.SelfLink, "family/"+image.Family, nil) {
-					t.Errorf("should suppress diff for image %q and family %q", image.SelfLink, image.Family)
+			if rawItems, ok := resp["items"].([]interface{}); ok {
+				for _, raw := range rawItems {
+					image, ok := raw.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					selfLink, _ := image["selfLink"].(string)
+					family, _ := image["family"].(string)
+					if !tpgcompute.DiskImageDiffSuppress("image", selfLink, "family/"+family, nil) {
+						t.Errorf("should suppress diff for image %q and family %q", selfLink, family)
+					}
 				}
 			}
-			token := resp.NextPageToken
+			token, _ := resp["nextPageToken"].(string)
 			paginate = token != ""
 			page++
 		}
@@ -616,7 +631,7 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -643,7 +658,7 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	importID := fmt.Sprintf("%s/%s/%s", pid, "us-central1-a", diskName)
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.BootstrapIamMembers(t, []acctest.IamMember{
 		{
@@ -690,7 +705,7 @@ func TestAccComputeDisk_pdHyperDiskEnableConfidentialCompute(t *testing.T) {
 		"confidential_compute": true,
 	}
 
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -906,7 +921,7 @@ func TestAccComputeDisk_multiWriter(t *testing.T) {
 }
 {{- end }}
 
-func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *compute.Disk) resource.TestCheckFunc {
+func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -919,23 +934,30 @@ func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *compute.Disk
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := config.NewComputeClient(config.UserAgent).Disks.Get(
-			p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/disks/%s",
+			config.ComputeBasePath, p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   p,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.Attributes["name"] {
+		if found["name"].(string) != rs.Primary.Attributes["name"] {
 			return fmt.Errorf("Disk not found")
 		}
 
-		*disk = *found
+		*disk = found
 
 		return nil
 	}
 }
 
-func testAccCheckEncryptionKey(t *testing.T, n string, disk *compute.Disk) resource.TestCheckFunc {
+func testAccCheckEncryptionKey(t *testing.T, n string, disk *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -943,11 +965,14 @@ func testAccCheckEncryptionKey(t *testing.T, n string, disk *compute.Disk) resou
 		}
 
 		attr := rs.Primary.Attributes["disk_encryption_key.0.sha256"]
-		if disk.DiskEncryptionKey == nil {
+		diskEncKey, ok := (*disk)["diskEncryptionKey"].(map[string]interface{})
+		if !ok {
 			return fmt.Errorf("Disk %s has mismatched encryption key.\nTF State: %+v\nGCP State: <empty>", n, attr)
-		} else if attr != disk.DiskEncryptionKey.Sha256 {
+		}
+		sha256, _ := diskEncKey["sha256"].(string)
+		if attr != sha256 {
 			return fmt.Errorf("Disk %s has mismatched encryption key.\nTF State: %+v.\nGCP State: %+v",
-				n, attr, disk.DiskEncryptionKey.Sha256)
+				n, attr, sha256)
 		}
 		return nil
 	}
@@ -956,20 +981,44 @@ func testAccCheckEncryptionKey(t *testing.T, n string, disk *compute.Disk) resou
 func testAccCheckComputeDisk_removeBackupSnapshot(t *testing.T, parentDiskName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		snapshot, err := config.NewComputeClient(config.UserAgent).Snapshots.List(envvar.GetTestProjectFromEnv()).Filter(fmt.Sprintf("name eq %s.*", parentDiskName)).Do()
+		project := envvar.GetTestProjectFromEnv()
+
+		listParams := neturl.Values{}
+		listParams.Set("filter", fmt.Sprintf("name eq %s.*", parentDiskName))
+		listURL := fmt.Sprintf("%sprojects/%s/global/snapshots?%s", config.ComputeBasePath, project, listParams.Encode())
+		snapshotResp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    listURL,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if len(snapshot.Items) == 0 {
+		items, ok := snapshotResp["items"].([]interface{})
+		if !ok || len(items) == 0 {
 			return fmt.Errorf("No snapshot found")
 		}
+		firstSnapshot, ok := items[0].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("No snapshot found")
+		}
+		snapshotName, _ := firstSnapshot["name"].(string)
 
-		op, err := config.NewComputeClient(config.UserAgent).Snapshots.Delete(envvar.GetTestProjectFromEnv(), snapshot.Items[0].Name).Do()
+		deleteURL := fmt.Sprintf("%sprojects/%s/global/snapshots/%s", config.ComputeBasePath, project, snapshotName)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   project,
+			RawURL:    deleteURL,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
-		return tpgcompute.ComputeOperationWaitTime(config, op, envvar.GetTestProjectFromEnv(), "Deleting Snapshot", config.UserAgent, 10*time.Minute)
+		return tpgcompute.ComputeOperationWaitTime(config, res, project, "Deleting Snapshot", config.UserAgent, 10*time.Minute)
 	}
 }
 
@@ -978,7 +1027,7 @@ func TestAccComputeDisk_cloneDisk(t *testing.T) {
 	pid := envvar.GetTestProjectFromEnv()
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1013,7 +1062,7 @@ func TestAccComputeDisk_architecture(t *testing.T) {
 		"random_suffix": context_1["random_suffix"],
 		"architecture":  "ARM64",
 	}
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1046,7 +1095,7 @@ func TestAccComputeDisk_sourceStorageObject(t *testing.T) {
 		"source_storage_object": "test-fixtures/empty-image.tar.gz",
 	}
 
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1072,7 +1121,7 @@ func TestAccComputeDisk_resourceManagerTags(t *testing.T) {
 		"project_id":    pid,
 	}
 
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1097,7 +1146,7 @@ func TestAccComputeDisk_sourceInstantSnapshot(t *testing.T) {
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -1151,9 +1200,9 @@ func TestAccComputeDisk_createSnapshotBeforeDestroy(t *testing.T) {
 	acctest.SkipIfVcr(t) // Disk cleanup test check 
 	t.Parallel()
 
-	var disk1 compute.Disk
-	var disk2 compute.Disk
-	var disk3 compute.Disk
+	var disk1 map[string]interface{}
+	var disk2 map[string]interface{}
+	var disk3 map[string]interface{}
 	context := map[string]interface{}{
 		"disk_name1":        fmt.Sprintf("tf-test-disk-%s", acctest.RandString(t, 10)),
 		"disk_name2":        fmt.Sprintf("test-%s", acctest.RandString(t, 44)), //this is over the snapshot character creation limit of 48
@@ -1660,7 +1709,7 @@ func TestAccComputeDisk_encryptionWithRSAEncryptedKey(t *testing.T) {
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
-	var disk compute.Disk
+	var disk map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_disk_test` to use direct HTTP rather than a client library
```
