### PR TITLE
Add Terraform support for Dashboard Chart for v1 endpoint

### DIFF
--- a/mmv1/products/chronicle/DashboardChart.yaml
+++ b/mmv1/products/chronicle/DashboardChart.yaml
@@ -19,7 +19,7 @@ description: >
 references:
   guides:
     'Google SecOps Guides': 'https://cloud.google.com/chronicle/docs/secops/secops-overview'
-  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1beta/projects.locations.instances.dashboardCharts'
+  api: 'https://cloud.google.com/chronicle/docs/reference/rest/v1/projects.locations.instances.dashboardCharts'
 
 base_url: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dashboardCharts
 self_link: projects/{{project}}/locations/{{location}}/instances/{{instance}}/dashboardCharts/{{chart_id}}
@@ -40,11 +40,9 @@ custom_code:
   update_encoder: "templates/terraform/update_encoder/chronicle_dashboard_chart_edit_mask.go.tmpl"
   decoder: "templates/terraform/decoders/chronicle_dashboard_chart.go.tmpl"
 
-min_version: 'beta'
 examples:
   - name: chronicle_dashboardchart_basic
     primary_resource_id: my_chart
-    min_version: 'beta'
     ignore_read_extra:
       - "dashboardUserData.0.lastViewedTime"
     vars:
@@ -54,7 +52,6 @@ examples:
 
   - name: chronicle_dashboardchart_full
     primary_resource_id: my_chart
-    min_version: 'beta'
     ignore_read_extra:
       - "dashboardUserData.0.lastViewedTime"
     vars:

--- a/mmv1/templates/terraform/examples/chronicle_dashboardchart_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_dashboardchart_basic.tf.tmpl
@@ -1,6 +1,5 @@
 # A Native Dashboard is required to create a Dashboard Chart.
 resource "google_chronicle_native_dashboard" "my_dashboard" {
-  provider     = google-beta
   location     = "us" 
   instance     = "%{chronicle_id}"
   display_name = "tf-test-dashboard-1%{random_suffix}"
@@ -23,7 +22,6 @@ resource "google_chronicle_native_dashboard" "my_dashboard" {
 }
 
 resource "google_chronicle_dashboard_chart" "my_chart" {
-  provider         = google-beta
   location         = "us" # Example region, adjust as necessary
   instance         = "{{index $.TestEnvVars "chronicle_id"}}"
   # This parameter creates an implicit dependency: Terraform will create

--- a/mmv1/templates/terraform/examples/chronicle_dashboardchart_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/chronicle_dashboardchart_full.tf.tmpl
@@ -1,6 +1,5 @@
 # A Native Dashboard is required to create a Dashboard Chart.
 resource "google_chronicle_native_dashboard" "my_dashboard" {
-  provider     = google-beta
   location     = "us" # Example region, adjust as necessary
   instance     = "{{index $.TestEnvVars "chronicle_id"}}"
   display_name = "{{index $.Vars "dashboard_name"}}"
@@ -27,7 +26,6 @@ resource "google_chronicle_native_dashboard" "my_dashboard" {
 }
 
 resource "google_chronicle_dashboard_chart" "my_chart" {
-  provider         = google-beta
   location         = google_chronicle_native_dashboard.my_dashboard.location
   instance         = google_chronicle_native_dashboard.my_dashboard.instance
   native_dashboard = google_chronicle_native_dashboard.my_dashboard.name
@@ -128,7 +126,6 @@ resource "google_chronicle_dashboard_chart" "my_chart" {
 }
 
 resource "google_chronicle_dashboard_chart" "button_tile" {
-  provider         = google-beta
   location         = google_chronicle_native_dashboard.my_dashboard.location
   instance         = google_chronicle_native_dashboard.my_dashboard.instance
   native_dashboard = google_chronicle_native_dashboard.my_dashboard.name
@@ -160,7 +157,6 @@ resource "google_chronicle_dashboard_chart" "button_tile" {
 }
 
 resource "google_chronicle_dashboard_chart" "markdown_tile" {
-  provider         = google-beta
   location         = google_chronicle_native_dashboard.my_dashboard.location
   instance         = google_chronicle_native_dashboard.my_dashboard.instance
   native_dashboard = google_chronicle_native_dashboard.my_dashboard.name

--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_dashboard_chart_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_dashboard_chart_test.go
@@ -1,7 +1,5 @@
 package chronicle_test
 
-{{- if ne $.TargetVersionName "ga" }}
-
 import (
 	"testing"
 
@@ -28,7 +26,7 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			{
 				Config: testAccChronicleDashboardChart_full(context),
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -42,7 +40,7 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 					},
 				},
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -50,13 +48,13 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			},
 			{
 				Config: testAccChronicleDashboardChart_update_map_chart(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_chronicle_dashboard_chart.my_chart", plancheck.ResourceActionUpdate),
 					},
 				},
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -64,13 +62,13 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			},
 			{
 				Config: testAccChronicleDashboardChart_update_pie_chart(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_chronicle_dashboard_chart.my_chart", plancheck.ResourceActionUpdate),
 					},
 				},
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -78,13 +76,13 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			},
 			{
 				Config: testAccChronicleDashboardChart_update_bar_chart_with_table(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_chronicle_dashboard_chart.my_chart", plancheck.ResourceActionUpdate),
 					},
 				},
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -92,13 +90,13 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			},
 			{
 				Config: testAccChronicleDashboardChart_update_gauge_chart(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_chronicle_dashboard_chart.my_chart", plancheck.ResourceActionUpdate),
 					},
 				},
 			},
-      {
+			{
 				ResourceName:            "google_chronicle_dashboard_chart.my_chart",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -106,7 +104,7 @@ func TestAccChronicleDashboardChart_chronicleDashboardchartFullExample_update(t 
 			},
 			{
 				Config: testAccChronicleDashboardChart_update_text_tile_complete(context),
-        ConfigPlanChecks: resource.ConfigPlanChecks{
+				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction("google_chronicle_dashboard_chart.my_chart", plancheck.ResourceActionUpdate),
 					},
@@ -793,5 +791,3 @@ resource "google_chronicle_dashboard_chart" "my_chart" {
   }
 }`
 }
-
-{{- end }}


### PR DESCRIPTION
This commit introduces Terraform resources for the Google Chronicle Data Table Row v1 API, including:

*   `google_chronicle_dashboard_chart`

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27214


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_chronicle_dashboard_chart` (ga)
```

