### PR TITLE
Migrate resource_compute_instance_group.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group.go.tmpl
@@ -132,10 +132,11 @@ func ResourceComputeInstanceGroup() *schema.Resource {
 	}
 }
 
-func getInstanceReferences(instanceUrls []string) (refs []*compute.InstanceReference) {
+func getInstanceReferences(instanceUrls []string) []interface{} {
+	var refs []interface{}
 	for _, v := range instanceUrls {
-		refs = append(refs, &compute.InstanceReference{
-			Instance: v,
+		refs = append(refs, map[string]interface{}{
+			"instance": v,
 		})
 	}
 	return refs
@@ -169,26 +170,36 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	name := d.Get("name").(string)
 
 	// Build the parameter
-	instanceGroup := &compute.InstanceGroup{
-		Name: name,
+	instanceGroup := map[string]interface{}{
+		"name": name,
 	}
 
 	// Set optional fields
 	if v, ok := d.GetOk("description"); ok {
-		instanceGroup.Description = v.(string)
+		instanceGroup["description"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("named_port"); ok {
-		instanceGroup.NamedPorts = getNamedPorts(v.([]interface{}))
+		instanceGroup["namedPorts"] = getNamedPorts(v.([]interface{}))
 	}
 
 	if v, ok := d.GetOk("network"); ok {
-		instanceGroup.Network = v.(string)
+		instanceGroup["network"] = v.(string)
 	}
 
 	log.Printf("[DEBUG] InstanceGroup insert request: %#v", instanceGroup)
-	op, err := config.NewComputeClient(userAgent).InstanceGroups.Insert(
-		project, zone, instanceGroup).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroups")
+	if err != nil {
+		return fmt.Errorf("Error creating InstanceGroup: %s", err)
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      instanceGroup,
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating InstanceGroup: %s", err)
 	}
@@ -197,7 +208,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", project, zone, name))
 
 	// Wait for the operation to complete
-	err = ComputeOperationWaitTime(config, op, project, "Creating InstanceGroup", userAgent, d.Timeout(schema.TimeoutCreate))
+	err = ComputeOperationWaitTime(config, res, project, "Creating InstanceGroup", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -219,19 +230,29 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 			}
 		}
 
-		addInstanceReq := &compute.InstanceGroupsAddInstancesRequest{
-			Instances: getInstanceReferences(instanceUrls),
+		addInstanceReq := map[string]interface{}{
+			"instances": getInstanceReferences(instanceUrls),
 		}
 
 		log.Printf("[DEBUG] InstanceGroup add instances request: %#v", addInstanceReq)
-		op, err := config.NewComputeClient(userAgent).InstanceGroups.AddInstances(
-			project, zone, name, addInstanceReq).Do()
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroups/{{"{{"}}name{{"}}"}}/addInstances")
+		if err != nil {
+			return err
+		}
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      addInstanceReq,
+		})
 		if err != nil {
 			return fmt.Errorf("Error adding instances to InstanceGroup: %s", err)
 		}
 
 		// Wait for the operation to complete
-		err = ComputeOperationWaitTime(config, op, project, "Adding instances to InstanceGroup", userAgent, d.Timeout(schema.TimeoutCreate))
+		err = ComputeOperationWaitTime(config, res, project, "Adding instances to InstanceGroup", userAgent, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return err
 		}
@@ -259,18 +280,77 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	name := d.Get("name").(string)
 
 	// retrieve instance group
-	instanceGroup, err := config.NewComputeClient(userAgent).InstanceGroups.Get(
-		project, zone, name).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroups/{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance Group %q", name))
 	}
 
+	instanceGroup := &struct {
+		Description string
+		Network     string
+		Size        int64
+		SelfLink    string
+		NamedPorts  []*compute.NamedPort
+	}{}
+	if v, ok := res["description"].(string); ok {
+		instanceGroup.Description = v
+	}
+	if v, ok := res["network"].(string); ok {
+		instanceGroup.Network = v
+	}
+	if v, ok := res["selfLink"].(string); ok {
+		instanceGroup.SelfLink = v
+	}
+	if v, ok := res["size"].(float64); ok {
+		instanceGroup.Size = int64(v)
+	}
+	if rawPorts, ok := res["namedPorts"].([]interface{}); ok {
+		for _, rawPort := range rawPorts {
+			if p, ok := rawPort.(map[string]interface{}); ok {
+				port := &compute.NamedPort{}
+				if v, ok := p["name"].(string); ok {
+					port.Name = v
+				}
+				if v, ok := p["port"].(float64); ok {
+					port.Port = int64(v)
+				}
+				instanceGroup.NamedPorts = append(instanceGroup.NamedPorts, port)
+			}
+		}
+	}
+
 	// retrieve instance group members
 	var memberUrls []string
-	members, err := config.NewComputeClient(userAgent).InstanceGroups.ListInstances(
-		project, zone, name, &compute.InstanceGroupsListInstancesRequest{
-			InstanceState: "ALL",
-		}).Do()
+	url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroups/{{"{{"}}name{{"}}"}}/listInstances")
+	if err != nil {
+		return err
+	}
+	reqBody := map[string]interface{}{
+		"instanceState": "ALL",
+	}
+	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      reqBody,
+	})
+	var members struct {
+		Items []struct {
+			Instance string
+		}
+	}
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't have any instances
@@ -282,6 +362,17 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error reading InstanceGroup Members: %s", err)
 		}
 	} else {
+		if rawItems, ok := resp["items"].([]interface{}); ok {
+			for _, rawItem := range rawItems {
+				if m, ok := rawItem.(map[string]interface{}); ok {
+					if instance, ok := m["instance"].(string); ok {
+						members.Items = append(members.Items, struct {
+							Instance string
+						}{Instance: instance})
+					}
+				}
+			}
+		}
 		for _, member := range members.Items {
 			memberUrls = append(memberUrls, member.Instance)
 		}
@@ -354,13 +445,24 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 		add, remove := tpgresource.CalcAddRemove(from, to)
 
 		if len(remove) > 0 {
-			removeReq := &compute.InstanceGroupsRemoveInstancesRequest{
-				Instances: getInstanceReferences(remove),
+			removeReq := map[string]interface{}{
+				"instances": getInstanceReferences(remove),
 			}
 
 			log.Printf("[DEBUG] InstanceGroup remove instances request: %#v", removeReq)
-			removeOp, err := config.NewComputeClient(userAgent).InstanceGroups.RemoveInstances(
-				project, zone, name, removeReq).Do()
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+			if err != nil {
+				return err
+			}
+			url = fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s/removeInstances", url, project, zone, name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      removeReq,
+			})
 			if err != nil {
 				if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 					log.Printf("[WARN] Instances already removed from InstanceGroup: %s", remove)
@@ -369,7 +471,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 				}
 			} else {
 				// Wait for the operation to complete
-				err = ComputeOperationWaitTime(config, removeOp, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
+				err = ComputeOperationWaitTime(config, res, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return err
 				}
@@ -378,19 +480,30 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 
 		if len(add) > 0 {
 
-			addReq := &compute.InstanceGroupsAddInstancesRequest{
-				Instances: getInstanceReferences(add),
+			addReq := map[string]interface{}{
+				"instances": getInstanceReferences(add),
 			}
 
 			log.Printf("[DEBUG] InstanceGroup adding instances request: %#v", addReq)
-			addOp, err := config.NewComputeClient(userAgent).InstanceGroups.AddInstances(
-				project, zone, name, addReq).Do()
+			url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+			if err != nil {
+				return err
+			}
+			url = fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s/addInstances", url, project, zone, name)
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   project,
+				RawURL:    url,
+				UserAgent: userAgent,
+				Body:      addReq,
+			})
 			if err != nil {
 				return fmt.Errorf("Error adding instances from InstanceGroup: %s", err)
 			}
 
 			// Wait for the operation to complete
-			err = ComputeOperationWaitTime(config, addOp, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
+			err = ComputeOperationWaitTime(config, res, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return err
 			}
@@ -400,18 +513,29 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("named_port") {
 		namedPorts := getNamedPorts(d.Get("named_port").([]interface{}))
 
-		namedPortsReq := &compute.InstanceGroupsSetNamedPortsRequest{
-			NamedPorts: namedPorts,
+		namedPortsReq := map[string]interface{}{
+			"namedPorts": namedPorts,
 		}
 
 		log.Printf("[DEBUG] InstanceGroup updating named ports request: %#v", namedPortsReq)
-		op, err := config.NewComputeClient(userAgent).InstanceGroups.SetNamedPorts(
-			project, zone, name, namedPortsReq).Do()
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+		if err != nil {
+			return err
+		}
+		url = fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s/setNamedPorts", url, project, zone, name)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      namedPortsReq,
+		})
 		if err != nil {
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
 		}
 
-		err = ComputeOperationWaitTime(config, op, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
+		err = ComputeOperationWaitTime(config, res, project, "Updating InstanceGroup", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -439,12 +563,23 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	name := d.Get("name").(string)
-	op, err := config.NewComputeClient(userAgent).InstanceGroups.Delete(project, zone, name).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s", url, project, zone, name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}
 
-	err = ComputeOperationWaitTime(config, op, project, "Deleting InstanceGroup", userAgent, d.Timeout(schema.TimeoutDelete))
+	err = ComputeOperationWaitTime(config, res, project, "Deleting InstanceGroup", userAgent, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: Migrate `resource_compute_instance_group.go.tmpl` resource to use direct HTTP rather then a client library
```
