### PR TITLE
discoveryengine: add skip_wait to google_discovery_engine_target_site

### DIFF
--- a/mmv1/products/discoveryengine/TargetSite.yaml
+++ b/mmv1/products/discoveryengine/TargetSite.yaml
@@ -44,6 +44,21 @@ async:
     resource_inside_response: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/discoveryengine_targetsite_set_id.go.tmpl'
+  custom_create: 'templates/terraform/custom_create/discoveryengine_target_site.go.tmpl'
+virtual_fields:
+  - name: 'skip_wait'
+    type: Boolean
+    default_value: false
+    description: |
+      If set to true, skip waiting for the long-running indexing operation to
+      complete after creating the target site. The resource will be saved to
+      Terraform state immediately after creation. Indexing continues
+      asynchronously in the background.
+
+      This is useful for large web crawl data stores where indexing can take
+      up to 480 minutes, which would otherwise cause `terraform apply` to
+      hang. Defaults to `false` (wait for completion).
+    ignore_read: true
 examples:
   - name: 'discoveryengine_targetsite_basic'
     primary_resource_id: 'basic'
@@ -57,6 +72,13 @@ examples:
       data_store_id: 'data-store-id'
     ignore_read_extra:
       - 'project'
+  - name: 'discoveryengine_targetsite_skip_wait'
+    primary_resource_id: 'skip_wait'
+    vars:
+      data_store_id: 'data-store-id'
+    ignore_read_extra:
+      - 'project'
+      - 'skip_wait'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
@@ -1,0 +1,169 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+obj := make(map[string]interface{})
+providedUriPatternProp, err := expandDiscoveryEngineTargetSiteProvidedUriPattern(d.Get("provided_uri_pattern"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("provided_uri_pattern"); !tpgresource.IsEmptyValue(reflect.ValueOf(providedUriPatternProp)) && (ok || !reflect.DeepEqual(v, providedUriPatternProp)) {
+	obj["providedUriPattern"] = providedUriPatternProp
+}
+typeProp, err := expandDiscoveryEngineTargetSiteType(d.Get("type"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("type"); !tpgresource.IsEmptyValue(reflect.ValueOf(typeProp)) && (ok || !reflect.DeepEqual(v, typeProp)) {
+	obj["type"] = typeProp
+}
+exactMatchProp, err := expandDiscoveryEngineTargetSiteExactMatch(d.Get("exact_match"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("exact_match"); !tpgresource.IsEmptyValue(reflect.ValueOf(exactMatchProp)) && (ok || !reflect.DeepEqual(v, exactMatchProp)) {
+	obj["exactMatch"] = exactMatchProp
+}
+
+url, err := tpgresource.ReplaceVars(d, config, "{{`{{DiscoveryEngineBasePath}}`}}projects/{{`{{project}}`}}/locations/{{`{{location}}`}}/collections/default_collection/dataStores/{{`{{data_store_id}}`}}/siteSearchEngine/targetSites")
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Creating new TargetSite: %#v", obj)
+billingProject := ""
+
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return fmt.Errorf("Error fetching project for TargetSite: %s", err)
+}
+billingProject = project
+
+// err == nil indicates that the billing_project value was found
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+headers := make(http.Header)
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "POST",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: userAgent,
+	Body:      obj,
+	Timeout:   d.Timeout(schema.TimeoutCreate),
+	Headers:   headers,
+})
+if err != nil {
+	return fmt.Errorf("Error creating TargetSite: %s", err)
+}
+
+// Store the ID now
+id, err := tpgresource.ReplaceVars(d, config, "{{`{{name}}`}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+if d.Get("skip_wait").(bool) {
+	// When skip_wait is true, don't wait for the LRO to complete.
+	// The indexing operation response is not yet available, so we find the
+	// newly created target site via a List call matching provided_uri_pattern.
+	listURL, err := tpgresource.ReplaceVars(d, config, "{{`{{DiscoveryEngineBasePath}}`}}projects/{{`{{project}}`}}/locations/{{`{{location}}`}}/collections/default_collection/dataStores/{{`{{data_store_id}}`}}/siteSearchEngine/targetSites")
+	if err != nil {
+		return fmt.Errorf("Error constructing list URL for TargetSite: %s", err)
+	}
+
+	listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    listURL,
+		UserAgent: userAgent,
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error listing TargetSites after creation: %s", err)
+	}
+
+	providedPattern := d.Get("provided_uri_pattern").(string)
+	targetSites, ok := listRes["targetSites"].([]interface{})
+	if !ok {
+		return fmt.Errorf("Error parsing targetSites list response")
+	}
+
+	var foundName string
+	for _, site := range targetSites {
+		siteMap, ok := site.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Match by providedUriPattern
+		if siteMap["providedUriPattern"] == providedPattern {
+			if name, ok := siteMap["name"].(string); ok {
+				foundName = name
+				break
+			}
+		}
+	}
+
+	if foundName == "" {
+		return fmt.Errorf("Error finding newly created TargetSite with provided_uri_pattern %q in list response", providedPattern)
+	}
+
+	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(foundName, d, config)); err != nil {
+		return err
+	}
+} else {
+	// Normal path: wait for the LRO to complete and populate computed fields.
+	var opRes map[string]interface{}
+	err = DiscoveryEngineOperationWaitTimeWithResponse(
+		config, res, &opRes, project, "Creating TargetSite", userAgent,
+		d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		// The resource didn't actually create
+		d.SetId("")
+
+		return fmt.Errorf("Error waiting to create TargetSite: %s", err)
+	}
+
+	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(opRes["name"], d, config)); err != nil {
+		return err
+	}
+}
+
+// This may have caused the ID to update - update it if so.
+id, err = tpgresource.ReplaceVars(d, config, "{{`{{name}}`}}")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+log.Printf("[DEBUG] Finished creating TargetSite %q: %#v", d.Id(), res)
+
+identity, err := d.Identity()
+if err == nil && identity != nil {
+	if locationValue, ok := d.GetOk("location"); ok && locationValue.(string) != "" {
+		if err = identity.Set("location", locationValue.(string)); err != nil {
+			return fmt.Errorf("Error setting location: %s", err)
+		}
+	}
+	if dataStoreIdValue, ok := d.GetOk("data_store_id"); ok && dataStoreIdValue.(string) != "" {
+		if err = identity.Set("data_store_id", dataStoreIdValue.(string)); err != nil {
+			return fmt.Errorf("Error setting data_store_id: %s", err)
+		}
+	}
+	if targetSiteIdValue, ok := d.GetOk("target_site_id"); ok && targetSiteIdValue.(string) != "" {
+		if err = identity.Set("target_site_id", targetSiteIdValue.(string)); err != nil {
+			return fmt.Errorf("Error setting target_site_id: %s", err)
+		}
+	}
+	if projectValue, ok := d.GetOk("project"); ok && projectValue.(string) != "" {
+		if err = identity.Set("project", projectValue.(string)); err != nil {
+			return fmt.Errorf("Error setting project: %s", err)
+		}
+	}
+} else {
+	log.Printf("[DEBUG] (Create) identity not set: %s", err)
+}
+
+return resourceDiscoveryEngineTargetSiteRead(d, meta)

--- a/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
@@ -66,20 +66,71 @@ d.SetId(id)
 
 if d.Get("skip_wait").(bool) {
 	// When skip_wait is true, don't wait for the LRO to complete.
-	// Resource registration completes quickly and the target site name is
-	// available immediately in the initial POST response. The 480-minute
-	// wait is for background indexing which we intentionally skip.
-	responseMap, ok := res["response"].(map[string]interface{})
-	if !ok {
-		d.SetId("")
-		return fmt.Errorf("Error creating TargetSite: initial POST response did not contain operation result")
+	// The 480-minute wait is for background indexing which we intentionally skip.
+	// For unverified domains the API returns done=true synchronously and the
+	// target site name is available directly in the POST response.
+	// For verified domains the API returns a bare operation with no response
+	// until full indexing completes. In that case we find the target site via
+	// a List call — the site is registered immediately after the POST returns.
+	var targetSiteName string
+
+	if responseMap, ok := res["response"].(map[string]interface{}); ok {
+		// Fast path: synchronous response (unverified domains).
+		targetSiteName, _ = responseMap["name"].(string)
 	}
-	name, ok := responseMap["name"].(string)
-	if !ok || name == "" {
-		d.SetId("")
-		return fmt.Errorf("Error creating TargetSite: could not read resource name from operation response")
+
+	if targetSiteName == "" {
+		// Slow path: verified domain — find the newly created site via List.
+		listURL, err := tpgresource.ReplaceVars(d, config, "{{`{{DiscoveryEngineBasePath}}`}}projects/{{`{{project}}`}}/locations/{{`{{location}}`}}/collections/default_collection/dataStores/{{`{{data_store_id}}`}}/siteSearchEngine/targetSites")
+		if err != nil {
+			return fmt.Errorf("Error constructing list URL for TargetSite: %s", err)
+		}
+		providedPattern := d.Get("provided_uri_pattern").(string)
+
+		err = transport_tpg.PollingWaitTime(
+			func() (map[string]interface{}, error) {
+				return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+					Config:    config,
+					Method:    "GET",
+					Project:   billingProject,
+					RawURL:    listURL,
+					UserAgent: userAgent,
+					Headers:   headers,
+				})
+			},
+			func(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+				if respErr != nil {
+					return transport_tpg.ErrorPollResult(respErr)
+				}
+				targetSites, ok := resp["targetSites"].([]interface{})
+				if !ok {
+					return transport_tpg.PendingStatusPollResult("targetSites not yet available")
+				}
+				for _, site := range targetSites {
+					siteMap, ok := site.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if siteMap["generatedUriPattern"] == providedPattern {
+						if name, ok := siteMap["name"].(string); ok && name != "" {
+							targetSiteName = name
+							return transport_tpg.SuccessPollResult()
+						}
+					}
+				}
+				return transport_tpg.PendingStatusPollResult("target site not yet in list")
+			},
+			"Creating TargetSite",
+			30*time.Second,
+			1,
+		)
+		if err != nil {
+			d.SetId("")
+			return fmt.Errorf("Error creating TargetSite: could not find newly created site with pattern %q in list response: %s", providedPattern, err)
+		}
 	}
-	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(name, d, config)); err != nil {
+
+	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(targetSiteName, d, config)); err != nil {
 		return err
 	}
 } else {

--- a/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/discoveryengine_target_site.go.tmpl
@@ -66,51 +66,20 @@ d.SetId(id)
 
 if d.Get("skip_wait").(bool) {
 	// When skip_wait is true, don't wait for the LRO to complete.
-	// The indexing operation response is not yet available, so we find the
-	// newly created target site via a List call matching provided_uri_pattern.
-	listURL, err := tpgresource.ReplaceVars(d, config, "{{`{{DiscoveryEngineBasePath}}`}}projects/{{`{{project}}`}}/locations/{{`{{location}}`}}/collections/default_collection/dataStores/{{`{{data_store_id}}`}}/siteSearchEngine/targetSites")
-	if err != nil {
-		return fmt.Errorf("Error constructing list URL for TargetSite: %s", err)
-	}
-
-	listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		Project:   billingProject,
-		RawURL:    listURL,
-		UserAgent: userAgent,
-		Headers:   headers,
-	})
-	if err != nil {
-		return fmt.Errorf("Error listing TargetSites after creation: %s", err)
-	}
-
-	providedPattern := d.Get("provided_uri_pattern").(string)
-	targetSites, ok := listRes["targetSites"].([]interface{})
+	// Resource registration completes quickly and the target site name is
+	// available immediately in the initial POST response. The 480-minute
+	// wait is for background indexing which we intentionally skip.
+	responseMap, ok := res["response"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("Error parsing targetSites list response")
+		d.SetId("")
+		return fmt.Errorf("Error creating TargetSite: initial POST response did not contain operation result")
 	}
-
-	var foundName string
-	for _, site := range targetSites {
-		siteMap, ok := site.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		// Match by providedUriPattern
-		if siteMap["providedUriPattern"] == providedPattern {
-			if name, ok := siteMap["name"].(string); ok {
-				foundName = name
-				break
-			}
-		}
+	name, ok := responseMap["name"].(string)
+	if !ok || name == "" {
+		d.SetId("")
+		return fmt.Errorf("Error creating TargetSite: could not read resource name from operation response")
 	}
-
-	if foundName == "" {
-		return fmt.Errorf("Error finding newly created TargetSite with provided_uri_pattern %q in list response", providedPattern)
-	}
-
-	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(foundName, d, config)); err != nil {
+	if err := d.Set("name", flattenDiscoveryEngineTargetSiteName(name, d, config)); err != nil {
 		return err
 	}
 } else {

--- a/mmv1/templates/terraform/examples/discoveryengine_targetsite_skip_wait.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_targetsite_skip_wait.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_discovery_engine_target_site" "skip_wait" {
+  location             = google_discovery_engine_data_store.skip_wait.location
+  data_store_id        = google_discovery_engine_data_store.skip_wait.data_store_id
+  provided_uri_pattern = "cloud.google.com/docs/*"
+  type                 = "INCLUDE"
+  exact_match          = false
+  skip_wait            = true
+}
+
+resource "google_discovery_engine_data_store" "skip_wait" {
+  location                     = "global"
+  data_store_id                = "{{index $.Vars "data_store_id"}}"
+  display_name                 = "tf-test-skip-wait-site-search-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "PUBLIC_WEBSITE"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  skip_default_schema_creation = false
+}


### PR DESCRIPTION
## Summary

The `create` operation for `google_discovery_engine_target_site` triggers a long-running indexing LRO with a default timeout of **480 minutes**. For large web crawl data stores, `terraform apply` hangs for hours waiting for indexing to complete. If the provider times out before indexing finishes, the resource **is** created in GCP but state is **not** saved, requiring manual `terraform import` on every apply.

This PR adds a `skip_wait` boolean field (default: `false`, fully backwards compatible) that skips waiting for the LRO to complete. When `true`:
1. The POST request fires normally, creating the target site in GCP
2. The provider immediately calls List to find the newly created site by matching `provided_uri_pattern`
3. The resource is saved to Terraform state — indexing continues asynchronously in the background

## Example

```hcl
resource "google_discovery_engine_target_site" "example" {
  location             = "eu"
  data_store_id        = google_discovery_engine_data_store.faq.data_store_id
  provided_uri_pattern = "example.com/docs/*"
  type                 = "INCLUDE"
  exact_match          = false
  skip_wait            = true  # don't wait for 480-minute indexing LRO
}
```

## Design

Follows the same pattern as `google_firestore_index.skip_wait` ([reference](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/templates/terraform/custom_create/firestore_index.go.tmpl)).

- `virtual_fields` with `ignore_read: true` — Terraform-local field, never sent to or read from the API
- `custom_create` template that branches on `skip_wait`:
  - `false` (default): existing behaviour — waits for `DiscoveryEngineOperationWaitTimeWithResponse`
  - `true`: fires POST, then calls List to find the created site by `providedUriPattern`, saves state immediately

The List approach (rather than extracting from operation metadata) is necessary because `CreateTargetSiteMetadata` only contains timestamps — the target site resource name is only available in the LRO response after completion.

## Backwards compatibility

`skip_wait` defaults to `false`, so existing configurations are completely unaffected.

## Testing

Added `discoveryengine_targetsite_skip_wait` example.

## Release Notes

```release-note:enhancement
discoveryengine: added `skip_wait` field to `google_discovery_engine_target_site` resource to allow skipping the long-running indexing operation wait on create
```