### PR TITLE
Moved some clients from config.go to individual service packages

### DIFF
--- a/mmv1/provider/terraform_tgc.go
+++ b/mmv1/provider/terraform_tgc.go
@@ -397,6 +397,7 @@ func (tgc TerraformGoogleConversion) CopyCommonFiles(outputFolder string, genera
 		"converters/google/resources/services/kms/kms_utils.go":                                 "third_party/terraform/services/kms/kms_utils.go",
 		"converters/google/resources/services/sourcerepo/source_repo_utils.go":                  "third_party/terraform/services/sourcerepo/source_repo_utils.go",
 		"converters/google/resources/services/pubsub/pubsub_utils.go":                           "third_party/terraform/services/pubsub/pubsub_utils.go",
+		"converters/google/resources/services/pubsub/client.go":                                 "third_party/terraform/services/pubsub/client.go",
 		"converters/google/resources/services/privateca/privateca_utils.go":                     "third_party/terraform/services/privateca/privateca_utils.go",
 		"converters/google/resources/services/bigquery/bigquery_dataset_iam.go":                 "third_party/tgc/services/bigquery/bigquery_dataset_iam.go",
 		"converters/google/resources/services/compute/compute_security_policy.go":               "third_party/tgc/services/compute/compute_security_policy.go",

--- a/mmv1/third_party/terraform/services/certificatemanager/client.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/client.go
@@ -1,0 +1,23 @@
+package certificatemanager
+
+import (
+	"log"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/certificatemanager/v1"
+	"google.golang.org/api/option"
+)
+
+func NewClient(c *transport_tpg.Config, userAgent string) *certificatemanager.Service {
+	certificateManagerClientBasePath := transport_tpg.RemoveBasePathVersion(c.CertificateManagerBasePath)
+	log.Printf("[INFO] Instantiating Certificate Manager client for path %s", certificateManagerClientBasePath)
+	clientCertificateManager, err := certificatemanager.NewService(c.Context, option.WithHTTPClient(c.Client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client certificate manager: %s", err)
+		return nil
+	}
+	clientCertificateManager.UserAgent = userAgent
+	clientCertificateManager.BasePath = certificateManagerClientBasePath
+
+	return clientCertificateManager
+}

--- a/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificates.go
+++ b/mmv1/third_party/terraform/services/certificatemanager/data_source_google_certificate_manager_certificates.go
@@ -57,7 +57,7 @@ func dataSourceGoogleCertificateManagerCertificatesRead(d *schema.ResourceData, 
 	filter := d.Get("filter").(string)
 
 	certificates := make([]map[string]interface{}, 0)
-	certificatesList, err := config.NewCertificateManagerClient(userAgent).Projects.Locations.Certificates.List(fmt.Sprintf("projects/%s/locations/%s", project, region)).Filter(filter).Do()
+	certificatesList, err := NewClient(config, userAgent).Projects.Locations.Certificates.List(fmt.Sprintf("projects/%s/locations/%s", project, region)).Filter(filter).Do()
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Certificates : %s %s", project, region))
 	}

--- a/mmv1/third_party/terraform/services/firebase/client.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/client.go.tmpl
@@ -1,0 +1,28 @@
+package firebase
+{{- if ne $.TargetVersionName "ga" }}
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	firebase "google.golang.org/api/firebase/v1beta1"
+	"google.golang.org/api/option"
+)
+
+func NewClient(ctx context.Context, c *transport_tpg.Config, userAgent string) *firebase.Service {
+	firebaseClientBasePath := transport_tpg.RemoveBasePathVersion(c.FirebaseBasePath)
+	firebaseClientBasePath = strings.ReplaceAll(firebaseClientBasePath, "/firebase/", "")
+	log.Printf("[INFO] Instantiating Google Cloud firebase client for path %s", firebaseClientBasePath)
+	clientFirebase, err := firebase.NewService(c.Context, option.WithHTTPClient(c.Client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client firebase: %s", err)
+		return nil
+	}
+	clientFirebase.UserAgent = userAgent
+	clientFirebase.BasePath = firebaseClientBasePath
+
+	return clientFirebase
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_admin_sdk_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_admin_sdk_config.go.tmpl
@@ -93,7 +93,7 @@ func (d *GoogleFirebaseAdminSdkConfigDataSource) Configure(ctx context.Context, 
 		return
 	}
 
-	p, ok := req.ProviderData.(*transport_tpg.Config)
+	config, ok := req.ProviderData.(*transport_tpg.Config)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
@@ -102,11 +102,11 @@ func (d *GoogleFirebaseAdminSdkConfigDataSource) Configure(ctx context.Context, 
 		return
 	}
 
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
+	d.client = NewClient(ctx, config, config.UserAgent)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	d.providerConfig = p
+	d.providerConfig = config
 }
 
 func (d *GoogleFirebaseAdminSdkConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_android_app_config.go.tmpl
@@ -92,7 +92,7 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Configure(ctx context.Context
 		return
 	}
 
-	p, ok := req.ProviderData.(*transport_tpg.Config)
+	config, ok := req.ProviderData.(*transport_tpg.Config)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
@@ -101,11 +101,11 @@ func (d *GoogleFirebaseAndroidAppConfigDataSource) Configure(ctx context.Context
 		return
 	}
 
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
+	d.client = NewClient(ctx, config, config.UserAgent)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	d.providerConfig = p
+	d.providerConfig = config
 }
 
 func (d *GoogleFirebaseAndroidAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_apple_app_config.go.tmpl
@@ -92,7 +92,7 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Configure(ctx context.Context, 
 		return
 	}
 
-	p, ok := req.ProviderData.(*transport_tpg.Config)
+	config, ok := req.ProviderData.(*transport_tpg.Config)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
@@ -101,11 +101,11 @@ func (d *GoogleFirebaseAppleAppConfigDataSource) Configure(ctx context.Context, 
 		return
 	}
 
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
+	d.client = NewClient(ctx, config, config.UserAgent)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	d.providerConfig = p
+	d.providerConfig = config
 }
 
 func (d *GoogleFirebaseAppleAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebase/data_source_google_firebase_web_app_config.go.tmpl
@@ -139,7 +139,7 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Configure(ctx context.Context, re
 		return
 	}
 
-	p, ok := req.ProviderData.(*transport_tpg.Config)
+	config, ok := req.ProviderData.(*transport_tpg.Config)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Unexpected Data Source Configure Type",
@@ -148,11 +148,11 @@ func (d *GoogleFirebaseWebAppConfigDataSource) Configure(ctx context.Context, re
 		return
 	}
 
-	d.client = p.NewFirebaseClient(ctx, p.UserAgent)
+	d.client = NewClient(ctx, config, config.UserAgent)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	d.providerConfig = p
+	d.providerConfig = config
 }
 
 func (d *GoogleFirebaseWebAppConfigDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {

--- a/mmv1/third_party/terraform/services/pubsub/client.go
+++ b/mmv1/third_party/terraform/services/pubsub/client.go
@@ -1,0 +1,24 @@
+package pubsub
+
+import (
+	"log"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/option"
+	pubsub "google.golang.org/api/pubsub/v1"
+)
+
+func NewClient(c *transport_tpg.Config, userAgent string) *pubsub.Service {
+	pubsubClientBasePath := transport_tpg.RemoveBasePathVersion(c.PubsubBasePath)
+	log.Printf("[INFO] Instantiating Google Pubsub client for path %s", pubsubClientBasePath)
+	wrappedPubsubClient := transport_tpg.ClientWithAdditionalRetries(c.Client, transport_tpg.PubsubTopicProjectNotReady)
+	clientPubsub, err := pubsub.NewService(c.Context, option.WithHTTPClient(wrappedPubsubClient))
+	if err != nil {
+		log.Printf("[WARN] Error creating client pubsub: %s", err)
+		return nil
+	}
+	clientPubsub.UserAgent = userAgent
+	clientPubsub.BasePath = pubsubClientBasePath
+
+	return clientPubsub
+}

--- a/mmv1/third_party/terraform/services/pubsub/iam_pubsub_subscription.go.tmpl
+++ b/mmv1/third_party/terraform/services/pubsub/iam_pubsub_subscription.go.tmpl
@@ -64,7 +64,7 @@ func (u *PubsubSubscriptionIamUpdater) GetResourceIamPolicy() (*cloudresourceman
 		return nil, err
 	}
 
-	p, err := u.Config.NewPubsubClient(userAgent).Projects.Subscriptions.GetIamPolicy(u.subscription).Do()
+	p, err := NewClient(u.Config, userAgent).Projects.Subscriptions.GetIamPolicy(u.subscription).Do()
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{"{{"}}err{{"}}"}}", u.DescribeResource()), err)
@@ -89,7 +89,7 @@ func (u *PubsubSubscriptionIamUpdater) SetResourceIamPolicy(policy *cloudresourc
 		return err
 	}
 
-	_, err = u.Config.NewPubsubClient(userAgent).Projects.Subscriptions.SetIamPolicy(u.subscription, &pubsub.SetIamPolicyRequest{
+	_, err = NewClient(u.Config, userAgent).Projects.Subscriptions.SetIamPolicy(u.subscription, &pubsub.SetIamPolicyRequest{
 		Policy: pubsubPolicy,
 	}).Do()
 

--- a/mmv1/third_party/terraform/services/pubsub/iam_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/iam_pubsub_subscription_test.go
@@ -118,7 +118,7 @@ func TestAccPubsubSubscriptionIamPolicy(t *testing.T) {
 func testAccCheckPubsubSubscriptionIam(t *testing.T, subscription, role string, members []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		p, err := config.NewPubsubClient(config.UserAgent).Projects.Subscriptions.GetIamPolicy(pubsub.GetComputedSubscriptionName(envvar.GetTestProjectFromEnv(), subscription)).Do()
+		p, err := pubsub.NewClient(config, config.UserAgent).Projects.Subscriptions.GetIamPolicy(pubsub.GetComputedSubscriptionName(envvar.GetTestProjectFromEnv(), subscription)).Do()
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/services/pubsub/iam_pubsub_topic_test.go
+++ b/mmv1/third_party/terraform/services/pubsub/iam_pubsub_topic_test.go
@@ -140,7 +140,7 @@ func TestAccPubsubTopicIamPolicy(t *testing.T) {
 func testAccCheckPubsubTopicIam(t *testing.T, topic, role string, members []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		p, err := config.NewPubsubClient(config.UserAgent).Projects.Topics.GetIamPolicy(pubsub.GetComputedTopicName(envvar.GetTestProjectFromEnv(), topic)).Do()
+		p, err := pubsub.NewClient(config, config.UserAgent).Projects.Topics.GetIamPolicy(pubsub.GetComputedTopicName(envvar.GetTestProjectFromEnv(), topic)).Do()
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/services/runtimeconfig/client.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/client.go.tmpl
@@ -1,0 +1,25 @@
+package runtimeconfig
+
+{{ if ne $.TargetVersionName `ga` -}}
+import (
+	"log"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/option"
+	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
+)
+
+func NewClient(c *transport_tpg.Config, userAgent string) *runtimeconfig.Service {
+	runtimeConfigClientBasePath := transport_tpg.RemoveBasePathVersion(c.RuntimeConfigBasePath)
+	log.Printf("[INFO] Instantiating Google Cloud Runtimeconfig client for path %s", runtimeConfigClientBasePath)
+	clientRuntimeconfig, err := runtimeconfig.NewService(c.Context, option.WithHTTPClient(c.Client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client runtime config: %s", err)
+		return nil
+	}
+	clientRuntimeconfig.UserAgent = userAgent
+	clientRuntimeconfig.BasePath = runtimeConfigClientBasePath
+
+	return clientRuntimeconfig
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config.go.tmpl
@@ -81,7 +81,7 @@ func resourceRuntimeconfigConfigCreate(d *schema.ResourceData, meta interface{})
 		runtimeConfig.Description = val.(string)
 	}
 
-	_, err = config.NewRuntimeconfigClient(userAgent).Projects.Configs.Create("projects/"+project, &runtimeConfig).Do()
+	_, err = NewClient(config, userAgent).Projects.Configs.Create("projects/"+project, &runtimeConfig).Do()
 
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func resourceRuntimeconfigConfigRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	fullName := d.Id()
-	runConfig, err := config.NewRuntimeconfigClient(userAgent).Projects.Configs.Get(fullName).Do()
+	runConfig, err := NewClient(config, userAgent).Projects.Configs.Get(fullName).Do()
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("RuntimeConfig %q", d.Id()))
 	}
@@ -150,7 +150,7 @@ func resourceRuntimeconfigConfigUpdate(d *schema.ResourceData, meta interface{})
 		runtimeConfig.Description = v.(string)
 	}
 
-	_, err = config.NewRuntimeconfigClient(userAgent).Projects.Configs.Update(fullName, &runtimeConfig).Do()
+	_, err = NewClient(config, userAgent).Projects.Configs.Update(fullName, &runtimeConfig).Do()
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func resourceRuntimeconfigConfigDelete(d *schema.ResourceData, meta interface{})
 
 	fullName := d.Id()
 
-	_, err = config.NewRuntimeconfigClient(userAgent).Projects.Configs.Delete(fullName).Do()
+	_, err = NewClient(config, userAgent).Projects.Configs.Delete(fullName).Do()
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config_test.go.tmpl
@@ -128,7 +128,7 @@ func testAccCheckRuntimeConfigExists(t *testing.T, resourceName string, runtimeC
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := config.NewRuntimeconfigClient(config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
+		found, err := NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func testAccCheckRuntimeconfigConfigDestroyProducer(t *testing.T) func(s *terraf
 				continue
 			}
 
-			_, err := config.NewRuntimeconfigClient(config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
+			_, err := NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
 
 			if err == nil {
 				return fmt.Errorf("Runtimeconfig still exists")

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_config_test.go.tmpl
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	runtimeconfig_tpg "github.com/hashicorp/terraform-provider-google/google/services/runtimeconfig"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -128,7 +129,7 @@ func testAccCheckRuntimeConfigExists(t *testing.T, resourceName string, runtimeC
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
+		found, err := runtimeconfig_tpg.NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
@@ -148,7 +149,7 @@ func testAccCheckRuntimeconfigConfigDestroyProducer(t *testing.T) func(s *terraf
 				continue
 			}
 
-			_, err := NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
+			_, err := runtimeconfig_tpg.NewClient(config, config.UserAgent).Projects.Configs.Get(rs.Primary.ID).Do()
 
 			if err == nil {
 				return fmt.Errorf("Runtimeconfig still exists")

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable.go.tmpl
@@ -93,7 +93,7 @@ func resourceRuntimeconfigVariableCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	createdVariable, err := config.NewRuntimeconfigClient(userAgent).Projects.Configs.Variables.Create(resourceRuntimeconfigFullName(project, parent), variable).Do()
+	createdVariable, err := NewClient(config, userAgent).Projects.Configs.Variables.Create(resourceRuntimeconfigFullName(project, parent), variable).Do()
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func resourceRuntimeconfigVariableRead(d *schema.ResourceData, meta interface{})
 	}
 
 	fullName := d.Id()
-	createdVariable, err := config.NewRuntimeconfigClient(userAgent).Projects.Configs.Variables.Get(fullName).Do()
+	createdVariable, err := NewClient(config, userAgent).Projects.Configs.Variables.Get(fullName).Do()
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func resourceRuntimeconfigVariableUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	createdVariable, err := config.NewRuntimeconfigClient(userAgent).Projects.Configs.Variables.Update(variable.Name, variable).Do()
+	createdVariable, err := NewClient(config, userAgent).Projects.Configs.Variables.Update(variable.Name, variable).Do()
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func resourceRuntimeconfigVariableDelete(d *schema.ResourceData, meta interface{
 
 	fullName := d.Id()
 
-	_, err = config.NewRuntimeconfigClient(userAgent).Projects.Configs.Variables.Delete(fullName).Do()
+	_, err = NewClient(config, userAgent).Projects.Configs.Variables.Delete(fullName).Do()
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable_test.go.tmpl
@@ -123,7 +123,7 @@ func testAccCheckRuntimeconfigVariableExists(t *testing.T, resourceName string, 
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := config.NewRuntimeconfigClient(config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
+		found, err := NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
@@ -187,7 +187,7 @@ func testAccCheckRuntimeconfigVariableDestroyProducer(t *testing.T) func(s *terr
 				continue
 			}
 
-			_, err := config.NewRuntimeconfigClient(config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
+			_, err := NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
 
 			if err == nil {
 				return fmt.Errorf("Runtimeconfig variable still exists")

--- a/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/runtimeconfig/resource_runtimeconfig_variable_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	runtimeconfig_tpg "github.com/hashicorp/terraform-provider-google/google/services/runtimeconfig"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -123,7 +124,7 @@ func testAccCheckRuntimeconfigVariableExists(t *testing.T, resourceName string, 
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
+		found, err := runtimeconfig_tpg.NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
@@ -187,7 +188,7 @@ func testAccCheckRuntimeconfigVariableDestroyProducer(t *testing.T) func(s *terr
 				continue
 			}
 
-			_, err := NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
+			_, err := runtimeconfig_tpg.NewClient(config, config.UserAgent).Projects.Configs.Variables.Get(rs.Primary.ID).Do()
 
 			if err == nil {
 				return fmt.Errorf("Runtimeconfig variable still exists")

--- a/mmv1/third_party/terraform/services/servicemanagement/client.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/client.go
@@ -1,0 +1,23 @@
+package servicemanagement
+
+import (
+	"log"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/option"
+	"google.golang.org/api/servicemanagement/v1"
+)
+
+func NewClient(c *transport_tpg.Config, userAgent string) *servicemanagement.APIService {
+	serviceManagementClientBasePath := transport_tpg.RemoveBasePathVersion(c.ServiceManagementBasePath)
+	log.Printf("[INFO] Instantiating Google Cloud Service Management client for path %s", serviceManagementClientBasePath)
+	clientServiceMan, err := servicemanagement.NewService(c.Context, option.WithHTTPClient(c.Client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client service management: %s", err)
+		return nil
+	}
+	clientServiceMan.UserAgent = userAgent
+	clientServiceMan.BasePath = serviceManagementClientBasePath
+
+	return clientServiceMan
+}

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service.go
@@ -241,10 +241,10 @@ func resourceEndpointsServiceCreate(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[DEBUG] Create Endpoint Service %q", serviceName)
 
 	log.Printf("[DEBUG] Checking for existing ManagedService %q", serviceName)
-	_, err = config.NewServiceManClient(userAgent).Services.Get(serviceName).Do()
+	_, err = NewClient(config, userAgent).Services.Get(serviceName).Do()
 	if err != nil {
 		log.Printf("[DEBUG] Creating new ServiceManagement ManagedService %q", serviceName)
-		op, err := config.NewServiceManClient(userAgent).Services.Create(
+		op, err := NewClient(config, userAgent).Services.Create(
 			&servicemanagement.ManagedService{
 				ProducerProjectId: project,
 				ServiceName:       serviceName,
@@ -315,7 +315,7 @@ func resourceEndpointsServiceUpdate(d *schema.ResourceData, meta interface{}) er
 	// with any new features that arise - this is why you provide a YAML config
 	// instead of providing the config in HCL.
 	log.Printf("[DEBUG] Submitting config for ManagedService %q", serviceName)
-	op, err := config.NewServiceManClient(userAgent).Services.Configs.Submit(
+	op, err := NewClient(config, userAgent).Services.Configs.Submit(
 		serviceName,
 		&servicemanagement.SubmitConfigSourceRequest{
 			ConfigSource: cfgSource,
@@ -341,7 +341,7 @@ func resourceEndpointsServiceUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[DEBUG] Creating new rollout for ManagedService %q", serviceName)
-	op, err = config.NewServiceManClient(userAgent).Services.Rollouts.Create(serviceName, &rollout).Do()
+	op, err = NewClient(config, userAgent).Services.Rollouts.Create(serviceName, &rollout).Do()
 	if err != nil {
 		return err
 	}
@@ -362,7 +362,7 @@ func resourceEndpointsServiceDelete(d *schema.ResourceData, meta interface{}) er
 
 	log.Printf("[DEBUG] Deleting ManagedService %q", d.Id())
 
-	op, err := config.NewServiceManClient(userAgent).Services.Delete(d.Get("service_name").(string)).Do()
+	op, err := NewClient(config, userAgent).Services.Delete(d.Get("service_name").(string)).Do()
 	if err != nil {
 		return err
 	}
@@ -380,7 +380,7 @@ func resourceEndpointsServiceRead(d *schema.ResourceData, meta interface{}) erro
 
 	log.Printf("[DEBUG] Reading ManagedService %q", d.Id())
 
-	service, err := config.NewServiceManClient(userAgent).Services.GetConfig(d.Get("service_name").(string)).Do()
+	service, err := NewClient(config, userAgent).Services.GetConfig(d.Get("service_name").(string)).Do()
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/services/servicemanagement"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -278,7 +279,7 @@ EOF
 func testAccCheckEndpointExistsByName(t *testing.T, serviceId string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		service, err := NewClient(config, config.UserAgent).Services.GetConfig(
+		service, err := servicemanagement.NewClient(config, config.UserAgent).Services.GetConfig(
 			fmt.Sprintf("%s.endpoints.%s.cloud.goog", serviceId, config.Project)).Do()
 		if err != nil {
 			return err
@@ -304,7 +305,7 @@ func testAccCheckEndpointServiceDestroyProducer(t *testing.T) func(s *terraform.
 			}
 
 			serviceName := rs.Primary.Attributes["service_name"]
-			service, err := NewClient(config, config.UserAgent).Services.GetConfig(serviceName).Do()
+			service, err := servicemanagement.NewClient(config, config.UserAgent).Services.GetConfig(serviceName).Do()
 			if err != nil {
 				// ServiceManagement returns 403 if service doesn't exist.
 				if !transport_tpg.IsGoogleApiErrorWithCode(err, 403) {

--- a/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/resource_endpoints_service_test.go
@@ -278,7 +278,7 @@ EOF
 func testAccCheckEndpointExistsByName(t *testing.T, serviceId string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
-		service, err := config.NewServiceManClient(config.UserAgent).Services.GetConfig(
+		service, err := NewClient(config, config.UserAgent).Services.GetConfig(
 			fmt.Sprintf("%s.endpoints.%s.cloud.goog", serviceId, config.Project)).Do()
 		if err != nil {
 			return err
@@ -304,7 +304,7 @@ func testAccCheckEndpointServiceDestroyProducer(t *testing.T) func(s *terraform.
 			}
 
 			serviceName := rs.Primary.Attributes["service_name"]
-			service, err := config.NewServiceManClient(config.UserAgent).Services.GetConfig(serviceName).Do()
+			service, err := NewClient(config, config.UserAgent).Services.GetConfig(serviceName).Do()
 			if err != nil {
 				// ServiceManagement returns 403 if service doesn't exist.
 				if !transport_tpg.IsGoogleApiErrorWithCode(err, 403) {

--- a/mmv1/third_party/terraform/services/servicemanagement/serviceman_operation.go
+++ b/mmv1/third_party/terraform/services/servicemanagement/serviceman_operation.go
@@ -24,7 +24,7 @@ func (w *ServiceManagementOperationWaiter) QueryOp() (interface{}, error) {
 
 func ServiceManagementOperationWaitTime(config *transport_tpg.Config, op *servicemanagement.Operation, activity, userAgent string, timeout time.Duration) (googleapi.RawMessage, error) {
 	w := &ServiceManagementOperationWaiter{
-		Service: config.NewServiceManClient(userAgent),
+		Service: NewClient(config, userAgent),
 	}
 
 	if err := w.SetOp(op); err != nil {

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -38,9 +38,7 @@ import (
 	appengine "google.golang.org/api/appengine/v1"
 	"google.golang.org/api/bigquery/v2"
 	"google.golang.org/api/bigtableadmin/v2"
-	"google.golang.org/api/certificatemanager/v1"
 	"google.golang.org/api/cloudbilling/v1"
-	"google.golang.org/api/cloudbuild/v1"
 {{- if ne $.TargetVersionName "ga" }}
 	cloudidentity "google.golang.org/api/cloudidentity/v1beta1"
 {{- else }}
@@ -68,14 +66,10 @@ import (
 	dataflow "google.golang.org/api/dataflow/v1b3"
 	"google.golang.org/api/dataproc/v1"
 	"google.golang.org/api/dns/v1"
-{{- if ne $.TargetVersionName "ga" }}
-	firebase "google.golang.org/api/firebase/v1beta1"
-{{- end }}
 	healthcare "google.golang.org/api/healthcare/v1"
 	"google.golang.org/api/iam/v1"
 	iamcredentials "google.golang.org/api/iamcredentials/v1"
 	cloudlogging "google.golang.org/api/logging/v2"
-	"google.golang.org/api/pubsub/v1"
 	runadminv2 "google.golang.org/api/run/v2"
 {{- if ne $.TargetVersionName "ga" }}
 	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
@@ -719,20 +713,6 @@ func (c *Config) getTokenSource(ctx context.Context, clientScopes []string, init
 // while most only want the host URL, some older ones also want the version and some
 // of those "projects" as well. You can find out if this is required by looking at
 // the basePath value in the client library file.
-func (c *Config) NewCertificateManagerClient(userAgent string) *certificatemanager.Service {
-	certificateManagerClientBasePath := RemoveBasePathVersion(c.CertificateManagerBasePath)
-	log.Printf("[INFO] Instantiating Certificate Manager client for path %s", certificateManagerClientBasePath)
-	clientCertificateManager, err := certificatemanager.NewService(c.Context, option.WithHTTPClient(c.Client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client certificate manager: %s", err)
-		return nil
-	}
-	clientCertificateManager.UserAgent = userAgent
-	clientCertificateManager.BasePath = certificateManagerClientBasePath
-
-	return clientCertificateManager
-}
-
 func (c *Config) NewComputeClient(userAgent string) *compute.Service {
 	log.Printf("[INFO] Instantiating GCE client for path %s", c.ComputeBasePath)
 	clientCompute, err := compute.NewService(c.Context, option.WithHTTPClient(c.Client))
@@ -774,23 +754,6 @@ func (c *Config) NewDnsClient(userAgent string) *dns.Service {
 
 	return clientDns
 }
-
-{{- if ne $.TargetVersionName "ga" }}
-func (c *Config) NewFirebaseClient(ctx context.Context, userAgent string) *firebase.Service {
-	firebaseClientBasePath := RemoveBasePathVersion(c.FirebaseBasePath)
-	firebaseClientBasePath = strings.ReplaceAll(firebaseClientBasePath, "/firebase/", "")
-	log.Printf("[INFO] Instantiating Google Cloud firebase client for path %s", firebaseClientBasePath)
-	clientFirebase, err := firebase.NewService(c.Context, option.WithHTTPClient(c.Client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client firebase: %s", err)
-		return nil
-	}
-	clientFirebase.UserAgent = userAgent
-	clientFirebase.BasePath = firebaseClientBasePath
-
-	return clientFirebase
-}
-{{- end }}
 
 func (c *Config) NewKmsClientWithCtx(ctx context.Context, userAgent string) *cloudkms.Service {
 	kmsClientBasePath := RemoveBasePathVersion(c.KMSBasePath)
@@ -888,21 +851,6 @@ func (c *Config) NewBackupDRClient(userAgent string) *backupdr.Service {
 	clientBackupdrAdmin.BasePath = backupdrClientBasePath
 
 	return clientBackupdrAdmin
-}
-
-func (c *Config) NewPubsubClient(userAgent string) *pubsub.Service {
-	pubsubClientBasePath := RemoveBasePathVersion(c.PubsubBasePath)
-	log.Printf("[INFO] Instantiating Google Pubsub client for path %s", pubsubClientBasePath)
-	wrappedPubsubClient := ClientWithAdditionalRetries(c.Client, PubsubTopicProjectNotReady)
-	clientPubsub, err := pubsub.NewService(c.Context, option.WithHTTPClient(wrappedPubsubClient))
-	if err != nil {
-		log.Printf("[WARN] Error creating client pubsub: %s", err)
-		return nil
-	}
-	clientPubsub.UserAgent = userAgent
-	clientPubsub.BasePath = pubsubClientBasePath
-
-	return clientPubsub
 }
 
 func (c *Config) NewDataflowClient(userAgent string) *dataflow.Service {
@@ -1031,20 +979,6 @@ func (c *Config) NewBillingClient(userAgent string) *cloudbilling.APIService {
 	clientBilling.BasePath = cloudBillingClientBasePath
 
 	return clientBilling
-}
-
-func (c *Config) NewBuildClient(userAgent string) *cloudbuild.Service {
-	cloudBuildClientBasePath := RemoveBasePathVersion(c.CloudBuildBasePath)
-	log.Printf("[INFO] Instantiating Google Cloud Build client for path %s", cloudBuildClientBasePath)
-	clientBuild, err := cloudbuild.NewService(c.Context, option.WithHTTPClient(c.Client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client build: %s", err)
-		return nil
-	}
-	clientBuild.UserAgent = userAgent
-	clientBuild.BasePath = cloudBuildClientBasePath
-
-	return clientBuild
 }
 
 func (c *Config) NewCloudFunctionsClient(userAgent string) *cloudfunctions.Service {

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -71,10 +71,6 @@ import (
 	iamcredentials "google.golang.org/api/iamcredentials/v1"
 	cloudlogging "google.golang.org/api/logging/v2"
 	runadminv2 "google.golang.org/api/run/v2"
-{{- if ne $.TargetVersionName "ga" }}
-	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
-{{- end }}
-	"google.golang.org/api/servicemanagement/v1"
 	"google.golang.org/api/servicenetworking/v1"
 	"google.golang.org/api/serviceusage/v1"
 	"google.golang.org/api/sourcerepo/v1"
@@ -895,22 +891,6 @@ func (c *Config) NewResourceManagerV3Client(userAgent string) *resourceManagerV3
 	return clientResourceManagerV3
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
-func(c *Config) NewRuntimeconfigClient(userAgent string) *runtimeconfig.Service {
-	runtimeConfigClientBasePath := RemoveBasePathVersion(c.RuntimeConfigBasePath)
-	log.Printf("[INFO] Instantiating Google Cloud Runtimeconfig client for path %s", runtimeConfigClientBasePath)
-	clientRuntimeconfig, err := runtimeconfig.NewService(c.Context, option.WithHTTPClient(c.Client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client runtime config: %s", err)
-		return nil
-	}
-	clientRuntimeconfig.UserAgent = userAgent
-	clientRuntimeconfig.BasePath = runtimeConfigClientBasePath
-
-	return clientRuntimeconfig
-}
-{{- end }}
-
 func (c *Config) NewIamClient(userAgent string) *iam.Service {
 	iamClientBasePath := RemoveBasePathVersion(c.IAMBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud IAM client for path %s", iamClientBasePath)
@@ -937,20 +917,6 @@ func (c *Config) NewIamCredentialsClient(userAgent string) *iamcredentials.Servi
 	clientIamCredentials.BasePath = iamCredentialsClientBasePath
 
 	return clientIamCredentials
-}
-
-func (c *Config) NewServiceManClient(userAgent string) *servicemanagement.APIService {
-	serviceManagementClientBasePath := RemoveBasePathVersion(c.ServiceManagementBasePath)
-	log.Printf("[INFO] Instantiating Google Cloud Service Management client for path %s", serviceManagementClientBasePath)
-	clientServiceMan, err := servicemanagement.NewService(c.Context, option.WithHTTPClient(c.Client))
-	if err != nil {
-		log.Printf("[WARN] Error creating client service management: %s", err)
-		return nil
-	}
-	clientServiceMan.UserAgent = userAgent
-	clientServiceMan.BasePath = serviceManagementClientBasePath
-
-	return clientServiceMan
 }
 
 func (c *Config) NewServiceUsageClient(userAgent string) *serviceusage.Service {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This moves a few clients from config.go to their individual service packages, reducing the amount of global code & simplifying a future move to using service packages as the location for BaseUrl computation (instead of global computation in config.go)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
