### PR TITLE
databasemigrationservice: Add objects config field to DMS migration job resource for selective migration

### DIFF
--- a/mmv1/products/databasemigrationservice/MigrationJob.yaml
+++ b/mmv1/products/databasemigrationservice/MigrationJob.yaml
@@ -75,6 +75,24 @@ examples:
       source_sqldb_pass: '"password" + randomSuffix'
       # for backward compatible
       source_sqldb_user: '"username" + randomSuffix'
+  - name: database_migration_service_migration_job_postgres_to_postgres_objects
+    primary_resource_id: psqltopsqlobjects
+    vars:
+      destination_cp: destination-cp
+      destination_csql: destination-csql
+      migration_id: my-migrationid
+      source_cp: source-cp
+      source_csql: source-csql
+      source_sqldb_cert: cert
+      source_sqldb_pass: password
+      source_sqldb_user: username
+    test_vars_overrides:
+      # for backward compatible
+      source_sqldb_cert: '"cert" + randomSuffix'
+      # for backward compatible
+      source_sqldb_pass: '"password" + randomSuffix'
+      # for backward compatible
+      source_sqldb_user: '"username" + randomSuffix'
   - name: database_migration_service_migration_job_postgres_to_alloydb
     primary_resource_id: psqltoalloydb
     vars:
@@ -294,3 +312,63 @@ properties:
         type: String
         description: |
           The name of the VPC network to peer with the Cloud SQL private network.
+  - name: objectsConfig
+    type: NestedObject
+    description: |
+      The objects that need to be migrated. If unset, the default is to migrate
+      all objects available on the source.
+    immutable: true
+    properties:
+      - name: sourceObjectsConfig
+        type: NestedObject
+        description: |
+          Configuration for the source objects to be migrated.
+        properties:
+          - name: objectsSelectionType
+            type: Enum
+            description: |
+              The objects selection type of the migration job. When set to
+              `SPECIFIED_OBJECTS`, only the objects listed in `objectConfigs` are
+              migrated. When set to `ALL_OBJECTS`, all objects available on the
+              source are migrated.
+            enum_values:
+              - ALL_OBJECTS
+              - SPECIFIED_OBJECTS
+          - name: objectConfigs
+            type: Array
+            description: |
+              The list of objects to migrate. Should only be set when
+              `objectsSelectionType` is `SPECIFIED_OBJECTS`.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: objectIdentifier
+                  type: NestedObject
+                  description: |
+                    The identifier of the migration job object.
+                  properties:
+                    - name: type
+                      type: Enum
+                      required: true
+                      description: |
+                        The category of the migration job object: `DATABASE`,
+                        `SCHEMA`, or `TABLE`.
+                      enum_values:
+                        - DATABASE
+                        - SCHEMA
+                        - TABLE
+                    - name: database
+                      type: String
+                      description: |
+                        The database name. Required only if the object uses
+                        a database name as part of its unique identifier.
+                    - name: schema
+                      type: String
+                      description: |
+                        The schema name. Required only if the object uses
+                        a schema name as part of its unique identifier.
+                    - name: table
+                      type: String
+                      description: |
+                        The table name. Required only if the object is a level
+                        below database or schema.

--- a/mmv1/products/databasemigrationservice/MigrationJob.yaml
+++ b/mmv1/products/databasemigrationservice/MigrationJob.yaml
@@ -323,6 +323,7 @@ properties:
         type: NestedObject
         description: |
           Configuration for the source objects to be migrated.
+        immutable: true
         properties:
           - name: objectsSelectionType
             type: Enum
@@ -331,6 +332,7 @@ properties:
               `SPECIFIED_OBJECTS`, only the objects listed in `objectConfigs` are
               migrated. When set to `ALL_OBJECTS`, all objects available on the
               source are migrated.
+            immutable: true
             enum_values:
               - ALL_OBJECTS
               - SPECIFIED_OBJECTS
@@ -339,6 +341,7 @@ properties:
             description: |
               The list of objects to migrate. Should only be set when
               `objectsSelectionType` is `SPECIFIED_OBJECTS`.
+            immutable: true
             item_type:
               type: NestedObject
               properties:
@@ -346,6 +349,7 @@ properties:
                   type: NestedObject
                   description: |
                     The identifier of the migration job object.
+                  immutable: true
                   properties:
                     - name: type
                       type: Enum
@@ -353,6 +357,7 @@ properties:
                       description: |
                         The category of the migration job object: `DATABASE`,
                         `SCHEMA`, or `TABLE`.
+                      immutable: true
                       enum_values:
                         - DATABASE
                         - SCHEMA
@@ -362,13 +367,16 @@ properties:
                       description: |
                         The database name. Required only if the object uses
                         a database name as part of its unique identifier.
+                      immutable: true
                     - name: schema
                       type: String
                       description: |
                         The schema name. Required only if the object uses
                         a schema name as part of its unique identifier.
+                      immutable: true
                     - name: table
                       type: String
                       description: |
                         The table name. Required only if the object is a level
                         below database or schema.
+                      immutable: true

--- a/mmv1/products/databasemigrationservice/MigrationJob.yaml
+++ b/mmv1/products/databasemigrationservice/MigrationJob.yaml
@@ -318,12 +318,14 @@ properties:
       The objects that need to be migrated. If unset, the default is to migrate
       all objects available on the source.
     immutable: true
+    default_from_api: true
     properties:
       - name: sourceObjectsConfig
         type: NestedObject
         description: |
           Configuration for the source objects to be migrated.
         immutable: true
+        default_from_api: true
         properties:
           - name: objectsSelectionType
             type: Enum
@@ -333,6 +335,7 @@ properties:
               migrated. When set to `ALL_OBJECTS`, all objects available on the
               source are migrated.
             immutable: true
+            default_from_api: true
             enum_values:
               - ALL_OBJECTS
               - SPECIFIED_OBJECTS

--- a/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
@@ -1,0 +1,108 @@
+data "google_project" "project" {
+}
+
+resource "google_sql_database_instance" "source_csql" {
+  name             = "{{index $.Vars "source_csql"}}"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-custom-2-13312"
+    deletion_protection_enabled = false
+  }
+  deletion_protection = false
+}
+
+resource "google_sql_ssl_cert" "source_sql_client_cert" {
+  common_name = "{{index $.Vars "source_sqldb_cert"}}"
+  instance    = google_sql_database_instance.source_csql.name
+
+  depends_on = [google_sql_database_instance.source_csql]
+}
+
+resource "google_sql_user" "source_sqldb_user" {
+  name     = "{{index $.Vars "source_sqldb_user"}}"
+  instance = google_sql_database_instance.source_csql.name
+  password = "{{index $.Vars "source_sqldb_pass"}}"
+
+  depends_on = [google_sql_ssl_cert.source_sql_client_cert]
+}
+
+resource "google_database_migration_service_connection_profile" "source_cp" {
+  location              = "us-central1"
+  connection_profile_id = "{{index $.Vars "source_cp"}}"
+  display_name          = "{{index $.Vars "source_cp"}}_display"
+  labels = {
+    foo = "bar"
+  }
+  postgresql {
+    host     = google_sql_database_instance.source_csql.ip_address.0.ip_address
+    port     = 3306
+    username = google_sql_user.source_sqldb_user.name
+    password = google_sql_user.source_sqldb_user.password
+    ssl {
+      client_key         = google_sql_ssl_cert.source_sql_client_cert.private_key
+      client_certificate = google_sql_ssl_cert.source_sql_client_cert.cert
+      ca_certificate     = google_sql_ssl_cert.source_sql_client_cert.server_ca_cert
+      type = "SERVER_CLIENT"
+    }
+    cloud_sql_id = "{{index $.Vars "source_csql"}}"
+  }
+
+  depends_on = [google_sql_user.source_sqldb_user]
+}
+
+resource "google_sql_database_instance" "destination_csql" {
+  name             = "{{index $.Vars "destination_csql"}}"
+  database_version = "POSTGRES_15"
+  settings {
+    tier = "db-custom-2-13312"
+    deletion_protection_enabled = false
+  }
+  deletion_protection = false
+}
+
+resource "google_database_migration_service_connection_profile" "destination_cp" {
+  location              = "us-central1"
+  connection_profile_id = "{{index $.Vars "destination_cp"}}"
+  display_name          = "{{index $.Vars "destination_cp"}}_display"
+  labels = {
+    foo = "bar"
+  }
+  postgresql {
+    cloud_sql_id = "{{index $.Vars "destination_csql"}}"
+  }
+  depends_on = [google_sql_database_instance.destination_csql]
+}
+
+resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceId}}" {
+  location         = "us-central1"
+  migration_job_id = "{{index $.Vars "migration_id"}}"
+  display_name     = "{{index $.Vars "migration_id"}}_display"
+  labels = {
+    foo = "bar"
+  }
+  static_ip_connectivity {
+  }
+  source      = google_database_migration_service_connection_profile.source_cp.name
+  destination = google_database_migration_service_connection_profile.destination_cp.name
+  type        = "CONTINUOUS"
+
+  objects_config {
+    source_objects_config {
+      objects_selection_type = "SPECIFIED_OBJECTS"
+      object_configs {
+        object_identifier {
+          type     = "DATABASE"
+          database = "my_database"
+        }
+      }
+      object_configs {
+        object_identifier {
+          type     = "TABLE"
+          database = "my_database"
+          schema   = "public"
+          table    = "my_table"
+        }
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_migration_job_postgres_to_postgres_objects.tf.tmpl
@@ -98,9 +98,9 @@ resource "google_database_migration_service_migration_job" "{{$.PrimaryResourceI
       object_configs {
         object_identifier {
           type     = "TABLE"
-          database = "my_database"
+          database = "my_other_database"
           schema   = "public"
-          table    = "my_table"
+          table    = "users"
         }
       }
     }


### PR DESCRIPTION
 **Description**                                                                                        

Add support for configuring which databases, schemas, or tables to migrate on `google_database_migration_service_migration_job` via the new `objects_config` block. The `objects_config` block maps directly to the API's [MigrationJobObjectsConfig](https://docs.cloud.google.com/database-migration/docs/reference/rest/v1/projects.locations.migrationJobs#MigrationJobObjectsConfig) and is the same field that gcloud's  `--database-filter` [flag](https://docs.cloud.google.com/sdk/gcloud/reference/database-migration/migration-jobs/create#--databases-filter) populates for homogeneous migrations.

Mark the whole subtree immutable since it is not in the API's update mask

**Tests Added**
- Added database_migration_service_migration_job_postgres_to_postgres_objects example demonstrating selection of a database and a specific table 

**Verification Results**
- Verified that the provider builds successfully with these changes.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
databasemigrationservice: added `objects_config` field to `google_database_migration_service_migration_job` resource
```
