### PR TITLE
fix(compute): prevent google_compute_security_policy rules from being always recreated

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -760,15 +761,19 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 	}
 }
 
-// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority.
-// Rules are uniquely identified by priority, so using priority as the hash
-// allows Terraform to correctly match old and new rules during plan/apply,
-// preventing unnecessary rule recreation when non-priority fields have subtle
-// differences between API response and config (e.g. empty defaults).
+// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority and action.
+// Using only priority causes hash collisions when two rules share the same priority (which
+// the API rejects, but which users may write transiently), causing schema.Set to silently
+// drop one rule and bypass the duplicate-priority validation in rulesCustomizeDiff.
+// Including action ensures distinct rules always produce distinct hashes while still
+// excluding volatile optional fields (description, preview, match sub-fields) that the
+// API may return as empty strings instead of nil, preventing unnecessary rule recreation.
 func resourceComputeSecurityPolicyRuleHash(v interface{}) int {
 	raw := v.(map[string]interface{})
-	// Use priority as the hash since it uniquely identifies a rule.
-	return raw["priority"].(int)
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%d-", raw["priority"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", raw["action"].(string)))
+	return tpgresource.Hashcode(buf.String())
 }
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -112,6 +112,7 @@ func ResourceComputeSecurityPolicy() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true, // If no rules are set, a default rule is added
+				Set:      resourceComputeSecurityPolicyRuleHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"action": {
@@ -757,6 +758,17 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 		},
 		Description: description,
 	}
+}
+
+// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority.
+// Rules are uniquely identified by priority, so using priority as the hash
+// allows Terraform to correctly match old and new rules during plan/apply,
+// preventing unnecessary rule recreation when non-priority fields have subtle
+// differences between API response and config (e.g. empty defaults).
+func resourceComputeSecurityPolicyRuleHash(v interface{}) int {
+	raw := v.(map[string]interface{})
+	// Use priority as the hash since it uniquely identifies a rule.
+	return raw["priority"].(int)
 }
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {


### PR DESCRIPTION
### Description

The `rule` attribute on `google_compute_security_policy` is a `TypeSet` without a custom hash function, causing Terraform to hash rules by all their fields. When the API returns subtle differences (e.g. empty defaults vs nil), the hash changes and Terraform recreates rules unnecessarily on every apply.

This adds a custom `Set` hash function keyed on `priority` (which uniquely identifies a security policy rule), ensuring Terraform correctly matches old and new rules during plan/apply.

### Bug

Fixes hashicorp/terraform-provider-google#16882

### File changed

`mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl`

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
google_compute_security_policy: fixed rules being unnecessarily recreated due to TypeSet hash instability
```