### PR TITLE
feat(ces): add security_settings to web_widget_config in google_ces_deployment

### DIFF
--- a/mmv1/products/ces/Deployment.yaml
+++ b/mmv1/products/ces/Deployment.yaml
@@ -118,6 +118,16 @@ properties:
           - name: webWidgetTitle
             type: String
             description: The title of the web widget.
+          - name: securitySettings
+            type: NestedObject
+            description: Security settings for the web widget.
+            properties:
+              - name: enablePublicAccess
+                type: Boolean
+                description: |-
+                  Whether to enable public access for the web widget deployment.
+                  When true, the widget can be embedded without additional
+                  authentication.
   - name: createTime
     type: String
     description: Timestamp when this deployment was created.

--- a/mmv1/templates/terraform/examples/ces_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_deployment_basic.tf.tmpl
@@ -23,6 +23,9 @@ resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
             modality = "CHAT_AND_VOICE"
             theme = "DARK"
             web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = true
+            }
         }
     }
 }

--- a/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
@@ -74,6 +74,9 @@ resource "google_ces_deployment" "my-deployment" {
             modality = "CHAT_AND_VOICE"
             theme = "DARK"
             web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = true
+            }
         }
     }
 }
@@ -107,6 +110,9 @@ resource "google_ces_deployment" "my-deployment" {
             modality = "CHAT_ONLY"
             theme = "LIGHT"
             web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = false
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

The `webWidgetConfig` block in `google_ces_deployment` is missing `securitySettings`, which the CES API supports. In particular, `enablePublicAccess` controls whether the web widget can be embedded without additional authentication.

Without this field in the Terraform provider, users must resort to a `local-exec` workaround to PATCH the deployment after creation/update. Adding `security_settings` as a native Terraform attribute eliminates this workaround.

## Changes

- `mmv1/products/ces/Deployment.yaml`: Add `securitySettings` nested object under `webWidgetConfig` with `enablePublicAccess` boolean field
- `mmv1/templates/terraform/examples/ces_deployment_basic.tf.tmpl`: Update example to show `security_settings` usage

## Example usage

```hcl
resource "google_ces_deployment" "example" {
  location     = "us"
  display_name = "My Deployment"
  app          = google_ces_app.my_app.name
  app_version  = "projects/.../versions/..."
  channel_profile {
    channel_type = "WEB_UI"
    web_widget_config {
      modality = "CHAT_AND_VOICE"
      security_settings {
        enable_public_access = true
      }
    }
  }
}
```

```release-note:enhancement
ces: added `security_settings` block to `web_widget_config` in `google_ces_deployment` resource to support configuring `enable_public_access`
```