### PR TITLE
feat: promote global UrlMap cache policy support to GA

### DIFF
--- a/mmv1/products/compute/UrlMap.yaml
+++ b/mmv1/products/compute/UrlMap.yaml
@@ -153,7 +153,6 @@ examples:
       mirror_backend_service_name: '"mirror" + randomSuffix'
   - name: 'url_map_cache_policy_basic'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       backend_service_name: 'home'
@@ -165,7 +164,6 @@ examples:
       backend_service_name: '"home" + randomSuffix'
   - name: 'url_map_cache_policy_multi_level'
     primary_resource_id: 'urlmap'
-    min_version: 'beta'
     vars:
       url_map_name: 'urlmap'
       backend_service_name: 'home'
@@ -1092,7 +1090,6 @@ properties:
                           required: true
                   - name: 'cachePolicy'
                     type: NestedObject
-                    min_version: beta
                     description: |
                       Specifies the cache policy configuration for matched traffic. Available
                       only for Global EXTERNAL_MANAGED load balancer schemes. At least one
@@ -2156,7 +2153,6 @@ properties:
                           required: true
                   - name: 'cachePolicy'
                     type: NestedObject
-                    min_version: beta
                     description: |
                       Specifies the cache policy configuration for matched traffic. Available
                       only for Global EXTERNAL_MANAGED load balancer schemes. At least one
@@ -3046,7 +3042,6 @@ properties:
                         function: 'validation.FloatBetween(0, 100)'
             - name: 'cachePolicy'
               type: NestedObject
-              min_version: beta
               description: |
                 Specifies the cache policy configuration for matched traffic. Available
                 only for Global EXTERNAL_MANAGED load balancer schemes. At least one
@@ -4081,7 +4076,6 @@ properties:
                   function: 'validation.FloatBetween(0, 100)'
       - name: 'cachePolicy'
         type: NestedObject
-        min_version: beta
         description: |
           Specifies the cache policy configuration for matched traffic. Available
           only for Global EXTERNAL_MANAGED load balancer schemes. At least one

--- a/mmv1/templates/terraform/examples/url_map_cache_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_cache_policy_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name     = "{{index $.Vars "url_map_name"}}"
   
   default_service = google_compute_backend_service.default.id
@@ -27,7 +26,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider = google-beta
   name     = "{{index $.Vars "backend_service_name"}}"
   
   protocol              = "HTTP"
@@ -37,7 +35,6 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/templates/terraform/examples/url_map_cache_policy_multi_level.tf.tmpl
+++ b/mmv1/templates/terraform/examples/url_map_cache_policy_multi_level.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
-  provider = google-beta
   name     = "{{index $.Vars "url_map_name"}}"
   
   default_service = google_compute_backend_service.default.id
@@ -130,7 +129,6 @@ resource "google_compute_url_map" "{{$.PrimaryResourceId}}" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider = google-beta
   name     = "{{index $.Vars "backend_service_name"}}"
   
   protocol              = "HTTP"
@@ -140,7 +138,6 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name     = "{{index $.Vars "health_check_name"}}"
   http_health_check {
     port = 80

--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
@@ -6,9 +6,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-{{ if ne $.TargetVersionName `ga` -}}
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-{{- end }}
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -432,7 +430,6 @@ func TestAccComputeUrlMap_routeRulesCustomErrorResponsePolicy(t *testing.T) {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeUrlMap_cachePolicyMultiLevelUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -440,7 +437,7 @@ func TestAccComputeUrlMap_cachePolicyMultiLevelUpdate(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		CheckDestroy:             testAccCheckComputeUrlMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
@@ -467,7 +464,6 @@ func TestAccComputeUrlMap_cachePolicyMultiLevelUpdate(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 func testAccComputeUrlMap_basic1(bsName, hcName, umName string) string {
 	return fmt.Sprintf(`
@@ -2154,11 +2150,9 @@ resource "google_compute_url_map" "url_map" {
 }
 {{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeUrlMap_cachePolicyMultiLevel(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_url_map" "urlmap" {
-  provider = google-beta
   name     = "urlmap-test-%s"
   
   default_service = google_compute_backend_service.default.id
@@ -2367,7 +2361,6 @@ resource "google_compute_url_map" "urlmap" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider = google-beta
   name     = "backend-test-%s"
   
   protocol              = "HTTP"
@@ -2377,7 +2370,6 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name     = "hc-test-%s"
   http_health_check {
     port = 80
@@ -2389,7 +2381,6 @@ resource "google_compute_health_check" "default" {
 func testAccComputeUrlMap_cachePolicyMultiLevelUpdate(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_url_map" "urlmap" {
-  provider = google-beta
   name     = "urlmap-test-%s"
   
   default_service = google_compute_backend_service.default.id
@@ -2513,7 +2504,6 @@ resource "google_compute_url_map" "urlmap" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider = google-beta
   name     = "backend-test-%s"
   
   protocol              = "HTTP"
@@ -2523,7 +2513,6 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   name     = "hc-test-%s"
   http_health_check {
     port = 80
@@ -2531,4 +2520,3 @@ resource "google_compute_health_check" "default" {
 }
 `, suffix, suffix, suffix)
 }
-{{- end }}


### PR DESCRIPTION
Promote support for cache policy field for global URL Map to GA. Cache policy allows to specify Cloud CDN caching behavior per route. For more information, refer to [documentation](https://clouddocs.devsite.corp.google.com/load-balancing/docs/https/setting-up-global-traffic-mgmt#cdn-cache-policy) and [API Reference](https://docs.cloud.google.com/compute/docs/reference/rest/beta/urlMaps). Field introduced in: https://github.com/GoogleCloudPlatform/magic-modules/pull/16899

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26919

**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
compute: added `cache_policy` field to `google_compute_url_map` (ga)
```
