### PR TITLE
Update dialogflow tests

### DIFF
--- a/mmv1/templates/terraform/examples/dialogflow_environment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_environment_basic.tf.tmpl
@@ -15,11 +15,6 @@ resource "time_sleep" "wait_enable_service_api" {
   ]
   create_duration = "30s"
 }
-resource "google_project_service_identity" "gcp_sa" {
-  service    = "dialogflow.googleapis.com"
-  project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_enable_service_api]
-}
 resource "google_dialogflow_agent" "basic_agent" {
   display_name = "example_agent"
   default_language_code = "en-us"

--- a/mmv1/templates/terraform/examples/dialogflow_version_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_version_full.tf.tmpl
@@ -15,11 +15,6 @@ resource "time_sleep" "wait_enable_service_api" {
   ]
   create_duration = "30s"
 }
-resource "google_project_service_identity" "gcp_sa" {
-  service    = "dialogflow.googleapis.com"
-  project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_enable_service_api]
-}
 resource "google_dialogflow_agent" "basic_agent" {
   display_name = "example_agent"
   default_language_code = "en"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26553
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25258

It seems that google_project_service_identity (which is beta-only) is not needed in these dialogflow tests

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
