### PR TITLE
Add new node types to Redis cluster and Memorystore services

### DIFF
--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -344,7 +344,7 @@ properties:
     type: String
     description:
       "Optional. Machine type for individual nodes of the instance.
-      \n Possible values:\n SHARED_CORE_NANO\nHIGHMEM_MEDIUM\nHIGHMEM_XLARGE\nSTANDARD_SMALL"
+      \n Possible values:\n SHARED_CORE_NANO\nCUSTOM_PICO\nCUSTOM_MICRO\nCUSTOM_MINI\nHIGHMEM_MEDIUM\nHIGHCPU_MEDIUM\nHIGHMEM_XLARGE\nSTANDARD_SMALL\nSTANDARD_LARGE\nHIGHMEM_2XLARGE"
     default_from_api: true
   - name: 'persistenceConfig'
     type: NestedObject

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -394,7 +394,10 @@ properties:
     enum_values:
       - 'REDIS_SHARED_CORE_NANO'
       - 'REDIS_HIGHMEM_MEDIUM'
+      - 'REDIS_HIGHCPU_MEDIUM'
+      - 'REDIS_STANDARD_LARGE'
       - 'REDIS_HIGHMEM_XLARGE'
+      - 'REDIS_HIGHMEM_2XLARGE'
       - 'REDIS_STANDARD_SMALL'
   - name: 'zoneDistributionConfig'
     type: NestedObject


### PR DESCRIPTION
Added new node types to the supported nodeType values for Redis and Memorystore.

```release-note:enhancement
redis: added new node types supported in `google_redis_cluster`.
```
