### PR TITLE
tgc-revival: Add accurate_time_config to NodePool.yaml to ignore in CAI tests

### DIFF
--- a/mmv1/products/container/NodePool.yaml
+++ b/mmv1/products/container/NodePool.yaml
@@ -79,6 +79,18 @@ properties:
             api_name: 'provisionedThroughput'
             type: 'Integer'
             is_missing_in_cai: true
+      - name: 'linuxNodeConfig'
+        type: 'NestedObject'
+        description: 'Parameters for Linux node configuration.'
+        properties:
+          - name: 'accurateTimeConfig'
+            type: 'NestedObject'
+            description: 'Accurate time configuration.'
+            properties:
+              - name: 'enablePtpKvmTimeSync'
+                type: 'Boolean'
+                description: 'Enable PTP KVM time sync.'
+                is_missing_in_cai: true
   - name: 'networkConfig'
     type: 'NestedObject'
     description: 'Networking configuration for this NodePool.'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
fix the test TestAccContainerNodePool_withAccurateTimeConfig failed in [tgc](https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
