### PR TITLE
`test_utils`: Add `listDisplayName` assertion

### DIFF
--- a/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
@@ -20,6 +20,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
 	"github.com/hashicorp/terraform-plugin-testing/echoprovider"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -84,6 +86,49 @@ func CheckDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourc
 		return nil
 	}
 }
+
+// List test utils
+
+// ListDisplayName captures a resource's display-name attribute during a
+// create step and exposes a knownvalue.Check that asserts list-query results
+// match the captured value.
+type ListDisplayName struct {
+	value string
+}
+
+// Capture returns a TestCheckFunc that copies the first non-empty value
+// among attrCandidates from resourceAddr's state into the captured value.
+// attrCandidates are checked in order from first index to last.
+func (c *ListDisplayName) Capture(resourceAddr string, attrCandidates []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceAddr]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceAddr)
+		}
+		for _, k := range attrCandidates {
+			if v, ok := rs.Primary.Attributes[k]; ok && v != "" {
+				c.value = v
+				return nil
+			}
+		}
+		return fmt.Errorf("no display name attribute found in state for resource %s; tried %v", resourceAddr, attrCandidates)
+	}
+}
+
+// Check returns a knownvalue.Check that compares against the
+// captured value. Fails if Capture has not run yet.
+func (c *ListDisplayName) Check() knownvalue.Check {
+	return knownvalue.StringFunc(func(v string) error {
+		if c.value == "" {
+			return fmt.Errorf("display name was not captured from create step")
+		}
+		if v != c.value {
+			return fmt.Errorf("expected display name %q, got %q", c.value, v)
+		}
+		return nil
+	})
+}
+
 
 // General test utils
 

--- a/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/acctest/test_utils.go.tmpl
@@ -115,9 +115,9 @@ func (c *ListDisplayName) Capture(resourceAddr string, attrCandidates []string) 
 	}
 }
 
-// Check returns a knownvalue.Check that compares against the
+// CheckValue returns a knownvalue.Check that compares against the
 // captured value. Fails if Capture has not run yet.
-func (c *ListDisplayName) Check() knownvalue.Check {
+func (c *ListDisplayName) CheckValue() knownvalue.Check {
 	return knownvalue.StringFunc(func(v string) error {
 		if c.value == "" {
 			return fmt.Errorf("display name was not captured from create step")

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck/queryfilter"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -49,7 +50,8 @@ func TestAccServiceAccountListResource_queryIdentity(t *testing.T) {
 					querycheck.ExpectLengthAtLeast("google_service_account.all_in_project", 1),
 					querycheck.ExpectResourceDisplayName(
 						"google_service_account.all_in_project",
-						listDisplayName.Check(),
+						queryfilter.ByDisplayName(listDisplayName.CheckValue()),
+						listDisplayName.CheckValue(),
 					),
 				},
 			},

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account_test.go
@@ -22,7 +22,7 @@ func TestAccServiceAccountListResource_queryIdentity(t *testing.T) {
 	accountId := "a" + acctest.RandString(t, 10)
 	project := envvar.GetTestProjectFromEnv()
 	expectedEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
-
+	listDisplayName := acctest.ListDisplayName{}
 	acctest.VcrTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_14_0),
@@ -35,6 +35,7 @@ func TestAccServiceAccountListResource_queryIdentity(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_service_account.acceptance", "email", expectedEmail),
 					resource.TestCheckResourceAttr("google_service_account.acceptance", "project", project),
+					listDisplayName.Capture("google_service_account.acceptance", []string{"display_name", "email"}),
 				),
 			},
 			{
@@ -46,6 +47,10 @@ func TestAccServiceAccountListResource_queryIdentity(t *testing.T) {
 						"project": knownvalue.StringExact(project),
 					}),
 					querycheck.ExpectLengthAtLeast("google_service_account.all_in_project", 1),
+					querycheck.ExpectResourceDisplayName(
+						"google_service_account.all_in_project",
+						listDisplayName.Check(),
+					),
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a new querycheck that captures the display_name provisioned from the first resource provisioning step without needing to be explicit in query tests

Supports query testing generation in magic-modules that is planned in:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17368

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
