### PR TITLE
Migrate resource compute instance group manager test to use transport_tpg 

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
   {{- end }}
   tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+  transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestForceNewResourcePoliciesWorkloadPolicyIfNewIsEmpty(t *testing.T) {
@@ -637,8 +638,15 @@ func testAccCheckInstanceGroupManagerDestroyProducer(t *testing.T) func(s *terra
 			if rs.Type != "google_compute_instance_group_manager" {
 				continue
 			}
-			_, err := tpgcompute.NewClient(config, config.UserAgent).InstanceGroupManagers.Get(
-				config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroupManagers/%s",
+				config.ComputeBasePath, config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+			_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   config.Project,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
 			if err == nil {
 				return fmt.Errorf("InstanceGroupManager still exists")
 			}


### PR DESCRIPTION
…_tpg

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_group_manager` resource  to use direct HTTP rather than a client library
```
