### PR TITLE
Migrated `resource_compute_instance.go.tmpl` partially to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1923,7 +1923,7 @@ func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.Reso
 	var res map[string]interface{}
 	var err error
 	if status == "TERMINATED" {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop", config.ComputeBasePath, project, zone, name)
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop?prettyPrint=false", config.ComputeBasePath, project, zone, name)
 		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -1932,7 +1932,7 @@ func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.Reso
 			UserAgent: userAgent,
 		})
 	} else if status == "SUSPENDED" {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/suspend", config.ComputeBasePath, project, zone, name)
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/suspend?prettyPrint=false", config.ComputeBasePath, project, zone, name)
 		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2029,7 +2029,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return fmt.Errorf("Error converting instance: %s", err)
 	}
-	insertUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances", config.ComputeBasePath, project, zone.Name)
+	insertUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances?prettyPrint=false", config.ComputeBasePath, project, zone.Name)
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "POST",
@@ -2550,7 +2550,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting tags: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setTags", config.ComputeBasePath, project, zone, d.Get("name").(string))
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setTags?prettyPrint=false", config.ComputeBasePath, project, zone, d.Get("name").(string))
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2578,7 +2578,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting labels: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setLabels", config.ComputeBasePath, project, zone, instance.Name)
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setLabels?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2639,7 +2639,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting remove resource policies request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/removeResourcePolicies", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/removeResourcePolicies?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -2666,7 +2666,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting add resource policies request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addResourcePolicies", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addResourcePolicies?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -2698,7 +2698,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting scheduling: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling", config.ComputeBasePath, project, zone, instance.Name)
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2848,7 +2848,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 				}
-				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 				url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 				if err != nil {
 					return err
@@ -2884,7 +2884,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2916,7 +2916,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2948,7 +2948,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2980,7 +2980,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -3012,7 +3012,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -3184,7 +3184,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// Detach the old disks.
 		for hash, deviceName := range oDisks {
 			if _, ok := nDisks[hash]; !ok {
-				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/detachDisk", config.ComputeBasePath, project, zone, instance.Name)
+				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/detachDisk?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 				url, err := transport_tpg.AddQueryParams(url, map[string]string{"deviceName": deviceName})
 				if err != nil {
 					return err
@@ -3214,7 +3214,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting attached disk: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/attachDisk", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/attachDisk?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3237,7 +3237,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// if any other boot_disk fields will be added here this should be wrapped in if d.HasChange("boot_disk")
 	if d.HasChange("boot_disk.0.auto_delete") {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDiskAutoDelete", config.ComputeBasePath, project, zone, instance.Name)
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDiskAutoDelete?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 		url, err := transport_tpg.AddQueryParams(url, map[string]string{
 			"autoDelete": strconv.FormatBool(d.Get("boot_disk.0.auto_delete").(bool)),
 			"deviceName": d.Get("boot_disk.0.device_name").(string),
@@ -3280,7 +3280,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("deletion_protection") {
 		nDeletionProtection := d.Get("deletion_protection").(bool)
 
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDeletionProtection", config.ComputeBasePath, project, zone, d.Get("name").(string))
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDeletionProtection?prettyPrint=false", config.ComputeBasePath, project, zone, d.Get("name").(string))
 		url, err := transport_tpg.AddQueryParams(url, map[string]string{
 			"deletionProtection": strconv.FormatBool(nDeletionProtection),
 		})
@@ -3391,7 +3391,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if statusBeforeUpdate != "TERMINATED" {
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3418,7 +3418,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting min cpu platform request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMinCpuPlatform", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMinCpuPlatform?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3448,7 +3448,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting machine type request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMachineType", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMachineType?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3478,7 +3478,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting service account request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setServiceAccount", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setServiceAccount?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3505,7 +3505,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting display device request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateDisplayDevice", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateDisplayDevice?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "PATCH",
@@ -3530,7 +3530,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting shielded vm config: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateShieldedInstanceConfig", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateShieldedInstanceConfig?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "PATCH",
@@ -3560,7 +3560,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting scheduling: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling", config.ComputeBasePath, project, zone, instance.Name)
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1919,18 +1919,33 @@ func getAllStatusBut(status string) []string {
 }
 
 func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.ResourceData, project, zone, status, userAgent string) error {
-	var op *compute.Operation
+	name := d.Get("name").(string)
+	var res map[string]interface{}
 	var err error
 	if status == "TERMINATED" {
-		op, err = NewClient(config, userAgent).Instances.Stop(project, zone, d.Get("name").(string)).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop", config.ComputeBasePath, project, zone, name)
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 	} else if status == "SUSPENDED" {
-		op, err = NewClient(config, userAgent).Instances.Suspend(project, zone, d.Get("name").(string)).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/suspend", config.ComputeBasePath, project, zone, name)
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 	}
 	if err != nil {
 		return fmt.Errorf("Error changing instance status after creation: %s", err)
 	}
 
-	waitErr := ComputeOperationWaitTime(config, op, project, "changing instance status", userAgent, d.Timeout(schema.TimeoutCreate))
+	waitErr := ComputeOperationWaitTime(config, res, project, "changing instance status", userAgent, d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		d.SetId("")
 		return waitErr
@@ -2010,7 +2025,19 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	{{- end }}
 
 	log.Printf("[INFO] Requesting instance creation")
-	op, err := NewClient(config, userAgent).Instances.Insert(project, zone.Name, instance).Do()
+	instanceBody, err := tpgresource.ConvertToMap(instance)
+	if err != nil {
+		return fmt.Errorf("Error converting instance: %s", err)
+	}
+	insertUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances", config.ComputeBasePath, project, zone.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    insertUrl,
+		UserAgent: userAgent,
+		Body:      instanceBody,
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating instance: %s", err)
 	}
@@ -2019,7 +2046,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := ComputeOperationWaitTime(config, op, project, "instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
+	waitErr := ComputeOperationWaitTime(config, res, project, "instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -2519,13 +2546,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err := tpgresource.Convert(tags, tagsV1); err != nil {
 			return err
 		}
-		op, err := NewClient(config, userAgent).Instances.SetTags(
-			project, zone, d.Get("name").(string), tagsV1).Do()
+		tagsBody, err := tpgresource.ConvertToMap(tagsV1)
+		if err != nil {
+			return fmt.Errorf("Error converting tags: %s", err)
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setTags", config.ComputeBasePath, project, zone, d.Get("name").(string))
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      tagsBody,
+		})
 		if err != nil {
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := ComputeOperationWaitTime(config, op, project, "tags to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+		opErr := ComputeOperationWaitTime(config, res, project, "tags to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -2536,12 +2574,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: labelFingerprint}
 
-		op, err := NewClient(config, userAgent).Instances.SetLabels(project, zone, instance.Name, &req).Do()
+		labelsBody, err := tpgresource.ConvertToMap(&req)
+		if err != nil {
+			return fmt.Errorf("Error converting labels: %s", err)
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setLabels", config.ComputeBasePath, project, zone, instance.Name)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      labelsBody,
+		})
 		if err != nil {
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := ComputeOperationWaitTime(config, op, project, "labels to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+		opErr := ComputeOperationWaitTime(config, res, project, "labels to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -2585,12 +2635,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if len(instance.ResourcePolicies) > 0 {
 			req := compute.InstancesRemoveResourcePoliciesRequest{ResourcePolicies: instance.ResourcePolicies}
 
-			op, err := NewClient(config, userAgent).Instances.RemoveResourcePolicies(project, zone, instance.Name, &req).Do()
+			body, err := tpgresource.ConvertToMap(&req)
+			if err != nil {
+				return fmt.Errorf("Error converting remove resource policies request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/removeResourcePolicies", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return fmt.Errorf("Error removing existing resource policies: %s", err)
 			}
 
-			opErr := ComputeOperationWaitTime(config, op, project, "resource policies to remove", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "resource policies to remove", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2600,12 +2662,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if len(resourcePolicies) > 0 {
 			req := compute.InstancesAddResourcePoliciesRequest{ResourcePolicies: resourcePolicies}
 
-			op, err := NewClient(config, userAgent).Instances.AddResourcePolicies(project, zone, instance.Name, &req).Do()
+			body, err := tpgresource.ConvertToMap(&req)
+			if err != nil {
+				return fmt.Errorf("Error converting add resource policies request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addResourcePolicies", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return fmt.Errorf("Error adding resource policies: %s", err)
 			}
 
-			opErr := ComputeOperationWaitTime(config, op, project, "resource policies to add", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "resource policies to add", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2620,14 +2694,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error creating request data to update scheduling: %s", err)
 		}
 
-		op, err := NewClient(config, userAgent).Instances.SetScheduling(
-			project, zone, instance.Name, scheduling).Do()
+		schedulingBody, err := tpgresource.ConvertToMap(scheduling)
+		if err != nil {
+			return fmt.Errorf("Error converting scheduling: %s", err)
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling", config.ComputeBasePath, project, zone, instance.Name)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      schedulingBody,
+		})
 		if err != nil {
 			return fmt.Errorf("Error updating scheduling policy: %s", err)
 		}
 
 		opErr := ComputeOperationWaitTime(
-			config, op, project, "scheduling policy update", userAgent,
+			config, res, project, "scheduling policy update", userAgent,
 			d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
@@ -2759,11 +2844,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if commonAliasIpRanges := CheckForCommonAliasIp(instNetworkInterface, networkInterface); len(commonAliasIpRanges) > 0 {
 					ni.AliasIpRanges = commonAliasIpRanges
 				}
-				op, err := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, ni).Do()
+				niBody, err := tpgresource.ConvertToMap(ni)
+				if err != nil {
+					return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+				}
+				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+				url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+				if err != nil {
+					return err
+				}
+				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+					Config:    config,
+					Method:    "PATCH",
+					Project:   project,
+					RawURL:    url,
+					UserAgent: userAgent,
+					Body:      niBody,
+				})
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{"{{"}}err{{"}}"}}", err)
 				}
-				opErr := ComputeOperationWaitTime(config, op, project, "updating alias ip ranges", userAgent, d.Timeout(schema.TimeoutUpdate))
+				opErr := ComputeOperationWaitTime(config, res, project, "updating alias ip ranges", userAgent, d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -2779,12 +2880,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				AliasIpRanges: networkInterface.AliasIpRanges,
 				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
-			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
-			op, err := updateCall()
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+			if err != nil {
+				return err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      niBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2796,12 +2912,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				StackType: d.Get(prefix+".stack_type").(string),
 				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
-			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
-			op, err := updateCall()
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+			if err != nil {
+				return err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      niBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2813,12 +2944,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				IgmpQuery: d.Get(prefix+".igmp_query").(string),
 				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
-			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
-			op, err := updateCall()
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+			if err != nil {
+				return err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      niBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2830,12 +2976,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				Ipv6Address: d.Get(prefix+".ipv6_address").(string),
 				Fingerprint:   instNetworkInterface.Fingerprint,
 			}
-			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
-			op, err := updateCall()
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+			if err != nil {
+				return err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      niBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -2847,12 +3008,27 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				InternalIpv6PrefixLength: d.Get(prefix+".internal_ipv6_prefix_length").(int64),
 				Fingerprint:              instNetworkInterface.Fingerprint,
 			}
-			updateCall := NewClient(config, userAgent).Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterfacePatchObj).Do
-			op, err := updateCall()
+			niBody, err := tpgresource.ConvertToMap(networkInterfacePatchObj)
+			if err != nil {
+				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface", config.ComputeBasePath, project, zone, instance.Name)
+			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
+			if err != nil {
+				return err
+			}
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      niBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error updating network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "network interface to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3008,12 +3184,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// Detach the old disks.
 		for hash, deviceName := range oDisks {
 			if _, ok := nDisks[hash]; !ok {
-				op, err := NewClient(config, userAgent).Instances.DetachDisk(project, zone, instance.Name, deviceName).Do()
+				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/detachDisk", config.ComputeBasePath, project, zone, instance.Name)
+				url, err := transport_tpg.AddQueryParams(url, map[string]string{"deviceName": deviceName})
+				if err != nil {
+					return err
+				}
+				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+					Config:    config,
+					Method:    "POST",
+					Project:   project,
+					RawURL:    url,
+					UserAgent: userAgent,
+				})
 				if err != nil {
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
 
-				opErr := ComputeOperationWaitTime(config, op, project, "detaching disk", userAgent, d.Timeout(schema.TimeoutUpdate))
+				opErr := ComputeOperationWaitTime(config, res, project, "detaching disk", userAgent, d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -3023,12 +3210,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		// Attach the new disks
 		for _, disk := range attach {
-			op, err := NewClient(config, userAgent).Instances.AttachDisk(project, zone, instance.Name, disk).Do()
+			diskBody, err := tpgresource.ConvertToMap(disk)
+			if err != nil {
+				return fmt.Errorf("Error converting attached disk: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/attachDisk", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      diskBody,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error attaching disk : {{"{{"}}err{{"}}"}}", err)
 			}
 
-			opErr := ComputeOperationWaitTime(config, op, project, "attaching disk", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "attaching disk", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3038,11 +3237,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// if any other boot_disk fields will be added here this should be wrapped in if d.HasChange("boot_disk")
 	if d.HasChange("boot_disk.0.auto_delete") {
-		op, err := NewClient(config, userAgent).Instances.SetDiskAutoDelete(project, zone, instance.Name, d.Get("boot_disk.0.auto_delete").(bool), d.Get("boot_disk.0.device_name").(string)).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDiskAutoDelete", config.ComputeBasePath, project, zone, instance.Name)
+		url, err := transport_tpg.AddQueryParams(url, map[string]string{
+			"autoDelete": strconv.FormatBool(d.Get("boot_disk.0.auto_delete").(bool)),
+			"deviceName": d.Get("boot_disk.0.device_name").(string),
+		})
+		if err != nil {
+			return err
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error changing auto_delete: %s", err)
 		}
-		opErr := ComputeOperationWaitTime(config, op, project, "changing auto_delete", userAgent, d.Timeout(schema.TimeoutUpdate))
+		opErr := ComputeOperationWaitTime(config, res, project, "changing auto_delete", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -3067,12 +3280,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("deletion_protection") {
 		nDeletionProtection := d.Get("deletion_protection").(bool)
 
-		op, err := NewClient(config, userAgent).Instances.SetDeletionProtection(project, zone, d.Get("name").(string)).DeletionProtection(nDeletionProtection).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDeletionProtection", config.ComputeBasePath, project, zone, d.Get("name").(string))
+		url, err := transport_tpg.AddQueryParams(url, map[string]string{
+			"deletionProtection": strconv.FormatBool(nDeletionProtection),
+		})
+		if err != nil {
+			return err
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
 
-		opErr := ComputeOperationWaitTime(config, op, project, "deletion protection to update", userAgent, d.Timeout(schema.TimeoutUpdate))
+		opErr := ComputeOperationWaitTime(config, res, project, "deletion protection to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -3165,12 +3391,19 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if statusBeforeUpdate != "TERMINATED" {
-			op, err := NewClient(config, userAgent).Instances.Stop(project, zone, instance.Name).Do()
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+			})
 			if err != nil {
 				return errwrap.Wrapf("Error stopping instance: {{"{{"}}err{{"}}"}}", err)
 			}
 
-			opErr := ComputeOperationWaitTime(config, op, project, "stopping instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "stopping instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3181,11 +3414,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			req := &compute.InstancesSetMinCpuPlatformRequest{
 				MinCpuPlatform: minCpuPlatform.(string),
 			}
-			op, err := NewClient(config, userAgent).Instances.SetMinCpuPlatform(project, zone, instance.Name, req).Do()
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting min cpu platform request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMinCpuPlatform", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return err
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating min cpu platform", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "updating min cpu platform", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3199,11 +3444,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			req := &compute.InstancesSetMachineTypeRequest{
 				MachineType: mt.RelativeLink(),
 			}
-			op, err := NewClient(config, userAgent).Instances.SetMachineType(project, zone, instance.Name, req).Do()
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting machine type request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMachineType", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return err
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating machinetype", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "updating machinetype", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3217,11 +3474,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				req.Email = saMap["email"].(string)
 				req.Scopes = tpgresource.CanonicalizeServiceScopes(tpgresource.ConvertStringSet(saMap["scopes"].(*schema.Set)))
 			}
-			op, err := NewClient(config, userAgent).Instances.SetServiceAccount(project, zone, instance.Name, req).Do()
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting service account request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setServiceAccount", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return err
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating service account", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "updating service account", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3232,11 +3501,23 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				EnableDisplay:   d.Get("enable_display").(bool),
 				ForceSendFields: []string{"EnableDisplay"},
 			}
-			op, err := NewClient(config, userAgent).Instances.UpdateDisplayDevice(project, zone, instance.Name, req).Do()
+			body, err := tpgresource.ConvertToMap(req)
+			if err != nil {
+				return fmt.Errorf("Error converting display device request: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateDisplayDevice", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
-			opErr := ComputeOperationWaitTime(config, op, project, "updating display device", userAgent, d.Timeout(schema.TimeoutUpdate))
+			opErr := ComputeOperationWaitTime(config, res, project, "updating display device", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -3245,12 +3526,24 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if d.HasChange("shielded_instance_config") {
 			shieldedVmConfig := expandShieldedVmConfigs(d)
 
-			op, err := NewClient(config, userAgent).Instances.UpdateShieldedInstanceConfig(project, zone, instance.Name, shieldedVmConfig).Do()
+			body, err := tpgresource.ConvertToMap(shieldedVmConfig)
+			if err != nil {
+				return fmt.Errorf("Error converting shielded vm config: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateShieldedInstanceConfig", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      body,
+			})
 			if err != nil {
 				return fmt.Errorf("Error updating shielded vm config: %s", err)
 			}
 
-			opErr := ComputeOperationWaitTime(config, op, project,
+			opErr := ComputeOperationWaitTime(config, res, project,
 				"shielded vm config update", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
@@ -3263,14 +3556,25 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return fmt.Errorf("Error creating request data to update scheduling: %s", err)
 			}
 
-			op, err := NewClient(config, userAgent).Instances.SetScheduling(
-				project, zone, instance.Name, scheduling).Do()
+			schedulingBody, err := tpgresource.ConvertToMap(scheduling)
+			if err != nil {
+				return fmt.Errorf("Error converting scheduling: %s", err)
+			}
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling", config.ComputeBasePath, project, zone, instance.Name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      schedulingBody,
+			})
 			if err != nil {
 				return fmt.Errorf("Error updating scheduling policy: %s", err)
 			}
 
 			opErr := ComputeOperationWaitTime(
-				config, op, project, "scheduling policy update", userAgent,
+				config, res, project, "scheduling policy update", userAgent,
 				d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1919,11 +1919,14 @@ func getAllStatusBut(status string) []string {
 }
 
 func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.ResourceData, project, zone, status, userAgent string) error {
-	name := d.Get("name").(string)
 	var res map[string]interface{}
 	var err error
 	if status == "TERMINATED" {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop?prettyPrint=false", config.ComputeBasePath, project, zone, name)
+		var url string
+		url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/stop")
+		if err != nil {
+			return fmt.Errorf("Error changing instance status after creation: %s", err)
+		}
 		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -1932,7 +1935,11 @@ func changeInstanceStatusOnCreation(config *transport_tpg.Config, d *schema.Reso
 			UserAgent: userAgent,
 		})
 	} else if status == "SUSPENDED" {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/suspend?prettyPrint=false", config.ComputeBasePath, project, zone, name)
+		var url string
+		url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/suspend")
+		if err != nil {
+			return fmt.Errorf("Error changing instance status after creation: %s", err)
+		}
 		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2029,7 +2036,10 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return fmt.Errorf("Error converting instance: %s", err)
 	}
-	insertUrl := fmt.Sprintf("%sprojects/%s/zones/%s/instances?prettyPrint=false", config.ComputeBasePath, project, zone.Name)
+	insertUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances")
+	if err != nil {
+		return fmt.Errorf("Error generating URL: %s", err)
+	}
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "POST",
@@ -2550,7 +2560,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting tags: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setTags?prettyPrint=false", config.ComputeBasePath, project, zone, d.Get("name").(string))
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setTags")
+		if err != nil {
+			return fmt.Errorf("Error generating URL: %s", err)
+		}
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2578,7 +2591,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting labels: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setLabels?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setLabels")
+		if err != nil {
+			return fmt.Errorf("Error generating URL: %s", err)
+		}
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2639,7 +2655,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting remove resource policies request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/removeResourcePolicies?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/removeResourcePolicies")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -2666,7 +2685,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting add resource policies request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/addResourcePolicies?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/addResourcePolicies")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -2698,7 +2720,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err != nil {
 			return fmt.Errorf("Error converting scheduling: %s", err)
 		}
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setScheduling")
+		if err != nil {
+			return fmt.Errorf("Error generating URL: %s", err)
+		}
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "POST",
@@ -2848,7 +2873,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 				}
-				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+				url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+				if err != nil {
+					return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+				}
 				url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 				if err != nil {
 					return err
@@ -2884,7 +2912,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2916,7 +2947,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2948,7 +2982,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -2980,7 +3017,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -3012,7 +3052,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return errwrap.Wrapf("Error converting network interface: {{"{{"}}err{{"}}"}}", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateNetworkInterface?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateNetworkInterface")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			url, err = transport_tpg.AddQueryParams(url, map[string]string{"networkInterface": networkName})
 			if err != nil {
 				return err
@@ -3184,8 +3227,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// Detach the old disks.
 		for hash, deviceName := range oDisks {
 			if _, ok := nDisks[hash]; !ok {
-				url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/detachDisk?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
-				url, err := transport_tpg.AddQueryParams(url, map[string]string{"deviceName": deviceName})
+				url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/detachDisk")
+				if err != nil {
+					return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+				}
+				url, err = transport_tpg.AddQueryParams(url, map[string]string{"deviceName": deviceName})
 				if err != nil {
 					return err
 				}
@@ -3214,7 +3260,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting attached disk: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/attachDisk?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/attachDisk")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3237,8 +3286,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 	// if any other boot_disk fields will be added here this should be wrapped in if d.HasChange("boot_disk")
 	if d.HasChange("boot_disk.0.auto_delete") {
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDiskAutoDelete?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
-		url, err := transport_tpg.AddQueryParams(url, map[string]string{
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setDiskAutoDelete")
+		if err != nil {
+			return fmt.Errorf("Error generating URL: %s", err)
+		}
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{
 			"autoDelete": strconv.FormatBool(d.Get("boot_disk.0.auto_delete").(bool)),
 			"deviceName": d.Get("boot_disk.0.device_name").(string),
 		})
@@ -3280,8 +3332,11 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("deletion_protection") {
 		nDeletionProtection := d.Get("deletion_protection").(bool)
 
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setDeletionProtection?prettyPrint=false", config.ComputeBasePath, project, zone, d.Get("name").(string))
-		url, err := transport_tpg.AddQueryParams(url, map[string]string{
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setDeletionProtection")
+		if err != nil {
+			return fmt.Errorf("Error generating URL: %s", err)
+		}
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{
 			"deletionProtection": strconv.FormatBool(nDeletionProtection),
 		})
 		if err != nil {
@@ -3391,7 +3446,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if statusBeforeUpdate != "TERMINATED" {
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/stop?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/stop")
+			if err != nil {
+				return errwrap.Wrapf("Error generating URL: {{"{{"}}err{{"}}"}}", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3418,7 +3476,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting min cpu platform request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMinCpuPlatform?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setMinCpuPlatform")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3448,7 +3509,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting machine type request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setMachineType?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setMachineType")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3478,7 +3542,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting service account request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setServiceAccount?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setServiceAccount")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",
@@ -3505,7 +3572,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting display device request: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateDisplayDevice?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateDisplayDevice")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "PATCH",
@@ -3530,7 +3600,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting shielded vm config: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/updateShieldedInstanceConfig?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/updateShieldedInstanceConfig")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "PATCH",
@@ -3560,7 +3633,10 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error converting scheduling: %s", err)
 			}
-			url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s/setScheduling?prettyPrint=false", config.ComputeBasePath, project, zone, instance.Name)
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setScheduling")
+			if err != nil {
+				return fmt.Errorf("Error generating URL: %s", err)
+			}
 			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 				Config:    config,
 				Method:    "POST",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: partially migrated `resource_compute_instance` resource to use direct HTTP rather then a client library
```
