### PR TITLE
Auto assign team test ticket to release shepherd

### DIFF
--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -3,7 +3,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: create-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["GITHUB_TOKEN", "SPREADSHEET_ID"]
+      secretEnv: ["GITHUB_TOKEN", "SPREADSHEET_ID", "GCB_TICKET_CREATION_SERVICE_ACCOUNT"]
       args:
         - 'create-test-failure-ticket'
     # - name: 'gcr.io/graphite-docker-images/go-plus'
@@ -25,3 +25,6 @@ availableSecrets:
       env: GITHUB_TOKEN
     - versionName: projects/673497134629/secrets/release-shepherd-spreadsheet-id/versions/latest
       env: SPREADSHEET_ID
+    - versionName: projects/673497134629/secrets/gcb-ticket-creation-service-account/versions/latest
+      env: GCB_TICKET_CREATION_SERVICE_ACCOUNT
+      

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -6,13 +6,13 @@ steps:
       secretEnv: ["GITHUB_TOKEN", "SPREADSHEET_ID", "GCB_TICKET_CREATION_SERVICE_ACCOUNT"]
       args:
         - 'create-test-failure-ticket'
-    # - name: 'gcr.io/graphite-docker-images/go-plus'
-    #   id: manage-test-failure-ticket
-    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-    #   secretEnv: ["GITHUB_TOKEN"]
-    #   waitFor: ["create-test-failure-ticket"]
-    #   args:
-    #     - 'manage-test-failure-ticket'
+    - name: 'gcr.io/graphite-docker-images/go-plus'
+      id: manage-test-failure-ticket
+      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["create-test-failure-ticket"]
+      args:
+        - 'manage-test-failure-ticket'
 
 timeout: 3600s
 options:

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -3,16 +3,16 @@ steps:
     - name: 'gcr.io/graphite-docker-images/go-plus'
       id: create-test-failure-ticket
       entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["GITHUB_TOKEN"]
+      secretEnv: ["GITHUB_TOKEN", "SPREADSHEET_ID"]
       args:
         - 'create-test-failure-ticket'
-    - name: 'gcr.io/graphite-docker-images/go-plus'
-      id: manage-test-failure-ticket
-      entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
-      secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["create-test-failure-ticket"]
-      args:
-        - 'manage-test-failure-ticket'
+    # - name: 'gcr.io/graphite-docker-images/go-plus'
+    #   id: manage-test-failure-ticket
+    #   entrypoint: '/workspace/.ci/scripts/go-plus/magician/exec.sh'
+    #   secretEnv: ["GITHUB_TOKEN"]
+    #   waitFor: ["create-test-failure-ticket"]
+    #   args:
+    #     - 'manage-test-failure-ticket'
 
 timeout: 3600s
 options:

--- a/.ci/gcb-test-failure-ticket.yaml
+++ b/.ci/gcb-test-failure-ticket.yaml
@@ -23,3 +23,5 @@ availableSecrets:
   secretManager:
     - versionName: projects/673497134629/secrets/github-classic--repo-workflow/versions/latest
       env: GITHUB_TOKEN
+    - versionName: projects/673497134629/secrets/release-shepherd-spreadsheet-id/versions/latest
+      env: SPREADSHEET_ID

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -495,18 +495,15 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		Milestone: github.Int(11),
 	}
 
+	// Only assign to shepherd if it's a terraform team owned ticket
 	if IsTerraformTeamOwned(testFailure) && shepherd != "" {
 		issueRquest.Assignee = github.String(shepherd)
 	}
 
-	fmt.Printf("Issue Title: %s\n", *issueRquest.Title)
-	fmt.Printf("release shepherd: %s\n", shepherd)
-	fmt.Printf("ticket labels: %s\n", ticketLabels)
-
-	// _, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
-	// if err != nil {
-	// 	return fmt.Errorf("error creating issue: %w", err)
-	// }
+	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
+	if err != nil {
+		return fmt.Errorf("error creating issue: %w", err)
+	}
 	return nil
 }
 

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -33,6 +33,9 @@ import (
 	"github.com/GoogleCloudPlatform/magic-modules/tools/issue-labeler/labeler"
 
 	_ "embed"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
 )
 
 var (
@@ -48,6 +51,8 @@ const (
 
 var ctftRequiredEnvironmentVariables = [...]string{
 	"GITHUB_TOKEN",
+	"SA_CREDENTIALS",
+	"SPREADSHEET_ID",
 }
 
 type testFailureRateLabel int64
@@ -130,7 +135,12 @@ var createTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		return execCreateTestFailureTicket(date, gh, gcs)
+		shepherd, err := getReleaseShepherd(context.Background(), env["SA_CREDENTIALS"], env["SPREADSHEET_ID"], date)
+		if err != nil {
+			return fmt.Errorf("failed to get release shepherd: %w", err)
+		}
+
+		return execCreateTestFailureTicket(date, gh, gcs, shepherd)
 	},
 }
 
@@ -142,7 +152,7 @@ func listCTFTRequiredEnvironmentVariables() string {
 	return result
 }
 
-func execCreateTestFailureTicket(now time.Time, gh *github.Client, gcs CloudstorageClient) error {
+func execCreateTestFailureTicket(now time.Time, gh *github.Client, gcs CloudstorageClient, shepherd string) error {
 	ctx := context.Background()
 
 	gaTestFailuresMap := make(map[string][]bool)
@@ -182,7 +192,7 @@ func execCreateTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 	// Create tickets
 	for _, testFailure := range testFailuresToday {
 		if shouldCreateTicket(testFailure, existTestNames, closedTestNames) {
-			err := createTicket(ctx, gh, testFailure)
+			err := createTicket(ctx, gh, testFailure, shepherd)
 			if err != nil {
 				return fmt.Errorf("error creating test failure ticket: %w", err)
 			}
@@ -463,7 +473,7 @@ func computeTicketLabels(testFailure *testFailure) ([]string, error) {
 	return ticketLabels, nil
 }
 
-func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailure) error {
+func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailure, shepherd string) error {
 	issueTitle := fmt.Sprintf("Failing test(s): %s", testFailure.TestName)
 	issueBody, err := formatIssueBody(*testFailure)
 	if err != nil {
@@ -482,6 +492,10 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		// Milestone: Near-Term Goals
 		// https://github.com/hashicorp/terraform-provider-google/milestone/11
 		Milestone: github.Int(11),
+	}
+
+	if IsTerraformTeamOwned(testFailure) && shepherd != "" {
+		issueRquest.Assignee = github.String(shepherd)
 	}
 
 	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
@@ -566,6 +580,100 @@ func storeErrorMessage(pVersion provider.Version, gcs CloudstorageClient, errorM
 	// compute object view path
 	link := fmt.Sprintf("https://storage.cloud.google.com/%s/%s", nightlyDataBucket, objectName)
 	return link, nil
+}
+
+// parseDate parses a date string in supported formats.
+func parseDate(s string) (time.Time, error) {
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse("1/2/2006", s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("could not parse date %s", s)
+}
+
+// getReleaseShepherd retrieves the current release shepherd's GitHub username from a Google Sheet.
+func getReleaseShepherd(ctx context.Context, credentialsJSON string, spreadsheetId string, now time.Time) (string, error) {
+	srv, err := sheets.NewService(ctx, option.WithCredentialsJSON([]byte(credentialsJSON)))
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve Sheets client: %w", err)
+	}
+
+	schedResp, err := srv.Spreadsheets.Values.Get(spreadsheetId, "Rotation Schedule!A:C").Do()
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve schedule: %w", err)
+	}
+
+	if len(schedResp.Values) == 0 {
+		return "", fmt.Errorf("no schedule data found")
+	}
+
+	// Look ahead to next week's rotation if it's the weekend.
+	if day := now.Weekday(); day == time.Friday {
+		now = now.AddDate(0, 0, 3)
+	} else if day == time.Saturday {
+		now = now.AddDate(0, 0, 2)
+	} else if day == time.Sunday {
+		now = now.AddDate(0, 0, 1)
+	}
+
+	var currentEmail string
+
+	// Find the latest date in the schedule that is before or equal to now.
+	for i := 1; i < len(schedResp.Values); i++ {
+		row := schedResp.Values[i]
+		if len(row) < 3 {
+			continue
+		}
+
+		dateStr := fmt.Sprintf("%v", row[0])
+		email := fmt.Sprintf("%v", row[2])
+
+		rowDate, err := parseDate(dateStr)
+		if err != nil {
+			fmt.Printf("Warning: unparsable date at row %d: %v\n", i+1, err)
+			continue
+		}
+
+		if rowDate.Before(now) || rowDate.Equal(now) {
+			currentEmail = email
+		} else {
+			break
+		}
+	}
+
+	if currentEmail == "" {
+		return "", fmt.Errorf("could not determine current rotation person")
+	}
+
+	partResp, err := srv.Spreadsheets.Values.Get(spreadsheetId, "Rotation Participants!A:C").Do()
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve participants data: %w", err)
+	}
+
+	var githubUsername string
+	// Look up GitHub username for the determined email.
+	for i := 1; i < len(partResp.Values); i++ {
+		row := partResp.Values[i]
+		if len(row) < 3 {
+			continue
+		}
+
+		username := fmt.Sprintf("%v", row[1])
+		email := fmt.Sprintf("%v", row[2])
+
+		if email == currentEmail {
+			githubUsername = username
+			break
+		}
+	}
+
+	if githubUsername == "" {
+		return "", fmt.Errorf("could not find GitHub username for email %s", currentEmail)
+	}
+
+	return githubUsername, nil
 }
 
 func init() {

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -51,7 +51,6 @@ const (
 
 var ctftRequiredEnvironmentVariables = [...]string{
 	"GITHUB_TOKEN",
-	"SA_CREDENTIALS",
 	"SPREADSHEET_ID",
 }
 
@@ -135,7 +134,7 @@ var createTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		shepherd, err := getReleaseShepherd(context.Background(), env["SA_CREDENTIALS"], env["SPREADSHEET_ID"], date)
+		shepherd, err := getReleaseShepherd(context.Background(), env["SPREADSHEET_ID"], date)
 		if err != nil {
 			return fmt.Errorf("failed to get release shepherd: %w", err)
 		}
@@ -594,8 +593,8 @@ func parseDate(s string) (time.Time, error) {
 }
 
 // getReleaseShepherd retrieves the current release shepherd's GitHub username from a Google Sheet.
-func getReleaseShepherd(ctx context.Context, credentialsJSON string, spreadsheetId string, now time.Time) (string, error) {
-	srv, err := sheets.NewService(ctx, option.WithCredentialsJSON([]byte(credentialsJSON)))
+func getReleaseShepherd(ctx context.Context, spreadsheetId string, now time.Time) (string, error) {
+	srv, err := sheets.NewService(ctx, option.WithScopes(sheets.SpreadsheetsReadonlyScope))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve Sheets client: %w", err)
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -471,7 +471,7 @@ func computeTicketRouting(testFailure *testFailure) ([]string, bool, error) {
 
 		// Fallback to terraform team and shepherd if no service label found. Also apply review label.
 		if len(labels) == 0 {
-			labels = append(labels, "service/terraform", "forward/review")
+			labels = append(labels, "service/terraform", "test/review")
 			shouldAssign = true
 		}
 	}
@@ -500,7 +500,7 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		Milestone: github.Int(11),
 	}
 
-	// Only assign to shepherd if it's a terraform team owned ticket or for forward/review tickets
+	// Only assign to shepherd if it's a terraform team owned ticket or for test/review tickets
 	if shouldAssign && shepherd != "" {
 		issueRquest.Assignee = github.String(shepherd)
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -598,7 +598,7 @@ func parseDate(s string) (time.Time, error) {
 
 // getReleaseShepherd retrieves the current release shepherd's GitHub username from a Google Sheet.
 func getReleaseShepherd(ctx context.Context, spreadsheetId string, now time.Time) (string, error) {
-	srv, err := sheets.NewService(ctx, option.WithScopes(sheets.SpreadsheetsReadonlyScope))
+	srv, err := sheets.NewService(ctx, option.WithScopes("https://www.googleapis.com/auth/cloud-platform"))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve Sheets client: %w", err)
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -506,17 +506,12 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 	// Only assign to shepherd if it's a terraform team owned ticket or for forward/review tickets
 	if shouldAssign && shepherd != "" {
 		issueRquest.Assignee = github.String(shepherd)
-		fmt.Printf("release shepherd assinged: %s\n", *issueRquest.Assignee)
 	}
 
-	fmt.Printf("Issue Title: %s\n", *issueRquest.Title)
-	fmt.Printf("release shepherd: %s\n", shepherd)
-	fmt.Printf("ticket labels: %s\n", ticketLabels)
-
-	// _, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
-	// if err != nil {
-	// 	return fmt.Errorf("error creating issue: %w", err)
-	// }
+	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
+	if err != nil {
+		return fmt.Errorf("error creating issue: %w", err)
+	}
 	return nil
 }
 

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -439,7 +439,8 @@ func ListIssuesWithOpts(ctx context.Context, gh *github.Client, opts *github.Iss
 	return allIssues, nil
 }
 
-func computeTicketLabels(testFailure *testFailure) ([]string, error) {
+// computeTicketRouting determines labels and whether to assign the ticket to the shepherd.
+func computeTicketRouting(testFailure *testFailure) ([]string, bool, error) {
 	failureRatelabel := testFailure.FailureRateLabels[provider.GA].String()
 
 	if testFailure.FailureRateLabels[provider.Beta] > testFailure.FailureRateLabels[provider.GA] {
@@ -457,24 +458,28 @@ func computeTicketLabels(testFailure *testFailure) ([]string, error) {
 		labels = append(labels, "crash")
 	}
 
+	shouldAssign := false
+
 	if IsTerraformTeamOwned(testFailure) {
-		// Apply terraform team label for team owned ticket
+		// Team-owned failures go to terraform team and shepherd.
 		labels = append(labels, "service/terraform")
+		shouldAssign = true
 	} else {
 		// Apply service labels to forward test failure ticket automatically
 		regexpLabels, err := labeler.BuildRegexLabels(labeler.EnrolledTeamsYaml)
 		if err != nil {
-			return nil, fmt.Errorf("error building regex labels: %w", err)
+			return nil, false, fmt.Errorf("error building regex labels: %w", err)
 		}
 		labels = append(labels, labeler.ComputeLabels([]string{testFailure.AffectedResource}, regexpLabels)...)
 
-		// Apply terraform team label if no service labels applied
+		// Fallback to terraform team and shepherd if no service label found. Also apply review label.
 		if len(labels) == 0 {
-			labels = append(labels, "service/terraform")
+			labels = append(labels, "service/terraform", "forward/review")
+			shouldAssign = true
 		}
 	}
 	ticketLabels = append(ticketLabels, labels...)
-	return ticketLabels, nil
+	return ticketLabels, shouldAssign, nil
 }
 
 func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailure, shepherd string) error {
@@ -484,7 +489,7 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		return fmt.Errorf("error formatting issue body: %w", err)
 	}
 
-	ticketLabels, err := computeTicketLabels(testFailure)
+	ticketLabels, shouldAssign, err := computeTicketRouting(testFailure)
 	if err != nil {
 		return fmt.Errorf("error getting ticket labels: %w", err)
 	}
@@ -498,8 +503,8 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		Milestone: github.Int(11),
 	}
 
-	// Only assign to shepherd if it's a terraform team owned ticket
-	if IsTerraformTeamOwned(testFailure) && shepherd != "" {
+	// Only assign to shepherd if it's a terraform team owned ticket or for forward/review tickets
+	if shouldAssign && shepherd != "" {
 		issueRquest.Assignee = github.String(shepherd)
 		fmt.Printf("release shepherd assinged: %s\n", *issueRquest.Assignee)
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -497,10 +497,14 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 		issueRquest.Assignee = github.String(shepherd)
 	}
 
-	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
-	if err != nil {
-		return fmt.Errorf("error creating issue: %w", err)
-	}
+	fmt.Printf("Issue Title: %s\n", *issueRquest.Title)
+	fmt.Printf("release shepherd: %s\n", shepherd)
+	fmt.Printf("ticket labels: %s\n", ticketLabels)
+
+	// _, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
+	// if err != nil {
+	// 	return fmt.Errorf("error creating issue: %w", err)
+	// }
 	return nil
 }
 

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -398,23 +398,26 @@ func failingTestNamesFromActiveIssues(ctx context.Context, gh *github.Client) ([
 }
 
 func failingTestNamesFromClosedIssuesToday(ctx context.Context, gh *github.Client, date time.Time) ([]string, error) {
-	lastday := date.AddDate(0, 0, -1)
-	opts := &github.IssueListByRepoOptions{
-		State:       "closed",
-		Labels:      []string{"test-failure"},
-		Since:       lastday,
-		ListOptions: github.ListOptions{PerPage: 100},
-	}
-	issues, err := ListIssuesWithOpts(ctx, gh, opts)
-	if err != nil {
-		return nil, err
-	}
-	tests, err := testNamesFromIssues(issues)
-	if err != nil {
-		return nil, err
-	}
+	var result []string
+	return result, nil
 
-	return tests, nil
+	// lastday := date.AddDate(0, 0, -1)
+	// opts := &github.IssueListByRepoOptions{
+	// 	State:       "closed",
+	// 	Labels:      []string{"test-failure"},
+	// 	Since:       lastday,
+	// 	ListOptions: github.ListOptions{PerPage: 100},
+	// }
+	// issues, err := ListIssuesWithOpts(ctx, gh, opts)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// tests, err := testNamesFromIssues(issues)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// return tests, nil
 }
 
 func ListIssuesWithOpts(ctx context.Context, gh *github.Client, opts *github.IssueListByRepoOptions) ([]*github.Issue, error) {
@@ -498,12 +501,17 @@ func createTicket(ctx context.Context, gh *github.Client, testFailure *testFailu
 	// Only assign to shepherd if it's a terraform team owned ticket
 	if IsTerraformTeamOwned(testFailure) && shepherd != "" {
 		issueRquest.Assignee = github.String(shepherd)
+		fmt.Printf("release shepherd assinged: %s\n", *issueRquest.Assignee)
 	}
 
-	_, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
-	if err != nil {
-		return fmt.Errorf("error creating issue: %w", err)
-	}
+	fmt.Printf("Issue Title: %s\n", *issueRquest.Title)
+	fmt.Printf("release shepherd: %s\n", shepherd)
+	fmt.Printf("ticket labels: %s\n", ticketLabels)
+
+	// _, _, err = gh.Issues.Create(ctx, GithubOwner, GithubRepo, issueRquest)
+	// if err != nil {
+	// 	return fmt.Errorf("error creating issue: %w", err)
+	// }
 	return nil
 }
 

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -398,26 +398,23 @@ func failingTestNamesFromActiveIssues(ctx context.Context, gh *github.Client) ([
 }
 
 func failingTestNamesFromClosedIssuesToday(ctx context.Context, gh *github.Client, date time.Time) ([]string, error) {
-	var result []string
-	return result, nil
+	lastday := date.AddDate(0, 0, -1)
+	opts := &github.IssueListByRepoOptions{
+		State:       "closed",
+		Labels:      []string{"test-failure"},
+		Since:       lastday,
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	issues, err := ListIssuesWithOpts(ctx, gh, opts)
+	if err != nil {
+		return nil, err
+	}
+	tests, err := testNamesFromIssues(issues)
+	if err != nil {
+		return nil, err
+	}
 
-	// lastday := date.AddDate(0, 0, -1)
-	// opts := &github.IssueListByRepoOptions{
-	// 	State:       "closed",
-	// 	Labels:      []string{"test-failure"},
-	// 	Since:       lastday,
-	// 	ListOptions: github.ListOptions{PerPage: 100},
-	// }
-	// issues, err := ListIssuesWithOpts(ctx, gh, opts)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	// tests, err := testNamesFromIssues(issues)
-	// if err != nil {
-	// 	return nil, err
-	// }
-
-	// return tests, nil
+	return tests, nil
 }
 
 func ListIssuesWithOpts(ctx context.Context, gh *github.Client, opts *github.IssueListByRepoOptions) ([]*github.Issue, error) {

--- a/.ci/magician/cmd/create_test_failure_ticket.go
+++ b/.ci/magician/cmd/create_test_failure_ticket.go
@@ -34,6 +34,7 @@ import (
 
 	_ "embed"
 
+	"google.golang.org/api/impersonate"
 	"google.golang.org/api/option"
 	"google.golang.org/api/sheets/v4"
 )
@@ -52,6 +53,7 @@ const (
 var ctftRequiredEnvironmentVariables = [...]string{
 	"GITHUB_TOKEN",
 	"SPREADSHEET_ID",
+	"GCB_TICKET_CREATION_SERVICE_ACCOUNT",
 }
 
 type testFailureRateLabel int64
@@ -134,7 +136,7 @@ var createTestFailureTicketCmd = &cobra.Command{
 		}
 		date := now.In(loc)
 
-		shepherd, err := getReleaseShepherd(context.Background(), env["SPREADSHEET_ID"], date)
+		shepherd, err := getReleaseShepherd(context.Background(), env["SPREADSHEET_ID"], env["GCB_TICKET_CREATION_SERVICE_ACCOUNT"], date)
 		if err != nil {
 			return fmt.Errorf("failed to get release shepherd: %w", err)
 		}
@@ -597,8 +599,16 @@ func parseDate(s string) (time.Time, error) {
 }
 
 // getReleaseShepherd retrieves the current release shepherd's GitHub username from a Google Sheet.
-func getReleaseShepherd(ctx context.Context, spreadsheetId string, now time.Time) (string, error) {
-	srv, err := sheets.NewService(ctx, option.WithScopes("https://www.googleapis.com/auth/cloud-platform"))
+func getReleaseShepherd(ctx context.Context, spreadsheetId string, sa string, now time.Time) (string, error) {
+	ts, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{
+		TargetPrincipal: sa,
+		Scopes:          []string{sheets.SpreadsheetsReadonlyScope},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create impersonated token source: %w", err)
+	}
+	// Initialize the Sheets service using the impersonated token source
+	srv, err := sheets.NewService(ctx, option.WithTokenSource(ts))
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve Sheets client: %w", err)
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket_test.go
+++ b/.ci/magician/cmd/create_test_failure_ticket_test.go
@@ -284,7 +284,7 @@ func TestComputeTicketRouting(t *testing.T) {
 					provider.GA: testFailure100,
 				},
 			},
-			expectLabels:   []string{"size/xs", "test-failure", "test-failure-100", "service/terraform", "forward/review"},
+			expectLabels:   []string{"size/xs", "test-failure", "test-failure-100", "service/terraform", "test/review"},
 			expectAssignee: true,
 		},
 	}

--- a/.ci/magician/cmd/create_test_failure_ticket_test.go
+++ b/.ci/magician/cmd/create_test_failure_ticket_test.go
@@ -233,10 +233,11 @@ func TestShouldCreateTicket(t *testing.T) {
 	}
 }
 
-func TestGetTicketLabels(t *testing.T) {
+func TestComputeTicketRouting(t *testing.T) {
 	cases := map[string]struct {
-		tf           testFailure
-		expectLabels []string
+		tf             testFailure
+		expectLabels   []string
+		expectAssignee bool
 	}{
 		"Team owned error": {
 			tf: testFailure{
@@ -247,7 +248,8 @@ func TestGetTicketLabels(t *testing.T) {
 					provider.GA: testFailure10,
 				},
 			},
-			expectLabels: []string{"size/xs", "test-failure", "test-failure-10", "service/terraform"},
+			expectLabels:   []string{"size/xs", "test-failure", "test-failure-10", "service/terraform"},
+			expectAssignee: true,
 		},
 		"Crash error": {
 			tf: testFailure{
@@ -258,7 +260,8 @@ func TestGetTicketLabels(t *testing.T) {
 					provider.GA: testFailure100,
 				},
 			},
-			expectLabels: []string{"size/xs", "test-failure", "test-failure-100", "service/compute-instances", "crash"},
+			expectLabels:   []string{"size/xs", "test-failure", "test-failure-100", "service/compute-instances", "crash"},
+			expectAssignee: false,
 		},
 		"Non-Team owned - has service label": {
 			tf: testFailure{
@@ -269,7 +272,8 @@ func TestGetTicketLabels(t *testing.T) {
 					provider.GA: testFailure50,
 				},
 			},
-			expectLabels: []string{"size/xs", "test-failure", "test-failure-50", "service/compute-instances"},
+			expectLabels:   []string{"size/xs", "test-failure", "test-failure-50", "service/compute-instances"},
+			expectAssignee: false,
 		},
 		"Non-Team owned - fallback label": {
 			tf: testFailure{
@@ -280,15 +284,16 @@ func TestGetTicketLabels(t *testing.T) {
 					provider.GA: testFailure100,
 				},
 			},
-			expectLabels: []string{"size/xs", "test-failure", "test-failure-100", "service/terraform"},
+			expectLabels:   []string{"size/xs", "test-failure", "test-failure-100", "service/terraform", "forward/review"},
+			expectAssignee: true,
 		},
 	}
-
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			labels, err := computeTicketLabels(&tc.tf)
+			labels, shouldAssign, err := computeTicketRouting(&tc.tf)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.expectLabels, labels)
+			assert.Equal(t, tc.expectAssignee, shouldAssign)
 		})
 	}
 }


### PR DESCRIPTION
Automatically assign team-owned test tickets to the current week's release shepherd. Weekend tickets (Fri-Sun nights) will be assigned to the following week's shepherd. Shepherd assignments and GH username are retrieved from the release shepherd rotation spreadsheet.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
