### PR TITLE
fix(bigqueryconnection): flatten authentication fields from API response

### DIFF
--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -162,8 +162,8 @@ examples:
     test_vars_overrides:
       username: '"user" + randomSuffix'
     ignore_read_extra:
-      # username and password are not returned by the API
-      - 'configuration.0.authentication.0.username_password.0.username'
+      # The plaintext password is redacted by the API on read, so it cannot
+      # be verified against the original config.
       - 'configuration.0.authentication.0.username_password.0.password'
     external_providers: ["random", "time"]
     # Random provider

--- a/mmv1/templates/terraform/custom_flatten/bigquery_connection_configuration_authentication_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/bigquery_connection_configuration_authentication_flatten.go.tmpl
@@ -11,14 +11,29 @@
 	limitations under the License.
 */ -}}
 func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+
+	password := map[string]interface{}{
+		// The API redacts the plaintext on read, so we keep the value from
+		// state to avoid a permadiff.
+		"plaintext": d.Get("configuration.0.authentication.0.username_password.0.password.0.plaintext"),
+	}
+	if originalPassword, ok := original["password"].(map[string]interface{}); ok {
+		if secretType, ok := originalPassword["secretType"]; ok {
+			password["secret_type"] = secretType
+		}
+	}
+
 	return []interface{}{
 		map[string]interface{}{
-			"username": d.Get("configuration.0.authentication.0.username_password.0.username"),
-			"password": []interface{}{
-				map[string]interface{}{
-					"plaintext": d.Get("configuration.0.authentication.0.username_password.0.password.0.plaintext"),
-				},
-			},
+			"username": original["username"],
+			"password": []interface{}{password},
 		},
 	}
 }


### PR DESCRIPTION
## Description

The custom flatten function for the `username_password` block in `google_bigquery_connection.configuration.authentication`, introduced in #17083, was returning values from state via `d.Get(...)` instead of the API response. This caused two visible bugs:

1. After importing an existing connection, `terraform plan` always reported `+ username = "..."` because the imported state was empty (`d.Get` returned `""`).
2. `secret_type` (output-only) was never populated, leaving it permanently `null` in state.

### Fix

- Read `username` and `password.secret_type` from the API response (`v`).
- Keep `password.plaintext` from state because the API redacts it on read (avoids a permadiff).
- Drop `configuration.0.authentication.0.username_password.0.username` from the example test's `ignore_read_extra`. It is no longer needed now that the field round-trips through state correctly.

### Behavior change

Limited to drift detection: external changes to `username` on the API side are now reflected on the next `terraform plan`, which matches Terraform's expected drift-detection semantics. Newly-created or already-applied resources see no diff (state and API agree).

## Reproduction

Before the fix, with a connection created out-of-band and imported into state:

```hcl
import {
  to = google_bigquery_connection.example
  id = "projects/my-project/locations/us-central1/connections/my-connection"
}

resource "google_bigquery_connection" "example" {
  configuration {
    connector_id = "google-alloydb"
    authentication {
      username_password {
        username = "dbuser"
        password { plaintext = "..." }
      }
    }
    # ...
  }
}
```

`terraform plan` reports `+ username = "dbuser"` even though the API already has the correct value.

## Release Note

```release-note:bug
bigqueryconnection: fixed an issue where `configuration.authentication.username_password.password.secret_type` is not populated and a diff on `configuration.authentication.username_password.username` after import in `google_bigquery_connection` resource
```