### PR TITLE
fix(monitoring): resolve perpetual diffs in google_monitoring_dashboard

### DIFF
--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go
@@ -43,6 +43,57 @@ func removeComputedKeys(old map[string]interface{}, new map[string]interface{}) 
 	return old
 }
 
+// removeEmptyConfigEntries removes keys from the config (new) that have empty
+// values (empty arrays, empty maps, empty strings) when the corresponding key
+// does not exist in the API response (old). This prevents perma-diffs when the
+// user's config includes empty values that the API naturally omits.
+func removeEmptyConfigEntries(old map[string]interface{}, new map[string]interface{}) map[string]interface{} {
+	for k, v := range new {
+		if old[k] == nil {
+			rv := reflect.ValueOf(v)
+			switch rv.Kind() {
+			case reflect.Slice:
+				if rv.Len() == 0 {
+					delete(new, k)
+				}
+			case reflect.Map:
+				if rv.Len() == 0 {
+					delete(new, k)
+				}
+			case reflect.String:
+				if rv.Len() == 0 {
+					delete(new, k)
+				}
+			}
+			continue
+		}
+
+		if reflect.ValueOf(v).Kind() == reflect.Map {
+			if oldVal, ok := old[k].(map[string]interface{}); ok {
+				new[k] = removeEmptyConfigEntries(oldVal, v.(map[string]interface{}))
+			}
+			continue
+		}
+
+		if reflect.ValueOf(v).Kind() == reflect.Slice {
+			oldSlice, oldOk := old[k].([]interface{})
+			newSlice := v.([]interface{})
+			if oldOk {
+				for i, j := range newSlice {
+					if reflect.ValueOf(j).Kind() == reflect.Map && len(oldSlice) > i {
+						if oldEntry, ok := oldSlice[i].(map[string]interface{}); ok {
+							newSlice[i] = removeEmptyConfigEntries(oldEntry, j.(map[string]interface{}))
+						}
+					}
+				}
+			}
+			continue
+		}
+	}
+
+	return new
+}
+
 func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	oldMap, err := structure.ExpandJsonFromString(old)
 	if err != nil {
@@ -54,6 +105,7 @@ func monitoringDashboardDiffSuppress(k, old, new string, d *schema.ResourceData)
 	}
 
 	oldMap = removeComputedKeys(oldMap, newMap)
+	newMap = removeEmptyConfigEntries(oldMap, newMap)
 	return reflect.DeepEqual(oldMap, newMap)
 }
 

--- a/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_internal_test.go
+++ b/mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_internal_test.go
@@ -1,0 +1,154 @@
+package monitoring
+
+import (
+	"testing"
+)
+
+func TestRemoveEmptyConfigEntries(t *testing.T) {
+	cases := []struct {
+		name     string
+		old      map[string]interface{}
+		new      map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "removes empty arrays not in API response",
+			old: map[string]interface{}{
+				"displayName": "test",
+			},
+			new: map[string]interface{}{
+				"displayName":      "test",
+				"dashboardFilters": []interface{}{},
+			},
+			expected: map[string]interface{}{
+				"displayName": "test",
+			},
+		},
+		{
+			name: "removes empty maps not in API response",
+			old: map[string]interface{}{
+				"displayName": "test",
+			},
+			new: map[string]interface{}{
+				"displayName": "test",
+				"labels":      map[string]interface{}{},
+			},
+			expected: map[string]interface{}{
+				"displayName": "test",
+			},
+		},
+		{
+			name: "removes empty strings not in API response",
+			old: map[string]interface{}{
+				"targetAxis": "Y1",
+			},
+			new: map[string]interface{}{
+				"targetAxis": "Y1",
+				"label":      "",
+			},
+			expected: map[string]interface{}{
+				"targetAxis": "Y1",
+			},
+		},
+		{
+			name: "preserves non-empty arrays",
+			old: map[string]interface{}{
+				"items": []interface{}{"a"},
+			},
+			new: map[string]interface{}{
+				"items": []interface{}{"a"},
+			},
+			expected: map[string]interface{}{
+				"items": []interface{}{"a"},
+			},
+		},
+		{
+			name: "handles nested maps recursively",
+			old: map[string]interface{}{
+				"widget": map[string]interface{}{
+					"title": "test",
+				},
+			},
+			new: map[string]interface{}{
+				"widget": map[string]interface{}{
+					"title":      "test",
+					"breakdowns": []interface{}{},
+				},
+			},
+			expected: map[string]interface{}{
+				"widget": map[string]interface{}{
+					"title": "test",
+				},
+			},
+		},
+		{
+			name: "handles nested slices of maps recursively",
+			old: map[string]interface{}{
+				"dataSets": []interface{}{
+					map[string]interface{}{
+						"plotType": "LINE",
+					},
+				},
+			},
+			new: map[string]interface{}{
+				"dataSets": []interface{}{
+					map[string]interface{}{
+						"plotType":   "LINE",
+						"breakdowns": []interface{}{},
+						"dimensions": []interface{}{},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"dataSets": []interface{}{
+					map[string]interface{}{
+						"plotType": "LINE",
+					},
+				},
+			},
+		},
+		{
+			name: "does not remove empty values that exist in API response",
+			old: map[string]interface{}{
+				"items": []interface{}{},
+			},
+			new: map[string]interface{}{
+				"items": []interface{}{},
+			},
+			expected: map[string]interface{}{
+				"items": []interface{}{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := removeEmptyConfigEntries(tc.old, tc.new)
+			if len(result) != len(tc.expected) {
+				t.Errorf("expected %d keys, got %d: %v", len(tc.expected), len(result), result)
+				return
+			}
+			for k, v := range tc.expected {
+				if result[k] == nil && v != nil {
+					t.Errorf("key %q missing from result", k)
+				}
+			}
+			for k := range result {
+				if tc.expected[k] == nil {
+					t.Errorf("unexpected key %q in result", k)
+				}
+			}
+		})
+	}
+}
+
+func TestMonitoringDashboardDiffSuppress_emptyArrays(t *testing.T) {
+	// Simulates the perma-diff scenario from issue #16173
+	// API response (old/state) omits empty arrays, config (new) includes them
+	old := `{"displayName":"test","mosaicLayout":{"columns":12,"tiles":[{"height":4,"widget":{"title":"SLO","xyChart":{"chartOptions":{"mode":"COLOR"},"dataSets":[{"plotType":"LINE","targetAxis":"Y1","timeSeriesQuery":{"timeSeriesFilter":{"aggregation":{"perSeriesAligner":"ALIGN_NEXT_OLDER"},"filter":"test"},"unitOverride":"10^2.%"}}],"thresholds":[{"targetAxis":"Y1","value":0.999}]}},"width":12}]}}`
+	new := `{"dashboardFilters":[],"displayName":"test","labels":{},"mosaicLayout":{"columns":12,"tiles":[{"height":4,"widget":{"title":"SLO","xyChart":{"chartOptions":{"mode":"COLOR"},"dataSets":[{"breakdowns":[],"dimensions":[],"measures":[],"plotType":"LINE","targetAxis":"Y1","timeSeriesQuery":{"timeSeriesFilter":{"aggregation":{"perSeriesAligner":"ALIGN_NEXT_OLDER"},"filter":"test"},"unitOverride":"10^2.%"}}],"thresholds":[{"label":"","targetAxis":"Y1","value":0.999}]}},"width":12}]}}`
+
+	if !monitoringDashboardDiffSuppress("dashboard_json", old, new, nil) {
+		t.Error("expected diff to be suppressed for empty arrays/maps/strings in config")
+	}
+}


### PR DESCRIPTION
### Description

When users include empty arrays (`dashboardFilters: []`), empty maps (`labels: {}`), or empty strings (`label: ""`) in their `google_monitoring_dashboard` JSON, the Cloud Monitoring API naturally omits these empty values from its response. The existing `removeComputedKeys` function only strips keys from the API response that aren't in the config, but doesn't handle the inverse case where the config has empty values the API omits.

This adds `removeEmptyConfigEntries` which strips empty values from the config when the corresponding key doesn't exist in the API response, preventing perpetual diffs on every plan.

### Bug

Fixes hashicorp/terraform-provider-google#16173

### Tests

Includes unit tests for the new `removeEmptyConfigEntries` function covering:
- Empty arrays, maps, and strings removal
- Nested map recursion
- Nested slice-of-maps recursion
- Integration test reproducing the perma-diff scenario

### Files changed

- `mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard.go`
- `mmv1/third_party/terraform/services/monitoring/resource_monitoring_dashboard_internal_test.go` (new)

```release-note:bug
google_monitoring_dashboard: fixed perpetual diffs caused by empty arrays, maps, or strings in dashboard JSON config
```