### PR TITLE
Add resource manager tags to Storage Pool

### DIFF
--- a/mmv1/products/compute/StoragePool.yaml
+++ b/mmv1/products/compute/StoragePool.yaml
@@ -29,7 +29,7 @@ update_verb: "PATCH"
 update_mask: false
 autogen_async: true
 async:
-  type: 'OpAsync'
+  type: "OpAsync"
   operation:
     base_url: "{{op_id}}"
 iam_policy:
@@ -45,14 +45,14 @@ examples:
     vars:
       storage_pool_name: "storage-pool-basic"
     ignore_read_extra:
-      - 'deletion_protection'
+      - "deletion_protection"
     exclude_test: true
   - name: "compute_storage_pool_full"
     primary_resource_id: "test-storage-pool-full"
     vars:
       storage_pool_name: "storage-pool-full"
     ignore_read_extra:
-      - 'deletion_protection'
+      - "deletion_protection"
     exclude_test: true
 parameters:
   - name: "zone"
@@ -194,9 +194,9 @@ properties:
       * `hyperdisk-throughput`
     required: true
     immutable: true
-    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
-    resource: 'StoragePoolType'
-    imports: 'selfLink'
+    custom_expand: "templates/terraform/custom_expand/resourceref_with_validation.go.tmpl"
+    resource: "StoragePoolType"
+    imports: "selfLink"
   - name: "status"
     type: NestedObject
     description: |
@@ -279,6 +279,26 @@ properties:
     type: KeyValueLabels
     description: |
       Labels to apply to this storage pool. These can be later modified by the setLabels method.
+  - name: "params"
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+      Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: "resourceManagerTags"
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the storage pool. Tag keys and values have the
+          same definition as resource manager tags. Keys and values can be either in numeric format,
+          such as tagKeys/{tag_key_id} and tagValues/{tag_value_id} or in namespaced format such as
+          {org_id|projectId}/{tag_key_short_name} and {tag_value_short_name}. The field is ignored when empty.
+          The field is immutable and causes resource replacement when mutated. This field is only
+          set at create time and modifying this field after creation will trigger recreation.
+          To apply tags to an existing resource, see the google_tags_tag_binding resource.
+        api_name: "resourceManagerTags"
+        ignore_read: true
+        immutable: true
 virtual_fields:
   - name: "deletion_protection"
     type: Boolean


### PR DESCRIPTION
Added resource manager tags support to Storage Pool.

```release-note:enhancement
compute: add `params.resourceManagerTags` field to the `google_compute_storage_pool`
```