### PR TITLE
Add `replica_zones` to `boot_disk.initialize_params` in `google_compute_instance`

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -233,6 +233,17 @@ properties:
                 * /projects/{project}/zones/{zone}/storagePools/{storagePool}
               required: false
               immutable: true
+            - name: 'replicaZones'
+              type: Array
+              description: |
+                A list of short names or self_links of zones in which to create a regional disk.
+              custom_expand: 'templates/terraform/custom_expand/array_resourceref_with_validation.go.tmpl'
+              item_type:
+                name: 'zone'
+                type: ResourceRef
+                description: 'A reference to a zone where the disk should be replicated to.'
+                resource: 'Zone'
+                imports: 'selfLink'
         - name: 'interface'
           type: Enum
           description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -104,6 +104,7 @@ var (
 		"boot_disk.0.initialize_params.0.storage_pool",
 		"boot_disk.0.initialize_params.0.resource_policies",
 		"boot_disk.0.initialize_params.0.architecture",
+		"boot_disk.0.initialize_params.0.replica_zones",
 	}
 
 	schedulingKeys = []string{
@@ -549,6 +550,18 @@ func ResourceComputeInstance() *schema.Resource {
 										AtLeastOneOf: initializeParamsKeys,
 										ValidateFunc: validation.StringInSlice([]string{"X86_64", "ARM64"}, false),
 										Description:  `The architecture of the disk. One of "X86_64" or "ARM64".`,
+									},
+
+									"replica_zones": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										ForceNew:     true,
+										AtLeastOneOf: initializeParamsKeys,
+										Description:  `A list of short names or self_links of zones in which to create a regional disk.`,
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+										},
 									},
 								},
 							},
@@ -1726,12 +1739,26 @@ func getInstance(config *transport_tpg.Config, d *schema.ResourceData) (*compute
 }
 
 func getDisk(diskUri string, d *schema.ResourceData, config *transport_tpg.Config) (*compute.Disk, error) {
-	source, err := tpgresource.ParseDiskFieldValue(diskUri, d, config)
+	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return nil, err
 	}
 
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if strings.Contains(diskUri, "regions/") {
+		source, err := tpgresource.ParseRegionDiskFieldValue(diskUri, d, config)
+		if err != nil {
+			return nil, err
+		}
+
+		disk, err := NewClient(config, userAgent).RegionDisks.Get(source.Project, source.Region, source.Name).Do()
+		if err != nil {
+			return nil, err
+		}
+
+		return disk, err
+	}
+
+	source, err := tpgresource.ParseDiskFieldValue(diskUri, d, config)
 	if err != nil {
 		return nil, err
 	}
@@ -2879,13 +2906,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("boot_disk") {
-		//default behavior for the disk is to have the same name as the instance
-		diskName := instance.Name
-		if v := tpgresource.GetResourceNameFromSelfLink(d.Get("boot_disk.0.source").(string)); v != diskName {
-			diskName = v
-		}
+		diskUri := d.Get("boot_disk.0.source").(string)
 
-		disk, err := NewClient(config, userAgent).Disks.Get(project, zone, diskName).Do()
+		disk, err := getDisk(diskUri, d, config)
 		if err != nil {
 			return fmt.Errorf("Error getting boot disk: %s", err)
 		}
@@ -2893,10 +2916,19 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		obj := make(map[string]interface{})
 
 		if d.HasChange("boot_disk.0.initialize_params") {
+			var locationType, location string
+			if disk.Region != "" {
+				locationType = "regions"
+				location = tpgresource.GetResourceNameFromSelfLink(disk.Region)
+			} else {
+				locationType = "zones"
+				location = tpgresource.GetResourceNameFromSelfLink(disk.Zone)
+			}
+			urlBase := fmt.Sprintf("{{"{{"}}ComputeBasePath{{"}}"}}projects/%s/%s/%s/disks/%s", project, locationType, location, disk.Name)
+
 			if d.HasChange("boot_disk.0.initialize_params.0.size") {
 				obj["sizeGb"] = d.Get("boot_disk.0.initialize_params.0.size").(int)
-				url := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/disks/{{"{{"}}name{{"}}"}}/resize"
-				err := updateDisk(d, config, userAgent, project, url, obj)
+				err := updateDisk(d, config, userAgent, project, urlBase+"/resize", obj)
 				if err != nil {
 					return err
 				}
@@ -2904,8 +2936,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if d.HasChange("boot_disk.0.initialize_params.0.labels") {
 				obj["labels"] = tpgresource.ConvertStringMap(d.Get("boot_disk.0.initialize_params.0.labels").(map[string]interface{}))
 				obj["labelFingerprint"] = disk.LabelFingerprint
-				url := "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/disks/{{"{{"}}name{{"}}"}}/setLabels"
-				err := updateDisk(d, config, userAgent, project, url, obj)
+				err := updateDisk(d, config, userAgent, project, urlBase+"/setLabels", obj)
 				if err != nil {
 					return err
 				}
@@ -3806,6 +3837,19 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.architecture"); ok {
 			disk.InitializeParams.Architecture = v.(string)
 		}
+
+		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.replica_zones"); ok {
+			replicaZones := []string{}
+			for _, zone := range v.([]interface{}) {
+				zoneStr := zone.(string)
+				if !strings.Contains(zoneStr, "/") {
+					project, _ := tpgresource.GetProject(d, config)
+					zoneStr = fmt.Sprintf("projects/%s/zones/%s", project, zoneStr)
+				}
+				replicaZones = append(replicaZones, zoneStr)
+			}
+			disk.InitializeParams.ReplicaZones = replicaZones
+		}
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.mode"); ok {
@@ -3874,6 +3918,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 			"provisioned_throughput": diskDetails.ProvisionedThroughput,
 			"enable_confidential_compute": diskDetails.EnableConfidentialCompute,
 			"storage_pool": tpgresource.GetResourceNameFromSelfLink(diskDetails.StoragePool),
+			"replica_zones": flattenReplicaZones(diskDetails.ReplicaZones),
 		{{"}}"}}
 	}
 
@@ -3925,6 +3970,14 @@ func flattenScratchDisk(disk *compute.AttachedDisk) map[string]interface{} {
 		"size": disk.DiskSizeGb,
 	}
 	return result
+}
+
+func flattenReplicaZones(zones []string) []interface{} {
+	rzs := make([]interface{}, len(zones))
+	for i, z := range zones {
+		rzs[i] = tpgresource.GetResourceNameFromSelfLink(z)
+	}
+	return rzs
 }
 
 func expandStoragePool(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
@@ -69,6 +69,8 @@ fields:
     api_field: 'disks.initializeParams.resourceManagerTags'
   - field: 'boot_disk.initialize_params.resource_policies'
     api_field: 'disks.initializeParams.resourcePolicies'
+  - field: 'boot_disk.initialize_params.replica_zones'
+    api_field: 'disks.initializeParams.replicaZones'
   - field: 'boot_disk.initialize_params.snapshot'
     api_field: 'disks.initializeParams.sourceSnapshot'
   - field: 'boot_disk.initialize_params.source_snapshot_encryption_key.kms_key_self_link'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
@@ -72,6 +72,8 @@ fields:
     api_field: 'disks.initializeParams.resourceManagerTags'
   - field: 'boot_disk.initialize_params.resource_policies'
     api_field: 'disks.initializeParams.resourcePolicies'
+  - field: 'boot_disk.initialize_params.replica_zones'
+    api_field: 'disks.initializeParams.replicaZones'
   - field: 'boot_disk.initialize_params.snapshot'
     api_field: 'disks.initializeParams.sourceSnapshot'
   - field: 'boot_disk.initialize_params.source_snapshot_encryption_key.kms_key_self_link'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
@@ -72,6 +72,8 @@ fields:
     api_field: 'disks.initializeParams.resourceManagerTags'
   - field: 'boot_disk.initialize_params.resource_policies'
     api_field: 'disks.initializeParams.resourcePolicies'
+  - field: 'boot_disk.initialize_params.replica_zones'
+    api_field: 'disks.initializeParams.replicaZones'
   - field: 'boot_disk.initialize_params.snapshot'
     api_field: 'disks.initializeParams.sourceSnapshot'
   - field: 'boot_disk.initialize_params.source_snapshot_encryption_key.kms_key_self_link'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -1041,6 +1041,37 @@ func TestAccComputeInstance_snapshot(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_repdBootFromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+
+	context := map[string]interface{}{
+		"network_name":    fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"subnetwork_name": fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"disk_name":       fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"snapshot_name":   fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+		"instance_name":   fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10)),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_repdBootFromSnapshot(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.instance", &instance),
+					resource.TestCheckResourceAttr("google_compute_instance.instance", "boot_disk.0.initialize_params.0.replica_zones.#", "2"),
+					resource.TestCheckResourceAttr("google_compute_instance.instance", "boot_disk.0.initialize_params.0.replica_zones.0", "us-central1-a"),
+					resource.TestCheckResourceAttr("google_compute_instance.instance", "boot_disk.0.initialize_params.0.replica_zones.1", "us-central1-b"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_snapshotEncryption(t *testing.T) {
 	t.Parallel()
 
@@ -13155,6 +13186,55 @@ resource "google_compute_instance" "foobar2" {
 	network_interface {
 		network = "default"
 	}
+}
+`, context)
+}
+
+func testAccComputeInstance_repdBootFromSnapshot(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name = "%{network_name}"
+}
+
+resource "google_compute_subnetwork" "sub" {
+  name          = "%{subnetwork_name}"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.net.id
+}
+
+resource "google_compute_disk" "zonal" {
+  name    = "%{disk_name}"
+  type    = "pd-ssd"
+  zone    = "us-central1-a"
+  image   = "debian-cloud/debian-11"
+  size    = 50
+}
+
+resource "google_compute_snapshot" "snapshot" {
+  name              = "%{snapshot_name}"
+  source_disk       = google_compute_disk.zonal.self_link
+  zone              = "us-central1-a"
+  storage_locations = ["us-central1"]
+}
+
+resource "google_compute_instance" "instance" {
+  name         = "%{instance_name}"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      snapshot      = google_compute_snapshot.snapshot.id
+      replica_zones = ["us-central1-a", "us-central1-b"]
+      size          = "200"
+      type          = "pd-ssd"
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.sub.id
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -357,6 +357,8 @@ is desired, you will need to modify your state file manually using
     * /zones/{zone}/storagePools/{storagePool}
     * /{storagePool}
 
+* `replica_zones` - (Optional) A list of short names or self_links of zones in which to create the disk. Setting this field converts the disk to a regional disk. You must provide exactly two replica zones, and one zone must be the same as the instance zone.
+
 <a name="nested_scratch_disk"></a>The `scratch_disk` block supports:
 
 * `interface` - (Required) The disk interface to use for attaching this disk; either SCSI or NVME.


### PR DESCRIPTION
This PR adds support for the `replica_zones` field in `boot_disk.initialize_params` for the `google_compute_instance` resource. This allows users to provision instances with Regional Persistent Disks as boot disks at instance creation time.

A follow-up PR will also enable creating a regional disk from a boot image

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->


```release-note:enhancement
compute: added `replica_zones` field to `google_compute_instance` resource
```