### PR TITLE
Dns record set list support

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider_mmv1_resources.go
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_mmv1_resources.go
@@ -3,6 +3,7 @@ package fwprovider
 import (
 	"github.com/hashicorp/terraform-plugin-framework/list"
 
+	"github.com/hashicorp/terraform-provider-google/google/services/dns"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 )
 
@@ -15,5 +16,6 @@ func listResourceFunc(lr list.ListResource) func() list.ListResource {
 var generatedListResources = []func() list.ListResource{}
 
 var handwrittenListResources = []func() list.ListResource{
+	listResourceFunc(dns.NewGoogleDnsRecordSetListResource()),
 	listResourceFunc(resourcemanager.NewGoogleServiceAccountListResource()),
 }

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -36,7 +36,7 @@ func NewGoogleDnsRecordSetListResource() list.ListResource {
 	listR.SDKv2Resource = ResourceDnsRecordSet()
 	listR.ListConfigFields = []tpgresource.ListConfigField{
 		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
-		{Name: "managed_zone", Kind: tpgresource.ListConfigKindString, Required: true},
+		{Name: "managed_zone", Kind: tpgresource.ListConfigKindString, Optional: false},
 		{Name: "name", Kind: tpgresource.ListConfigKindString, Optional: true},
 		{Name: "type", Kind: tpgresource.ListConfigKindString, Optional: true},
 	}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -1,0 +1,134 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"google.golang.org/api/dns/v1"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type GoogleDnsRecordSetListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleDnsRecordSetListModel struct {
+	Project     types.String `tfsdk:"project"`
+	ManagedZone types.String `tfsdk:"managed_zone"`
+	Name        types.String `tfsdk:"name"`
+	Type        types.String `tfsdk:"type"`
+}
+
+func NewGoogleDnsRecordSetListResource() list.ListResource {
+	listR := &GoogleDnsRecordSetListResource{}
+	listR.TypeName = "google_dns_record_set"
+	listR.SDKv2Resource = ResourceDnsRecordSet()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "managed_zone", Kind: tpgresource.ListConfigKindString, Required: true},
+		{Name: "name", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "type", Kind: tpgresource.ListConfigKindString, Optional: true},
+	}
+	return listR
+}
+
+func (listR *GoogleDnsRecordSetListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	var data GoogleDnsRecordSetListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	project := listR.GetProject(data.Project)
+	managedZone := data.ManagedZone.ValueString()
+	name := data.Name.ValueString()
+	recordType := data.Type.ValueString()
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListDnsRecordSets(listR.Client, project, managedZone, name, recordType, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
+				return err
+			}
+
+			if !push(result) {
+				return errors.New("stream closed")
+			}
+			return nil
+		})
+		if err != nil {
+			diags.AddError("API Error", err.Error())
+			result := listReq.NewListResult(ctx)
+			result.Diagnostics = diags
+			push(result)
+		}
+	}
+}
+
+func ListDnsRecordSets(config *transport_tpg.Config, project, managedZone, name, recordType string, callback func(rd *schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	d := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
+	if err := d.Set("managed_zone", managedZone); err != nil {
+		return fmt.Errorf("error setting managed_zone on temporary resource data: %w", err)
+	}
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	req := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, managedZone)
+	if name != "" {
+		req.Name(name)
+		if recordType != "" {
+			req.Type(recordType)
+		}
+	}
+
+	return req.Pages(context.Background(), func(page *dns.ResourceRecordSetsListResponse) error {
+		for _, rrset := range page.Rrsets {
+			if recordType != "" && name == "" && rrset.Type != recordType {
+				continue
+			}
+
+			rd := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
+			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s/rrsets/%s/%s", project, managedZone, rrset.Name, rrset.Type))
+
+			if err := populateDnsRecordSetResourceData(rd, rrset, project, managedZone); err != nil {
+				return err
+			}
+			if err := callback(rd); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
@@ -1,0 +1,86 @@
+package dns_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("tf-test-zone-%s", acctest.RandString(t, 10))
+	recordLabel := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	project := envvar.GetTestProjectFromEnv()
+	expectedName := fmt.Sprintf("%s.%s.hashicorptest.com.", recordLabel, zoneName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSetListResourceBasic(zoneName, recordLabel),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "name", expectedName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "type", "A"),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccDnsRecordSetListQuery(zoneName),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_dns_record_set.all_in_zone", map[string]knownvalue.Check{
+						"project":      knownvalue.StringExact(project),
+						"managed_zone": knownvalue.StringExact(zoneName),
+						"name":         knownvalue.StringExact(expectedName),
+						"type":         knownvalue.StringExact("A"),
+					}),
+					querycheck.ExpectLengthAtLeast("google_dns_record_set.all_in_zone", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccDnsRecordSetListResourceBasic(zoneName, recordLabel string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "zone" {
+  name     = %q
+  dns_name = "%s.hashicorptest.com."
+}
+
+resource "google_dns_record_set" "foobar" {
+  managed_zone = google_dns_managed_zone.zone.name
+  name         = "%s.${google_dns_managed_zone.zone.dns_name}"
+  type         = "A"
+  ttl          = 300
+  rrdatas      = ["192.168.1.0"]
+}
+`, zoneName, zoneName, recordLabel)
+}
+
+func testAccDnsRecordSetListQuery(zoneName string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_dns_record_set" "all_in_zone" {
+  provider = google
+
+  config {
+    managed_zone = %q
+  }
+}
+`, zoneName)
+}

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -100,6 +100,30 @@ func ResourceDnsRecordSet() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 		),
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"managed_zone": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"name": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"type": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"managed_zone": {
 				Type:             schema.TypeString,
@@ -460,7 +484,17 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	if len(resp.Rrsets) > 1 {
 		return fmt.Errorf("Only expected 1 record set, got %d", len(resp.Rrsets))
 	}
-	rrset := resp.Rrsets[0]
+
+	return populateDnsRecordSetResourceData(d, resp.Rrsets[0], project, zone)
+}
+
+func populateDnsRecordSetResourceData(d *schema.ResourceData, rrset *dns.ResourceRecordSet, project, managedZone string) error {
+	if err := d.Set("managed_zone", managedZone); err != nil {
+		return fmt.Errorf("Error setting managed_zone: %s", err)
+	}
+	if err := d.Set("name", rrset.Name); err != nil {
+		return fmt.Errorf("Error setting name: %s", err)
+	}
 	if err := d.Set("type", rrset.Type); err != nil {
 		return fmt.Errorf("Error setting type: %s", err)
 	}
@@ -477,7 +511,12 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
 
-	return nil
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":      project,
+		"managed_zone": managedZone,
+		"name":         rrset.Name,
+		"type":         rrset.Type,
+	})
 }
 
 func resourceDnsRecordSetDelete(d *schema.ResourceData, meta interface{}) error {

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_dns_record_set.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "Cloud DNS"
+description: |-
+  List Google Cloud DNS record sets in a managed zone for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_dns_record_set (list)
+
+Lists Cloud DNS **record sets** in a managed zone for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_dns_record_set`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_dns_record_set" "all_in_zone" {
+  provider = google
+
+  config {
+    managed_zone = "my-managed-zone"
+
+    # Optional. Defaults to the provider project when omitted.
+    # project = "other-project"
+
+    # Optional filters.
+    # name = "www.example.com."
+    # type = "A"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `managed_zone` - (Required) Managed zone name to list record sets from.
+* `project` - (Optional) Project ID to list record sets from. If unset, the provider's
+  configured default project is used (same idea as the managed resource).
+* `name` - (Optional) Filter results to a specific DNS record name.
+* `type` - (Optional) Filter results to a specific DNS record type.
+
+## Results
+
+By default each result includes **resource identity** for `google_dns_record_set` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `project` - Project ID when applicable.
+* `managed_zone` - Managed zone name.
+* `name` - DNS record name.
+* `type` - DNS record type.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_dns_record_set` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set#attributes-reference)
+(for example `ttl`, `rrdatas`, and `routing_policy` where present in state).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds handwritten list support for `google_dns_record_set` in magic-modules for use with `terraform query`.

This PR:
- adds a handwritten `google_dns_record_set` list resource implementation
- adds resource identity support to `google_dns_record_set`
- registers the new handwritten list resource in the framework provider
- adds acceptance test coverage for DNS record set query identity
- adds list-resource documentation for `google_dns_record_set`

Local downstream acceptance test pass:

```hcl
make testacc TEST=./google/services/dns TESTARGS='-run=TestAccDNSRecordSetListResource_queryIdentity$$'
sh -c "'/Users/tavasya/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/dns -v -run=TestAccDNSRecordSetListResource_queryIdentity$ -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDNSRecordSetListResource_queryIdentity
=== PAUSE TestAccDNSRecordSetListResource_queryIdentity
=== CONT  TestAccDNSRecordSetListResource_queryIdentity
--- PASS: TestAccDNSRecordSetListResource_queryIdentity (12.19s)
PASS
ok   github.com/hashicorp/terraform-provider-google/google/services/dns  13.265s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dns: added list resource support for `google_dns_record_set` for use with `terraform query`
```

```release-note:note
dns: added resource identity support to `google_dns_record_set`
```