### PR TITLE
add senario field to google_ces_evaluation resource

### DIFF
--- a/mmv1/products/ces/Evaluation.yaml
+++ b/mmv1/products/ces/Evaluation.yaml
@@ -47,6 +47,22 @@ examples:
       evaluation_id: eval-toolset
       app_id: app-id-toolset
       app_display_name: my-app-toolset
+  - name: ces_evaluation_scenario_full
+    min_version: beta
+    primary_resource_id: ces_evaluation_scenario_full
+    vars:
+      evaluation_id: eval-scenario-full
+      app_id: app-id-scenario
+      app_display_name: my-app-scenario
+      tool_id: tool-id-scenario
+  - name: ces_evaluation_scenario_toolset
+    min_version: beta
+    primary_resource_id: ces_evaluation_scenario_toolset
+    vars:
+      evaluation_id: eval-scen-ts
+      app_id: app-id-scenario-ts
+      app_display_name: my-app-scenario-ts
+      toolset_id: ts-scen
 parameters:
   - name: location
     type: String
@@ -490,5 +506,226 @@ properties:
       - name: evaluationExpectations
         type: Array
         description: "The evaluation expectations to evaluate the replayed conversation against. Format: projects/{project}/locations/{location}/apps/{app}/evaluationExpectations/{evaluationExpectation}"
+        item_type:
+          type: String
+  - name: scenario
+    type: NestedObject
+    description: Scenario input.
+    properties:
+      - name: task
+        type: String
+        description: The task to evaluate.
+        required: true
+      - name: userFacts
+        type: Array
+        description: Facts about the user as a key value pair.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: name
+              type: String
+              description: The name of the user fact.
+              required: true
+            - name: value
+              type: String
+              description: The value of the user fact.
+              required: true
+      - name: maxTurns
+        type: Integer
+        description: Max turns.
+      - name: rubrics
+        type: Array
+        description: Rubrics.
+        required: true
+        item_type:
+          type: String
+      - name: scenarioExpectations
+        type: Array
+        description: Scenario expectations.
+        required: true
+        item_type:
+          type: NestedObject
+          properties:
+            - name: toolExpectation
+              type: NestedObject
+              description: Tool expectation.
+              properties:
+                - name: expectedToolCall
+                  type: NestedObject
+                  description: Expected tool call.
+                  properties:
+                    - name: id
+                      type: String
+                      description: Optional. The unique identifier of the tool call.
+                    - name: displayName
+                      type: String
+                      description: Output only. Display name of the tool.
+                      output: true
+                    - name: args
+                      type: KeyValuePairs
+                      description: The input parameters and values for the tool in JSON object format.
+                    - name: tool
+                      type: String
+                      description: Name of the tool.
+                    - name: toolsetTool
+                      type: NestedObject
+                      description: The toolset tool.
+                      properties:
+                        - name: toolset
+                          type: String
+                          description: Required. The toolset name.
+                        - name: toolId
+                          type: String
+                          description: The tool ID.
+                - name: mockToolResponse
+                  type: NestedObject
+                  description: Mock tool response.
+                  properties:
+                    - name: id
+                      type: String
+                      description: Optional. Matching ID of the tool call.
+                    - name: displayName
+                      type: String
+                      description: Output only. Display name of the tool.
+                      output: true
+                    - name: response
+                      type: KeyValuePairs
+                      description: The tool execution result in JSON object format.
+                    - name: tool
+                      type: String
+                      description: Name of the tool to execute.
+                    - name: toolsetTool
+                      type: NestedObject
+                      description: The toolset tool that got executed.
+                      properties:
+                        - name: toolset
+                          type: String
+                          description: Required. The toolset name.
+                        - name: toolId
+                          type: String
+                          description: The tool ID.
+            - name: agentResponse
+              type: NestedObject
+              description: Agent response.
+              properties:
+                - name: role
+                  type: String
+                  description: The role within the conversation, e.g., user, agent.
+                - name: chunks
+                  type: Array
+                  description: Content of the message as a series of chunks.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: text
+                        type: String
+                        description: Text data.
+                      - name: updatedVariables
+                        type: KeyValuePairs
+                        description: Updated variables in JSON object format.
+                      - name: blob
+                        type: NestedObject
+                        description: Represents a blob input or output in the conversation.
+                        properties:
+                          - name: mimeType
+                            type: String
+                            description: The IANA standard MIME type of the source data.
+                            required: true
+                          - name: data
+                            type: String
+                            description: Raw bytes of the blob.
+                            required: true
+                      - name: image
+                        type: NestedObject
+                        description: Represents an image input or output in the conversation.
+                        properties:
+                          - name: mimeType
+                            type: String
+                            description: The IANA standard MIME type of the source data.
+                            required: true
+                          - name: data
+                            type: String
+                            description: Raw bytes of the image.
+                            required: true
+                      - name: toolCall
+                        type: NestedObject
+                        description: Request for the client or the agent to execute the specified tool.
+                        properties:
+                          - name: id
+                            type: String
+                            description: The unique identifier of the tool call.
+                          - name: displayName
+                            type: String
+                            description: Display name of the tool.
+                            output: true
+                          - name: args
+                            type: KeyValuePairs
+                            description: The input parameters and values for the tool in JSON object format.
+                          - name: tool
+                            type: String
+                            description: The resource name of the tool.
+                          - name: toolsetTool
+                            type: NestedObject
+                            description: A tool that is created from a toolset.
+                            properties:
+                              - name: toolset
+                                type: String
+                                description: The resource name of the Toolset.
+                                required: true
+                              - name: toolId
+                                type: String
+                                description: The tool ID to filter the tools to retrieve the schema for.
+                      - name: toolResponse
+                        type: NestedObject
+                        description: The execution result of a specific tool from the client or the agent.
+                        properties:
+                          - name: id
+                            type: String
+                            description: The matching ID of the tool call the response is for.
+                          - name: displayName
+                            type: String
+                            description: Display name of the tool.
+                            output: true
+                          - name: response
+                            type: KeyValuePairs
+                            description: The tool execution result in JSON object format.
+                          - name: tool
+                            type: String
+                            description: The resource name of the tool.
+                          - name: toolsetTool
+                            type: NestedObject
+                            description: A tool that is created from a toolset.
+                            properties:
+                              - name: toolset
+                                type: String
+                                description: The resource name of the Toolset.
+                                required: true
+                              - name: toolId
+                                type: String
+                                description: The tool ID to filter the tools to retrieve the schema for.
+                      - name: agentTransfer
+                        type: NestedObject
+                        description: Represents an event indicating the transfer of a conversation to a different agent.
+                        properties:
+                          - name: targetAgent
+                            type: String
+                            description: The agent to which the conversation is being transferred.
+                            required: true
+                          - name: displayName
+                            type: String
+                            description: Display name of the agent.
+                            output: true
+      - name: variableOverrides
+        type: KeyValuePairs
+        description: Variables / Session Parameters as context for the session, keyed by variable names. Members of this struct will override any default values set by the system.
+      - name: userGoalBehavior
+        type: String
+        description: User goal behavior.
+      - name: taskCompletionBehavior
+        type: String
+        description: Task completion behavior.
+      - name: evaluationExpectations
+        type: Array
+        description: Evaluation expectations.
         item_type:
           type: String

--- a/mmv1/templates/terraform/examples/ces_evaluation_scenario_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_evaluation_scenario_full.tf.tmpl
@@ -1,0 +1,114 @@
+resource "google_ces_app" "app" {
+  provider = google-beta
+  app_id = "{{index $.Vars "app_id"}}"
+  location = "us"
+  display_name = "{{index $.Vars "app_display_name"}}"
+
+  language_settings {
+    default_language_code    = "en-US"
+  }
+  time_zone_settings {
+    time_zone = "America/Los_Angeles"
+  }
+}
+
+resource "google_ces_tool" "tool" {
+  provider = google-beta
+  location       = "us"
+  app            = google_ces_app.app.app_id
+  tool_id        = "{{index $.Vars "tool_id"}}"
+  execution_type = "SYNCHRONOUS"
+  python_function {
+      name = "example_function"
+      python_code = "def example_function() -> int: return 0"
+  }
+}
+
+resource "google_ces_evaluation" "ces_evaluation_scenario_full" {
+  provider = google-beta
+  evaluation_id = "{{index $.Vars "evaluation_id"}}"
+  display_name = "my-evaluation-scenario-full"
+  location     = "us"
+  app          = google_ces_app.app.app_id
+  description  = "Full evaluation for testing scenario"
+  tags         = ["test", "full", "scenario"]
+
+  scenario {
+    task = "Test task"
+    max_turns = 5
+    rubrics = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/rubrics/dummy-rubric"]
+    user_goal_behavior = "USER_GOAL_SATISFIED"
+    task_completion_behavior = "TASK_SATISFIED"
+    variable_overrides = {
+      key = "value"
+    }
+    evaluation_expectations = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/evaluationExpectations/dummy-exp"]
+
+    user_facts {
+      name = "user_name"
+      value = "John Doe"
+    }
+
+    scenario_expectations {
+      tool_expectation {
+        expected_tool_call {
+          id = "tool-call-id"
+          tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+          args = {
+            param = "value"
+          }
+        }
+        mock_tool_response {
+          id = "tool-call-id"
+          response = { result = "mocked" }
+          tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+        }
+      }
+    }
+
+    scenario_expectations {
+      agent_response {
+        role = "agent"
+        chunks {
+          text = "Hello"
+        }
+        chunks {
+          updated_variables = { "key": "value" }
+        }
+        chunks {
+          blob {
+            mime_type = "text/plain"
+            data = "c29tZSBibG9iIGRhdGE="
+          }
+        }
+        chunks {
+          image {
+            mime_type = "image/png"
+            data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+          }
+        }
+        chunks {
+          tool_call {
+            id = "tool-call-id-3"
+            tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+            args = {
+              param = "value"
+            }
+          }
+        }
+        chunks {
+          tool_response {
+            id = "tool-call-id-3"
+            response = { result = "success" }
+            tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+          }
+        }
+        chunks {
+          agent_transfer {
+            target_agent = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/agents/dummy-agent"
+          }
+        }
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/ces_evaluation_scenario_toolset.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_evaluation_scenario_toolset.tf.tmpl
@@ -1,0 +1,118 @@
+resource "google_ces_app" "app" {
+  provider = google-beta
+  app_id = "{{index $.Vars "app_id"}}"
+  location = "us"
+  display_name = "{{index $.Vars "app_display_name"}}"
+
+  language_settings {
+    default_language_code    = "en-US"
+  }
+  time_zone_settings {
+    time_zone = "America/Los_Angeles"
+  }
+}
+
+resource "google_ces_toolset" "toolset" {
+  provider = google-beta
+  toolset_id = "{{index $.Vars "toolset_id"}}"
+  location = "us"
+  app      = google_ces_app.app.app_id
+  display_name = "Basic toolset display name"
+  description = "Test description"
+  execution_type = "SYNCHRONOUS"
+
+  open_api_toolset {
+    open_api_schema = <<-EOT
+      openapi: 3.0.0
+      info:
+        title: My Sample API
+        version: 1.0.0
+        description: A simple API example
+      servers:
+        - url: https://api.example.com/v1
+      paths: {}
+    EOT
+    ignore_unknown_fields = false
+  }
+}
+
+resource "google_ces_evaluation" "ces_evaluation_scenario_toolset" {
+  provider = google-beta
+  evaluation_id = "{{index $.Vars "evaluation_id"}}"
+  display_name = "my-evaluation-scenario-toolset"
+  location     = "us"
+  app          = google_ces_app.app.app_id
+  description  = "Full evaluation for testing scenario with toolset"
+  tags         = ["test", "full", "scenario", "toolset"]
+
+  scenario {
+    task = "Test task"
+    max_turns = 5
+    rubrics = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/rubrics/dummy-rubric"]
+    user_goal_behavior = "USER_GOAL_SATISFIED"
+    task_completion_behavior = "TASK_SATISFIED"
+    variable_overrides = {
+      key = "value"
+    }
+    evaluation_expectations = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/evaluationExpectations/dummy-exp"]
+
+    user_facts {
+      name = "user_name"
+      value = "John Doe"
+    }
+
+    scenario_expectations {
+      tool_expectation {
+        expected_tool_call {
+          id = "tool-call-id"
+          toolset_tool {
+            toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+            tool_id = "dummy-tool"
+          }
+          args = {
+            param = "value"
+          }
+        }
+        mock_tool_response {
+          id = "tool-call-id"
+          response = { result = "mocked" }
+          toolset_tool {
+            toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+            tool_id = "dummy-tool"
+          }
+        }
+      }
+    }
+
+    scenario_expectations {
+      agent_response {
+        role = "agent"
+        chunks {
+          text = "Hello"
+        }
+        chunks {
+          tool_call {
+            id = "tool-call-id-3"
+            toolset_tool {
+              toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+              tool_id = "dummy-tool"
+            }
+            args = {
+              param = "value"
+            }
+          }
+        }
+        chunks {
+          tool_response {
+            id = "tool-call-id-3"
+            response = { result = "success" }
+            toolset_tool {
+              toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+              tool_id = "dummy-tool"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/ces/resource_ces_evaluation_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/ces/resource_ces_evaluation_test.go.tmpl
@@ -489,6 +489,313 @@ resource "google_ces_evaluation" "ces_evaluation_toolset" {
 }
 `, context)
 }
+
+
+func TestAccCESEvaluation_scenario_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"app_display_name": "tf-test-my-app-scenario-update" + randomSuffix,
+		"app_id":           "tf-test-app-scenario-" + randomSuffix,
+		"evaluation_id":    "tf-test-eval-scenario-" + randomSuffix,
+		"tool_id":          "tf-test-tool-id-scenario" + randomSuffix,
+		"tool_update_id":   "tf-test-tool-upd-" + randomSuffix,
+		"random_suffix":    randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckCESEvaluationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESEvaluation_cesEvaluationScenarioFullExample(context),
+			},
+			{
+				ResourceName:            "google_ces_evaluation.ces_evaluation_scenario_full",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "evaluation_id", "location"},
+			},
+			{
+				Config: testAccCESEvaluation_cesEvaluationScenarioUpdateFields(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_evaluation.ces_evaluation_scenario_full", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_evaluation.ces_evaluation_scenario_full",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "evaluation_id", "location"},
+			},
+		},
+	})
+}
+
+func TestAccCESEvaluation_scenario_toolset_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"app_display_name": "tf-test-my-app-scen-ts-upd" + randomSuffix,
+		"app_id":           "tf-test-app-scen-ts-" + randomSuffix,
+		"evaluation_id":    "tf-test-eval-scen-ts-" + randomSuffix,
+		"toolset_id":       "tf-test-ts-scen-" + randomSuffix,
+		"toolset_update_id": "tf-test-ts-scen-upd-" + randomSuffix,
+		"random_suffix":    randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckCESEvaluationDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESEvaluation_cesEvaluationScenarioToolsetExample(context),
+			},
+			{
+				ResourceName:            "google_ces_evaluation.ces_evaluation_scenario_toolset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "evaluation_id", "location"},
+			},
+			{
+				Config: testAccCESEvaluation_cesEvaluationScenarioToolsetUpdateFields(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_evaluation.ces_evaluation_scenario_toolset", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_evaluation.ces_evaluation_scenario_toolset",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "evaluation_id", "location"},
+			},
+		},
+	})
+}
+
+func testAccCESEvaluation_cesEvaluationScenarioUpdateFields(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "app" {
+  provider = google-beta
+  app_id = "%{app_id}"
+  location = "us"
+  display_name = "%{app_display_name}"
+
+  language_settings {
+    default_language_code    = "en-US"
+  }
+  time_zone_settings {
+    time_zone = "America/Los_Angeles"
+  }
+}
+
+resource "google_ces_tool" "tool" {
+  provider = google-beta
+  location       = "us"
+  app            = google_ces_app.app.app_id
+  tool_id        = "%{tool_update_id}"
+  execution_type = "SYNCHRONOUS"
+  python_function {
+    name = "example_function"
+    python_code = "def example_function() -> int: return 0"
+  }
+}
+
+resource "google_ces_evaluation" "ces_evaluation_scenario_full" {
+  provider = google-beta
+  evaluation_id = "%{evaluation_id}"
+  display_name = "my-evaluation-scenario-updated"
+  location     = "us"
+  app          = google_ces_app.app.app_id
+  description  = "Updated evaluation for testing scenario"
+  tags         = ["test", "updated", "scenario"]
+
+  scenario {
+    task = "Updated Test task"
+    max_turns = 10
+    rubrics = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/rubrics/dummy-rubric-updated"]
+    user_goal_behavior = "USER_GOAL_REJECTED"
+    task_completion_behavior = "TASK_REJECTED"
+    variable_overrides = {
+      key = "updated_value"
+    }
+    evaluation_expectations = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/evaluationExpectations/dummy-exp-updated"]
+
+    user_facts {
+      name = "user_name"
+      value = "Jane Doe"
+    }
+    user_facts {
+      name = "user_role"
+      value = "admin"
+    }
+
+    scenario_expectations {
+      tool_expectation {
+        expected_tool_call {
+          id = "tool-call-id-updated"
+          tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+          args = {
+            param = "updated_value"
+          }
+        }
+        mock_tool_response {
+          id = "tool-call-id-updated"
+          response = { result = "mocked_updated" }
+          tool = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/tools/${google_ces_tool.tool.tool_id}"
+        }
+      }
+    }
+
+    scenario_expectations {
+      agent_response {
+        role = "agent"
+        chunks {
+          text = "Hello Updated"
+        }
+        chunks {
+          updated_variables = { "key": "updated_value" }
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccCESEvaluation_cesEvaluationScenarioToolsetUpdateFields(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "app" {
+  provider = google-beta
+  app_id = "%{app_id}"
+  location = "us"
+  display_name = "%{app_display_name}"
+
+  language_settings {
+    default_language_code    = "en-US"
+  }
+  time_zone_settings {
+    time_zone = "America/Los_Angeles"
+  }
+}
+
+resource "google_ces_toolset" "toolset" {
+  provider = google-beta
+  toolset_id = "%{toolset_update_id}"
+  location = "us"
+  app      = google_ces_app.app.app_id
+  display_name = "Basic toolset display name updated"
+  description = "Test description updated"
+  execution_type = "SYNCHRONOUS"
+
+  open_api_toolset {
+    open_api_schema = <<-EOT
+      openapi: 3.0.0
+      info:
+        title: My Sample API Updated
+        version: 1.1.0
+        description: A simple API example updated
+      servers:
+        - url: https://api.example.com/v2
+      paths: {}
+    EOT
+    ignore_unknown_fields = true
+  }
+}
+
+resource "google_ces_evaluation" "ces_evaluation_scenario_toolset" {
+  provider = google-beta
+  evaluation_id = "%{evaluation_id}"
+  display_name = "my-evaluation-scenario-toolset-updated"
+  location     = "us"
+  app          = google_ces_app.app.app_id
+  description  = "Full evaluation for testing scenario with toolset updated"
+  tags         = ["test", "updated", "scenario", "toolset"]
+
+  scenario {
+    task = "Updated Test task"
+    max_turns = 10
+    rubrics = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/rubrics/dummy-rubric-updated"]
+    user_goal_behavior = "USER_GOAL_REJECTED"
+    task_completion_behavior = "TASK_REJECTED"
+    variable_overrides = {
+      key = "updated_value"
+    }
+    evaluation_expectations = ["projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/evaluationExpectations/dummy-exp-updated"]
+
+    user_facts {
+      name = "user_name"
+      value = "Jane Doe"
+    }
+
+    scenario_expectations {
+      tool_expectation {
+        expected_tool_call {
+          id = "tool-call-id-updated"
+          toolset_tool {
+            toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+            tool_id = "dummy-tool-updated"
+          }
+          args = {
+            param = "updated_value"
+          }
+        }
+        mock_tool_response {
+          id = "tool-call-id-updated"
+          response = { result = "mocked_updated" }
+          toolset_tool {
+            toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+            tool_id = "dummy-tool-updated"
+          }
+        }
+      }
+    }
+
+    scenario_expectations {
+      agent_response {
+        role = "agent"
+        chunks {
+          text = "Hello Updated"
+        }
+        chunks {
+          tool_call {
+            id = "tool-call-id-3-updated"
+            toolset_tool {
+              toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+              tool_id = "dummy-tool-updated"
+            }
+            args = {
+              param = "updated_value"
+            }
+          }
+        }
+        chunks {
+          tool_response {
+            id = "tool-call-id-3-updated"
+            response = { result = "success_updated" }
+            toolset_tool {
+              toolset = "projects/${google_ces_app.app.project}/locations/us/apps/${google_ces_app.app.app_id}/toolsets/${google_ces_toolset.toolset.toolset_id}"
+              tool_id = "dummy-tool-updated"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, context)
+}
+
 {{ else }}
 // TestAccCESEvaluation_update is not available in GA
 {{ end }}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
part of https://github.com/hashicorp/terraform-provider-google/issues/26230

API: https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/rest/v1beta/projects.locations.apps.evaluations

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
ces: added `scenario` field to `google_ces_evaluation` resource (beta)
```
