### PR TITLE
Document that Security Profiles can have a project parent.

### DIFF
--- a/mmv1/products/networksecurity/SecurityProfile.yaml
+++ b/mmv1/products/networksecurity/SecurityProfile.yaml
@@ -113,7 +113,7 @@ parameters:
     type: String
     description: |
       The name of the parent this security profile belongs to.
-      Format: organizations/{organization_id}.
+      Format: `organizations/{organization_id}` or `projects/{project_id}`.
     url_param_only: true
     immutable: true
 properties:

--- a/mmv1/products/networksecurity/SecurityProfileGroup.yaml
+++ b/mmv1/products/networksecurity/SecurityProfileGroup.yaml
@@ -105,7 +105,7 @@ parameters:
     type: String
     description: |
       The name of the parent this security profile group belongs to.
-      Format: organizations/{organization_id}.
+      Format: `organizations/{organization_id}` or `projects/{project_id}`.
     url_param_only: true
     immutable: true
 properties:


### PR DESCRIPTION
Documenting that the `parent` parameter can have either organizations or projects as valid values on Security Profile and Security Profile Group resources.

```release-note:none
networksecurity: documented that security profiles and security profile groups can be created at the project level
```
