### PR TITLE
Migrate resource compute instance group test to use transport_tpg

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_test.go
@@ -3,24 +3,19 @@ package compute_test
 import (
 	"fmt"
 	"testing"
+
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func TestAccComputeInstanceGroup_basic(t *testing.T) {
 	t.Parallel()
 
-	var instanceGroup compute.InstanceGroup
+	var instanceGroup map[string]interface{}
 	var resourceName = "google_compute_instance_group.basic"
 	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	var zone = "us-central1-c"
@@ -90,7 +85,7 @@ func TestAccComputeInstanceGroup_rename(t *testing.T) {
 func TestAccComputeInstanceGroup_update(t *testing.T) {
 	t.Parallel()
 
-	var instanceGroup compute.InstanceGroup
+	var instanceGroup map[string]interface{}
 	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -131,7 +126,7 @@ func TestAccComputeInstanceGroup_update(t *testing.T) {
 func TestAccComputeInstanceGroup_outOfOrderInstances(t *testing.T) {
 	t.Parallel()
 
-	var instanceGroup compute.InstanceGroup
+	var instanceGroup map[string]interface{}
 	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -153,7 +148,7 @@ func TestAccComputeInstanceGroup_outOfOrderInstances(t *testing.T) {
 func TestAccComputeInstanceGroup_network(t *testing.T) {
 	t.Parallel()
 
-	var instanceGroup compute.InstanceGroup
+	var instanceGroup map[string]interface{}
 	var instanceName = fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -186,8 +181,15 @@ func testAccComputeInstanceGroup_destroyProducer(t *testing.T) func(s *terraform
 			if rs.Type != "google_compute_instance_group" {
 				continue
 			}
-			_, err := compute_tpg.NewClient(config, config.UserAgent).InstanceGroups.Get(
-				config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+			url := fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s",
+				config.ComputeBasePath, config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+			_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   config.Project,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
 			if err == nil {
 				return fmt.Errorf("InstanceGroup still exists")
 			}
@@ -197,7 +199,7 @@ func testAccComputeInstanceGroup_destroyProducer(t *testing.T) func(s *terraform
 	}
 }
 
-func testAccComputeInstanceGroup_exists(t *testing.T, n string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_exists(t *testing.T, n string, instanceGroup *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -210,19 +212,26 @@ func testAccComputeInstanceGroup_exists(t *testing.T, n string, instanceGroup *c
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := compute_tpg.NewClient(config, config.UserAgent).InstanceGroups.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s",
+			config.ComputeBasePath, config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		*instanceGroup = *found
+		*instanceGroup = found
 
 		return nil
 	}
 }
 
-func testAccComputeInstanceGroup_updated(t *testing.T, n string, size int64, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_updated(t *testing.T, n string, size int64, instanceGroup *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -235,23 +244,32 @@ func testAccComputeInstanceGroup_updated(t *testing.T, n string, size int64, ins
 
 		config := acctest.GoogleProviderConfig(t)
 
-		instanceGroup, err := compute_tpg.NewClient(config, config.UserAgent).InstanceGroups.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s",
+			config.ComputeBasePath, config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+		instanceGroupRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		// Cannot check the target pool as the instance creation is asynchronous.  However, can
-		// check the target_size.
-		if instanceGroup.Size != size {
-			return fmt.Errorf("instance count incorrect. saw real value %v instead of expected value %v", instanceGroup.Size, size)
+		instanceGroupSize, ok := instanceGroupRes["size"].(float64)
+		if !ok {
+			return fmt.Errorf("size field missing or wrong type in instance group response")
+		}
+		if int64(instanceGroupSize) != size {
+			return fmt.Errorf("instance count incorrect. saw real value %v instead of expected value %v", int64(instanceGroupSize), size)
 		}
 
 		return nil
 	}
 }
 
-func testAccComputeInstanceGroup_named_ports(t *testing.T, n string, np map[string]int64, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_named_ports(t *testing.T, n string, np map[string]int64, instanceGroup *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -264,17 +282,35 @@ func testAccComputeInstanceGroup_named_ports(t *testing.T, n string, np map[stri
 
 		config := acctest.GoogleProviderConfig(t)
 
-		instanceGroup, err := compute_tpg.NewClient(config, config.UserAgent).InstanceGroups.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s",
+			config.ComputeBasePath, config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+		instanceGroupRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
+		}
+
+		rawNamedPorts, ok := instanceGroupRes["namedPorts"].([]interface{})
+		if !ok {
+			return fmt.Errorf("namedPorts field missing or wrong type in instance group response")
 		}
 
 		var found bool
-		for _, namedPort := range instanceGroup.NamedPorts {
+		for _, rawPort := range rawNamedPorts {
+			namedPort, ok := rawPort.(map[string]interface{})
+			if !ok {
+				continue
+			}
 			found = false
+			portName, _ := namedPort["name"].(string)
+			portNum, _ := namedPort["port"].(float64)
 			for name, port := range np {
-				if namedPort.Name == name && namedPort.Port == port {
+				if portName == name && int64(portNum) == port {
 					found = true
 				}
 			}
@@ -287,7 +323,7 @@ func testAccComputeInstanceGroup_named_ports(t *testing.T, n string, np map[stri
 	}
 }
 
-func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup string, nNetwork string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup string, nNetwork string, instanceGroup *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 
@@ -298,8 +334,14 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 		if rsInstanceGroup.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		instanceGroup, err := compute_tpg.NewClient(config, config.UserAgent).InstanceGroups.Get(
-			config.Project, rsInstanceGroup.Primary.Attributes["zone"], rsInstanceGroup.Primary.Attributes["name"]).Do()
+		instanceGroupRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:  config,
+			Method:  "GET",
+			Project: config.Project,
+			RawURL: fmt.Sprintf("%sprojects/%s/zones/%s/instanceGroups/%s",
+				config.ComputeBasePath, config.Project, rsInstanceGroup.Primary.Attributes["zone"], rsInstanceGroup.Primary.Attributes["name"]),
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
@@ -311,14 +353,28 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 		if rsNetwork.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		network, err := compute_tpg.NewClient(config, config.UserAgent).Networks.Get(
-			config.Project, rsNetwork.Primary.Attributes["name"]).Do()
+		networkRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:  config,
+			Method:  "GET",
+			Project: config.Project,
+			RawURL: fmt.Sprintf("%sprojects/%s/global/networks/%s",
+				config.ComputeBasePath, config.Project, rsNetwork.Primary.Attributes["name"]),
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if instanceGroup.Network != network.SelfLink {
-			return fmt.Errorf("network incorrect: actual=%s vs expected=%s", instanceGroup.Network, network.SelfLink)
+		instanceGroupNetwork, ok := instanceGroupRes["network"].(string)
+		if !ok {
+			return fmt.Errorf("network field missing or wrong type in instance group response")
+		}
+		networkSelfLink, ok := networkRes["selfLink"].(string)
+		if !ok {
+			return fmt.Errorf("selfLink field missing or wrong type in network response")
+		}
+		if instanceGroupNetwork != networkSelfLink {
+			return fmt.Errorf("network incorrect: actual=%s vs expected=%s", instanceGroupNetwork, networkSelfLink)
 		}
 
 		return nil


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_group_tes` resource  to use direct HTTP rather than a client library
```
