### PR TITLE
Revert "Fix oracledatabase adb basic and full tests"

### DIFF
--- a/mmv1/products/oracledatabase/AutonomousDatabase.yaml
+++ b/mmv1/products/oracledatabase/AutonomousDatabase.yaml
@@ -66,8 +66,6 @@ examples:
       database_name: 'mydatabase'
       endpoint_name: 'myendpoint'
       deletion_protection: 'true'
-      odb_network: 'projects/my-project/locations/us-east4/odbNetworks/my-odbnetwork'
-      odb_subnet: 'projects/my-project/locations/us-east4/odbNetworks/my-odbnetwork/odbSubnets/my-odbsubnet'
     ignore_read_extra:
       - 'deletion_protection'
     test_vars_overrides:
@@ -75,8 +73,6 @@ examples:
       deletion_protection: 'false'
       database_name: 'fmt.Sprintf("tftestdatabase%s", acctest.RandString(t, 10))'
       endpoint_name: 'fmt.Sprintf("tftestendpoint%s", acctest.RandString(t, 10))'
-      odb_network: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork"'
-      odb_subnet: '"projects/oci-terraform-testing-prod/locations/us-east4/odbNetworks/tf-test-permanent-odbnetwork/odbSubnets/tf-test-permanent-client-odbsubnet"'
     # Skip in VCR until the test issue is resolved
     # TODO(shuyama): Add GH issue link
     skip_vcr: true

--- a/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/oracledatabase_autonomous_database_full.tf.tmpl
@@ -5,8 +5,6 @@ resource "google_oracle_database_autonomous_database" "{{$.PrimaryResourceId}}"{
   display_name = "autonomousDatabase displayname"
   database = "{{index $.Vars "database_name"}}"
   admin_password = "123Abpassword"
-  odb_network = "{{index $.Vars "odb_network"}}"
-  odb_subnet = "{{index $.Vars "odb_subnet"}}"
   network = data.google_compute_network.default.id
   cidr = "10.5.0.0/24"
   labels = {

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_autonomous_databases_test.go
@@ -19,6 +19,7 @@ func TestAccOracleDatabaseAutonomousDatabases_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.#"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.display_name"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.cidr"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.network"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.entitlement_id"),
 					resource.TestCheckResourceAttrSet("data.google_oracle_database_autonomous_databases.my-adbs", "autonomous_databases.0.database"),


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#17119

adb should return cidr, and network is already specified so we do not need to specify odbnetwork