### PR TITLE
Add DocumentAI Schema resource

### DIFF
--- a/mmv1/products/documentai/Schema.yaml
+++ b/mmv1/products/documentai/Schema.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'Schema'
+description: |
+  NextSchema is a collection of SchemaVersions.
+references:
+  api: 'https://cloud.google.com/document-ai/docs/reference/rest/v1/projects.locations.schemas'
+docs:
+base_url: 'projects/{{project}}/locations/{{location}}/schemas'
+self_link: 'projects/{{project}}/locations/{{location}}/schemas/{{name}}'
+update_verb: 'PATCH'
+update_mask: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+examples:
+  - name: 'documentai_schema'
+    primary_resource_id: 'schema'
+    vars:
+      display_name: 'my-schema'
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The location of the resource.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      The resource name of the Schema.
+    output: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
+  - name: 'displayName'
+    type: String
+    description: |
+      The user-defined name of the Schema.
+  - name: 'labels'
+    type: KeyValueLabels
+    description: |
+      The Google Cloud labels for the Schema.
+  - name: 'createTime'
+    type: Time
+    description: |
+      The time when the Schema was created.
+    output: true
+  - name: 'updateTime'
+    type: Time
+    description: |
+      The time when the Schema was last updated.
+    output: true

--- a/mmv1/templates/terraform/examples/documentai_schema.tf.tmpl
+++ b/mmv1/templates/terraform/examples/documentai_schema.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_document_ai_schema" "{{$.PrimaryResourceId}}" {
+  location     = "us"
+  display_name = "{{index $.Vars "display_name"}}"
+  labels = {
+    "env" = "test"
+  }
+}

--- a/mmv1/third_party/terraform/services/documentai/resource_document_ai_schema_test.go
+++ b/mmv1/third_party/terraform/services/documentai/resource_document_ai_schema_test.go
@@ -1,0 +1,59 @@
+package documentai_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDocumentAISchema_update(t *testing.T) {
+	t.Parallel()
+
+	context1 := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"display_name":  "my-schema",
+	}
+
+	context2 := map[string]interface{}{
+		"random_suffix": context1["random_suffix"],
+		"display_name":  "updated-schema",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDocumentAISchema_basic(context1),
+			},
+			{
+				ResourceName:            "google_document_ai_schema.schema",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+			{
+				Config: testAccDocumentAISchema_basic(context2),
+			},
+			{
+				ResourceName:            "google_document_ai_schema.schema",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccDocumentAISchema_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_document_ai_schema" "schema" {
+  location     = "us"
+  display_name = "%{display_name}"
+  labels = {
+    "env" = "test"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25831

This is a very simple resource, obviously, but one-shot everything other than the update test with Antigravity which was neat! (I haven't used any skills w it yet)

It's not very useful on its own, with https://docs.cloud.google.com/document-ai/docs/reference/rest/v1/projects.locations.schemas.schemaVersions holding the "real" contents.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_document_ai_schema`
```
