### PR TITLE
feat: expose configId output field in google_discovery_engine_widget_config

### DIFF
--- a/mmv1/products/discoveryengine/WidgetConfig.yaml
+++ b/mmv1/products/discoveryengine/WidgetConfig.yaml
@@ -71,6 +71,10 @@ properties:
       The full resource name of the widget config. Format:
       `projects/{project}/locations/{location}/collections/{collection_id}/engines/{engine_id}/widgetConfigs/{widget_config_id}`.
     output: true
+  - name: 'configId'
+    type: String
+    description: 'Output only. Unique obfuscated identifier of a WidgetConfig.'
+    output: true
   - name: 'accessSettings'
     type: NestedObject
     description: 'Describes widget access settings.'

--- a/mmv1/templates/terraform/examples/discoveryengine_widgetconfig_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_widgetconfig_basic.tf.tmpl
@@ -36,3 +36,7 @@ resource "google_discovery_engine_widget_config" "basic" {
     }
   }
 }
+
+output "widget_config_id" {
+  value = google_discovery_engine_widget_config.basic.config_id
+}


### PR DESCRIPTION
This exposes the config_id of the widget config as output only.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27047

```release-note:enhancement
discoveryengine: added `config_id` attribute to `google_discovery_engine_widget_config`
```
