### PR TITLE
 Migrate partially `resource_compute_instance_template.go.tmpl` resources to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -3,6 +3,7 @@ package compute
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -1799,7 +1800,27 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		Name:        itName,
 	}
 
-	op, err := NewClient(config, userAgent).InstanceTemplates.Insert(project, instanceTemplate).Do()
+	itBytes, err := json.Marshal(instanceTemplate)
+	if err != nil {
+		return fmt.Errorf("Error marshaling instance template: %s", err)
+	}
+	var itBody map[string]interface{}
+	if err := json.Unmarshal(itBytes, &itBody); err != nil {
+		return fmt.Errorf("Error unmarshaling instance template: %s", err)
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates")
+	if err != nil {
+		return err
+	}
+	op, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      itBody,
+	})
 	if err != nil {
 		return fmt.Errorf("Error creating instance template: %s", err)
 	}
@@ -1807,7 +1828,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	// Store the ID now
 	d.SetId(fmt.Sprintf("projects/%s/global/instanceTemplates/%s", project, instanceTemplate.Name))
 	// And also the unique ID
-	d.Set("self_link_unique", fmt.Sprintf("%v?uniqueId=%v", d.Id(), op.TargetId))
+	d.Set("self_link_unique", fmt.Sprintf("%v?uniqueId=%v", d.Id(), op["targetId"]))
 
 	err = ComputeOperationWaitTime(config, op, project, "Creating Instance Template", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
@@ -2095,13 +2116,34 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 
 	splits := strings.Split(idStr, "/")
-	{{- if eq $.TargetVersionName "ga" }}
-	instanceTemplate, err := NewClient(config, userAgent).InstanceTemplates.Get(project, splits[len(splits)-1]).Do()
-	{{- else }}
-	instanceTemplate, err := NewClient(config, userAgent).InstanceTemplates.Get(project, splits[len(splits)-1]).View("FULL").Do()
-	{{- end }}
+	baseUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates")
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseUrl, splits[len(splits)-1])
+{{- if ne $.TargetVersionName "ga" }}
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"view": "FULL"})
+	if err != nil {
+		return err
+	}
+{{- end }}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance Template %q", d.Get("name").(string)))
+	}
+	itBytes, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("Error marshaling instance template response: %s", err)
+	}
+	var instanceTemplate compute.InstanceTemplate
+	if err := json.Unmarshal(itBytes, &instanceTemplate); err != nil {
+		return fmt.Errorf("Error unmarshaling instance template response: %s", err)
 	}
 	// Set the metadata fingerprint if there is one.
 	if instanceTemplate.Properties.Metadata != nil {
@@ -2343,8 +2385,18 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 	}
 
 	splits := strings.Split(d.Id(), "/")
-	op, err := NewClient(config, userAgent).InstanceTemplates.Delete(
-		project, splits[len(splits)-1]).Do()
+	baseUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/global/instanceTemplates")
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/%s", baseUrl, splits[len(splits)-1])
+	op, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return fmt.Errorf("Error deleting instance template: %s", err)
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: Migrate partially `resource_compute_instance_template.go.tmpl` resource to use direct HTTP rather than a client library
```
