### PR TITLE
feat: add preconfiguredWafConfig example to a tf doc

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicyRule.yaml
@@ -70,6 +70,11 @@ examples:
     primary_resource_id: 'policy'
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'organization_security_policy_rule_with_body_exclude'
+    min_version: 'beta'
+    primary_resource_id: 'policy'
+    test_env_vars:
+      org_id: 'ORG_ID'
 parameters:
   - name: 'policyId'
     type: String

--- a/mmv1/templates/terraform/examples/organization_security_policy_rule_with_body_exclude.tf.tmpl
+++ b/mmv1/templates/terraform/examples/organization_security_policy_rule_with_body_exclude.tf.tmpl
@@ -1,0 +1,44 @@
+resource "google_compute_organization_security_policy" "{{$.PrimaryResourceId}}" {
+  provider   = google-beta
+  short_name = "tf-test%{random_suffix}"
+  parent     = "organizations/{{index $.TestEnvVars "org_id"}}"
+  type       = "CLOUD_ARMOR"
+}
+
+resource "google_compute_organization_security_policy_rule" "{{$.PrimaryResourceId}}" {
+  provider  = google-beta
+  policy_id = google_compute_organization_security_policy.{{$.PrimaryResourceId}}.id
+  
+  action   = "allow" 
+  priority = 100
+
+  match {
+    versioned_expr = "SRC_IPS_V1"
+    config {
+      src_ip_ranges = ["192.168.0.0/16"]
+    }
+  }
+
+  preconfigured_waf_config {
+
+    exclusion {
+      target_rule_set = "sqli-v33-stable"
+      target_rule_ids = ["owasp-crs-v030301-id942100-sqli"]
+
+      request_query_param {
+        operator = "CONTAINS"
+        value    = "debug_token"
+      }
+
+      request_header {
+        operator = "STARTS_WITH"
+        value    = "X-Internal-Custom"
+      }
+
+      request_cookie {
+        operator = "EQUALS"
+        value    = "session_id"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Hello Folks, this PR is to create a example to how to use a preconfiguredWafConfig on google_compute_organization_security_policy_rule resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `preconfiguredWafConfig` example to `google_compute_organization_security_policy_rule` resource
```
