### PR TITLE
`transport`: add `itemName` fallback for `transport.ListPages()`

### DIFF
--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -218,11 +218,6 @@ type ListPagesOptions struct {
 // calls Flattener to write each element into TempData, then invokes Callback for further
 // processing of each item.
 func ListPages(opt ListPagesOptions) error {
-	itemKey := opt.ItemName
-	if itemKey == "" {
-		itemKey = "items"
-	}
-
 	params := make(map[string]string)
 	if opt.Filter != "" {
 		params["filter"] = opt.Filter
@@ -250,8 +245,12 @@ func ListPages(opt ListPagesOptions) error {
 			return HandleListGoogleApiError(err, url)
 		}
 
-		if v, ok := res[itemKey].([]interface{}); ok {
-			for _, item := range v {
+		items, ok := res[opt.ItemName].([]interface{})
+		if !ok && opt.ItemName != "items" {
+			items, ok = res["items"].([]interface{})
+		}
+		if ok {
+			for _, item := range items {
 				itemMap, ok := item.(map[string]interface{})
 				if !ok {
 					return fmt.Errorf("expected item to be map[string]interface{}, got %T", item)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

I noticed that [sweeper_file.go.tmpl](https://github.com/GoogleCloudPlatform/magic-modules/blob/e52561484cc49648e3054b0d0fa9820885dac558/mmv1/templates/terraform/sweeper_file.go.tmpl#L205-L216) includes a fallback for `items`when the default list key value is used but returns `!ok`

Including this fallback makes sense in the case of `ListPages` as we would default to using `collection_url_key` in generated list resources but due to the generation not including the fallback an explicit change to `collection_url_key -> items` was often necessary

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
