### PR TITLE
SuppressDiff when ALL_OBJECTS_ENCRYPTION_ENABLED state is used.

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2361,8 +2361,9 @@ func ResourceContainerCluster() *schema.Resource {
             "state": {
               Type:         schema.TypeString,
               Required:     true,
-              ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
-              Description:  `ENCRYPTED or DECRYPTED.`,
+              ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "ALL_OBJECTS_ENCRYPTION_ENABLED", "DECRYPTED"}, false),
+              Description:  `ENCRYPTED, ALL_OBJECTS_ENCRYPTION_ENABLED or DECRYPTED.`,
+              DiffSuppressFunc: DatabaseEncryptionSuppress,
             },
             "key_name": {
               Type:        schema.TypeString,
@@ -8830,6 +8831,18 @@ func SecretManagerCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 		}
 	}
 	return false
+}
+
+func DatabaseEncryptionSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The API sometimes returns ALL_OBJECTS_ENCRYPTION_ENABLED when the user sets ENCRYPTED
+	// and vice versa (depending on the cluster version and underlying resource storage).
+	if old == "ALL_OBJECTS_ENCRYPTION_ENABLED" && new == "ENCRYPTED" {
+		return true
+	}
+	if old == "ENCRYPTED" && new == "ALL_OBJECTS_ENCRYPTION_ENABLED" {
+                return true
+	}
+        return false
 }
 
 {{ if ne $.TargetVersionName `ga` -}}


### PR DESCRIPTION
This PR adds a `DiffSuppressFunc` to the `database_encryption.state` field within the `google_container_cluster` resource. 

Currently, when a user sets the database encryption state to `ENCRYPTED` in their Terraform configuration, the Google Cloud API returns `ALL_OBJECTS_ENCRYPTION_ENABLED` for newer versions of GKE clusters. This discrepancy triggers a continuous diff (permadiff), causing Terraform to attempt an update on every run. This PR suppresses the diff specifically for this scenario, allowing Terraform to recognize that the infrastructure matches the intended configuration.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26882

```release-note:bug
container: fixed a permadiff in `google_container_cluster` where `database_encryption.state` returning `ALL_OBJECTS_ENCRYPTION_ENABLED` instead of the configured `ENCRYPTED` caused unintended reapplies
```
