### PR TITLE
feat(networkservices): Add forwardAttributes to service extensions

### DIFF
--- a/mmv1/products/networkservices/AuthzExtension.yaml
+++ b/mmv1/products/networkservices/AuthzExtension.yaml
@@ -150,6 +150,40 @@ properties:
       The metadata provided here is included as part of the metadata_context (of type google.protobuf.Struct) in the ProcessingRequest message sent to the extension server. The metadata is available under the namespace com.google.authz_extension.<resourceName>. The following variables are supported in the metadata Struct:
 
       {forwarding_rule_id} - substituted with the forwarding rule's fully qualified resource name.
+  - name: 'forwardAttributes'
+    type: Array
+    description: |
+      List of request and connection attributes to forward to the extension. You can (only) specify this
+      property for plugin and callout extensions.
+      Further information can be found at https://docs.cloud.google.com/service-extensions/docs/attributes.
+    item_type:
+      type: Enum
+      description: Request or connection attribute to forward that are applicable to authorization extensions
+      enum_values:
+        - 'connection.client_cert_chain'
+        - 'connection.client_cert_chain_verified'
+        - 'connection.client_cert_dnsname_sans'
+        - 'connection.client_cert_error'
+        - 'connection.client_cert_issuer_dn'
+        - 'connection.client_cert_leaf'
+        - 'connection.client_cert_present'
+        - 'connection.client_cert_serial_number'
+        - 'connection.client_cert_spiffe_id'
+        - 'connection.client_cert_subject_dn'
+        - 'connection.client_cert_uri_sans'
+        - 'connection.client_cert_valid_not_after'
+        - 'connection.client_cert_valid_not_before'
+        - 'connection.sha256_peer_certificate_digest'
+        - 'connection.sni'
+        - 'request.backend_service_name'
+        - 'request.backend_service_project_number'
+        - 'request.host'
+        - 'request.mcp_method'
+        - 'request.mcp_param'
+        - 'request.method'
+        - 'request.path'
+        - 'request.query'
+        - 'request.scheme'
   - name: 'forwardHeaders'
     type: Array
     description: |

--- a/mmv1/products/networkservices/LbEdgeExtension.yaml
+++ b/mmv1/products/networkservices/LbEdgeExtension.yaml
@@ -161,6 +161,31 @@ properties:
                 item_type:
                   type: String
                 min_size: 1
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of request and connection attributes to forward to the extension. You can (only) specify this
+                  property for plugin and callout extensions.
+                  Further information can be found at https://docs.cloud.google.com/service-extensions/docs/attributes.
+                item_type:
+                  type: Enum
+                  description: Request or connection attribute to forward that are applicable to edge extensions
+                  enum_values:
+                    - 'connection.sha256_peer_certificate_digest'
+                    - 'connection.sni'
+                    - 'connection.tls_ja4_fingerprint'
+                    - 'connection.tls_version'
+                    - 'request.host'
+                    - 'request.method'
+                    - 'request.path'
+                    - 'request.query'
+                    - 'request.scheme'
+                    - 'source.client_city'
+                    - 'source.client_city_lat_long'
+                    - 'source.client_region'
+                    - 'source.client_region_subdivision'
+                    - 'source.ip'
+                    - 'source.port'
               - name: 'forwardHeaders'
                 type: Array
                 description: |

--- a/mmv1/products/networkservices/LbRouteExtension.yaml
+++ b/mmv1/products/networkservices/LbRouteExtension.yaml
@@ -201,6 +201,23 @@ properties:
                    When set to FALSE: * If response headers have not been delivered to the downstream client,
                    a generic 500 error is returned to the client. The error response can be tailored by
                    configuring a custom error response in the load balancer.
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of request and connection attributes to forward to the extension. You can (only) specify this
+                  property for plugin and callout extensions.
+                  Further information can be found at https://docs.cloud.google.com/service-extensions/docs/attributes.
+                item_type:
+                  type: Enum
+                  description: Request or connection attribute to forward that are applicable to route extensions
+                  enum_values:
+                    - 'request.host'
+                    - 'request.method'
+                    - 'request.path'
+                    - 'request.query'
+                    - 'request.scheme'
+                    - 'source.ip'
+                    - 'source.port'
               - name: 'forwardHeaders'
                 type: Array
                 description: |

--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -173,6 +173,50 @@ properties:
                    When set to FALSE: * If response headers have not been delivered to the downstream client,
                    a generic 500 error is returned to the client. The error response can be tailored by
                    configuring a custom error response in the load balancer.
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of request and connection attributes to forward to the extension. You can (only) specify this
+                  property for plugin and callout extensions.
+                  Further information can be found at https://docs.cloud.google.com/service-extensions/docs/attributes.
+                item_type:
+                  type: Enum
+                  description: Request or connection attribute to forward that are applicable to traffic extensions
+                  enum_values:
+                    - 'connection.client_cert_chain'
+                    - 'connection.client_cert_chain_verified'
+                    - 'connection.client_cert_dnsname_sans'
+                    - 'connection.client_cert_error'
+                    - 'connection.client_cert_issuer_dn'
+                    - 'connection.client_cert_leaf'
+                    - 'connection.client_cert_present'
+                    - 'connection.client_cert_serial_number'
+                    - 'connection.client_cert_spiffe_id'
+                    - 'connection.client_cert_subject_dn'
+                    - 'connection.client_cert_uri_sans'
+                    - 'connection.client_cert_valid_not_after'
+                    - 'connection.client_cert_valid_not_before'
+                    - 'connection.client_encrypted'
+                    - 'connection.protocol'
+                    - 'connection.sha256_peer_certificate_digest'
+                    - 'connection.sni'
+                    - 'connection.tls_cipher_suite'
+                    - 'connection.tls_ja3_fingerprint'
+                    - 'connection.tls_ja4_fingerprint'
+                    - 'connection.tls_version'
+                    - 'destination.ip'
+                    - 'destination.port'
+                    - 'request.backend_service_name'
+                    - 'request.backend_service_project_number'
+                    - 'request.host'
+                    - 'request.method'
+                    - 'request.origin'
+                    - 'request.path'
+                    - 'request.query'
+                    - 'request.scheme'
+                    - 'source.client_region'
+                    - 'source.ip'
+                    - 'source.port'
               - name: 'forwardHeaders'
                 type: Array
                 description: |

--- a/mmv1/templates/terraform/examples/network_services_authz_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_authz_extension_basic.tf.tmpl
@@ -19,5 +19,6 @@ resource "google_network_services_authz_extension" "{{$.PrimaryResourceId}}" {
   service               = google_compute_region_backend_service.default.self_link
   timeout               = "0.1s"
   fail_open             = false
+  forward_attributes    = ["connection.client_cert_chain"]
   forward_headers       = ["Authorization"]
 }

--- a/mmv1/templates/terraform/examples/network_services_lb_route_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_route_extension_basic.tf.tmpl
@@ -209,11 +209,12 @@ resource "google_network_services_lb_route_extension" "{{$.PrimaryResourceId}}" 
         timeout   = "0.1s"
         fail_open = false
 
-        forward_headers  = ["custom-header"]
+        forward_attributes = ["source.ip", "source.port"]
+        forward_headers    = ["custom-header"]
 
-        supported_events = ["REQUEST_HEADERS", "REQUEST_BODY", "REQUEST_TRAILERS"]
+        supported_events       = ["REQUEST_HEADERS", "REQUEST_BODY", "REQUEST_TRAILERS"]
         request_body_send_mode = "BODY_SEND_MODE_FULL_DUPLEX_STREAMED"
-        metadata = {
+        metadata               = {
             "key" = "value"
         }
     }

--- a/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
@@ -200,9 +200,10 @@ resource "google_network_services_lb_traffic_extension" "{{$.PrimaryResourceId}}
           timeout   = "0.1s"
           fail_open = false
 
-          supported_events = ["REQUEST_HEADERS"]
-          forward_headers = ["custom-header"]
-          metadata = {
+          supported_events   = ["REQUEST_HEADERS"]
+          forward_attributes = ["source.ip", "source.port"]
+          forward_headers    = ["custom-header"]
+          metadata           = {
             "key1" = "value1"
             "key2" = "value2"
           }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_authz_extension_test.go
@@ -161,6 +161,7 @@ resource "google_network_services_authz_extension" "default" {
   service               = google_compute_region_backend_service.default.self_link
   timeout               = "0.1s"
   fail_open             = false
+  forward_attributes    = ["connection.client_cert_chain"]
   forward_headers       = ["Authorization"]
 }
 `, context)
@@ -280,6 +281,7 @@ resource "google_network_services_authz_extension" "default" {
   service               = google_compute_region_backend_service.updated.self_link
   timeout               = "0.1s"
   fail_open             = false
+  forward_attributes    = ["connection.client_cert_chain", "connection.sni"]
   forward_headers       = ["Authorization"]
 
   metadata = {

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_route_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_route_extension_test.go
@@ -260,7 +260,8 @@ resource "google_network_services_lb_route_extension" "default" {
       timeout   = "0.1s"
       fail_open = false
 
-      forward_headers  = ["custom-header"]
+      forward_attributes = ["request.host"]
+      forward_headers    = ["custom-header"]
     }
   }
 
@@ -622,6 +623,8 @@ resource "google_network_services_lb_route_extension" "default" {
       timeout   = "0.2s"
       fail_open = false
 
+      # Omitting "forward_attributes" to clear the value 
+      # forward_attributes = []
       forward_headers  = ["custom-header"]
     }
   }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_traffic_extension_test.go
@@ -249,9 +249,10 @@ resource "google_network_services_lb_traffic_extension" "default" {
       timeout   = "0.1s"
       fail_open = false
 
-      supported_events = ["REQUEST_HEADERS"]
-      forward_headers  = ["custom-header"]
-      metadata = {
+      supported_events   = ["REQUEST_HEADERS"]
+      forward_attributes = []
+      forward_headers    = ["custom-header"]
+      metadata           = {
         "exampleId" = "test"
       }
     }
@@ -568,9 +569,10 @@ resource "google_network_services_lb_traffic_extension" "default" {
       timeout   = "0.1s"
       fail_open = false
 
-      supported_events = ["REQUEST_HEADERS"]
-      forward_headers = ["custom-header"]
-      metadata = {
+      supported_events   = ["REQUEST_HEADERS"]
+      forward_attributes = ["source.ip", "source.port"]
+      forward_headers    = ["custom-header"]
+      metadata           = {
         "exampleId" = "test"
       }
     }


### PR DESCRIPTION
On 2026-04-10 it was announced (https://docs.cloud.google.com/release-notes#April_10_2026) that "forward attributes" have been made available to load balancer service extensions.

> **Service Extensions**
>
> Feature
>
> When configuring extensions by using plugins or callouts, you can specify some request and connection attributes to forward to backend services. For more information, see (supported attributes).

It is documented at https://docs.cloud.google.com/service-extensions/docs/attributes, and I can see it is available in the UI/console of GCP. However, the Terraform provider does not support it. I am new to GCP, and was wondering in general how product/service features are implemented and converging across different tools

I opened https://issuetracker.google.com/issues/508285995 earlier today because the docs that I mentioned before suggested that `gcloud` would be the way to use the `forwardAttributes`. I am not 100% clear if this "Magic Module" change would solve the `gcloud` issue as well (I hope this would be the single source of truth for both Terraform as well as the `gcloud` client).

Happy if someone can give me pointers if I'm missing something here. Please bear with me, as everything here is new to me.

```release-note:enhancement
networkservices: added `forwardAttributes` field to `authz_extension`, `lb_edge_extension`, `lb_route_extension` and `lb_traffic_extension` resources
```
