### PR TITLE
Expose numeric ID for google_compute_address

### DIFF
--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -260,3 +260,9 @@ properties:
       Partial URL, as in:
         * `projects/{{projectId}}/regions/region/publicDelegatedPrefixes/{{pdp-name}}`
         * `regions/{{region}}/publicDelegatedPrefixes/{{pdp-name}}`
+  - name: 'addressId'
+    type: String
+    api_name: 'id'
+    description: |
+      The unique numeric identifier for the resource. This identifier is defined by the server.
+    output: true

--- a/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_address_test.go
@@ -27,6 +27,24 @@ func TestAccComputeAddress_networkTier(t *testing.T) {
 	})
 }
 
+func TestAccComputeAddress_addressId(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeAddressDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeAddress_networkTier(acctest.RandString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_compute_address.foobar", "address_id"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeAddress_internal(t *testing.T) {
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },


### PR DESCRIPTION
Expose numeric ID for google_compute_address. This is an output-only field that can be used for operations such as applying tags.

```release-note:enhancement
compute: added `address_id` field to `google_compute_address` resource
```
