### PR TITLE
feat(networksecurity): add org-level support to google_network_security_address_groups datasource

### DIFF
--- a/mmv1/third_party/terraform/services/networksecurity/data_source_google_network_security_address_groups.go
+++ b/mmv1/third_party/terraform/services/networksecurity/data_source_google_network_security_address_groups.go
@@ -16,9 +16,17 @@ func DataSourceNetworkSecurityAddressGroups() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"project": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"parent"},
+			},
+			"parent": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Description: `The parent of the Address Group. Use "organizations/{organization_id}" ` +
+					`for organization-level address groups or "projects/{project_id}" for project-level address groups.`,
+				ConflictsWith: []string{"project"},
 			},
 			"location": {
 				Type:     schema.TypeString,
@@ -60,15 +68,24 @@ func dataSourceNetworkSecurityAddressGroups(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	project, err := tpgresource.GetProject(d, config)
-	if err != nil {
-		return err
-	}
 	location := d.Get("location").(string)
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{NetworkSecurityBasePath}}projects/{{project}}/locations/{{location}}/addressGroups")
-	if err != nil {
-		return err
+	var url string
+	var project string
+
+	if parent, ok := d.GetOk("parent"); ok {
+		url = fmt.Sprintf("%s%s/locations/%s/addressGroups", config.NetworkSecurityBasePath, parent.(string), location)
+	} else {
+		// Project-level, defaults to provider project if not set
+		project, err = tpgresource.GetProject(d, config)
+		if err != nil {
+			return err
+		}
+
+		url, err = tpgresource.ReplaceVars(d, config, "{{NetworkSecurityBasePath}}projects/{{project}}/locations/{{location}}/addressGroups")
+		if err != nil {
+			return err
+		}
 	}
 
 	var allAddressGroups []interface{}
@@ -100,7 +117,11 @@ func dataSourceNetworkSecurityAddressGroups(d *schema.ResourceData, meta interfa
 	}
 
 	if len(allAddressGroups) == 0 {
-		log.Printf("[DEBUG] No Address Groups found for project %s in location %s", project, location)
+		if parent, ok := d.GetOk("parent"); ok {
+			log.Printf("[DEBUG] No Address Groups found for parent %s in location %s", parent.(string), location)
+		} else {
+			log.Printf("[DEBUG] No Address Groups found for project %s in location %s", project, location)
+		}
 	}
 
 	flattenedGroups := make([]map[string]interface{}, 0, len(allAddressGroups))
@@ -120,7 +141,11 @@ func dataSourceNetworkSecurityAddressGroups(d *schema.ResourceData, meta interfa
 		return fmt.Errorf("error setting address_groups state: %s", err)
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/locations/%s", project, location))
+	if parent, ok := d.GetOk("parent"); ok {
+		d.SetId(fmt.Sprintf("%s/locations/%s", parent.(string), location))
+	} else {
+		d.SetId(fmt.Sprintf("projects/%s/locations/%s", project, location))
+	}
 
 	return nil
 }

--- a/mmv1/third_party/terraform/services/networksecurity/data_source_google_network_security_address_groups_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/data_source_google_network_security_address_groups_test.go
@@ -56,3 +56,52 @@ data "google_network_security_address_groups" "all" {
 }
 `, context)
 }
+
+func TestAccDataSourceNetworkSecurityAddressGroups_organization(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"location":      "us-central1",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceNetworkSecurityAddressGroupsOrganizationConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_network_security_address_groups.org_all", "address_groups.#"),
+					resource.TestCheckResourceAttr("data.google_network_security_address_groups.org_all", "address_groups.0.location", context["location"].(string)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceNetworkSecurityAddressGroupsOrganizationConfig(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google-beta" {
+  region = "%{location}"
+}
+
+resource "google_network_security_address_group" "org_basic" {
+  provider    = google-beta
+  name        = "tf-test-ag-org-%{random_suffix}"
+  parent      = "organizations/%{org_id}"
+  location    = "%{location}"
+  type        = "IPV4"
+  capacity    = 100
+  items       = ["208.80.154.224/32"]
+}
+
+data "google_network_security_address_groups" "org_all" {
+  provider   = google-beta
+  parent     = "organizations/%{org_id}"
+  location   = "%{location}"
+  depends_on = [google_network_security_address_group.org_basic]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/network_security_address_groups.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/network_security_address_groups.html.markdown
@@ -2,12 +2,12 @@
 subcategory: "Network Security"
 description: |-
   AddressGroups are used to group IP addresses together for use in firewall policies.
-  This data source allows you to list address groups in a project and location.
+  This data source allows you to list address groups in a project or organization and location.
 ---
 
 # google_network_security_address_groups
 
-AddressGroups are used to group IP addresses together for use in firewall policies. This data source allows you to list address groups in a project and location.
+AddressGroups are used to group IP addresses together for use in firewall policies. This data source allows you to list address groups in a project or organization and location.
 
 To get more information about Address Groups, see:
 
@@ -15,12 +15,21 @@ To get more information about Address Groups, see:
 * How-to Guides
     * [Official Documentation](https://cloud.google.com/firewall/docs/about-address-groups)
 
-## Example Usage
+## Example Usage - Project Level
 
 ```hcl
 data "google_network_security_address_groups" "all" {
   location = "us-central1"
   project  = "my-project-id"
+}
+```
+
+## Example Usage - Organization Level
+
+```hcl
+data "google_network_security_address_groups" "org_all" {
+  location = "us-central1"
+  parent   = "organizations/123456789"
 }
 ```
 
@@ -30,13 +39,19 @@ The following arguments are supported:
 
 * `location` - (Required) The location of the Address Group.
 
-* `project` - (Optional) The ID of the project.
+- - -
+
+* `project` - (Optional) The ID of the project. Conflicts with `parent`.
+
+* `parent` - (Optional) The parent of the Address Group. Use `organizations/{organization_id}` for organization-level address groups or `projects/{project_id}` for project-level address groups. Conflicts with `project`.
+
+~> **Note:** Exactly one of `project` or `parent` should be specified. If neither is set, the project is inferred from the provider configuration.
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `address_groups` - A list of Address Groups in the selected project and location. Structure is [defined below](#nested_address_groups).
+* `address_groups` - A list of Address Groups in the selected project or organization and location. Structure is [defined below](#nested_address_groups).
 
 <a name="nested_address_groups"></a>The `address_groups` block supports:
 


### PR DESCRIPTION
Add optional 'parent' field to the google_network_security_address_groups data source, enabling listing of address groups at the organization level (e.g. parent = "organizations/123456789") in addition to the existing project-level support.

- Add `parent` field (Optional) which is mutually exclusive with `project`
- Setting `parent` takes precedence, falling through to project-level path for backward compatibility
- Add test for organization-level listing
- Update documentation with org-level example and field descriptions

---

- API: https://docs.cloud.google.com/firewall/docs/reference/network-security/rest/v1/organizations.locations.addressGroups/get

```release-note:enhancement
networksecurity: added `parent` field to `google_network_security_address_groups` data source
```
