### PR TITLE
Migrate resource_compute_region_instance_group_manager_test.go.tmpl to new API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ mmv1/build/*
 .vscode
 *.code-workspace
 
+# windsurf workspace settings
+.windsurf/
+
 # ignore serialization generation build data
 tpgtools/temp.serial
 tpgtools/serialization.go

--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,6 @@ mmv1/build/*
 .vscode
 *.code-workspace
 
-# windsurf workspace settings
-.windsurf/
-
 # ignore serialization generation build data
 tpgtools/temp.serial
 tpgtools/serialization.go

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -11,7 +11,7 @@ import (
   {{- if ne $.TargetVersionName "ga" }}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
   {{- end }}
-	"github.com/hashicorp/terraform-provider-google/google/services/compute"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
@@ -619,8 +619,18 @@ func testAccCheckRegionInstanceGroupManagerDestroyProducer(t *testing.T) func(s 
 			if rs.Type != "google_compute_region_instance_group_manager" {
 				continue
 			}
-			_, err := compute.NewClient(config, config.UserAgent).RegionInstanceGroupManagers.Get(
-				rs.Primary.Attributes["project"], rs.Primary.Attributes["region"], rs.Primary.Attributes["name"]).Do()
+			url := fmt.Sprintf("%sprojects/%s/regions/%s/instanceGroupManagers/%s",
+				config.ComputeBasePath,
+				rs.Primary.Attributes["project"],
+				rs.Primary.Attributes["region"],
+				rs.Primary.Attributes["name"])
+			_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   rs.Primary.Attributes["project"],
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
 			if err == nil {
 				return fmt.Errorf("RegionInstanceGroupManager still exists")
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:
compute: migrated `resource_compute_region_instance_group_manager_test` file to use direct HTTP rather than a client library
```
