### PR TITLE
Extended registry product struct to include REP Url & custom endpoint information & add custom endpoint fields based on registry

### DIFF
--- a/mmv1/templates/terraform/product.go.tmpl
+++ b/mmv1/templates/terraform/product.go.tmpl
@@ -23,7 +23,7 @@ import (
     "{{ $.ImportPath }}/registry"
 )
 
-var product = registry.Product{
+var Product = registry.Product{
     Name: "{{ lower $.Name }}",
     BaseUrl: "{{ $.Version.BaseUrl }}",
     {{- if $.Version.RepUrl }}
@@ -34,5 +34,5 @@ var product = registry.Product{
 }
 
 func init() {
-    product.Register()
+    Product.Register()
 }

--- a/mmv1/templates/terraform/product.go.tmpl
+++ b/mmv1/templates/terraform/product.go.tmpl
@@ -23,11 +23,16 @@ import (
     "{{ $.ImportPath }}/registry"
 )
 
-const ProductName = "{{ lower $.Name }}"
+var product = registry.Product{
+    Name: "{{ lower $.Name }}",
+    BaseUrl: "{{ $.Version.BaseUrl }}",
+    {{- if $.Version.RepUrl }}
+    RepUrl: "{{ $.Version.RepUrl }}",
+    {{- end }}
+    CustomEndpointField: "{{ underscore $.Name }}_custom_endpoint",
+    CustomEndpointEnvVar: "GOOGLE_{{ upper (underscore $.Name) }}_CUSTOM_ENDPOINT",
+}
 
 func init() {
-    registry.Product{
-        Name: "{{ lower $.Name }}",
-	    BaseUrl: "{{ $.Version.BaseUrl }}",
-    }.Register()
+    product.Register()
 }

--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -21,6 +21,7 @@ import (
     "github.com/hashicorp/terraform-provider-google/google/fwvalidators"
     "github.com/hashicorp/terraform-provider-google/google/functions"
     "github.com/hashicorp/terraform-provider-google/google/fwmodels"
+    "github.com/hashicorp/terraform-provider-google/google/registry"
     "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
     "github.com/hashicorp/terraform-provider-google/google/services/apigee"
     "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
@@ -179,15 +180,6 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             "prefer_regional_endpoints": schema.BoolAttribute{
                 Optional: true,
             },
-            // Generated Products
-            {{- range $product := $.Products }}
-            "{{ underscore $product.Name }}_custom_endpoint": &schema.StringAttribute{
-                Optional:     true,
-                Validators: []validator.String{
-                    transport_tpg.CustomEndpointValidator(),
-                },
-            },
-            {{- end }}
 
             // Handwritten Products / Versioned / Atypical Entries
             "cloud_billing_custom_endpoint": &schema.StringAttribute{
@@ -321,6 +313,14 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             },
         },
     }
+	for _, p := range registry.ListProducts() {
+        resp.Schema.Attributes[p.CustomEndpointField] = &schema.StringAttribute{
+            Optional:     true,
+            Validators: []validator.String{
+                transport_tpg.CustomEndpointValidator(),
+            },
+        }
+	}
 }
 
 // Configure prepares the metadata/'meta' required for data sources and resources to function.

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -188,15 +188,6 @@ func Provider() *schema.Provider {
 				Optional: true,
 			},
 
-			// Generated Products
-			{{- range $product := $.Products }}
-			"{{ underscore $product.Name }}_custom_endpoint": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: transport_tpg.ValidateCustomEndpoint,
-			},
-			{{- end }}
-
 			// Handwritten Products / Versioned / Atypical Entries
 			transport_tpg.CloudBillingCustomEndpointEntryKey:           transport_tpg.CloudBillingCustomEndpointEntry,
 			transport_tpg.DataflowCustomEndpointEntryKey:               transport_tpg.DataflowCustomEndpointEntry,
@@ -234,6 +225,14 @@ func Provider() *schema.Provider {
 		DataSourcesMap: registry.DatasourceMap(),
 {{- end }}
 		ResourcesMap: registry.ResourceMap(),
+	}
+
+	for _, p := range registry.ListProducts() {
+		provider.Schema[p.CustomEndpointField] = &schema.Schema{
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: transport_tpg.ValidateCustomEndpoint,
+		}
 	}
 
 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {

--- a/mmv1/third_party/terraform/registry/registry.go
+++ b/mmv1/third_party/terraform/registry/registry.go
@@ -14,6 +14,12 @@ type Product struct {
 	Name string
 	// BaseUrl is the base URL for API requests. It may contain Magic Modules templating directives.
 	BaseUrl string
+	// RepUrl is the base URL for regional API requests. It may contain Magic Modules templating directives.
+	RepUrl string
+	// CustomEndpointField is the name of the product's custom endpoint field in the provider schema.
+	CustomEndpointField string
+	// CustomEndpointEnvVar is the name of the product's custom endpoint environment variable.
+	CustomEndpointEnvVar string
 }
 
 // Register adds the product definition to the internal product registry.

--- a/mmv1/third_party/terraform/registry/registry.go
+++ b/mmv1/third_party/terraform/registry/registry.go
@@ -2,6 +2,9 @@ package registry
 
 import (
 	"log"
+	"maps"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -30,6 +33,14 @@ func (p Product) Register() {
 		log.Fatalf("Duplicate registration attempt for product %q", p.Name)
 	}
 	products.m[p.Name] = p
+}
+
+func ListProducts() []Product {
+	l := slices.Collect(maps.Values(products.m))
+	slices.SortFunc(l, func(a, b Product) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	return l
 }
 
 type registeredProducts struct {


### PR DESCRIPTION
This is a prerequisite to using this information to configure the provider based on included products; I'm splitting it into a separate PR for easier review and because the implementation could go multiple directions based on this.

For example, https://github.com/GoogleCloudPlatform/magic-modules/pull/17011 keeps base path determination in the provider/config, but sets up custom endpoint fields from the list of products instead of at generation time. That will stay the same regardless, because custom endpoints are part of the provider itself.

However, there's an open question of how to handle BasePaths; the PR above takes the approach of creating a BasePaths map of product names to base paths; however, that just duplicates data and introduces the opportunity for confusion. It may be better to manage base path computation inside resource methods.

Either way, the changes in this PR need to happen, so I've factored them out to be reviewed and merged.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
