### PR TITLE
Migrate resource_compute_instance_migrate to use transport_tpg

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_migrate.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_migrate.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"fmt"
 	"log"
+	neturl "net/url"
 	"strconv"
 	"strings"
 
@@ -10,12 +11,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceComputeInstanceMigrateState(
@@ -201,9 +196,11 @@ func migrateStateV3toV4(is *terraform.InstanceState, meta interface{}) (*terrafo
 	if err != nil {
 		return is, fmt.Errorf("migration error: %s", err)
 	}
-	allDisks := make(map[string]*compute.Disk)
+	allDisks := make(map[string]map[string]interface{})
 	for _, disk := range diskList {
-		allDisks[disk.Name] = disk
+		if name, ok := disk["name"].(string); ok {
+			allDisks[name] = disk
+		}
 	}
 
 	hasBootDisk := is.Attributes["boot_disk.#"] == "1"
@@ -242,11 +239,21 @@ func migrateStateV3toV4(is *terraform.InstanceState, meta interface{}) (*terrafo
 				return is, fmt.Errorf("migration error: found scratch disk at index 0")
 			}
 
-			for _, disk := range instance.Disks {
-				if disk.Boot {
-					is.Attributes["boot_disk.0.source"] = tpgresource.GetResourceNameFromSelfLink(disk.Source)
-					is.Attributes["boot_disk.0.device_name"] = disk.DeviceName
-					break
+			if rawDisks, ok := instance["disks"].([]interface{}); ok {
+				for _, rawDisk := range rawDisks {
+					disk, ok := rawDisk.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					if boot, ok := disk["boot"].(bool); ok && boot {
+						if source, ok := disk["source"].(string); ok {
+							is.Attributes["boot_disk.0.source"] = tpgresource.GetResourceNameFromSelfLink(source)
+						}
+						if deviceName, ok := disk["deviceName"].(string); ok {
+							is.Attributes["boot_disk.0.device_name"] = deviceName
+						}
+						break
+					}
 				}
 			}
 			is.Attributes["boot_disk.0.auto_delete"] = is.Attributes["disk.0.auto_delete"]
@@ -283,8 +290,12 @@ func migrateStateV3toV4(is *terraform.InstanceState, meta interface{}) (*terrafo
 				return is, fmt.Errorf("migration error: %s", err)
 			}
 
-			is.Attributes[fmt.Sprintf("attached_disk.%d.source", attachedDisks)] = disk.Source
-			is.Attributes[fmt.Sprintf("attached_disk.%d.device_name", attachedDisks)] = disk.DeviceName
+			if source, ok := disk["source"].(string); ok {
+				is.Attributes[fmt.Sprintf("attached_disk.%d.source", attachedDisks)] = source
+			}
+			if deviceName, ok := disk["deviceName"].(string); ok {
+				is.Attributes[fmt.Sprintf("attached_disk.%d.device_name", attachedDisks)] = deviceName
+			}
 			is.Attributes[fmt.Sprintf("attached_disk.%d.disk_encryption_key_raw", attachedDisks)] = is.Attributes[fmt.Sprintf("disk.%d.disk_encryption_key_raw", i)]
 			is.Attributes[fmt.Sprintf("attached_disk.%d.disk_encryption_key_sha256", attachedDisks)] = is.Attributes[fmt.Sprintf("disk.%d.disk_encryption_key_sha256", i)]
 
@@ -317,7 +328,7 @@ func migrateStateV4toV5(is *terraform.InstanceState, meta interface{}) (*terrafo
 	return is, nil
 }
 
-func getInstanceFromInstanceState(config *transport_tpg.Config, is *terraform.InstanceState) (*compute.Instance, error) {
+func getInstanceFromInstanceState(config *transport_tpg.Config, is *terraform.InstanceState) (map[string]interface{}, error) {
 	project, ok := is.Attributes["project"]
 	if !ok {
 		if config.Project == "" {
@@ -336,8 +347,14 @@ func getInstanceFromInstanceState(config *transport_tpg.Config, is *terraform.In
 		}
 	}
 
-	instance, err := NewClient(config, config.UserAgent).Instances.Get(
-		project, zone, is.ID).Do()
+	url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s", config.ComputeBasePath, project, zone, is.ID)
+	instance, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: config.UserAgent,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error reading instance: %s", err)
 	}
@@ -345,7 +362,7 @@ func getInstanceFromInstanceState(config *transport_tpg.Config, is *terraform.In
 	return instance, nil
 }
 
-func getAllDisksFromInstanceState(config *transport_tpg.Config, is *terraform.InstanceState) ([]*compute.Disk, error) {
+func getAllDisksFromInstanceState(config *transport_tpg.Config, is *terraform.InstanceState) ([]map[string]interface{}, error) {
 	project, ok := is.Attributes["project"]
 	if !ok {
 		if config.Project == "" {
@@ -364,15 +381,35 @@ func getAllDisksFromInstanceState(config *transport_tpg.Config, is *terraform.In
 		}
 	}
 
-	diskList := []*compute.Disk{}
+	diskList := []map[string]interface{}{}
 	token := ""
 	for {
-		disks, err := NewClient(config, config.UserAgent).Disks.List(project, zone).PageToken(token).Do()
+		params := neturl.Values{}
+		if token != "" {
+			params.Set("pageToken", token)
+		}
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/disks", config.ComputeBasePath, project, zone)
+		if len(params) > 0 {
+			url = fmt.Sprintf("%s?%s", url, params.Encode())
+		}
+		disks, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("error reading disks: %s", err)
 		}
-		diskList = append(diskList, disks.Items...)
-		token = disks.NextPageToken
+		if rawItems, ok := disks["items"].([]interface{}); ok {
+			for _, rawItem := range rawItems {
+				if disk, ok := rawItem.(map[string]interface{}); ok {
+					diskList = append(diskList, disk)
+				}
+			}
+		}
+		token, _ = disks["nextPageToken"].(string)
 		if token == "" {
 			break
 		}
@@ -381,7 +418,7 @@ func getAllDisksFromInstanceState(config *transport_tpg.Config, is *terraform.In
 	return diskList, nil
 }
 
-func getDiskFromAttributes(config *transport_tpg.Config, instance *compute.Instance, allDisks map[string]*compute.Disk, attributes map[string]string, i int) (*compute.AttachedDisk, error) {
+func getDiskFromAttributes(config *transport_tpg.Config, instance map[string]interface{}, allDisks map[string]map[string]interface{}, attributes map[string]string, i int) (map[string]interface{}, error) {
 	if diskSource := attributes[fmt.Sprintf("disk.%d.disk", i)]; diskSource != "" {
 		return getDiskFromSource(instance, diskSource)
 	}
@@ -409,52 +446,78 @@ func getDiskFromAttributes(config *transport_tpg.Config, instance *compute.Insta
 	return getDiskFromAutoDeleteAndImage(config, instance, allDisks, autoDelete, image, project, zone)
 }
 
-func getDiskFromSource(instance *compute.Instance, source string) (*compute.AttachedDisk, error) {
-	for _, disk := range instance.Disks {
-		if disk.Boot || disk.Type == "SCRATCH" {
+func getDiskFromSource(instance map[string]interface{}, source string) (map[string]interface{}, error) {
+	rawDisks, _ := instance["disks"].([]interface{})
+	for _, rawDisk := range rawDisks {
+		disk, ok := rawDisk.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		boot, _ := disk["boot"].(bool)
+		diskType, _ := disk["type"].(string)
+		if boot || diskType == "SCRATCH" {
 			// Ignore boot/scratch disks since this is just for finding attached disks
 			continue
 		}
 		// we can just compare suffixes because terraform only allows setting "disk" by name and uses
 		// the zone of the instance so we know there can be no duplicate names.
-		if strings.HasSuffix(disk.Source, "/"+source) {
+		diskSource, _ := disk["source"].(string)
+		if strings.HasSuffix(diskSource, "/"+source) {
 			return disk, nil
 		}
 	}
 	return nil, fmt.Errorf("could not find attached disk with source %q", source)
 }
 
-func getDiskFromDeviceName(instance *compute.Instance, deviceName string) (*compute.AttachedDisk, error) {
-	for _, disk := range instance.Disks {
-		if disk.Boot || disk.Type == "SCRATCH" {
+func getDiskFromDeviceName(instance map[string]interface{}, deviceName string) (map[string]interface{}, error) {
+	rawDisks, _ := instance["disks"].([]interface{})
+	for _, rawDisk := range rawDisks {
+		disk, ok := rawDisk.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		boot, _ := disk["boot"].(bool)
+		diskType, _ := disk["type"].(string)
+		if boot || diskType == "SCRATCH" {
 			// Ignore boot/scratch disks since this is just for finding attached disks
 			continue
 		}
-		if disk.DeviceName == deviceName {
+		dn, _ := disk["deviceName"].(string)
+		if dn == deviceName {
 			return disk, nil
 		}
 	}
 	return nil, fmt.Errorf("could not find attached disk with deviceName %q", deviceName)
 }
 
-func getDiskFromEncryptionKey(instance *compute.Instance, encryptionKey string) (*compute.AttachedDisk, error) {
+func getDiskFromEncryptionKey(instance map[string]interface{}, encryptionKey string) (map[string]interface{}, error) {
 	encryptionSha, err := hash256(encryptionKey)
 	if err != nil {
 		return nil, err
 	}
-	for _, disk := range instance.Disks {
-		if disk.Boot || disk.Type == "SCRATCH" {
+	rawDisks, _ := instance["disks"].([]interface{})
+	for _, rawDisk := range rawDisks {
+		disk, ok := rawDisk.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		boot, _ := disk["boot"].(bool)
+		diskType, _ := disk["type"].(string)
+		if boot || diskType == "SCRATCH" {
 			// Ignore boot/scratch disks since this is just for finding attached disks
 			continue
 		}
-		if disk.DiskEncryptionKey.Sha256 == encryptionSha {
-			return disk, nil
+		if keyMap, ok := disk["diskEncryptionKey"].(map[string]interface{}); ok {
+			sha, _ := keyMap["sha256"].(string)
+			if sha == encryptionSha {
+				return disk, nil
+			}
 		}
 	}
 	return nil, fmt.Errorf("could not find attached disk with encryption hash %q", encryptionSha)
 }
 
-func getDiskFromAutoDeleteAndImage(config *transport_tpg.Config, instance *compute.Instance, allDisks map[string]*compute.Disk, autoDelete bool, image, project, zone string) (*compute.AttachedDisk, error) {
+func getDiskFromAutoDeleteAndImage(config *transport_tpg.Config, instance map[string]interface{}, allDisks map[string]map[string]interface{}, autoDelete bool, image, project, zone string) (map[string]interface{}, error) {
 	img, err := ResolveImage(config, project, image, config.UserAgent)
 	if err != nil {
 		return nil, err
@@ -462,21 +525,34 @@ func getDiskFromAutoDeleteAndImage(config *transport_tpg.Config, instance *compu
 	imgParts := strings.Split(img, "/projects/")
 	canonicalImage := imgParts[len(imgParts)-1]
 
-	for i, disk := range instance.Disks {
-		if disk.Boot || disk.Type == "SCRATCH" {
+	rawDisks, _ := instance["disks"].([]interface{})
+	for i, rawDisk := range rawDisks {
+		disk, ok := rawDisk.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		boot, _ := disk["boot"].(bool)
+		diskType, _ := disk["type"].(string)
+		if boot || diskType == "SCRATCH" {
 			// Ignore boot/scratch disks since this is just for finding attached disks
 			continue
 		}
-		if disk.AutoDelete == autoDelete {
+		diskAutoDelete, _ := disk["autoDelete"].(bool)
+		if diskAutoDelete == autoDelete {
 			// Read the disk to check if its image matches
-			fullDisk := allDisks[tpgresource.GetResourceNameFromSelfLink(disk.Source)]
-			sourceImage, err := tpgresource.GetRelativePath(fullDisk.SourceImage)
+			diskSource, _ := disk["source"].(string)
+			fullDisk := allDisks[tpgresource.GetResourceNameFromSelfLink(diskSource)]
+			if fullDisk == nil {
+				continue
+			}
+			diskSourceImage, _ := fullDisk["sourceImage"].(string)
+			sourceImage, err := tpgresource.GetRelativePath(diskSourceImage)
 			if err != nil {
 				return nil, err
 			}
 			if canonicalImage == sourceImage {
 				// Delete this disk because there might be multiple that match
-				instance.Disks = append(instance.Disks[:i], instance.Disks[i+1:]...)
+				instance["disks"] = append(rawDisks[:i], rawDisks[i+1:]...)
 				return disk, nil
 			}
 		}
@@ -487,22 +563,35 @@ func getDiskFromAutoDeleteAndImage(config *transport_tpg.Config, instance *compu
 	// This assumes that all disks with a given family have a sourceImage whose name starts with the name of
 	// the image family.
 	canonicalImage = strings.Replace(canonicalImage, "/family/", "/", -1)
-	for i, disk := range instance.Disks {
-		if disk.Boot || disk.Type == "SCRATCH" {
+	rawDisks, _ = instance["disks"].([]interface{})
+	for i, rawDisk := range rawDisks {
+		disk, ok := rawDisk.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		boot, _ := disk["boot"].(bool)
+		diskType, _ := disk["type"].(string)
+		if boot || diskType == "SCRATCH" {
 			// Ignore boot/scratch disks since this is just for finding attached disks
 			continue
 		}
-		if disk.AutoDelete == autoDelete {
+		diskAutoDelete, _ := disk["autoDelete"].(bool)
+		if diskAutoDelete == autoDelete {
 			// Read the disk to check if its image matches
-			fullDisk := allDisks[tpgresource.GetResourceNameFromSelfLink(disk.Source)]
-			sourceImage, err := tpgresource.GetRelativePath(fullDisk.SourceImage)
+			diskSource, _ := disk["source"].(string)
+			fullDisk := allDisks[tpgresource.GetResourceNameFromSelfLink(diskSource)]
+			if fullDisk == nil {
+				continue
+			}
+			diskSourceImage, _ := fullDisk["sourceImage"].(string)
+			sourceImage, err := tpgresource.GetRelativePath(diskSourceImage)
 			if err != nil {
 				return nil, err
 			}
 
 			if strings.Contains(sourceImage, "/"+canonicalImage+"-") {
 				// Delete this disk because there might be multiple that match
-				instance.Disks = append(instance.Disks[:i], instance.Disks[i+1:]...)
+				instance["disks"] = append(rawDisks[:i], rawDisks[i+1:]...)
 				return disk, nil
 			}
 		}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_migrate` resource  to use direct HTTP rather than a client library
```
