### PR TITLE
Added validation to non-PF custom endpoints

### DIFF
--- a/mmv1/third_party/terraform/transport/provider_handwritten_endpoint.go
+++ b/mmv1/third_party/terraform/transport/provider_handwritten_endpoint.go
@@ -67,32 +67,37 @@ var ContainerAzureCustomEndpointEntry = &schema.Schema{
 }
 var ApikeysEndpointEntryKey = "apikeys_custom_endpoint"
 var ApikeysEndpointEntry = &schema.Schema{
-	Type:     schema.TypeString,
-	Optional: true,
+	Type:         schema.TypeString,
+	Optional:     true,
+	ValidateFunc: ValidateCustomEndpoint,
 }
 
 var AssuredWorkloadsEndpointEntryKey = "assured_workloads_custom_endpoint"
 var AssuredWorkloadsEndpointEntry = &schema.Schema{
-	Type:     schema.TypeString,
-	Optional: true,
+	Type:         schema.TypeString,
+	Optional:     true,
+	ValidateFunc: ValidateCustomEndpoint,
 }
 
 var CloudResourceManagerEndpointEntryKey = "cloud_resource_manager_custom_endpoint"
 var CloudResourceManagerEndpointEntry = &schema.Schema{
-	Type:     schema.TypeString,
-	Optional: true,
+	Type:         schema.TypeString,
+	Optional:     true,
+	ValidateFunc: ValidateCustomEndpoint,
 }
 
 var FirebaserulesEndpointEntryKey = "firebaserules_custom_endpoint"
 var FirebaserulesEndpointEntry = &schema.Schema{
-	Type:     schema.TypeString,
-	Optional: true,
+	Type:         schema.TypeString,
+	Optional:     true,
+	ValidateFunc: ValidateCustomEndpoint,
 }
 
 var RecaptchaEnterpriseEndpointEntryKey = "recaptcha_enterprise_custom_endpoint"
 var RecaptchaEnterpriseEndpointEntry = &schema.Schema{
-	Type:     schema.TypeString,
-	Optional: true,
+	Type:         schema.TypeString,
+	Optional:     true,
+	ValidateFunc: ValidateCustomEndpoint,
 }
 
 func ValidateCustomEndpoint(v interface{}, k string) (ws []string, errors []error) {


### PR DESCRIPTION
This validation already happens on the plugin-framework side, so this shouldn't be a breaking change.

I tested this locally by removing the PF validation for `recaptcha_enterprise_custom_endpoint` and then re-adding it; despite that being an MMv1 (well, DCL) resource, the PF provider validation does catch the problem.

This is basically just cleanup to make it more clear what's happening (so that when these fields are added via the registry, the conversion easier to understand / track.)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
