### PR TITLE
feat: Add support for the emptyDir DISK medium for cloudrunv2 jobs

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -108,6 +108,15 @@ examples:
       cloud_run_job_name: 'cloudrun-job'
     ignore_read_extra:
       - 'deletion_protection'
+  - name: 'cloudrunv2_job_emptydir_disk'
+    primary_resource_id: 'default'
+    vars:
+      cloud_run_job_name: 'cloudrun-job'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      'deletion_protection': 'false'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'cloudrunv2_job_run_job'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -639,6 +648,7 @@ properties:
                       default_value: "MEMORY"
                       enum_values:
                         - 'MEMORY'
+                        - 'DISK'
                     - name: 'sizeLimit'
                       type: String
                       description: |-

--- a/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir_disk.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_job_emptydir_disk.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.Vars "cloud_run_job_name"}}"
+  location = "us-central1"
+  launch_stage = "BETA"
+  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+	volume_mounts {
+	  name = "empty-dir-volume"
+	  mount_path = "/mnt"
+	}
+      }
+      volumes {
+        name = "empty-dir-volume"
+	empty_dir {
+	  medium = "DISK"
+	  size_limit = "10Gi"
+	}
+      }
+    }
+  }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `DISK` fields to `google_cloud_run_v2_job` resource
```

Fixes: b/504657179
