### PR TITLE
fix(sql): resolve permadiff for connection_pool_config when pooling disabled

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -3066,7 +3066,10 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["database_flags"] = flattenDatabaseFlags(settings.DatabaseFlags)
 	}
 
-	if settings.ConnectionPoolConfig != nil {
+	// Always flatten connection_pool_config when the user has configured it, even
+	// if the API returns nil (which happens when connection_pooling_enabled = false).
+	// This prevents a perpetual diff where Terraform wants to re-add the block.
+	if settings.ConnectionPoolConfig != nil || len(d.Get("settings.0.connection_pool_config").(*schema.Set).List()) > 0 {
 		data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
 	}
 

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -3066,10 +3066,10 @@ func flattenSettings(settings *sqladmin.Settings, iType string, d *schema.Resour
 		data["database_flags"] = flattenDatabaseFlags(settings.DatabaseFlags)
 	}
 
-	// Always flatten connection_pool_config when the user has configured it, even
-	// if the API returns nil (which happens when connection_pooling_enabled = false).
-	// This prevents a perpetual diff where Terraform wants to re-add the block.
-	if settings.ConnectionPoolConfig != nil || len(d.Get("settings.0.connection_pool_config").(*schema.Set).List()) > 0 {
+	// When connection_pooling_enabled=false the API returns nil for ConnectionPoolConfig.
+	// We still need to flatten if the user has configured the block to avoid a permadiff.
+	poolConfigSet, _ := d.Get("settings.0.connection_pool_config").(*schema.Set)
+	if settings.ConnectionPoolConfig != nil || (poolConfigSet != nil && poolConfigSet.Len() > 0) {
 		data["connection_pool_config"] = flattenConnectionPoolConfig(settings.ConnectionPoolConfig)
 	}
 


### PR DESCRIPTION
### Description

When `connection_pooling_enabled` is set to `false` in a `google_sql_database_instance` resource, the Cloud SQL Admin API returns `nil` for `ConnectionPoolConfig`. The `flattenSettings` function previously only called `flattenConnectionPoolConfig` when the API response was non-nil, causing Terraform to detect a diff on every plan and attempt to re-add the block.

This change calls `flattenConnectionPoolConfig` whenever the user has configured the `connection_pool_config` block in their HCL, even if the API returns nil. The flatten function already handles nil input gracefully by returning a default struct with `connection_pooling_enabled = false`.

Also fixes a panic caused by an unsafe type assertion on `d.Get("settings.0.connection_pool_config")` during import/new resource creation when the settings path does not yet exist in state.

### Bug

Fixes hashicorp/terraform-provider-google#27186

### Steps to reproduce

1. Create a `google_sql_database_instance` with:
```hcl
settings {
  connection_pool_config {
    connection_pooling_enabled = false
  }
}
```
2. Run `terraform apply`
3. Run `terraform plan` again — it shows a perpetual diff wanting to re-add the block

### Expected behavior

`terraform plan` shows no changes after the initial apply.

### File changed

`mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl`

```release-note:bug
google_sql_database_instance: fixed permadiff on `connection_pool_config` when `connection_pooling_enabled` is set to `false`
```