### PR TITLE
Calculate mtls closer to universe domain

### DIFF
--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -321,8 +321,7 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 	// at client creation. Since we use a shared client for requests we must
 	// rewrite the endpoints to be mtls endpoints for the scenario where
 	// mtls is enabled.
-	config.IsMtls = isMtls()
-	if config.IsMtls {
+	if isMtls() {
 		// if mtls is enabled switch all default endpoints to use the mtls endpoint
 		for key, bp := range transport_tpg.DefaultBasePaths {
 			transport_tpg.DefaultBasePaths[key] = getMtlsEndpoint(bp)

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -18,18 +18,6 @@ import (
 
 // Provider returns a *schema.Provider.
 func Provider() *schema.Provider {
-
-	// The mtls service client gives the type of endpoint (mtls/regular)
-	// at client creation. Since we use a shared client for requests we must
-	// rewrite the endpoints to be mtls endpoints for the scenario where
-	// mtls is enabled.
-	if isMtls() {
-		// if mtls is enabled switch all default endpoints to use the mtls endpoint
-		for key, bp := range transport_tpg.DefaultBasePaths {
-			transport_tpg.DefaultBasePaths[key] = getMtlsEndpoint(bp)
-		}
-	}
-
 	provider := &schema.Provider{
 		// See: https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux
 		// "The schema and configuration handling must exactly match between all underlying providers of the mux server"
@@ -327,6 +315,18 @@ func ProviderConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 		config.AccessToken = transport_tpg.MultiEnvSearch([]string{
 			"GOOGLE_OAUTH_ACCESS_TOKEN",
 		})
+	}
+
+	// The mtls service client gives the type of endpoint (mtls/regular)
+	// at client creation. Since we use a shared client for requests we must
+	// rewrite the endpoints to be mtls endpoints for the scenario where
+	// mtls is enabled.
+	config.IsMtls = isMtls()
+	if config.IsMtls {
+		// if mtls is enabled switch all default endpoints to use the mtls endpoint
+		for key, bp := range transport_tpg.DefaultBasePaths {
+			transport_tpg.DefaultBasePaths[key] = getMtlsEndpoint(bp)
+		}
 	}
 	
 	// Set the universe domain to the configured value, if any

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -243,6 +243,7 @@ type Config struct {
 	Region                                    string
 	BillingProject                            string
 	Zone                                      string
+	IsMtls                                    bool
 	UniverseDomain                            string
 	Scopes                                    []string
 	BatchingConfig                            *BatchingConfig

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -243,7 +243,6 @@ type Config struct {
 	Region                                    string
 	BillingProject                            string
 	Zone                                      string
-	IsMtls                                    bool
 	UniverseDomain                            string
 	Scopes                                    []string
 	BatchingConfig                            *BatchingConfig


### PR DESCRIPTION
Mtls enablement behaves similarly to UniverseDomain in terms of modifying base paths. Keeping the code closer makes it easier to understand what's going on. I think this should be functionally equivalent.

MTLS behavior can be tested by setting env var `GOOGLE_API_USE_MTLS_ENDPOINT=always`

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
