### PR TITLE
`resourcemanager`: add `google_project_service` list resource

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
@@ -1,0 +1,131 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+)
+
+type GoogleProjectServiceListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+// GoogleProjectServiceListModel matches [ListResourceMetadata.ListConfigFields] (tfsdk names and types).
+type GoogleProjectServiceListModel struct {
+	Project types.String `tfsdk:"project"`
+}
+
+func NewGoogleProjectServiceListResource() list.ListResource {
+	listR := &GoogleProjectServiceListResource{}
+	listR.TypeName = "google_project_service"
+	listR.SDKv2Resource = ResourceGoogleProjectService()
+	listR.ListConfigFields = []tpgresource.ListConfigField{{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true}}
+	return listR
+}
+
+func (listR *GoogleProjectServiceListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	var data GoogleProjectServiceListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	project := tpgresource.GetResourceNameFromSelfLink(listR.GetProject(data.Project))
+
+	tempData := ResourceGoogleProjectService().Data(&terraform.InstanceState{})
+	if err := tempData.Set("project", project); err != nil {
+		diags.AddError("Config Error", fmt.Sprintf("Error setting project: %s", err))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(tempData, listR.Client.UserAgent)
+	if err != nil {
+		diags.AddError("Config Error", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	billingProject := project
+	if bp, err := tpgresource.GetBillingProject(tempData, listR.Client); err == nil {
+		billingProject = bp
+	}
+
+	// Service Usage's Services.List endpoint is eventually consistent across
+	// replicas, and paginated calls can also span replicas, so a single read
+	// may occasionally miss recently-enabled services. Call the endpoint
+	// directly (bypassing the request batcher) multiple times, spaced apart in
+	// time, and union the results so we're unlikely to miss a service that
+	// only a subset of replicas know about yet.
+	const (
+		maxAttempts  = 12
+		sleepBetween = 5 * time.Second
+	)
+	servicesList := make(map[string]struct{})
+	for i := 0; i < maxAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				diags.AddError("Context Error", ctx.Err().Error())
+				stream.Results = list.ListResultsStreamDiagnostics(diags)
+				return
+			case <-time.After(sleepBetween):
+			}
+		}
+		page, err := ListCurrentlyEnabledServices(project, billingProject, userAgent, listR.Client, time.Minute)
+		if err != nil {
+			diags.AddError("API Error", err.Error())
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+		for s := range page {
+			servicesList[s] = struct{}{}
+		}
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		for serviceName := range servicesList {
+			rd := ResourceGoogleProjectService().Data(&terraform.InstanceState{})
+			if err := rd.Set("project", project); err != nil {
+				diags.AddError("Config Error", fmt.Sprintf("Error setting project: %s", err))
+				stream.Results = list.ListResultsStreamDiagnostics(diags)
+				return
+			}
+			if err := rd.Set("service", serviceName); err != nil {
+				diags.AddError("Config Error", fmt.Sprintf("Error setting service: %s", err))
+				stream.Results = list.ListResultsStreamDiagnostics(diags)
+				return
+			}
+			rd.SetId(fmt.Sprintf("%s/%s", project, serviceName))
+
+			result := listReq.NewListResult(ctx)
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "service"); err != nil {
+				diags.AddError("Schema Error", err.Error())
+				stream.Results = list.ListResultsStreamDiagnostics(diags)
+				return
+			}
+			if !push(result) {
+				stream.Results = list.ListResultsStreamDiagnostics(diags)
+				return
+			}
+		}
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+	}
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
@@ -68,36 +68,11 @@ func (listR *GoogleProjectServiceListResource) List(ctx context.Context, listReq
 		billingProject = bp
 	}
 
-	// Service Usage's Services.List endpoint is eventually consistent across
-	// replicas, and paginated calls can also span replicas, so a single read
-	// may occasionally miss recently-enabled services. Call the endpoint
-	// directly (bypassing the request batcher) multiple times, spaced apart in
-	// time, and union the results so we're unlikely to miss a service that
-	// only a subset of replicas know about yet.
-	const (
-		maxAttempts  = 12
-		sleepBetween = 5 * time.Second
-	)
-	servicesList := make(map[string]struct{})
-	for i := 0; i < maxAttempts; i++ {
-		if i > 0 {
-			select {
-			case <-ctx.Done():
-				diags.AddError("Context Error", ctx.Err().Error())
-				stream.Results = list.ListResultsStreamDiagnostics(diags)
-				return
-			case <-time.After(sleepBetween):
-			}
-		}
-		page, err := ListCurrentlyEnabledServices(project, billingProject, userAgent, listR.Client, time.Minute)
-		if err != nil {
-			diags.AddError("API Error", err.Error())
-			stream.Results = list.ListResultsStreamDiagnostics(diags)
-			return
-		}
-		for s := range page {
-			servicesList[s] = struct{}{}
-		}
+	servicesList, err := ListCurrentlyEnabledServices(project, billingProject, userAgent, listR.Client, 10*time.Minute)
+	if err != nil {
+		diags.AddError("API Error", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
 	}
 
 	stream.Results = func(push func(list.ListResult) bool) {

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service.go
@@ -13,8 +13,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_project_service",
+		ProductName: "resourcemanager",
+		Func:        NewGoogleProjectServiceListResource,
+	}.Register()
+}
 
 type GoogleProjectServiceListResource struct {
 	tpgresource.ListResourceMetadata

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
@@ -29,6 +29,13 @@ func TestAccProjectServiceListResource_queryIdentity(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
+				Config: testAccProjectServiceList_prereq(project, service),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_service.prereq", "service", service),
+					resource.TestCheckResourceAttr("google_project_service.prereq", "project", project),
+				),
+			},
+			{
 				Query:  true,
 				Config: testAccProjectServiceListQuery(project),
 				QueryResultChecks: []querycheck.QueryResultCheck{
@@ -41,6 +48,15 @@ func TestAccProjectServiceListResource_queryIdentity(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccProjectServiceList_prereq(project, service string) string {
+	return fmt.Sprintf(`
+resource "google_project_service" "prereq" {
+  project = %q
+  service = %q
+}
+`, project, service)
 }
 
 func testAccProjectServiceListQuery(project string) string {

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
@@ -1,0 +1,56 @@
+package resourcemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+// TestAccProjectServiceListResource_queryIdentity lists enabled project services via the
+// provider list resource API and asserts a known identity appears (Terraform 1.14+).
+func TestAccProjectServiceListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	service := "iam.googleapis.com"
+	project := acctest.BootstrapProject(t, "tf-boot-proj-svc-list-", envvar.GetTestBillingAccountFromEnv(t), []string{service}).ProjectId
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Query:  true,
+				Config: testAccProjectServiceListQuery(project),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_project_service.all_in_project", map[string]knownvalue.Check{
+						"service": knownvalue.StringExact(service),
+						"project": knownvalue.StringExact(project),
+					}),
+					querycheck.ExpectLengthAtLeast("google_project_service.all_in_project", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectServiceListQuery(project string) string {
+	return fmt.Sprintf(`
+list "google_project_service" "all_in_project" {
+  provider = google
+
+  config {
+    project = %q
+  }
+}
+`, project)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 )
 
 // TestAccProjectServiceListResource_queryIdentity lists enabled project services via the
@@ -19,7 +20,7 @@ func TestAccProjectServiceListResource_queryIdentity(t *testing.T) {
 	t.Parallel()
 
 	service := "iam.googleapis.com"
-	project := acctest.BootstrapProject(t, "tf-boot-proj-svc-list-", envvar.GetTestBillingAccountFromEnv(t), []string{service}).ProjectId
+	project := resourcemanager.BootstrapProject(t, "tf-boot-proj-svc-list-", envvar.GetTestBillingAccountFromEnv(t), []string{service}).ProjectId
 
 	acctest.VcrTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -289,6 +289,10 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	}
 	servicesList := servicesRaw.(map[string]struct{})
 
+	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
+		return err
+	}
+
 	srv := d.Get("service").(string)
 	if _, ok := servicesList[srv]; ok {
 		if err := d.Set("project", project); err != nil {
@@ -304,8 +308,7 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 			return err
 		}
 		return nil
-	}
-	
+	}	
 
 	log.Printf("[DEBUG] service %s not in enabled services for project %s, removing from state", srv, project)
 	d.SetId("")

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -354,13 +354,6 @@ func disableServiceUsageProjectService(service, project string, d *schema.Resour
 	return nil
 }
 
-func setGoogleProjectServiceResourceIdentity(d *schema.ResourceData, project, service string) error {
-	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
-		"project": project,
-		"service": service,
-	})
-}
-
 func init() {
 	registry.Schema{
 		Name: "google_project_service",

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -356,6 +356,19 @@ func resourceGoogleProjectServiceDelete(d *schema.ResourceData, meta interface{}
 func resourceGoogleProjectServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 	// This update method is no-op because the only updatable fields
 	// are state/config-only, i.e. they aren't sent in requests to the API.
+	config := meta.(*transport_tpg.Config)
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+	project = tpgresource.GetResourceNameFromSelfLink(project)
+	srv := d.Get("service").(string)
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": project,
+		"service": srv,
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -289,10 +289,6 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	}
 	servicesList := servicesRaw.(map[string]struct{})
 
-	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
-		return err
-	}
-
 	srv := d.Get("service").(string)
 	if _, ok := servicesList[srv]; ok {
 		if err := d.Set("project", project); err != nil {
@@ -300,6 +296,9 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 		}
 		if err := d.Set("service", srv); err != nil {
 			return fmt.Errorf("Error setting service: %s", err)
+		}
+		if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
+			return err
 		}
 		if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
 			"project": project,

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -99,6 +99,22 @@ func ResourceGoogleProjectService() *schema.Resource {
 			tpgresource.DefaultProviderProject,
 		),
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"service": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"service": {
 				Type:         schema.TypeString,
@@ -138,6 +154,35 @@ func ResourceGoogleProjectService() *schema.Resource {
 }
 
 func resourceGoogleProjectServiceImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if d.Id() == "" {
+		identity, err := d.Identity()
+		if err != nil {
+			return nil, fmt.Errorf("google_project_service import: %w", err)
+		}
+		serviceV, ok := identity.GetOk("service")
+		if !ok {
+			return nil, fmt.Errorf("import via identity requires identity attribute %q", "service")
+		}
+		serviceStr, ok := serviceV.(string)
+		if !ok || serviceStr == "" {
+			return nil, fmt.Errorf("import via identity requires identity attribute %q to be a non-empty string", "service")
+		}
+		var projectStr string
+		if projectV, ok := identity.GetOk("project"); ok && projectV != nil {
+			if s, ok := projectV.(string); ok {
+				projectStr = s
+			}
+		}
+		if projectStr == "" {
+			config, ok := m.(*transport_tpg.Config)
+			if !ok || config.Project == "" {
+				return nil, fmt.Errorf("import via identity requires identity attribute %q or a default project in the provider configuration", "project")
+			}
+		}
+		projectStr = tpgresource.GetResourceNameFromSelfLink(projectStr)
+		d.SetId(fmt.Sprintf("%s/%s", projectStr, serviceStr))
+	}
+
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("Invalid google_project_service id format for import, expecting `{project}/{service}`, found %s", d.Id())
@@ -147,6 +192,12 @@ func resourceGoogleProjectServiceImport(d *schema.ResourceData, m interface{}) (
 	}
 	if err := d.Set("service", parts[1]); err != nil {
 		return nil, fmt.Errorf("Error setting service: %s", err)
+	}
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": parts[0],
+		"service": parts[1],
+	}); err != nil {
+		return nil, err
 	}
 	return []*schema.ResourceData{d}, nil
 }
@@ -177,6 +228,12 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 		}
 		if err := d.Set("service", srv); err != nil {
 			return fmt.Errorf("Error setting service: %s", err)
+		}
+		if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+			"project": project,
+			"service": srv,
+		}); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -240,8 +297,11 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 		if err := d.Set("service", srv); err != nil {
 			return fmt.Errorf("Error setting service: %s", err)
 		}
-		if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
-		    return err
+		if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+			"project": project,
+			"service": srv,
+		}); err != nil {
+			return err
 		}
 		return nil
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -354,6 +354,13 @@ func disableServiceUsageProjectService(service, project string, d *schema.Resour
 	return nil
 }
 
+func setGoogleProjectServiceResourceIdentity(d *schema.ResourceData, project, service string) error {
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": project,
+		"service": service,
+	})
+}
+
 func init() {
 	registry.Schema{
 		Name: "google_project_service",

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service_test.go.tmpl
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 // Test that services can be enabled and disabled on a project
@@ -188,6 +189,45 @@ func TestAccProjectService_renamedService(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccProjectService_importBlockWithResourceIdentity exercises plannable import using the resource identity block (Terraform 1.12+).
+func TestAccProjectService_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	service := "iam.googleapis.com"
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectService_identityImport(project, service),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_service.ps", "project", project),
+					resource.TestCheckResourceAttr("google_project_service.ps", "service", service),
+				),
+			},
+			{
+				ResourceName:    "google_project_service.ps",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
+func testAccProjectService_identityImport(project, service string) string {
+	return fmt.Sprintf(`
+resource "google_project_service" "ps" {
+  project = "%s"
+  service = "%s"
+}
+`, project, service)
 }
 
 func testAccCheckProjectService(t *testing.T, services []string, pid string, expectEnabled bool) resource.TestCheckFunc {

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_project_service.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+  List enabled Google Cloud project services (APIs) for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_project_service (list)
+
+Lists **enabled Service Usage APIs** for a Google Cloud project—one entry per enabled
+service, matching what you manage with
+[`google_project_service`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service)—for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_project_service" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "other-project"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID to list enabled services for. If unset, the provider's
+  configured default project is used (same idea as the managed resource).
+
+## Results
+
+By default each result includes **resource identity** for `google_project_service` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `service` - API identifier (for example `compute.googleapis.com`) (required for identity).
+* `project` - Project ID when applicable.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_project_service` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service#attributes-reference)
+(for example `disable_dependent_services` and `disable_on_destroy` where present in state).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

## [TeamCity Build](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_RESOURCEMANAGER?branch=refs%2Fheads%2Fauto-pr-17297) with multiple runs made

<img width="2720" height="1136" alt="image" src="https://github.com/user-attachments/assets/e7df4f67-89bd-4039-bfa4-9e27c549136e" />



change from this PR to the initial PR that was reverted was bootstrapping a project for starting a service followed by the query run

i think what was happening was due to the project being used containing upto 144 services it required multiple GET requests with `newPageTokens` being used. There might've been a case where the service itself wasn't propagated fully so when newPages were being obtained they still didnt' have the existing service set.



**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-list-resource
`google_project_service`
```
