### PR TITLE
Enable AIP-155 idempotency for subset of Compute resources

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -128,6 +128,10 @@ type Resource struct {
 	// updates. This is typical of newer GCP APIs.
 	UpdateMask bool `yaml:"update_mask,omitempty"`
 
+	// [Optional] If set to true, this resource supports requestId for idempotency.
+	// This is typical of newer GCP APIs complying with AIP-155.
+	SupportsRequestId bool `yaml:"supports_request_id,omitempty"`
+
 	// [Optional] The HTTP verb used during create. Defaults to POST.
 	CreateVerb string `yaml:"create_verb,omitempty"`
 
@@ -797,6 +801,14 @@ func (r Resource) GetAsync() *Async {
 	}
 
 	return r.ProductMetadata.Async
+}
+
+// Returns true if the resource supports requestId for idempotency.
+func (r Resource) HasSupportsRequestId() bool {
+	if r.SupportsRequestId {
+		return true
+	}
+	return false
 }
 
 // Return the resource-specific identity properties, or a best guess of the

--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -35,6 +35,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/beta/addresses'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/addresses'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -36,6 +36,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/v1/disks'
 docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/disks'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/Firewall.yaml
+++ b/mmv1/products/compute/Firewall.yaml
@@ -36,6 +36,7 @@ docs:
     * `enable_logging` - (Optional, Deprecated) This field denotes whether to enable logging for a particular firewall rule.
     If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor of `log_config`
 base_url: 'projects/{{project}}/global/firewalls'
+supports_request_id: true
 has_self_link: true
 update_verb: 'PATCH'
 timeouts:

--- a/mmv1/products/compute/FirewallPolicy.yaml
+++ b/mmv1/products/compute/FirewallPolicy.yaml
@@ -25,6 +25,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/firewallPolicies'
 docs:
 base_url: 'locations/global/firewallPolicies'
+supports_request_id: true
 self_link: 'locations/global/firewallPolicies/{{name}}'
 create_url: 'locations/global/firewallPolicies?parentId={{parent}}'
 update_verb: 'PATCH'

--- a/mmv1/products/compute/FirewallPolicyAssociation.yaml
+++ b/mmv1/products/compute/FirewallPolicyAssociation.yaml
@@ -25,6 +25,7 @@ references:
 docs:
 id_format: 'locations/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}'
 base_url: 'locations/global/firewallPolicies/{{firewall_policy}}'
+supports_request_id: true
 self_link: 'locations/global/firewallPolicies/{{firewall_policy}}/getAssociation?name={{name}}'
 create_url: 'locations/global/firewallPolicies/{{firewall_policy}}/addAssociation'
 delete_url: 'locations/global/firewallPolicies/{{firewall_policy}}/removeAssociation?name={{name}}'

--- a/mmv1/products/compute/FirewallPolicyRule.yaml
+++ b/mmv1/products/compute/FirewallPolicyRule.yaml
@@ -24,6 +24,7 @@ references:
 docs:
 id_format: 'locations/global/firewallPolicies/{{firewall_policy}}/rules/{{priority}}'
 base_url: 'locations/global/firewallPolicies/{{firewall_policy}}'
+supports_request_id: true
 self_link: 'locations/global/firewallPolicies/{{firewall_policy}}/getRule?priority={{priority}}'
 create_url: 'locations/global/firewallPolicies/{{firewall_policy}}/addRule'
 update_url: 'locations/global/firewallPolicies/{{firewall_policy}}/patchRule?priority={{priority}}'

--- a/mmv1/products/compute/ForwardingRule.yaml
+++ b/mmv1/products/compute/ForwardingRule.yaml
@@ -28,6 +28,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/v1/forwardingRules'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/forwardingRules'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/GlobalAddress.yaml
+++ b/mmv1/products/compute/GlobalAddress.yaml
@@ -25,6 +25,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/v1/globalAddresses'
 docs:
 base_url: 'projects/{{project}}/global/addresses'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/GlobalForwardingRule.yaml
+++ b/mmv1/products/compute/GlobalForwardingRule.yaml
@@ -29,6 +29,7 @@ description: |
 exclude_attribution_label: true
 docs:
 base_url: 'projects/{{project}}/global/forwardingRules'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/HealthCheck.yaml
+++ b/mmv1/products/compute/HealthCheck.yaml
@@ -38,6 +38,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/healthChecks'
 docs:
 base_url: 'projects/{{project}}/global/healthChecks'
+supports_request_id: true
 has_self_link: true
 timeouts:
   insert_minutes: 20

--- a/mmv1/products/compute/InstanceGroupManager.yaml
+++ b/mmv1/products/compute/InstanceGroupManager.yaml
@@ -27,6 +27,7 @@ description: |
 exclude: true
 docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers'
+supports_request_id: true
 has_self_link: true
 timeouts:
   insert_minutes: 20

--- a/mmv1/products/compute/InstanceTemplate.yaml
+++ b/mmv1/products/compute/InstanceTemplate.yaml
@@ -5,6 +5,7 @@ description: |
   Resource that enables a convenient way to save a virtual machine (VM) instance's configuration
   that includes all of its properties and allows you to create a new instance from it.
 base_url: 'projects/{{project}}/global/instanceTemplates'
+supports_request_id: true
 has_self_link: true
 exclude_resource: true
 properties:

--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -23,6 +23,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/interconnectAttachments'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/interconnectAttachments'
+supports_request_id: true
 has_self_link: true
 update_verb: 'PATCH'
 timeouts:

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -22,6 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networks'
 docs:
 base_url: 'projects/{{project}}/global/networks'
+supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/products/compute/NetworkAttachment.yaml
+++ b/mmv1/products/compute/NetworkAttachment.yaml
@@ -22,6 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networkAttachments'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/networkAttachments'
+supports_request_id: true
 update_verb: 'PATCH'
 timeouts:
   insert_minutes: 20

--- a/mmv1/products/compute/NetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicy.yaml
@@ -17,6 +17,7 @@ api_resource_type_kind: FirewallPolicy
 description: "The Compute NetworkFirewallPolicy resource"
 docs:
 base_url: 'projects/{{project}}/global/firewallPolicies'
+supports_request_id: true
 self_link: 'projects/{{project}}/global/firewallPolicies/{{name}}'
 create_url: 'projects/{{project}}/global/firewallPolicies'
 update_verb: 'PATCH'

--- a/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
@@ -24,6 +24,7 @@ references:
 docs:
 id_format: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}'
 base_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}'
+supports_request_id: true
 self_link: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/getAssociation?name={{name}}'
 create_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/addAssociation'
 delete_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/removeAssociation?name={{name}}'

--- a/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
@@ -25,6 +25,7 @@ references:
 docs:
 id_format: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/packetMirroringRules/{{priority}}'
 base_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}'
+supports_request_id: true
 self_link: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/getPacketMirroringRule?priority={{priority}}'
 create_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/addPacketMirroringRule'
 update_url: 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/patchPacketMirroringRule?priority={{priority}}'

--- a/mmv1/products/compute/NetworkFirewallPolicyRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyRule.yaml
@@ -20,6 +20,7 @@ description: |
 references:
   api: https://cloud.google.com/compute/docs/reference/rest/v1/networkFirewallPolicies/addRule
 base_url: projects/{{project}}/global/firewallPolicies/{{firewall_policy}}
+supports_request_id: true
 self_link: projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/getRule?priority={{priority}}
 create_url: projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/addRule
 delete_url: projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/removeRule?priority={{priority}}

--- a/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
@@ -17,6 +17,7 @@ api_resource_type_kind: FirewallPolicy
 description: "The Compute NetworkFirewallPolicy resource"
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies'
+supports_request_id: true
 self_link: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{name}}'
 create_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies'
 update_verb: 'PATCH'

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyAssociation.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyAssociation.yaml
@@ -20,6 +20,7 @@ references:
   guides: {}
   api: https://cloud.google.com/compute/docs/reference/rest/v1/regionNetworkFirewallPolicies/addAssociation
 base_url: projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}
+supports_request_id: true
 immutable: true
 self_link: projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/getAssociation?name={{name}}
 create_url: projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/addAssociation

--- a/mmv1/products/compute/RegionNetworkFirewallPolicyRule.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyRule.yaml
@@ -24,6 +24,7 @@ references:
 docs:
 id_format: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/{{priority}}'
 base_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}'
+supports_request_id: true
 self_link: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/getRule?priority={{priority}}'
 create_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/addRule'
 update_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{firewall_policy}}/patchRule?priority={{priority}}'

--- a/mmv1/products/compute/Route.yaml
+++ b/mmv1/products/compute/Route.yaml
@@ -49,6 +49,7 @@ docs:
       `next_hop_instance`.  Omit if `next_hop_instance` is specified as
       a URL.
 base_url: 'projects/{{project}}/global/routes'
+supports_request_id: true
 has_self_link: true
 immutable: true
 mutex: 'projects/{{project}}/global/networks/{{network}}/peerings'

--- a/mmv1/products/compute/Router.yaml
+++ b/mmv1/products/compute/Router.yaml
@@ -22,6 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routers'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/routers'
+supports_request_id: true
 has_self_link: true
 # Since Terraform has separate resources for router, router interface, and
 # router peer, calling PUT on the router will delete the interface and peer.

--- a/mmv1/products/compute/RouterNat.yaml
+++ b/mmv1/products/compute/RouterNat.yaml
@@ -26,6 +26,7 @@ references:
 docs:
 id_format: '{{project}}/{{region}}/{{router}}/{{name}}'
 base_url: 'projects/{{project}}/regions/{{region}}/routers/{{router}}'
+supports_request_id: true
 self_link: 'projects/{{project}}/regions/{{region}}/routers/{{router}}'
 create_url: 'projects/{{project}}/regions/{{region}}/routers/{{router}}'
 create_verb: 'PATCH'

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -22,6 +22,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/beta/serviceAttachments'
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/serviceAttachments'
+supports_request_id: true
 has_self_link: true
 update_verb: 'PATCH'
 timeouts:

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -42,6 +42,7 @@ references:
     Private Google Access: https://cloud.google.com/vpc/docs/configure-private-google-access
   api: https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks
 base_url: projects/{{project}}/regions/{{region}}/subnetworks
+supports_request_id: true
 immutable: true
 has_self_link: true
 collection_url_key: items

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -368,6 +368,7 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutCreate),
         Headers: headers,
+        SendRequestId: {{ $.HasSupportsRequestId }},
 {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{- end}}
@@ -1361,6 +1362,7 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutDelete),
         Headers: headers,
+        SendRequestId: {{ $.HasSupportsRequestId }},
         {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{- join $.ErrorRetryPredicates "," -}}{{"}"}},
         {{- end }}

--- a/mmv1/third_party/terraform/fwtransport/framework_utils.go
+++ b/mmv1/third_party/terraform/fwtransport/framework_utils.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -73,6 +74,7 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []transport_tpg.RetryErrorPredicateFunc
 	ErrorAbortPredicates []transport_tpg.RetryErrorPredicateFunc
+	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]interface{}, error) {
@@ -99,6 +101,11 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 		opt.Timeout = DefaultRequestTimeout
 	}
 
+	var requestId string
+	if opt.SendRequestId {
+		requestId = uuid.New().String()
+	}
+
 	var res *http.Response
 	err := transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
@@ -110,7 +117,11 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 				}
 			}
 
-			u, err := transport_tpg.AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
+			queryParams := map[string]string{"alt": "json"}
+			if requestId != "" {
+				queryParams["requestId"] = requestId
+			}
+			u, err := transport_tpg.AddQueryParams(opt.RawURL, queryParams)
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -3,6 +3,7 @@ package compute
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -1715,18 +1716,46 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		Properties:  instanceProperties,
 		Name:        itName,
 	}
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates")
+	if err != nil {
+		return err
+	}
 
-	op, err := config.NewComputeClient(userAgent).InstanceTemplates.Insert(project, instanceTemplate).Do()
+	var obj map[string]interface{}
+	e, err := json.Marshal(instanceTemplate)
+	if err != nil {
+		return fmt.Errorf("Error marshaling instance template: %s", err)
+	}
+	err = json.Unmarshal(e, &obj)
+	if err != nil {
+		return fmt.Errorf("Error unmarshaling instance template: %s", err)
+	}
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:        config,
+		Method:        "POST",
+		Project:       project,
+		RawURL:        url,
+		UserAgent:     userAgent,
+		Body:          obj,
+		Timeout:       d.Timeout(schema.TimeoutCreate),
+		SendRequestId: true,
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating instance template: %s", err)
 	}
 
 	// Store the ID now
 	d.SetId(fmt.Sprintf("projects/%s/global/instanceTemplates/%s", project, instanceTemplate.Name))
-	// And also the unique ID
-	d.Set("self_link_unique", fmt.Sprintf("%v?uniqueId=%v", d.Id(), op.TargetId))
 
-	err = ComputeOperationWaitTime(config, op, project, "Creating Instance Template", userAgent, d.Timeout(schema.TimeoutCreate))
+	targetId := ""
+	if v, ok := res["targetId"]; ok {
+		targetId = fmt.Sprintf("%v", v)
+	}
+	// And also the unique ID
+	d.Set("self_link_unique", fmt.Sprintf("%v?uniqueId=%v", d.Id(), targetId))
+
+	err = ComputeOperationWaitTime(config, res, project, "Creating Instance Template", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -2224,14 +2253,25 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	splits := strings.Split(d.Id(), "/")
-	op, err := config.NewComputeClient(userAgent).InstanceTemplates.Delete(
-		project, splits[len(splits)-1]).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates/{{"{{"}}name{{"}}"}}")
 	if err != nil {
-		return fmt.Errorf("Error deleting instance template: %s", err)
+		return err
 	}
 
-	err = ComputeOperationWaitTime(config, op, project, "Deleting Instance Template", userAgent, d.Timeout(schema.TimeoutDelete))
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:        config,
+		Method:        "DELETE",
+		Project:       project,
+		RawURL:        url,
+		UserAgent:     userAgent,
+		Timeout:       d.Timeout(schema.TimeoutDelete),
+		SendRequestId: true,
+	})
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, "Instance Template")
+	}
+
+	err = ComputeOperationWaitTime(config, res, project, "Deleting Instance Template", userAgent, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_peer.go.tmpl
@@ -605,13 +605,14 @@ func resourceComputeRouterBgpPeerCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "PATCH",
-		Project:   billingProject,
-		RawURL:    url,
-		UserAgent: userAgent,
-		Body:      obj,
-		Timeout:   d.Timeout(schema.TimeoutCreate),
+		Config:        config,
+		Method:        "PATCH",
+		Project:       billingProject,
+		RawURL:        url,
+		UserAgent:     userAgent,
+		Body:          obj,
+		Timeout:       d.Timeout(schema.TimeoutCreate),
+		SendRequestId: true,
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating RouterBgpPeer: %s", err)
@@ -1043,13 +1044,14 @@ func resourceComputeRouterBgpPeerDelete(d *schema.ResourceData, meta interface{}
 	}
 
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-		Config:    config,
-		Method:    "PATCH",
-		Project:   billingProject,
-		RawURL:    url,
-		UserAgent: userAgent,
-		Body:      obj,
-		Timeout:   d.Timeout(schema.TimeoutDelete),
+		Config:        config,
+		Method:        "PATCH",
+		Project:       billingProject,
+		RawURL:        url,
+		UserAgent:     userAgent,
+		Body:          obj,
+		Timeout:       d.Timeout(schema.TimeoutDelete),
+		SendRequestId: true,
 	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, "RouterBgpPeer")

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
@@ -27,6 +28,7 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []RetryErrorPredicateFunc
 	ErrorAbortPredicates []RetryErrorPredicateFunc
+	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
@@ -57,6 +59,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 		opt.Timeout = DefaultRequestTimeout
 	}
 
+	var requestId string
+	if opt.SendRequestId {
+		requestId = uuid.New().String()
+	}
+
 	var res *http.Response
 	err := Retry(RetryOptions{
 		RetryFunc: func() error {
@@ -68,7 +75,11 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 				}
 			}
 
-			u, err := AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
+			queryParams := map[string]string{"alt": "json"}
+			if requestId != "" {
+				queryParams["requestId"] = requestId
+			}
+			u, err := AddQueryParams(opt.RawURL, queryParams)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Follow up to #17259 - implementing `requestId` for selected compute resources

1. Adding  supports_request_id: true  to the Magic Modules YAML definitions for those resources.
2. Updating the manual template for  google_compute_router_peer  ( resource_compute_router_peer.go.tmpl ) to pass  SendRequestId: true .
3. Updating the manual template for  google_compute_instance_template  ( resource_compute_instance_template.go.tmpl ) to use  transport_tpg.SendRequest  and pass  SendRequestId: true .

Affected resources:
* google_compute_address
* google_compute_disk
* google_compute_firewall
* google_compute_firewall_policy
* google_compute_firewall_policy_association
* google_compute_firewall_policy_rule
* google_compute_forwarding_rule
* google_compute_global_address
* google_compute_global_forwarding_rule
* google_compute_health_check
* google_compute_instance_group_manager
* google_compute_instance_template
* google_compute_interconnect_attachment
* google_compute_network
* google_compute_network_attachment
* google_compute_network_firewall_policy
* google_compute_network_firewall_policy_association
* google_compute_network_firewall_policy_packet_mirroring_rule
* google_compute_network_firewall_policy_rule
* google_compute_region_network_firewall_policy
* google_compute_region_network_firewall_policy_association
* google_compute_region_network_firewall_policy_rule
* google_compute_route
* google_compute_router
* google_compute_router_nat
* google_compute_router_peer
* google_compute_service_attachment
* google_compute_subnetwork


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for idempotency via `requestId` query parameter to selected resources
```
