### PR TITLE
Migrate `resource_compute_network_peering.go.tmpl` resource to use direct HTTP rather than a client library

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
@@ -3,25 +3,19 @@ package compute
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
-	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
-	
+
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 const peerNetworkLinkRegex = "projects/(" + verify.ProjectRegex + ")/global/networks/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
@@ -43,8 +37,8 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-            tpgresource.DefaultProviderDeletionPolicy("DELETE"),
-        ),
+			tpgresource.DefaultProviderDeletionPolicy("DELETE"),
+		),
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -116,20 +110,20 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: verify.ValidateEnum([]string{"IPV4_ONLY", "IPV4_IPV6"}),
-				Description: `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
-				Default: "IPV4_ONLY",
+				Description:  `Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. The default value is IPV4_ONLY. Possible values: ["IPV4_ONLY", "IPV4_IPV6"]`,
+				Default:      "IPV4_ONLY",
 			},
 
 			"update_strategy": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: verify.ValidateEnum([]string{"INDEPENDENT", "CONSENSUS"}),
-				Description: `The update strategy determines the semantics for updates and deletes to the peering connection configuration. The default value is INDEPENDENT. Possible values: ["INDEPENDENT", "CONSENSUS"]`,
-				Default: "INDEPENDENT",
+				Description:  `The update strategy determines the semantics for updates and deletes to the peering connection configuration. The default value is INDEPENDENT. Possible values: ["INDEPENDENT", "CONSENSUS"]`,
+				Default:      "INDEPENDENT",
 			},
 			//UDP schema start
-            "deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
-//UDP schema end
+			"deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
+			//UDP schema end
 		},
 		UseJSONNumber: true,
 	}
@@ -137,7 +131,7 @@ func ResourceComputeNetworkPeering() *schema.Resource {
 
 func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -151,8 +145,9 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	request := &compute.NetworksAddPeeringRequest{}
-	request.NetworkPeering = expandNetworkPeering(d)
+	request := map[string]interface{}{
+		"networkPeering": expandNetworkPeering(d),
+	}
 
 	// Only one peering operation at a time can be performed for a given network.
 	// Lock on both networks, sorted so we don't deadlock for A <--> B peering pairs.
@@ -162,12 +157,20 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		defer transport_tpg.MutexStore.Unlock(kn)
 	}
 
-	addOp, err := NewClient(config, userAgent).Networks.AddPeering(networkFieldValue.Project, networkFieldValue.Name, request).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s/addPeering", transport_tpg.BaseUrl(Product, config), networkFieldValue.Project, networkFieldValue.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   networkFieldValue.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      request,
+	})
 	if err != nil {
 		return fmt.Errorf("Error adding network peering: %s", err)
 	}
 
-	err = ComputeOperationWaitTime(config, addOp, networkFieldValue.Project, "Adding Network Peering", userAgent, d.Timeout(schema.TimeoutCreate))
+	err = ComputeOperationWaitTime(config, res, networkFieldValue.Project, "Adding Network Peering", userAgent, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -179,7 +182,7 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 
 func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -190,66 +193,72 @@ func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	network, err := NewClient(config, userAgent).Networks.Get(networkFieldValue.Project, networkFieldValue.Name).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s", transport_tpg.BaseUrl(Product, config), networkFieldValue.Project, networkFieldValue.Name)
+	network, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   networkFieldValue.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Network %q", networkFieldValue.Name))
 	}
 
 	peering := findPeeringFromNetwork(network, peeringName)
 	if peering == nil {
-		log.Printf("[WARN] Removing network peering %s from network %s because it's gone", peeringName, network.Name)
+		log.Printf("[WARN] Removing network peering %s from network %s because it's gone", peeringName, network["name"])
 		d.SetId("")
 		return nil
 	}
 
-	if err := d.Set("peer_network", peering.Network); err != nil {
+	if err := d.Set("peer_network", peering["network"]); err != nil {
 		return fmt.Errorf("Error setting peer_network: %s", err)
 	}
-	if err := d.Set("name", peering.Name); err != nil {
+	if err := d.Set("name", peering["name"]); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if err := d.Set("import_custom_routes", peering.ImportCustomRoutes); err != nil {
+	if err := d.Set("import_custom_routes", peering["importCustomRoutes"]); err != nil {
 		return fmt.Errorf("Error setting import_custom_routes: %s", err)
 	}
-	if err := d.Set("export_custom_routes", peering.ExportCustomRoutes); err != nil {
+	if err := d.Set("export_custom_routes", peering["exportCustomRoutes"]); err != nil {
 		return fmt.Errorf("Error setting export_custom_routes: %s", err)
 	}
-	if err := d.Set("import_subnet_routes_with_public_ip", peering.ImportSubnetRoutesWithPublicIp); err != nil {
+	if err := d.Set("import_subnet_routes_with_public_ip", peering["importSubnetRoutesWithPublicIp"]); err != nil {
 		return fmt.Errorf("Error setting import_subnet_routes_with_public_ip: %s", err)
 	}
-	if err := d.Set("export_subnet_routes_with_public_ip", peering.ExportSubnetRoutesWithPublicIp); err != nil {
+	if err := d.Set("export_subnet_routes_with_public_ip", peering["exportSubnetRoutesWithPublicIp"]); err != nil {
 		return fmt.Errorf("Error setting export_subnet_routes_with_public_ip: %s", err)
 	}
-	if err := d.Set("state", peering.State); err != nil {
+	if err := d.Set("state", peering["state"]); err != nil {
 		return fmt.Errorf("Error setting state: %s", err)
 	}
-	if err := d.Set("state_details", peering.StateDetails); err != nil {
+	if err := d.Set("state_details", peering["stateDetails"]); err != nil {
 		return fmt.Errorf("Error setting state_details: %s", err)
 	}
-	if err := d.Set("stack_type", flattenNetworkPeeringStackType(peering.StackType, d, config)); err != nil {
+	if err := d.Set("stack_type", flattenNetworkPeeringStackType(peering["stackType"], d, config)); err != nil {
 		return fmt.Errorf("Error setting stack_type: %s", err)
 	}
-	
-	if err := d.Set("update_strategy", flattenNetworkPeeringUpdateStrategy(peering.UpdateStrategy, d, config)); err != nil {
+
+	if err := d.Set("update_strategy", flattenNetworkPeeringUpdateStrategy(peering["updateStrategy"], d, config)); err != nil {
 		return fmt.Errorf("Error setting update_strategy: %s", err)
 	}
 
-        
-    if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
-        return err
-    }
-    
+	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func resourceComputeNetworkPeeringUpdate(d *schema.ResourceData, meta interface{}) error {
-    
-    if tpgresource.DeletionPolicyPreUpdate(d, ResourceComputeNetworkPeering) {
-        return ResourceComputeNetworkPeering().Read(d, meta)
-    }
-    
+
+	if tpgresource.DeletionPolicyPreUpdate(d, ResourceComputeNetworkPeering) {
+		return ResourceComputeNetworkPeering().Read(d, meta)
+	}
+
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -263,8 +272,9 @@ func resourceComputeNetworkPeeringUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	request := &compute.NetworksUpdatePeeringRequest{}
-	request.NetworkPeering = expandNetworkPeering(d)
+	request := map[string]interface{}{
+		"networkPeering": expandNetworkPeering(d),
+	}
 
 	// Only one peering operation at a time can be performed for a given network.
 	// Lock on both networks, sorted so we don't deadlock for A <--> B peering pairs.
@@ -274,12 +284,20 @@ func resourceComputeNetworkPeeringUpdate(d *schema.ResourceData, meta interface{
 		defer transport_tpg.MutexStore.Unlock(kn)
 	}
 
-	updateOp, err := NewClient(config, userAgent).Networks.UpdatePeering(networkFieldValue.Project, networkFieldValue.Name, request).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s/updatePeering", transport_tpg.BaseUrl(Product, config), networkFieldValue.Project, networkFieldValue.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   networkFieldValue.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      request,
+	})
 	if err != nil {
 		return fmt.Errorf("Error updating network peering: %s", err)
 	}
 
-	err = ComputeOperationWaitTime(config, updateOp, networkFieldValue.Project, "Updating Network Peering", userAgent, d.Timeout(schema.TimeoutUpdate))
+	err = ComputeOperationWaitTime(config, res, networkFieldValue.Project, "Updating Network Peering", userAgent, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}
@@ -288,15 +306,15 @@ func resourceComputeNetworkPeeringUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{}) error {
-	
-    if ok, err := tpgresource.DeletionPolicyPreDelete(d); err != nil{
-        return err
-    }else if ok{
-        return nil
-    }
-    
+
+	if ok, err := tpgresource.DeletionPolicyPreDelete(d); err != nil {
+		return err
+	} else if ok {
+		return nil
+	}
+
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -312,8 +330,8 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	request := &compute.NetworksRemovePeeringRequest{
-		Name: name,
+	request := map[string]interface{}{
+		"name": name,
 	}
 
 	// Only one peering operation at a time can be performed for a given network.
@@ -324,7 +342,15 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 		defer transport_tpg.MutexStore.Unlock(kn)
 	}
 
-	removeOp, err := NewClient(config, userAgent).Networks.RemovePeering(networkFieldValue.Project, networkFieldValue.Name, request).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s/removePeering", transport_tpg.BaseUrl(Product, config), networkFieldValue.Project, networkFieldValue.Name)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   networkFieldValue.Project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      request,
+	})
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Peering `%s` already removed from network `%s`", name, networkFieldValue.Name)
@@ -332,7 +358,7 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error removing peering `%s` from network `%s`: %s", name, networkFieldValue.Name, err)
 		}
 	} else {
-		err = ComputeOperationWaitTime(config, removeOp, networkFieldValue.Project, "Removing Network Peering", userAgent, d.Timeout(schema.TimeoutDelete))
+		err = ComputeOperationWaitTime(config, res, networkFieldValue.Project, "Removing Network Peering", userAgent, d.Timeout(schema.TimeoutDelete))
 		if err != nil {
 			return err
 		}
@@ -341,27 +367,38 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func findPeeringFromNetwork(network *compute.Network, peeringName string) *compute.NetworkPeering {
-	for _, p := range network.Peerings {
-		if p.Name == peeringName {
+func findPeeringFromNetwork(network map[string]interface{}, peeringName string) map[string]interface{} {
+	peerings, ok := network["peerings"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, raw := range peerings {
+		p, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if p["name"].(string) == peeringName {
 			return p
 		}
 	}
 	return nil
 }
-func expandNetworkPeering(d *schema.ResourceData) *compute.NetworkPeering {
-		return &compute.NetworkPeering{
-			ExchangeSubnetRoutes:           true,
-			Name:                           d.Get("name").(string),
-			Network:                        d.Get("peer_network").(string),
-			ExportCustomRoutes:             d.Get("export_custom_routes").(bool),
-			ImportCustomRoutes:             d.Get("import_custom_routes").(bool),
-			ExportSubnetRoutesWithPublicIp: d.Get("export_subnet_routes_with_public_ip").(bool),
-			ImportSubnetRoutesWithPublicIp: d.Get("import_subnet_routes_with_public_ip").(bool),
-			StackType:                      d.Get("stack_type").(string),
-			UpdateStrategy:                 d.Get("update_strategy").(string),
-			ForceSendFields:                []string{"ExportSubnetRoutesWithPublicIp", "ImportCustomRoutes", "ExportCustomRoutes"},
-		}
+func expandNetworkPeering(d *schema.ResourceData) map[string]interface{} {
+	np := map[string]interface{}{
+		"exchangeSubnetRoutes":           true,
+		"name":                           d.Get("name").(string),
+		"network":                        d.Get("peer_network").(string),
+		"exportCustomRoutes":             d.Get("export_custom_routes").(bool),
+		"importCustomRoutes":             d.Get("import_custom_routes").(bool),
+		"exportSubnetRoutesWithPublicIp": d.Get("export_subnet_routes_with_public_ip").(bool),
+		"stackType":                      d.Get("stack_type").(string),
+		"updateStrategy":                 d.Get("update_strategy").(string),
+	}
+	// Field has no schema Default, so omit when unset to match omitempty behavior.
+	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok { //nolint:staticcheck
+		np["importSubnetRoutesWithPublicIp"] = v.(bool)
+	}
+	return np
 }
 
 func flattenNetworkPeeringStackType(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
@@ -403,19 +440,26 @@ func resourceComputeNetworkPeeringImport(d *schema.ResourceData, meta interface{
 	network := splits[1]
 	name := splits[2]
 
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return nil, err
 	}
 
 	// Since the format of the network URL in the peering might be different depending on the ComputeBasePath,
 	// just read the network self link from the API.
-	net, err := NewClient(config, userAgent).Networks.Get(project, network).Do()
+	url := fmt.Sprintf("%sprojects/%s/global/networks/%s", transport_tpg.BaseUrl(Product, config), project, network)
+	net, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return nil, transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Network %q", splits[1]))
 	}
 
-	if err := d.Set("network", tpgresource.ConvertSelfLinkToV1(net.SelfLink)); err != nil {
+	if err := d.Set("network", tpgresource.ConvertSelfLinkToV1(net["selfLink"].(string))); err != nil {
 		return nil, fmt.Errorf("Error setting network: %s", err)
 	}
 	if err := d.Set("name", name); err != nil {
@@ -431,9 +475,9 @@ func resourceComputeNetworkPeeringImport(d *schema.ResourceData, meta interface{
 
 func init() {
 	registry.Schema{
-		Name: "google_compute_network_peering",
+		Name:        "google_compute_network_peering",
 		ProductName: "compute",
-		Type: registry.SchemaTypeResource,
-		Schema: ResourceComputeNetworkPeering(),
+		Type:        registry.SchemaTypeResource,
+		Schema:      ResourceComputeNetworkPeering(),
 	}.Register()
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
@@ -384,21 +384,25 @@ func findPeeringFromNetwork(network map[string]interface{}, peeringName string) 
 	return nil
 }
 func expandNetworkPeering(d *schema.ResourceData) map[string]interface{} {
-	np := map[string]interface{}{
+	networkPeering := map[string]interface{}{
 		"exchangeSubnetRoutes":           true,
 		"name":                           d.Get("name").(string),
 		"network":                        d.Get("peer_network").(string),
 		"exportCustomRoutes":             d.Get("export_custom_routes").(bool),
 		"importCustomRoutes":             d.Get("import_custom_routes").(bool),
 		"exportSubnetRoutesWithPublicIp": d.Get("export_subnet_routes_with_public_ip").(bool),
-		"stackType":                      d.Get("stack_type").(string),
-		"updateStrategy":                 d.Get("update_strategy").(string),
+	}
+	if d.HasChange("stack_type") {
+		networkPeering["stackType"] = d.Get("stack_type").(string)
+	}
+	if d.HasChange("update_strategy") {
+		networkPeering["updateStrategy"] = d.Get("update_strategy").(string)
 	}
 	// Field has no schema Default, so omit when unset to match omitempty behavior.
 	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok { //nolint:staticcheck
-		np["importSubnetRoutesWithPublicIp"] = v.(bool)
+		networkPeering["importSubnetRoutesWithPublicIp"] = v.(bool)
 	}
-	return np
+	return networkPeering
 }
 
 func flattenNetworkPeeringStackType(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
@@ -395,7 +395,7 @@ func expandNetworkPeering(d *schema.ResourceData) map[string]interface{} {
 		"updateStrategy":                 d.Get("update_strategy").(string),
 	}
 	// Only include when true: matches typed library omitempty behavior for booleans not in ForceSendFields
-	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok && v.(bool) { //nolint:staticcheck
+	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok && v.(bool) {
 		networkPeering["importSubnetRoutesWithPublicIp"] = true
 	}
 	return networkPeering

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
@@ -391,16 +391,14 @@ func expandNetworkPeering(d *schema.ResourceData) map[string]interface{} {
 		"exportCustomRoutes":             d.Get("export_custom_routes").(bool),
 		"importCustomRoutes":             d.Get("import_custom_routes").(bool),
 		"exportSubnetRoutesWithPublicIp": d.Get("export_subnet_routes_with_public_ip").(bool),
+		"stackType":                      d.Get("stack_type").(string),
+		"updateStrategy":                 d.Get("update_strategy").(string),
 	}
-	if d.HasChange("stack_type") {
-		networkPeering["stackType"] = d.Get("stack_type").(string)
-	}
-	if d.HasChange("update_strategy") {
-		networkPeering["updateStrategy"] = d.Get("update_strategy").(string)
-	}
-	// Field has no schema Default, so omit when unset to match omitempty behavior.
-	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok { //nolint:staticcheck
-		networkPeering["importSubnetRoutesWithPublicIp"] = v.(bool)
+	// Only include when true: matches typed library omitempty behavior for booleans not in
+	// ForceSendFields. Read unconditionally sets this field (even to false), so GetOkExists
+	// returns ok=true after the first Read and would incorrectly send false in update bodies.
+	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok && v.(bool) { //nolint:staticcheck
+		networkPeering["importSubnetRoutesWithPublicIp"] = true
 	}
 	return networkPeering
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_network_peering.go
@@ -394,9 +394,7 @@ func expandNetworkPeering(d *schema.ResourceData) map[string]interface{} {
 		"stackType":                      d.Get("stack_type").(string),
 		"updateStrategy":                 d.Get("update_strategy").(string),
 	}
-	// Only include when true: matches typed library omitempty behavior for booleans not in
-	// ForceSendFields. Read unconditionally sets this field (even to false), so GetOkExists
-	// returns ok=true after the first Read and would incorrectly send false in update bodies.
+	// Only include when true: matches typed library omitempty behavior for booleans not in ForceSendFields
 	if v, ok := d.GetOkExists("import_subnet_routes_with_public_ip"); ok && v.(bool) { //nolint:staticcheck
 		networkPeering["importSubnetRoutesWithPublicIp"] = true
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrate `resource_compute_network_peering.go.tmpl` resource to use direct HTTP rather than a client library
```
