### PR TITLE
[Compute] Add 'options' field to google_compute_region_disk_resource_policy_attachment

### DIFF
--- a/mmv1/products/compute/RegionDiskResourcePolicyAttachment.yaml
+++ b/mmv1/products/compute/RegionDiskResourcePolicyAttachment.yaml
@@ -48,6 +48,13 @@ examples:
       disk_name: my-disk
       policy_name: my-resource-policy
       snapshot_name: my-snapshot
+  - name: region_disk_resource_policy_attachment_options
+    primary_resource_id: attachment
+    vars:
+      base_disk_name: my-base-disk
+      disk_name: my-disk
+      policy_name: my-resource-policy
+      snapshot_name: my-snapshot
 parameters:
   - name: disk
     type: ResourceRef
@@ -71,3 +78,6 @@ properties:
     description: |
       The resource policy to be attached to the disk for scheduling snapshot
       creation. Do not specify the self link.
+  - name: options
+    type: String
+    description: Internal use only.

--- a/mmv1/templates/terraform/examples/region_disk_resource_policy_attachment_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_disk_resource_policy_attachment_options.tf.tmpl
@@ -1,0 +1,47 @@
+resource "google_compute_region_disk_resource_policy_attachment" "{{$.PrimaryResourceId}}" {
+  name = google_compute_resource_policy.policy.name
+  disk = google_compute_region_disk.ssd.name
+  region = "us-central1"
+  options = "my-options"
+}
+
+resource "google_compute_disk" "disk" {
+  name  = "{{index $.Vars "base_disk_name"}}"
+  image = "debian-cloud/debian-11"
+  size  = 50
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name  = "{{index $.Vars "snapshot_name"}}"
+  source_disk = google_compute_disk.disk.name
+  zone        = "us-central1-a"
+}
+
+resource "google_compute_region_disk" "ssd" {
+  name  = "{{index $.Vars "disk_name"}}"
+  replica_zones = ["us-central1-a", "us-central1-f"]
+  snapshot = google_compute_snapshot.snapdisk.id
+  size  = 50
+  type  = "pd-ssd"
+  region  = "us-central1"
+}
+
+resource "google_compute_resource_policy" "policy" {
+  name = "{{index $.Vars "policy_name"}}"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time = "04:00"
+      }
+    }
+  }
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-11"
+  project = "debian-cloud"
+}


### PR DESCRIPTION
This PR adds the `options` field to the `google_compute_region_disk_resource_policy_attachment` resource.

```release-note:enhancement
compute: added `options` field to `google_compute_region_disk_resource_policy_attachment` resource
```