### PR TITLE
`resourceIdentity`: log error on missing identity()

### DIFF
--- a/mmv1/third_party/terraform/tpgresource/list_resource.go
+++ b/mmv1/third_party/terraform/tpgresource/list_resource.go
@@ -168,11 +168,11 @@ func SetResourceIdentityAttributes(d *schema.ResourceData, attrs map[string]inte
 	identity, err := d.Identity()
 	if err != nil || identity == nil {
 		log.Printf("[DEBUG] SetResourceIdentityAttributes: skipping, identity unavailable: %v", err)
-		return nil
-	}
-	for k, v := range attrs {
-		if err := identity.Set(k, v); err != nil {
-			return fmt.Errorf("error setting identity field %q: %w", k, err)
+	} else {
+		for k, v := range attrs {
+			if err := identity.Set(k, v); err != nil {
+				return fmt.Errorf("error setting identity field %q: %w", k, err)
+			}
 		}
 	}
 	return nil

--- a/mmv1/third_party/terraform/tpgresource/list_resource.go
+++ b/mmv1/third_party/terraform/tpgresource/list_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/list"
 	listschema "github.com/hashicorp/terraform-plugin-framework/list/schema"
@@ -165,8 +166,9 @@ func (listR *ListResourceMetadata) GetLocation(override types.String) string {
 
 func SetResourceIdentityAttributes(d *schema.ResourceData, attrs map[string]interface{}) error {
 	identity, err := d.Identity()
-	if err != nil {
-		return fmt.Errorf("error getting identity: %w", err)
+	if err != nil || identity == nil {
+		log.Printf("[DEBUG] SetResourceIdentityAttributes: skipping, identity unavailable: %v", err)
+		return nil
 	}
 	for k, v := range attrs {
 		if err := identity.Set(k, v); err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We started running into test failures for [TestAccDataSourceGoogleProjectService_basic](https://hashicorp.teamcity.com/test/-670599146253252213?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&expandedTest=build%3A%28id%3A650097%29%2Cid%3A2000000030) which outputted:
```
Error: error getting identity: Resource does not have Identity schema. Please set one in order to use Identity(). This is always a problem in the provider code.
```

This is due to the same read being shared between resources and data-sources, since data sources do not support identity they are expected to not have identity called. To mitigate this the error from `SetResourceIdentityAttributes` is instead logged rather than returning to the caller method (in this case would be Read)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
