### PR TITLE
Migrate resource_compute_project_metadata_item to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata.go.tmpl
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -76,8 +77,7 @@ func resourceComputeProjectMetadataCreateOrUpdate(d *schema.ResourceData, meta i
 		Items: expandComputeMetadata(d.Get("metadata").(map[string]interface{})),
 	}
 
-	err = resourceComputeProjectMetadataSet(projectID, userAgent, config, md, d.Timeout(schema.TimeoutCreate))
-	if err != nil {
+	if err = resourceComputeProjectMetadataSet(d, projectID, userAgent, config, md, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
 	}
 
@@ -104,7 +104,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 	// but would create metadata for the provider project on a destroy/create.
 	projectId := d.Id()
 
-	project, err := NewClient(config, userAgent).Projects.Get(projectId).Do()
+	project, err := getComputeProject(d, config, projectId, userAgent)
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Project metadata for project %q", projectId))
 	}
@@ -134,18 +134,17 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 	}
 
 	md := &compute.Metadata{}
-	err = resourceComputeProjectMetadataSet(projectID, userAgent, config, md, d.Timeout(schema.TimeoutDelete))
-	if err != nil {
+	if err = resourceComputeProjectMetadataSet(d, projectID, userAgent, config, md, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
 	}
 
 	return resourceComputeProjectMetadataRead(d, meta)
 }
 
-func resourceComputeProjectMetadataSet(projectID, userAgent string, config *transport_tpg.Config, md *compute.Metadata, timeout time.Duration) error {
+func resourceComputeProjectMetadataSet(d *schema.ResourceData, projectID, userAgent string, config *transport_tpg.Config, md *compute.Metadata, timeout time.Duration) error {
 	createMD := func() error {
 		log.Printf("[DEBUG] Loading project service: %s", projectID)
-		project, err := NewClient(config, userAgent).Projects.Get(projectID).Do()
+		project, err := getComputeProject(d, config, projectID, userAgent)
 		if err != nil {
 			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
@@ -153,17 +152,76 @@ func resourceComputeProjectMetadataSet(projectID, userAgent string, config *tran
 		if project.CommonInstanceMetadata != nil {
 			md.Fingerprint = project.CommonInstanceMetadata.Fingerprint
 		}
-		op, err := NewClient(config, userAgent).Projects.SetCommonInstanceMetadata(projectID, md).Do()
+
+		body, err := computeMetadataToMap(md)
+		if err != nil {
+			return fmt.Errorf("Error encoding metadata: %s", err)
+		}
+
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+		if err != nil {
+			return err
+		}
+		url = fmt.Sprintf("%sprojects/%s/setCommonInstanceMetadata", url, projectID)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   projectID,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      body,
+			Timeout:   timeout,
+		})
 		if err != nil {
 			return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
 		}
 
-		log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
-		return ComputeOperationWaitTime(config, op, project.Name, "SetCommonMetadata", userAgent, timeout)
+		log.Printf("[DEBUG] SetCommonMetadata: %v", res["selfLink"])
+		return ComputeOperationWaitTime(config, res, project.Name, "SetCommonMetadata", userAgent, timeout)
 	}
 
 	err := transport_tpg.MetadataRetryWrapper(createMD)
 	return err
+}
+
+func getComputeProject(d *schema.ResourceData, config *transport_tpg.Config, projectID, userAgent string) (*compute.Project, error) {
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+	if err != nil {
+		return nil, err
+	}
+	url = fmt.Sprintf("%sprojects/%s", url, projectID)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   projectID,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	resBytes, err := json.Marshal(res)
+	if err != nil {
+		return nil, err
+	}
+	project := &compute.Project{}
+	if err := json.Unmarshal(resBytes, project); err != nil {
+		return nil, err
+	}
+	return project, nil
+}
+
+func computeMetadataToMap(md *compute.Metadata) (map[string]interface{}, error) {
+	mdBytes, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+	body := map[string]interface{}{}
+	if err := json.Unmarshal(mdBytes, &body); err != nil {
+		return nil, err
+	}
+	return body, nil
 }
 
 func init() {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_item.go.tmpl
@@ -85,8 +85,7 @@ func resourceComputeProjectMetadataItemCreate(d *schema.ResourceData, meta inter
 	key := d.Get("key").(string)
 	val := d.Get("value").(string)
 
-	err = updateComputeCommonInstanceMetadata(config, projectID, key, userAgent, &val, d.Timeout(schema.TimeoutCreate), failIfPresent)
-	if err != nil {
+	if err = updateComputeCommonInstanceMetadata(d, config, projectID, key, userAgent, &val, d.Timeout(schema.TimeoutCreate), failIfPresent); err != nil {
 		return err
 	}
 
@@ -108,7 +107,7 @@ func resourceComputeProjectMetadataItemRead(d *schema.ResourceData, meta interfa
 	}
 
 	log.Printf("[DEBUG] Loading project metadata: %s", projectID)
-	project, err := NewClient(config, userAgent).Projects.Get(projectID).Do()
+	project, err := getComputeProject(d, config, projectID, userAgent)
 	if err != nil {
 		return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 	}
@@ -151,8 +150,7 @@ func resourceComputeProjectMetadataItemUpdate(d *schema.ResourceData, meta inter
 		_, n := d.GetChange("value")
 		new := n.(string)
 
-		err = updateComputeCommonInstanceMetadata(config, projectID, key, userAgent, &new, d.Timeout(schema.TimeoutUpdate), overwritePresent)
-		if err != nil {
+		if err = updateComputeCommonInstanceMetadata(d, config, projectID, key, userAgent, &new, d.Timeout(schema.TimeoutUpdate), overwritePresent); err != nil {
 			return err
 		}
 	}
@@ -173,8 +171,7 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 
 	key := d.Get("key").(string)
 
-	err = updateComputeCommonInstanceMetadata(config, projectID, key, userAgent, nil, d.Timeout(schema.TimeoutDelete), overwritePresent)
-	if err != nil {
+	if err = updateComputeCommonInstanceMetadata(d, config, projectID, key, userAgent, nil, d.Timeout(schema.TimeoutDelete), overwritePresent); err != nil {
 		return err
 	}
 
@@ -201,14 +198,14 @@ func resourceComputeProjectMetadataItemImportState(d *schema.ResourceData, meta 
 	return []*schema.ResourceData{d}, nil
 }
 
-func updateComputeCommonInstanceMetadata(config *transport_tpg.Config, projectID, key, userAgent string, afterVal *string, timeout time.Duration, failIfPresent metadataPresentBehavior) error {
+func updateComputeCommonInstanceMetadata(d *schema.ResourceData, config *transport_tpg.Config, projectID, key, userAgent string, afterVal *string, timeout time.Duration, failIfPresent metadataPresentBehavior) error {
 	updateMD := func() error {
 		lockName := fmt.Sprintf("projects/%s/commoninstancemetadata", projectID)
 		transport_tpg.MutexStore.Lock(lockName)
 		defer transport_tpg.MutexStore.Unlock(lockName)
 
 		log.Printf("[DEBUG] Loading project metadata: %s", projectID)
-		project, err := NewClient(config, userAgent).Projects.Get(projectID).Do()
+		project, err := getComputeProject(d, config, projectID, userAgent)
 		if err != nil {
 			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
@@ -243,22 +240,35 @@ func updateComputeCommonInstanceMetadata(config *transport_tpg.Config, projectID
 			fingerprint = project.CommonInstanceMetadata.Fingerprint
 		}
 
-		// Attempt to write the new value now
-		op, err := NewClient(config, userAgent).Projects.SetCommonInstanceMetadata(
-			projectID,
-			&compute.Metadata{
-				Fingerprint: fingerprint,
-				Items:       expandComputeMetadata(md),
-			},
-		).Do()
+		body, err := computeMetadataToMap(&compute.Metadata{
+			Fingerprint: fingerprint,
+			Items:       expandComputeMetadata(md),
+		})
+		if err != nil {
+			return fmt.Errorf("Error encoding metadata: %s", err)
+		}
 
+		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+		if err != nil {
+			return err
+		}
+		url = fmt.Sprintf("%sprojects/%s/setCommonInstanceMetadata", url, projectID)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   projectID,
+			RawURL:    url,
+			UserAgent: userAgent,
+			Body:      body,
+			Timeout:   timeout,
+		})
 		if err != nil {
 			return err
 		}
 
-		log.Printf("[DEBUG] SetCommonInstanceMetadata: %d (%s)", op.Id, op.SelfLink)
+		log.Printf("[DEBUG] SetCommonInstanceMetadata: %v", res["selfLink"])
 
-		return ComputeOperationWaitTime(config, op, project.Name, "SetCommonInstanceMetadata", userAgent, timeout)
+		return ComputeOperationWaitTime(config, res, project.Name, "SetCommonInstanceMetadata", userAgent, timeout)
 	}
 
 	return transport_tpg.MetadataRetryWrapper(updateMD)


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates `ResourceComputeProjectMetadataItem` resource to use transport_tpg.SendRequest instead of NewClient

```release-note:note
compute: migrated `resource_compute_project_metadata_item.go.tmpl` resource to use direct HTTP rather than a client library
```
