### PR TITLE
fix(compute): include preconfigured_waf_config in PatchRule updateMask

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1106,6 +1106,14 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					updateMask = append(updateMask, "rate_limit_options.enforce_on_key_name")
 				}
 
+			    // Detect changes to preconfigured_waf_config so that removing or clearing
+				// the block is propagated to the API. Without listing the field in the
+				// updateMask, the PatchRule call will not clear the existing value because
+				// the request body omits nil pointers.
+				if fmt.Sprintf("%v", oRules[priority]["preconfigured_waf_config"]) != fmt.Sprintf("%v", nRules[priority]["preconfigured_waf_config"]) {
+					updateMask = append(updateMask, "preconfigured_waf_config")
+				}
+
 				client := NewClient(config, userAgent)
 
 				// If the rule is in new, and its priority is in old, but its hash is different than the one in old, update it.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_test.go.tmpl
@@ -161,7 +161,6 @@ func TestAccComputeSecurityPolicy_withPreconfiguredWafConfig(t *testing.T) {
 				ResourceName:      "google_compute_security_policy.policy",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"rule.1.preconfigured_waf_config.#", "rule.1.preconfigured_waf_config.0.%"}, // API will still return a empty object
 			},
 		},
 	})


### PR DESCRIPTION
When `preconfigured_waf_config` is removed from a `google_compute_security_policy` rule, the removal is silently ignored by the API. Every subsequent plan shows the same delete+add diff for the affected rule, resulting in a perpetual permadrift.

- This PR proposes that we compare old vs. new `preconfigured_waf_config` for each updated rule and append `preconfigured_waf_config` to the `updateMask` when they differ.
- Also removes the `ImportStateVerifyIgnore`workaround that was added in #11946 for the _removed test step, the API should correctly clears the field, so the import state will match the config.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27177

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
google_compute_security_policy: fixed permadrift when removing preconfigured_waf_config from a rule
```
