### PR TITLE
TGC: Improve test runner error reporting and retry logic

### DIFF
--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -231,7 +231,7 @@ func testSingleResource(t *testing.T, testName string, testData ResourceTestData
 	// Sometimes, the reason for missing fields could be CAI asset data issue.
 	if len(missingKeys) > 0 {
 		log.Printf("%s: missing fields in resource %s after cai2hcl conversion:\n%s", testName, testData.ResourceAddress, missingKeys)
-		return retry.RetryableError(fmt.Errorf("missing fields"))
+		return retry.RetryableError(fmt.Errorf("missing fields: %v", missingKeys))
 	}
 	log.Printf("%s: Step 1 passes for resource %s. All of the fields in raw config are in export config", testName, testData.ResourceAddress)
 
@@ -245,7 +245,7 @@ func testSingleResource(t *testing.T, testName string, testData ResourceTestData
 	ancestryCache, defaultProject := getAncestryCache(assets)
 	roundtripAssets, roundtripConfigData, err := getRoundtripConfig(t, testName, tfDir, ancestryCache, defaultProject, logger)
 	if err != nil {
-		return fmt.Errorf("error when converting the round-trip config: %#v", err)
+		return retry.RetryableError(fmt.Errorf("error when converting the round-trip config: %v", err))
 	}
 
 	rtTfFile := fmt.Sprintf("%s_roundtrip.tf", strings.ReplaceAll(testName, "/", "_"))
@@ -570,7 +570,9 @@ func getRoundtripConfig(t *testing.T, testName string, tfDir string, ancestryCac
 // Converts tf file to CAI assets
 func tfplan2caiConvert(t *testing.T, tfFileName, jsonFileName string, tfDir string, ancestryCache map[string]string, defaultProject string, logger *zap.Logger) ([]caiasset.Asset, error) {
 	// Run terraform init and terraform apply to generate tfplan.json files
-	terraformWorkflow(t, tfDir, tfFileName, defaultProject)
+	if err := terraformWorkflow(t, tfDir, tfFileName, defaultProject); err != nil {
+		return nil, err
+	}
 
 	planFile := fmt.Sprintf("%s.tfplan.json", tfFileName)
 	planfilePath := filepath.Join(tfDir, planFile)

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -117,18 +117,15 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, primaryResour
 			t.Logf("%s: Starting test with retry logic.", tName)
 
 			if err := retry.Do(context.Background(), backoffPolicy, flakyAction); err != nil {
-				allUnavailable := len(attemptErrors) > 0
 				var firstRealError error
 				for _, e := range attemptErrors {
 					if !strings.Contains(e.Error(), "test data is unavailable") {
-						allUnavailable = false
-						if firstRealError == nil {
-							firstRealError = e
-						}
+						firstRealError = e
+						break
 					}
 				}
 
-				if allUnavailable {
+				if firstRealError == nil {
 					t.Skipf("%s: Test skipped because data was unavailable after all %d attempts: %v", tName, len(attemptErrors), err)
 				} else {
 					t.Fatalf("%s: Failed after %d attempts. First real error: %v", tName, len(attemptErrors), firstRealError)

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -118,19 +118,23 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, primaryResour
 
 			if err := retry.Do(context.Background(), backoffPolicy, flakyAction); err != nil {
 				allUnavailable := len(attemptErrors) > 0
-				var firstRealError error
 				for _, e := range attemptErrors {
 					if !strings.Contains(e.Error(), "test data is unavailable") {
 						allUnavailable = false
-						if firstRealError == nil {
-							firstRealError = e
-						}
+						break
 					}
 				}
 
 				if allUnavailable {
 					t.Skipf("%s: Test skipped because data was unavailable after all %d attempts: %v", tName, len(attemptErrors), err)
 				} else {
+					var firstRealError error
+					for _, e := range attemptErrors {
+						if !strings.Contains(e.Error(), "test data is unavailable") {
+							firstRealError = e
+							break
+						}
+					}
 					t.Fatalf("%s: Failed after %d attempts. First real error: %v", tName, len(attemptErrors), firstRealError)
 				}
 			}

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -117,15 +117,18 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, primaryResour
 			t.Logf("%s: Starting test with retry logic.", tName)
 
 			if err := retry.Do(context.Background(), backoffPolicy, flakyAction); err != nil {
+				allUnavailable := len(attemptErrors) > 0
 				var firstRealError error
 				for _, e := range attemptErrors {
 					if !strings.Contains(e.Error(), "test data is unavailable") {
-						firstRealError = e
-						break
+						allUnavailable = false
+						if firstRealError == nil {
+							firstRealError = e
+						}
 					}
 				}
 
-				if firstRealError == nil {
+				if allUnavailable {
 					t.Skipf("%s: Test skipped because data was unavailable after all %d attempts: %v", tName, len(attemptErrors), err)
 				} else {
 					t.Fatalf("%s: Failed after %d attempts. First real error: %v", tName, len(attemptErrors), firstRealError)

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -570,7 +570,7 @@ func getRoundtripConfig(t *testing.T, testName string, tfDir string, ancestryCac
 // Converts tf file to CAI assets
 func tfplan2caiConvert(t *testing.T, tfFileName, jsonFileName string, tfDir string, ancestryCache map[string]string, defaultProject string, logger *zap.Logger) ([]caiasset.Asset, error) {
 	// Run terraform init and terraform apply to generate tfplan.json files
-	if err := terraformWorkflow(t, tfDir, tfFileName, defaultProject); err != nil {
+	if err := terraformWorkflow(tfDir, tfFileName, defaultProject); err != nil {
 		return nil, err
 	}
 

--- a/mmv1/third_party/tgc_next/test/assert_test_files.go
+++ b/mmv1/third_party/tgc_next/test/assert_test_files.go
@@ -118,17 +118,20 @@ func BidirectionalConversion(t *testing.T, ignoredFields []string, primaryResour
 
 			if err := retry.Do(context.Background(), backoffPolicy, flakyAction); err != nil {
 				allUnavailable := len(attemptErrors) > 0
+				var firstRealError error
 				for _, e := range attemptErrors {
 					if !strings.Contains(e.Error(), "test data is unavailable") {
 						allUnavailable = false
-						break
+						if firstRealError == nil {
+							firstRealError = e
+						}
 					}
 				}
 
 				if allUnavailable {
 					t.Skipf("%s: Test skipped because data was unavailable after all %d attempts: %v", tName, len(attemptErrors), err)
 				} else {
-					t.Fatalf("%s: Failed after %d attempts. Last error: %v", tName, len(attemptErrors), err)
+					t.Fatalf("%s: Failed after %d attempts. First real error: %v", tName, len(attemptErrors), firstRealError)
 				}
 			}
 		})

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -30,7 +30,7 @@ const (
 	defaultProject      = "ci-test-project-nightly-beta"
 )
 
-func terraformWorkflow(t *testing.T, dir, name, project string) error {
+func terraformWorkflow(dir, name, project string) error {
 	defer os.Remove(filepath.Join(dir, fmt.Sprintf("%s.tf", name)))
 	defer os.Remove(filepath.Join(dir, fmt.Sprintf("%s.tfplan", name)))
 
@@ -53,37 +53,37 @@ terraform {
 		}
 	}
 
-	if err := terraformInit(t, "terraform", dir, project); err != nil {
+	if err := terraformInit("terraform", dir, project); err != nil {
 		return err
 	}
-	if err := terraformPlan(t, "terraform", dir, project, name+".tfplan"); err != nil {
+	if err := terraformPlan("terraform", dir, project, name+".tfplan"); err != nil {
 		return err
 	}
-	payload, err := terraformShow(t, "terraform", dir, project, name+".tfplan")
+	payload, err := terraformShow("terraform", dir, project, name+".tfplan")
 	if err != nil {
 		return err
 	}
-	if err := saveFile(t, dir, name+".tfplan.json", payload); err != nil {
+	if err := saveFile(dir, name+".tfplan.json", payload); err != nil {
 		return err
 	}
 	return nil
 }
 
-func terraformInit(t *testing.T, executable, dir, project string) error {
-	_, err := terraformExec(t, executable, dir, project, "init", "-input=false")
+func terraformInit(executable, dir, project string) error {
+	_, err := terraformExec(executable, dir, project, "init", "-input=false")
 	return err
 }
 
-func terraformPlan(t *testing.T, executable, dir, project, tfplan string) error {
-	_, err := terraformExec(t, executable, dir, project, "plan", "-input=false", "-refresh=false", "-out", tfplan)
+func terraformPlan(executable, dir, project, tfplan string) error {
+	_, err := terraformExec(executable, dir, project, "plan", "-input=false", "-refresh=false", "-out", tfplan)
 	return err
 }
 
-func terraformShow(t *testing.T, executable, dir, project, tfplan string) ([]byte, error) {
-	return terraformExec(t, executable, dir, project, "show", "--json", tfplan)
+func terraformShow(executable, dir, project, tfplan string) ([]byte, error) {
+	return terraformExec(executable, dir, project, "show", "--json", tfplan)
 }
 
-func terraformExec(t *testing.T, executable, dir, project string, args ...string) ([]byte, error) {
+func terraformExec(executable, dir, project string, args ...string) ([]byte, error) {
 	if project == "" {
 		project = defaultProject
 	}
@@ -100,11 +100,11 @@ func terraformExec(t *testing.T, executable, dir, project string, args ...string
 	}
 	cmd.Dir = dir
 	wantError := false
-	payload, _, err := run(t, cmd, wantError)
+	payload, _, err := run(cmd, wantError)
 	return payload, err
 }
 
-func saveFile(t *testing.T, dir, filename string, payload []byte) error {
+func saveFile(dir, filename string, payload []byte) error {
 	fullpath := filepath.Join(dir, filename)
 	f, err := os.Create(fullpath)
 	if err != nil {
@@ -119,7 +119,7 @@ func saveFile(t *testing.T, dir, filename string, payload []byte) error {
 }
 
 // run a command and return error on non-zero exit instead of t.Fatalf.
-func run(t *testing.T, cmd *exec.Cmd, wantError bool) ([]byte, []byte, error) {
+func run(cmd *exec.Cmd, wantError bool) ([]byte, []byte, error) {
 	var stderr, stdout bytes.Buffer
 	cmd.Stderr, cmd.Stdout = &stderr, &stdout
 	err := cmd.Run()

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
+
 )
 
 // Writes the data into a JSON file

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
 )
 
 // Writes the data into a JSON file

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -123,7 +123,7 @@ func run(t *testing.T, cmd *exec.Cmd, wantError bool) ([]byte, []byte, error) {
 	var stderr, stdout bytes.Buffer
 	cmd.Stderr, cmd.Stdout = &stderr, &stdout
 	err := cmd.Run()
-	
+
 	// Do not log output here to avoid cluttering test results on retries.
 	// The full output is included in the error returned on failure.
 
@@ -131,19 +131,6 @@ func run(t *testing.T, cmd *exec.Cmd, wantError bool) ([]byte, []byte, error) {
 		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("running %s: \nerror=%v \nstderr=%s", cmd.String(), err, stderr.String())
 	}
 	return stdout.Bytes(), stderr.Bytes(), nil
-}
-
-func GetSubTestName(fullTestName string) string {
-	_, after, found := strings.Cut(fullTestName, "/")
-	if !found {
-		return ""
-	}
-	return after
-}
-
-type TestCase struct {
-	Name string
-	Skip string
 }
 
 // Creates a deep copy of a source map using JSON marshalling and unmarshalling.
@@ -159,4 +146,17 @@ func DeepCopyMap(source interface{}, destination interface{}) error {
 	}
 
 	return nil
+}
+
+type TestCase struct {
+	Name string
+	Skip string
+}
+
+func GetSubTestName(fullTestName string) string {
+	_, after, found := strings.Cut(fullTestName, "/")
+	if !found {
+		return ""
+	}
+	return after
 }

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -30,7 +30,7 @@ const (
 	defaultProject      = "ci-test-project-nightly-beta"
 )
 
-func terraformWorkflow(t *testing.T, dir, name, project string) {
+func terraformWorkflow(t *testing.T, dir, name, project string) error {
 	defer os.Remove(filepath.Join(dir, fmt.Sprintf("%s.tf", name)))
 	defer os.Remove(filepath.Join(dir, fmt.Sprintf("%s.tfplan", name)))
 
@@ -49,29 +49,41 @@ terraform {
 }
 `
 		if err := os.WriteFile(tfFile, append(content, []byte(override)...), 0644); err != nil {
-			t.Fatalf("Error writing provider override to %s: %v", tfFile, err)
+			return fmt.Errorf("Error writing provider override to %s: %v", tfFile, err)
 		}
 	}
 
-	terraformInit(t, "terraform", dir, project)
-	terraformPlan(t, "terraform", dir, project, name+".tfplan")
-	payload := terraformShow(t, "terraform", dir, project, name+".tfplan")
-	saveFile(t, dir, name+".tfplan.json", payload)
+	if err := terraformInit(t, "terraform", dir, project); err != nil {
+		return err
+	}
+	if err := terraformPlan(t, "terraform", dir, project, name+".tfplan"); err != nil {
+		return err
+	}
+	payload, err := terraformShow(t, "terraform", dir, project, name+".tfplan")
+	if err != nil {
+		return err
+	}
+	if err := saveFile(t, dir, name+".tfplan.json", payload); err != nil {
+		return err
+	}
+	return nil
 }
 
-func terraformInit(t *testing.T, executable, dir, project string) {
-	terraformExec(t, executable, dir, project, "init", "-input=false")
+func terraformInit(t *testing.T, executable, dir, project string) error {
+	_, err := terraformExec(t, executable, dir, project, "init", "-input=false")
+	return err
 }
 
-func terraformPlan(t *testing.T, executable, dir, project, tfplan string) {
-	terraformExec(t, executable, dir, project, "plan", "-input=false", "-refresh=false", "-out", tfplan)
+func terraformPlan(t *testing.T, executable, dir, project, tfplan string) error {
+	_, err := terraformExec(t, executable, dir, project, "plan", "-input=false", "-refresh=false", "-out", tfplan)
+	return err
 }
 
-func terraformShow(t *testing.T, executable, dir, project, tfplan string) []byte {
+func terraformShow(t *testing.T, executable, dir, project, tfplan string) ([]byte, error) {
 	return terraformExec(t, executable, dir, project, "show", "--json", tfplan)
 }
 
-func terraformExec(t *testing.T, executable, dir, project string, args ...string) []byte {
+func terraformExec(t *testing.T, executable, dir, project string, args ...string) ([]byte, error) {
 	if project == "" {
 		project = defaultProject
 	}
@@ -88,44 +100,50 @@ func terraformExec(t *testing.T, executable, dir, project string, args ...string
 	}
 	cmd.Dir = dir
 	wantError := false
-	payload, _ := run(t, cmd, wantError)
-	return payload
+	payload, _, err := run(t, cmd, wantError)
+	return payload, err
 }
 
-func saveFile(t *testing.T, dir, filename string, payload []byte) {
+func saveFile(t *testing.T, dir, filename string, payload []byte) error {
 	fullpath := filepath.Join(dir, filename)
 	f, err := os.Create(fullpath)
 	if err != nil {
-		t.Fatalf("error while creating file %s, error %v", fullpath, err)
+		return fmt.Errorf("error while creating file %s, error %v", fullpath, err)
 	}
+	defer f.Close()
 	_, err = f.Write(payload)
 	if err != nil {
-		t.Fatalf("error while writing to file %s, error %v", fullpath, err)
+		return fmt.Errorf("error while writing to file %s, error %v", fullpath, err)
 	}
+	return nil
 }
 
-// run a command and call t.Fatal on non-zero exit.
-func run(t *testing.T, cmd *exec.Cmd, wantError bool) ([]byte, []byte) {
+// run a command and return error on non-zero exit instead of t.Fatalf.
+func run(t *testing.T, cmd *exec.Cmd, wantError bool) ([]byte, []byte, error) {
 	var stderr, stdout bytes.Buffer
 	cmd.Stderr, cmd.Stdout = &stderr, &stdout
 	err := cmd.Run()
+	
+	// Do not log output here to avoid cluttering test results on retries.
+	// The full output is included in the error returned on failure.
+
 	if gotError := (err != nil); gotError != wantError {
-		t.Fatalf("running %s: \nerror=%v \nstderr=%s \nstdout=%s", cmd.String(), err, stderr.String(), stdout.String())
+		return stdout.Bytes(), stderr.Bytes(), fmt.Errorf("running %s: \nerror=%v \nstderr=%s", cmd.String(), err, stderr.String())
 	}
-	// Print env, stdout and stderr if verbose flag is used.
-	if len(cmd.Env) != 0 {
-		t.Logf("=== Environment Variable of %s ===", cmd.String())
-		t.Log(strings.Join(cmd.Env, "\n"))
+	return stdout.Bytes(), stderr.Bytes(), nil
+}
+
+func GetSubTestName(fullTestName string) string {
+	_, after, found := strings.Cut(fullTestName, "/")
+	if !found {
+		return ""
 	}
-	if stdout.String() != "" {
-		t.Logf("=== STDOUT of %s ===", cmd.String())
-		t.Log(stdout.String())
-	}
-	if stderr.String() != "" {
-		t.Logf("=== STDERR of %s ===", cmd.String())
-		t.Log(stderr.String())
-	}
-	return stdout.Bytes(), stderr.Bytes()
+	return after
+}
+
+type TestCase struct {
+	Name string
+	Skip string
 }
 
 // Creates a deep copy of a source map using JSON marshalling and unmarshalling.
@@ -141,17 +159,4 @@ func DeepCopyMap(source interface{}, destination interface{}) error {
 	}
 
 	return nil
-}
-
-type TestCase struct {
-	Name string
-	Skip string
-}
-
-func GetSubTestName(fullTestName string) string {
-	_, after, found := strings.Cut(fullTestName, "/")
-	if !found {
-		return ""
-	}
-	return after
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
1. It includes the logic in `assert_test_files.go` to report the first error that is not `"test data is unavailable"`
1. Show the error message for each failed in the end of the logs.
2. Add the retry logic for `terraform plan` errors
3. Removed `t *testing.T` from the signatures of the following functions in mmv1/third_party/tgc_next/test/utils.go:

4. Updated the calls inside those functions to no longer pass `t`.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
