### PR TITLE
Add cloudaicompanion observability settings to Terraform

### DIFF
--- a/mmv1/products/cloudaicompanion/GdaObservabilitySetting.yaml
+++ b/mmv1/products/cloudaicompanion/GdaObservabilitySetting.yaml
@@ -1,0 +1,80 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GdaObservabilitySetting
+description: A setting that controls observability features for Gemini Data Analytics.
+base_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings
+self_link: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/gdaObservabilitySettings?gdaObservabilitySettingId={{gda_observability_setting_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/gdaObservabilitySettings/{{gda_observability_setting_id}}
+autogen_status: R2RhT2JzZXJ2YWJpbGl0eVNldHRpbmc=
+autogen_async: true
+examples:
+  - name: gda_observability_setting_basic
+    primary_resource_id: example
+    vars:
+      resource_name: test-resource
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: gdaObservabilitySettingId
+    type: String
+    required: true
+    description: |-
+      Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      gda_observability_setting_id from the method_signature of Create RPC.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: conversationalAnalyticsSetting
+    type: NestedObject
+    description: Message describing Setting for Conversational Analytics.
+    properties:
+      - name: feedbackEnabled
+        type: Boolean
+        description: Whether to enable feedback.
+      - name: loggingEnabled
+        type: Boolean
+        description: Whether to enable logging.
+      - name: metricsEnabled
+        type: Boolean
+        description: Whether to enable metrics.
+      - name: tracesEnabled
+        type: Boolean
+        description: Whether to enable traces.
+  - name: createTime
+    type: String
+    description: '[Output only] Create time stamp.'
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gdaObservabilitySettings/{gda_observability_setting}
+    output: true
+  - name: updateTime
+    type: String
+    description: '[Output only] Update time stamp.'
+    output: true

--- a/mmv1/products/cloudaicompanion/GeminiGcpEnablementSetting.yaml
+++ b/mmv1/products/cloudaicompanion/GeminiGcpEnablementSetting.yaml
@@ -1,0 +1,106 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GeminiGcpEnablementSetting
+description: A setting that controls the enablement of Gemini features for Google Cloud.
+base_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings
+self_link: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings?geminiGcpEnablementSettingId={{gemini_gcp_enablement_setting_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/geminiGcpEnablementSettings/{{gemini_gcp_enablement_setting_id}}
+autogen_status: R2VtaW5pR2NwRW5hYmxlbWVudFNldHRpbmc=
+autogen_async: true
+examples:
+  - name: gemini_gcp_enablement_setting_basic
+    primary_resource_id: example
+    vars:
+      resource_name: test-resource
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: geminiGcpEnablementSettingId
+    type: String
+    required: true
+    description: |-
+      Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      gemini_gcp_enablement_setting_id from the method_signature of Create RPC
+    immutable: true
+    url_param_only: true
+properties:
+  - name: createTime
+    type: String
+    description: '[Output only] Create time stamp.'
+    output: true
+  - name: customInstructions
+    type: String
+    description: Contains custom instructions to be applied to the GCA agent.
+  - name: disableWebGrounding
+    type: Boolean
+    description: |-
+      Whether web grounding should be disabled.
+      DEPRECATED: Use web_grounding_type instead.
+  - name: enableCustomerDataSharing
+    type: Boolean
+    description: Not implemented.
+  - name: geminiEnterpriseProject
+    type: String
+    description: |-
+      The Gemini enterprise project for this setting.
+      Format: projects/{project}
+      The `{project}` segment can be the project ID or project number.
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: mutationsEnabled
+    type: Boolean
+    description: |-
+      Indicates whether resource mutations are enabled.
+      If not set, resource mutations are disabled.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/geminiGcpEnablementSettings/{geminiGcpEnablementSetting}
+    output: true
+  - name: proactiveAgentsEnabled
+    type: Boolean
+    description: |-
+      Indicates whether proactive agents are enabled.
+      If not set, proactive agents are disabled.
+  - name: releaseChannel
+    type: String
+    description: |-
+      Specifies the release channel for Gemini features. The release channel
+      determines which set of features are available to the user.
+      Possible values:
+      STABLE
+      EXPERIMENTAL
+  - name: updateTime
+    type: String
+    description: '[Output only] Update time stamp.'
+    output: true
+  - name: webGroundingType
+    type: String
+    description: |-
+      Web grounding type.
+      Possible values:
+      GROUNDING_WITH_GOOGLE_SEARCH
+      WEB_GROUNDING_FOR_ENTERPRISE

--- a/mmv1/products/cloudaicompanion/GibqObservabilitySetting.yaml
+++ b/mmv1/products/cloudaicompanion/GibqObservabilitySetting.yaml
@@ -1,0 +1,81 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GibqObservabilitySetting
+description: A setting that controls observability features for Gemini in BigQuery.
+base_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings
+self_link: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}
+create_url: projects/{{project}}/locations/{{location}}/gibqObservabilitySettings?gibqObservabilitySettingId={{gibq_observability_setting_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/gibqObservabilitySettings/{{gibq_observability_setting_id}}
+autogen_status: R2licU9ic2VydmFiaWxpdHlTZXR0aW5n
+autogen_async: true
+examples:
+  - name: gibq_observability_setting_basic
+    primary_resource_id: example
+    vars:
+      resource_name: test-resource
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: gibqObservabilitySettingId
+    type: String
+    required: true
+    description: |-
+      Id of the requesting object.
+      If auto-generating Id server-side, remove this field and
+      gibq_observability_setting_id from the method_signature of
+      Create RPC.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: conversationalAnalyticsSetting
+    type: NestedObject
+    description: Message describing Setting for Conversational Analytics.
+    properties:
+      - name: feedbackEnabled
+        type: Boolean
+        description: Whether to enable feedback.
+      - name: loggingEnabled
+        type: Boolean
+        description: Whether to enable logging.
+      - name: metricsEnabled
+        type: Boolean
+        description: Whether to enable metrics.
+      - name: tracesEnabled
+        type: Boolean
+        description: Whether to enable traces.
+  - name: createTime
+    type: String
+    description: '[Output only] Create time stamp.'
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: name
+    type: String
+    description: |-
+      Identifier. Name of the resource.
+      Format:projects/{project}/locations/{location}/gibqObservabilitySettings/{gibq_observability_setting}
+    output: true
+  - name: updateTime
+    type: String
+    description: '[Output only] Update time stamp.'
+    output: true

--- a/mmv1/products/cloudaicompanion/product.yaml
+++ b/mmv1/products/cloudaicompanion/product.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GeminiforGoogleCloud
+display_name: Gemini for Google Cloud
+scopes:
+    - https://www.googleapis.com/auth/cloud-platform
+versions:
+    - base_url: https://cloudaicompanion.googleapis.com/v1/
+      name: ga
+async:
+  operation:
+    base_url: 'projects/{{project}}/locations/{{location}}/operations/{{op_id}}'
+

--- a/mmv1/templates/terraform/examples/gda_observability_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gda_observability_setting_basic.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_cloudaicompanion_gda_observability_setting" "example" {
+  provider = google-beta
+  location = "global"
+  gda_observability_setting_id = "default"
+  
+  conversational_analytics_setting {
+    feedback_enabled = true
+    logging_enabled  = true
+    metrics_enabled  = true
+    traces_enabled   = true
+  }
+
+  labels = {
+    "env" = "test"
+  }
+}

--- a/mmv1/templates/terraform/examples/gemini_gcp_enablement_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gemini_gcp_enablement_setting_basic.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_cloudaicompanion_gemini_gcp_enablement_setting" "example" {
+  provider = google-beta
+  location = "global"
+  gemini_gcp_enablement_setting_id = "default"
+  
+  web_grounding_type        = "GROUNDING_WITH_GOOGLE_SEARCH"
+  proactive_agents_enabled   = true
+  mutations_enabled          = true
+  release_channel           = "EXPERIMENTAL"
+
+  labels = {
+    "env" = "test"
+  }
+}
+

--- a/mmv1/templates/terraform/examples/gibq_observability_setting_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/gibq_observability_setting_basic.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_cloudaicompanion_gibq_observability_setting" "example" {
+  provider = google-beta
+  location = "global"
+  gibq_observability_setting_id = "default"
+  
+  conversational_analytics_setting {
+    feedback_enabled = true
+    logging_enabled  = true
+    metrics_enabled  = true
+    traces_enabled   = true
+  }
+
+  labels = {
+    "env" = "test"
+  }
+}
+


### PR DESCRIPTION
This PR adds support for new observability settings in the `cloudaicompanion` service. These settings allow administrators to control telemetry features (logging, metrics, traces, and feedback) for Gemini in BigQuery and Gemini Data Analytics.

**New Resources:**
* `google_geminifor_google_cloud_gibq_observability_setting`
* `google_geminifor_google_cloud_gda_observability_setting`
* `google_geminifor_google_cloud_gemini_gcp_enablement_setting`

Tracking Bug: b/508755895

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
cloudaicompanion: Added new resources for managing Gemini for Google Cloud observability settings:
  - `google_geminifor_google_cloud_gibq_observability_setting`
  - `google_geminifor_google_cloud_gda_observability_setting`
  - `google_geminifor_google_cloud_gemini_gcp_enablement_setting`
