### PR TITLE
tgc-revival: remove terraform init during integration tests

### DIFF
--- a/mmv1/templates/tgc_next/test/test_file.go.tmpl
+++ b/mmv1/templates/tgc_next/test/test_file.go.tmpl
@@ -15,7 +15,6 @@
 package {{$.PackageName}}_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/test"

--- a/mmv1/templates/tgc_next/test/test_file.go.tmpl
+++ b/mmv1/templates/tgc_next/test/test_file.go.tmpl
@@ -22,9 +22,8 @@ import (
 )
 
 func TestAcc{{$.ResourceName}}(t *testing.T) {
-	if os.Getenv("WRITE_FILES") != "" {
-		t.Parallel()
-	}
+	t.Parallel()
+
 	tests := []test.TestCase{
 {{- range $t := $.TGCTests }}
 		{

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -52,9 +52,6 @@ terraform {
 		}
 	}
 
-	if err := terraformInit("terraform", dir, project); err != nil {
-		return err
-	}
 	if err := terraformPlan("terraform", dir, project, name+".tfplan"); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

`terraform init` is skipped as provider development overrides is used when running TGC integration tests (e.g., when [TF_CLI_CONFIG_FILE](https://github.com/GoogleCloudPlatform/magic-modules/blob/main/mmv1/third_party/tgc_next/Makefile#L21) points to a config with provider_installation overrides). Removing it will speed up tests.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
