### PR TITLE
feat: enable data sources for HTTP(S) Target Proxies

### DIFF
--- a/mmv1/products/compute/RegionTargetHttpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpProxy.yaml
@@ -25,6 +25,8 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/targetHttpProxies'
 has_self_link: true
 immutable: true
+datasource_experimental:
+  generate: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionTargetHttpsProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpsProxy.yaml
@@ -25,6 +25,8 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/targetHttpsProxies'
 has_self_link: true
 immutable: true
+datasource_experimental:
+  generate: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -25,6 +25,8 @@ docs:
 base_url: 'projects/{{project}}/global/targetHttpProxies'
 has_self_link: true
 immutable: true
+datasource_experimental:
+  generate: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/TargetHttpsProxy.yaml
+++ b/mmv1/products/compute/TargetHttpsProxy.yaml
@@ -25,6 +25,8 @@ docs:
 base_url: 'projects/{{project}}/global/targetHttpsProxies'
 has_self_link: true
 immutable: true
+datasource_experimental:
+  generate: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Enables data sources for:
- `google_compute_target_http_proxy`
- `google_compute_target_https_proxy`
- `google_compute_region_target_http_proxy`
- `google_compute_region_target_https_proxy`

Fixes b/302797446
Fixes https://github.com/hashicorp/terraform-provider-google/issues/11437

```release-note:enhancement
compute: added data sources for `google_compute_target_http_proxy`, `google_compute_target_https_proxy`, `google_compute_region_target_http_proxy`, and `google_compute_region_target_https_proxy`
```