### PR TITLE
Migrated resource_compute_image_test.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_image_test.go.tmpl
@@ -1,10 +1,12 @@
 package compute_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 
@@ -253,9 +255,24 @@ func testAccCheckComputeImageExists(t *testing.T, n string, image *compute.Image
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := config.NewComputeClient(config.UserAgent).Images.Get(
-			config.Project, rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/global/images/%s", config.ComputeBasePath, config.Project, rs.Primary.Attributes["name"])
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
+			return err
+		}
+
+		var found compute.Image
+		resBytes, err := json.Marshal(res)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(resBytes, &found); err != nil {
 			return err
 		}
 
@@ -263,7 +280,7 @@ func testAccCheckComputeImageExists(t *testing.T, n string, image *compute.Image
 			return fmt.Errorf("Image not found")
 		}
 
-		*image = *found
+		*image = found
 
 		return nil
 	}
@@ -412,17 +429,26 @@ func testAccCheckComputeImageResolution(t *testing.T, n string) resource.TestChe
 		family := rs.Primary.Attributes["family"]
 		link := rs.Primary.Attributes["self_link"]
 
-		latestDebian, err := config.NewComputeClient(config.UserAgent).Images.GetFromFamily("debian-cloud", "debian-11").Do()
+		url := fmt.Sprintf("%sprojects/%s/global/images/family/%s", config.ComputeBasePath, "debian-cloud", "debian-11")
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error retrieving latest debian: %s", err)
 		}
 
+		latestDebian := res
+
 		images := map[string]string{
-			"family/" + latestDebian.Family:                            "projects/debian-cloud/global/images/family/" + latestDebian.Family,
-			"projects/debian-cloud/global/images/" + latestDebian.Name: "projects/debian-cloud/global/images/" + latestDebian.Name,
-			latestDebian.Family:                                        "projects/debian-cloud/global/images/family/" + latestDebian.Family,
-			latestDebian.Name:                                          "projects/debian-cloud/global/images/" + latestDebian.Name,
-			latestDebian.SelfLink:                                      latestDebian.SelfLink,
+			"family/" + latestDebian["family"].(string):                            "projects/debian-cloud/global/images/family/" + latestDebian["family"].(string),
+			"projects/debian-cloud/global/images/" + latestDebian["name"].(string): "projects/debian-cloud/global/images/" + latestDebian["name"].(string),
+			latestDebian["family"].(string):                                        "projects/debian-cloud/global/images/family/" + latestDebian["family"].(string),
+			latestDebian["name"].(string):                                          "projects/debian-cloud/global/images/" + latestDebian["name"].(string),
+			latestDebian["selfLink"].(string):                                      latestDebian["selfLink"].(string),
 
 			"global/images/" + name:          "global/images/" + name,
 			"global/images/family/" + family: "global/images/family/" + family,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: Migrated `resource_compute_image_test.go.tmpl` resource to use direct HTTP rather then a client library
```
