### PR TITLE
Revert "Fix Tag Key Import Issue from issue #20073"

### DIFF
--- a/mmv1/products/tags/TagKey.yaml
+++ b/mmv1/products/tags/TagKey.yaml
@@ -125,6 +125,7 @@ properties:
 
       Purpose data corresponds to the policy system that the tag is intended for. For example, the GCE_FIREWALL purpose expects data in the following format: `network = "<project-name>/<vpc-name>"`.
     immutable: true
+    ignore_read: true
   - name: 'allowedValuesRegex'
     type: String
     description: |


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#17196

This causes a diff like the following:

```
              ~ purpose_data         = { # forces replacement
                  ~ "organization" = "1234567890" -> "auto"
                }
```

```release-note:bug
google_tags_tag_key: remove ignore_read: true from purposeData to fix issue #20073 (revert)
```