### PR TITLE
fix perma-diff in google_dialogflow_cx_test_case session_parameters

### DIFF
--- a/mmv1/products/dialogflowcx/TestCase.yaml
+++ b/mmv1/products/dialogflowcx/TestCase.yaml
@@ -35,6 +35,7 @@ custom_code:
   pre_read: 'templates/terraform/pre_create/dialogflow_set_location.go.tmpl'
   pre_update: 'templates/terraform/pre_create/dialogflow_set_location.go.tmpl'
   pre_delete: 'templates/terraform/pre_create/dialogflow_set_location.go.tmpl'
+  constants: 'templates/terraform/constants/dialogflowcx_test_case_session_parameters_diff_suppress.go.tmpl'
 exclude_sweeper: true
 examples:
   - name: 'dialogflowcx_test_case_full'
@@ -194,6 +195,7 @@ properties:
               description: |
                 The session parameters available to the bot at this point.
               state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+              diff_suppress_func: 'dialogflowcxTestCaseSessionParametersDiffSuppress'
               custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
               custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
               validation:

--- a/mmv1/products/dialogflowcx/TestCase.yaml
+++ b/mmv1/products/dialogflowcx/TestCase.yaml
@@ -42,9 +42,6 @@ examples:
     primary_resource_id: 'basic_test_case'
     vars:
       agent_name: 'dialogflowcx-agent'
-    # Skip in VCR until the test issue is resolved
-    # https://github.com/hashicorp/terraform-provider-google/issues/21532
-    skip_vcr: true
 parameters:
   - name: 'parent'
     type: String

--- a/mmv1/templates/terraform/constants/dialogflowcx_test_case_session_parameters_diff_suppress.go.tmpl
+++ b/mmv1/templates/terraform/constants/dialogflowcx_test_case_session_parameters_diff_suppress.go.tmpl
@@ -1,0 +1,22 @@
+func dialogflowcxTestCaseSessionParametersDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// Treat empty string and empty JSON object as equivalent
+	if (old == "" || old == "{}") && (new == "" || new == "{}") {
+		return true
+	}
+
+	if old == "" || new == "" {
+		return old == new
+	}
+
+	var oldJson, newJson interface{}
+
+	if err := json.Unmarshal([]byte(old), &oldJson); err != nil {
+		return false
+	}
+
+	if err := json.Unmarshal([]byte(new), &newJson); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(oldJson, newJson)
+}

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_test_case_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflow_cx_test_case_test.go
@@ -12,10 +12,6 @@ import (
 func TestAccDialogflowCXTestCase_update(t *testing.T) {
 	t.Parallel()
 
-	// Skip in VCR until the test issue is resolved
-	// https://github.com/hashicorp/terraform-provider-google/issues/25227
-	acctest.SkipIfVcr(t)
-
 	context := map[string]interface{}{
 		"org_id":          envvar.GetTestOrgFromEnv(t),
 		"billing_account": envvar.GetTestBillingAccountFromEnv(t),


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25227
Fixes https://github.com/hashicorp/terraform-provider-google/issues/21532

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
dialogflowcx: fixed a perma-diff in `google_dialogflow_cx_test_case` when `session_parameters` was omitted from the configuration
```
