### PR TITLE
Add accurate_time_config to container cluster node_config in TGC

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
@@ -1088,6 +1088,21 @@ func schemaNodeConfig() *schema.Schema {
 									},
 								},
 							},
+							"accurate_time_config": {
+								Type:        schema.TypeList,
+								Optional:    true,
+								MaxItems:    1,
+								Description: `The settings for the accurate time configuration.`,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"enable_ptp_kvm_time_sync": {
+											Type:        schema.TypeBool,
+											Optional:    true,
+											Description: `Whether to enable accurate time synchronization with PTP-KVM.`,
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -3171,8 +3186,23 @@ func flattenLinuxNodeConfig(v interface{}) []map[string]interface{} {
 		"transparent_hugepage_defrag":  c["transparentHugepageDefrag"],
 		"node_kernel_module_loading":   flattenNodeKernelModuleLoading(c["nodeKernelModuleLoading"]),
 		"swap_config":                  flattenSwapConfig(c["swapConfig"]),
+		"accurate_time_config":         flattenAccurateTimeConfig(c["accurateTimeConfig"]),
 	}
 
+	return []map[string]interface{}{transformed}
+}
+
+func flattenAccurateTimeConfig(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	c, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	transformed := map[string]interface{}{
+		"enable_ptp_kvm_time_sync": c["enablePtpKvmTimeSync"],
+	}
 	return []map[string]interface{}{transformed}
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fix the failed test in [TGC](https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/) 

The test failed is because the field is in CAI asset json file, but not supported in TGC.

```
TestAccContainerCluster_withNodeConfigLinuxNodeConfig_step12: missing fields in resource google_container_cluster.with_linux_node_config after cai2hcl conversion:
[node_config.linux_node_config.accurate_time_config.enable_ptp_kvm_time_sync]
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
