### PR TITLE
Add autoUpgradeConfig field to RolloutSequence resource.

### DIFF
--- a/mmv1/products/gkehub2/RolloutSequence.yaml
+++ b/mmv1/products/gkehub2/RolloutSequence.yaml
@@ -130,3 +130,30 @@ properties:
           type: String
           description: |
             Soak time after upgrading all the clusters in the stage, specified in seconds.
+  - name: 'autoUpgradeConfig'
+    type: NestedObject
+    description: |
+      Configuration for automatic upgrades.
+      If not specified, the system applies default behavior.
+    properties:
+      - name: 'rolloutCreationScope'
+        type: NestedObject
+        description: |
+          Specifies the scope of automation for the creation of rollouts.
+          Represents the types of rollouts (version upgrades) the sequence should
+          initiate automatically.
+          If this field is not specified, it defaults to all types.
+          If this field is specified, but the nested upgradeTypes field is empty,
+          most automatic rollouts are disabled for this sequence.
+          Exceptions are rollouts enforcing our security policies (e.g. such as
+          end-of-support and outdated control plane patch enforcements).
+          These policy enforcements cannot be disabled.
+        properties:
+          - name: 'upgradeTypes'
+            type: Array
+            is_set: true
+            description: |
+              The list of enabled upgrade types.
+              Current valid values are `CONTROL_PLANE_MINOR`, `CONTROL_PLANE_PATCH`, `NODE_MINOR`, and `NODE_PATCH`.
+            item_type:
+              type: String

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_rollout_sequence_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_rollout_sequence_test.go.tmpl
@@ -87,6 +87,16 @@ resource "google_gke_hub_rollout_sequence" "rollout_sequence" {
     fleet_projects = ["projects/%{project_id}"]
     soak_duration  = "60s"
   }
+  auto_upgrade_config {
+    rollout_creation_scope {
+      upgrade_types = [
+        "CONTROL_PLANE_MINOR",
+        "CONTROL_PLANE_PATCH",
+        "NODE_MINOR",
+        "NODE_PATCH"
+      ]
+    }
+  }
 }
 `, context)
 }
@@ -110,6 +120,14 @@ resource "google_gke_hub_rollout_sequence" "rollout_sequence" {
   stages {
         fleet_projects = ["projects/%{project_id}"]
         soak_duration  = "60s"
+  }
+  auto_upgrade_config {
+    rollout_creation_scope {
+      upgrade_types = [
+        "CONTROL_PLANE_PATCH",
+        "NODE_PATCH"
+      ]
+    }
   }
   labels = {
     some_key = "some_value"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27024

`AutoUpgradeConfig` field has been added to the Rollout Sequence resource, this should be reflected in Terraform.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
gkehub: added `auto_upgrade_config` field to `google_gke_hub_rollout_sequence` resource (beta)
```
