### PR TITLE
Promote `connection_tracking_policy` field in `google_compute_region_backend_service` from beta to GA

### DIFF
--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -116,7 +116,6 @@ examples:
       network_name: 'rbs-net'
   - name: 'region_backend_service_connection_tracking'
     primary_resource_id: 'default'
-    min_version: 'beta'
     vars:
       region_backend_service_name: 'region-service'
       health_check_name: 'rbs-health-check'
@@ -1413,7 +1412,6 @@ properties:
       Connection Tracking configuration for this BackendService.
       This is available only for Layer 4 Internal Load Balancing and
       Network Load Balancing.
-    min_version: 'beta'
     properties:
       - name: 'idleTimeoutSec'
         type: Integer

--- a/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_connection_tracking.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
-  provider                        = google-beta
   name                            = "{{index $.Vars "region_backend_service_name"}}"
   region                          = "us-central1"
   health_checks                   = [google_compute_region_health_check.health_check.id]
@@ -11,12 +10,11 @@ resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
     tracking_mode                                = "PER_SESSION"
     connection_persistence_on_unhealthy_backends = "NEVER_PERSIST"
     idle_timeout_sec                             = 60
-    enable_strong_affinity                       = true
+    enable_strong_affinity                       = false
   }
 }
 
 resource "google_compute_region_health_check" "health_check" {
-  provider           = google-beta
   name               = "{{index $.Vars "health_check_name"}}"
   region             = "us-central1"
 


### PR DESCRIPTION
This change promotes the `connection_tracking_policy` field in `google_compute_region_backend_service` resource from beta to GA. This allows users to configure connection tracking policy for regional backend services in the google provider.

The corresponding acceptance test is also updated to test it in the google provider.

```release-note:enhancement
compute: added `connection_tracking_policy` field to `google_compute_region_backend_service` resource (ga)
```
