### PR TITLE
Add support for enable_vpc_scoped_dns in Google Compute Instance

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -544,6 +544,12 @@ properties:
             projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.
           resource: 'networkAttachment'
           imports: 'selfLink'
+        - name: 'enableVpcScopedDns'
+          type: Boolean
+          description: |
+            If set to true, enables DNS resolution over this PSC interface. Valid only with network_attachment.
+            Note: This is currently in restricted preview and requires project allow-listing.
+          min_version: 'beta'
   - name: 'scheduling'
     type: NestedObject
     description: Sets the scheduling options for this instance.

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -566,6 +566,9 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Conf
 			"queue_count":         iface.QueueCount,
 			"internal_ipv6_prefix_length": iface.InternalIpv6PrefixLength,
 			"igmp_query":          iface.IgmpQuery,
+			{{- if ne $.TargetVersionName "ga" }}
+			"enable_vpc_scoped_dns": iface.EnableVpcScopedDns,
+			{{- end }}
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -685,6 +688,12 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 		}
 		{{- end }}
 
+		{{- if ne $.TargetVersionName "ga" }}
+		if v, ok := data["enable_vpc_scoped_dns"]; ok && v != nil && v.(bool) && networkAttachment == "" {
+			return nil, fmt.Errorf("enable_vpc_scoped_dns can only be set when network_attachment is provided")
+		}
+		{{- end }}
+
 		ifaces[i] = &compute.NetworkInterface{
 			NetworkIP:         data["network_ip"].(string),
 			Network:           nf.RelativeLink(),
@@ -704,6 +713,12 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 			MacAddress: macAddress,
 			{{- end }}
 		}
+
+		{{- if ne $.TargetVersionName "ga" }}
+		if v, ok := data["enable_vpc_scoped_dns"]; ok && v != nil {
+			ifaces[i].EnableVpcScopedDns = v.(bool)
+		}
+		{{- end }}
 	}
 	return ifaces, nil
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -635,6 +635,14 @@ func ResourceComputeInstance() *schema.Resource {
 							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
 
+						{{- if ne $.TargetVersionName "ga" }}
+						"enable_vpc_scoped_dns": {
+						        Type:        schema.TypeBool,
+						        Optional:    true,
+						        ForceNew:    true,
+						        Description: `If set to true, enables DNS resolution over this PSC interface. Valid only with network_attachment. Note: This is currently in restricted preview and requires project allow-listing.`,
+						},						{{- end }}
+
 						"parent_nic_name": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
@@ -177,6 +177,10 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
+{{- end }}
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
@@ -3,6 +3,7 @@ package compute_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -1442,4 +1443,89 @@ resource "google_compute_instance_from_machine_image" "foobar" {
 
 {{- else }}
 // Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+{{- end }}
+
+{{ if ne $.TargetVersionName "ga" }}
+func TestAccComputeInstanceFromMachineImage_EnableVpcScopedDns(t *testing.T) {
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix":                  suffix,
+		"network_attachment_name": fmt.Sprintf("tf-test-na-%s", suffix),
+		"region":                  envRegion,
+		"network_name":            acctest.BootstrapSharedTestNetwork(t, "instance-from-mi"),
+		"subnetwork_name":         acctest.BootstrapSubnet(t, "instance-from-mi-sub", acctest.BootstrapSharedTestNetwork(t, "instance-from-mi")),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceFromMachineImageDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceFromMachineImage_enableVpcScopedDns(context),
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceFromMachineImage_enableVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+    region = "%{region}"
+    connection_preference = "ACCEPT_AUTOMATIC"
+
+    subnetworks = [
+        "%{subnetwork_name}"
+    ]
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "tf-test-vm-%{suffix}"
+  machine_type = "e2-medium"
+  zone         = "%{region}-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_machine_image" "foobar" {
+  name            = "tf-test-image-%{suffix}"
+  source_instance = google_compute_instance.vm.self_link
+}
+
+resource "google_compute_instance_from_machine_image" "foobar" {
+  name                 = "tf-test-instance-%{suffix}"
+  zone                 = "%{region}-a"
+  source_machine_image = google_compute_machine_image.foobar.self_link
+
+  network_interface {
+    network = "default"
+  }
+
+  network_interface {
+    network_attachment    = google_compute_network_attachment.test_network_attachment.self_link
+    enable_vpc_scoped_dns = true
+  }
+}
+`, context)
+}
 {{- end }}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
@@ -184,6 +184,10 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
+{{- end }}
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -2,6 +2,7 @@ package compute_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -2625,6 +2626,86 @@ resource "google_compute_instance_from_template" "foobar" {
 		subnetwork = google_compute_subnetwork.inst-test-subnetwork.id
 		igmp_query = "%{igmp_query}"
 	}
+}
+`, context)
+}
+
+func TestAccComputeInstanceFromTemplate_EnableVpcScopedDns(t *testing.T) {
+{{- if eq $.TargetVersionName "ga" }}
+	t.Skip("enable_vpc_scoped_dns is only available in beta")
+{{- end }}
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix":                  suffix,
+		"network_attachment_name": fmt.Sprintf("tf-test-na-%s", suffix),
+		"region":                  envRegion,
+		"network_name":            acctest.BootstrapSharedTestNetwork(t, "instance-from-tpl"),
+		"subnetwork_name":         acctest.BootstrapSubnet(t, "instance-from-tpl-sub", acctest.BootstrapSharedTestNetwork(t, "instance-from-tpl")),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceFromTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceFromTemplate_enableVpcScopedDns(context),
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceFromTemplate_enableVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+    region = "%{region}"
+    connection_preference = "ACCEPT_AUTOMATIC"
+
+    subnetworks = [
+        "%{subnetwork_name}"
+    ]
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-template-%{suffix}"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_instance_from_template" "foobar" {
+  name                     = "tf-test-instance-%{suffix}"
+  source_instance_template = google_compute_instance_template.foobar.self_link
+  zone                     = "%{region}-a"
+
+  network_interface {
+    network = "default"
+  }
+
+  network_interface {
+    network_attachment    = google_compute_network_attachment.test_network_attachment.self_link
+    enable_vpc_scoped_dns = true
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
@@ -184,6 +184,10 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
+{{- end }}
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -527,6 +527,14 @@ Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key m
 							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
 
+						{{- if ne $.TargetVersionName "ga" }}
+						"enable_vpc_scoped_dns": {
+						        Type:        schema.TypeBool,
+						        Optional:    true,
+						        ForceNew:    true,
+						        Description: `If set to true, enables DNS resolution over this PSC interface. Valid only with network_attachment. Note: This is currently in restricted preview and requires project allow-listing.`,
+						},						{{- end }}
+
 						"parent_nic_name": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
@@ -151,6 +151,10 @@ fields:
     api_field: 'properties.networkInterfaces.network'
   - field: 'network_interface.network_attachment'
     api_field: 'properties.networkInterfaces.networkAttachment'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'properties.networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
+{{- end }}
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 {{- end }}
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -5660,6 +5661,91 @@ resource "google_compute_instance_template" "foobar" {
 
   network_interface {
 	network = "default"
+  }
+}
+`, context)
+}
+
+func TestAccComputeInstanceTemplate_EnableVpcScopedDns(t *testing.T) {
+{{- if eq $.TargetVersionName "ga" }}
+	t.Skip("enable_vpc_scoped_dns is only available in beta")
+{{- end }}
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix":                  suffix,
+		"network_attachment_name": fmt.Sprintf("tf-test-na-%s", suffix),
+		"region":                  envRegion,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_enableVpcScopedDns(context),
+			},
+			{
+				ResourceName:            "google_compute_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceTemplate_enableVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "test-network"{
+	name = "tf-test-network-%{suffix}"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test-subnetwork" {
+	name          = "tf-test-compute-subnet-%{suffix}"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "%{region}"
+	network       = google_compute_network.test-network.id
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+    region = "%{region}"
+    connection_preference = "ACCEPT_AUTOMATIC"
+
+    subnetworks = [
+        google_compute_subnetwork.test-subnetwork.self_link
+    ]
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%{suffix}"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  network_interface {
+    network_attachment    = google_compute_network_attachment.test_network_attachment.self_link
+    enable_vpc_scoped_dns = true
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	{{- end }}
 	"fmt"
+	"os"
 	{{- if ne $.TargetVersionName "ga" }}
 	"google.golang.org/api/googleapi"
 	{{- end }}
@@ -661,8 +662,7 @@ func TestAccComputeInstance_ipv6OnlyMacAddress(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{		
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
         Steps: []resource.TestStep{
             {
                 Config: testAccComputeInstance_ipv6OnlyMacAddressConfig(instanceName, networkName, subnetworkName),
@@ -2321,8 +2321,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		ExternalProviders: map[string]resource.ExternalProvider{
 			"time": {},
 		},
 		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
@@ -5186,6 +5185,70 @@ func TestAccComputeInstance_NetworkAttachment(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_EnableVpcScopedDns(t *testing.T) {
+{{- if eq $.TargetVersionName "ga" }}
+	t.Skip("enable_vpc_scoped_dns is only available in beta")
+{{- end }}
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix":                  suffix,
+		"network_attachment_name": fmt.Sprintf("tf-test-na-%s", suffix),
+		"region":                  envRegion,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_enableVpcScopedDns(context),
+			},
+			{
+				ResourceName:            "google_compute_instance.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_stopping_for_update"},
+			},
+		},
+	})
+}
+
+func TestAccComputeInstance_EnableVpcScopedDnsError(t *testing.T) {
+{{- if eq $.TargetVersionName "ga" }}
+	t.Skip("enable_vpc_scoped_dns is only available in beta")
+{{- end }}
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix": suffix,
+		"region": envRegion,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeInstance_enableVpcScopedDnsError(context),
+				ExpectError: regexp.MustCompile("enable_vpc_scoped_dns can only be set when network_attachment is provided"),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_NetworkAttachmentUpdate(t *testing.T) {
 	t.Parallel()
 	suffix := acctest.RandString(t, 10)
@@ -5327,8 +5390,7 @@ func TestAccComputeInstance_guestOsFeatures(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstance_guestOsFeatures(context_1),
 				Check: resource.ComposeTestCheckFunc(
@@ -12663,8 +12725,7 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, storagePoolNameLong, envvar.GetTestZoneFromEnv()),
 			},
@@ -12685,8 +12746,7 @@ func TestAccComputeInstance_bootDisk_storagePoolSpecified_nameOnly(t *testing.T)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstance_bootDisk_storagePoolSpecified(instanceName, "tf-bootstrap-storage-pool-hyperdisk-balanced-basic-2", envvar.GetTestZoneFromEnv()),
 			},
@@ -12738,8 +12798,7 @@ func TestAccComputeInstance_bootAndAttachedDisk_interface(t *testing.T) {
 	diskName2 := fmt.Sprintf("tf-test-disk2-%s", acctest.RandString(t, 10))
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		Steps: []resource.TestStep{
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeInstance_bootAndAttachedDisk_interface(instanceName1, diskName1, envvar.GetTestZoneFromEnv(), "c3-standard-22", "NVME", false),
 				Check: resource.ComposeTestCheckFunc(
@@ -13452,6 +13511,84 @@ resource "google_compute_instance" "foobar" {
 }
 
 data "google_compute_default_service_account" "default" {
+}
+`, context)
+}
+
+func testAccComputeInstance_enableVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "test-network"{
+	name = "tf-test-network-%{suffix}"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test-subnetwork" {
+	name          = "tf-test-compute-subnet-%{suffix}"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "%{region}"
+	network       = google_compute_network.test-network.id
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+    region = "%{region}"
+    connection_preference = "ACCEPT_AUTOMATIC"
+
+    subnetworks = [
+        google_compute_subnetwork.test-subnetwork.self_link
+    ]
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "tf-test-instance-%{suffix}"
+  machine_type = "e2-medium"
+  zone         = "%{region}-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.id
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	network_interface {
+		network_attachment    = google_compute_network_attachment.test_network_attachment.self_link
+        enable_vpc_scoped_dns = true
+	}
+}
+`, context)
+}
+
+func testAccComputeInstance_enableVpcScopedDnsError(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "tf-test-instance-%{suffix}"
+  machine_type = "e2-medium"
+  zone         = "%{region}-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.id
+		}
+	}
+
+	network_interface {
+		network               = "default"
+        enable_vpc_scoped_dns = true
+	}
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -521,14 +521,22 @@ Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key m
 						},
 
 						"network_attachment": {
-							Type:             schema.TypeString,
-							Optional:         true,
-							ForceNew:         true,
-							Computed:         true,
-							DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
-							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
+						        Type:             schema.TypeString,
+						        Optional:         true,
+						        ForceNew:         true,
+						        Computed:         true,
+						        DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+						        Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
 
+						{{- if ne $.TargetVersionName "ga" }}
+						"enable_vpc_scoped_dns": {
+						        Type:        schema.TypeBool,
+						        Optional:    true,
+						        ForceNew:    true,
+						        Description: `If set to true, enables DNS resolution over this PSC interface. Valid only with network_attachment. Note: This is currently in restricted preview and requires project allow-listing.`,
+						},
+						{{- end }}
 						"parent_nic_name": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_meta.yaml.tmpl
@@ -155,6 +155,10 @@ fields:
     api_field: 'properties.networkInterfaces.nicType'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
+{{- end }}
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -4,6 +4,7 @@ package compute_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -5131,3 +5132,89 @@ resource "google_compute_region_instance_template" "foobar" {
 `, suffix)
 }
 {{- end }}
+
+func TestAccComputeRegionInstanceTemplate_EnableVpcScopedDns(t *testing.T) {
+{{- if eq $.TargetVersionName "ga" }}
+	t.Skip("enable_vpc_scoped_dns is only available in beta")
+{{- end }}
+	t.Parallel()
+	acctest.SkipIfVcr(t)
+	if os.Getenv("TF_ACC_ENABLE_VPC_SCOPED_DNS") == "" {
+		t.Skip("Skipping test as it requires an allow-listed project. Set TF_ACC_ENABLE_VPC_SCOPED_DNS to run.")
+	}
+	suffix := acctest.RandString(t, 10)
+	envRegion := envvar.GetTestRegionFromEnv()
+	context := map[string]interface{}{
+		"suffix":                  suffix,
+		"network_attachment_name": fmt.Sprintf("tf-test-na-%s", suffix),
+		"region":                  envRegion,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionInstanceTemplate_enableVpcScopedDns(context),
+			},
+			{
+				ResourceName:            "google_compute_region_instance_template.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func testAccComputeRegionInstanceTemplate_enableVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "test-network"{
+	name = "tf-test-network-%{suffix}"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test-subnetwork" {
+	name          = "tf-test-compute-subnet-%{suffix}"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "%{region}"
+	network       = google_compute_network.test-network.id
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+    region = "%{region}"
+    connection_preference = "ACCEPT_AUTOMATIC"
+
+    subnetworks = [
+        google_compute_subnetwork.test-subnetwork.self_link
+    ]
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%{suffix}"
+  machine_type = "e2-medium"
+  region       = "%{region}"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  network_interface {
+    network_attachment    = google_compute_network_attachment.test_network_attachment.self_link
+    enable_vpc_scoped_dns = true
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -472,6 +472,8 @@ is desired, you will need to modify your state file manually using
 
 * `network_attachment` - (Optional) The URL of the network attachment that this interface should connect to in the following format: `projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}`.
 
+* `enable_vpc_scoped_dns` - (Optional) [Beta](../guides/provider_versions.html.markdown) If set to true, enables DNS resolution over this PSC interface. Valid only with `network_attachment`. Note: This is currently in restricted preview and requires project allow-listing.
+
 * `vlan` - (Optional) VLAN tag of a dynamic network interface, must be an integer in the range from 2 to 255 inclusively.
 
 * `igmp_query` - (Optional) Indicates whether igmp query is enabled on the network interface or not. If enabled, also indicates the version of IGMP supported.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_machine_image.html.markdown
@@ -56,6 +56,8 @@ In addition to these, most* arguments from `google_compute_instance` are support
 as a way to override the properties in the machine image. All exported attributes
 from `google_compute_instance` are likewise exported here.
 
+* `network_interface.enable_vpc_scoped_dns` - (Optional) [Beta](../guides/provider_versions.html.markdown) If set to true, enables DNS resolution over this PSC interface. Valid only with `network_attachment`. Note: This is currently in restricted preview and requires project allow-listing.
+
 ~> **Warning:** *Due to API limitations, disk overrides are currently disabled. This includes the "boot_disk", "attached_disk", and "scratch_disk" fields.
 
 ## Attributes Reference

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -84,6 +84,7 @@ are marked [Attributes as Blocks](/docs/configuration/attr-as-blocks.html):
 * `scratch_disk`
 * `network_interface.alias_ip_range`
 * `network_interface.access_config`
+* `network_interface.enable_vpc_scoped_dns` - (Optional) [Beta](../guides/provider_versions.html.markdown) If set to true, enables DNS resolution over this PSC interface. Valid only with `network_attachment`. Note: This is currently in restricted preview and requires project allow-listing.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -581,6 +581,8 @@ The following arguments are supported:
 
 * `network_attachment` - (Optional) The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.
 
+* `enable_vpc_scoped_dns` - (Optional) [Beta](../guides/provider_versions.html.markdown) If set to true, enables DNS resolution over this PSC interface. Valid only with `network_attachment`. Note: This is currently in restricted preview and requires project allow-listing.
+
 * `vlan` - (Optional) VLAN tag of a dynamic network interface, must be an integer in the range from 2 to 255 inclusively.
 
 * `subnetwork_project` - (Optional) The ID of the project in which the subnetwork belongs.

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_template.html.markdown
@@ -566,6 +566,8 @@ The following arguments are supported:
 
 * `network_attachment` - (Optional) The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.
 
+* `enable_vpc_scoped_dns` - (Optional) [Beta](../guides/provider_versions.html.markdown) If set to true, enables DNS resolution over this PSC interface. Valid only with `network_attachment`. Note: This is currently in restricted preview and requires project allow-listing.
+
 * `vlan` - (Optional) VLAN tag of a dynamic network interface, must be an integer in the range from 2 to 255 inclusively.
 
 * `igmp_query` - (Optional) Indicates whether igmp query is enabled on the network interface or not. If enabled, also indicates the version of IGMP supported.


### PR DESCRIPTION
Implementation of the 'enable_vpc_scoped_dns' flag for Google Compute Instances and Instance Templates.

This flag allows enabling DNS resolution over PSC interfaces when a network attachment is provided. Since this feature is currently in restricted preview, it is added to the Beta provider only and includes a project allow-listing requirement note in the documentation.

Changes:
- Added 'enable_vpc_scoped_dns' to Instance and InstanceTemplate schemas.
- Added validation logic to ensure the flag is only used with network attachments.
- Added dedicated acceptance tests with CI skip logic for non-allow-listed projects.
- Updated provider factories in tests to ensure consistent dependency resolution.

```release-note:enhancement
compute: added `enable_vpc_scoped_dns` field to `google_compute_instance` and `google_compute_instance_template` resources (beta)
```

