### PR TITLE
discoveryengine: add pre-delete hook to detach stores on destroy

### DIFF
--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -35,6 +35,7 @@ import_format:
   - 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataConnector'
 custom_code:
   constants: "templates/terraform/constants/discoveryengine_data_connector.go.tmpl"
+  pre_delete: "templates/terraform/pre_delete/discoveryengine_data_connector.go.tmpl"
 state_upgraders: true
 schema_version: 1
 timeouts:
@@ -58,6 +59,16 @@ examples:
     primary_resource_id: 'jira-with-actions'
     vars:
       collection_id: 'collection-id'
+
+virtual_fields:
+  - name: 'detach_stores_on_destroy'
+    description: |
+      If set to `true`, Terraform will detach the associated Data Stores from any Search Engine before deleting the Data Connector.
+      This addresses a circular dependency issue where deleting the Data Connector fails if its stores are in use.
+      Defaults to `false`.
+    type: Boolean
+    default_value: false
+
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -61,13 +61,13 @@ examples:
       collection_id: 'collection-id'
 
 virtual_fields:
-  - name: 'detach_stores_on_destroy'
+  - name: 'deletion_policy'
     description: |
-      If set to `true`, Terraform will detach the associated Data Stores from any Search Engine before deleting the Data Connector.
-      This addresses a circular dependency issue where deleting the Data Connector fails if its stores are in use.
-      Defaults to `false`.
-    type: Boolean
-    default_value: false
+      Policy to determine if the data stores should be forcefully detached from
+      the search engines before destroying the data connector.
+      Possible values: DEFAULT, FORCE.
+    type: String
+    default_value: "DEFAULT"
 
 parameters:
   - name: 'location'

--- a/mmv1/templates/terraform/pre_delete/discoveryengine_data_connector.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/discoveryengine_data_connector.go.tmpl
@@ -1,0 +1,134 @@
+if d.Get("detach_stores_on_destroy").(bool) {
+	log.Printf("[DEBUG] detach_stores_on_destroy is true, checking for linked search engines")
+
+	// 1. Get stores from entities
+	entitiesObj := d.Get("entities")
+	entities, ok := entitiesObj.([]interface{})
+	if !ok {
+		return fmt.Errorf("error converting entities to []interface{}")
+	}
+
+	var storeIds []string
+	for _, entityObj := range entities {
+		entity, ok := entityObj.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		storeNameObj, ok := entity["data_store"]
+		if !ok {
+			continue
+		}
+		storeName, ok := storeNameObj.(string)
+		if !ok || storeName == "" {
+			continue
+		}
+		// Extract store ID from full name: projects/*/locations/*/collections/*/dataStores/*
+		parts := strings.Split(storeName, "/")
+		if len(parts) > 0 {
+			storeIds = append(storeIds, parts[len(parts)-1])
+		}
+	}
+
+	if len(storeIds) == 0 {
+		log.Printf("[DEBUG] No stores found in DataConnector to detach")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Stores to detach: %v", storeIds)
+
+	// 2. List engines in the collection
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	location := d.Get("location").(string)
+	collectionId := d.Get("collection_id").(string)
+
+	baseUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}DiscoveryEngineBasePath{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	enginesUrl := baseUrl + fmt.Sprintf("projects/%s/locations/%s/collections/%s/engines", project, location, collectionId)
+
+	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    enginesUrl,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return fmt.Errorf("error listing engines: %s", err)
+	}
+
+	enginesObj, ok := resp["engines"]
+	if !ok {
+		log.Printf("[DEBUG] No engines found in collection")
+		return nil
+	}
+	engines, ok := enginesObj.([]interface{})
+	if !ok {
+		return fmt.Errorf("error converting engines to []interface{}")
+	}
+
+	for _, engineObj := range engines {
+		engine, ok := engineObj.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		engineName := engine["name"].(string)
+		dataStoreIdsObj, ok := engine["dataStoreIds"]
+		if !ok {
+			continue
+		}
+		dataStoreIds, ok := dataStoreIdsObj.([]interface{})
+		if !ok {
+			continue
+		}
+
+		var newStoreIds []string
+		modified := false
+		for _, idObj := range dataStoreIds {
+			id, ok := idObj.(string)
+			if !ok {
+				continue
+			}
+			matched := false
+			for _, targetId := range storeIds {
+				if id == targetId {
+					matched = true
+					modified = true
+					break
+				}
+			}
+			if !matched {
+				newStoreIds = append(newStoreIds, id)
+			}
+		}
+
+		if modified {
+			log.Printf("[DEBUG] Detaching stores from engine %s", engineName)
+			// Call PATCH on engine to update dataStoreIds
+			engineUrl := baseUrl + engineName
+			updateMask := "dataStoreIds"
+			
+			// Construct request body
+			body := map[string]interface{}{
+				"dataStoreIds": newStoreIds,
+			}
+
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "PATCH",
+				Project:   project,
+				RawURL:    engineUrl + "?updateMask=" + updateMask,
+				UserAgent: userAgent,
+				Body:      body,
+			})
+			if err != nil {
+				return fmt.Errorf("error updating engine %s: %s", engineName, err)
+			}
+			log.Printf("[DEBUG] Successfully detached stores from engine %s", engineName)
+		}
+	}
+}

--- a/mmv1/templates/terraform/pre_delete/discoveryengine_data_connector.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/discoveryengine_data_connector.go.tmpl
@@ -1,5 +1,5 @@
-if d.Get("detach_stores_on_destroy").(bool) {
-	log.Printf("[DEBUG] detach_stores_on_destroy is true, checking for linked search engines")
+if d.Get("deletion_policy").(string) == "FORCE" {
+	log.Printf("[DEBUG] deletion_policy is FORCE, checking for linked search engines")
 
 	// 1. Get stores from entities
 	entitiesObj := d.Get("entities")

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
@@ -256,3 +256,97 @@ func TestAccDiscoveryEngineDataConnector_DataConnectorEntitiesParamsDiffSuppress
 		}
 	}
 }
+
+func TestAccDiscoveryEngineDataConnector_detachStoresOnDestroy(t *testing.T) {
+	// Skips this test as it requires complex IdP setup.
+	t.Skip()
+
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDiscoveryEngineDataConnector_detachStoresOnDestroy(context),
+			},
+			{
+				ResourceName:            "google_discovery_engine_data_connector.servicenow-basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"collection_display_name", "collection_id", "location", "params", "update_time", "action_config.0.action_params", "action_config.0.create_bap_connection"},
+			},
+		},
+	})
+}
+
+func testAccDiscoveryEngineDataConnector_detachStoresOnDestroy(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_connector" "servicenow-basic" {
+  location                     = "global"
+  collection_id                = "tf-test-collection-id%{random_suffix}"
+  collection_display_name      = "tf-test-dataconnector-servicenow"
+  data_source                  = "servicenow"
+  data_source_version          = 3
+  params = {
+    auth_type                  = "OAUTH_PASSWORD_GRANT"
+    instance_uri               = "https://gcpconnector1.service-now.com/"
+    client_id                  = "SECRET_MANAGER_RESOURCE_NAME"
+    client_secret              = "SECRET_MANAGER_RESOURCE_NAME"
+    static_ip_enabled          = "false"
+    user_account               = "connectorsuserqa@google.com"
+    password                   = "SECRET_MANAGER_RESOURCE_NAME"
+  }
+  refresh_interval             = "86400s"
+  entities {
+    entity_name                = "catalog"
+
+    params = jsonencode({
+      "inclusion_filters" : {
+        "knowledgeBaseSysId" : [
+          "123"
+        ]
+      }
+    })
+  }
+  entities {
+    entity_name = "incident"
+    params = jsonencode({
+      "inclusion_filters" : {
+        "knowledgeBaseSysId" : [
+          "123"
+        ]
+      }
+    })
+  }
+  entities {
+    entity_name = "knowledge_base"
+    params = jsonencode({
+      "inclusion_filters" : {
+        "knowledgeBaseSysId" : [
+          "123"
+        ]
+      }
+    })
+  }
+  static_ip_enabled            = false
+  destination_configs {
+    key = "url"
+    destinations {
+      host = "https://gcpconnector1.service-now.com/"
+      port = 123
+    }
+  }
+  connector_modes              = ["DATA_INGESTION"]
+  sync_mode                    = "PERIODIC"
+  detach_stores_on_destroy     = true
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
@@ -352,4 +352,3 @@ resource "google_discovery_engine_data_connector" "jira-with-actions" {
 }
 `, context)
 }
-

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
@@ -257,7 +257,7 @@ func TestAccDiscoveryEngineDataConnector_DataConnectorEntitiesParamsDiffSuppress
 	}
 }
 
-func TestAccDiscoveryEngineDataConnector_detachStoresOnDestroy(t *testing.T) {
+func TestAccDiscoveryEngineDataConnector_deletionPolicyForce(t *testing.T) {
 	// Skips this test as it requires complex IdP setup.
 	t.Skip()
 
@@ -275,19 +275,19 @@ func TestAccDiscoveryEngineDataConnector_detachStoresOnDestroy(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDiscoveryEngineDataConnector_detachStoresOnDestroy(context),
+				Config: testAccDiscoveryEngineDataConnector_deletionPolicyForce(context),
 			},
 			{
 				ResourceName:            "google_discovery_engine_data_connector.servicenow-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"collection_display_name", "collection_id", "location", "params", "update_time", "action_config.0.action_params", "action_config.0.create_bap_connection"},
+				ImportStateVerifyIgnore: []string{"collection_display_name", "collection_id", "location", "params", "update_time", "action_config.0.action_params", "action_config.0.create_bap_connection", "deletion_policy"},
 			},
 		},
 	})
 }
 
-func testAccDiscoveryEngineDataConnector_detachStoresOnDestroy(context map[string]interface{}) string {
+func testAccDiscoveryEngineDataConnector_deletionPolicyForce(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_discovery_engine_data_connector" "servicenow-basic" {
   location                     = "global"
@@ -346,7 +346,7 @@ resource "google_discovery_engine_data_connector" "servicenow-basic" {
   }
   connector_modes              = ["DATA_INGESTION"]
   sync_mode                    = "PERIODIC"
-  detach_stores_on_destroy     = true
+  deletion_policy              = "FORCE"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/resource_discovery_engine_data_connector_test.go
@@ -258,9 +258,6 @@ func TestAccDiscoveryEngineDataConnector_DataConnectorEntitiesParamsDiffSuppress
 }
 
 func TestAccDiscoveryEngineDataConnector_deletionPolicyForce(t *testing.T) {
-	// Skips this test as it requires complex IdP setup.
-	t.Skip()
-
 	t.Parallel()
 
 	context := map[string]interface{}{
@@ -278,10 +275,10 @@ func TestAccDiscoveryEngineDataConnector_deletionPolicyForce(t *testing.T) {
 				Config: testAccDiscoveryEngineDataConnector_deletionPolicyForce(context),
 			},
 			{
-				ResourceName:            "google_discovery_engine_data_connector.servicenow-basic",
+				ResourceName:            "google_discovery_engine_data_connector.jira-with-actions",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"collection_display_name", "collection_id", "location", "params", "update_time", "action_config.0.action_params", "action_config.0.create_bap_connection", "deletion_policy"},
+				ImportStateVerifyIgnore: []string{"collection_display_name", "collection_id", "location", "params", "update_time", "action_config.0.action_params", "action_config.0.create_bap_connection", "deletion_policy", "data_source_version", "auto_run_disabled", "incremental_sync_disabled", "sync_mode"},
 			},
 		},
 	})
@@ -289,64 +286,70 @@ func TestAccDiscoveryEngineDataConnector_deletionPolicyForce(t *testing.T) {
 
 func testAccDiscoveryEngineDataConnector_deletionPolicyForce(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_discovery_engine_data_connector" "servicenow-basic" {
+resource "google_discovery_engine_data_connector" "jira-with-actions" {
   location                     = "global"
   collection_id                = "tf-test-collection-id%{random_suffix}"
-  collection_display_name      = "tf-test-dataconnector-servicenow"
-  data_source                  = "servicenow"
-  data_source_version          = 3
+  collection_display_name      = "Jira Federated"
+  data_source                  = "jira"
   params = {
-    auth_type                  = "OAUTH_PASSWORD_GRANT"
-    instance_uri               = "https://gcpconnector1.service-now.com/"
-    client_id                  = "SECRET_MANAGER_RESOURCE_NAME"
-    client_secret              = "SECRET_MANAGER_RESOURCE_NAME"
-    static_ip_enabled          = "false"
-    user_account               = "connectorsuserqa@google.com"
-    password                   = "SECRET_MANAGER_RESOURCE_NAME"
+    instance_uri               = "https://example.atlassian.net"
+    instance_id                = "dummy"
+    client_id                  = "dummy"
+    client_secret              = "dummy"
+    refresh_token              = "dummy"
+    auth_type                  = "OAUTH"
   }
   refresh_interval             = "86400s"
   entities {
-    entity_name                = "catalog"
-
-    params = jsonencode({
-      "inclusion_filters" : {
-        "knowledgeBaseSysId" : [
-          "123"
-        ]
-      }
-    })
+    entity_name                = "project"
   }
   entities {
-    entity_name = "incident"
-    params = jsonencode({
-      "inclusion_filters" : {
-        "knowledgeBaseSysId" : [
-          "123"
-        ]
-      }
-    })
+    entity_name                = "issue"
   }
   entities {
-    entity_name = "knowledge_base"
-    params = jsonencode({
-      "inclusion_filters" : {
-        "knowledgeBaseSysId" : [
-          "123"
-        ]
-      }
-    })
+    entity_name                = "comment"
+  }
+  entities {
+    entity_name                = "attachment"
   }
   static_ip_enabled            = false
   destination_configs {
     key = "url"
     destinations {
-      host = "https://gcpconnector1.service-now.com/"
+      host = "https://example.atlassian.net"
       port = 123
     }
+    params                     = jsonencode({
+      "destination_type": "private"
+    })
   }
-  connector_modes              = ["DATA_INGESTION"]
+  connector_modes              = ["FEDERATED", "ACTIONS"]
   sync_mode                    = "PERIODIC"
+  auto_run_disabled            = true
+  incremental_sync_disabled    = true
+  action_config {
+    action_params = {
+      instance_uri             = "https://example.atlassian.net"
+      instance_id              = "dummy"
+      client_id                = "dummy"
+      client_secret            = "dummy"
+      auth_type                = "OAUTH"
+    }
+    create_bap_connection      = true
+  }
+  bap_config {
+    supported_connector_modes = ["ACTIONS"]
+    enabled_actions = [
+      "create_issue",
+      "update_issue",
+      "change_issue_status",
+      "create_comment",
+      "update_comment",
+      "upload_attachment",
+    ]
+  }
   deletion_policy              = "FORCE"
 }
 `, context)
 }
+


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR updates the google_discovery_engine_data_connector resource to use the standard Google provider pattern for deletion behavior by introducing the deletion_policy field.

It adds a custom pre_delete hook that detaches associated Data Stores from Search Engines before deleting the Data Connector when deletion_policy = "FORCE", preventing circular dependency/destruction order errors and leaving the resource clean.

An acceptance test was added (TestAccDiscoveryEngineDataConnector_deletionPolicyForce) using the Jira data source (avoiding the complex IdP setup requirements needed for ServiceNow).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
discoveryengine: added `deletion_policy` field to `google_discovery_engine_data_connector` resource to handle destruction order dependencies.
```
