### PR TITLE
[NetworkManagement] Add gke_pod and network_type to google_network_management_connectivity_test

### DIFF
--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -56,6 +56,10 @@ examples:
     primary_resource_id: endpoints-test
     vars:
       primary_resource_name: conn-test-endpoints
+  - name: network_management_connectivity_test_gke_pod
+    primary_resource_id: pod-test
+    vars:
+      primary_resource_name: conn-test-pod
 properties:
   - name: name
     type: String
@@ -230,6 +234,16 @@ properties:
           2. When you are using Shared VPC and the IP address that you provide is
           from the service project. In this case, the network that the IP address
           resides in is defined in the host project.
+      - name: gkePod
+        type: String
+        description: A [GKE Pod](https://cloud.google.com/kubernetes-engine/docs/concepts/pod) URI.
+      - name: networkType
+        type: Enum
+        description: For source endpoints, type of the network where the endpoint is located. Not relevant for destination endpoints.
+        enum_values:
+          - GCP_NETWORK
+          - NON_GCP_NETWORK
+          - INTERNET
   - name: protocol
     type: String
     default_value: TCP

--- a/mmv1/templates/terraform/examples/network_management_connectivity_test_gke_pod.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_management_connectivity_test_gke_pod.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_network_management_connectivity_test" "{{$.PrimaryResourceId}}" {
+  name = "{{index $.Vars "primary_resource_name"}}"
+  source {
+    ip_address = "10.0.0.1"
+    project_id = "test-project"
+    network_type = "GCP_NETWORK"
+  }
+
+  destination {
+    ip_address = "10.0.0.2"
+    project_id = "test-project"
+    network_type = "GCP_NETWORK"
+    gke_pod = "projects/test-project/locations/us-central1/clusters/cluster-name/namespaces/default/pods/pod-name"
+  }
+
+  protocol = "TCP"
+}


### PR DESCRIPTION
Adds the `gke_pod` and `network_type` fields to the `destination` block of the `google_network_management_connectivity_test` resource to support GKE Pod and network type specification for destination endpoints. Also includes the corresponding acceptance tests.

```release-note:enhancement
networkmanagement: added `gke_pod` and `network_type` fields to `google_network_management_connectivity_test` resource
```