### PR TITLE
tgc-revival: add validation for empty tgc tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -82,7 +82,7 @@ clean-tgc:
 		rm -rf ./tfplan2cai/converters/google/provider;\
 		rm -rf ./tfplan2cai/converters/google/resources;\
 		rm -rf ./cai2hcl/*;\
-		find ./tfplan2cai/test/** -type f -exec git rm {} \; > /dev/null;\
+		rm -rf ./tfplan2cai/test/*;\
 		rm -rf ./pkg/*;\
 		rm -rf ./test/*;\
 		rm -rf ./cmd/*;\

--- a/mmv1/products/kms/KeyHandle.yaml
+++ b/mmv1/products/kms/KeyHandle.yaml
@@ -49,7 +49,6 @@ async:
 custom_code:
   decoder: 'templates/terraform/decoders/kms.go.tmpl'
   tgc_decoder: 'templates/tgc_next/decoders/kms.go.tmpl'
-include_in_tgc_next: true
 examples:
   - name: 'kms_key_handle_basic'
     primary_resource_id: 'example-keyhandle'

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -112,7 +112,9 @@ func (tgc TerraformGoogleConversionNext) GenerateObject(object api.Resource, out
 		log.Printf("Error adding examples from handwritten tests: %v", err)
 	}
 
-	tgc.GenerateResourceTests(object, *templateData, outputFolder)
+	if err := tgc.GenerateResourceTests(object, *templateData, outputFolder); err != nil {
+		log.Fatalf("Error generating resource tests: %v", err)
+	}
 }
 
 func (tgc TerraformGoogleConversionNext) GenerateResource(object api.Resource, templateData TemplateData, outputFolder string, generateCode, generateDocs bool) {
@@ -137,9 +139,15 @@ func (tgc TerraformGoogleConversionNext) GenerateResource(object api.Resource, t
 func (tgc TerraformGoogleConversionNext) GenerateCaiToHclObjects(outputFolder, resourceToGenerate string, generateCode, generateDocs bool) {
 }
 
-func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resource, templateData TemplateData, outputFolder string) {
+func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resource, templateData TemplateData, outputFolder string) error {
 	if len(object.TGCTests) == 0 {
-		return
+		return fmt.Errorf("No TGC tests for resource %s", object.Name)
+	}
+
+	for _, test := range object.TGCTests {
+		if !strings.HasPrefix(test.Name, "TestAcc") {
+			return fmt.Errorf("TGC test name %s for resource %s does not start with TestAcc", test.Name, object.Name)
+		}
 	}
 
 	productName := tgc.Product.ApiName
@@ -149,6 +157,7 @@ func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resou
 	}
 	targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_%s_generated_test.go", productName, google.Underscore(object.Name)))
 	templateData.GenerateTGCNextTestFile(targetFilePath, object)
+	return nil
 }
 
 // GenerateProduct creates the product.go file for a given service directory.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
No tests exist for kms key handle (`google_kms_key_handle`), so don't support it in tgc.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
