### PR TITLE
Add source image support to `compute_region_disk`

### DIFF
--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -128,8 +128,6 @@ parameters:
       [google_compute_image data source](/docs/providers/google/d/compute_image.html).
       For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
       These images can be referred by family name here.
-
-      **Note:** This field is currently behind an allowlist and requires special permission to use.
     api_name: sourceImage
     immutable: true
     diff_suppress_func: 'DiskImageDiffSuppress'
@@ -182,8 +180,6 @@ properties:
     description: |
       The customer-supplied encryption key of the source image. Required if
       the source image is protected by a customer-supplied encryption key.
-
-      **Note:** This field is currently behind an allowlist and requires special permission to use.
     immutable: true
     ignore_read: true
     properties:
@@ -226,8 +222,6 @@ properties:
       disk. For example, if you created the persistent disk from an image
       that was later deleted and recreated under the same name, the source
       image ID would identify the exact version of the image that was used.
-
-      **Note:** This field is currently behind an allowlist and requires special permission to use.
     output: true
   - name: 'sourceSnapshotEncryptionKey'
     type: NestedObject

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -91,12 +91,6 @@ examples:
     primary_resource_id: 'primary'
     vars:
       region_disk_name: 'my-region-hyperdisk'
-  - name: 'region_disk_from_image'
-    primary_resource_id: 'regiondisk'
-    vars:
-      region_disk_name: 'my-region-disk-from-image'
-    # Hidden from docs because this feature is behind an allowlist
-    exclude_docs: true
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -191,12 +185,23 @@ properties:
 
       **Note:** This field is currently behind an allowlist and requires special permission to use.
     immutable: true
+    ignore_read: true
     properties:
       - name: 'rawKey'
         type: String
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
+        sensitive: true
+        is_missing_in_cai: true
+      - name: 'rsaEncryptedKey'
+        type: String
+        description: |
+          Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit
+          customer-supplied encryption key to either encrypt or decrypt
+          this resource. You can provide either the rawKey or the rsaEncryptedKey.
+        sensitive: true
+        is_missing_in_cai: true
       - name: 'sha256'
         type: String
         description: |
@@ -208,6 +213,11 @@ properties:
         type: String
         description: |
           The name of the encryption key that is stored in Google Cloud KMS.
+      - name: 'kmsKeyServiceAccount'
+        type: String
+        description: |
+          The service account used for the encryption request for the given KMS key.
+          If absent, the Compute Engine Service Agent service account is used.
   - name: 'sourceImageId'
     type: String
     description: |

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -91,6 +91,12 @@ examples:
     primary_resource_id: 'primary'
     vars:
       region_disk_name: 'my-region-hyperdisk'
+  - name: 'region_disk_from_image'
+    primary_resource_id: 'regiondisk'
+    vars:
+      region_disk_name: 'my-region-disk-from-image'
+    # Hidden from docs because this feature is behind an allowlist
+    exclude_docs: true
 parameters:
   - name: 'region'
     type: ResourceRef
@@ -116,9 +122,27 @@ parameters:
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Snapshot'
     imports: 'selfLink'
+  - name: 'image'
+    type: String
+    description: |
+      The image from which to initialize this disk. This can be
+      one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
+      `projects/{project}/global/images/family/{family}`, `global/images/{image}`,
+      `global/images/family/{family}`, `family/{family}`, `{project}/{family}`,
+      `{project}/{image}`, `{family}`, or `{image}`. If referred by family, the
+      images names must include the family name. If they don't, use the
+      [google_compute_image data source](/docs/providers/google/d/compute_image.html).
+      For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
+      These images can be referred by family name here.
+
+      **Note:** This field is currently behind an allowlist and requires special permission to use.
+    api_name: sourceImage
+    immutable: true
+    diff_suppress_func: 'DiskImageDiffSuppress'
 properties:
   - name: 'diskEncryptionKey'
     type: NestedObject
+    
     description: |
       Encrypts the disk using a customer-supplied encryption key.
 
@@ -160,6 +184,42 @@ properties:
         type: String
         description: |
           The name of the encryption key that is stored in Google Cloud KMS.
+  - name: 'sourceImageEncryptionKey'
+    type: NestedObject
+    description: |
+      The customer-supplied encryption key of the source image. Required if
+      the source image is protected by a customer-supplied encryption key.
+
+      **Note:** This field is currently behind an allowlist and requires special permission to use.
+    immutable: true
+    properties:
+      - name: 'rawKey'
+        type: String
+        description: |
+          Specifies a 256-bit customer-supplied encryption key, encoded in
+          RFC 4648 base64 to either encrypt or decrypt this resource.
+      - name: 'sha256'
+        type: String
+        description: |
+          The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
+          encryption key that protects this resource.
+        output: true
+        # TODO Change to ResourceRef once KMS is in Magic Modules
+      - name: 'kmsKeyName'
+        type: String
+        description: |
+          The name of the encryption key that is stored in Google Cloud KMS.
+  - name: 'sourceImageId'
+    type: String
+    description: |
+      The ID value of the image used to create this disk. This value
+      identifies the exact image that was used to create this persistent
+      disk. For example, if you created the persistent disk from an image
+      that was later deleted and recreated under the same name, the source
+      image ID would identify the exact version of the image that was used.
+
+      **Note:** This field is currently behind an allowlist and requires special permission to use.
+    output: true
   - name: 'sourceSnapshotEncryptionKey'
     type: NestedObject
     description: |

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -142,7 +142,6 @@ parameters:
 properties:
   - name: 'diskEncryptionKey'
     type: NestedObject
-    
     description: |
       Encrypts the disk using a customer-supplied encryption key.
 

--- a/mmv1/templates/terraform/examples/region_disk_from_image.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_disk_from_image.tf.tmpl
@@ -1,9 +1,0 @@
-resource "google_compute_region_disk" "regiondisk" {
-  name          = "{{index $.Vars "region_disk_name"}}"
-  image         = "debian-cloud/debian-12"
-  type          = "pd-ssd"
-  region        = "us-central1"
-  size          = 200
-
-  replica_zones = ["us-central1-a", "us-central1-f"]
-}

--- a/mmv1/templates/terraform/examples/region_disk_from_image.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_disk_from_image.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_compute_region_disk" "regiondisk" {
+  name          = "{{index $.Vars "region_disk_name"}}"
+  image         = "debian-cloud/debian-12"
+  type          = "pd-ssd"
+  region        = "us-central1"
+  size          = 200
+
+  replica_zones = ["us-central1-a", "us-central1-f"]
+}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -1079,6 +1079,80 @@ resource "google_compute_region_disk" "disk_from_rsa_image" {
 `, context)
 }
 
+func TestAccComputeRegionDisk_fromImageKMSWithServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	kms := acctest.BootstrapKMSKey(t)
+	suffix := acctest.RandString(t, 10)
+	diskName := fmt.Sprintf("tf-test-kms-sa-disk-%s", suffix)
+	imageName := fmt.Sprintf("tf-test-kms-sa-image-%s", suffix)
+
+	context := map[string]interface{}{
+		"random_suffix":     suffix,
+		"kms_key_self_link": kms.CryptoKey.Name,
+		"image_name":        imageName,
+		"disk_name":         diskName,
+	}
+
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
+
+	var disk compute.Disk
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionDisk_fromImageKMSWithServiceAccount(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.kms_disk", &disk),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeRegionDisk_fromImageKMSWithServiceAccount(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "debian" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+data "google_compute_default_service_account" "default" {
+}
+
+resource "google_compute_image" "kms_image" {
+  name         = "%{image_name}"
+  source_image = data.google_compute_image.debian.self_link
+
+  image_encryption_key {
+    kms_key_self_link = "%{kms_key_self_link}"
+  }
+}
+
+resource "google_compute_region_disk" "kms_disk" {
+  name          = "%{disk_name}"
+  image         = google_compute_image.kms_image.self_link
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  size          = 200
+
+  source_image_encryption_key {
+    kms_key_name = "%{kms_key_self_link}"
+    kms_key_service_account = data.google_compute_default_service_account.default.email
+  }
+}
+`, context)
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeRegionDisk_VSSWindowsDefault(diskName string) string {
     return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -883,6 +883,202 @@ resource "google_compute_region_disk" "kms-encrypted-name" {
 `, context)
 }
 
+func TestAccComputeRegionDisk_fromImageKMS(t *testing.T) {
+	t.Parallel()
+
+	kms := acctest.BootstrapKMSKey(t)
+	suffix := acctest.RandString(t, 10)
+	diskName := fmt.Sprintf("tf-test-kms-disk-%s", suffix)
+	imageName := fmt.Sprintf("tf-test-kms-image-%s", suffix)
+
+	context := map[string]interface{}{
+		"random_suffix":     suffix,
+		"kms_key_self_link": kms.CryptoKey.Name,
+		"image_name":        imageName,
+		"disk_name":         diskName,
+	}
+
+	acctest.BootstrapIamMembers(t, []acctest.IamMember{
+		{
+			Member: "serviceAccount:service-{project_number}@compute-system.iam.gserviceaccount.com",
+			Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+		},
+	})
+
+	var disk compute.Disk
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionDisk_fromImageKMS(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.kms_disk", &disk),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeRegionDisk_fromImageKMS(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "debian" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "kms_image" {
+  name         = "%{image_name}"
+  source_image = data.google_compute_image.debian.self_link
+
+  image_encryption_key {
+    kms_key_self_link = "%{kms_key_self_link}"
+  }
+}
+
+resource "google_compute_region_disk" "kms_disk" {
+  name          = "%{disk_name}"
+  image         = google_compute_image.kms_image.self_link
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  size          = 200
+
+  source_image_encryption_key {
+    kms_key_name = "%{kms_key_self_link}"
+  }
+}
+`, context)
+}
+
+func TestAccComputeRegionDisk_fromImageCSEK(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	diskName := fmt.Sprintf("tf-test-csek-disk-%s", suffix)
+	imageName := fmt.Sprintf("tf-test-csek-image-%s", suffix)
+
+	context := map[string]interface{}{
+		"random_suffix": suffix,
+		"raw_key":       "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=",
+		"image_name":    imageName,
+		"disk_name":     diskName,
+	}
+
+	var disk compute.Disk
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionDisk_fromImageCSEK(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.csek_disk", &disk),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeRegionDisk_fromImageCSEK(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "debian" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "csek_image" {
+  name              = "%{image_name}"
+  source_image      = data.google_compute_image.debian.self_link
+  storage_locations = ["us"]
+
+  image_encryption_key {
+    raw_key = "%{raw_key}"
+  }
+}
+
+resource "google_compute_region_disk" "csek_disk" {
+  name          = "%{disk_name}"
+  image         = google_compute_image.csek_image.self_link
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  size          = 200
+
+  source_image_encryption_key {
+    raw_key = "%{raw_key}"
+  }
+}
+`, context)
+}
+
+func TestAccComputeRegionDisk_fromImageRSA(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	diskName := fmt.Sprintf("tf-test-rsa-disk-%s", suffix)
+	imageName := fmt.Sprintf("tf-test-rsa-image-%s", suffix)
+
+	context := map[string]interface{}{
+		"random_suffix":     suffix,
+		"rsa_encrypted_key": "fB6BS8tJGhGVDZDjGt1pwUo2wyNbkzNxgH1avfOtiwB9X6oPG94gWgenygitnsYJyKjdOJ7DyXLmxwQOSmnCYCUBWdKCSssyLV5907HL2mb5TfqmgHk5JcArI/t6QADZWiuGtR+XVXqiLa5B9usxFT2BTmbHvSKfkpJ7McCNc/3U0PQR8euFRZ9i75o/w+pLHFMJ05IX3JB0zHbXMV173PjObiV3ItSJm2j3mp5XKabRGSA5rmfMnHIAMz6stGhcuom6+bMri2u/axmPsdxmC6MeWkCkCmPjaKsVz1+uQUNCJkAnzesluhoD+R6VjFDm4WI7yYabu4MOOAOTaQXdEg==",
+		"image_name":        imageName,
+		"disk_name":         diskName,
+	}
+
+	var disk compute.Disk
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionDiskDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionDisk_fromImageRSA(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeRegionDiskExists(
+						t, "google_compute_region_disk.disk_from_rsa_image", &disk),
+				),
+			},
+		},
+	})
+}
+
+func testAccComputeRegionDisk_fromImageRSA(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "debian" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_image" "rsa_image" {
+  name              = "%{image_name}"
+  source_image      = data.google_compute_image.debian.self_link
+  storage_locations = ["us"]
+
+  image_encryption_key {
+    rsa_encrypted_key = "%{rsa_encrypted_key}"
+  }
+}
+
+resource "google_compute_region_disk" "disk_from_rsa_image" {
+  name          = "%{disk_name}"
+  image         = google_compute_image.rsa_image.self_link
+  region        = "us-central1"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  size          = 200
+
+  source_image_encryption_key {
+    rsa_encrypted_key = "%{rsa_encrypted_key}"
+  }
+}
+`, context)
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 func testAccComputeRegionDisk_VSSWindowsDefault(diskName string) string {
     return fmt.Sprintf(`


### PR DESCRIPTION
This PR adds support for creating regional disks from images in `RegionDisk.yaml`.

This is the follow-up PR mentioned in #17326 to enable creating a regional disk from a boot image.

Note that this feature is behind a long term allowlist so I've hidden the example from the documentation page.

```release-note:enhancement
compute: added `image`, `source_image_encryption_key`, and `source_image_id` fields to `google_compute_region_disk` resource. This field is currently behind an allowlist. 
```