### PR TITLE
Fix mmv1 yaml merge to properly handle pointers

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -327,6 +327,13 @@ func Merge(self, otherObj reflect.Value, version string) {
 
 		if selfObj.Field(i).Kind() == reflect.Slice {
 			DeepMerge(selfObj.Field(i), otherObj.Field(i), version)
+		} else if selfObj.Field(i).Kind() == reflect.Pointer {
+			// merge the objects that are being pointed to, if both exist (namely, ItemTypes)
+			if reflect.Indirect(selfObj.Field(i)).IsValid() && reflect.Indirect(otherObj.Field(i)).IsValid() {
+				Merge(selfObj.Field(i), reflect.Indirect(otherObj.Field(i)), version)
+			} else {
+				selfObj.Field(i).Set(otherObj.Field(i))
+			}
 		} else {
 			selfObj.Field(i).Set(otherObj.Field(i))
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Preview of the internal diffs can be found at https://cloud-internal-review.git.corp.google.com/c/cloud-graphite-eng/magic-modules-private-overrides/+/65310

This essentially treats yaml fields that happen to be pointers the same as non-pointers, which was most likely its intended behavior (the yaml itself doesn't even use the pointer concept).

The specific case that was identified was "array of objects", which uses an ItemType, which is a parsed as a pointer. Nearly all fields were being merged using overrides, except ItemTypes were being completely overwritten by overrides, resulting in the need to duplicate all existing fields. Not only was this cumbersome, but it was confusing to have fields merge differently. This change makes the behavior consistent.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
