### PR TITLE
[DRAFT] Migrated compute_instance_helpers.go.tmpl to use transport_tpg.SendRequest - new APIs

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -53,6 +53,18 @@ func expandAliasIpRanges(ranges []interface{}) []*compute.AliasIpRange {
 	return ipRanges
 }
 
+func expandAliasIpRanges_v2(ranges []interface{}) []interface{} {
+	ipRanges := make([]interface{}, 0, len(ranges))
+	for _, raw := range ranges {
+		data := raw.(map[string]interface{})
+		ipRanges = append(ipRanges, map[string]interface{}{
+			"ipCidrRange":         data["ip_cidr_range"].(string),
+			"subnetworkRangeName": data["subnetwork_range_name"].(string),
+		})
+	}
+	return ipRanges
+}
+
 func flattenAliasIpRange(d *schema.ResourceData, ranges []*compute.AliasIpRange, i int) []map[string]interface{} {
 	prefix := fmt.Sprintf("network_interface.%d", i)
 
@@ -245,6 +257,23 @@ func expandComputeMaxRunDuration(v interface{}) (*compute.Duration, error) {
 	return &duration, nil
 }
 
+func expandComputeMaxRunDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(original["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = original["nanos"].(int)
+	}
+	if val := reflect.ValueOf(original["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = original["seconds"].(int)
+	}
+	return result, nil
+}
+
 func expandComputeMaxRunDurationNanos(v interface{}) (interface{}, error) {
 	return v, nil
 }
@@ -271,6 +300,21 @@ func expandComputeOnInstanceStopAction(v interface{}) (*compute.SchedulingOnInst
 	return &onInstanceStopAction, nil	
 }
 
+func expandComputeOnInstanceStopAction_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	if d, ok := original["discard_local_ssd"]; ok {
+		return map[string]interface{}{
+			"discardLocalSsd": d.(bool),
+		}, nil
+	}
+	return nil, nil
+}
+
 func expandComputeLocalSsdRecoveryTimeout(v interface{}) (*compute.Duration, error) {
 	l := v.([]interface{})
 	duration := compute.Duration{}
@@ -294,6 +338,23 @@ func expandComputeLocalSsdRecoveryTimeout(v interface{}) (*compute.Duration, err
 		duration.Seconds = int64(transformedSeconds.(int))
 	}
 	return &duration, nil
+}
+
+func expandComputeLocalSsdRecoveryTimeout_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(original["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = original["nanos"].(int)
+	}
+	if val := reflect.ValueOf(original["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = original["seconds"].(int)
+	}
+	return result, nil
 }
 
 func expandComputeLocalSsdRecoveryTimeoutNanos(v interface{}) (interface{}, error) {
@@ -328,6 +389,28 @@ func expandGracefulShutdown(v interface{}) (*compute.SchedulingGracefulShutdown,
 	return &gracefulShutdown, nil
 }
 
+func expandGracefulShutdown_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	originalMaxDuration := original["max_duration"].([]interface{})
+	maxDuration, err := expandGracefulShutdownMaxDuration_v2(originalMaxDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]interface{}{
+		"enabled": original["enabled"].(bool),
+	}
+	if maxDuration != nil {
+		result["maxDuration"] = maxDuration
+	}
+	return result, nil
+}
+
 func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error) {
 	l := v.([]interface{})
 	duration := compute.Duration{}
@@ -350,6 +433,23 @@ func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error)
 	duration.ForceSendFields = append(duration.ForceSendFields, "Seconds")
 
 	return &duration, nil
+}
+
+func expandGracefulShutdownMaxDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	maxDurationMap := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(maxDurationMap["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = maxDurationMap["nanos"].(int)
+	}
+	if val := reflect.ValueOf(maxDurationMap["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = maxDurationMap["seconds"].(int)
+	}
+	return result, nil
 }
 {{ end }}
 
@@ -481,6 +581,23 @@ func expandComputePreemptionNoticeDuration(v interface{}) (*compute.Duration, er
 	}
 
 	return &duration, nil
+}
+
+func expandComputePreemptionNoticeDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if transformedNanos, ok := original["nanos"]; ok && transformedNanos != nil {
+		result["nanos"] = transformedNanos.(int)
+	}
+	if transformedSeconds, ok := original["seconds"]; ok && transformedSeconds != nil {
+		result["seconds"] = transformedSeconds.(int)
+	}
+	return result, nil
 }
 
 func flattenComputePreemptionNoticeDuration(v *compute.Duration) []interface{} {
@@ -736,6 +853,24 @@ func expandServiceAccounts(configs []interface{}) []*compute.ServiceAccount {
 	return accounts
 }
 
+func expandServiceAccounts_v2(configs []interface{}) []interface{} {
+	accounts := make([]interface{}, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		email := data["email"].(string)
+		if email == "" {
+			email = "default"
+		}
+
+		accounts[i] = map[string]interface{}{
+			"email":  email,
+			"scopes": tpgresource.CanonicalizeServiceScopes(tpgresource.ConvertStringSet(data["scopes"].(*schema.Set))),
+		}
+	}
+	return accounts
+}
+
 func flattenGuestAccelerators(accelerators []*compute.AcceleratorConfig) []map[string]interface{} {
 	acceleratorsSchema := make([]map[string]interface{}, len(accelerators))
 	for i, accelerator := range accelerators {
@@ -764,6 +899,21 @@ func resourceInstanceTags(d tpgresource.TerraformResourceData) *compute.Tags {
 	return tags
 }
 
+func resourceInstanceTags_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if v := d.Get("tags"); v != nil {
+		vs := v.(*schema.Set)
+		items := make([]interface{}, vs.Len())
+		for i, v := range vs.List() {
+			items[i] = v.(string)
+		}
+		return map[string]interface{}{
+			"items":       items,
+			"fingerprint": d.Get("tags_fingerprint").(string),
+		}
+	}
+	return nil
+}
+
 func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) *compute.ShieldedInstanceConfig {
 	if _, ok := d.GetOk("shielded_instance_config"); !ok {
 		return nil
@@ -778,6 +928,19 @@ func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) *compute.Shiel
 	}
 }
 
+func expandShieldedVmConfigs_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("shielded_instance_config"); !ok {
+		return nil
+	}
+
+	prefix := "shielded_instance_config.0"
+	return map[string]interface{}{
+		"enableSecureBoot":          d.Get(prefix + ".enable_secure_boot").(bool),
+		"enableVtpm":                d.Get(prefix + ".enable_vtpm").(bool),
+		"enableIntegrityMonitoring": d.Get(prefix + ".enable_integrity_monitoring").(bool),
+	}
+}
+
 func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *compute.ConfidentialInstanceConfig {
 	if _, ok := d.GetOk("confidential_instance_config"); !ok {
 		return nil
@@ -787,6 +950,18 @@ func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *comp
 	return &compute.ConfidentialInstanceConfig{
 		EnableConfidentialCompute: d.Get(prefix + ".enable_confidential_compute").(bool),
 		ConfidentialInstanceType: d.Get(prefix + ".confidential_instance_type").(string),
+	}
+}
+
+func expandConfidentialInstanceConfig_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("confidential_instance_config"); !ok {
+		return nil
+	}
+
+	prefix := "confidential_instance_config.0"
+	return map[string]interface{}{
+		"enableConfidentialCompute": d.Get(prefix + ".enable_confidential_compute").(bool),
+		"confidentialInstanceType": d.Get(prefix + ".confidential_instance_type").(string),
 	}
 }
 
@@ -814,6 +989,22 @@ func expandAdvancedMachineFeatures(d tpgresource.TerraformResourceData) *compute
 		VisibleCoreCount:           int64(d.Get(prefix + ".visible_core_count").(int)),
 		PerformanceMonitoringUnit:  d.Get(prefix + ".performance_monitoring_unit").(string),
 		EnableUefiNetworking:       d.Get(prefix + ".enable_uefi_networking").(bool),
+	}
+}
+
+func expandAdvancedMachineFeatures_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("advanced_machine_features"); !ok {
+		return nil
+	}
+
+	prefix := "advanced_machine_features.0"
+	return map[string]interface{}{
+		"enableNestedVirtualization": d.Get(prefix + ".enable_nested_virtualization").(bool),
+		"threadsPerCore":             d.Get(prefix + ".threads_per_core").(int),
+		"turboMode":                  d.Get(prefix + ".turbo_mode").(string),
+		"visibleCoreCount":           d.Get(prefix + ".visible_core_count").(int),
+		"performanceMonitoringUnit":  d.Get(prefix + ".performance_monitoring_unit").(string),
+		"enableUefiNetworking":       d.Get(prefix + ".enable_uefi_networking").(bool),
 	}
 }
 
@@ -850,6 +1041,15 @@ func expandDisplayDevice(d tpgresource.TerraformResourceData) *compute.DisplayDe
 	return &compute.DisplayDevice{
 		EnableDisplay:   d.Get("enable_display").(bool),
 		ForceSendFields: []string{"EnableDisplay"},
+	}
+}
+
+func expandDisplayDevice_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("enable_display"); !ok {
+		return nil
+	}
+	return map[string]interface{}{
+		"enableDisplay": d.Get("enable_display").(bool),
 	}
 }
 
@@ -1086,6 +1286,37 @@ func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.Re
 	return &affinity, nil
 }
 
+func expandReservationAffinity_v2(d tpgresource.TerraformResourceData) (map[string]interface{}, error) {
+	_, ok := d.GetOk("reservation_affinity")
+	if !ok {
+		return nil, nil
+	}
+
+	prefix := "reservation_affinity.0"
+	reservationAffinityType := d.Get(prefix + ".type").(string)
+
+	affinity := map[string]interface{}{
+		"consumeReservationType": reservationAffinityType,
+	}
+
+	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
+	if (reservationAffinityType == "SPECIFIC_RESERVATION") != hasSpecificReservation {
+		return nil, fmt.Errorf("specific_reservation must be set when reservation_affinity is SPECIFIC_RESERVATION, and not set otherwise")
+	}
+
+	prefix = prefix + ".specific_reservation.0"
+	if hasSpecificReservation {
+		values := make([]interface{}, 0)
+		for _, v := range d.Get(prefix + ".values").([]interface{}) {
+			values = append(values, v.(string))
+		}
+		affinity["key"] = d.Get(prefix + ".key").(string)
+		affinity["values"] = values
+	}
+
+	return affinity, nil
+}
+
 func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[string]interface{} {
 	if affinity == nil {
 		return nil
@@ -1125,6 +1356,26 @@ func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config 
 	}, nil
 }
 
+func expandNetworkPerformanceConfig_v2(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+	configs, ok := d.GetOk("network_performance_config")
+	if !ok {
+		return nil, nil
+	}
+
+	npcSlice := configs.([]interface{})
+	if len(npcSlice) > 1 {
+		return nil, fmt.Errorf("cannot specify multiple network_performance_configs")
+	}
+
+	if len(npcSlice) == 0 || npcSlice[0] == nil {
+		return nil, nil
+	}
+	npc := npcSlice[0].(map[string]interface{})
+	return map[string]interface{}{
+		"totalEgressBandwidthTier": npc["total_egress_bandwidth_tier"].(string),
+	}, nil
+}
+
 func flattenComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
 	if v == nil {
 		return nil
@@ -1149,6 +1400,19 @@ func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeatu
 	var result []*compute.GuestOsFeature
 	for _, feature := range v.([]interface{}) {
 		result = append(result, &compute.GuestOsFeature{Type: feature.(string)})
+	}
+	return result
+}
+
+func expandComputeInstanceGuestOsFeatures_v2(v interface{}) []interface{} {
+	if v == nil {
+		return nil
+	}
+	var result []interface{}
+	for _, feature := range v.([]interface{}) {
+		result = append(result, map[string]interface{}{
+			"type": feature.(string),
+		})
 	}
 	return result
 }
@@ -1178,6 +1442,20 @@ func expandComputeInstanceEncryptionKey(d tpgresource.TerraformResourceData) *co
 	}
 }
 
+func expandComputeInstanceEncryptionKey_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	iek, ok := d.GetOk("instance_encryption_key")
+	if !ok {
+		return nil
+	}
+
+	iekRes := iek.([]interface{})[0].(map[string]interface{})
+	return map[string]interface{}{
+		"kmsKeyName":           iekRes["kms_key_self_link"].(string),
+		"sha256":               iekRes["sha256"].(string),
+		"kmsKeyServiceAccount": iekRes["kms_key_service_account"].(string),
+	}
+}
+
 func flattenComputeInstanceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
 	if v == nil {
 		return nil
@@ -1204,6 +1482,22 @@ func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceDat
 		KmsKeyName:           cekRes["kms_key_self_link"].(string),
 		Sha256:               cekRes["sha256"].(string),
 		KmsKeyServiceAccount: cekRes["kms_key_service_account"].(string),
+	}
+}
+
+func expandComputeInstanceSourceEncryptionKey_v2(d tpgresource.TerraformResourceData, field string) map[string]interface{} {
+	cek, ok := d.GetOk(field)
+	if !ok {
+		return nil
+	}
+
+	cekRes := cek.([]interface{})[0].(map[string]interface{})
+	return map[string]interface{}{
+		"rsaEncryptedKey":      cekRes["rsa_encrypted_key"].(string),
+		"rawKey":               cekRes["raw_key"].(string),
+		"kmsKeyName":           cekRes["kms_key_self_link"].(string),
+		"sha256":               cekRes["sha256"].(string),
+		"kmsKeyServiceAccount": cekRes["kms_key_service_account"].(string),
 	}
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `compute_instance_helpers` resource to use direct HTTP rather than a client library
```
