### PR TITLE
feat: Add support for the emptyDir DISK medium for cloudrunv2 workerpool

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -114,6 +114,15 @@ examples:
       - 'deletion_protection'
     # Currently failing
     skip_vcr: true
+  - name: 'cloudrunv2_worker_pool_emptydir_disk'
+    primary_resource_id: 'default'
+    vars:
+      cloud_run_worker_pool_name: 'cloudrun-worker-pool'
+      deletion_protection: 'true'
+    test_vars_overrides:
+      'deletion_protection': 'false'
+    ignore_read_extra:
+      - 'deletion_protection'
   - name: 'cloudrunv2_worker_pool_mount_nfs'
     primary_resource_id: 'default'
     vars:
@@ -726,6 +735,7 @@ properties:
                   default_value: "MEMORY"
                   enum_values:
                     - 'MEMORY'
+                    - 'DISK'
                 - name: 'sizeLimit'
                   type: String
                   description: |-

--- a/mmv1/templates/terraform/examples/cloudrunv2_worker_pool_emptydir_disk.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_worker_pool_emptydir_disk.tf.tmpl
@@ -1,0 +1,28 @@
+resource "google_cloud_run_v2_worker_pool" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.Vars "cloud_run_worker_pool_name"}}"
+  location     = "us-central1"
+  launch_stage = "BETA"
+  deletion_protection =  "{{index $.Vars "deletion_protection"}}"
+
+  template {
+    containers {
+        image = "us-docker.pkg.dev/cloudrun/container/worker-pool"
+        volume_mounts {
+            name = "empty-dir-volume"
+            mount_path = "/mnt"
+        }
+    }
+    volumes {
+        name = "empty-dir-volume"
+        empty_dir {
+            medium = "DISK"
+            size_limit = "10Gi"
+        }
+      }
+  }
+  lifecycle {
+    ignore_changes = [
+      launch_stage,
+    ]
+  }
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
cloudrunv2: added `DISK` fields to `google_cloud_run_v2_worker_pool` resource
```
 Fixed: b/505090254