### PR TITLE
Suppress diff for zero node counts to fix perma-drift

### DIFF
--- a/mmv1/products/hypercomputecluster/Cluster.yaml
+++ b/mmv1/products/hypercomputecluster/Cluster.yaml
@@ -306,6 +306,7 @@ properties:
               - name: count
                 type: String
                 required: true
+                diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("0")'
                 description: Number of login node instances to create.
               - name: enableOsLogin
                 type: Boolean
@@ -441,6 +442,7 @@ properties:
                     alphanumeric, and at most 63 characters).
                 - name: maxDynamicNodeCount
                   type: String
+                  diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("0")'
                   description: |-
                     Controls how many additional nodes a cluster can bring online to handle
                     workloads. Set this value to enable dynamic node creation and limit the
@@ -449,6 +451,7 @@ properties:
                     on static nodes.
                 - name: staticNodeCount
                   type: String
+                  diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("0")'
                   description: |-
                     Number of nodes to be statically created for this nodeset. The cluster will
                     attempt to ensure that at least this many nodes exist at all times.


### PR DESCRIPTION
Fixes b/503320140

This PR resolves a Terraform perma-drift issue in the `google_hypercomputecluster_cluster` resource that occurs when users explicitly set node counts (`count`, `static_node_count`, or `max_dynamic_node_count`) to `0`. 

Because the backend API uses proto3, it omits these default `0` values from the JSON response payload. This causes Terraform to see an empty state and incorrectly report a drift against the user's `"0"` configuration. 

This PR adds `diff_suppress_func: 'tpgresource.EmptyOrDefaultStringSuppress("0")'` to these fields so Terraform correctly treats the empty API response as equivalent to `"0"`.


```release-note:bug
hypercomputecluster: fixed a permadiff in `google_hypercomputecluster_cluster` when `count`, `static_node_count`, or `max_dynamic_node_count` were explicitly set to `0`.
```
