### PR TITLE
Add Terraform support for Native Dashboard for v1 endpoint

### DIFF
--- a/mmv1/products/chronicle/NativeDashboard.yaml
+++ b/mmv1/products/chronicle/NativeDashboard.yaml
@@ -17,7 +17,7 @@ description: A configuration for a native dashboard within a Google SecOps (Chro
 references:
   guides:
     'Google SecOps Guides': 'https://cloud.google.com/chronicle/docs/secops/secops-overview'
-  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.nativeDashboards'
+  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.nativeDashboards'
 base_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/nativeDashboards
 self_link: 'projects/{{project}}/locations/{{location}}/instances/{{instance}}/nativeDashboards/{{dashboard_id}}'
 create_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/nativeDashboards
@@ -28,11 +28,9 @@ import_format:
 update_mask: true
 update_verb: PATCH
 
-min_version: 'beta'
 examples:
   - name: chronicle_nativedashboard_basic
     primary_resource_id: my_basic_dashboard
-    min_version: 'beta'
     ignore_read_extra:
       - "last_viewed_time"
     vars:

--- a/mmv1/templates/terraform/examples/chronicle_nativedashboard_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_nativedashboard_basic.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_chronicle_native_dashboard" "my_basic_dashboard" {
-  provider     = google-beta
   location     = "us"
   instance     = "{{index $.TestEnvVars "chronicle_id"}}"
   display_name = "{{index $.Vars "dashboard_name"}}"

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_native_dashboard_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_native_dashboard_test.go
@@ -1,7 +1,5 @@
 package chronicle_test
 
-{{- if ne $.TargetVersionName "ga" }}
-
 import (
 	"testing"
 
@@ -121,5 +119,3 @@ resource "google_chronicle_native_dashboard" "my_dashboard" {
 }
 `, context)
 }
-
-{{- end }}


### PR DESCRIPTION
This commit introduces Terraform resources for the Google Chronicle Data Table Row v1 API, including:

*   `google_chronicle_native_dashboard`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27213
Fixed https://github.com/hashicorp/terraform-provider-google/issues/27308
Fixed https://github.com/hashicorp/terraform-provider-google/issues/27307
Fixed https://github.com/hashicorp/terraform-provider-google/issues/27305


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_chronicle_native_dashboard` (ga)
```

