### PR TITLE
compute: add resource_manager_tags to google_compute_instant_snapshot

### DIFF
--- a/mmv1/products/compute/InstantSnapshot.yaml
+++ b/mmv1/products/compute/InstantSnapshot.yaml
@@ -119,3 +119,18 @@ properties:
     output: true
     update_url: 'projects/{{project}}/zones/{{zone}}/instantSnapshots/{{name}}/setLabels'
     update_verb: 'POST'
+  - name: 'params'
+    type: NestedObject
+    ignore_read: true
+    immutable: true
+    description: |
+     Additional params passed with the request, but not persisted as part of resource payload
+    properties:
+      - name: 'resourceManagerTags'
+        type: KeyValuePairs
+        description: |
+          Resource manager tags to be bound to the instant snapshot. Tag keys and values have the
+          same definition as resource manager tags. Keys must be in the format tagKeys/{tag_key_id},
+          and values are in the format tagValues/456.
+        api_name: resourceManagerTags
+        ignore_read: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instant_snapshot_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instant_snapshot_test.go.tmpl
@@ -157,3 +157,52 @@ resource "google_compute_instant_snapshot" "foobar" {
 }
 `, context)
 }
+
+func TestAccComputeInstantSnapshot_resourceManagerTags(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	suffix := acctest.RandString(t, 10)
+	tagKeyResult := acctest.BootstrapSharedTestTagKeyDetails(t, "crm-instant-snapshots-tagkey", "organizations/"+org, make(map[string]interface{}))
+	sharedTagKey, _ := tagKeyResult["shared_tag_key"]
+	tagValueResult := acctest.BootstrapSharedTestTagValueDetails(t, "crm-instant-snapshots-tagvalue", sharedTagKey, org)
+
+	context := map[string]interface{}{
+		"random_suffix": suffix,
+		"tag_key_id":    tagKeyResult["name"],
+		"tag_value_id":  tagValueResult["name"],
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstantSnapshotDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstantSnapshot_resourceManagerTags(context),
+			},
+		},
+	})
+}
+
+func testAccComputeInstantSnapshot_resourceManagerTags(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_disk" "disk" {
+  name = "tf-test-disk-%{random_suffix}"
+  type = "pd-standard"
+  zone = "us-central1-a"
+  size = 10
+}
+
+resource "google_compute_instant_snapshot" "foobar" {
+  name        = "tf-test-instant-snapshot-%{random_suffix}"
+  source_disk = google_compute_disk.disk.self_link
+  zone        = google_compute_disk.disk.zone
+  params {
+    resource_manager_tags = {
+      "%{tag_key_id}" = "%{tag_value_id}"
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Adds `params.resource_manager_tags` to `google_compute_instant_snapshot` so IAM resource manager tags can be bound at instant snapshot creation. The field is input-only and ForceNew, matching the existing pattern on `google_compute_network` (#14119) and other Compute resources.

```release-note:enhancement
compute: added `params.resource_manager_tags` field to `google_compute_instant_snapshot` resource
```
