### PR TITLE
Add policy-based challenge fields to RecaptchaEnterprise Key

### DIFF
--- a/mmv1/third_party/terraform/services/recaptchaenterprise/key.go.tmpl
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/key.go.tmpl
@@ -43,7 +43,7 @@ func (v KeyWebSettingsIntegrationTypeEnum) Validate() error {
 		// Empty enum is okay.
 		return nil
 	}
-	for _, s := range []string{"SCORE", "CHECKBOX", "INVISIBLE"} {
+	for _, s := range []string{"SCORE", "CHECKBOX", "INVISIBLE", "POLICY_BASED_CHALLENGE"} {
 		if string(v) == s {
 			return nil
 		}
@@ -170,6 +170,7 @@ type KeyWebSettings struct {
 	AllowAmpTraffic             *bool                                          `json:"allowAmpTraffic"`
 	IntegrationType             *KeyWebSettingsIntegrationTypeEnum             `json:"integrationType"`
 	ChallengeSecurityPreference *KeyWebSettingsChallengeSecurityPreferenceEnum `json:"challengeSecurityPreference"`
+	ChallengeSettings           *KeyWebSettingsChallengeSettings               `json:"challengeSettings"`
 }
 
 type jsonKeyWebSettings KeyWebSettings
@@ -197,6 +198,8 @@ func (r *KeyWebSettings) UnmarshalJSON(data []byte) error {
 
 		r.ChallengeSecurityPreference = res.ChallengeSecurityPreference
 
+		r.ChallengeSettings = res.ChallengeSettings
+
 	}
 	return nil
 }
@@ -217,6 +220,125 @@ func (r *KeyWebSettings) String() string {
 func (r *KeyWebSettings) HashCode() string {
 	// Placeholder for a more complex hash method that handles ordering, etc
 	// Hash resource body for easy comparison later
+	hash := sha256.Sum256([]byte(r.String()))
+	return fmt.Sprintf("%x", hash)
+}
+
+type KeyWebSettingsChallengeSettings struct {
+	empty           bool                                                     `json:"-"`
+	DefaultSettings *KeyWebSettingsChallengeSettingsDefaultSettings          `json:"defaultSettings"`
+	ActionSettings  map[string]KeyWebSettingsChallengeSettingsActionSettings `json:"actionSettings"`
+}
+
+type jsonKeyWebSettingsChallengeSettings KeyWebSettingsChallengeSettings
+
+func (r *KeyWebSettingsChallengeSettings) UnmarshalJSON(data []byte) error {
+	var res jsonKeyWebSettingsChallengeSettings
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	if len(m) == 0 {
+		*r = *EmptyKeyWebSettingsChallengeSettings
+	} else {
+		r.DefaultSettings = res.DefaultSettings
+		r.ActionSettings = res.ActionSettings
+	}
+	return nil
+}
+
+var EmptyKeyWebSettingsChallengeSettings *KeyWebSettingsChallengeSettings = &KeyWebSettingsChallengeSettings{empty: true}
+
+func (r *KeyWebSettingsChallengeSettings) Empty() bool {
+	return r.empty
+}
+
+func (r *KeyWebSettingsChallengeSettings) String() string {
+	return dcl.SprintResource(r)
+}
+
+func (r *KeyWebSettingsChallengeSettings) HashCode() string {
+	hash := sha256.Sum256([]byte(r.String()))
+	return fmt.Sprintf("%x", hash)
+}
+
+type KeyWebSettingsChallengeSettingsDefaultSettings struct {
+	empty          bool     `json:"-"`
+	ScoreThreshold *float64 `json:"scoreThreshold"`
+}
+
+type jsonKeyWebSettingsChallengeSettingsDefaultSettings KeyWebSettingsChallengeSettingsDefaultSettings
+
+func (r *KeyWebSettingsChallengeSettingsDefaultSettings) UnmarshalJSON(data []byte) error {
+	var res jsonKeyWebSettingsChallengeSettingsDefaultSettings
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	if len(m) == 0 {
+		*r = *EmptyKeyWebSettingsChallengeSettingsDefaultSettings
+	} else {
+		r.ScoreThreshold = res.ScoreThreshold
+	}
+	return nil
+}
+
+var EmptyKeyWebSettingsChallengeSettingsDefaultSettings *KeyWebSettingsChallengeSettingsDefaultSettings = &KeyWebSettingsChallengeSettingsDefaultSettings{empty: true}
+
+func (r *KeyWebSettingsChallengeSettingsDefaultSettings) Empty() bool {
+	return r.empty
+}
+
+func (r *KeyWebSettingsChallengeSettingsDefaultSettings) String() string {
+	return dcl.SprintResource(r)
+}
+
+func (r *KeyWebSettingsChallengeSettingsDefaultSettings) HashCode() string {
+	hash := sha256.Sum256([]byte(r.String()))
+	return fmt.Sprintf("%x", hash)
+}
+
+type KeyWebSettingsChallengeSettingsActionSettings struct {
+	empty          bool     `json:"-"`
+	ScoreThreshold *float64 `json:"scoreThreshold"`
+}
+
+type jsonKeyWebSettingsChallengeSettingsActionSettings KeyWebSettingsChallengeSettingsActionSettings
+
+func (r *KeyWebSettingsChallengeSettingsActionSettings) UnmarshalJSON(data []byte) error {
+	var res jsonKeyWebSettingsChallengeSettingsActionSettings
+	if err := json.Unmarshal(data, &res); err != nil {
+		return err
+	}
+
+	var m map[string]interface{}
+	json.Unmarshal(data, &m)
+
+	if len(m) == 0 {
+		*r = *EmptyKeyWebSettingsChallengeSettingsActionSettings
+	} else {
+		r.ScoreThreshold = res.ScoreThreshold
+	}
+	return nil
+}
+
+var EmptyKeyWebSettingsChallengeSettingsActionSettings *KeyWebSettingsChallengeSettingsActionSettings = &KeyWebSettingsChallengeSettingsActionSettings{empty: true}
+
+func (r *KeyWebSettingsChallengeSettingsActionSettings) Empty() bool {
+	return r.empty
+}
+
+func (r *KeyWebSettingsChallengeSettingsActionSettings) String() string {
+	return dcl.SprintResource(r)
+}
+
+func (r *KeyWebSettingsChallengeSettingsActionSettings) HashCode() string {
 	hash := sha256.Sum256([]byte(r.String()))
 	return fmt.Sprintf("%x", hash)
 }

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/key_internal.go
@@ -53,6 +53,34 @@ func (r *KeyWebSettings) validate() error {
 	if err := dcl.Required(r, "integrationType"); err != nil {
 		return err
 	}
+	if !dcl.IsEmptyValueIndirect(r.ChallengeSettings) {
+		if err := r.ChallengeSettings.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (r *KeyWebSettingsChallengeSettings) validate() error {
+	if err := dcl.Required(r, "defaultSettings"); err != nil {
+		return err
+	}
+	if !dcl.IsEmptyValueIndirect(r.DefaultSettings) {
+		if err := r.DefaultSettings.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (r *KeyWebSettingsChallengeSettingsDefaultSettings) validate() error {
+	if err := dcl.Required(r, "scoreThreshold"); err != nil {
+		return err
+	}
+	return nil
+}
+func (r *KeyWebSettingsChallengeSettingsActionSettings) validate() error {
+	if err := dcl.Required(r, "scoreThreshold"); err != nil {
+		return err
+	}
 	return nil
 }
 func (r *KeyAndroidSettings) validate() error {
@@ -635,8 +663,109 @@ func canonicalizeKeyWebSettings(des, initial *KeyWebSettings, opts ...dcl.ApplyO
 	} else {
 		cDes.ChallengeSecurityPreference = des.ChallengeSecurityPreference
 	}
+	cDes.ChallengeSettings = canonicalizeKeyWebSettingsChallengeSettings(des.ChallengeSettings, initial.ChallengeSettings, opts...)
 
 	return cDes
+}
+
+func canonicalizeKeyWebSettingsChallengeSettings(des, initial *KeyWebSettingsChallengeSettings, opts ...dcl.ApplyOption) *KeyWebSettingsChallengeSettings {
+	if des == nil {
+		return initial
+	}
+	if des.empty {
+		return des
+	}
+
+	if initial == nil {
+		return des
+	}
+
+	cDes := &KeyWebSettingsChallengeSettings{}
+
+	cDes.DefaultSettings = canonicalizeKeyWebSettingsChallengeSettingsDefaultSettings(des.DefaultSettings, initial.DefaultSettings, opts...)
+	cDes.ActionSettings = canonicalizeKeyWebSettingsChallengeSettingsActionSettingsMap(des.ActionSettings, initial.ActionSettings, opts...)
+
+	return cDes
+}
+
+func canonicalizeKeyWebSettingsChallengeSettingsDefaultSettings(des, initial *KeyWebSettingsChallengeSettingsDefaultSettings, opts ...dcl.ApplyOption) *KeyWebSettingsChallengeSettingsDefaultSettings {
+	if des == nil {
+		return initial
+	}
+	if des.empty {
+		return des
+	}
+
+	if initial == nil {
+		return des
+	}
+
+	cDes := &KeyWebSettingsChallengeSettingsDefaultSettings{}
+
+	if dcl.IsZeroValue(des.ScoreThreshold) || (dcl.IsEmptyValueIndirect(des.ScoreThreshold) && dcl.IsEmptyValueIndirect(initial.ScoreThreshold)) {
+		cDes.ScoreThreshold = initial.ScoreThreshold
+	} else {
+		cDes.ScoreThreshold = des.ScoreThreshold
+	}
+
+	return cDes
+}
+
+func canonicalizeKeyWebSettingsChallengeSettingsActionSettings(des, initial *KeyWebSettingsChallengeSettingsActionSettings, opts ...dcl.ApplyOption) *KeyWebSettingsChallengeSettingsActionSettings {
+	if des == nil {
+		return initial
+	}
+	if des.empty {
+		return des
+	}
+
+	if initial == nil {
+		return des
+	}
+
+	cDes := &KeyWebSettingsChallengeSettingsActionSettings{}
+
+	if dcl.IsZeroValue(des.ScoreThreshold) || (dcl.IsEmptyValueIndirect(des.ScoreThreshold) && dcl.IsEmptyValueIndirect(initial.ScoreThreshold)) {
+		cDes.ScoreThreshold = initial.ScoreThreshold
+	} else {
+		cDes.ScoreThreshold = des.ScoreThreshold
+	}
+
+	return cDes
+}
+
+func canonicalizeKeyWebSettingsChallengeSettingsActionSettingsMap(des, initial map[string]KeyWebSettingsChallengeSettingsActionSettings, opts ...dcl.ApplyOption) map[string]KeyWebSettingsChallengeSettingsActionSettings {
+	if dcl.IsEmptyValueIndirect(des) {
+		return initial
+	}
+
+	if len(des) != len(initial) {
+		items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+		for k, d := range des {
+			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, nil, opts...)
+			if cd != nil {
+				items[k] = *cd
+			}
+		}
+		return items
+	}
+
+	items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	for k, d := range des {
+		i, ok := initial[k]
+		if ok {
+			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, &i, opts...)
+			if cd != nil {
+				items[k] = *cd
+			}
+		} else {
+			cd := canonicalizeKeyWebSettingsChallengeSettingsActionSettings(&d, nil, opts...)
+			if cd != nil {
+				items[k] = *cd
+			}
+		}
+	}
+	return items
 }
 
 func canonicalizeKeyWebSettingsSlice(des, initial []KeyWebSettings, opts ...dcl.ApplyOption) []KeyWebSettings {
@@ -690,8 +819,97 @@ func canonicalizeNewKeyWebSettings(c *Client, des, nw *KeyWebSettings) *KeyWebSe
 	if dcl.BoolCanonicalize(des.AllowAmpTraffic, nw.AllowAmpTraffic) {
 		nw.AllowAmpTraffic = des.AllowAmpTraffic
 	}
+	nw.ChallengeSettings = canonicalizeNewKeyWebSettingsChallengeSettings(c, des.ChallengeSettings, nw.ChallengeSettings)
 
 	return nw
+}
+
+func canonicalizeNewKeyWebSettingsChallengeSettings(c *Client, des, nw *KeyWebSettingsChallengeSettings) *KeyWebSettingsChallengeSettings {
+	if des == nil {
+		return nw
+	}
+
+	if nw == nil {
+		if dcl.IsEmptyValueIndirect(des) {
+			c.Config.Logger.Info("Found explicitly empty value for KeyWebSettingsChallengeSettings while comparing non-nil desired to nil actual.  Returning desired object.")
+			return des
+		}
+		return nil
+	}
+
+	nw.DefaultSettings = canonicalizeNewKeyWebSettingsChallengeSettingsDefaultSettings(c, des.DefaultSettings, nw.DefaultSettings)
+	nw.ActionSettings = canonicalizeNewKeyWebSettingsChallengeSettingsActionSettingsMap(c, des.ActionSettings, nw.ActionSettings)
+
+	return nw
+}
+
+func canonicalizeNewKeyWebSettingsChallengeSettingsDefaultSettings(c *Client, des, nw *KeyWebSettingsChallengeSettingsDefaultSettings) *KeyWebSettingsChallengeSettingsDefaultSettings {
+	if des == nil {
+		return nw
+	}
+
+	if nw == nil {
+		if dcl.IsEmptyValueIndirect(des) {
+			c.Config.Logger.Info("Found explicitly empty value for KeyWebSettingsChallengeSettingsDefaultSettings while comparing non-nil desired to nil actual.  Returning desired object.")
+			return des
+		}
+		return nil
+	}
+
+	if dcl.IsZeroValue(des.ScoreThreshold) || (dcl.IsEmptyValueIndirect(des.ScoreThreshold) && dcl.IsEmptyValueIndirect(nw.ScoreThreshold)) {
+		nw.ScoreThreshold = des.ScoreThreshold
+	} else if nw.ScoreThreshold != nil && des.ScoreThreshold != nil && *des.ScoreThreshold == *nw.ScoreThreshold {
+		nw.ScoreThreshold = des.ScoreThreshold
+	}
+
+	return nw
+}
+
+func canonicalizeNewKeyWebSettingsChallengeSettingsActionSettings(c *Client, des, nw *KeyWebSettingsChallengeSettingsActionSettings) *KeyWebSettingsChallengeSettingsActionSettings {
+	if des == nil {
+		return nw
+	}
+
+	if nw == nil {
+		if dcl.IsEmptyValueIndirect(des) {
+			c.Config.Logger.Info("Found explicitly empty value for KeyWebSettingsChallengeSettingsActionSettings while comparing non-nil desired to nil actual.  Returning desired object.")
+			return des
+		}
+		return nil
+	}
+
+	if dcl.IsZeroValue(des.ScoreThreshold) || (dcl.IsEmptyValueIndirect(des.ScoreThreshold) && dcl.IsEmptyValueIndirect(nw.ScoreThreshold)) {
+		nw.ScoreThreshold = des.ScoreThreshold
+	} else if nw.ScoreThreshold != nil && des.ScoreThreshold != nil && *des.ScoreThreshold == *nw.ScoreThreshold {
+		nw.ScoreThreshold = des.ScoreThreshold
+	}
+
+	return nw
+}
+
+func canonicalizeNewKeyWebSettingsChallengeSettingsActionSettingsMap(c *Client, des, nw map[string]KeyWebSettingsChallengeSettingsActionSettings) map[string]KeyWebSettingsChallengeSettingsActionSettings {
+	if des == nil {
+		return nw
+	}
+
+	if nw == nil {
+		if dcl.IsEmptyValueIndirect(des) {
+			c.Config.Logger.Info("Found explicitly empty value for KeyWebSettingsChallengeSettingsActionSettings while comparing non-nil desired to nil actual.  Returning desired object.")
+			return des
+		}
+		return nil
+	}
+
+	items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	for k, d := range des {
+		n, ok := nw[k]
+		if ok {
+			items[k] = *canonicalizeNewKeyWebSettingsChallengeSettingsActionSettings(c, &d, &n)
+		} else {
+			items[k] = d
+		}
+	}
+	return items
 }
 
 func canonicalizeNewKeyWebSettingsSet(c *Client, des, nw []KeyWebSettings) []KeyWebSettings {
@@ -1381,6 +1599,155 @@ func compareKeyWebSettingsNewStyle(d, a interface{}, fn dcl.FieldName) ([]*dcl.F
 		}
 		diffs = append(diffs, ds...)
 	}
+
+	if ds, err := dcl.Diff(desired.ChallengeSettings, actual.ChallengeSettings, dcl.DiffInfo{ObjectFunction: compareKeyWebSettingsChallengeSettingsNewStyle, EmptyObject: EmptyKeyWebSettingsChallengeSettings, OperationSelector: dcl.TriggersOperation("updateKeyUpdateKeyOperation")}, fn.AddNest("ChallengeSettings")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, ds...)
+	}
+
+	return diffs, nil
+}
+
+func compareKeyWebSettingsChallengeSettingsNewStyle(d, a interface{}, fn dcl.FieldName) ([]*dcl.FieldDiff, error) {
+	var diffs []*dcl.FieldDiff
+
+	desired, ok := d.(*KeyWebSettingsChallengeSettings)
+	if !ok {
+		desiredNotPointer, ok := d.(KeyWebSettingsChallengeSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettings or *KeyWebSettingsChallengeSettings", d)
+		}
+		desired = &desiredNotPointer
+	}
+	actual, ok := a.(*KeyWebSettingsChallengeSettings)
+	if !ok {
+		actualNotPointer, ok := a.(KeyWebSettingsChallengeSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettings", a)
+		}
+		actual = &actualNotPointer
+	}
+
+	if ds, err := dcl.Diff(desired.DefaultSettings, actual.DefaultSettings, dcl.DiffInfo{ObjectFunction: compareKeyWebSettingsChallengeSettingsDefaultSettingsNewStyle, EmptyObject: EmptyKeyWebSettingsChallengeSettingsDefaultSettings, OperationSelector: dcl.TriggersOperation("updateKeyUpdateKeyOperation")}, fn.AddNest("DefaultSettings")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, ds...)
+	}
+
+	if ds, err := dcl.Diff(desired.ActionSettings, actual.ActionSettings, dcl.DiffInfo{ObjectFunction: compareKeyWebSettingsChallengeSettingsActionSettingsMapNewStyle, EmptyObject: EmptyKeyWebSettingsChallengeSettingsActionSettings, OperationSelector: dcl.TriggersOperation("updateKeyUpdateKeyOperation")}, fn.AddNest("ActionSettings")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, ds...)
+	}
+
+	return diffs, nil
+}
+
+func compareKeyWebSettingsChallengeSettingsDefaultSettingsNewStyle(d, a interface{}, fn dcl.FieldName) ([]*dcl.FieldDiff, error) {
+	var diffs []*dcl.FieldDiff
+
+	desired, ok := d.(*KeyWebSettingsChallengeSettingsDefaultSettings)
+	if !ok {
+		desiredNotPointer, ok := d.(KeyWebSettingsChallengeSettingsDefaultSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettingsDefaultSettings or *KeyWebSettingsChallengeSettingsDefaultSettings", d)
+		}
+		desired = &desiredNotPointer
+	}
+	actual, ok := a.(*KeyWebSettingsChallengeSettingsDefaultSettings)
+	if !ok {
+		actualNotPointer, ok := a.(KeyWebSettingsChallengeSettingsDefaultSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettingsDefaultSettings", a)
+		}
+		actual = &actualNotPointer
+	}
+
+	if ds, err := dcl.Diff(desired.ScoreThreshold, actual.ScoreThreshold, dcl.DiffInfo{OperationSelector: dcl.TriggersOperation("updateKeyUpdateKeyOperation")}, fn.AddNest("ScoreThreshold")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, ds...)
+	}
+
+	return diffs, nil
+}
+
+func compareKeyWebSettingsChallengeSettingsActionSettingsNewStyle(d, a interface{}, fn dcl.FieldName) ([]*dcl.FieldDiff, error) {
+	var diffs []*dcl.FieldDiff
+
+	desired, ok := d.(*KeyWebSettingsChallengeSettingsActionSettings)
+	if !ok {
+		desiredNotPointer, ok := d.(KeyWebSettingsChallengeSettingsActionSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettingsActionSettings or *KeyWebSettingsChallengeSettingsActionSettings", d)
+		}
+		desired = &desiredNotPointer
+	}
+	actual, ok := a.(*KeyWebSettingsChallengeSettingsActionSettings)
+	if !ok {
+		actualNotPointer, ok := a.(KeyWebSettingsChallengeSettingsActionSettings)
+		if !ok {
+			return nil, fmt.Errorf("obj %v is not a KeyWebSettingsChallengeSettingsActionSettings", a)
+		}
+		actual = &actualNotPointer
+	}
+
+	if ds, err := dcl.Diff(desired.ScoreThreshold, actual.ScoreThreshold, dcl.DiffInfo{OperationSelector: dcl.TriggersOperation("updateKeyUpdateKeyOperation")}, fn.AddNest("ScoreThreshold")); len(ds) != 0 || err != nil {
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, ds...)
+	}
+
+	return diffs, nil
+}
+
+func compareKeyWebSettingsChallengeSettingsActionSettingsMapNewStyle(d, a interface{}, fn dcl.FieldName) ([]*dcl.FieldDiff, error) {
+	var diffs []*dcl.FieldDiff
+
+	desired, ok := d.(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	if !ok {
+		return nil, fmt.Errorf("obj %v is not a map[string]KeyWebSettingsChallengeSettingsActionSettings", d)
+	}
+	actual, ok := a.(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	if !ok {
+		return nil, fmt.Errorf("obj %v is not a map[string]KeyWebSettingsChallengeSettingsActionSettings", a)
+	}
+
+	for k, desiredVal := range desired {
+		if actualVal, ok := actual[k]; ok {
+			if ds, err := compareKeyWebSettingsChallengeSettingsActionSettingsNewStyle(&desiredVal, &actualVal, fn.AddNest(k)); len(ds) != 0 || err != nil {
+				if err != nil {
+					return nil, err
+				}
+				diffs = append(diffs, ds...)
+			}
+		} else {
+			if ds, err := compareKeyWebSettingsChallengeSettingsActionSettingsNewStyle(&desiredVal, nil, fn.AddNest(k)); len(ds) != 0 || err != nil {
+				if err != nil {
+					return nil, err
+				}
+				diffs = append(diffs, ds...)
+			}
+		}
+	}
+
+	for k, actualVal := range actual {
+		if _, ok := desired[k]; !ok {
+			if ds, err := compareKeyWebSettingsChallengeSettingsActionSettingsNewStyle(nil, &actualVal, fn.AddNest(k)); len(ds) != 0 || err != nil {
+				if err != nil {
+					return nil, err
+				}
+				diffs = append(diffs, ds...)
+			}
+		}
+	}
+
 	return diffs, nil
 }
 
@@ -1763,6 +2130,11 @@ func expandKeyWebSettings(c *Client, f *KeyWebSettings, res *Key) (map[string]in
 	if v := f.ChallengeSecurityPreference; !dcl.IsEmptyValueIndirect(v) {
 		m["challengeSecurityPreference"] = v
 	}
+	if v, err := expandKeyWebSettingsChallengeSettings(c, f.ChallengeSettings, res); err != nil {
+		return nil, fmt.Errorf("error expanding ChallengeSettings into challengeSettings: %w", err)
+	} else if !dcl.IsEmptyValueIndirect(v) {
+		m["challengeSettings"] = v
+	}
 
 	return m, nil
 }
@@ -1785,8 +2157,141 @@ func flattenKeyWebSettings(c *Client, i interface{}, res *Key) *KeyWebSettings {
 	r.AllowAmpTraffic = dcl.FlattenBool(m["allowAmpTraffic"])
 	r.IntegrationType = flattenKeyWebSettingsIntegrationTypeEnum(m["integrationType"])
 	r.ChallengeSecurityPreference = flattenKeyWebSettingsChallengeSecurityPreferenceEnum(m["challengeSecurityPreference"])
+	r.ChallengeSettings = flattenKeyWebSettingsChallengeSettings(c, m["challengeSettings"], res)
 
 	return r
+}
+
+func expandKeyWebSettingsChallengeSettings(c *Client, f *KeyWebSettingsChallengeSettings, res *Key) (map[string]interface{}, error) {
+	if dcl.IsEmptyValueIndirect(f) {
+		return nil, nil
+	}
+
+	m := make(map[string]interface{})
+	if v, err := expandKeyWebSettingsChallengeSettingsDefaultSettings(c, f.DefaultSettings, res); err != nil {
+		return nil, fmt.Errorf("error expanding DefaultSettings into defaultSettings: %w", err)
+	} else if !dcl.IsEmptyValueIndirect(v) {
+		m["defaultSettings"] = v
+	}
+	if v, err := expandKeyWebSettingsChallengeSettingsActionSettingsMap(c, f.ActionSettings, res); err != nil {
+		return nil, fmt.Errorf("error expanding ActionSettings into actionSettings: %w", err)
+	} else if !dcl.IsEmptyValueIndirect(v) {
+		m["actionSettings"] = v
+	}
+
+	return m, nil
+}
+
+func flattenKeyWebSettingsChallengeSettings(c *Client, i interface{}, res *Key) *KeyWebSettingsChallengeSettings {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	r := &KeyWebSettingsChallengeSettings{}
+
+	if dcl.IsEmptyValueIndirect(i) {
+		return EmptyKeyWebSettingsChallengeSettings
+	}
+	r.DefaultSettings = flattenKeyWebSettingsChallengeSettingsDefaultSettings(c, m["defaultSettings"], res)
+	r.ActionSettings = flattenKeyWebSettingsChallengeSettingsActionSettingsMap(c, m["actionSettings"], res)
+
+	return r
+}
+
+func expandKeyWebSettingsChallengeSettingsDefaultSettings(c *Client, f *KeyWebSettingsChallengeSettingsDefaultSettings, res *Key) (map[string]interface{}, error) {
+	if dcl.IsEmptyValueIndirect(f) {
+		return nil, nil
+	}
+
+	m := make(map[string]interface{})
+	if v := f.ScoreThreshold; !dcl.IsEmptyValueIndirect(v) {
+		m["scoreThreshold"] = v
+	}
+
+	return m, nil
+}
+
+func flattenKeyWebSettingsChallengeSettingsDefaultSettings(c *Client, i interface{}, res *Key) *KeyWebSettingsChallengeSettingsDefaultSettings {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	r := &KeyWebSettingsChallengeSettingsDefaultSettings{}
+
+	if dcl.IsEmptyValueIndirect(i) {
+		return EmptyKeyWebSettingsChallengeSettingsDefaultSettings
+	}
+	r.ScoreThreshold = dcl.FlattenDouble(m["scoreThreshold"])
+
+	return r
+}
+
+func expandKeyWebSettingsChallengeSettingsActionSettings(c *Client, f *KeyWebSettingsChallengeSettingsActionSettings, res *Key) (map[string]interface{}, error) {
+	if dcl.IsEmptyValueIndirect(f) {
+		return nil, nil
+	}
+
+	m := make(map[string]interface{})
+	if v := f.ScoreThreshold; !dcl.IsEmptyValueIndirect(v) {
+		m["scoreThreshold"] = v
+	}
+
+	return m, nil
+}
+
+func flattenKeyWebSettingsChallengeSettingsActionSettings(c *Client, i interface{}, res *Key) *KeyWebSettingsChallengeSettingsActionSettings {
+	m, ok := i.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	r := &KeyWebSettingsChallengeSettingsActionSettings{}
+
+	if dcl.IsEmptyValueIndirect(i) {
+		return EmptyKeyWebSettingsChallengeSettingsActionSettings
+	}
+	r.ScoreThreshold = dcl.FlattenDouble(m["scoreThreshold"])
+
+	return r
+}
+
+func expandKeyWebSettingsChallengeSettingsActionSettingsMap(c *Client, f map[string]KeyWebSettingsChallengeSettingsActionSettings, res *Key) (map[string]interface{}, error) {
+	if f == nil {
+		return nil, nil
+	}
+
+	items := make(map[string]interface{})
+	for k, item := range f {
+		i, err := expandKeyWebSettingsChallengeSettingsActionSettings(c, &item, res)
+		if err != nil {
+			return nil, err
+		}
+		if i != nil {
+			items[k] = i
+		}
+	}
+
+	return items, nil
+}
+
+func flattenKeyWebSettingsChallengeSettingsActionSettingsMap(c *Client, i interface{}, res *Key) map[string]KeyWebSettingsChallengeSettingsActionSettings {
+	a, ok := i.(map[string]interface{})
+	if !ok {
+		return map[string]KeyWebSettingsChallengeSettingsActionSettings{}
+	}
+
+	if len(a) == 0 {
+		return map[string]KeyWebSettingsChallengeSettingsActionSettings{}
+	}
+
+	items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	for k, item := range a {
+		items[k] = *flattenKeyWebSettingsChallengeSettingsActionSettings(c, item.(map[string]interface{}), res)
+	}
+
+	return items
 }
 
 // expandKeyAndroidSettingsMap expands the contents of KeyAndroidSettings into a JSON

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key.go
@@ -219,7 +219,7 @@ func RecaptchaEnterpriseKeyWebSettingsSchema() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "Required. Describes how this key is integrated with the website. Possible values: SCORE, CHECKBOX, INVISIBLE",
+				Description: "Required. Describes how this key is integrated with the website. Possible values: SCORE, CHECKBOX, INVISIBLE, POLICY_BASED_CHALLENGE",
 			},
 
 			"allow_all_domains": {
@@ -246,6 +246,66 @@ func RecaptchaEnterpriseKeyWebSettingsSchema() *schema.Resource {
 				Computed:    true,
 				Optional:    true,
 				Description: "Settings for the frequency and difficulty at which this key triggers captcha challenges. This should only be specified for IntegrationTypes CHECKBOX and INVISIBLE. Possible values: CHALLENGE_SECURITY_PREFERENCE_UNSPECIFIED, USABILITY, BALANCE, SECURITY",
+			},
+
+			"challenge_settings": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Settings for POLICY_BASED_CHALLENGE keys to control when a challenge is triggered.",
+				MaxItems:    1,
+				Elem:        RecaptchaEnterpriseKeyWebSettingsChallengeSettingsSchema(),
+			},
+		},
+	}
+}
+
+func RecaptchaEnterpriseKeyWebSettingsChallengeSettingsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"default_settings": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: "Defines when a challenge is triggered by default.",
+				MaxItems:    1,
+				Elem:        RecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettingsSchema(),
+			},
+
+			"action_settings": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The action to score threshold map. The action name should be the same as the action name passed in the `data-action` attribute. Action names are case-insensitive.",
+				Elem:        RecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsSchema(),
+				Set:         schema.HashResource(RecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsSchema()),
+			},
+		},
+	}
+}
+
+func RecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettingsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"score_threshold": {
+				Type:        schema.TypeFloat,
+				Required:    true,
+				Description: "A challenge is triggered if the end-user score is below that threshold. Value must be between 0 and 1 (inclusive).",
+			},
+		},
+	}
+}
+
+func RecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsSchema() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"action": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The action name.",
+			},
+
+			"score_threshold": {
+				Type:        schema.TypeFloat,
+				Required:    true,
+				Description: "A challenge is triggered if the end-user score is below that threshold. Value must be between 0 and 1 (inclusive).",
 			},
 		},
 	}
@@ -640,6 +700,7 @@ func expandRecaptchaEnterpriseKeyWebSettings(o interface{}) *KeyWebSettings {
 		AllowAmpTraffic:             dcl.Bool(obj["allow_amp_traffic"].(bool)),
 		AllowedDomains:              tpgdclresource.ExpandStringArray(obj["allowed_domains"]),
 		ChallengeSecurityPreference: KeyWebSettingsChallengeSecurityPreferenceEnumRef(obj["challenge_security_preference"].(string)),
+		ChallengeSettings:           expandRecaptchaEnterpriseKeyWebSettingsChallengeSettings(obj["challenge_settings"]),
 	}
 }
 
@@ -653,10 +714,114 @@ func flattenRecaptchaEnterpriseKeyWebSettings(obj *KeyWebSettings) interface{} {
 		"allow_amp_traffic":             obj.AllowAmpTraffic,
 		"allowed_domains":               obj.AllowedDomains,
 		"challenge_security_preference": obj.ChallengeSecurityPreference,
+		"challenge_settings":            flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettings(obj.ChallengeSettings),
 	}
 
 	return []interface{}{transformed}
 
+}
+
+func expandRecaptchaEnterpriseKeyWebSettingsChallengeSettings(o interface{}) *KeyWebSettingsChallengeSettings {
+	if o == nil {
+		return EmptyKeyWebSettingsChallengeSettings
+	}
+	objArr := o.([]interface{})
+	if len(objArr) == 0 || objArr[0] == nil {
+		return EmptyKeyWebSettingsChallengeSettings
+	}
+	obj := objArr[0].(map[string]interface{})
+	return &KeyWebSettingsChallengeSettings{
+		DefaultSettings: expandRecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettings(obj["default_settings"]),
+		ActionSettings:  expandRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsMap(obj["action_settings"]),
+	}
+}
+
+func flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettings(obj *KeyWebSettingsChallengeSettings) interface{} {
+	if obj == nil || obj.Empty() {
+		return nil
+	}
+	transformed := map[string]interface{}{
+		"default_settings": flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettings(obj.DefaultSettings),
+		"action_settings":  flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsMap(obj.ActionSettings),
+	}
+
+	return []interface{}{transformed}
+}
+
+func expandRecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettings(o interface{}) *KeyWebSettingsChallengeSettingsDefaultSettings {
+	if o == nil {
+		return EmptyKeyWebSettingsChallengeSettingsDefaultSettings
+	}
+	objArr := o.([]interface{})
+	if len(objArr) == 0 || objArr[0] == nil {
+		return EmptyKeyWebSettingsChallengeSettingsDefaultSettings
+	}
+	obj := objArr[0].(map[string]interface{})
+	return &KeyWebSettingsChallengeSettingsDefaultSettings{
+		ScoreThreshold: dcl.Float64(obj["score_threshold"].(float64)),
+	}
+}
+
+func flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettingsDefaultSettings(obj *KeyWebSettingsChallengeSettingsDefaultSettings) interface{} {
+	if obj == nil || obj.Empty() {
+		return nil
+	}
+	transformed := map[string]interface{}{}
+	if obj.ScoreThreshold != nil {
+		transformed["score_threshold"] = *obj.ScoreThreshold
+	}
+
+	return []interface{}{transformed}
+}
+
+func expandRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettings(o interface{}) *KeyWebSettingsChallengeSettingsActionSettings {
+	if o == nil {
+		return EmptyKeyWebSettingsChallengeSettingsActionSettings
+	}
+	obj := o.(map[string]interface{})
+	return &KeyWebSettingsChallengeSettingsActionSettings{
+		ScoreThreshold: dcl.Float64(obj["score_threshold"].(float64)),
+	}
+}
+
+func flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettings(obj KeyWebSettingsChallengeSettingsActionSettings) interface{} {
+	transformed := map[string]interface{}{
+		"score_threshold": obj.ScoreThreshold,
+	}
+	return transformed
+}
+
+func expandRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsMap(o interface{}) map[string]KeyWebSettingsChallengeSettingsActionSettings {
+	if o == nil {
+		return nil
+	}
+	s := o.(*schema.Set)
+	items := make(map[string]KeyWebSettingsChallengeSettingsActionSettings)
+	for _, v := range s.List() {
+		obj := v.(map[string]interface{})
+		action := obj["action"].(string)
+		items[action] = KeyWebSettingsChallengeSettingsActionSettings{
+			ScoreThreshold: dcl.Float64(obj["score_threshold"].(float64)),
+		}
+	}
+	return items
+}
+
+func flattenRecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsMap(obj map[string]KeyWebSettingsChallengeSettingsActionSettings) interface{} {
+	if obj == nil {
+		return nil
+	}
+	transformed := make([]interface{}, 0, len(obj))
+	for k, v := range obj {
+		m := map[string]interface{}{
+			"action": k,
+		}
+		if v.ScoreThreshold != nil {
+			m["score_threshold"] = *v.ScoreThreshold
+		}
+		transformed = append(transformed, m)
+	}
+	return schema.NewSet(schema.HashResource(RecaptchaEnterpriseKeyWebSettingsChallengeSettingsActionSettingsSchema()), transformed)
 }
 
 func flattenRecaptchaEnterpriseKeyLabels(v map[string]string, d *schema.ResourceData) interface{} {

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_generated_test.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_generated_test.go
@@ -222,6 +222,15 @@ func TestAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKey(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
+			{
+				Config: testAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKeyUpdate0(context),
+			},
+			{
+				ResourceName:            "google_recaptcha_enterprise_key.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
 		},
 	})
 }
@@ -541,6 +550,42 @@ resource "google_recaptcha_enterprise_key" "primary" {
       action_settings {
         action          = "signup"
         score_threshold = 0.7
+      }
+    }
+  }
+
+  labels = {
+    label-one = "value-one"
+  }
+}
+`, context)
+}
+
+func testAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKeyUpdate0(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_recaptcha_enterprise_key" "primary" {
+  display_name = "policy-based-challenge-key-%{random_suffix}"
+  project      = "%{project_name}"
+
+  web_settings {
+    allow_all_domains = false
+    allowed_domains   = ["www.example.com"]
+    allow_amp_traffic = false
+    integration_type  = "POLICY_BASED_CHALLENGE"
+
+    challenge_settings {
+      default_settings {
+        score_threshold = 0.6
+      }
+
+      action_settings {
+        action          = "login"
+        score_threshold = 0.4
+      }
+
+      action_settings {
+        action          = "signup"
+        score_threshold = 0.8
       }
     }
   }

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_generated_test.go
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_generated_test.go
@@ -200,6 +200,31 @@ func TestAccRecaptchaEnterpriseKey_WebScoreKey(t *testing.T) {
 		},
 	})
 }
+func TestAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKey(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project_name":  envvar.GetTestProjectFromEnv(),
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckRecaptchaEnterpriseKeyDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKey(context),
+			},
+			{
+				ResourceName:            "google_recaptcha_enterprise_key.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
 
 func testAccRecaptchaEnterpriseKey_AndroidKey(context map[string]interface{}) string {
 	return acctest.Nprintf(`
@@ -489,4 +514,40 @@ func testAccCheckRecaptchaEnterpriseKeyDestroyProducer(t *testing.T) func(s *ter
 		}
 		return nil
 	}
+}
+
+func testAccRecaptchaEnterpriseKey_WebPolicyBasedChallengeKey(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_recaptcha_enterprise_key" "primary" {
+  display_name = "policy-based-challenge-key-%{random_suffix}"
+  project      = "%{project_name}"
+
+  web_settings {
+    allow_all_domains = false
+    allowed_domains   = ["www.example.com"]
+    allow_amp_traffic = false
+    integration_type  = "POLICY_BASED_CHALLENGE"
+
+    challenge_settings {
+      default_settings {
+        score_threshold = 0.5
+      }
+
+      action_settings {
+        action          = "login"
+        score_threshold = 0.3
+      }
+
+      action_settings {
+        action          = "signup"
+        score_threshold = 0.7
+      }
+    }
+  }
+
+  labels = {
+    label-one = "value-one"
+  }
+}
+`, context)
 }

--- a/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_meta.yaml
+++ b/mmv1/third_party/terraform/services/recaptchaenterprise/resource_recaptcha_enterprise_key_meta.yaml
@@ -26,3 +26,7 @@ fields:
   - api_field: 'webSettings.allowedDomains'
   - api_field: 'webSettings.challengeSecurityPreference'
   - api_field: 'webSettings.integrationType'
+  - api_field: 'webSettings.challengeSettings.defaultSettings.scoreThreshold'
+  - field: 'web_settings.challenge_settings.action_settings.action'
+    provider_only: true
+  - api_field: 'webSettings.challengeSettings.actionSettings.scoreThreshold'

--- a/mmv1/third_party/terraform/website/docs/r/recaptcha_enterprise_key.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/recaptcha_enterprise_key.html.markdown
@@ -261,8 +261,41 @@ The `web_settings` block supports:
     
 * `integration_type` -
   (Required)
-  Required. Describes how this key is integrated with the website. Possible values: SCORE, CHECKBOX, INVISIBLE
+  Required. Describes how this key is integrated with the website. Possible values: SCORE, CHECKBOX, INVISIBLE, POLICY_BASED_CHALLENGE
     
+* `challenge_settings` -
+  (Optional)
+  Settings for POLICY_BASED_CHALLENGE keys to control when a challenge is triggered.
+  Structure is documented below.
+
+The `challenge_settings` block supports:
+
+* `default_settings` -
+  (Required)
+  Defines when a challenge is triggered by default.
+  Structure is documented below.
+
+* `action_settings` -
+  (Optional)
+  The action to score threshold map. The action name should be the same as the action name passed in the `data-action` attribute. Action names are case-insensitive.
+  Structure is documented below.
+
+The `default_settings` block supports:
+
+* `score_threshold` -
+  (Required)
+  A challenge is triggered if the end-user score is below that threshold. Value must be between 0 and 1 (inclusive).
+
+The `action_settings` block supports:
+
+* `action` -
+  (Required)
+  The action name.
+
+* `score_threshold` -
+  (Required)
+  A challenge is triggered if the end-user score is below that threshold. Value must be between 0 and 1 (inclusive).
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
recaptchaenterprise: added `POLICY_BASED_CHALLENGE` `intergration_type` and `challenge_settings` to `google_recaptcha_enterprise_key`
```
