### PR TITLE
feat: expose the numeric id attribute as generated_id for RegionNetworkEndpointGroup

### DIFF
--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -147,6 +147,12 @@ properties:
     description: |
       An optional description of this resource. Provide this property when
       you create the resource.
+  - name: 'generated_id'
+    type: Integer
+    api_name: 'id'
+    output: true
+    description: |
+      The uniquely generated identifier for the resource. This identifier is defined by the server.
   - name: 'networkEndpointType'
     type: Enum
     description: |

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_network_endpoint_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_region_network_endpoint_group_test.go
@@ -22,7 +22,11 @@ func TestAccDataSourceRegionNetworkEndpointGroup_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceRegionNetworkEndpointGroup_basic(context),
-				Check:  acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_compute_region_network_endpoint_group.cloudrun_neg", "google_compute_region_network_endpoint_group.cloudrun_neg", []string{"name", "region"}),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores("data.google_compute_region_network_endpoint_group.cloudrun_neg", "google_compute_region_network_endpoint_group.cloudrun_neg", []string{"name", "region"}),
+					resource.TestCheckResourceAttrSet("data.google_compute_region_network_endpoint_group.cloudrun_neg", "generated_id"),
+					resource.TestCheckResourceAttrSet("google_compute_region_network_endpoint_group.cloudrun_neg", "generated_id"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
This exposes the server generated id for `google_compute_region_network_endpoint_group` as `generated_id`, similar to `google_compute_network_endpoint_group`.

Fixes b/434706584
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23672

```release-note:enhancement
compute: added `generated_id` attribute to `google_compute_region_network_endpoint_group`
```