### PR TITLE
Tavasyag/bigquery table list

### DIFF
--- a/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
@@ -1,0 +1,166 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bigquery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type GoogleBigQueryTableListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleBigQueryTableListModel struct {
+	DatasetID types.String `tfsdk:"dataset_id"`
+	Project   types.String `tfsdk:"project"`
+}
+
+func NewGoogleBigQueryTableListResource() list.ListResource {
+	listR := &GoogleBigQueryTableListResource{}
+	listR.TypeName = "google_bigquery_table"
+	listR.SDKv2Resource = ResourceBigQueryTable()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "dataset_id", Kind: tpgresource.ListConfigKindString, Optional: false},
+		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
+	}
+	return listR
+}
+
+func (listR *GoogleBigQueryTableListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	var data GoogleBigQueryTableListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	project := listR.GetProject(data.Project)
+	datasetID := data.DatasetID.ValueString()
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListBigQueryTables(listR.Client, project, datasetID, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "table_id"); err != nil {
+				return err
+			}
+
+			if !push(result) {
+				return errors.New("stream closed")
+			}
+			return nil
+		})
+		if err != nil {
+			diags.AddError("API Error", err.Error())
+			result := listReq.NewListResult(ctx)
+			result.Diagnostics = diags
+			push(result)
+		}
+	}
+}
+
+func flattenGoogleBigQueryTableListItem(res map[string]interface{}, d *schema.ResourceData, _ *transport_tpg.Config) error {
+	tableRef, ok := res["tableReference"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("missing tableReference in BigQuery tables list response")
+	}
+
+	tableID, ok := tableRef["tableId"].(string)
+	if !ok || tableID == "" {
+		return fmt.Errorf("missing tableReference.tableId in BigQuery tables list response")
+	}
+
+	project := d.Get("project").(string)
+	datasetID := d.Get("dataset_id").(string)
+
+	if v, ok := tableRef["projectId"].(string); ok && v != "" {
+		project = v
+	}
+	if v, ok := tableRef["datasetId"].(string); ok && v != "" {
+		datasetID = v
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project: %w", err)
+	}
+	if err := d.Set("dataset_id", datasetID); err != nil {
+		return fmt.Errorf("error setting dataset_id: %w", err)
+	}
+	if err := d.Set("table_id", tableID); err != nil {
+		return fmt.Errorf("error setting table_id: %w", err)
+	}
+
+	if labels, ok := res["labels"].(map[string]interface{}); ok {
+		if err := d.Set("labels", labels); err != nil {
+			return fmt.Errorf("error setting labels: %w", err)
+		}
+	}
+
+	if tableType, ok := res["type"].(string); ok && tableType != "" {
+		if err := d.Set("type", tableType); err != nil {
+			return fmt.Errorf("error setting type: %w", err)
+		}
+	}
+
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
+	return nil
+}
+
+func ListBigQueryTables(config *transport_tpg.Config, project, datasetID string, callback func(rd *schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	d := ResourceBigQueryTable().Data(&terraform.InstanceState{})
+	if err := d.Set("dataset_id", datasetID); err != nil {
+		return fmt.Errorf("error setting dataset_id on temporary resource data: %w", err)
+	}
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+	url, err := tpgresource.ReplaceVars(d, config, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}/tables")
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:         config,
+		TempData:       d,
+		ListURL:        url,
+		BillingProject: billingProject,
+		UserAgent:      userAgent,
+		ItemName:       "tables",
+		Flattener:      flattenGoogleBigQueryTableListItem,
+		Callback:       callback,
+	})
+}

--- a/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/bigquery/v2"
 )
 
 type GoogleBigQueryTableListResource struct {
@@ -79,43 +80,21 @@ func (listR *GoogleBigQueryTableListResource) List(ctx context.Context, listReq 
 }
 
 func flattenGoogleBigQueryTableListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
-	tableRef, ok := res["tableReference"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("missing tableReference in BigQuery tables list response")
+	var table bigquery.Table
+	if err := tpgresource.Convert(res, &table); err != nil {
+		return fmt.Errorf("error converting BigQuery tables list response: %w", err)
 	}
 
-	tableID, ok := tableRef["tableId"].(string)
-	if !ok || tableID == "" {
+	if table.TableReference == nil || table.TableReference.TableId == "" {
 		return fmt.Errorf("missing tableReference.tableId in BigQuery tables list response")
 	}
 
 	project := d.Get("project").(string)
-	datasetID := d.Get("dataset_id").(string)
-
-	if v, ok := tableRef["projectId"].(string); ok && v != "" {
-		project = v
-	}
-	if v, ok := tableRef["datasetId"].(string); ok && v != "" {
-		datasetID = v
+	if table.TableReference.ProjectId != "" {
+		project = table.TableReference.ProjectId
 	}
 
-	labels := make(map[string]string)
-	if rawLabels, ok := res["labels"].(map[string]interface{}); ok {
-		for key, value := range rawLabels {
-			stringValue, ok := value.(string)
-			if !ok {
-				return fmt.Errorf("unexpected label value type for %q", key)
-			}
-			labels[key] = stringValue
-		}
-	}
-
-	tableType := ""
-	if value, ok := res["type"].(string); ok {
-		tableType = value
-	}
-
-	return populateBigQueryTableCommonResourceData(d, config, project, datasetID, tableID, tableType, labels)
+	return ResourceBigQueryTableFlatten(d, config, project, &table)
 }
 
 func ListBigQueryTables(config *transport_tpg.Config, project, datasetID string, callback func(rd *schema.ResourceData) error) error {

--- a/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
@@ -78,7 +78,7 @@ func (listR *GoogleBigQueryTableListResource) List(ctx context.Context, listReq 
 	}
 }
 
-func flattenGoogleBigQueryTableListItem(res map[string]interface{}, d *schema.ResourceData, _ *transport_tpg.Config) error {
+func flattenGoogleBigQueryTableListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
 	tableRef, ok := res["tableReference"].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("missing tableReference in BigQuery tables list response")
@@ -99,30 +99,23 @@ func flattenGoogleBigQueryTableListItem(res map[string]interface{}, d *schema.Re
 		datasetID = v
 	}
 
-	if err := d.Set("project", project); err != nil {
-		return fmt.Errorf("error setting project: %w", err)
-	}
-	if err := d.Set("dataset_id", datasetID); err != nil {
-		return fmt.Errorf("error setting dataset_id: %w", err)
-	}
-	if err := d.Set("table_id", tableID); err != nil {
-		return fmt.Errorf("error setting table_id: %w", err)
-	}
-
-	if labels, ok := res["labels"].(map[string]interface{}); ok {
-		if err := d.Set("labels", labels); err != nil {
-			return fmt.Errorf("error setting labels: %w", err)
+	labels := make(map[string]string)
+	if rawLabels, ok := res["labels"].(map[string]interface{}); ok {
+		for key, value := range rawLabels {
+			stringValue, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("unexpected label value type for %q", key)
+			}
+			labels[key] = stringValue
 		}
 	}
 
-	if tableType, ok := res["type"].(string); ok && tableType != "" {
-		if err := d.Set("type", tableType); err != nil {
-			return fmt.Errorf("error setting type: %w", err)
-		}
+	tableType := ""
+	if value, ok := res["type"].(string); ok {
+		tableType = value
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
-	return nil
+	return populateBigQueryTableCommonResourceData(d, config, project, datasetID, tableID, tableType, labels)
 }
 
 func ListBigQueryTables(config *transport_tpg.Config, project, datasetID string, callback func(rd *schema.ResourceData) error) error {

--- a/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
+++ b/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table.go
@@ -14,10 +14,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"google.golang.org/api/bigquery/v2"
 )
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_bigquery_table",
+		ProductName: "bigquery",
+		Func:        NewGoogleBigQueryTableListResource,
+	}.Register()
+}
 
 type GoogleBigQueryTableListResource struct {
 	tpgresource.ListResourceMetadata

--- a/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/list_google_bigquery_table_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package bigquery_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccBigQueryTableListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableBasicSchema(datasetID, tableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "dataset_id", datasetID),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "project", project),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "table_id", tableID),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccBigQueryTableListQuery(project, datasetID),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_bigquery_table.all_in_dataset", map[string]knownvalue.Check{
+						"dataset_id": knownvalue.StringExact(datasetID),
+						"project":    knownvalue.StringExact(project),
+						"table_id":   knownvalue.StringExact(tableID),
+					}),
+					querycheck.ExpectLengthAtLeast("google_bigquery_table.all_in_dataset", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccBigQueryTableListQuery(project, datasetID string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_bigquery_table" "all_in_dataset" {
+  provider = google
+
+  config {
+    project    = %q
+    dataset_id = %q
+  }
+}
+`, project, datasetID)
+}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -2167,6 +2167,11 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
+	return ResourceBigQueryTableFlatten(d, config, userAgent, project, res)
+}
+
+
+func ResourceBigQueryTableFlatten(d *schema.ResourceData, config *transport_tpg.Config, userAgent, project string, res *bigquery.Table) error {
 	if err := d.Set("description", res.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -2167,11 +2167,41 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
-	return ResourceBigQueryTableFlatten(d, config, userAgent, project, res)
+	if err := ResourceBigQueryTableFlatten(d, config, project, res); err != nil {
+		return err
+	}
+
+	// TODO: Update when the Get API fields for TableReplicationInfo are available in the client library.
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}BigQueryBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/datasets/{{"{{"}}dataset_id{{"}}"}}/tables/{{"{{"}}table_id{{"}}"}}")
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Reading BigQuery table through API: %s", url)
+
+	getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return err
+	}
+
+	if v, ok := getRes["tableReplicationInfo"]; ok {
+		tableReplicationInfo := flattenTableReplicationInfo(v.(map[string]interface{}))
+
+		if err := d.Set("table_replication_info", tableReplicationInfo); err != nil {
+			return fmt.Errorf("Error setting table replication info: %s", err)
+		}
+	}
+
+	return nil
 }
 
 
-func ResourceBigQueryTableFlatten(d *schema.ResourceData, config *transport_tpg.Config, userAgent, project string, res *bigquery.Table) error {
+func ResourceBigQueryTableFlatten(d *schema.ResourceData, config *transport_tpg.Config, project string, res *bigquery.Table) error {
 	if err := d.Set("description", res.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -2355,32 +2385,6 @@ func ResourceBigQueryTableFlatten(d *schema.ResourceData, config *transport_tpg.
 
 	if err := d.Set("resource_tags", res.ResourceTags); err != nil {
 		return fmt.Errorf("Error setting resource tags: %s", err)
-	}
-
-	// TODO: Update when the Get API fields for TableReplicationInfo are available in the client library.
-	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}BigQueryBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/datasets/{{"{{"}}dataset_id{{"}}"}}/tables/{{"{{"}}table_id{{"}}"}}")
-	if err != nil {
-		return err
-	}
-
-	log.Printf("[INFO] Reading BigQuery table through API: %s", url)
-
-	getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "GET",
-		RawURL:    url,
-		UserAgent: userAgent,
-	})
-	if err != nil {
-		return err
-	}
-
-	if v, ok := getRes["tableReplicationInfo"]; ok {
-		tableReplicationInfo := flattenTableReplicationInfo(v.(map[string]interface{}))
-
-		if err := d.Set("table_replication_info", tableReplicationInfo); err != nil {
-			return fmt.Errorf("Error setting table replication info: %s", err)
-		}
 	}
 
 	if res.ExternalCatalogTableOptions != nil {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -2319,10 +2319,11 @@ func ResourceBigQueryTableFlatten(d *schema.ResourceData, config *transport_tpg.
 			_, viewPresent := d.GetOk("view")
 			_, materializedViewPresent := d.GetOk("materialized_view")
 			managePolicyTags := !viewPresent && !materializedViewPresent
-			configSchema, err = expandSchema(v, managePolicyTags)
+			parsedConfigSchema, err := expandSchema(v, managePolicyTags)
 			if err != nil {
 				return err
 			}
+			configSchema = parsedConfigSchema
 		}
 
 		schemaFiltered := res.Schema

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -2167,9 +2167,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
-	if err := d.Set("project", project); err != nil {
-		return fmt.Errorf("Error setting project: %s", err)
-	}
 	if err := d.Set("description", res.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
@@ -2181,15 +2178,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if err := d.Set("max_staleness", res.MaxStaleness); err != nil {
 		return fmt.Errorf("Error setting max_staleness: %s", err)
-	}
-	if err := tpgresource.SetLabels(res.Labels, d, "labels"); err != nil {
-		return fmt.Errorf("Error setting labels: %s", err)
-	}
-	if err := tpgresource.SetLabels(res.Labels, d, "terraform_labels"); err != nil {
-		return fmt.Errorf("Error setting terraform_labels: %s", err)
-	}
-	if err := d.Set("effective_labels", res.Labels); err != nil {
-		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}
 	if err := d.Set("creation_time", res.CreationTime); err != nil {
 		return fmt.Errorf("Error setting creation_time: %s", err)
@@ -2206,12 +2194,6 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("num_bytes", res.NumBytes); err != nil {
 		return fmt.Errorf("Error setting num_bytes: %s", err)
 	}
-	if err := d.Set("table_id", res.TableReference.TableId); err != nil {
-		return fmt.Errorf("Error setting table_id: %s", err)
-	}
-	if err := d.Set("dataset_id", res.TableReference.DatasetId); err != nil {
-		return fmt.Errorf("Error setting dataset_id: %s", err)
-	}
 	if err := d.Set("num_long_term_bytes", res.NumLongTermBytes); err != nil {
 		return fmt.Errorf("Error setting num_long_term_bytes: %s", err)
 	}
@@ -2221,8 +2203,8 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("self_link", res.SelfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("type", res.Type); err != nil {
-		return fmt.Errorf("Error setting type: %s", err)
+	if err := populateBigQueryTableCommonResourceData(d, config, project, res.TableReference.DatasetId, res.TableReference.TableId, res.Type, res.Labels); err != nil {
+		return err
 	}
 
 	// determine whether the deprecated require_partition_filter field is used
@@ -2404,10 +2386,51 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	return nil
+}
+
+func populateBigQueryTableCommonResourceData(d *schema.ResourceData, config *transport_tpg.Config, project, datasetID, tableID, tableType string, labels map[string]string) error {
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("dataset_id", datasetID); err != nil {
+		return fmt.Errorf("Error setting dataset_id: %s", err)
+	}
+	if err := d.Set("table_id", tableID); err != nil {
+		return fmt.Errorf("Error setting table_id: %s", err)
+	}
+	if err := tpgresource.SetLabels(labels, d, "labels"); err != nil {
+		return fmt.Errorf("Error setting labels: %s", err)
+	}
+	terraformLabels := make(map[string]string)
+	if config != nil {
+		for key, value := range config.DefaultLabels {
+			terraformLabels[key] = value
+		}
+	}
+	if configuredLabels, ok := d.GetOk("labels"); ok {
+		for key, value := range configuredLabels.(map[string]interface{}) {
+			terraformLabels[key] = value.(string)
+		}
+	}
+	if _, hasAttributionLabel := labels[transport_tpg.AttributionKey]; hasAttributionLabel {
+		terraformLabels[transport_tpg.AttributionKey] = transport_tpg.AttributionValue
+	}
+	if err := d.Set("terraform_labels", terraformLabels); err != nil {
+		return fmt.Errorf("Error setting terraform_labels: %s", err)
+	}
+	if err := d.Set("effective_labels", labels); err != nil {
+		return fmt.Errorf("Error setting effective_labels: %s", err)
+	}
+	if err := d.Set("type", tableType); err != nil {
+		return fmt.Errorf("Error setting type: %s", err)
+	}
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", project, datasetID, tableID))
+
 	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 		"project":    project,
-		"dataset_id": d.Get("dataset_id"),
-		"table_id":   d.Get("table_id"),
+		"dataset_id": datasetID,
+		"table_id":   tableID,
 	}); err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -3866,6 +3866,9 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	}
 
 	// Explicitly set virtual fields with default values to their default values on import
+	if err := d.Set("ignore_auto_generated_schema", false); err != nil {
+		return nil, fmt.Errorf("Error setting ignore_auto_generated_schema: %s", err)
+	}
 
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/datasets/{{"{{"}}dataset_id{{"}}"}}/tables/{{"{{"}}table_id{{"}}"}}")

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table.go.tmpl
@@ -690,6 +690,27 @@ func ResourceBigQueryTable() *schema.Resource {
 			resourceBigQueryTableSchemaCustomizeDiff,
 			tpgresource.SetLabelsDiff,
 		),
+
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"dataset_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"table_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			// TableId: [Required] The ID of the table. The ID must contain only
 			// letters (a-z, A-Z), numbers (0-9), or underscores (_). The maximum
@@ -2381,6 +2402,14 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("external_catalog_table_options", externalCatalogTableOptions); err != nil {
 			return fmt.Errorf("Error setting external_catalog_table_options: %s", err)
 		}
+	}
+
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":    project,
+		"dataset_id": d.Get("dataset_id"),
+		"table_id":   d.Get("table_id"),
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/bigquery"
@@ -41,6 +42,38 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_auto_generated_schema", "generated_schema_columns"},
+			},
+		},
+	})
+}
+
+func TestAccBigQueryTable_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableBasicSchemaForIdentityImport(datasetID, tableID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "project", project),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "dataset_id", datasetID),
+					resource.TestCheckResourceAttr("google_bigquery_table.test", "table_id", tableID),
+				),
+			},
+			{
+				ResourceName:    "google_bigquery_table.test",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
 		},
 	})
@@ -2408,6 +2441,29 @@ resource "google_bigquery_table" "test" {
     "name": "id",
     "type": "INTEGER"
   }
+]
+EOH
+
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTableBasicSchemaForIdentityImport(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+	dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+	table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+
+	schema = <<EOH
+[
+	{
+		"name": "id",
+		"type": "INTEGER"
+	}
 ]
 EOH
 

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_table_test.go
@@ -75,6 +75,9 @@ func TestAccBigQueryTable_importBlockWithResourceIdentity(t *testing.T) {
 				ImportState:     true,
 				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
+			{
+				Config: testAccBigQueryTableBasicSchema(datasetID, tableID),
+			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_bigquery_table.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "BigQuery"
+description: |-
+  List Google BigQuery tables in a dataset for use with terraform query and
+  .tfquery.hcl files.
+---
+
+# google_bigquery_table (list)
+
+Lists Google BigQuery **tables** in a dataset for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_bigquery_table`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_bigquery_table" "all_in_dataset" {
+  provider = google
+
+  config {
+    dataset_id = "example_dataset"
+
+    # Optional. Defaults to the provider project when omitted.
+    # project = "other-project"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `dataset_id` - (Required) Dataset ID to list BigQuery tables from.
+* `project` - (Optional) Project ID containing the dataset. If unset, the provider's
+  configured default project is used (same idea as the managed resource).
+
+## Results
+
+By default each result includes **resource identity** for `google_bigquery_table` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `dataset_id` - Dataset ID containing the table (required for identity).
+* `project` - Project ID containing the dataset.
+* `table_id` - BigQuery table ID (required for identity).
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_bigquery_table` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table#attributes-reference)
+that are present in state for each listed table.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds handwritten list-resource support for `google_bigquery_table`.

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/27369?reload=1

Changes in this PR:
- add resource identity support to `google_bigquery_table`
- add handwritten `google_bigquery_table` list resource
- register the BigQuery table list resource in the framework provider
- add acceptance coverage for `terraform query` identity results
- add list-resource documentation for `google_bigquery_table`

## Testing


```bash
make testacc TEST=./google/services/bigquery TESTARGS='-run=TestAccBigQueryTableListResource_queryIdentity$$'
```

```text
=== RUN   TestAccBigQueryTableListResource_queryIdentity
--- PASS: TestAccBigQueryTableListResource_queryIdentity (7.52s)
PASS
ok   github.com/hashicorp/terraform-provider-google/google/services/bigquery  8.613s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
bigquery: add list-resource support for `google_bigquery_table`
```

```release-note:note
bigquery: add resource-identity support to `google_bigquery_table`
```