### PR TITLE
Add support for sending AIP-155 requestId query parameter

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -128,6 +128,10 @@ type Resource struct {
 	// updates. This is typical of newer GCP APIs.
 	UpdateMask bool `yaml:"update_mask,omitempty"`
 
+	// [Optional] If set to true, this resource supports requestId for idempotency.
+	// This is typical of newer GCP APIs complying with AIP-155.
+	SupportsRequestId bool `yaml:"supports_request_id,omitempty"`
+
 	// [Optional] The HTTP verb used during create. Defaults to POST.
 	CreateVerb string `yaml:"create_verb,omitempty"`
 
@@ -797,6 +801,14 @@ func (r Resource) GetAsync() *Async {
 	}
 
 	return r.ProductMetadata.Async
+}
+
+// Returns true if the resource supports requestId for idempotency.
+func (r Resource) HasSupportsRequestId() bool {
+	if r.SupportsRequestId {
+		return true
+	}
+	return false
 }
 
 // Return the resource-specific identity properties, or a best guess of the

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -22,6 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networks'
 docs:
 base_url: 'projects/{{project}}/global/networks'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -368,6 +368,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutCreate),
         Headers: headers,
+        SendRequestId: {{ $.HasSupportsRequestId }},
 {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{- end}}
@@ -1361,6 +1362,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutDelete),
         Headers: headers,
+        SendRequestId: {{ $.HasSupportsRequestId }},
         {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{- join $.ErrorRetryPredicates "," -}}{{"}"}},
         {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -368,7 +368,9 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutCreate),
         Headers: headers,
+{{- if $.HasSupportsRequestId }}
         SendRequestId: {{ $.HasSupportsRequestId }},
+{{- end }}
 {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{- end}}
@@ -1362,7 +1364,9 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutDelete),
         Headers: headers,
+        {{- if $.HasSupportsRequestId }}
         SendRequestId: {{ $.HasSupportsRequestId }},
+        {{- end }}
         {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{- join $.ErrorRetryPredicates "," -}}{{"}"}},
         {{- end }}

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1023,6 +1023,9 @@ if len(updateMask) > 0 {
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutUpdate),
 		Headers:   headers,
+{{- if $.HasSupportsRequestId }}
+        SendRequestId: {{ $.HasSupportsRequestId }},
+{{- end }}
 {{-              if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{-             end}}
@@ -1208,6 +1211,9 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
             UserAgent: userAgent,
             Body: obj,
             Timeout: d.Timeout(schema.TimeoutUpdate),
+{{- if $.HasSupportsRequestId }}
+            SendRequestId: {{ $.HasSupportsRequestId }},
+{{- end }}
 {{-                  if $.ErrorRetryPredicates -}}
         	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{-                 end}}

--- a/mmv1/third_party/terraform/fwtransport/framework_utils.go
+++ b/mmv1/third_party/terraform/fwtransport/framework_utils.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -73,6 +74,7 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []transport_tpg.RetryErrorPredicateFunc
 	ErrorAbortPredicates []transport_tpg.RetryErrorPredicateFunc
+	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]interface{}, error) {
@@ -99,6 +101,11 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 		opt.Timeout = DefaultRequestTimeout
 	}
 
+	var requestId string
+	if opt.SendRequestId {
+		requestId = uuid.New().String()
+	}
+
 	var res *http.Response
 	err := transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
@@ -110,7 +117,11 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 				}
 			}
 
-			u, err := transport_tpg.AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
+			queryParams := map[string]string{"alt": "json"}
+			if requestId != "" {
+				queryParams["requestId"] = requestId
+			}
+			u, err := transport_tpg.AddQueryParams(opt.RawURL, queryParams)
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
@@ -27,6 +28,7 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []RetryErrorPredicateFunc
 	ErrorAbortPredicates []RetryErrorPredicateFunc
+	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
@@ -57,6 +59,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 		opt.Timeout = DefaultRequestTimeout
 	}
 
+	var requestId string
+	if opt.SendRequestId {
+		requestId = uuid.New().String()
+	}
+
 	var res *http.Response
 	err := Retry(RetryOptions{
 		RetryFunc: func() error {
@@ -68,7 +75,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 				}
 			}
 
-			u, err := AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
+			queryParams := map[string]string{"alt": "json"}
+			if requestId != "" {
+				queryParams["requestId"] = requestId
+			}
+			u, err := AddQueryParams(opt.RawURL, queryParams)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
[AIP-155](https://google.aip.dev/155) provides idempotency guarantees for clients. This PR implements client-side part, so calls to Google APIs can leverage backend capabilites.

Currently, when a request is sent and a transient network occurs, retry mechanism will send second request. While this is not a major problem when running Get or Update operations, it is a problem when sending Create or Delete request (before Long Running Operation handle is returned).

When Create operation times out or errors out with transient network error and is retried, a second call will fail with the message that object already exists and this will fail the whole operation.

Similar situation is in case of Delete operation, though there the message is that object doesn't exists.

With this change, by sending the same RequestId identifier, we oblige backend to return the same message as for original request - hence providing client-side idempotency.

To prove that solution works as expected, this feature is enabled for `google_compute_network` resource.

**Release Note Template for Downstream PRs (will be copied)**

No release notes, as this should not affect the users yet, this PR just provides the capability. There will be follow-up PRs, that enable this capability for specific resources.

```release-note:none
reverted
```

Selected compute resources PR: #17262