### PR TITLE
Added registry for TGC next

### DIFF
--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -75,6 +75,7 @@ func NewTerraformGoogleConversionNext(product *api.Product, versionName string, 
 		templateFS:                 templateFS,
 	}
 
+	t.Product.ImportPath = ImportPathFromVersion(versionName)
 	for _, r := range t.Product.Objects {
 		r.ImportPath = ImportPathFromVersion(versionName)
 	}
@@ -83,6 +84,7 @@ func NewTerraformGoogleConversionNext(product *api.Product, versionName string, 
 }
 
 func (tgc TerraformGoogleConversionNext) Generate(outputFolder, resourceToGenerate string, generateCode, generateDocs bool) {
+	tgc.GenerateProduct(outputFolder)
 	for _, object := range tgc.Product.Objects {
 		object.ExcludeIfNotInVersion(tgc.Product.Version)
 
@@ -147,6 +149,21 @@ func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resou
 	}
 	targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_%s_generated_test.go", productName, google.Underscore(object.Name)))
 	templateData.GenerateTGCNextTestFile(targetFilePath, object)
+}
+
+// GenerateProduct creates the product.go file for a given service directory.
+// This will be used to seed the directory and add a package-level comment
+// specific to the product.
+func (tgc *TerraformGoogleConversionNext) GenerateProduct(outputFolder string) {
+	targetFolder := path.Join(outputFolder, "pkg", "services", tgc.Product.ApiName)
+	if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
+		log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
+	}
+
+	targetFilePath := path.Join(targetFolder, "product.go")
+	templateData := NewTemplateData(outputFolder, tgc.TargetVersionName, tgc.templateFS)
+	templateData.GenerateProductFile(targetFilePath, *tgc.Product)
+	tgc.replaceImportPath(targetFolder, "product.go")
 }
 
 func (tgc TerraformGoogleConversionNext) CompileCommonFiles(outputFolder string, products []*api.Product, overridePath string) {

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -160,6 +160,7 @@ func (tgc TerraformGoogleConversionNext) CompileCommonFiles(outputFolder string,
 		"pkg/provider/provider.go":                       "third_party/terraform/provider/provider.go.tmpl",
 		"pkg/provider/provider_validators.go":            "third_party/terraform/provider/provider_validators.go",
 		"pkg/provider/provider_mmv1_resources.go":        "templates/tgc_next/provider/provider_mmv1_resources.go.tmpl",
+		"pkg/registry/registry.go":                       "third_party/terraform/registry/registry.go",
 
 		// services
 		"pkg/services/compute/compute_instance_helpers.go": "third_party/terraform/services/compute/compute_instance_helpers.go.tmpl",

--- a/mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl
+++ b/mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl
@@ -4,18 +4,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	{{- range $object := $.ResourcesForVersion }}
-	  "github.com/hashicorp/terraform-provider-google/google/services/{{ $object.ServiceName }}"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/{{ $object.ServiceName }}"
 	{{- end }}
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/services/container"
-	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/services/resourcemanager"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
+	_ "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/services/container"
+	_ "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/services/resourcemanager"
 )
 
 var handwrittenResources = map[string]*schema.Resource{
 	// ####### START handwritten resources ###########
-	"google_compute_instance":    compute.ResourceComputeInstance(),
-	"google_container_cluster":   container.ResourceContainerCluster(),
-	"google_container_node_pool": container.ResourceContainerNodePool(),
-	"google_project":             resourcemanager.ResourceGoogleProject(),
+	"google_compute_instance":    registry.Resource("google_compute_instance"),
+	"google_container_cluster":   registry.Resource("google_container_cluster"),
+	"google_container_node_pool": registry.Resource("google_container_node_pool"),
+	"google_project":             registry.Resource("google_project"),
 	// ####### END handwritten resources ###########
 }
 
@@ -23,7 +24,7 @@ var handwrittenResources = map[string]*schema.Resource{
 var generatedResources = map[string]*schema.Resource{
 	{{- range $object := $.ResourcesForVersion }}
 		{{- if $object.ResourceName }}
-			"{{ $object.TerraformName }}": {{ $object.ServiceName }}.Resource{{ $object.ResourceName -}}(),
+			"{{ $object.TerraformName }}": registry.Resource("{{ $object.TerraformName }}"),
 		{{- end }}
 	{{- end }}
 }

--- a/mmv1/templates/tgc_next/services/resource.go.tmpl
+++ b/mmv1/templates/tgc_next/services/resource.go.tmpl
@@ -34,6 +34,7 @@ import (
   "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 
 
+  "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
   "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tgcresource"
   "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tpgresource"
   transport_tpg "github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/transport"
@@ -64,6 +65,15 @@ var (
     _ = transport_tpg.Config{}
     _ = verify.ProjectRegex
 )
+
+func init() {
+    registry.Schema{
+        Name: "{{ $.TerraformName }}",
+        ProductName: "{{ lower $.ProductMetadata.Name }}",
+        Type: registry.SchemaTypeResource,
+        Schema: Resource{{ $.ResourceName -}}(),
+    }.Register()
+}
 
 {{ if $.DefineAssetTypeForResourceInProduct -}}
 const {{ $.CaiResourceType -}}AssetType string = "{{ $.CaiAssetType }}"

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"strings"
 
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tgcresource"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tpgresource"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/verify"
@@ -11,6 +12,15 @@ import (
 
 	"google.golang.org/api/compute/v1"
 )
+
+func init() {
+	registry.Schema{
+		Name:        "google_compute_instance",
+		ProductName: "compute",
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceComputeInstance(),
+	}.Register()
+}
 
 // ComputeInstanceAssetType is the CAI asset type name for compute instance.
 const ComputeInstanceAssetType string = "compute.googleapis.com/Instance"

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -12,9 +12,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"google.golang.org/api/container/v1"
 
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tpgresource"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/verify"
 )
+
+func init() {
+	registry.Schema{
+		Name:        "google_container_cluster",
+		ProductName: "container",
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceContainerCluster(),
+	}.Register()
+}
 
 // ContainerClusterAssetType is the CAI asset type name for container cluster.
 const ContainerClusterAssetType string = "container.googleapis.com/Cluster"

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
@@ -4,8 +4,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/tpgresource"
 )
+
+func init() {
+	registry.Schema{
+		Name:        "google_container_node_pool",
+		ProductName: "container",
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceContainerNodePool(),
+	}.Register()
+}
 
 // ContainerNodePoolAssetType is the CAI asset type name for container node pool.
 const ContainerNodePoolAssetType string = "container.googleapis.com/NodePool"

--- a/mmv1/third_party/tgc_next/pkg/services/resourcemanager/project.go
+++ b/mmv1/third_party/tgc_next/pkg/services/resourcemanager/project.go
@@ -3,11 +3,21 @@ package resourcemanager
 import (
 	"strings"
 
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/verify"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+func init() {
+	registry.Schema{
+		Name:        "google_project",
+		ProductName: "resourcemanager",
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceGoogleProject(),
+	}.Register()
+}
 
 // ProjectAssetType is the CAI asset type name for project.
 const ProjectAssetType string = "cloudresourcemanager.googleapis.com/Project"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

TGC next has its own copies of the provider resources it uses. This means that we need to give it its own registry, so that we can better handle dependencies (similar to what we're doing in the provider.) This is a prerequisite to https://github.com/GoogleCloudPlatform/magic-modules/pull/17011.

attn @SirGitsalot FYI but I'm requesting review from @zli82016 since this impacts TGC.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
