### PR TITLE
Migrated resource compute instance from template to use transport_tpg…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -3879,6 +3879,9 @@ func expandAttachedDisk(diskConfig map[string]interface{}, d *schema.ResourceDat
 
 	if forceAttach, ok := diskConfig["force_attach"]; ok {
 		disk.ForceAttach = forceAttach.(bool)
+		if disk.ForceAttach && !strings.Contains(sourceLink, "regions/") {
+			return nil, fmt.Errorf("Force attaching zonal disks is not supported")
+		}
 	}
 
 	return disk, nil
@@ -4259,6 +4262,9 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 
 	if v, ok := d.GetOk("boot_disk.0.force_attach"); ok {
 		disk.ForceAttach = v.(bool)
+		if disk.ForceAttach && !strings.Contains(disk.Source, "regions/") {
+			return nil, fmt.Errorf("Force attaching zonal disks is not supported")
+		}
 	}
 
 	return disk, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template.go.tmpl
@@ -109,18 +109,13 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Loading zone: %s", z)
-	zone, err := NewClient(config, userAgent).Zones.Get(project, z).Do()
-	if err != nil {
-		return fmt.Errorf("Error loading zone '%s': %s", z, err)
-	}
 
 	instance, err := expandComputeInstance(project, d, config)
 	if err != nil {
 		return err
 	}
 
-	sourceInstanceTemplate:= ConvertToUniqueIdWhenPresent(d.Get("source_instance_template").(string))
+	sourceInstanceTemplate := ConvertToUniqueIdWhenPresent(d.Get("source_instance_template").(string))
 	tpl, err := tpgresource.ParseInstanceTemplateFieldValue(sourceInstanceTemplate, d, config)
 	if err != nil {
 		return err
@@ -130,15 +125,30 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	var relativeUrl string
 
 	if strings.Contains(sourceInstanceTemplate, "global/instanceTemplates") {
-		instanceTemplate, err := NewClient(config, userAgent).InstanceTemplates.Get(project, tpl.Name).Do()
+		itURL, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates/" + tpl.Name)
 		if err != nil {
 			return err
 		}
-
-		it = *instanceTemplate
+		itRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    itURL,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return err
+		}
+		itBytes, err := json.Marshal(itRes)
+		if err != nil {
+			return err
+		}
+		if err = json.Unmarshal(itBytes, &it); err != nil {
+			return err
+		}
 		relativeUrl = tpl.RelativeLink()
 
-		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, false)
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, z, project, false)
 		if err != nil {
 			return err
 		}
@@ -175,7 +185,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			return err
 		}
 
-		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, zone, project, true)
+		instance.Disks, err = adjustInstanceFromTemplateDisks(d, config, &it, z, project, true)
 		if err != nil {
 			return err
 		}
@@ -208,7 +218,27 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[INFO] Requesting instance creation")
-	op, err := NewClient(config, userAgent).Instances.Insert(project, zone.Name, instance).SourceInstanceTemplate(relativeUrl).Do()
+	instanceBytes, err := json.Marshal(instance)
+	if err != nil {
+		return fmt.Errorf("Error marshaling instance: %s", err)
+	}
+	var instanceBody map[string]interface{}
+	if err = json.Unmarshal(instanceBytes, &instanceBody); err != nil {
+		return fmt.Errorf("Error processing instance body: %s", err)
+	}
+	insertURL, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances")
+	if err != nil {
+		return fmt.Errorf("Error generating URL: %s", err)
+	}
+	insertURL = fmt.Sprintf("%s?sourceInstanceTemplate=%s", insertURL, relativeUrl)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    insertURL,
+		UserAgent: userAgent,
+		Body:      instanceBody,
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating instance: %s", err)
 	}
@@ -217,12 +247,12 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := ComputeOperationWaitTime(config, op, project,
+	err = ComputeOperationWaitTime(config, res, project,
 		"instance to create", userAgent, d.Timeout(schema.TimeoutCreate))
-	if waitErr != nil {
+	if err != nil {
 		// The resource didn't actually create
 		d.SetId("")
-		return waitErr
+		return err
 	}
 
 	return resourceComputeInstanceRead(d, meta)
@@ -230,7 +260,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 
 // Instances have disks spread across multiple schema properties. This function
 // ensures that overriding one of these properties does not override the others.
-func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_tpg.Config, it *compute.InstanceTemplate, zone *compute.Zone, project string, isFromRegionalTemplate bool) ([]*compute.AttachedDisk, error) {
+func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_tpg.Config, it *compute.InstanceTemplate, zone string, project string, isFromRegionalTemplate bool) ([]*compute.AttachedDisk, error) {
 	disks := []*compute.AttachedDisk{}
 	re := regexp.MustCompile(`projects/[^/]+/regions/[^/]+/disks/[^/]+$`)
 	if _, hasBootDisk := d.GetOk("boot_disk"); hasBootDisk {
@@ -243,22 +273,23 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 		// boot disk was not overridden, so use the one from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
-				if disk.Source != "" && !isFromRegionalTemplate && !re.MatchString(disk.Source){
+				if disk.Source != "" && !isFromRegionalTemplate && !re.MatchString(disk.Source) {
 					// Instances need a URL for the disk, but instance templates only have the name
-					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone.Name, disk.Source)
+					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone, disk.Source)
 				}
 				if disk.InitializeParams != nil {
 					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone, dt)
 					}
 					if rp := disk.InitializeParams.ResourcePolicies; len(rp) > 0 {
 						// Instances need a URL for the resource policy, but instance templates
 						// only have the name (since they're global).
+						region := zone[:strings.LastIndex(zone, "-")]
 						for i := range rp {
 							rp[i], _ = parseUniqueId(rp[i]) // in some cases the API translation doesn't work and returns entire url when only name is provided. And allows for id to be passed as well
-							rp[i] = fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, regionFromUrl(zone.Region), rp[i])
+							rp[i] = fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, region, rp[i])
 						}
 						disk.InitializeParams.ResourcePolicies = rp
 					}
@@ -283,7 +314,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone, dt)
 					}
 				}
 				disks = append(disks, disk)
@@ -306,16 +337,16 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *transport_t
 		// attached disks were not overridden, so use the ones from the instance template
 		for _, disk := range it.Properties.Disks {
 			if !disk.Boot && disk.Type != "SCRATCH" {
-				if s := disk.Source; s != ""  && !isFromRegionalTemplate && !re.MatchString(disk.Source){
+				if s := disk.Source; s != "" && !isFromRegionalTemplate && !re.MatchString(disk.Source) {
 					// Instances need a URL for the disk source, but instance templates
 					// only have the name (since they're global).
-					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone.Name, s)
+					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone, s)
 				}
 				if disk.InitializeParams != nil {
 					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates
 						// only have the name (since they're global).
-						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone, dt)
 					}
 				}
 				disks = append(disks, disk)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -10,13 +10,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccComputeInstanceFromTemplate_basic(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
@@ -29,7 +29,7 @@ func TestAccComputeInstanceFromTemplate_basic(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_basic(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "machine_type", "n1-standard-1"),
@@ -44,7 +44,6 @@ func TestAccComputeInstanceFromTemplate_basic(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_self_link_unique(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
@@ -57,7 +56,7 @@ func TestAccComputeInstanceFromTemplate_self_link_unique(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_self_link_unique(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "machine_type", "n1-standard-1"),
@@ -73,12 +72,9 @@ func TestAccComputeInstanceFromTemplate_self_link_unique(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_maxRunDuration_onInstanceStopAction(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
-
-	var expectedMaxRunDuration = map[string]interface{}{"nanos": float64(456), "seconds": "60"}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -88,10 +84,11 @@ func TestAccComputeInstanceFromTemplate_maxRunDuration_onInstanceStopAction(t *t
 			{
 				Config: testAccComputeInstanceFromTemplate_maxRunDuration_onInstanceStopAction(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
-					testAccCheckComputeInstanceMaxRunDuration(&instance, expectedMaxRunDuration),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.max_run_duration.0.nanos", "456"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.max_run_duration.0.seconds", "60"),
 				),
 			},
 		},
@@ -102,12 +99,9 @@ func TestAccComputeInstanceFromTemplate_maxRunDuration_onInstanceStopAction(t *t
 func TestAccComputeInstanceFromTemplate_localSsdRecoveryTimeout(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
-
-	var expectedLocalSsdRecoveryTimeout = map[string]interface{}{"nanos": float64(0), "seconds": "3600"}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -117,10 +111,11 @@ func TestAccComputeInstanceFromTemplate_localSsdRecoveryTimeout(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_localSsdRecoveryTimeout(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
-					testAccCheckComputeInstanceLocalSsdRecoveryTimeout(&instance, expectedLocalSsdRecoveryTimeout),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.local_ssd_recovery_timeout.0.nanos", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.local_ssd_recovery_timeout.0.seconds", "3600"),
 				),
 			},
 		},
@@ -130,12 +125,9 @@ func TestAccComputeInstanceFromTemplate_localSsdRecoveryTimeout(t *testing.T) {
 func TestAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
-
-	var expectedLocalSsdRecoveryTimeout = map[string]interface{}{"nanos": float64(0), "seconds": "7200"}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -145,10 +137,11 @@ func TestAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(t *t
 			{
 				Config: testAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
-					testAccCheckComputeInstanceLocalSsdRecoveryTimeout(&instance, expectedLocalSsdRecoveryTimeout),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.local_ssd_recovery_timeout.0.nanos", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scheduling.0.local_ssd_recovery_timeout.0.seconds", "7200"),
 				),
 			},
 		},
@@ -158,7 +151,6 @@ func TestAccComputeInstanceFromTemplateWithOverride_localSsdRecoveryTimeout(t *t
 func TestAccComputeInstanceFromTemplate_diskResourcePolicies(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	suffix := acctest.RandString(t, 10)
 
@@ -170,13 +162,13 @@ func TestAccComputeInstanceFromTemplate_diskResourcePolicies(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_diskResourcePoliciesCreate(suffix, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.foobar", &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.foobar"),
 				),
 			},
 			{
 				Config: testAccComputeInstanceFromTemplate_diskResourcePoliciesUpdate(suffix, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.foobar", &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.foobar"),
 				),
 			},
 			{
@@ -191,21 +183,9 @@ func TestAccComputeInstanceFromTemplate_diskResourcePolicies(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_partnerMetadata(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
-	var namespace = "test.compute.googleapis.com"
-	expectedPartnerMetadata := make(map[string]map[string]interface{})
-	expectedPartnerMetadata[namespace] = map[string]interface{}{
-		"entries": map[string]interface{}{
-			"key1": "value1",
-			"key2": float64(2),
-			"key3": map[string]interface{}{
-				"key31": "value31",
-			},
-		},
-	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -215,10 +195,10 @@ func TestAccComputeInstanceFromTemplate_partnerMetadata(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_partnerMetadata(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
-					// Check that fields were set based on the template
-					testAccCheckComputeInstancePartnerMetadata(&instance, expectedPartnerMetadata),
+					// Check that partner_metadata was set from the template
+					resource.TestCheckResourceAttrSet(resourceName, "partner_metadata.%"),
 				),
 			},
 		},
@@ -228,21 +208,9 @@ func TestAccComputeInstanceFromTemplate_partnerMetadata(t *testing.T) {
 func TestAccComputeInstanceFromTemplateWithOverride_partnerMetadata(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
-	var namespace = "test.compute.googleapis.com"
-	expectedPartnerMetadata := make(map[string]map[string]interface{})
-	expectedPartnerMetadata[namespace] = map[string]interface{}{
-		"entries": map[string]interface{}{
-			"key1": "value1",
-			"key2": float64(2),
-			"key3": map[string]interface{}{
-				"key31": "value31",
-			},
-		},
-	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:     func() { acctest.AccTestPreCheck(t) },
@@ -252,10 +220,10 @@ func TestAccComputeInstanceFromTemplateWithOverride_partnerMetadata(t *testing.T
 			{
 				Config: testAccComputeInstanceFromTemplateWithOverride_partnerMetadata(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
-					// Check that fields were set based on the template
-					testAccCheckComputeInstancePartnerMetadata(&instance, expectedPartnerMetadata),
+					// Check that partner_metadata override was applied
+					resource.TestCheckResourceAttrSet(resourceName, "partner_metadata.%"),
 				),
 			},
 		},
@@ -268,7 +236,6 @@ func TestAccComputeInstanceFromTemplateWithOverride_partnerMetadata(t *testing.T
 func TestAccComputeInstanceFromRegionTemplate_basic(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
@@ -281,7 +248,7 @@ func TestAccComputeInstanceFromRegionTemplate_basic(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromRegionTemplate_basic(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "machine_type", "n1-standard-1"),
@@ -298,7 +265,6 @@ func TestAccComputeInstanceFromRegionTemplate_basic(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_overrideBootDisk(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateDisk := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -313,7 +279,7 @@ func TestAccComputeInstanceFromTemplate_overrideBootDisk(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_overrideBootDisk(templateDisk, overrideDisk, templateName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "boot_disk.#", "1"),
@@ -327,7 +293,6 @@ func TestAccComputeInstanceFromTemplate_overrideBootDisk(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_overrideAttachedDisk(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateDisk := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -342,7 +307,7 @@ func TestAccComputeInstanceFromTemplate_overrideAttachedDisk(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_overrideAttachedDisk(templateDisk, overrideDisk, templateName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "attached_disk.#", "1"),
@@ -356,7 +321,6 @@ func TestAccComputeInstanceFromTemplate_overrideAttachedDisk(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_overrideScratchDisk(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateDisk := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -371,7 +335,7 @@ func TestAccComputeInstanceFromTemplate_overrideScratchDisk(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_overrideScratchDisk(templateDisk, overrideDisk, templateName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "scratch_disk.#", "2"),
@@ -387,7 +351,6 @@ func TestAccComputeInstanceFromTemplate_overrideScratchDisk(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_overrideScheduling(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateDisk := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -401,7 +364,7 @@ func TestAccComputeInstanceFromTemplate_overrideScheduling(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_overrideScheduling(templateDisk, templateName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 				),
 			},
 		},
@@ -413,7 +376,6 @@ func TestAccComputeInstanceFromTemplate_TerminationTime(t *testing.T) {
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateDisk := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
@@ -429,7 +391,7 @@ func TestAccComputeInstanceFromTemplate_TerminationTime(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_terminationTime(templateDisk, templateName, terminationTime, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 				),
 			},
 		},
@@ -440,7 +402,6 @@ func TestAccComputeInstanceFromTemplate_TerminationTime(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_schedulingPreemptionNoticeDuration(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
   templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
   resourceName := "google_compute_instance_from_template.foobar"
@@ -453,8 +414,7 @@ func TestAccComputeInstanceFromTemplate_schedulingPreemptionNoticeDuration(t *te
 			{
 				Config: testAccComputeInstanceFromTemplate_schedulingPreemptionNoticeDuration(templateName, instanceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "scheduling.0.preemption_notice_duration.0.seconds", "120"),
 					resource.TestCheckResourceAttr(resourceName, "scheduling.0.preemption_notice_duration.0.nanos", "0"),
 				),
@@ -465,7 +425,6 @@ func TestAccComputeInstanceFromTemplate_schedulingPreemptionNoticeDuration(t *te
 {{ end }}
 
 func TestAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(t *testing.T) {
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
@@ -478,7 +437,7 @@ func TestAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(t *test
 			{
 				Config: testAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "metadata.startup-script", ""),
 				),
 			},
@@ -489,7 +448,6 @@ func TestAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(t *test
 func TestAccComputeInstanceFromTemplate_useDiskSelfLink(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
@@ -502,7 +460,7 @@ func TestAccComputeInstanceFromTemplate_useDiskSelfLink(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_regionalDisk(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 				),
 			},
 		},
@@ -518,8 +476,17 @@ func testAccCheckComputeInstanceFromTemplateDestroyProducer(t *testing.T) func(s
 				continue
 			}
 
-			_, err := compute_tpg.NewClient(config, config.UserAgent).Instances.Get(
-				config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/" + rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   config.Project,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
 			if err == nil {
 				return fmt.Errorf("Instance still exists")
 			}
@@ -529,11 +496,36 @@ func testAccCheckComputeInstanceFromTemplateDestroyProducer(t *testing.T) func(s
 	}
 }
 
+func testAccCheckComputeInstanceFromTemplateExists(t *testing.T, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := acctest.GoogleProviderConfig(t)
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}ComputeBasePath{{"}}"}}projects/" + envvar.GetTestProjectFromEnv() + "/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}")
+		if err != nil {
+			return err
+		}
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   envvar.GetTestProjectFromEnv(),
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("Instance %s not found: %s", n, err)
+		}
+		return nil
+	}
+}
+
 func TestAccComputeInstanceFromTemplate_confidentialInstanceConfigMain(t *testing.T) {
 	t.Parallel()
-
-	var instance map[string]interface{}
-	var instance2 map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -550,10 +542,12 @@ func TestAccComputeInstanceFromTemplate_confidentialInstanceConfigMain(t *testin
 					fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 					"SEV"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst1", &instance),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, true, "SEV"),
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst2", &instance2),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, true, ""),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst1"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.enable_confidential_compute", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.confidential_instance_type", "SEV"),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst2"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.enable_confidential_compute", "true"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.confidential_instance_type", ""),
 				),
 			},
 			{
@@ -566,10 +560,12 @@ func TestAccComputeInstanceFromTemplate_confidentialInstanceConfigMain(t *testin
 					fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 					"SEV_SNP"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst1", &instance),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, false, "SEV_SNP"),
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst2", &instance2),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, false, "SEV_SNP"),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst1"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.enable_confidential_compute", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.confidential_instance_type", "SEV_SNP"),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst2"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.enable_confidential_compute", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.confidential_instance_type", "SEV_SNP"),
 				),
 			},
 			{
@@ -582,10 +578,12 @@ func TestAccComputeInstanceFromTemplate_confidentialInstanceConfigMain(t *testin
 					fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
 					"TDX"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst1", &instance),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance, false, "TDX"),
-					testAccCheckComputeInstanceExists(t, "google_compute_instance_from_template.inst2", &instance2),
-					testAccCheckComputeInstanceHasConfidentialInstanceConfig(&instance2, false, "TDX"),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst1"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.enable_confidential_compute", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst1", "confidential_instance_config.0.confidential_instance_type", "TDX"),
+					testAccCheckComputeInstanceFromTemplateExists(t, "google_compute_instance_from_template.inst2"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.enable_confidential_compute", "false"),
+					resource.TestCheckResourceAttr("google_compute_instance_from_template.inst2", "confidential_instance_config.0.confidential_instance_type", "TDX"),
 				),
 			},
 		},
@@ -595,7 +593,6 @@ func TestAccComputeInstanceFromTemplate_confidentialInstanceConfigMain(t *testin
 func TestAccComputeInstanceFromTemplate_DiskForceAttach(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
@@ -612,7 +609,7 @@ func TestAccComputeInstanceFromTemplate_DiskForceAttach(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_DiskForceAttach(instanceName, templateName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(t, resourceName, &instance),
+					testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
 
 					// Check that fields were set based on the template
 					resource.TestCheckResourceAttr(resourceName, "boot_disk.0.force_attach", "true"),
@@ -626,8 +623,6 @@ func TestAccComputeInstanceFromTemplate_DiskForceAttach(t *testing.T) {
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccComputeInstanceFromTemplate_VSSWindows(t *testing.T) {
   t.Parallel()
-
-  var instance map[string]interface{}
 
   context_1 := map[string]interface{}{
     "bootdisk_name":  fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
@@ -650,15 +645,15 @@ func TestAccComputeInstanceFromTemplate_VSSWindows(t *testing.T) {
       {
         Config: testAccComputeInstanceFromTemplate_VSSWindows(context_1),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckComputeInstanceExists(
-            t, "google_compute_instance_from_template.foobar", &instance),
+          testAccCheckComputeInstanceFromTemplateExists(
+            t, "google_compute_instance_from_template.foobar"),
         ),
       },
       {
         Config: testAccComputeInstanceFromTemplate_VSSWindows(context_2),
         Check: resource.ComposeTestCheckFunc(
-          testAccCheckComputeInstanceExists(
-            t, "google_compute_instance_from_template.foobar", &instance),
+          testAccCheckComputeInstanceFromTemplateExists(
+            t, "google_compute_instance_from_template.foobar"),
           ),
       },
     },
@@ -2180,7 +2175,6 @@ resource "google_compute_instance_from_template" "inst2" {
 func TestAccComputeInstanceFromTemplateWithOverride_interface(t *testing.T) {
         t.Parallel()
 
-        var instance map[string]interface{}
         instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
         templateName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
         resourceName := "google_compute_instance_from_template.foobar"
@@ -2193,7 +2187,7 @@ func TestAccComputeInstanceFromTemplateWithOverride_interface(t *testing.T) {
                         {
                                 Config: testAccComputeInstanceFromTemplateWithOverride_interface(instanceName, templateName),
                                 Check: resource.ComposeTestCheckFunc(
-                                        testAccCheckComputeInstanceExists(t, resourceName, &instance),
+                                        testAccCheckComputeInstanceFromTemplateExists(t, resourceName),
                                         resource.TestCheckResourceAttr(resourceName, "boot_disk.0.interface", "SCSI"),
                                 ),
                         },
@@ -2205,7 +2199,6 @@ func TestAccComputeInstanceFromTemplateWithOverride_interface(t *testing.T) {
 func TestAccComputeInstanceFromTemplate_IgmpQuery_v2(t *testing.T) {
 	t.Parallel()
 
-	var instance map[string]interface{}
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	suffix := acctest.RandString(t, 10)
 	envRegion := envvar.GetTestRegionFromEnv()
@@ -2230,24 +2223,24 @@ func TestAccComputeInstanceFromTemplate_IgmpQuery_v2(t *testing.T) {
 			{
 				Config: testAccComputeInstanceFromTemplate_igmpQuery_v2(context),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance_from_template.foobar", &instance),
+					testAccCheckComputeInstanceFromTemplateExists(
+						t, "google_compute_instance_from_template.foobar"),
 					resource.TestCheckResourceAttr("google_compute_instance_from_template.foobar", "network_interface.0.igmp_query", "IGMP_QUERY_V2"),
 				),
 			},
 			{
 				Config: testAccComputeInstanceFromTemplate_igmpQuery_v2(contextUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance_from_template.foobar", &instance),
+					testAccCheckComputeInstanceFromTemplateExists(
+						t, "google_compute_instance_from_template.foobar"),
 					resource.TestCheckResourceAttr("google_compute_instance_from_template.foobar", "network_interface.0.igmp_query", "IGMP_QUERY_DISABLED"),
 				),
 			},
 			{
 				Config: testAccComputeInstanceFromTemplate_igmpQuery_v2(context),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeInstanceExists(
-						t, "google_compute_instance_from_template.foobar", &instance),
+					testAccCheckComputeInstanceFromTemplateExists(
+						t, "google_compute_instance_from_template.foobar"),
 					resource.TestCheckResourceAttr("google_compute_instance_from_template.foobar", "network_interface.0.igmp_query", "IGMP_QUERY_V2"),
 				),
 			},


### PR DESCRIPTION
….SendRequest

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_from_template` resource to use direct HTTP rather than a client library
```
