### PR TITLE
Removed reference to provider_mmv1_resources in datasource contribution docs

### DIFF
--- a/docs/content/convert/add-new-resource-tgc.md
+++ b/docs/content/convert/add-new-resource-tgc.md
@@ -72,14 +72,15 @@ func ResourceGoogleProject() *schema.Resource {
 		}
 	}
 }
-```
 
-You will also need to add an entry to [`tgc_next/provider/provider_mmv1_resources.go.tmpl`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/tgc_next/provider/provider_mmv1_resources.go.tmpl), which is used to generate [`pkg/provider/provider_mmv1_resources.go`](https://github.com/GoogleCloudPlatform/terraform-google-conversion/blob/main/pkg/provider/provider_mmv1_resources.go). Each entry in `provider_mmv1_resources.go.tmpl` maps a terraform resource name to a function that returns the resource schema - in this case:
-
-```golang
-// ...
-"google_product_resource": product.ResourceName(),
-// ...
+func init() {
+	registry.Schema{
+		Name:        "google_product_resource",
+		ProductName: "product",
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceGoogleProject(),
+	}.Register()
+}
 ```
 
 ##### Resource_tfplan2cai.go file

--- a/docs/content/develop/add-handwritten-datasource.md
+++ b/docs/content/develop/add-handwritten-datasource.md
@@ -169,16 +169,6 @@ added to that resource. You can create a new datasource of this type as follows:
    - If there is `labels` field with type `KeyValueLabels` in the corresponding resource: After calling the resource read method, call the function `tpgresource.SetDataSourceLabels(d)` to make `labels` and `terraform_labels` have all of the labels on the resource.
    - If there is `annotations` field with type `KeyValueAnnotations` in the corresponding resource: After calling the resource read method, call the function `tpgresource.SetDataSourceAnnotations(d)` to make `annotations` have all of the annotations on the resource.
 
-1. Add the datasource to `handwrittenDatasources` in [`magic-modules/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl)
-   ```go
-   var handwrittenDatasources = map[string]*schema.Resource{
-     // ...
-     "google_memorystore_instance": registry.DataSource("google_memorystore_instance"),
-     "google_memcache_instance":    registry.DataSource("google_memcache_instance"),
-     "google_redis_instance":       registry.DataSource("google_redis_instance"),
-     // ...
-   }
-   ```
 1. [Add documentation](#add-documentation)
 
 For creating a datasource based off an existing resource you can [make use of the

--- a/docs/content/develop/add-iam-support.md
+++ b/docs/content/develop/add-iam-support.md
@@ -92,8 +92,6 @@ iam_policy:
    - If any of the added Go code is beta-only:
      - Change the file suffix to `.go.tmpl`
      - Wrap each beta-only code block (including any imports) in a separate version guard: `{{- if ne $.TargetVersionName "ga" -}}...{{- else }}...{{- end }}`
-4. Register the binding, member, and policy resources `handwrittenIAMResources` in [`magic-modules/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl)
-   - Add a version guard for any beta-only resources.
 {{< /tab >}}
 {{% /tabs %}}
 

--- a/docs/content/develop/add-resource.md
+++ b/docs/content/develop/add-resource.md
@@ -165,12 +165,10 @@ For more information about types of resources and the generation process overall
    - Remove the comments at the top of the file.
    - If any of the added Go code (including any imports) is beta-only, change the file suffix to `.go.tmpl` and wrap the beta-only code in a version guard: `{{- if ne $.TargetVersionName "ga" -}}...{{- else }}...{{- end }}`.
      - If the whole resource is beta-only, wrap everything except package declarations. Otherwise, individually wrap each logically-related block of code in a version guard (field, test, etc) rather than grouping adjacent version-guarded sections - it's easier to read and easier to modify as things move out of beta.
-5. Register the resource `handwrittenResources` in [`magic-modules/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl`](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/terraform/provider/provider_mmv1_resources.go.tmpl)
-   - Add a version guard for any beta-only resources.
-6. Optional: Complete other handwritten tasks that require the MMv1 configuration file.
+5. Optional: Complete other handwritten tasks that require the MMv1 configuration file.
     - [Add resource tests]({{< ref "/test/test" >}})
     - [Add IAM support]({{<ref "/develop/add-iam-support" >}})
-7. Delete the MMv1 configuration file.
+6. Delete the MMv1 configuration file.
 {{< /tab >}}
 {{% /tabs %}}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
