### PR TITLE
Replaced BasePath usage in universe tests, acm, ad, alloydb, and apigee

### DIFF
--- a/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
+++ b/mmv1/third_party/terraform/provider/universe/universe_domain_compute_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -144,7 +145,7 @@ func testAccCheckComputeDiskDestroyProducer(t *testing.T) func(s *terraform.Stat
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/disks/{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(compute.Product, config)+"projects/{{project}}/zones/{{zone}}/disks/{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_folder_service_account.go
@@ -37,7 +37,7 @@ func dataSourceAccessApprovalFolderServiceAccountRead(d *schema.ResourceData, me
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AccessApprovalBasePath}}folders/{{folder_id}}/serviceAccount")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"folders/{{folder_id}}/serviceAccount")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_organization_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_organization_service_account.go
@@ -37,7 +37,7 @@ func dataSourceAccessApprovalOrganizationServiceAccountRead(d *schema.ResourceDa
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AccessApprovalBasePath}}organizations/{{organization_id}}/serviceAccount")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{organization_id}}/serviceAccount")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_project_service_account.go
+++ b/mmv1/third_party/terraform/services/accessapproval/data_source_access_approval_project_service_account.go
@@ -37,7 +37,7 @@ func dataSourceAccessApprovalProjectServiceAccountRead(d *schema.ResourceData, m
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AccessApprovalBasePath}}projects/{{project_id}}/serviceAccount")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project_id}}/serviceAccount")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_access_policy.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_access_policy.go
@@ -46,7 +46,7 @@ func dataSourceAccessContextManagerAccessPolicyRead(d *schema.ResourceData, meta
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AccessContextManagerBasePath}}accessPolicies?parent={{parent}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"accessPolicies?parent={{parent}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_supported_service.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_supported_service.go
@@ -75,7 +75,7 @@ func dataSourceAccessContextManagerSupportedServiceRead(d *schema.ResourceData, 
 	}
 
 	serviceName := d.Get("service_name").(string)
-	urlRequest := fmt.Sprintf("%sservices/%s", config.AccessContextManagerBasePath, serviceName)
+	urlRequest := fmt.Sprintf("%sservices/%s", transport_tpg.BaseUrl(Product, config), serviceName)
 
 	headers := make(http.Header)
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_supported_services.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/data_source_access_context_manager_supported_services.go
@@ -65,7 +65,7 @@ func dataSourceAccessContextManagerSupportedServicesRead(d *schema.ResourceData,
 		return err
 	}
 
-	urlRequest := config.AccessContextManagerBasePath + "services"
+	urlRequest := transport_tpg.BaseUrl(Product, config) + "services"
 
 	headers := make(http.Header)
 	supportedServices := make([]map[string]interface{}, 0)

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_condition_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -66,7 +67,7 @@ func testAccCheckAccessContextManagerAccessLevelConditionPresent(t *testing.T, n
 		}
 
 		config := acctest.GoogleProviderConfig(t)
-		url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{access_level}}")
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{access_level}}")
 		if err != nil {
 			return err
 		}
@@ -98,8 +99,7 @@ func testAccCheckAccessContextManagerAccessLevelConditionDestroyProducer(t *test
 			}
 
 			config := acctest.GoogleProviderConfig(t)
-
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{access_level}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{access_level}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_level_test.go.tmpl
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -80,7 +81,7 @@ func testAccCheckAccessContextManagerAccessLevelDestroyProducer(t *testing.T) fu
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}AccessContextManagerBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{"{{"}}name{{"}}"}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_levels_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_levels_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -61,7 +62,7 @@ func testAccCheckAccessContextManagerAccessLevelsDestroyProducer(t *testing.T) f
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{parent}}/accessLevels")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{parent}}/accessLevels")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_sweeper.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_sweeper.go
@@ -35,7 +35,7 @@ func testSweepAccessContextManagerPolicies(region string) error {
 	log.Printf("[DEBUG] Listing Access Policies for org %q", testOrg)
 
 	parent := neturl.QueryEscape(fmt.Sprintf("organizations/%s", testOrg))
-	listUrl := fmt.Sprintf("%saccessPolicies?parent=%s", config.AccessContextManagerBasePath, parent)
+	listUrl := fmt.Sprintf("%saccessPolicies?parent=%s", transport_tpg.BaseUrl(Product, config), parent)
 
 	resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
@@ -66,7 +66,7 @@ func testSweepAccessContextManagerPolicies(region string) error {
 	policy := policies[0].(map[string]interface{})
 	log.Printf("[DEBUG] Deleting test Access Policies %q", policy["name"])
 
-	policyUrl := config.AccessContextManagerBasePath + policy["name"].(string)
+	policyUrl := transport_tpg.BaseUrl(Product, config) + policy["name"].(string)
 	if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "DELETE",

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.tmpl
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -90,7 +91,7 @@ func testAccCheckAccessContextManagerAccessPolicyDestroyProducer(t *testing.T) f
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}AccessContextManagerBasePath{{"}}"}}accessPolicies/{{"{{"}}name{{"}}"}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"accessPolicies/{{"{{"}}name{{"}}"}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_authorized_orgs_desc_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_authorized_orgs_desc_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -67,7 +68,7 @@ func testAccCheckAccessContextManagerAuthorizedOrgsDescDestroyProducer(t *testin
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -1,62 +1,62 @@
 package accesscontextmanager_test
 
 import (
-  "fmt"
-  "strings"
-  "testing"
+	"fmt"
+	"strings"
+	"testing"
 
-  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-  "github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-  "github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
-  "github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
-  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
-  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  context := map[string]interface{}{
-    "org_id":        envvar.GetTestOrgFromEnv(t),
-    "org_domain":    envvar.GetTestOrgDomainFromEnv(t),
-    "cust_id":       envvar.GetTestCustIdFromEnv(t),
-    "random_suffix": acctest.RandString(t, 10),
-  }
+	context := map[string]interface{}{
+		"org_id":        envvar.GetTestOrgFromEnv(t),
+		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+		"cust_id":       envvar.GetTestCustIdFromEnv(t),
+		"random_suffix": acctest.RandString(t, 10),
+	}
 
-  acctest.VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy:             testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
-      },
-      {
-        ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"organization_id"},
-      },
-      {
-        Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
-      },
-      {
-        ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"organization_id"},
-      },
-    },
-  })
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+			},
+			{
+				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization_id"},
+			},
+			{
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
+			},
+			{
+				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization_id"},
+			},
+		},
+	})
 }
 
 func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_cloud_identity_group" "group" {
   display_name = "tf-test-my-identity-group%{random_suffix}"
 
@@ -137,7 +137,7 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
 }
 
 func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_cloud_identity_group" "group" {
   display_name = "tf-test-my-identity-group%{random_suffix}"
 
@@ -219,33 +219,33 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
 }
 
 func testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t *testing.T) func(s *terraform.State) error {
-  return func(s *terraform.State) error {
-    for name, rs := range s.RootModule().Resources {
-      if rs.Type != "google_access_context_manager_gcp_user_access_binding" {
-        continue
-      }
-      if strings.HasPrefix(name, "data.") {
-        continue
-      }
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_access_context_manager_gcp_user_access_binding" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
 
-      config := acctest.GoogleProviderConfig(t)
+			config := acctest.GoogleProviderConfig(t)
 
-      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"organizations/{{organization_id}}/gcpUserAccessBindings/{{name}}")
-      if err != nil {
-        return err
-      }
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"organizations/{{organization_id}}/gcpUserAccessBindings/{{name}}")
+			if err != nil {
+				return err
+			}
 
-      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-        Config:    config,
-        Method:    "GET",
-        RawURL:    url,
-        UserAgent: config.UserAgent,
-      })
-      if err == nil {
-        return fmt.Errorf("AccessContextManagerGcpUserAccessBinding still exists at %s", url)
-      }
-    }
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("AccessContextManagerGcpUserAccessBinding still exists at %s", url)
+			}
+		}
 
-    return nil
-  }
+		return nil
+	}
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -1,61 +1,62 @@
 package accesscontextmanager_test
 
 import (
-	"fmt"
-	"strings"
-	"testing"
+  "fmt"
+  "strings"
+  "testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
+  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  "github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
+  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
+  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	context := map[string]interface{}{
-		"org_id":        envvar.GetTestOrgFromEnv(t),
-		"org_domain":    envvar.GetTestOrgDomainFromEnv(t),
-		"cust_id":       envvar.GetTestCustIdFromEnv(t),
-		"random_suffix": acctest.RandString(t, 10),
-	}
+  context := map[string]interface{}{
+    "org_id":        envvar.GetTestOrgFromEnv(t),
+    "org_domain":    envvar.GetTestOrgDomainFromEnv(t),
+    "cust_id":       envvar.GetTestCustIdFromEnv(t),
+    "random_suffix": acctest.RandString(t, 10),
+  }
 
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
-			},
-			{
-				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"organization_id"},
-			},
-			{
-				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
-			},
-			{
-				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"organization_id"},
-			},
-		},
-	})
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+      },
+      {
+        ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"organization_id"},
+      },
+      {
+        Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context),
+      },
+      {
+        ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"organization_id"},
+      },
+    },
+  })
 }
 
 func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+  return acctest.Nprintf(`
 resource "google_cloud_identity_group" "group" {
   display_name = "tf-test-my-identity-group%{random_suffix}"
 
@@ -110,33 +111,33 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
     scope {
       client_scope {
         restricted_client_application {
-	        client_id = "TEST_APPLICATION"
+          client_id = "TEST_APPLICATION"
          }
       }
     }
     active_settings {
-  	  access_levels = [
-  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
-  	  ]
-  	  session_settings {
-  		  session_length = "3600s"
-  		  session_length_enabled = true
-  		  session_reauth_method = "LOGIN"
-  		  use_oidc_max_age = false
-  	  }
-  	}
-  	dry_run_settings {
-  	  access_levels = [
-  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
-  	  ]
-  	}
+      access_levels = [
+        google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+      ]
+      session_settings {
+        session_length = "3600s"
+        session_length_enabled = true
+        session_reauth_method = "LOGIN"
+        use_oidc_max_age = false
+      }
+    }
+    dry_run_settings {
+      access_levels = [
+        google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+      ]
+    }
   }
 }
 `, context)
 }
 
 func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingNamedExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+  return acctest.Nprintf(`
 resource "google_cloud_identity_group" "group" {
   display_name = "tf-test-my-identity-group%{random_suffix}"
 
@@ -191,60 +192,60 @@ resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_acces
     scope {
       client_scope {
         restricted_client_application {
-	        name = "Cloud Console"
+          name = "Cloud Console"
          }
       }
     }
     active_settings {
-  	  access_levels = [
-  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
-  	  ]
-  	  session_settings {
-  		  max_inactivity = "400s"
-  		  session_length = "3600s"
-  		  session_length_enabled = true
-  		  session_reauth_method = "LOGIN"
-  		  use_oidc_max_age = false
-  	  }
-  	}
-  	dry_run_settings {
-  	  access_levels = [
-  		  google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
-  	  ]
-  	}
+      access_levels = [
+        google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+      ]
+      session_settings {
+        max_inactivity = "400s"
+        session_length = "3600s"
+        session_length_enabled = true
+        session_reauth_method = "LOGIN"
+        use_oidc_max_age = false
+      }
+    }
+    dry_run_settings {
+      access_levels = [
+        google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+      ]
+    }
   }
 }
 `, context)
 }
 
 func testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_access_context_manager_gcp_user_access_binding" {
-				continue
-			}
-			if strings.HasPrefix(name, "data.") {
-				continue
-			}
+  return func(s *terraform.State) error {
+    for name, rs := range s.RootModule().Resources {
+      if rs.Type != "google_access_context_manager_gcp_user_access_binding" {
+        continue
+      }
+      if strings.HasPrefix(name, "data.") {
+        continue
+      }
 
-			config := acctest.GoogleProviderConfig(t)
+      config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}organizations/{{organization_id}}/gcpUserAccessBindings/{{name}}")
-			if err != nil {
-				return err
-			}
+      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"organizations/{{organization_id}}/gcpUserAccessBindings/{{name}}")
+      if err != nil {
+        return err
+      }
 
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "GET",
-				RawURL:    url,
-				UserAgent: config.UserAgent,
-			})
-			if err == nil {
-				return fmt.Errorf("AccessContextManagerGcpUserAccessBinding still exists at %s", url)
-			}
-		}
+      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config:    config,
+        Method:    "GET",
+        RawURL:    url,
+        UserAgent: config.UserAgent,
+      })
+      if err == nil {
+        return fmt.Errorf("AccessContextManagerGcpUserAccessBinding still exists at %s", url)
+      }
+    }
 
-		return nil
-	}
+    return nil
+  }
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_egress_policy_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_egress_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -52,7 +53,7 @@ func testAccCheckAccessContextManagerServicePerimeterDryRunEgressPolicyDestroyPr
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_ingress_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -51,7 +52,7 @@ func testAccCheckAccessContextManagerServicePerimeterDryRunIngressPolicyDestroyP
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_resource_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_dry_run_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -56,7 +57,7 @@ func testAccCheckAccessContextManagerServicePerimeterDryRunResourceDestroyProduc
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter_name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter_name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_egress_policy_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_egress_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -52,7 +53,7 @@ func testAccCheckAccessContextManagerServicePerimeterEgressPolicyDestroyProducer
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_ingress_policy_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_ingress_policy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -51,7 +52,7 @@ func testAccCheckAccessContextManagerServicePerimeterIngressPolicyDestroyProduce
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_resource_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -56,7 +57,7 @@ func testAccCheckAccessContextManagerServicePerimeterResourceDestroyProducer(t *
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter_name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{perimeter_name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -98,7 +98,7 @@ func testAccCheckAccessContextManagerServicePerimeterDestroyProducer(t *testing.
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}AccessContextManagerBasePath{{"}}"}}{{"{{"}}name{{"}}"}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{"{{"}}name{{"}}"}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
@@ -1,90 +1,91 @@
 package accesscontextmanager_test
 
 import (
-	"fmt"
-	"testing"
+  "fmt"
+  "testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  "github.com/hashicorp/terraform-plugin-testing/terraform"
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
+  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
+  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 func testAccAccessContextManagerServicePerimeters_basicTest(t *testing.T) {
-	org := envvar.GetTestOrgFromEnv(t)
-	projectNumber := envvar.GetTestProjectNumberFromEnv()
+  org := envvar.GetTestOrgFromEnv(t)
+  projectNumber := envvar.GetTestProjectNumberFromEnv()
 
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
-			},
-			{
-				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"service_perimeters"},
-			},
-			{
-				Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter", projectNumber),
-			},
-			{
-				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"service_perimeters"},
-			},
-			{
-				Config: testAccAccessContextManagerServicePerimeters_empty(org, "my policy", "level"),
-			},
-			{
-				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"service_perimeters"},
-			},
-		},
-	})
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy:             testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
+      },
+      {
+        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"service_perimeters"},
+      },
+      {
+        Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter", projectNumber),
+      },
+      {
+        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"service_perimeters"},
+      },
+      {
+        Config: testAccAccessContextManagerServicePerimeters_empty(org, "my policy", "level"),
+      },
+      {
+        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"service_perimeters"},
+      },
+    },
+  })
 }
 
 func testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_access_context_manager_service_perimeters" {
-				continue
-			}
+  return func(s *terraform.State) error {
+    for _, rs := range s.RootModule().Resources {
+      if rs.Type != "google_access_context_manager_service_perimeters" {
+        continue
+      }
 
-			config := acctest.GoogleProviderConfig(t)
+      config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{parent}}/servicePerimeters")
-			if err != nil {
-				return err
-			}
+      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{parent}}/servicePerimeters")
+      if err != nil {
+        return err
+      }
 
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "GET",
-				RawURL:    url,
-				UserAgent: config.UserAgent,
-			})
-			if err == nil {
-				return fmt.Errorf("ServicePerimeters still exists at %s", url)
-			}
-		}
+      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config:    config,
+        Method:    "GET",
+        RawURL:    url,
+        UserAgent: config.UserAgent,
+      })
+      if err == nil {
+        return fmt.Errorf("ServicePerimeters still exists at %s", url)
+      }
+    }
 
-		return nil
-	}
+    return nil
+  }
 }
 
 func testAccAccessContextManagerServicePerimeters_basic(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3 string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
@@ -156,7 +157,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
 }
 
 func testAccAccessContextManagerServicePerimeters_update(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3, perimeterTitleName4, projectNumber string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
@@ -214,93 +215,93 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
     use_explicit_dry_run_spec = true
     spec {
     restricted_services = ["bigquery.googleapis.com", "storage.googleapis.com"]
-    	access_levels       = [google_access_context_manager_access_level.test-access.name]
+      access_levels       = [google_access_context_manager_access_level.test-access.name]
     
-    	vpc_accessible_services {
-    		enable_restriction = true
-    		allowed_services   = ["bigquery.googleapis.com", "storage.googleapis.com"]
-    	}
+      vpc_accessible_services {
+        enable_restriction = true
+        allowed_services   = ["bigquery.googleapis.com", "storage.googleapis.com"]
+      }
     
-    	ingress_policies {
-    		title = "ingress policy title 1"
-    		ingress_from {
-    			sources {
-    				access_level = google_access_context_manager_access_level.test-access.name
-    			}
-    			identity_type = "ANY_IDENTITY"
-    		}
+      ingress_policies {
+        title = "ingress policy title 1"
+        ingress_from {
+          sources {
+            access_level = google_access_context_manager_access_level.test-access.name
+          }
+          identity_type = "ANY_IDENTITY"
+        }
     
-    		ingress_to {
-    			resources = [ "*" ]
-    			operations {
-    				service_name = "bigquery.googleapis.com"
+        ingress_to {
+          resources = [ "*" ]
+          operations {
+            service_name = "bigquery.googleapis.com"
     
-    				method_selectors {
-    					method = "BigQueryStorage.ReadRows"
-    				}
+            method_selectors {
+              method = "BigQueryStorage.ReadRows"
+            }
     
-    				method_selectors {
-    					method = "TableService.ListTables"
-    				}
+            method_selectors {
+              method = "TableService.ListTables"
+            }
     
-    				method_selectors {
-    					permission = "bigquery.jobs.get"
-    				}
-    			}
+            method_selectors {
+              permission = "bigquery.jobs.get"
+            }
+          }
     
-    			operations {
-    				service_name = "storage.googleapis.com"
+          operations {
+            service_name = "storage.googleapis.com"
     
-    				method_selectors {
-    					method = "google.storage.objects.create"
-    				}
-    			}
-    		}
-    	}
-    	ingress_policies {
-    		title = "ingress policy title 2"
-    		ingress_from {
-    			identities = ["group:test@google.com"]
-    		}
-    		ingress_to {
-    			resources = ["*"]
+            method_selectors {
+              method = "google.storage.objects.create"
+            }
+          }
+        }
+      }
+      ingress_policies {
+        title = "ingress policy title 2"
+        ingress_from {
+          identities = ["group:test@google.com"]
+        }
+        ingress_to {
+          resources = ["*"]
           roles = ["roles/bigquery.admin"]
-    		}
-    	}
+        }
+      }
     
-    	egress_policies {
-    		title = "egress policy title 1"
-    		egress_from {
-    			identity_type = "ANY_USER_ACCOUNT"
-    		}
-    		egress_to {
-    			operations {
-    				service_name = "bigquery.googleapis.com"
-    				method_selectors {
-    					permission = "externalResource.read"
-    				}
-    			}
-    			external_resources = ["s3://bucket1"]
-    		}
-    	}
-    	egress_policies {
-    		title = "egress policy title 2"
-    		egress_from {
-    			identities = ["group:test@google.com"]
-    		}
-    		egress_to {
-    			resources = ["*"]
-          roles = ["roles/bigquery.admin"]
-    		}
-    	}
       egress_policies {
-    		egress_from {
-    			sources {
+        title = "egress policy title 1"
+        egress_from {
+          identity_type = "ANY_USER_ACCOUNT"
+        }
+        egress_to {
+          operations {
+            service_name = "bigquery.googleapis.com"
+            method_selectors {
+              permission = "externalResource.read"
+            }
+          }
+          external_resources = ["s3://bucket1"]
+        }
+      }
+      egress_policies {
+        title = "egress policy title 2"
+        egress_from {
+          identities = ["group:test@google.com"]
+        }
+        egress_to {
+          resources = ["*"]
+          roles = ["roles/bigquery.admin"]
+        }
+      }
+      egress_policies {
+        egress_from {
+          sources {
             resource = "projects/%s"
           }
           source_restriction = "SOURCE_RESTRICTION_ENABLED"
-    		}
-    	}
+        }
+      }
     }
     status {
       restricted_services = ["bigquery.googleapis.com", "storage.googleapis.com"]
@@ -402,7 +403,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
 }
 
 func testAccAccessContextManagerServicePerimeters_empty(org, policyTitle, levelTitleName string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_services_perimeters_test.go
@@ -1,91 +1,91 @@
 package accesscontextmanager_test
 
 import (
-  "fmt"
-  "testing"
+	"fmt"
+	"testing"
 
-  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-  "github.com/hashicorp/terraform-plugin-testing/terraform"
-  "github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
-  "github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
-  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
-  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/accesscontextmanager"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
 // can exist, they need to be run serially. See AccessPolicy for the test runner.
 func testAccAccessContextManagerServicePerimeters_basicTest(t *testing.T) {
-  org := envvar.GetTestOrgFromEnv(t)
-  projectNumber := envvar.GetTestProjectNumberFromEnv()
+	org := envvar.GetTestOrgFromEnv(t)
+	projectNumber := envvar.GetTestProjectNumberFromEnv()
 
-  acctest.VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    CheckDestroy:             testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
-      },
-      {
-        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"service_perimeters"},
-      },
-      {
-        Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter", projectNumber),
-      },
-      {
-        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"service_perimeters"},
-      },
-      {
-        Config: testAccAccessContextManagerServicePerimeters_empty(org, "my policy", "level"),
-      },
-      {
-        ResourceName:            "google_access_context_manager_service_perimeters.test-access",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"service_perimeters"},
-      },
-    },
-  })
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerServicePerimeters_basic(org, "my policy", "level", "storage_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter"),
+			},
+			{
+				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_perimeters"},
+			},
+			{
+				Config: testAccAccessContextManagerServicePerimeters_update(org, "my policy", "level", "storage_perimeter", "bigquery_perimeter", "bigtable_perimeter", "bigquery_omni_perimeter", projectNumber),
+			},
+			{
+				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_perimeters"},
+			},
+			{
+				Config: testAccAccessContextManagerServicePerimeters_empty(org, "my policy", "level"),
+			},
+			{
+				ResourceName:            "google_access_context_manager_service_perimeters.test-access",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"service_perimeters"},
+			},
+		},
+	})
 }
 
 func testAccCheckAccessContextManagerServicePerimetersDestroyProducer(t *testing.T) func(s *terraform.State) error {
-  return func(s *terraform.State) error {
-    for _, rs := range s.RootModule().Resources {
-      if rs.Type != "google_access_context_manager_service_perimeters" {
-        continue
-      }
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_access_context_manager_service_perimeters" {
+				continue
+			}
 
-      config := acctest.GoogleProviderConfig(t)
+			config := acctest.GoogleProviderConfig(t)
 
-      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{parent}}/servicePerimeters")
-      if err != nil {
-        return err
-      }
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(accesscontextmanager.Product, config)+"{{parent}}/servicePerimeters")
+			if err != nil {
+				return err
+			}
 
-      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-        Config:    config,
-        Method:    "GET",
-        RawURL:    url,
-        UserAgent: config.UserAgent,
-      })
-      if err == nil {
-        return fmt.Errorf("ServicePerimeters still exists at %s", url)
-      }
-    }
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("ServicePerimeters still exists at %s", url)
+			}
+		}
 
-    return nil
-  }
+		return nil
+	}
 }
 
 func testAccAccessContextManagerServicePerimeters_basic(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3 string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
@@ -157,7 +157,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
 }
 
 func testAccAccessContextManagerServicePerimeters_update(org, policyTitle, levelTitleName, perimeterTitleName1, perimeterTitleName2, perimeterTitleName3, perimeterTitleName4, projectNumber string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"
@@ -403,7 +403,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
 }
 
 func testAccAccessContextManagerServicePerimeters_empty(org, policyTitle, levelTitleName string) string {
-  return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
   title  = "%s"

--- a/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_trust_test.go
+++ b/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_trust_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/services/activedirectory"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -93,7 +94,7 @@ func testAccCheckActiveDirectoryDomainTrustDestroyProducer(t *testing.T) func(s 
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ActiveDirectoryBasePath}}projects/{{project}}/locations/global/domains/{{domain}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(activedirectory.Product, config)+"projects/{{project}}/locations/global/domains/{{domain}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_update_test.go
+++ b/mmv1/third_party/terraform/services/activedirectory/resource_active_directory_domain_update_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/services/activedirectory"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -102,7 +103,7 @@ func testAccCheckActiveDirectoryDomainDestroyProducer(t *testing.T) func(s *terr
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ActiveDirectoryBasePath}}{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(activedirectory.Product, config)+"{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_locations.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_locations.go
@@ -83,7 +83,7 @@ func dataSourceAlloydbLocationsRead(d *schema.ResourceData, meta interface{}) er
 		billingProject = bp
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AlloydbBasePath}}projects/{{project}}/locations")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations")
 	if err != nil {
 		return fmt.Errorf("Error setting api endpoint")
 	}
@@ -131,7 +131,7 @@ func dataSourceAlloydbLocationsRead(d *schema.ResourceData, meta interface{}) er
 		if res["nextPageToken"] == nil || res["nextPageToken"].(string) == "" {
 			break
 		}
-		url, err = tpgresource.ReplaceVars(d, config, "{{AlloydbBasePath}}projects/{{project}}/locations?pageToken="+res["nextPageToken"].(string))
+		url, err = tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations?pageToken="+res["nextPageToken"].(string))
 		if err != nil {
 			return fmt.Errorf("Error setting api endpoint")
 		}

--- a/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_supported_database_flags.go
+++ b/mmv1/third_party/terraform/services/alloydb/data_source_alloydb_supported_database_flags.go
@@ -136,7 +136,7 @@ func dataSourceAlloydbSupportedDatabaseFlagsRead(d *schema.ResourceData, meta in
 		billingProject = bp
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{AlloydbBasePath}}projects/{{project}}/locations/{{location}}/supportedDatabaseFlags")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/supportedDatabaseFlags")
 	if err != nil {
 		return fmt.Errorf("Error setting api endpoint")
 	}

--- a/mmv1/third_party/terraform/services/apigee/apigee_utils.go
+++ b/mmv1/third_party/terraform/services/apigee/apigee_utils.go
@@ -22,7 +22,7 @@ func resourceApigeeNatAddressActivate(config *transport_tpg.Config, d *schema.Re
 	}
 
 	// 2. activation
-	activateUrl, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}{{instance_id}}/natAddresses/{{name}}:activate")
+	activateUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"{{instance_id}}/natAddresses/{{name}}:activate")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/fw_resource_apigee_keystores_aliases_key_cert_file.go
+++ b/mmv1/third_party/terraform/services/apigee/fw_resource_apigee_keystores_aliases_key_cert_file.go
@@ -208,7 +208,7 @@ func (r *ApigeeKeystoresAliasesKeyCertFileResource) Create(ctx context.Context, 
 	var schemaDefaultVals fwtransport.DefaultVars
 
 	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, r.providerConfig.UserAgent)
-	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases?format=keycertfile&alias={{alias}}&ignoreExpiryValidation=true")
+	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, transport_tpg.BaseUrl(Product, r.providerConfig)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases?format=keycertfile&alias={{alias}}&ignoreExpiryValidation=true")
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -289,7 +289,7 @@ func (r *ApigeeKeystoresAliasesKeyCertFileResource) Update(ctx context.Context, 
 
 	var schemaDefaultVals fwtransport.DefaultVars
 
-	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}?ignoreExpiryValidation=true")
+	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, transport_tpg.BaseUrl(Product, r.providerConfig)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}?ignoreExpiryValidation=true")
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -335,7 +335,7 @@ func (r *ApigeeKeystoresAliasesKeyCertFileResource) Delete(ctx context.Context, 
 	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, r.providerConfig.UserAgent)
 
 	var schemaDefaultVals fwtransport.DefaultVars
-	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
+	url := fwtransport.ReplaceVars(ctx, req, &resp.Diagnostics, schemaDefaultVals, r.providerConfig, transport_tpg.BaseUrl(Product, r.providerConfig)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -360,7 +360,7 @@ func (r *ApigeeKeystoresAliasesKeyCertFileResource) refresh(ctx context.Context,
 	userAgent := fwtransport.GenerateFrameworkUserAgentString(metaData, r.providerConfig.UserAgent)
 
 	var schemaDefaultVals fwtransport.DefaultVars
-	url := fwtransport.ReplaceVars(ctx, req, diags, schemaDefaultVals, r.providerConfig, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
+	url := fwtransport.ReplaceVars(ctx, req, diags, schemaDefaultVals, r.providerConfig, transport_tpg.BaseUrl(Product, r.providerConfig)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
 	if diags.HasError() {
 		return
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api.go
@@ -166,7 +166,7 @@ func resourceApigeeApiCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error, \"config_bundle\" must be specified")
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/apis?name={{name}}&action=import")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/apis?name={{name}}&action=import")
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func resourceApigeeApiRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/apis/{{name}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/apis/{{name}}")
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func resourceApigeeApiDelete(d *schema.ResourceData, meta interface{}) error {
 
 	billingProject := ""
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/apis/{{name}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/apis/{{name}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_api_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_api_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -141,7 +142,7 @@ func testAccCheckApigeeApiDestroyProducer(t *testing.T) func(s *terraform.State)
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/apis/{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/apis/{{name}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
@@ -1,53 +1,53 @@
 package apigee_test
 
 import (
-  "fmt"
-  "strings"
-  "testing"
+	"fmt"
+	"strings"
+	"testing"
 
-  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-  "github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-  "github.com/hashicorp/terraform-provider-google/google/acctest"
-  "github.com/hashicorp/terraform-provider-google/google/envvar"
-  "github.com/hashicorp/terraform-provider-google/google/services/apigee"
-  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
-  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(t *testing.T) {
-  acctest.SkipIfVcr(t)
-  t.Parallel()
+	acctest.SkipIfVcr(t)
+	t.Parallel()
 
-  context := map[string]interface{}{
-    "billing_account": envvar.GetTestBillingAccountFromEnv(t),
-    "org_id":          envvar.GetTestOrgFromEnv(t),
-    "random_suffix":   acctest.RandString(t, 10),
-  }
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
 
-  acctest.VcrTest(t, resource.TestCase{
-    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-    ExternalProviders: map[string]resource.ExternalProvider{
-      "time": {},
-    },
-    CheckDestroy: testAccCheckApigeeEndpointAttachmentDestroyProducer(t),
-    Steps: []resource.TestStep{
-      {
-        Config: testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context),
-      },
-      {
-        ResourceName:            "google_apigee_endpoint_attachment.apigee_endpoint_attachment",
-        ImportState:             true,
-        ImportStateVerify:       true,
-        ImportStateVerifyIgnore: []string{"endpoint_attachment_id", "org_id"},
-      },
-    },
-  })
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeEndpointAttachmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context),
+			},
+			{
+				ResourceName:            "google_apigee_endpoint_attachment.apigee_endpoint_attachment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"endpoint_attachment_id", "org_id"},
+			},
+		},
+	})
 }
 
 func testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context map[string]interface{}) string {
-  return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_project" "project" {
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
@@ -218,40 +218,40 @@ resource "google_apigee_endpoint_attachment" "apigee_endpoint_attachment" {
 }
 
 func testAccCheckApigeeEndpointAttachmentDestroyProducer(t *testing.T) func(s *terraform.State) error {
-  return func(s *terraform.State) error {
-    for name, rs := range s.RootModule().Resources {
-      if rs.Type != "google_apigee_endpoint_attachment" {
-        continue
-      }
-      if strings.HasPrefix(name, "data.") {
-        continue
-      }
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_apigee_endpoint_attachment" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
 
-      config := acctest.GoogleProviderConfig(t)
+			config := acctest.GoogleProviderConfig(t)
 
-      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"{{org_id}}/endpointAttachments/{{endpoint_attachment_id}}")
-      if err != nil {
-        return err
-      }
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"{{org_id}}/endpointAttachments/{{endpoint_attachment_id}}")
+			if err != nil {
+				return err
+			}
 
-      billingProject := ""
+			billingProject := ""
 
-      if config.BillingProject != "" {
-        billingProject = config.BillingProject
-      }
+			if config.BillingProject != "" {
+				billingProject = config.BillingProject
+			}
 
-      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-        Config:    config,
-        Method:    "GET",
-        Project:   billingProject,
-        RawURL:    url,
-        UserAgent: config.UserAgent,
-      })
-      if err == nil {
-        return fmt.Errorf("ApigeeEndpointAttachment still exists at %s", url)
-      }
-    }
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   billingProject,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				return fmt.Errorf("ApigeeEndpointAttachment still exists at %s", url)
+			}
+		}
 
-    return nil
-  }
+		return nil
+	}
 }

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_endpoint_attachment_test.go
@@ -1,52 +1,53 @@
 package apigee_test
 
 import (
-	"fmt"
-	"strings"
-	"testing"
+  "fmt"
+  "strings"
+  "testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
+  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+  "github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/services/apigee"
+  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
+  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(t *testing.T) {
-	acctest.SkipIfVcr(t)
-	t.Parallel()
+  acctest.SkipIfVcr(t)
+  t.Parallel()
 
-	context := map[string]interface{}{
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"random_suffix":   acctest.RandString(t, 10),
-	}
+  context := map[string]interface{}{
+    "billing_account": envvar.GetTestBillingAccountFromEnv(t),
+    "org_id":          envvar.GetTestOrgFromEnv(t),
+    "random_suffix":   acctest.RandString(t, 10),
+  }
 
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckApigeeEndpointAttachmentDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context),
-			},
-			{
-				ResourceName:            "google_apigee_endpoint_attachment.apigee_endpoint_attachment",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"endpoint_attachment_id", "org_id"},
-			},
-		},
-	})
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    ExternalProviders: map[string]resource.ExternalProvider{
+      "time": {},
+    },
+    CheckDestroy: testAccCheckApigeeEndpointAttachmentDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context),
+      },
+      {
+        ResourceName:            "google_apigee_endpoint_attachment.apigee_endpoint_attachment",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        ImportStateVerifyIgnore: []string{"endpoint_attachment_id", "org_id"},
+      },
+    },
+  })
 }
 
 func testAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample(context map[string]interface{}) string {
-	return acctest.Nprintf(`
+  return acctest.Nprintf(`
 resource "google_project" "project" {
   project_id      = "tf-test%{random_suffix}"
   name            = "tf-test%{random_suffix}"
@@ -217,40 +218,40 @@ resource "google_apigee_endpoint_attachment" "apigee_endpoint_attachment" {
 }
 
 func testAccCheckApigeeEndpointAttachmentDestroyProducer(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		for name, rs := range s.RootModule().Resources {
-			if rs.Type != "google_apigee_endpoint_attachment" {
-				continue
-			}
-			if strings.HasPrefix(name, "data.") {
-				continue
-			}
+  return func(s *terraform.State) error {
+    for name, rs := range s.RootModule().Resources {
+      if rs.Type != "google_apigee_endpoint_attachment" {
+        continue
+      }
+      if strings.HasPrefix(name, "data.") {
+        continue
+      }
 
-			config := acctest.GoogleProviderConfig(t)
+      config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}{{org_id}}/endpointAttachments/{{endpoint_attachment_id}}")
-			if err != nil {
-				return err
-			}
+      url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"{{org_id}}/endpointAttachments/{{endpoint_attachment_id}}")
+      if err != nil {
+        return err
+      }
 
-			billingProject := ""
+      billingProject := ""
 
-			if config.BillingProject != "" {
-				billingProject = config.BillingProject
-			}
+      if config.BillingProject != "" {
+        billingProject = config.BillingProject
+      }
 
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "GET",
-				Project:   billingProject,
-				RawURL:    url,
-				UserAgent: config.UserAgent,
-			})
-			if err == nil {
-				return fmt.Errorf("ApigeeEndpointAttachment still exists at %s", url)
-			}
-		}
+      _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config:    config,
+        Method:    "GET",
+        Project:   billingProject,
+        RawURL:    url,
+        UserAgent: config.UserAgent,
+      })
+      if err == nil {
+        return fmt.Errorf("ApigeeEndpointAttachment still exists at %s", url)
+      }
+    }
 
-		return nil
-	}
+    return nil
+  }
 }

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_api_revision_deployment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_api_revision_deployment_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -310,7 +311,7 @@ func testAccCheckApigeeEnvironmentApiRevisionDeploymentDestroyProducer(t *testin
 			config := acctest.GoogleProviderConfig(t)
 
 			url, err := tpgresource.ReplaceVarsForTest(config, rs,
-				"{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/apis/{{api}}/revisions/{{revision}}/deployments")
+				transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/apis/{{api}}/revisions/{{revision}}/deployments")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
@@ -97,7 +97,7 @@ func resourceApigeeFlowhookCreate(d *schema.ResourceData, meta interface{}) erro
 		obj["continueOnError"] = continue_on_errorProp
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func resourceApigeeFlowhookRead(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
 	if err != nil {
 		return err
 	}
@@ -191,7 +191,7 @@ func resourceApigeeFlowhookDelete(d *schema.ResourceData, meta interface{}) erro
 
 	billingProject := ""
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -153,7 +154,7 @@ func testAccCheckApigeeFlowhookDestroyProducer(t *testing.T) func(s *terraform.S
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_key_cert_file_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_key_cert_file_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -155,7 +156,7 @@ func testAccCheckApigeeKeystoresAliasesKeyCertFileDestroyProducer(t *testing.T) 
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12.go
@@ -183,7 +183,7 @@ func ResourceApigeeKeystoresAliasesPkcs12Create(d *schema.ResourceData, meta int
 	_, err = io.Copy(certFilePartWriter, file)
 	bw.Close()
 	file.Close()
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases?format=pkcs12&alias={{alias}}&ignoreExpiryValidation=true")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases?format=pkcs12&alias={{alias}}&ignoreExpiryValidation=true")
 	if err != nil {
 		return err
 	}
@@ -220,7 +220,7 @@ func ResourceApigeeKeystoresAliasesPkcs12Read(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
 	if err != nil {
 		return err
 	}
@@ -267,7 +267,7 @@ func ResourceApigeeKeystoresAliasesPkcs12Delete(d *schema.ResourceData, meta int
 
 	billingProject := ""
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/keystores/{{keystore}}/aliases/{{alias}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_keystores_aliases_pkcs12_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -146,7 +147,7 @@ func testAccCheckApigeeKeystoresAliasesPkcs12DestroyProducer(t *testing.T) func(
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}{{keystore_id}}/aliases/{{alias}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"{{keystore_id}}/aliases/{{alias}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_security_action_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -26,7 +27,7 @@ func testAccCheckApigeeSecurityActionDestroyProducer(t *testing.T) func(s *terra
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{env_id}}/securityActions/{{security_action_id}}")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -167,7 +167,7 @@ func resourceApigeeSharedFlowCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error, \"config_bundle\" must be specified")
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/sharedflows?name={{name}}&action=import")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows?name={{name}}&action=import")
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func resourceApigeeSharedFlowRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/sharedflows/{{name}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows/{{name}}")
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func resourceApigeeSharedFlowDelete(d *schema.ResourceData, meta interface{}) er
 
 	billingProject := ""
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/sharedflows/{{name}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows/{{name}}")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -70,7 +70,7 @@ func resourceApigeeSharedflowDeploymentCreate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func resourceApigeeSharedflowDeploymentRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func resourceApigeeSharedflowDeploymentUpdate(d *schema.ResourceData, meta inter
 		return err
 	}
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func resourceApigeeSharedflowDeploymentDelete(d *schema.ResourceData, meta inter
 
 	billingProject := ""
 
-	url, err := tpgresource.ReplaceVars(d, config, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
@@ -155,7 +156,7 @@ func testAccCheckApigeeSharedflowDeploymentDestroyProducer(t *testing.T) func(s 
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/apigee"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -141,7 +142,7 @@ func testAccCheckApigeeSharedFlowDestroyProducer(t *testing.T) func(s *terraform
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ApigeeBasePath}}organizations/{{org_id}}/sharedflows/{{name}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/sharedflows/{{name}}")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is an initial set of replacements of BasePath usage in handwritten files with the transport_tpg.BaseUrl function.

Note: String concatenation is used instead of URL joining because URL joining would escape `{}` characters, preventing ReplaceVars from working properly.

Options considered:

- This PR
  - Pros: compile time verification; explicit about how the base URL is calculated.
  - Cons: requires rewriting large number of handwritten files; some code duplication in that `config` has to be passed twice.
- Pass `product` to ReplaceVars and implicitly add the base URL to the beginning of the URL
  - Pros: compile time verification; doesn't require passing config twice.
  - Cons: Breaks separation of concerns; ReplaceVars would no longer just be replacing vars. There's probably some usage somewhere outside of URL building that would need to be split out. More implicit behavior.
- Automatically make ReplaceVars detect `{{ProductNameBasePath}}` variables, trim the BasePath suffix, look up the relevant product in the registry (with the lowercase `productname`), and compute its BaseUrl using the config that was also passed in.
  - Pros: ReplaceVars usage could remain unchanged - many fewer files would need to be modified. (There are about 960 uses of BasePaths in `services`, most of which are via ReplaceVars.)
  - Cons: ReplaceVars can't have compile time checks (this is also a problem today) and base URL calculation is implicit.
  - EDIT: Planning to do this as a compatibility shim to ease the migration off `config.*BasePath` fields: https://github.com/GoogleCloudPlatform/magic-modules/pull/17385

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
