### PR TITLE
[DRAFT] Migrated compute_instance_helpers.go.tmpl to use transport_tpg.SendRequest - new APIs - 2

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -231,6 +231,122 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 	return scheduling, nil
 }
 
+func expandScheduling_v2(v interface{}) (map[string]interface{}, error) {
+	if v == nil {
+		return map[string]interface{}{"automaticRestart": true}, nil
+	}
+
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return map[string]interface{}{"automaticRestart": true}, nil
+	}
+
+	if len(ls) > 1 || ls[0] == nil {
+		return nil, fmt.Errorf("expected exactly one scheduling block")
+	}
+
+	original := ls[0].(map[string]interface{})
+	scheduling := map[string]interface{}{}
+
+	if v, ok := original["automatic_restart"]; ok {
+		scheduling["automaticRestart"] = v.(bool)
+	}
+	if v, ok := original["preemptible"]; ok {
+		scheduling["preemptible"] = v.(bool)
+	}
+	if v, ok := original["on_host_maintenance"]; ok {
+		scheduling["onHostMaintenance"] = v.(string)
+	}
+	if v, ok := original["node_affinities"]; ok && v != nil {
+		naSet := v.(*schema.Set).List()
+		nodeAffinities := make([]interface{}, 0, len(naSet))
+		for _, nodeAffRaw := range naSet {
+			if nodeAffRaw == nil {
+				continue
+			}
+			nodeAff := nodeAffRaw.(map[string]interface{})
+			nodeAffinities = append(nodeAffinities, map[string]interface{}{
+				"key":      nodeAff["key"].(string),
+				"operator": nodeAff["operator"].(string),
+				"values":   tpgresource.ConvertStringArr(nodeAff["values"].(*schema.Set).List()),
+			})
+		}
+		scheduling["nodeAffinities"] = nodeAffinities
+	}
+	if v, ok := original["min_node_cpus"]; ok {
+		scheduling["minNodeCpus"] = v.(int)
+	}
+	if v, ok := original["provisioning_model"]; ok {
+		scheduling["provisioningModel"] = v.(string)
+	}
+	if v, ok := original["instance_termination_action"]; ok {
+		scheduling["instanceTerminationAction"] = v.(string)
+	}
+	if v, ok := original["availability_domain"]; ok && v != nil {
+		scheduling["availabilityDomain"] = v.(int)
+	}
+	if v, ok := original["max_run_duration"]; ok {
+		transformedMaxRunDuration, err := expandComputeMaxRunDuration_v2(v)
+		if err != nil {
+			return nil, err
+		}
+		if transformedMaxRunDuration != nil {
+			scheduling["maxRunDuration"] = transformedMaxRunDuration
+		}
+	}
+	if v, ok := original["on_instance_stop_action"]; ok {
+		transformedOnInstanceStopAction, err := expandComputeOnInstanceStopAction_v2(v)
+		if err != nil {
+			return nil, err
+		}
+		if transformedOnInstanceStopAction != nil {
+			scheduling["onInstanceStopAction"] = transformedOnInstanceStopAction
+		}
+	}
+{{- if ne $.TargetVersionName "ga" }}
+	if v, ok := original["host_error_timeout_seconds"]; ok {
+		scheduling["hostErrorTimeoutSeconds"] = v.(int)
+	}
+	if v, ok := original["maintenance_interval"]; ok {
+		scheduling["maintenanceInterval"] = v.(string)
+	}
+	if v, ok := original["graceful_shutdown"]; ok {
+		transformedGracefulShutdown, err := expandGracefulShutdown_v2(v)
+		if err != nil {
+			return nil, err
+		}
+		if transformedGracefulShutdown != nil {
+			scheduling["gracefulShutdown"] = transformedGracefulShutdown
+		}
+	}
+	if v, ok := original["skip_guest_os_shutdown"]; ok {
+		scheduling["skipGuestOsShutdown"] = v.(bool)
+	}
+	if v, ok := original["preemption_notice_duration"]; ok {
+		transformedPreemptionNoticeDuration, err := expandComputePreemptionNoticeDuration_v2(v)
+		if err != nil {
+			return nil, err
+		}
+		if transformedPreemptionNoticeDuration != nil {
+			scheduling["preemptionNoticeDuration"] = transformedPreemptionNoticeDuration
+		}
+	}
+{{- end }}
+	if v, ok := original["local_ssd_recovery_timeout"]; ok {
+		transformedLocalSsdRecoveryTimeout, err := expandComputeLocalSsdRecoveryTimeout_v2(v)
+		if err != nil {
+			return nil, err
+		}
+		if transformedLocalSsdRecoveryTimeout != nil {
+			scheduling["localSsdRecoveryTimeout"] = transformedLocalSsdRecoveryTimeout
+		}
+	}
+	if v, ok := original["termination_time"]; ok {
+		scheduling["terminationTime"] = v.(string)
+	}
+	return scheduling, nil
+}
+
 func expandComputeMaxRunDuration(v interface{}) (*compute.Duration, error) {
 	l := v.([]interface{})
 	duration := compute.Duration{}
@@ -738,6 +854,26 @@ func expandAccessConfigs(configs []interface{}) []*compute.AccessConfig {
 	return acs
 }
 
+func expandAccessConfigs_v2(configs []interface{}) []interface{} {
+	acs := make([]interface{}, len(configs))
+	for i, raw := range configs {
+		ac := map[string]interface{}{
+			"type": "ONE_TO_ONE_NAT",
+		}
+		if raw != nil {
+			data := raw.(map[string]interface{})
+			ac["natIP"] = data["nat_ip"].(string)
+			ac["networkTier"] = data["network_tier"].(string)
+			if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
+				ac["setPublicPtr"] = true
+				ac["publicPtrDomainName"] = ptr.(string)
+			}
+		}
+		acs[i] = ac
+	}
+	return acs
+}
+
 func expandIpv6AccessConfigs(configs []interface{}) []*compute.AccessConfig {
 	iacs := make([]*compute.AccessConfig, len(configs))
 	for i, raw := range configs {
@@ -763,6 +899,37 @@ func expandIpv6AccessConfigs(configs []interface{}) []*compute.AccessConfig {
 			}
 			iacs[i].Type = "DIRECT_IPV6" // Currently only type supported
 		}
+	}
+	return iacs
+}
+
+func expandIpv6AccessConfigs_v2(configs []interface{}) []interface{} {
+	iacs := make([]interface{}, len(configs))
+	for i, raw := range configs {
+		iac := map[string]interface{}{
+			"type": "DIRECT_IPV6",
+		}
+		if raw != nil {
+			data := raw.(map[string]interface{})
+			iac["networkTier"] = data["network_tier"].(string)
+			if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
+				iac["publicPtrDomainName"] = ptr.(string)
+			}
+			if eip, ok := data["external_ipv6"]; ok && eip != "" {
+				iac["externalIpv6"] = eip.(string)
+			}
+			if eipl, ok := data["external_ipv6_prefix_length"]; ok && eipl != "" {
+				if strVal, ok := eipl.(string); ok {
+					if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+						iac["externalIpv6PrefixLength"] = intVal
+					}
+				}
+			}
+			if name, ok := data["name"]; ok && name != "" {
+				iac["name"] = name.(string)
+			}
+		}
+		iacs[i] = iac
 	}
 	return iacs
 }
@@ -821,6 +988,59 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 			MacAddress: macAddress,
 			{{- end }}
 		}
+	}
+	return ifaces, nil
+}
+
+func expandNetworkInterfaces_v2(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]interface{}, error) {
+	configs := d.Get("network_interface").([]interface{})
+	ifaces := make([]interface{}, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		var networkAttachment = ""
+		network := data["network"].(string)
+		subnetwork := data["subnetwork"].(string)
+		if networkAttachmentObj, ok := data["network_attachment"]; ok {
+			networkAttachment = networkAttachmentObj.(string)
+		}
+		if networkAttachment == "" && network == "" && subnetwork == "" {
+			return nil, fmt.Errorf("exactly one of network, subnetwork, or network_attachment must be provided")
+		}
+
+		nf, err := tpgresource.ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for network %q: %s", network, err)
+		}
+
+		subnetProjectField := fmt.Sprintf("network_interface.%d.subnetwork_project", i)
+		sf, err := tpgresource.ParseSubnetworkFieldValueWithProjectField(subnetwork, subnetProjectField, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
+		}
+
+		iface := map[string]interface{}{
+			"networkIP":                data["network_ip"].(string),
+			"network":                  nf.RelativeLink(),
+			"networkAttachment":        networkAttachment,
+			"vlan":                     data["vlan"].(int),
+			"subnetwork":               sf.RelativeLink(),
+			"accessConfigs":            expandAccessConfigs_v2(data["access_config"].([]interface{})),
+			"aliasIpRanges":            expandAliasIpRanges_v2(data["alias_ip_range"].([]interface{})),
+			"nicType":                  data["nic_type"].(string),
+			"stackType":                data["stack_type"].(string),
+			"queueCount":               data["queue_count"].(int),
+			"ipv6AccessConfigs":        expandIpv6AccessConfigs_v2(data["ipv6_access_config"].([]interface{})),
+			"ipv6Address":              data["ipv6_address"].(string),
+			"internalIpv6PrefixLength": data["internal_ipv6_prefix_length"].(int),
+			"igmpQuery":                data["igmp_query"].(string),
+		}
+		{{- if ne $.TargetVersionName "ga" }}
+		if macAddressObj, ok := data["mac_address"]; ok && macAddressObj.(string) != "" {
+			iface["macAddress"] = macAddressObj.(string)
+		}
+		{{- end }}
+		ifaces[i] = iface
 	}
 	return ifaces, nil
 }

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -53,6 +53,18 @@ func expandAliasIpRanges(ranges []interface{}) []*compute.AliasIpRange {
 	return ipRanges
 }
 
+func expandAliasIpRanges_v2(ranges []interface{}) []interface{} {
+	ipRanges := make([]interface{}, 0, len(ranges))
+	for _, raw := range ranges {
+		data := raw.(map[string]interface{})
+		ipRanges = append(ipRanges, map[string]interface{}{
+			"ipCidrRange":         data["ip_cidr_range"].(string),
+			"subnetworkRangeName": data["subnetwork_range_name"].(string),
+		})
+	}
+	return ipRanges
+}
+
 func flattenAliasIpRange(d *schema.ResourceData, ranges []*compute.AliasIpRange, i int) []map[string]interface{} {
 	prefix := fmt.Sprintf("network_interface.%d", i)
 
@@ -245,6 +257,23 @@ func expandComputeMaxRunDuration(v interface{}) (*compute.Duration, error) {
 	return &duration, nil
 }
 
+func expandComputeMaxRunDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(original["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = original["nanos"].(int)
+	}
+	if val := reflect.ValueOf(original["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = original["seconds"].(int)
+	}
+	return result, nil
+}
+
 func expandComputeMaxRunDurationNanos(v interface{}) (interface{}, error) {
 	return v, nil
 }
@@ -271,6 +300,21 @@ func expandComputeOnInstanceStopAction(v interface{}) (*compute.SchedulingOnInst
 	return &onInstanceStopAction, nil	
 }
 
+func expandComputeOnInstanceStopAction_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	if d, ok := original["discard_local_ssd"]; ok {
+		return map[string]interface{}{
+			"discardLocalSsd": d.(bool),
+		}, nil
+	}
+	return nil, nil
+}
+
 func expandComputeLocalSsdRecoveryTimeout(v interface{}) (*compute.Duration, error) {
 	l := v.([]interface{})
 	duration := compute.Duration{}
@@ -294,6 +338,23 @@ func expandComputeLocalSsdRecoveryTimeout(v interface{}) (*compute.Duration, err
 		duration.Seconds = int64(transformedSeconds.(int))
 	}
 	return &duration, nil
+}
+
+func expandComputeLocalSsdRecoveryTimeout_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(original["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = original["nanos"].(int)
+	}
+	if val := reflect.ValueOf(original["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = original["seconds"].(int)
+	}
+	return result, nil
 }
 
 func expandComputeLocalSsdRecoveryTimeoutNanos(v interface{}) (interface{}, error) {
@@ -328,6 +389,28 @@ func expandGracefulShutdown(v interface{}) (*compute.SchedulingGracefulShutdown,
 	return &gracefulShutdown, nil
 }
 
+func expandGracefulShutdown_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	originalMaxDuration := original["max_duration"].([]interface{})
+	maxDuration, err := expandGracefulShutdownMaxDuration_v2(originalMaxDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]interface{}{
+		"enabled": original["enabled"].(bool),
+	}
+	if maxDuration != nil {
+		result["maxDuration"] = maxDuration
+	}
+	return result, nil
+}
+
 func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error) {
 	l := v.([]interface{})
 	duration := compute.Duration{}
@@ -350,6 +433,23 @@ func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error)
 	duration.ForceSendFields = append(duration.ForceSendFields, "Seconds")
 
 	return &duration, nil
+}
+
+func expandGracefulShutdownMaxDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	maxDurationMap := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if val := reflect.ValueOf(maxDurationMap["nanos"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["nanos"] = maxDurationMap["nanos"].(int)
+	}
+	if val := reflect.ValueOf(maxDurationMap["seconds"]); val.IsValid() && !tpgresource.IsEmptyValue(val) {
+		result["seconds"] = maxDurationMap["seconds"].(int)
+	}
+	return result, nil
 }
 {{ end }}
 
@@ -481,6 +581,23 @@ func expandComputePreemptionNoticeDuration(v interface{}) (*compute.Duration, er
 	}
 
 	return &duration, nil
+}
+
+func expandComputePreemptionNoticeDuration_v2(v interface{}) (map[string]interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	original := l[0].(map[string]interface{})
+
+	result := map[string]interface{}{}
+	if transformedNanos, ok := original["nanos"]; ok && transformedNanos != nil {
+		result["nanos"] = transformedNanos.(int)
+	}
+	if transformedSeconds, ok := original["seconds"]; ok && transformedSeconds != nil {
+		result["seconds"] = transformedSeconds.(int)
+	}
+	return result, nil
 }
 
 func flattenComputePreemptionNoticeDuration(v *compute.Duration) []interface{} {
@@ -736,6 +853,24 @@ func expandServiceAccounts(configs []interface{}) []*compute.ServiceAccount {
 	return accounts
 }
 
+func expandServiceAccounts_v2(configs []interface{}) []interface{} {
+	accounts := make([]interface{}, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		email := data["email"].(string)
+		if email == "" {
+			email = "default"
+		}
+
+		accounts[i] = map[string]interface{}{
+			"email":  email,
+			"scopes": tpgresource.CanonicalizeServiceScopes(tpgresource.ConvertStringSet(data["scopes"].(*schema.Set))),
+		}
+	}
+	return accounts
+}
+
 func flattenGuestAccelerators(accelerators []*compute.AcceleratorConfig) []map[string]interface{} {
 	acceleratorsSchema := make([]map[string]interface{}, len(accelerators))
 	for i, accelerator := range accelerators {
@@ -764,6 +899,21 @@ func resourceInstanceTags(d tpgresource.TerraformResourceData) *compute.Tags {
 	return tags
 }
 
+func resourceInstanceTags_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if v := d.Get("tags"); v != nil {
+		vs := v.(*schema.Set)
+		items := make([]interface{}, vs.Len())
+		for i, v := range vs.List() {
+			items[i] = v.(string)
+		}
+		return map[string]interface{}{
+			"items":       items,
+			"fingerprint": d.Get("tags_fingerprint").(string),
+		}
+	}
+	return nil
+}
+
 func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) *compute.ShieldedInstanceConfig {
 	if _, ok := d.GetOk("shielded_instance_config"); !ok {
 		return nil
@@ -778,6 +928,19 @@ func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) *compute.Shiel
 	}
 }
 
+func expandShieldedVmConfigs_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("shielded_instance_config"); !ok {
+		return nil
+	}
+
+	prefix := "shielded_instance_config.0"
+	return map[string]interface{}{
+		"enableSecureBoot":          d.Get(prefix + ".enable_secure_boot").(bool),
+		"enableVtpm":                d.Get(prefix + ".enable_vtpm").(bool),
+		"enableIntegrityMonitoring": d.Get(prefix + ".enable_integrity_monitoring").(bool),
+	}
+}
+
 func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *compute.ConfidentialInstanceConfig {
 	if _, ok := d.GetOk("confidential_instance_config"); !ok {
 		return nil
@@ -787,6 +950,18 @@ func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *comp
 	return &compute.ConfidentialInstanceConfig{
 		EnableConfidentialCompute: d.Get(prefix + ".enable_confidential_compute").(bool),
 		ConfidentialInstanceType: d.Get(prefix + ".confidential_instance_type").(string),
+	}
+}
+
+func expandConfidentialInstanceConfig_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("confidential_instance_config"); !ok {
+		return nil
+	}
+
+	prefix := "confidential_instance_config.0"
+	return map[string]interface{}{
+		"enableConfidentialCompute": d.Get(prefix + ".enable_confidential_compute").(bool),
+		"confidentialInstanceType": d.Get(prefix + ".confidential_instance_type").(string),
 	}
 }
 
@@ -814,6 +989,22 @@ func expandAdvancedMachineFeatures(d tpgresource.TerraformResourceData) *compute
 		VisibleCoreCount:           int64(d.Get(prefix + ".visible_core_count").(int)),
 		PerformanceMonitoringUnit:  d.Get(prefix + ".performance_monitoring_unit").(string),
 		EnableUefiNetworking:       d.Get(prefix + ".enable_uefi_networking").(bool),
+	}
+}
+
+func expandAdvancedMachineFeatures_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("advanced_machine_features"); !ok {
+		return nil
+	}
+
+	prefix := "advanced_machine_features.0"
+	return map[string]interface{}{
+		"enableNestedVirtualization": d.Get(prefix + ".enable_nested_virtualization").(bool),
+		"threadsPerCore":             d.Get(prefix + ".threads_per_core").(int),
+		"turboMode":                  d.Get(prefix + ".turbo_mode").(string),
+		"visibleCoreCount":           d.Get(prefix + ".visible_core_count").(int),
+		"performanceMonitoringUnit":  d.Get(prefix + ".performance_monitoring_unit").(string),
+		"enableUefiNetworking":       d.Get(prefix + ".enable_uefi_networking").(bool),
 	}
 }
 
@@ -850,6 +1041,15 @@ func expandDisplayDevice(d tpgresource.TerraformResourceData) *compute.DisplayDe
 	return &compute.DisplayDevice{
 		EnableDisplay:   d.Get("enable_display").(bool),
 		ForceSendFields: []string{"EnableDisplay"},
+	}
+}
+
+func expandDisplayDevice_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	if _, ok := d.GetOk("enable_display"); !ok {
+		return nil
+	}
+	return map[string]interface{}{
+		"enableDisplay": d.Get("enable_display").(bool),
 	}
 }
 
@@ -1086,6 +1286,37 @@ func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.Re
 	return &affinity, nil
 }
 
+func expandReservationAffinity_v2(d tpgresource.TerraformResourceData) (map[string]interface{}, error) {
+	_, ok := d.GetOk("reservation_affinity")
+	if !ok {
+		return nil, nil
+	}
+
+	prefix := "reservation_affinity.0"
+	reservationAffinityType := d.Get(prefix + ".type").(string)
+
+	affinity := map[string]interface{}{
+		"consumeReservationType": reservationAffinityType,
+	}
+
+	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
+	if (reservationAffinityType == "SPECIFIC_RESERVATION") != hasSpecificReservation {
+		return nil, fmt.Errorf("specific_reservation must be set when reservation_affinity is SPECIFIC_RESERVATION, and not set otherwise")
+	}
+
+	prefix = prefix + ".specific_reservation.0"
+	if hasSpecificReservation {
+		values := make([]interface{}, 0)
+		for _, v := range d.Get(prefix + ".values").([]interface{}) {
+			values = append(values, v.(string))
+		}
+		affinity["key"] = d.Get(prefix + ".key").(string)
+		affinity["values"] = values
+	}
+
+	return affinity, nil
+}
+
 func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[string]interface{} {
 	if affinity == nil {
 		return nil
@@ -1125,6 +1356,26 @@ func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config 
 	}, nil
 }
 
+func expandNetworkPerformanceConfig_v2(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
+	configs, ok := d.GetOk("network_performance_config")
+	if !ok {
+		return nil, nil
+	}
+
+	npcSlice := configs.([]interface{})
+	if len(npcSlice) > 1 {
+		return nil, fmt.Errorf("cannot specify multiple network_performance_configs")
+	}
+
+	if len(npcSlice) == 0 || npcSlice[0] == nil {
+		return nil, nil
+	}
+	npc := npcSlice[0].(map[string]interface{})
+	return map[string]interface{}{
+		"totalEgressBandwidthTier": npc["total_egress_bandwidth_tier"].(string),
+	}, nil
+}
+
 func flattenComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
 	if v == nil {
 		return nil
@@ -1149,6 +1400,19 @@ func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeatu
 	var result []*compute.GuestOsFeature
 	for _, feature := range v.([]interface{}) {
 		result = append(result, &compute.GuestOsFeature{Type: feature.(string)})
+	}
+	return result
+}
+
+func expandComputeInstanceGuestOsFeatures_v2(v interface{}) []interface{} {
+	if v == nil {
+		return nil
+	}
+	var result []interface{}
+	for _, feature := range v.([]interface{}) {
+		result = append(result, map[string]interface{}{
+			"type": feature.(string),
+		})
 	}
 	return result
 }
@@ -1178,6 +1442,20 @@ func expandComputeInstanceEncryptionKey(d tpgresource.TerraformResourceData) *co
 	}
 }
 
+func expandComputeInstanceEncryptionKey_v2(d tpgresource.TerraformResourceData) map[string]interface{} {
+	iek, ok := d.GetOk("instance_encryption_key")
+	if !ok {
+		return nil
+	}
+
+	iekRes := iek.([]interface{})[0].(map[string]interface{})
+	return map[string]interface{}{
+		"kmsKeyName":           iekRes["kms_key_self_link"].(string),
+		"sha256":               iekRes["sha256"].(string),
+		"kmsKeyServiceAccount": iekRes["kms_key_service_account"].(string),
+	}
+}
+
 func flattenComputeInstanceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
 	if v == nil {
 		return nil
@@ -1204,6 +1482,22 @@ func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceDat
 		KmsKeyName:           cekRes["kms_key_self_link"].(string),
 		Sha256:               cekRes["sha256"].(string),
 		KmsKeyServiceAccount: cekRes["kms_key_service_account"].(string),
+	}
+}
+
+func expandComputeInstanceSourceEncryptionKey_v2(d tpgresource.TerraformResourceData, field string) map[string]interface{} {
+	cek, ok := d.GetOk(field)
+	if !ok {
+		return nil
+	}
+
+	cekRes := cek.([]interface{})[0].(map[string]interface{})
+	return map[string]interface{}{
+		"rsaEncryptedKey":      cekRes["rsa_encrypted_key"].(string),
+		"rawKey":               cekRes["raw_key"].(string),
+		"kmsKeyName":           cekRes["kms_key_self_link"].(string),
+		"sha256":               cekRes["sha256"].(string),
+		"kmsKeyServiceAccount": cekRes["kms_key_service_account"].(string),
 	}
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3399,6 +3399,86 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 	return disk, nil
 }
 
+func expandAttachedDisk_v2(diskConfig map[string]interface{}, d *schema.ResourceData, meta interface{}) (map[string]interface{}, error) {
+	config := meta.(*transport_tpg.Config)
+
+	s := diskConfig["source"].(string)
+	var sourceLink string
+	if strings.Contains(s, "regions/") {
+		source, err := tpgresource.ParseRegionDiskFieldValue(s, d, config)
+		if err != nil {
+			return nil, err
+		}
+		sourceLink = source.RelativeLink()
+	} else {
+		source, err := tpgresource.ParseDiskFieldValue(s, d, config)
+		if err != nil {
+			return nil, err
+		}
+		sourceLink = source.RelativeLink()
+	}
+
+	disk := map[string]interface{}{
+		"source": sourceLink,
+	}
+
+	if v, ok := diskConfig["mode"]; ok {
+		disk["mode"] = v.(string)
+	}
+	if v, ok := diskConfig["device_name"]; ok {
+		disk["deviceName"] = v.(string)
+	}
+	if v, ok := d.GetOk("boot_disk.0.interface"); ok && v != "" {
+		disk["interface"] = v.(string)
+	}
+
+	var diskEncryptionKey map[string]interface{}
+
+	keyValue, keyOk := diskConfig["disk_encryption_key_raw"]
+	if keyOk && keyValue != "" {
+		diskEncryptionKey = map[string]interface{}{
+			"rawKey": keyValue.(string),
+		}
+	}
+
+	keyValue, keyOk = diskConfig["disk_encryption_key_rsa"]
+	if keyOk && keyValue != "" {
+		diskEncryptionKey = map[string]interface{}{
+			"rsaEncryptedKey": keyValue.(string),
+		}
+	}
+
+	kmsValue, kmsOk := diskConfig["kms_key_self_link"]
+	if kmsOk {
+		if keyOk && keyValue != "" && kmsValue != "" {
+			return nil, errors.New("Only one of kms_key_self_link and disk_encryption_key_raw can be set")
+		}
+		if kmsValue != "" {
+			diskEncryptionKey = map[string]interface{}{
+				"kmsKeyName": kmsValue.(string),
+			}
+		}
+	}
+
+	kmsServiceAccount, kmsServiceAccountOk := diskConfig["disk_encryption_service_account"]
+	if kmsServiceAccountOk && kmsServiceAccount != "" {
+		if diskEncryptionKey == nil {
+			diskEncryptionKey = map[string]interface{}{}
+		}
+		diskEncryptionKey["kmsKeyServiceAccount"] = kmsServiceAccount.(string)
+	}
+
+	if diskEncryptionKey != nil {
+		disk["diskEncryptionKey"] = diskEncryptionKey
+	}
+
+	if forceAttach, ok := diskConfig["force_attach"]; ok {
+		disk["forceAttach"] = forceAttach.(bool)
+	}
+
+	return disk, nil
+}
+
 // See comment on expandInstanceTemplateGuestAccelerators regarding why this
 // code is duplicated.
 func expandInstanceGuestAccelerators(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]*compute.AcceleratorConfig, error) {
@@ -3423,6 +3503,30 @@ func expandInstanceGuestAccelerators(d tpgresource.TerraformResourceData, config
 		})
 	}
 
+	return guestAccelerators, nil
+}
+
+func expandInstanceGuestAccelerators_v2(d tpgresource.TerraformResourceData, config *transport_tpg.Config) ([]interface{}, error) {
+	configs, ok := d.GetOk("guest_accelerator")
+	if !ok {
+		return nil, nil
+	}
+	accels := configs.([]interface{})
+	guestAccelerators := make([]interface{}, 0, len(accels))
+	for _, raw := range accels {
+		data := raw.(map[string]interface{})
+		if data["count"].(int) == 0 {
+			continue
+		}
+		at, err := tpgresource.ParseAcceleratorFieldValue(data["type"].(string), d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse accelerator type: %v", err)
+		}
+		guestAccelerators = append(guestAccelerators, map[string]interface{}{
+			"acceleratorCount": data["count"].(int),
+			"acceleratorType":  at.RelativeLink(),
+		})
+	}
 	return guestAccelerators, nil
 }
 
@@ -3586,6 +3690,14 @@ func expandParams(d *schema.ResourceData) (*compute.InstanceParams, error) {
 		params.ResourceManagerTags = tpgresource.ExpandStringMap(d, "params.0.resource_manager_tags")
 	}
 
+	return params, nil
+}
+
+func expandParams_v2(d *schema.ResourceData) (map[string]interface{}, error) {
+	params := map[string]interface{}{}
+	if _, ok := d.GetOk("params.0.resource_manager_tags"); ok {
+		params["resourceManagerTags"] = tpgresource.ExpandStringMap(d, "params.0.resource_manager_tags")
+	}
 	return params, nil
 }
 
@@ -3846,6 +3958,29 @@ func expandScratchDisks(d *schema.ResourceData, config *transport_tpg.Config, pr
 		})
 	}
 
+	return scratchDisks, nil
+}
+
+func expandScratchDisks_v2(d *schema.ResourceData, config *transport_tpg.Config, project string) ([]interface{}, error) {
+	diskType, err := readDiskType(config, d, "local-ssd")
+	if err != nil {
+		return nil, fmt.Errorf("Error loading disk type 'local-ssd': %s", err)
+	}
+
+	n := d.Get("scratch_disk.#").(int)
+	scratchDisks := make([]interface{}, 0, n)
+	for i := 0; i < n; i++ {
+		scratchDisks = append(scratchDisks, map[string]interface{}{
+			"autoDelete": true,
+			"type":       "SCRATCH",
+			"deviceName": d.Get(fmt.Sprintf("scratch_disk.%d.device_name", i)).(string),
+			"interface":  d.Get(fmt.Sprintf("scratch_disk.%d.interface", i)).(string),
+			"diskSizeGb": d.Get(fmt.Sprintf("scratch_disk.%d.size", i)).(int),
+			"initializeParams": map[string]interface{}{
+				"diskType": diskType.RelativeLink(),
+			},
+		})
+	}
 	return scratchDisks, nil
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3961,29 +3961,6 @@ func expandScratchDisks(d *schema.ResourceData, config *transport_tpg.Config, pr
 	return scratchDisks, nil
 }
 
-func expandScratchDisks_v2(d *schema.ResourceData, config *transport_tpg.Config, project string) ([]interface{}, error) {
-	diskType, err := readDiskType(config, d, "local-ssd")
-	if err != nil {
-		return nil, fmt.Errorf("Error loading disk type 'local-ssd': %s", err)
-	}
-
-	n := d.Get("scratch_disk.#").(int)
-	scratchDisks := make([]interface{}, 0, n)
-	for i := 0; i < n; i++ {
-		scratchDisks = append(scratchDisks, map[string]interface{}{
-			"autoDelete": true,
-			"type":       "SCRATCH",
-			"deviceName": d.Get(fmt.Sprintf("scratch_disk.%d.device_name", i)).(string),
-			"interface":  d.Get(fmt.Sprintf("scratch_disk.%d.interface", i)).(string),
-			"diskSizeGb": d.Get(fmt.Sprintf("scratch_disk.%d.size", i)).(int),
-			"initializeParams": map[string]interface{}{
-				"diskType": diskType.RelativeLink(),
-			},
-		})
-	}
-	return scratchDisks, nil
-}
-
 func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
 	result := map[string]interface{}{
 		"device_name": disk.DeviceName,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `compute_instance_helpers` resource to use direct HTTP rather than a client library
```
