### PR TITLE
Disable writable cgroups node pool test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -6032,6 +6032,9 @@ resource "google_container_node_pool" "np" {
 
 func TestAccContainerNodePool_writableCgroups(t *testing.T) {
 	t.Parallel()
+	// TODO(chrishenzie): Convert this to a negative test (expecting failure)
+	// once the API behavior change is fully rolled out.
+	t.Skip("Skipping due to API behavior change blocking writable cgroups modifications on node pools")
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	nodepool := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))


### PR DESCRIPTION
Skip `TestAccContainerNodePool_writableCgroups`. Modifying `writable_cgroups` on node pool updates is now blocked by the GKE API to prevent silent failures.

Linked to internal bug b/507417042

Assisted-by: Antigravity

```release-note:none
```

CC @samuelkarp 