### PR TITLE
Update each property of Memorystore instances in a separate request

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -254,6 +254,7 @@ properties:
     description: "The automated backup config for a instance."
     custom_flatten: 'templates/terraform/custom_flatten/memorystore_instance_automated_backup_config.go.tmpl'
     custom_expand: 'templates/terraform/custom_expand/memorystore_instance_automated_backup_config.go.tmpl'
+    send_empty_value: true
     update_id: 'automatedBackupConfig'
     update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=automatedBackupConfig'
     update_verb: 'PATCH'

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -254,6 +254,9 @@ properties:
     description: "The automated backup config for a instance."
     custom_flatten: 'templates/terraform/custom_flatten/memorystore_instance_automated_backup_config.go.tmpl'
     custom_expand: 'templates/terraform/custom_expand/memorystore_instance_automated_backup_config.go.tmpl'
+    update_id: 'automatedBackupConfig'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=automatedBackupConfig'
+    update_verb: 'PATCH'
     properties:
       - name: 'fixedFrequencySchedule'
         type: NestedObject
@@ -291,6 +294,9 @@ properties:
       is 0 replicas. "
     default_from_api: true
     send_empty_value: true
+    update_id: 'replicaCount'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=replicaCount'
+    update_verb: 'PATCH'
   - name: 'authorizationMode'
     type: String
     description:
@@ -309,6 +315,9 @@ properties:
     type: Integer
     description: "Required. Number of shards for the instance. "
     required: true
+    update_id: 'shardCount'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=shardCount'
+    update_verb: 'PATCH'
   - name: 'discoveryEndpoints'
     type: Array
     description:
@@ -346,10 +355,16 @@ properties:
       "Optional. Machine type for individual nodes of the instance.
       \n Possible values:\n SHARED_CORE_NANO\nHIGHMEM_MEDIUM\nHIGHMEM_XLARGE\nSTANDARD_SMALL"
     default_from_api: true
+    update_id: 'nodeType'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=nodeType'
+    update_verb: 'PATCH'
   - name: 'persistenceConfig'
     type: NestedObject
     description: "Represents persistence configuration for a instance. "
     default_from_api: true
+    update_id: 'persistenceConfig'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=persistenceConfig'
+    update_verb: 'PATCH'
     properties:
       - name: 'mode'
         type: Enum
@@ -389,6 +404,9 @@ properties:
   - name: 'maintenancePolicy'
     type: NestedObject
     description: Maintenance policy for a cluster
+    update_id: 'maintenancePolicy'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=maintenancePolicy'
+    update_verb: 'PATCH'
     properties:
       - name: 'createTime'
         type: String
@@ -510,6 +528,9 @@ properties:
     description: |
       This field can be used to trigger self service update to indicate the desired maintenance version. The input to this field can be determined by the available_maintenance_versions field.
       *Note*: This field can only be specified when updating an existing cluster to a newer version. Downgrades are currently not supported!
+    update_id: 'maintenanceVersion'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=maintenanceVersion'
+    update_verb: 'PATCH'
   - name: 'effectiveMaintenanceVersion'
     type: String
     description: |
@@ -526,9 +547,15 @@ properties:
     type: String
     description: "Optional. Engine version of the instance."
     default_from_api: true
+    update_id: 'engineVersion'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=engineVersion'
+    update_verb: 'PATCH'
   - name: 'engineConfigs'
     type: KeyValuePairs
     description: "Optional. User-provided engine configurations for the instance. "
+    update_id: 'engineConfigs'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=engineConfigs'
+    update_verb: 'PATCH'
   - name: 'nodeConfig'
     type: NestedObject
     description: "Represents configuration for nodes of the instance. "
@@ -563,6 +590,9 @@ properties:
     type: Boolean
     description: "Optional. If set to true deletion of the instance will fail. "
     default_value: true
+    update_id: 'deletionProtectionEnabled'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=deletionProtectionEnabled'
+    update_verb: 'PATCH'
   - name: 'endpoints'
     type: Array
     description: "Endpoints for the instance."
@@ -633,6 +663,9 @@ properties:
     type: NestedObject
     description: Cross instance replication config
     default_from_api: true
+    update_id: 'crossInstanceReplicationConfig'
+    update_url: 'projects/{{project}}/locations/{{location}}/instances/{{instance_id}}?updateMask=crossInstanceReplicationConfig'
+    update_verb: 'PATCH'
     properties:
       - name: 'instanceRole'
         type: Enum

--- a/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
+++ b/mmv1/third_party/terraform/services/memorystore/resource_memorystore_instance_test.go
@@ -609,6 +609,39 @@ func TestAccMemorystoreInstance_switchoverAndDetachSecondary(t *testing.T) {
 	})
 }
 
+// Validate that multiple fields can be updated simultaneously.
+// The Memorystore API requires exactly 1 update_mask field per request,
+// so the provider must split multi-field updates into separate requests.
+func TestAccMemorystoreInstance_updateMultipleFields(t *testing.T) {
+	t.Parallel()
+
+	name := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckMemorystoreInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: createOrUpdateMemorystoreInstance(&InstanceParams{name: name, replicaCount: 1, shardCount: 3, zoneDistributionMode: "MULTI_ZONE", deletionProtectionEnabled: false, engineConfigs: map[string]string{"maxmemory-policy": "volatile-ttl"}, maintenanceDay: "MONDAY", maintenanceHours: 1, maintenanceMinutes: 0, maintenanceSeconds: 0, maintenanceNanos: 0}),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: createOrUpdateMemorystoreInstance(&InstanceParams{name: name, replicaCount: 0, shardCount: 3, zoneDistributionMode: "MULTI_ZONE", deletionProtectionEnabled: false, engineConfigs: map[string]string{"maxmemory-policy": "allkeys-lru"}, maintenanceDay: "WEDNESDAY", maintenanceHours: 5, maintenanceMinutes: 0, maintenanceSeconds: 0, maintenanceNanos: 0}),
+			},
+			{
+				ResourceName:      "google_memorystore_instance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 // Validate that instance endpoints are updated for the instance
 func TestAccMemorystoreInstance_updateInstanceEndpoints(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes hashicorp/terraform-provider-google#20101

This PR updates the Memorystore `Instance` definition to submit updates for multiple properties in multiple PATCH requests, one per property.

The Memorystore API allows updating only one instance field per PATCH request, but the provider was sending all changed fields in a single request (e.g., `updateMask=replicaCount,engineConfigs`), causing updates to multiple fields to fail with:

```
Error: Error updating Cluster "projects/foobar/locations/us-west2/clusters/primary": googleapi: Error 400: exactly 1 update_mask field must be specified per update request
Details:
[
  {
    "@type": "type.googleapis.com/google.rpc.BadRequest",
    "fieldViolations": [
      {
        "field": "update_mask"
      }
    ]
  }
]

  with module.app.google_redis_cluster.primary,
  on ../../modules/app/redis.tf line 29, in resource "google_redis_cluster" "primary":
  29: resource "google_redis_cluster" "primary" {
```

Each of the 11 mutable non-label properties now specifies `update_id`, `update_verb`, and `update_url` (with a single-field `updateMask` query parameter).

I left `labels` in the main update path because it seems `KeyValueLabels` is [handled specially](https://github.com/GoogleCloudPlatform/magic-modules/blob/3f303e19a/mmv1/api/resource.go#L2030-L2034) as part of the provider's [built-in handling](https://googlecloudplatform.github.io/magic-modules/best-practices/labels-and-annotations/) for merging provider-level default labels with resource-level labels (via `effective_labels` and `terraform_labels`). As the sole remaining field in the main update body, I _think_ that should work, but let me know if I misinterpreted the behavior here.

I also added a test to cover a multi-property update and confirmed it now works on a test GCP project.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
memorystore: fixed an issue preventing updating multiple properties at once for `google_redis_cluster`
```
