### PR TITLE
[Compute] Add region to snapshot_properties in google_compute_resource_policy

### DIFF
--- a/mmv1/products/compute/ResourcePolicy.yaml
+++ b/mmv1/products/compute/ResourcePolicy.yaml
@@ -16,7 +16,6 @@ name: ResourcePolicy
 description: |
   A policy that can be attached to a resource to specify or schedule actions on that resource.
 references:
-  guides: {}
   api: https://cloud.google.com/compute/docs/reference/rest/v1/resourcePolicies
 base_url: projects/{{project}}/regions/{{region}}/resourcePolicies
 has_self_link: true
@@ -36,8 +35,8 @@ async:
     base_url: '{{op_id}}'
 include_in_tgc_next: true
 tgc_tests:
-  - name: 'TestAccComputeResourcePolicy_withTopologyMode'
-    skip: 'The test should not in GA provider'
+  - name: TestAccComputeResourcePolicy_withTopologyMode
+    skip: The test should not in GA provider
 custom_code:
   constants: templates/terraform/constants/compute_resource_policy.go.tmpl
 examples:
@@ -99,6 +98,10 @@ examples:
   - name: resource_policy_placement_policy_tpu_topology
     primary_resource_id: baz
     min_version: beta
+    vars:
+      name: gce-policy
+  - name: resource_policy_snapshot_schedule_region
+    primary_resource_id: policy
     vars:
       name: gce-policy
 parameters:
@@ -288,6 +291,9 @@ properties:
               Creates the new snapshot in the snapshot chain labeled with the
               specified name. The chain name must be 1-63 characters long and comply
               with RFC1035.
+          - name: region
+            type: String
+            description: Region where the snapshot is scoped to.
   - name: groupPlacementPolicy
     type: NestedObject
     description: |
@@ -441,7 +447,6 @@ properties:
           - workload_policy.0.max_topology_distance
       - name: acceleratorTopologyMode
         type: Enum
-        is_missing_in_cai: true
         description: |
           Specifies the connection mode for the accelerator topology.
           Supported values are:
@@ -450,10 +455,11 @@ properties:
 
           If not specified, the default is AUTO_CONNECT.
           This field can be set only when the workload policy type is HIGH_THROUGHPUT and cannot be set if max topology distance is set.
+        immutable: true
         min_version: beta
+        conflicts:
+          - workload_policy.0.max_topology_distance
         enum_values:
           - AUTO_CONNECT
           - PROVISION_ONLY
-        immutable: true
-        conflicts:
-          - workload_policy.0.max_topology_distance
+        is_missing_in_cai: true

--- a/mmv1/templates/terraform/examples/resource_policy_snapshot_schedule_region.tf.tmpl
+++ b/mmv1/templates/terraform/examples/resource_policy_snapshot_schedule_region.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_compute_resource_policy" "{{$.PrimaryResourceId}}" {
+  name   = "{{index $.Vars "name"}}"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      hourly_schedule {
+        hours_in_cycle = 20
+        start_time     = "23:00"
+      }
+    }
+    retention_policy {
+      max_retention_days    = 14
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = {
+        my_label = "value"
+      }
+      storage_locations = ["us"]
+      guest_flush       = true
+      region            = "us-central1"
+    }
+  }
+}


### PR DESCRIPTION
Adds the `region` field to `snapshot_schedule_policy.snapshot_properties` in the `google_compute_resource_policy` resource. This field allows users to specify the region where the snapshot is scoped to.

```release-note:enhancement
compute: added `snapshot_schedule_policy.snapshot_properties.region` field to `google_compute_resource_policy` resource
```