### PR TITLE
container: bump `acceleratorNetworkProfile` to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -242,9 +242,7 @@ func ResourceContainerCluster() *schema.Resource {
 			containerClusterEnableK8sBetaApisCustomizeDiff,
 			containerClusterNodeVersionCustomizeDiff,
 			tpgresource.SetDiffForLabelsWithCustomizedName("resource_labels"),
-			{{ if ne $.TargetVersionName `ga` }}
 			clusterAcceleratorNetworkProfileCustomizeDiff,
-			{{- end }}
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -8974,7 +8972,6 @@ func containerClusterNodeVersionCustomizeDiffFunc(diff tpgresource.TerraformReso
 	return nil
 }
 
-{{ if ne $.TargetVersionName `ga` }}
 func clusterAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 	// 1. SKIP ON CREATE
 	if diff.Id() == "" {
@@ -9123,7 +9120,6 @@ func clusterAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *sche
 
 	return nil
 }
-{{- end }}
 
 func init() {
 	registry.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -448,10 +448,8 @@ fields:
     api_field: 'nodePools.name'
   - field: 'node_pool.name_prefix'
     provider_only: true
-  {{- if ne $.TargetVersionName "ga" }}
   - field: 'node_pool.network_config.accelerator_network_profile'
     api_field: 'nodePools.networkConfig.acceleratorNetworkProfile'
-  {{- end }}
   - field: 'node_pool.network_config.additional_node_network_configs.network'
     api_field: 'nodePools.networkConfig.additionalNodeNetworkConfigs.network'
   - field: 'node_pool.network_config.additional_node_network_configs.subnetwork'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -17284,7 +17284,6 @@ resource "google_container_cluster" "with_kubelet_config" {
 `, clusterName, networkName, subnetworkName, npName, npName)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_nodePool_acceleratorNetworkProfile(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -17367,7 +17366,6 @@ func TestAccContainerCluster_nodePool_acceleratorNetworkProfile(t *testing.T) {
 		},
 	})
 }
-{{- end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerCluster_nodePool_additionalNodeNetworkConfigs_manual(clusterName string) string {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -202,9 +202,7 @@ func ResourceContainerNodePool() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			tpgresource.DefaultProviderProject,
 			resourceNodeConfigEmptyGuestAccelerator,
-			{{ if ne $.TargetVersionName `ga` }}
 			nodePoolAcceleratorNetworkProfileCustomizeDiff,
-			{{- end }}
 		),
 
 		UseJSONNumber: true,
@@ -1507,9 +1505,7 @@ func flattenNodeNetworkConfig(c *container.NodeNetworkConfig, d *schema.Resource
 			"additional_node_network_configs": flattenAdditionalNodeNetworkConfig(c.AdditionalNodeNetworkConfigs),
 			"additional_pod_network_configs":  flattenAdditionalPodNetworkConfig(c.AdditionalPodNetworkConfigs),
 			"subnetwork":                      c.Subnetwork,
-			{{ if ne $.TargetVersionName `ga` }}
 			"accelerator_network_profile": 	   c.AcceleratorNetworkProfile,
-			{{- end }}
 		})
 	}
 	return result
@@ -1624,11 +1620,9 @@ func expandNodeNetworkConfig(v interface{}) *container.NodeNetworkConfig {
 			nnc.NetworkPerformanceConfig.TotalEgressBandwidthTier = total_egress_bandwidth_tier.(string)
 		}
 	}
-	{{ if ne $.TargetVersionName `ga` }}
 	if v, ok := networkNodeConfig["accelerator_network_profile"]; ok {
 		nnc.AcceleratorNetworkProfile = v.(string)
 	}
-	{{- end }}
 
 	// Allow user to set the top-level node-pool subnetwork via network_config.subnetwork
 	if v, ok := networkNodeConfig["subnetwork"]; ok {
@@ -2049,7 +2043,6 @@ func retryWhileIncompatibleOperation(timeout time.Duration, lockKey string, f fu
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` }}
 func nodePoolAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 	log.Printf("[DEBUG] ANP CustomizeDiff: Running...")
 
@@ -2131,7 +2124,6 @@ func nodePoolAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *sch
 
 	return nil
 }
-{{- end }}
 
 func init() {
 	registry.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -541,14 +541,12 @@ var schemaNodePool = map[string]*schema.Schema{
 		Description: `Networking configuration for this NodePool. If specified, it overrides the cluster-level defaults.`,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-			{{ if ne $.TargetVersionName `ga` }}
 				"accelerator_network_profile": {
 					Type:        schema.TypeString,
 					Description: "The accelerator network profile to use for this node pool.",
 					Optional:    true,
 					ForceNew: 	 true,
 				},
-			{{- end }}
 				"create_pod_range": {
 					Type:         schema.TypeBool,
 					Optional:     true,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
@@ -29,8 +29,7 @@ fields:
   - api_field: 'name'
   - field: 'name_prefix'
     provider_only: true
-  - field: 'network_config.accelerator_network_profile'
-    api_field: 'networkConfig.acceleratorNetworkProfile'
+  - api_field: 'networkConfig.acceleratorNetworkProfile'
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.network'
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.subnetwork'
   - field: 'network_config.additional_pod_network_configs.max_pods_per_node'

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
@@ -29,7 +29,8 @@ fields:
   - api_field: 'name'
   - field: 'name_prefix'
     provider_only: true
-  - api_field: 'networkConfig.acceleratorNetworkProfile'
+  - field: 'network_config.accelerator_network_profile'
+    api_field: 'networkConfig.acceleratorNetworkProfile'
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.network'
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.subnetwork'
   - field: 'network_config.additional_pod_network_configs.max_pods_per_node'

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
@@ -29,9 +29,7 @@ fields:
   - api_field: 'name'
   - field: 'name_prefix'
     provider_only: true
-  {{ if ne $.TargetVersionName `ga` }}
   - api_field: 'networkConfig.acceleratorNetworkProfile'
-  {{- end }}
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.network'
   - api_field: 'networkConfig.additionalNodeNetworkConfigs.subnetwork'
   - field: 'network_config.additional_pod_network_configs.max_pods_per_node'

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -6410,7 +6410,6 @@ resource "google_container_node_pool" "np" {
 `, cluster, np, networkName, subnetworkName, storagePoolResourceName, location)
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerNodePool_acceleratorNetworkProfile(clusterName, npName string) string {
     return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
@@ -6504,9 +6503,7 @@ func TestAccContainerNodePool_acceleratorNetworkProfile(t *testing.T) {
         },
     })
 }
-{{- end }}
 
-{{ if ne $.TargetVersionName `ga` -}}
 func testAccContainerNodePool_acceleratorNetworkProfile_manual(clusterName, npName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "main_net" {
@@ -6811,4 +6808,3 @@ func TestAccContainerNodePool_acceleratorNetworkProfile_Lifecycle(t *testing.T) 
 		},
 	})
 }
-{{- end }}

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -225,7 +225,7 @@ cluster.
 
 * `subnetwork` - (Optional) The subnetwork path for the node pool. Format: `projects/{project}/regions/{region}/subnetworks/{subnetwork}`. If the cluster is associated with multiple subnetworks, the subnetwork for the node pool is picked based on the IP utilization during node pool creation and is immutable
 
-* `accelerator_network_profile` (Optional, [Beta](../guides/provider_versions.html.markdown)) - Specifies the accelerator network profile for nodes in this node pool. Setting to `"auto"` enables GKE to automatically configure high-performance networking settings for nodes with accelerators (like GPUs). GKE manages the underlying resources (like VPCs and subnets) for this configuration.
+* `accelerator_network_profile` (Optional, (../guides/provider_versions.html.markdown)) - Specifies the accelerator network profile for nodes in this node pool. Setting to `"auto"` enables GKE to automatically configure high-performance networking settings for nodes with accelerators (like GPUs). GKE manages the underlying resources (like VPCs and subnets) for this configuration.
 
 <a name="nested_additional_node_network_configs"></a>The `additional_node_network_configs` block supports:
 


### PR DESCRIPTION
```release-note: enhancement
container: added `node_pool.network_config.accelerator_network_profile` to `google_container_cluster` resource and `network_config.accelerator_network_profile` to `google_container_node_pool` resource (GA)
```
