### PR TITLE
dns: add list resource for google_dns_record_set

### DIFF
--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -16,8 +16,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-// var _ tpgresource.ListResourceWithRawV5Schemas = &GoogleDnsRecordSetResource{}
-
 type GoogleDnsRecordSetResource struct {
 	tpgresource.ListResourceMetadata
 }

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -1,0 +1,196 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	googledns "google.golang.org/api/dns/v1"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google/tpgresource"
+)
+
+var _ tpgresource.ListResourceWithRawV5Schemas = &GoogleDnsRecordSetResource{}
+
+type GoogleDnsRecordSetResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleDnsRecordSetListModel struct {
+	Project	  types.String `tfsdk:"project"`
+	ManagedZone types.String `tfsdk:"managed_zone"`
+	Name         types.String `tfsdk:"name"`
+	Type         types.String `tfsdk:"type"`
+}
+
+func NewGoogleDnsRecordSetListResource() list.ListResource {
+	listR := &GoogleDnsRecordSetResource{}
+	listR.TypeName + "google_dns_record_set"
+	listR.SDKv2Resource = ResourceDNSRecordSet()
+	ListR.ListConfigFields = []tpgresource.listConfigField{
+		{Name: "project", Kind: tpgresource.listConfigKindString, Optional: true},
+		{Name: "managed_zone", Kind: tpgresource.listConfigKindString, Required: false}, 
+		{Name: "name", Kind: tpgresource.listConfigKindString, Optional: true},
+		{Name: "type", Kind: tpgresource.listConfigKindString, Optional: true},
+	}
+	return listR
+}
+
+func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream,) {
+	var data GoogleDnsRecordSetListModel
+	diags := req.Config.Get(ctx, &data)
+	
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	if listR.Client == nil {
+		diags = append(diags, frameworkdiag.NewErrorDiagnostic(
+			"provider not configured", 
+			"The Google provider client is not available; ensure the prtovider is configured.",
+			))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	project := ListR.GetProject(data.Project)
+	managedZone := data.ManagedZone.ValueString()
+	recordName := ""
+	recordType := ""
+
+	if !data.Name.IsNull() && !data.Name.IsUnknown() {
+		recordName = data.Name.ValueString()
+	}
+
+	if !data.Type.IsNull() && !data.Type.IsUnknown() {
+		recordType = data.Type.ValueString()
+	}
+
+	stream.Results = func(push fucn(list.ListResult) bool {
+		err := ListDnsRecordSets(listR.Client, project, managedZone, recordName, recordType, func(rd *schema.ResourceData) error {
+			result := req.NewListResult(ctx)
+
+			if err:= listR.setResult(ctx, req.IncludeResource, &result, rd): err !=nil {
+				return err
+			}
+
+			if !push(result) {
+				return errors.New("stream closed")
+			}
+			return nil
+		})
+
+		if err != nil {
+			diags.AddError("API Error", err.Error())
+			result := req.NewListResult(ctx)
+			result.Diagnostic = diags
+			push(result)
+		}
+
+		stream.Results = list.ListResultsStramDiagnostics(diags)
+	}
+}
+
+func flattenGoogleDNSRecordSetListItem(
+	rrset *googledns.ResourceRecordSet,
+	d *schema.ResourceData,
+	project string,
+    managedZone string,
+) error {
+	if err := d.set("peoject", project); err != nil {
+		return fmt.Errorf("error setting project: %w", err)
+	}
+
+	if err := d.set("managed_zone", managedZone); err != nil {
+		return fmt.Errorf("error setting managed_zone: %w", err)
+	}
+
+	if err := d.set("name", rrset.Name); err != nil {
+		return fmt.Errorf("error setting name: %w", err)
+	}
+
+	if err := d.set("type", rrset.Type); err != nil {
+		return fmt.Errorf("error setting type: %w", err)
+	}
+
+	if err := d.set("ttl", rrset.Ttl); err != nil {
+		return fmt.Errorf("error setting ttl: %w", err)
+	}
+
+	if err := d.set("rrdatas", rrset.Rrdatas); err != nil {
+		return fmt.Errorf("error setting rrdatas: %w", err)
+	}
+
+	if err := d.set("routing_policy", flattenRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
+		return fmt.Errorf("error setting routing_policy: %w", err)
+	}	
+
+	d.SetId(fmt.Sprintf(
+		"project/%s/managedZones/%s/rrsets/%s/%s",
+		project,
+		managedZone,
+		rrset.Name,
+		rrset.Type,			
+	)
+
+	return nil
+}
+
+func ListDnsRecordSets(
+	config * transport_tpg.Config,
+	project string,
+	managedZone string,
+	recordName string,
+	recordType string,
+	callback func(*schema.ResourceData) error,
+) error {
+	if config == nil {
+		return ftm.Errorf("provider client is not configured")
+	}
+
+	tempData := resourceDnsRecordSet().Data(&terraform.InstanceState{})
+	if project != "" {
+		if err := tempData.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+	if err := tempData.Set("managed_zone", managedZone); err != nil {
+		return fmt.Errorf("error setting managed_zone on temporary resource data: %w", err)
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(tempdata, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	req := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, managedZone)
+	
+	if recordName != "" {
+		req = req.Name(recordName)
+		if recordType != "" {
+			req = req.Type(recordType)
+		}
+	}
+
+	return req.Pages(context.Background(), func(resp *googledns.ResourceRecordSetsListResponse) error {
+		for _, rrset := range resp.Rrsets {
+			rd := resourceDnsRecordSet().Data(&terraform.InstanceState{})
+
+			if err := flattenGoogleDNSRecordSetListItem(rrset, rd, project, managedZone); err != nil {
+				return err
+			}
+
+			if err := callback(rd); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -11,41 +11,41 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	googledns "google.golang.org/api/dns/v1"
+
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-	"github.com/hashicorp/terraform-provider-google/tpgresource"
 )
 
-var _ tpgresource.ListResourceWithRawV5Schemas = &GoogleDnsRecordSetResource{}
+// var _ tpgresource.ListResourceWithRawV5Schemas = &GoogleDnsRecordSetResource{}
 
 type GoogleDnsRecordSetResource struct {
 	tpgresource.ListResourceMetadata
 }
 
 type GoogleDnsRecordSetListModel struct {
-	Project	  types.String `tfsdk:"project"`
+	Project     types.String `tfsdk:"project"`
 	ManagedZone types.String `tfsdk:"managed_zone"`
-	Name         types.String `tfsdk:"name"`
-	Type         types.String `tfsdk:"type"`
+	Name        types.String `tfsdk:"name"`
+	Type        types.String `tfsdk:"type"`
 }
 
 func NewGoogleDnsRecordSetListResource() list.ListResource {
 	listR := &GoogleDnsRecordSetResource{}
-	listR.TypeName + "google_dns_record_set"
-	listR.SDKv2Resource = ResourceDNSRecordSet()
-	ListR.ListConfigFields = []tpgresource.listConfigField{
-		{Name: "project", Kind: tpgresource.listConfigKindString, Optional: true},
-		{Name: "managed_zone", Kind: tpgresource.listConfigKindString, Required: false}, 
-		{Name: "name", Kind: tpgresource.listConfigKindString, Optional: true},
-		{Name: "type", Kind: tpgresource.listConfigKindString, Optional: true},
+	listR.TypeName = "google_dns_record_set"
+	listR.SDKv2Resource = ResourceDnsRecordSet()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "managed_zone", Kind: tpgresource.ListConfigKindString, Optional: false},
+		{Name: "name", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "type", Kind: tpgresource.ListConfigKindString, Optional: true},
 	}
 	return listR
 }
 
-func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream,) {
+func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
 	var data GoogleDnsRecordSetListModel
 	diags := req.Config.Get(ctx, &data)
-	
+
 	if diags.HasError() {
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
@@ -53,14 +53,14 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 
 	if listR.Client == nil {
 		diags = append(diags, frameworkdiag.NewErrorDiagnostic(
-			"provider not configured", 
+			"provider not configured",
 			"The Google provider client is not available; ensure the prtovider is configured.",
-			))
+		))
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}
 
-	project := ListR.GetProject(data.Project)
+	project := listR.GetProject(data.Project)
 	managedZone := data.ManagedZone.ValueString()
 	recordName := ""
 	recordType := ""
@@ -73,11 +73,11 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 		recordType = data.Type.ValueString()
 	}
 
-	stream.Results = func(push fucn(list.ListResult) bool {
+	stream.Results = func(push func(list.ListResult) bool) {
 		err := ListDnsRecordSets(listR.Client, project, managedZone, recordName, recordType, func(rd *schema.ResourceData) error {
 			result := req.NewListResult(ctx)
 
-			if err:= listR.setResult(ctx, req.IncludeResource, &result, rd): err !=nil {
+			if err := listR.SetResult(ctx, req.IncludeResource, &result, rd); err != nil {
 				return err
 			}
 
@@ -90,11 +90,11 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 		if err != nil {
 			diags.AddError("API Error", err.Error())
 			result := req.NewListResult(ctx)
-			result.Diagnostic = diags
+			result.Diagnostics = diags
 			push(result)
 		}
 
-		stream.Results = list.ListResultsStramDiagnostics(diags)
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
 	}
 }
 
@@ -102,49 +102,49 @@ func flattenGoogleDNSRecordSetListItem(
 	rrset *googledns.ResourceRecordSet,
 	d *schema.ResourceData,
 	project string,
-    managedZone string,
+	managedZone string,
 ) error {
-	if err := d.set("peoject", project); err != nil {
+	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("error setting project: %w", err)
 	}
 
-	if err := d.set("managed_zone", managedZone); err != nil {
+	if err := d.Set("managed_zone", managedZone); err != nil {
 		return fmt.Errorf("error setting managed_zone: %w", err)
 	}
 
-	if err := d.set("name", rrset.Name); err != nil {
+	if err := d.Set("name", rrset.Name); err != nil {
 		return fmt.Errorf("error setting name: %w", err)
 	}
 
-	if err := d.set("type", rrset.Type); err != nil {
+	if err := d.Set("type", rrset.Type); err != nil {
 		return fmt.Errorf("error setting type: %w", err)
 	}
 
-	if err := d.set("ttl", rrset.Ttl); err != nil {
+	if err := d.Set("ttl", rrset.Ttl); err != nil {
 		return fmt.Errorf("error setting ttl: %w", err)
 	}
 
-	if err := d.set("rrdatas", rrset.Rrdatas); err != nil {
+	if err := d.Set("rrdatas", rrset.Rrdatas); err != nil {
 		return fmt.Errorf("error setting rrdatas: %w", err)
 	}
 
-	if err := d.set("routing_policy", flattenRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
+	if err := d.Set("routing_policy", flattenDnsRecordSetRoutingPolicy(rrset.RoutingPolicy)); err != nil {
 		return fmt.Errorf("error setting routing_policy: %w", err)
-	}	
+	}
 
 	d.SetId(fmt.Sprintf(
 		"project/%s/managedZones/%s/rrsets/%s/%s",
 		project,
 		managedZone,
 		rrset.Name,
-		rrset.Type,			
-	)
+		rrset.Type,
+	))
 
 	return nil
 }
 
 func ListDnsRecordSets(
-	config * transport_tpg.Config,
+	config *transport_tpg.Config,
 	project string,
 	managedZone string,
 	recordName string,
@@ -152,10 +152,10 @@ func ListDnsRecordSets(
 	callback func(*schema.ResourceData) error,
 ) error {
 	if config == nil {
-		return ftm.Errorf("provider client is not configured")
+		return fmt.Errorf("provider client is not configured")
 	}
 
-	tempData := resourceDnsRecordSet().Data(&terraform.InstanceState{})
+	tempData := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
 	if project != "" {
 		if err := tempData.Set("project", project); err != nil {
 			return fmt.Errorf("error setting project on temporary resource data: %w", err)
@@ -165,13 +165,13 @@ func ListDnsRecordSets(
 		return fmt.Errorf("error setting managed_zone on temporary resource data: %w", err)
 	}
 
-	userAgent, err := tpgresource.GenerateUserAgentString(tempdata, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(tempData, config.UserAgent)
 	if err != nil {
 		return err
 	}
 
 	req := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, managedZone)
-	
+
 	if recordName != "" {
 		req = req.Name(recordName)
 		if recordType != "" {
@@ -181,7 +181,7 @@ func ListDnsRecordSets(
 
 	return req.Pages(context.Background(), func(resp *googledns.ResourceRecordSetsListResponse) error {
 		for _, rrset := range resp.Rrsets {
-			rd := resourceDnsRecordSet().Data(&terraform.InstanceState{})
+			rd := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
 
 			if err := flattenGoogleDNSRecordSetListItem(rrset, rd, project, managedZone); err != nil {
 				return err

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -58,6 +58,21 @@ func (listR *GoogleDnsRecordSetResource) Metadata(ctx context.Context, req resou
 	}
 }
 
+// validateListRequest validates the list request configuration
+func validateListRequest(data GoogleDnsRecordSetListModel) error {
+	// managed_zone is required
+	if data.ManagedZone.IsNull() || data.ManagedZone.IsUnknown() {
+		return fmt.Errorf("managed_zone is required for listing DNS record sets")
+	}
+
+	managedZone := data.ManagedZone.ValueString()
+	if managedZone == "" {
+		return fmt.Errorf("managed_zone cannot be empty")
+	}
+
+	return nil
+}
+
 func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
 	var data GoogleDnsRecordSetListModel
 	diags := req.Config.Get(ctx, &data)
@@ -67,10 +82,16 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 		return
 	}
 
+	if err := validateListRequest(data); err != nil {
+		diags.AddError("Invalid request parameters", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
 	if listR.Client == nil {
 		diags = append(diags, frameworkdiag.NewErrorDiagnostic(
 			"provider not configured",
-			"The Google provider client is not available; ensure the prtovider is configured.",
+			"The Google provider client is not available; ensure the provider is configured.",
 		))
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
@@ -90,10 +111,14 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 	}
 
 	stream.Results = func(push func(list.ListResult) bool) {
+		// Initialize diags within the stream function to capture errors from the API call
+		var streamDiags frameworkdiag.Diagnostics
+
 		err := ListDnsRecordSets(listR.Client, project, managedZone, recordName, recordType, func(rd *schema.ResourceData) error {
 			result := req.NewListResult(ctx)
 
 			if err := listR.SetResult(ctx, req.IncludeResource, &result, rd); err != nil {
+				streamDiags.AddError("Failed to set result", err.Error())
 				return err
 			}
 
@@ -104,13 +129,17 @@ func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.List
 		})
 
 		if err != nil {
-			diags.AddError("API Error", err.Error())
+			streamDiags.AddError("API Error listing DNS record sets", fmt.Sprintf("Failed to list DNS record sets in zone %q: %v", managedZone, err))
 			result := req.NewListResult(ctx)
-			result.Diagnostics = diags
+			result.Diagnostics = streamDiags
 			push(result)
+			return
 		}
 
-		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		// Only set stream diagnostics if there were errors during result processing
+		if streamDiags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(streamDiags)
+		}
 	}
 }
 
@@ -159,6 +188,15 @@ func flattenGoogleDNSRecordSetListItem(
 	return nil
 }
 
+var recordSetSchemaCache *schema.Resource
+
+func getRecordSetSchema() *schema.Resource {
+	if recordSetSchemaCache == nil {
+		recordSetSchemaCache = ResourceDnsRecordSet()
+	}
+	return recordSetSchemaCache
+}
+
 func ListDnsRecordSets(
 	config *transport_tpg.Config,
 	project string,
@@ -171,7 +209,13 @@ func ListDnsRecordSets(
 		return fmt.Errorf("provider client is not configured")
 	}
 
-	tempData := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
+	// Validate required parameters
+	if managedZone == "" {
+		return fmt.Errorf("managed_zone is required for listing DNS record sets")
+	}
+
+	schema := getRecordSetSchema()
+	tempData := schema.Data(&terraform.InstanceState{})
 	if project != "" {
 		if err := tempData.Set("project", project); err != nil {
 			return fmt.Errorf("error setting project on temporary resource data: %w", err)
@@ -197,7 +241,7 @@ func ListDnsRecordSets(
 
 	return req.Pages(context.Background(), func(resp *googledns.ResourceRecordSetsListResponse) error {
 		for _, rrset := range resp.Rrsets {
-			rd := ResourceDnsRecordSet().Data(&terraform.InstanceState{})
+			rd := schema.Data(&terraform.InstanceState{})
 
 			if err := flattenGoogleDNSRecordSetListItem(rrset, rd, project, managedZone); err != nil {
 				return err

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -7,6 +7,7 @@ import (
 
 	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -47,6 +48,14 @@ func NewGoogleDnsRecordSetListResource() list.ListResource {
 		{Name: "type", Kind: tpgresource.ListConfigKindString, Optional: true},
 	}
 	return listR
+}
+
+func (listR *GoogleDnsRecordSetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	listR.ListResourceMetadata.Metadata(ctx, req, resp)
+
+	resp.ResourceBehavior = resource.ResourceBehavior{
+		MutableIdentity: true,
+	}
 }
 
 func (listR *GoogleDnsRecordSetResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -177,7 +177,7 @@ func ListDnsRecordSets(
 		return err
 	}
 
-	req := config.NewDnsClient(userAgent).ResourceRecordSets.List(project, managedZone)
+	req := config.NewClient(config, userAgent).ResourceRecordSets.List(project, managedZone)
 
 	if recordName != "" {
 		req = req.Name(recordName)

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -12,9 +12,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	googledns "google.golang.org/api/dns/v1"
 
+	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_dns_record_set",
+		ProductName: "dns",
+		Func:        NewGoogleDnsRecordSetListResource,
+	}.Register()
+}
 
 type GoogleDnsRecordSetResource struct {
 	tpgresource.ListResourceMetadata

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -188,15 +188,6 @@ func flattenGoogleDNSRecordSetListItem(
 	return nil
 }
 
-var recordSetSchemaCache *schema.Resource
-
-func getRecordSetSchema() *schema.Resource {
-	if recordSetSchemaCache == nil {
-		recordSetSchemaCache = ResourceDnsRecordSet()
-	}
-	return recordSetSchemaCache
-}
-
 func ListDnsRecordSets(
 	config *transport_tpg.Config,
 	project string,
@@ -214,8 +205,8 @@ func ListDnsRecordSets(
 		return fmt.Errorf("managed_zone is required for listing DNS record sets")
 	}
 
-	schema := getRecordSetSchema()
-	tempData := schema.Data(&terraform.InstanceState{})
+	recordSetSchema := ResourceDnsRecordSet()
+	tempData := recordSetSchema.Data(&terraform.InstanceState{})
 	if project != "" {
 		if err := tempData.Set("project", project); err != nil {
 			return fmt.Errorf("error setting project on temporary resource data: %w", err)
@@ -230,27 +221,54 @@ func ListDnsRecordSets(
 		return err
 	}
 
-	req := NewClient(config, userAgent).ResourceRecordSets.List(project, managedZone)
-
-	if recordName != "" {
-		req = req.Name(recordName)
-		if recordType != "" {
-			req = req.Type(recordType)
-		}
+	url, err := tpgresource.ReplaceVars(tempData, config, "{{DNSBasePath}}projects/{{project}}/managedZones/{{managed_zone}}/rrsets")
+	if err != nil {
+		return err
 	}
+	queryParams := make(map[string]string)
+	if recordName != "" {
+		queryParams["name"] = recordName
+	}
+	if recordType != "" {
+		queryParams["type"] = recordType
+	}
+	for {
+		reqURL, err := transport_tpg.AddQueryParams(url, queryParams)
+		if err != nil {
+			return err
+		}
 
-	return req.Pages(context.Background(), func(resp *googledns.ResourceRecordSetsListResponse) error {
-		for _, rrset := range resp.Rrsets {
-			rd := schema.Data(&terraform.InstanceState{})
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    reqURL,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return err
+		}
 
+		var listResp googledns.ResourceRecordSetsListResponse
+		if err := tpgresource.Convert(res, &listResp); err != nil {
+			return fmt.Errorf("error parsing DNS record set list response: %w", err)
+		}
+
+		for _, rrset := range listResp.Rrsets {
+			rd := recordSetSchema.Data(&terraform.InstanceState{})
 			if err := flattenGoogleDNSRecordSetListItem(rrset, rd, project, managedZone); err != nil {
 				return err
 			}
-
 			if err := callback(rd); err != nil {
 				return err
 			}
 		}
-		return nil
-	})
+
+		if listResp.NextPageToken == "" {
+			break
+		}
+
+		queryParams["pageToken"] = listResp.NextPageToken
+	}
+	return nil
 }

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set.go
@@ -177,7 +177,7 @@ func ListDnsRecordSets(
 		return err
 	}
 
-	req := config.NewClient(config, userAgent).ResourceRecordSets.List(project, managedZone)
+	req := NewClient(config, userAgent).ResourceRecordSets.List(project, managedZone)
 
 	if recordName != "" {
 		req = req.Name(recordName)

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
@@ -1,4 +1,4 @@
-package resourcemanager_test
+package dns_test
 
 import (
 	"fmt"
@@ -16,9 +16,10 @@ import (
 func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
 	t.Parallel()
 
-	zoneName := "dnszone-test-" + acctest.RandString(t, 10)
+	zoneName := "list-dnszone-test-" + acctest.RandString(t, 10)
 	project := envvar.GetTestProjectFromEnv()
-	recordName := fmt.Sprintf("test-record.%s.hashicorptest.com", zoneName)
+	t.Logf("Using project %s for testing", project)
+	recordName := fmt.Sprintf("test-record.%s.hashicorptest.com.", zoneName)
 
 	acctest.VcrTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
@@ -28,7 +29,7 @@ func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDNSRecordSet_Basic(zoneName, "127.0.0.10", 300),
+				Config: testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
@@ -1,0 +1,69 @@
+package resourcemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	zoneName := "dnszone-test-" + acctest.RandString(t, 10)
+	project := envvar.GetTestProjectFromEnv()
+	recordName := fmt.Sprintf("test-record.%s.hashicorptest.com", zoneName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSRecordSet_Basic(zoneName, "127.0.0.10", 300),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "name", recordName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "type", "A"),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccDNSRecordSetListQuery(project, zoneName),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_dns_record_set.all_in_zone", map[string]knownvalue.Check{
+						"project":      knownvalue.StringExact(project),
+						"managed_zone": knownvalue.StringExact(zoneName),
+						"name":         knownvalue.StringExact(recordName),
+						"type":         knownvalue.StringExact("A"),
+					}),
+					querycheck.ExpectLengthAtLeast("google_dns_record_set.all_in_zone", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccDNSRecordSetListQuery(project, managedZone string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_dns_record_set" "all_in_zone" {
+  provider = google
+
+  config {
+    project = %q
+    managed_zone = %q
+  }
+}
+`, project, managedZone)
+}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
@@ -45,7 +45,6 @@ func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
 						"project":      knownvalue.StringExact(project),
 						"managed_zone": knownvalue.StringExact(zoneName),
 						"name":         knownvalue.StringExact(recordName),
-						"type":         knownvalue.StringExact("A"),
 					}),
 					querycheck.ExpectLengthAtLeast("google_dns_record_set.all_in_zone", 1),
 				},

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_record_set_test.go
@@ -45,6 +45,7 @@ func TestAccDNSRecordSetListResource_queryIdentity(t *testing.T) {
 						"project":      knownvalue.StringExact(project),
 						"managed_zone": knownvalue.StringExact(zoneName),
 						"name":         knownvalue.StringExact(recordName),
+						"type":         knownvalue.StringExact("A"),
 					}),
 					querycheck.ExpectLengthAtLeast("google_dns_record_set.all_in_zone", 1),
 				},

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -101,6 +101,30 @@ func ResourceDnsRecordSet() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 		),
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"managed_zone": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"name": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"type": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"managed_zone": {
 				Type:             schema.TypeString,
@@ -483,6 +507,14 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
 		return err
+	}
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":      project,
+		"managed_zone": zone,
+		"name":         rrset.Name,
+		"type":         rrset.Type,
+	}); err != nil {
+		return fmt.Errorf("Error setting resource identity: %s", err)
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -117,6 +117,10 @@ func ResourceDnsRecordSet() *schema.Resource {
 						Type:              schema.TypeString,
 						RequiredForImport: true,
 					},
+					"type": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
 				}
 			},
 		},
@@ -254,6 +258,7 @@ func ResourceDnsRecordSet() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: `The DNS record set type.`,
 			},
 
@@ -508,6 +513,7 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 		"project":      project,
 		"managed_zone": zone,
 		"name":         rrset.Name,
+		"type":         rrset.Type,
 	}); err != nil {
 		return fmt.Errorf("Error setting resource identity: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -258,7 +258,6 @@ func ResourceDnsRecordSet() *schema.Resource {
 			"type": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: `The DNS record set type.`,
 			},
 

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -117,10 +117,6 @@ func ResourceDnsRecordSet() *schema.Resource {
 						Type:              schema.TypeString,
 						RequiredForImport: true,
 					},
-					"type": {
-						Type:              schema.TypeString,
-						RequiredForImport: true,
-					},
 				}
 			},
 		},
@@ -512,7 +508,6 @@ func resourceDnsRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 		"project":      project,
 		"managed_zone": zone,
 		"name":         rrset.Name,
-		"type":         rrset.Type,
 	}); err != nil {
 		return fmt.Errorf("Error setting resource identity: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set.go
@@ -95,7 +95,6 @@ func ResourceDnsRecordSet() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceDnsRecordSetImportState,
 		},
-
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderDeletionPolicy("DELETE"),
 			tpgresource.DefaultProviderProject,
@@ -123,6 +122,10 @@ func ResourceDnsRecordSet() *schema.Resource {
 					},
 				}
 			},
+		},
+
+		ResourceBehavior: schema.ResourceBehavior{
+			MutableIdentity: true,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -592,6 +592,40 @@ func testAccCheckDnsRecordSetSetRrdataOutOfBand(t *testing.T, zoneName, rrsetNam
 	}
 }
 
+func TestAccDNSRecordSet_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(t, 10))
+	project := envvar.GetTestProjectFromEnv()
+	recordName := fmt.Sprintf("test-record.%s.hashicorptest.com.", zoneName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "name", recordName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "type", "A"),
+				),
+			},
+			{
+				ResourceName:    "google_dns_record_set.foobar",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func testAccCheckDnsRecordSetDestroyProducer(t *testing.T) func(s *terraform.State) error {
 
 	return func(s *terraform.State) error {

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -605,7 +606,7 @@ func TestAccDNSRecordSet_importBlockWithResourceIdentity(t *testing.T) {
 		},
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccStorageBucketDestroyProducer(t),
+		CheckDestroy:             testAccCheckDnsRecordSetDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsRecordSet_basic(zoneName, "127.0.0.10", 300),

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -614,6 +614,7 @@ func TestAccDNSRecordSet_importBlockWithResourceIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "name", recordName),
+					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "type", "A"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dns/resource_dns_record_set_test.go.tmpl
@@ -614,7 +614,6 @@ func TestAccDNSRecordSet_importBlockWithResourceIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "project", project),
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "managed_zone", zoneName),
 					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "name", recordName),
-					resource.TestCheckResourceAttr("google_dns_record_set.foobar", "type", "A"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_dns_record_set.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_dns_record_set.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Cloud DNS"
+description: |-
+  List Google Cloud DNS record sets in a managed zone for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_dns_record_set (list)
+
+Lists **DNS record sets** in a Google Cloud DNS managed zone for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_dns_record_set`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_dns_record_set" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "my-project"
+
+    # Required. Cloud DNS record-set listing is scoped to a managed zone.
+    # managed_zone = "my-zone"
+
+    # Optional. Exact record-set name filter.
+    # name = "www.example.com"
+
+    # Optional. Record type filter. Best used with name.
+    # type = "A"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID whose DNS record sets are listed. If unset, the provider's
+  configured default project is used.
+
+* `managed_zone` - (Required) Managed zone whose record sets are listed.
+
+* `name` - (Optional) Exact DNS record-set name to filter by.
+
+* `type` - (Optional) DNS record type to filter by such as A, AAAA, CNAME, MX, or TXT.
+
+## Results
+
+By default each result includes **resource identity** for `google_dns_record_set` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `project` - Project ID when applicable.
+* `managed_zone` - Managed Zone name.
+* `name` - DNS record-set name.
+* `type` - DNS record type.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_dns_record_set` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set#attributes-reference)
+(for example ttl, rrdatas, and routing policy).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/26904

Added List resource and resource identity support to google_dns_record_set

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-list-resource
 `google_dns_record_set`
```

```release-note:enhancement
dns: add resource identity support for `google_dns_record_set` resource
```