### PR TITLE
Update composer v2 image version in tests

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
@@ -1693,7 +1693,7 @@ resource "google_composer_environment" "test" {
     }
 
     software_config {
-      image_version = "composer-2.16.7-airflow-2.10.5"
+      image_version = "composer-2.16.11-airflow-2.11.1"
     }
   }
   depends_on = [google_project_iam_member.composer-worker]


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26914
Fix update composer v2 image

Release Note Template for Downstream PRs (will be copied)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
