### PR TITLE
fix(compute): prevent panic in google_compute_service_attachment target_service expansion

### DIFF
--- a/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
@@ -1,8 +1,7 @@
 func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
-	resource := strings.Split(v.(string), "/")
-	if len(resource) < 4 {
-		return nil, fmt.Errorf("invalid value for target_service")
-	}
-
+	// Accept both full self_link URLs and short resource names.
+	// The DiffSuppressFunc (CompareSelfLinkOrResourceName) already handles
+	// comparing self_links with names, so we pass the value through and let
+	// the API validate it. This avoids panics and confusing errors when users
+	// reference resources by name (e.g. google_network_services_gateway.*.name).
 	return v, nil
-}

--- a/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl
@@ -5,3 +5,4 @@ func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.T
 	// the API validate it. This avoids panics and confusing errors when users
 	// reference resources by name (e.g. google_network_services_gateway.*.name).
 	return v, nil
+}


### PR DESCRIPTION
### Description

The custom expand function for `target_service` in `google_compute_service_attachment` previously split the input by "/" and required at least 4 segments, returning an error for short resource names. Users referencing resources by name (e.g. `google_network_services_gateway.*.name`) hit confusing "invalid value for target_service" errors.

Since the DiffSuppressFunc (`CompareSelfLinkOrResourceName`) already handles comparing self_links with names, and the API validates the value, we can simply pass the value through.

### Bug

Fixes hashicorp/terraform-provider-google#22206

### File changed

`mmv1/templates/terraform/custom_expand/service_attachment_target_service.go.tmpl`

```release-note:bug
google_compute_service_attachment: fixed panic when expanding `target_service` for short resource names
```