### PR TITLE
add chromepolicy to enabled apis for CI + terraform fmt

### DIFF
--- a/.ci/infra/terraform/main.tf
+++ b/.ci/infra/terraform/main.tf
@@ -236,6 +236,7 @@ module "project-services" {
     "blockchainnodeengine.googleapis.com",
     "certificatemanager.googleapis.com",
     "ces.googleapis.com",
+    "chromepolicy.googleapis.com",
     "chronicle.googleapis.com",
     "cloudaicompanion.googleapis.com",
     "cloudapis.googleapis.com",
@@ -390,7 +391,7 @@ module "project-services" {
 }
 
 resource "google_project_service_identity" "bigtable_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -398,7 +399,7 @@ resource "google_project_service_identity" "bigtable_sa" {
 }
 
 resource "google_project_service_identity" "secretmanager_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -406,7 +407,7 @@ resource "google_project_service_identity" "secretmanager_sa" {
 }
 
 resource "google_project_service_identity" "sqladmin_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -414,7 +415,7 @@ resource "google_project_service_identity" "sqladmin_sa" {
 }
 
 resource "google_project_service_identity" "osconfig_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -422,7 +423,7 @@ resource "google_project_service_identity" "osconfig_sa" {
 }
 
 resource "google_project_service_identity" "progressiverollout_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -430,7 +431,7 @@ resource "google_project_service_identity" "progressiverollout_sa" {
 }
 
 resource "google_project_service_identity" "parametermanager_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id
@@ -438,7 +439,7 @@ resource "google_project_service_identity" "parametermanager_sa" {
 }
 
 resource "google_project_service_identity" "dlp_sa" {
-  provider = google-beta
+  provider   = google-beta
   depends_on = [module.project-services]
 
   project = google_project.proj.project_id


### PR DESCRIPTION
this is a prerequistie for #17106 per https://github.com/GoogleCloudPlatform/magic-modules/pull/17106#discussion_r3101812759

this change needs to land before that PR can be properly reviewed, so the CI updates


cc @BBBmau 

```release-note:none
```