### PR TITLE
Migrate resource_compute_region_disk_test to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_disk_test.go.tmpl
@@ -2,12 +2,13 @@
 package compute_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
 
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -475,9 +476,24 @@ func testAccCheckComputeRegionDiskExists(t *testing.T, n string, disk *compute.D
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := compute_tpg.NewClient(config, config.UserAgent).RegionDisks.Get(
-			p, rs.Primary.Attributes["region"], rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/regions/%s/disks/%s", config.ComputeBasePath, p, rs.Primary.Attributes["region"], rs.Primary.Attributes["name"])
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   p,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
+			return err
+		}
+
+		var found compute.Disk
+		resBytes, err := json.Marshal(res)
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal(resBytes, &found); err != nil {
 			return err
 		}
 
@@ -485,7 +501,7 @@ func testAccCheckComputeRegionDiskExists(t *testing.T, n string, disk *compute.D
 			return fmt.Errorf("RegionDisk not found")
 		}
 
-		*disk = *found
+		*disk = found
 
 		return nil
 	}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates testAccCheckComputeRegionDiskExists function to use transport_tpg.SendRequest instead of NewClient

```release-note:note
compute: migrated `resource_compute_region_disk_test.go.tmpl` test to use direct HTTP rather than a client library
```
