### PR TITLE
Feat: add support to advanced options config on google compute organization security policy

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -47,6 +47,13 @@ examples:
       short_name: "my-short-name"
     test_env_vars:
       org_id: 'ORG_ID'
+  - name: 'organization_security_policy_with_advanced_options'
+    primary_resource_id: 'policy'
+    min_version: "beta"
+    vars:
+      sec_policy_name: 'policy'
+    test_env_vars:
+      org_id: 'ORG_ID'
 parameters:
   - name: 'parent'
     type: String
@@ -97,3 +104,49 @@ properties:
       - 'CLOUD_ARMOR_EDGE'
       - 'CLOUD_ARMOR_INTERNAL_SERVICE'
       - 'CLOUD_ARMOR_NETWORK'
+  - name: 'advancedOptionsConfig'
+    type: NestedObject
+    description: |
+      Additional options for this security policy.
+    properties:
+      - name: 'jsonParsing'
+        type: Enum
+        description: |
+          JSON body parsing. Supported values include: "DISABLED", "STANDARD", "STANDARD_WITH_GRAPHQL".
+        enum_values:
+          - 'DISABLED'
+          - 'STANDARD'
+          - 'STANDARD_WITH_GRAPHQL'
+      - name: 'jsonCustomConfig'
+        type: NestedObject
+        description: 'Custom JSON parsing configurations.'
+        properties:
+          - name: 'contentTypes'
+            type: Array
+            item_type: 
+              type: String
+            description: 'A list of content types to be parsed as JSON.'
+      - name: 'logLevel'
+        type: Enum
+        description: 'Logging level. Supported values include: "NORMAL", "VERBOSE".'
+        enum_values:
+          - 'NORMAL'
+          - 'VERBOSE'
+      - name: 'userIpRequestHeaders'
+        type: Array
+        item_type: 
+          type: String
+        description: 'An optional list of case-insensitive request header names to use for resolving the client source IP address.'
+        is_set: true
+      - name: requestBodyInspectionSize
+        type: Enum
+        description: |
+          The maximum request size chosen by the customer with Waf enabled. Values supported are "8KB", "16KB, "32KB", "48KB" and "64KB".
+          Values are case insensitive.
+        enum_values:
+          - "8KB"
+          - "16KB"
+          - "32KB"
+          - "48KB"
+          - "64KB"
+        min_version: "beta"

--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -123,7 +123,7 @@ properties:
         properties:
           - name: 'contentTypes'
             type: Array
-            item_type: 
+            item_type:
               type: String
             description: 'A list of content types to be parsed as JSON.'
       - name: 'logLevel'
@@ -134,7 +134,7 @@ properties:
           - 'VERBOSE'
       - name: 'userIpRequestHeaders'
         type: Array
-        item_type: 
+        item_type:
           type: String
         description: 'An optional list of case-insensitive request header names to use for resolving the client source IP address.'
         is_set: true
@@ -150,3 +150,4 @@ properties:
           - "48KB"
           - "64KB"
         min_version: "beta"
+        

--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -150,4 +150,3 @@ properties:
           - "48KB"
           - "64KB"
         min_version: "beta"
-        

--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -49,7 +49,6 @@ examples:
       org_id: 'ORG_ID'
   - name: 'organization_security_policy_with_advanced_options'
     primary_resource_id: 'policy'
-    min_version: "beta"
     vars:
       sec_policy_name: 'policy'
     test_env_vars:

--- a/mmv1/products/compute/OrganizationSecurityPolicy.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicy.yaml
@@ -126,6 +126,8 @@ properties:
             item_type:
               type: String
             description: 'A list of content types to be parsed as JSON.'
+            is_set: true
+            required: true
       - name: 'logLevel'
         type: Enum
         description: 'Logging level. Supported values include: "NORMAL", "VERBOSE".'
@@ -138,10 +140,10 @@ properties:
           type: String
         description: 'An optional list of case-insensitive request header names to use for resolving the client source IP address.'
         is_set: true
-      - name: requestBodyInspectionSize
+      - name: 'requestBodyInspectionSize'
         type: Enum
         description: |
-          The maximum request size chosen by the customer with Waf enabled. Values supported are "8KB", "16KB, "32KB", "48KB" and "64KB".
+          The maximum request size chosen by the customer with Waf enabled. Values supported are "8KB", "16KB", "32KB", "48KB" and "64KB".
           Values are case insensitive.
         enum_values:
           - "8KB"
@@ -149,4 +151,3 @@ properties:
           - "32KB"
           - "48KB"
           - "64KB"
-        min_version: "beta"

--- a/mmv1/templates/terraform/examples/organization_security_policy_with_advanced_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/organization_security_policy_with_advanced_options.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_compute_organization_security_policy" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  short_name = "{{index $.Vars "sec_policy_name"}}"
+  parent       = "organizations/{{index $.TestEnvVars "org_id"}}"
+  type         = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD_WITH_GRAPHQL"
+    log_level    = "VERBOSE"
+    
+    json_custom_config {
+      content_types = ["application/vnd.api+json"]
+    }
+
+    user_ip_request_headers     = ["X-Forwarded-For"]
+    request_body_inspection_size = "64KB"
+  }
+}

--- a/mmv1/templates/terraform/examples/organization_security_policy_with_advanced_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/organization_security_policy_with_advanced_options.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_organization_security_policy" "{{$.PrimaryResourceId}}" {
-  provider    = google-beta
   short_name = "{{index $.Vars "sec_policy_name"}}"
   parent       = "organizations/{{index $.TestEnvVars "org_id"}}"
   type         = "CLOUD_ARMOR"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_organization_security_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_organization_security_policy_test.go
@@ -68,6 +68,75 @@ func TestAccComputeOrganizationSecurityPolicy_organizationSecurityPolicyShortNam
 	})
 }
 
+func TestAccComputeOrganizationSecurityPolicy_advancedOptionsConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeOrganizationSecurityPolicyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeOrganizationSecurityPolicy_advancedOptionsConfigPreUpdate(context),
+			},
+			{
+				Config: testAccComputeOrganizationSecurityPolicy_advancedOptionsConfigPostUpdate(context),
+			},
+			{
+				ResourceName:            "google_compute_organization_security_policy.policy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"display_name", "parent"},
+			},
+		},
+	})
+}
+
+func testAccComputeOrganizationSecurityPolicy_advancedOptionsConfigPreUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_organization_security_policy" "policy" {
+  short_name = "tf-test%{random_suffix}"
+  parent     = "organizations/%{org_id}"
+  type       = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD"
+    log_level    = "NORMAL"
+
+    user_ip_request_headers      = ["X-Forwarded-For"]
+    request_body_inspection_size = "8KB"
+  }
+}
+`, context)
+}
+
+func testAccComputeOrganizationSecurityPolicy_advancedOptionsConfigPostUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_organization_security_policy" "policy" {
+  short_name = "tf-test%{random_suffix}"
+  parent     = "organizations/%{org_id}"
+  type       = "CLOUD_ARMOR"
+
+  advanced_options_config {
+    json_parsing = "STANDARD_WITH_GRAPHQL"
+    log_level    = "VERBOSE"
+
+    json_custom_config {
+      content_types = ["application/vnd.api+json"]
+    }
+
+    user_ip_request_headers      = ["X-Forwarded-For", "True-Client-IP"]
+    request_body_inspection_size = "64KB"
+  }
+}
+`, context)
+}
+
 func testAccComputeOrganizationSecurityPolicy_organizationSecurityPolicyPreUpdateExample(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_compute_organization_security_policy" "policy" {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Hello Folks, this PR is to create a support to advanced_options_config field on google_compute_organization_security_policy resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `advanced_options_config` field on `google_compute_organization_security_policy` resource
```
