### PR TITLE
Migrate resource_compute_project_default_network_tier.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_default_network_tier.go
@@ -13,12 +13,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceComputeProjectDefaultNetworkTier() *schema.Resource {
@@ -36,7 +30,7 @@ func ResourceComputeProjectDefaultNetworkTier() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-            tpgresource.DefaultProviderDeletionPolicy("DELETE"),
+			tpgresource.DefaultProviderDeletionPolicy("DELETE"),
 			tpgresource.DefaultProviderProject,
 		),
 
@@ -64,7 +58,7 @@ func ResourceComputeProjectDefaultNetworkTier() *schema.Resource {
 
 func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -74,17 +68,29 @@ func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceDa
 		return err
 	}
 
-	request := &compute.ProjectsSetDefaultNetworkTierRequest{
-		NetworkTier: d.Get("network_tier").(string),
+	request := map[string]interface{}{
+		"networkTier": d.Get("network_tier").(string),
 	}
-	op, err := NewClient(config, userAgent).Projects.SetDefaultNetworkTier(projectID, request).Do()
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}")
+	if err != nil {
+		return fmt.Errorf("SetDefaultNetworkTier failed: %s", err)
+	}
+	url = fmt.Sprintf("%sprojects/%s/setDefaultNetworkTier", url, projectID)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   projectID,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      request,
+	})
 	if err != nil {
 		return fmt.Errorf("SetDefaultNetworkTier failed: %s", err)
 	}
 
-	log.Printf("[DEBUG] SetDefaultNetworkTier: %d (%s)", op.Id, op.SelfLink)
-	err = ComputeOperationWaitTime(config, op, projectID, "SetDefaultNetworkTier", userAgent, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
+	log.Printf("[DEBUG] SetDefaultNetworkTier: %v", res["selfLink"])
+	if err = ComputeOperationWaitTime(config, res, projectID, "SetDefaultNetworkTier", userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("SetDefaultNetworkTier failed: %s", err)
 	}
 
@@ -95,20 +101,30 @@ func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceDa
 
 func resourceComputeProjectDefaultNetworkTierRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
 
 	projectId := d.Id()
 
-	project, err := NewClient(config, userAgent).Projects.Get(projectId).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{ComputeBasePath}}")
+	if err != nil {
+		return err
+	}
+	url = fmt.Sprintf("%sprojects/%s", url, projectId)
+	project, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   projectId,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Project data for project %q", projectId))
 	}
 
-	err = d.Set("network_tier", project.DefaultNetworkTier)
-	if err != nil {
+	if err = d.Set("network_tier", project["defaultNetworkTier"].(string)); err != nil {
 		return fmt.Errorf("Error setting default network tier: %s", err)
 	}
 
@@ -127,9 +143,9 @@ func resourceComputeProjectDefaultNetworkTierDelete(d *schema.ResourceData, meta
 
 func init() {
 	registry.Schema{
-		Name: "google_compute_project_default_network_tier",
+		Name:        "google_compute_project_default_network_tier",
 		ProductName: "compute",
-		Type: registry.SchemaTypeResource,
-		Schema: ResourceComputeProjectDefaultNetworkTier(),
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceComputeProjectDefaultNetworkTier(),
 	}.Register()
 }


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates `ResourceComputeProjectDefaultNetworkTier` resource to use transport_tpg.SendRequest instead of NewClient

```release-note:note
compute: migrated `google_compute_project_default_network_tier` resource to use direct HTTP rather than a client library
```
