### PR TITLE
Update composer_environment documentation and use the new name

### DIFF
--- a/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -1,18 +1,19 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
-  Provides Cloud Composer environment configuration data.
+  Provides Managed Airflow environment configuration data.
 ---
 
 # google_composer_environment
 
-Provides access to Cloud Composer environment configuration in a region for a given project.
+Provides access to Managed Airflow environment configuration in a region for a
+given project.
 
-To get more information about Composer Environment, see:
+To get more information about Managed Airflow Environment, see:
 
 * [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments)
 * How-to Guides
-    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+    * [Official Documentation](https://docs.cloud.google.com/composer/docs/latest/composer-overview)
 
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_image_versions.html.markdown
@@ -1,18 +1,18 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
-  Provides available Cloud Composer versions.
+  Provides available Managed Airflow versions.
 ---
 
 # google_composer_image_versions
 
-Provides access to available Cloud Composer versions in a region for a given project.
+Provides access to available Managed Airflow versions in a region for a given project.
 
-To get more information about Composer Image Versions, see:
+To get more information about Managed Airflow image versions, see:
 
 * [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.imageVersions)
 * How-to Guides
-    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+    * [Official Documentation](https://docs.cloud.google.com/composer/docs/composer-versions)
 
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_config_map.html.markdown
@@ -1,18 +1,18 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
   User workloads ConfigMap used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
 ---
 
 # google_composer_user_workloads_config_map
 
-Provides access to Kubernetes ConfigMap configuration for a given project, region and Composer Environment.
+Provides access to Kubernetes ConfigMap configuration for a given project, region and Managed Airflow Environment.
 
-To get more information about Composer User Workloads Config Map, see:
+To get more information about Managed Airflow User Workloads Config Map, see:
 
 * [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsConfigMaps)
 * How-to Guides
-    * [Official Documentation](https://cloud.google.com/composer/docs/concepts/overview)
+    * [Official Documentation](https://clouddocs.devsite.corp.google.com/composer/docs/composer-3/use-kubernetes-pod-operator#secret-config)
 
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/composer_user_workloads_secret.html.markdown
@@ -1,18 +1,19 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
   User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
 ---
 
 # google_composer_user_workloads_secret
 
-Provides access to Kubernetes Secret configuration for a given project, region and Composer Environment.
+Provides access to Kubernetes Secret configuration for a given project, region
+and Managed Airflow Environment.
 
-To get more information about Composer User Workloads Secrets, see:
+To get more information about Managed Airflow User Workloads Secrets, see:
 
 * [API documentation](https://cloud.google.com/composer/docs/reference/rest/v1/projects.locations.environments.userWorkloadsSecrets)
 * How-to Guides
-    * [Official Documentation](https://cloud.google.com/artifact-registry/docs/overview)
+    * [Official Documentation](https://clouddocs.devsite.corp.google.com/composer/docs/composer-3/use-kubernetes-pod-operator#secret-config)
     
 ## Example Usage
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
   An environment for running orchestration tasks.
 ---
@@ -12,47 +12,51 @@ Environments run Apache Airflow software on Google infrastructure.
 
 To get more information about Environments, see:
 
-* [Cloud Composer documentation](https://cloud.google.com/composer/docs)
-* [Cloud Composer API documentation](https://cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments)
-* How-to Guides (Cloud Composer 2)
-  * [Creating environments](https://cloud.google.com/composer/docs/composer-2/create-environments)
-  * [Scaling environments](https://cloud.google.com/composer/docs/composer-2/scale-environments)
-  * [Configuring Shared VPC for Composer Environments](https://cloud.google.com/composer/docs/composer-2/configure-shared-vpc)
-* How-to Guides (Cloud Composer 3)
-  * [Creating environments](https://cloud.google.com/composer/docs/composer-3/create-environments)
-  * [Scaling environments](https://cloud.google.com/composer/docs/composer-3/scale-environments)
-  * [Change environment networking type (Private or Public IP)](https://cloud.google.com/composer/docs/composer-3/change-networking-type)
-  * [Connect an environment to a VPC network](https://cloud.google.com/composer/docs/composer-3/connect-vpc-network)
+* [Managed Service for Apache Airflow documentation](https://docs.cloud.google.com/composer/docs)
+* [Managed Airflow API documentation](https://docs.cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments)
+* How-to Guides for Managed Airflow (Gen 3)
+  * [Creating environments](https://docs.cloud.google.com/composer/docs/composer-3/create-environments)
+  * [Scaling environments](https://docs.cloud.google.com/composer/docs/composer-3/scale-environments)
+  * [Change environment networking type (Private or Public IP)](https://docs.cloud.google.com/composer/docs/composer-3/change-networking-type)
+  * [Connect an environment to a VPC network](https://docs.cloud.google.com/composer/docs/composer-3/connect-vpc-network)
+* How-to Guides for Managed Airflow (Gen 2)
+  * [Creating environments](https://docs.cloud.google.com/composer/docs/composer-2/create-environments)
+  * [Scaling environments](https://docs.cloud.google.com/composer/docs/composer-2/scale-environments)
+  * [Configuring Shared VPC](https://docs.cloud.google.com/composer/docs/composer-2/configure-shared-vpc)
 * [Apache Airflow Documentation](http://airflow.apache.org/)
 
 -> **Note**
-  Cloud Composer 1 is in the post-maintenance mode. Google does 
-  not release any further updates to Cloud Composer 1, including new versions 
-  of Airflow, bugfixes, and security updates. We recommend using
-  Cloud Composer 2 or Cloud Composer 3 instead.
+  Managed Airflow (Legacy Gen 1) is in the post-maintenance mode. Google
+  doesn't release any further updates to Managed Service for
+  Managed Airflow (Legacy Gen 1), including new versions of Airflow, bugfixes,
+  and security updates. We recommend using Managed Airflow (Gen 3) or
+  Managed Airflow (Gen 2) instead.
 
-Several special considerations apply to managing Cloud Composer environments 
-with Terraform:
+Several special considerations apply to using Terraform with
+Managed Service for Apache Airflow:
 
-* The Environment resource is based on several layers of GCP infrastructure. 
-    Terraform does not manage these underlying resources. For example, in Cloud 
-    Composer 2, this includes a Kubernetes Engine cluster, Cloud Storage, and 
-    Compute networking resources.
+* The Environment resource is based on several layers of Google Cloud
+    infrastructure. Terraform doesn't manage these underlying resources. For
+    example, in Managed Airflow (Gen 2), this includes a Google Kubernetes
+    Engine cluster, Cloud Storage, and Compute networking resources.
 * Creating or updating an environment usually takes around 25 minutes.
-* In some cases errors in the configuration will be detected and reported only 
-    during the process of the environment creation. If you encounter such 
-    errors, please verify your configuration is valid against GCP Cloud Composer before filing bugs for the Terraform provider.
+* In some cases, errors in the configuration are detected and reported only
+    during the process of environment creation. If you encounter such
+    errors, please verify that your configuration is valid for the Managed
+    Airflow environment you are creating before filing bugs for the Terraform
+    provider.
 * **Environments have Google Cloud Storage buckets that are not automatically 
     deleted** with the environment.
-    See [Delete environments](https://cloud.google.com/composer/docs/composer-2/delete-environments)
+    See [Delete environments](https://docs.cloud.google.com/composer/docs/composer-3/delete-environments)
     for more information.
-* Please refer to
-    [Troubleshooting pages](https://cloud.devsite.corp.google.com/composer/docs/composer-2/troubleshooting-environment-creation) if you encounter
-    problems.
+* See
+    [Troubleshooting pages](https://docs.cloud.google.com/composer/docs/composer-3/troubleshooting-environment-creation)
+    if you encounter problems.
 
-## Example Usage
+## Example usage
 
-### Basic Usage (Cloud Composer 3)
+### Basic usage in Managed Airflow (Gen 3)
+
 ```hcl
 resource "google_composer_environment" "test" {
   name   = "example-composer-env"
@@ -65,7 +69,8 @@ resource "google_composer_environment" "test" {
 }
 ```
 
-### Basic Usage (Cloud Composer 2)
+### Basic usage in Managed Airflow (Gen 2)
+
 ```hcl
 resource "google_composer_environment" "test" {
   name   = "example-composer-env"
@@ -78,7 +83,8 @@ resource "google_composer_environment" "test" {
 }
 ```
 
-### Basic Usage (Cloud Composer 1)
+### Basic Usage in Managed Airflow (Legacy Gen 1)
+
 ```hcl
 resource "google_composer_environment" "test" {
   name   = "example-composer-env"
@@ -91,18 +97,18 @@ resource "google_composer_environment" "test" {
 }
 ```
 
-### With GKE and Compute Resource Dependencies
+### With environment resources configuration
 
 -> **Note**
   To use custom service accounts, you must give at least the
-  `role/composer.worker` role to the service account of the Cloud Composer 
+  `role/composer.worker` role to the service account of the Managed Airflow
   environment. For more information, see the
-  [Access Control](https://cloud.google.com/composer/docs/how-to/access-control)
-  page in the Cloud Composer documentation.
+  [Access Control](https://docs.cloud.google.com/composer/docs/composer-3/access-control)
+  page in the Managed Airflow documentation.
   You might need to assign additional roles depending on specific workflows 
   that the Airflow DAGs will be running.
 
-#### GKE and Compute Resource Dependencies (Cloud Composer 3)
+#### Environment resources configuration in Managed Airflow (Gen 3)
 
 ```hcl
 provider "google" {
@@ -160,7 +166,7 @@ resource "google_composer_environment" "test" {
 
 resource "google_service_account" "test" {
   account_id   = "composer-env-account"
-  display_name = "Test Service Account for Composer Environment"
+  display_name = "Test Service Account for Managed Airflow Environment"
 }
 
 resource "google_project_iam_member" "composer-worker" {
@@ -170,7 +176,7 @@ resource "google_project_iam_member" "composer-worker" {
 }
 ```
 
-#### GKE and Compute Resource Dependencies (Cloud Composer 2)
+#### Environment resources configuration in Managed Airflow (Gen 2)
 
 ```hcl
 provider "google" {
@@ -232,7 +238,7 @@ resource "google_compute_subnetwork" "test" {
 
 resource "google_service_account" "test" {
   account_id   = "composer-env-account"
-  display_name = "Test Service Account for Composer Environment"
+  display_name = "Test Service Account for Managed Airflow"
 }
 
 resource "google_project_iam_member" "composer-worker" {
@@ -242,7 +248,7 @@ resource "google_project_iam_member" "composer-worker" {
 }
 ```
 
-#### GKE and Compute Resource Dependencies (Cloud Composer 1)
+#### Environment resources configuration in Managed Airflow (Legacy Gen 1)
 
 ```hcl
 resource "google_composer_environment" "test" {
@@ -290,7 +296,7 @@ resource "google_compute_subnetwork" "test" {
 
 resource "google_service_account" "test" {
   account_id   = "composer-env-account"
-  display_name = "Test Service Account for Composer Environment"
+  display_name = "Test Service Account for Managed Airflow"
 }
 
 resource "google_project_iam_member" "composer-worker" {
@@ -299,9 +305,9 @@ resource "google_project_iam_member" "composer-worker" {
 }
 ```
 
-### Cloud Composer 3 networking configuration
+### Networking configuration in Managed Airflow (Gen 3)
 
-In Cloud Composer 3, networking configuration is simplified compared to
+In Managed Airflow (Gen 3), networking configuration is simplified compared to
 previous versions. You don't need to specify network ranges, and can attach
 custom VPC networks to your environment.
 
@@ -326,7 +332,7 @@ resource "google_composer_environment" "example" {
 }
 ```
 
-Attach a custom VPC network (Cloud Composer creates a new network attachment):
+Attach a custom VPC network (Managed Airflow creates a new network attachment):
 
 ```hcl
 resource "google_composer_environment" "example" {
@@ -345,7 +351,7 @@ resource "google_composer_environment" "example" {
 }
 ```
 
-Attach a custom VPC network (use existing network attachment):
+Attach a custom VPC network (use an existing network attachment):
 
 ```hcl
 resource "google_composer_environment" "example" {
@@ -363,10 +369,12 @@ resource "google_composer_environment" "example" {
 }
 ```
 
-If you specify an existing network attachment that you also manage in Terraform, then Terraform will revert changes
-to the attachment done by Cloud Composer when you apply configuration changes. As a result, the environment will no
-longer use the attachment. To address this problem, make sure that Terraform ignores changes to the
-`producer_accept_lists` parameter of the attachment, as follows:
+If you specify an existing network attachment that you also manage in
+Terraform, then Terraform will revert changes to the attachment that were done
+by Managed Airflow when you apply configuration changes. As a result, the
+environment will no longer use the attachment. To address this, make sure that
+Terraform ignores changes to the `producer_accept_lists` parameter of the
+attachment, as follows:
 
 ```hcl
 resource "google_compute_network_attachment" "example" {
@@ -392,7 +400,7 @@ resource "google_composer_environment" "example" {
 }
 ```
 
-### With Software (Airflow) Config
+### Airflow configuration options, Python packages, and environment variables
 
 ```hcl
 resource "google_composer_environment" "test" {
@@ -406,7 +414,7 @@ resource "google_composer_environment" "test" {
 
       pypi_packages = {
         numpy = ""
-        scipy = "==1.1.0"
+        scipy = ">=1.1.0"
       }
 
       env_variables = {
@@ -417,7 +425,7 @@ resource "google_composer_environment" "test" {
 }
 ```
 
-## Argument Reference - Cloud Composer 1
+## Argument Reference for Managed Airflow (Gen 3)
 
 The following arguments are supported:
 
@@ -427,414 +435,8 @@ The following arguments are supported:
 
 * `config` -
   (Optional)
-  Configuration parameters for this environment  Structure is [documented below](#nested_config_c1).
-
-* `labels` -
-  (Optional)
-  User-defined labels for this environment. The labels map can contain
-  no more than 64 entries. Entries of the labels map are UTF8 strings
-  that comply with the following restrictions:
-  Label keys must be between 1 and 63 characters long and must conform
-  to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
-  Label values must be between 0 and 63 characters long and must
-  conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
-  No more than 64 labels can be associated with a given environment.
-  Both keys and values must be <= 128 bytes in size.
-
-  **Note**: This field is non-authoritative, and will only manage the labels present in your configuration.
-  Please refer to the field 'effective_labels' for all of the labels present on the resource.
-
-* `terraform_labels` -
-  The combination of labels configured directly on the resource and default labels configured on the provider.
-
-* `effective_labels` -
-  All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.
-
-* `region` -
-  (Optional)
-  The location or Compute Engine region for the environment.
-
-* `project` -
-  (Optional) The ID of the project in which the resource belongs.
-  If it is not provided, the provider project is used.
-
-<a name="nested_config_c1"></a>The `config` block supports:
-
-* `node_count` -
-  (Optional, Cloud Composer 1 only)
-  The number of nodes in the Kubernetes Engine cluster of the environment.
-
-* `node_config` -
-  (Optional)
-  The configuration used for the Kubernetes Engine cluster.  Structure is [documented below](#nested_node_config_c1).
-
-* `software_config` -
-  (Optional)
-  The configuration settings for software inside the environment.  Structure is [documented below](#nested_software_config_c1).
-
-* `private_environment_config` -
-  (Optional)
-  The configuration used for the Private IP Cloud Composer environment. Structure is [documented below](#nested_private_environment_config_c1).
-
-* `web_server_network_access_control` -
-  The network-level access control policy for the Airflow web server.
-  If unspecified, no network-level access restrictions are applied.
-
-* `database_config` -
-  (Optional, Cloud Composer 1 only)
-  The configuration settings for Cloud SQL instance used internally
-  by Apache Airflow software.
-
-* `web_server_config` -
-  (Optional, Cloud Composer 1 only)
-  The configuration settings for the Airflow web server App Engine instance.
-
-* `encryption_config` -
-  (Optional)
-  The encryption options for the Cloud Composer environment and its
-  dependencies.
-
-* `maintenance_window` -
-  (Optional, [Beta](../guides/provider_versions.html.markdown))
-  The configuration settings for Cloud Composer maintenance windows.
-
-* `master_authorized_networks_config` -
-  (Optional)
-  Configuration options for the master authorized networks feature. Enabled
-  master authorized networks will disallow all external traffic to access
-  Kubernetes master through HTTPS except traffic from the given CIDR blocks,
-  Google Compute Engine Public IPs and Google Prod IPs. Structure is
-  [documented below](#nested_master_authorized_networks_config_c1).
-
-<a name="nested_node_config_c1"></a>The `node_config` block supports:
-
-* `zone` -
-  (Optional, Cloud Composer 1 only)
-  The Compute Engine zone in which to deploy the VMs running the
-  Apache Airflow software, specified as the zone name or
-  relative resource name (e.g. "projects/{project}/zones/{zone}"). Must
-  belong to the enclosing environment's project and region.
-
-* `machine_type` -
-  (Optional, Cloud Composer 1 only)
-  The Compute Engine machine type used for cluster instances,
-  specified as a name or relative resource name. For example:
-  "projects/{project}/zones/{zone}/machineTypes/{machineType}". Must belong
-  to the enclosing environment's project and region/zone.
-
-* `network` -
-  (Optional)
-  The Compute Engine network to be used for machine
-  communications, specified as a self-link, relative resource name
-  (for example "projects/{project}/global/networks/{network}"), by name.
-
-  The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's
-  project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.
-
-* `subnetwork` -
-  (Optional)
-  The Compute Engine subnetwork to be used for machine
-  communications, specified as a self-link, relative resource name (for example,
-  "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided,
-  network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
-
-* `disk_size_gb` -
-  (Optional, Cloud Composer 1 only)
-  The disk size in GB used for node VMs. Minimum size is 20GB.
-  If unspecified, defaults to 100GB. Cannot be updated.
-
-* `oauth_scopes` -
-  (Optional, Cloud Composer 1 only)
-  The set of Google API scopes to be made available on all node
-  VMs. Cannot be updated. If empty, defaults to
-  `["https://www.googleapis.com/auth/cloud-platform"]`.
-
-* `service_account` -
-  (Optional)
-  The Google Cloud Platform Service Account to be used by the
-  node VMs. If a service account is not specified, the "default"
-  Compute Engine service account is used. Cannot be updated. If given,
-  note that the service account must have `roles/composer.worker`
-  for any GCP resources created under the Cloud Composer Environment.
-
-* `tags` -
-  (Optional)
-  The list of instance tags applied to all node VMs. Tags are
-  used to identify valid sources or targets for network
-  firewalls. Each tag within the list must comply with RFC1035.
-  Cannot be updated.
-
-* `ip_allocation_policy` -
-  (Optional)
-  Configuration for controlling how IPs are allocated in the GKE cluster.
-  Structure is [documented below](#nested_ip_allocation_policy_c1).
-  Cannot be updated.
-
-* `max_pods_per_node` -
-  (Optional, [Beta](../guides/provider_versions.html.markdown),
-  Cloud Composer 1 only)
-  The maximum pods per node in the GKE cluster allocated during environment
-  creation. Lowering this value reduces IP address consumption by the Cloud
-  Composer Kubernetes cluster. This value can only be set if the environment is VPC-Native.
-  The range of possible values is 8-110, and the default is 32.
-  Cannot be updated.
-
-* `enable_ip_masq_agent` -
-  (Optional)
-  Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines
-  nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for
-  all destination addresses, except between pods traffic.
-  See the [documentation](https://cloud.google.com/composer/docs/enable-ip-masquerade-agent).
-
-<a name="nested_software_config_c1"></a>The `software_config` block supports:
-
-* `airflow_config_overrides` -
-  (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
-  separated by a hyphen, for example "core-dags_are_paused_at_creation".
-
-  Section names must not contain hyphens ("-"), opening square brackets ("["), or closing square brackets ("]").
-  The property name must not be empty and cannot contain "=" or ";". Section and property names cannot contain
-  characters: "." Apache Airflow configuration property names must be written in snake_case. Property values can
-  contain any character, and can be written in any lower/upper case format. Certain Apache Airflow configuration
-  property values are [blacklisted](https://cloud.google.com/composer/docs/concepts/airflow-configurations#airflow_configuration_blacklists),
-  and cannot be overridden.
-
-* `pypi_packages` -
-  (Optional)
-  Custom Python Package Index (PyPI) packages to be installed
-  in the environment. Keys refer to the lowercase package name (e.g. "numpy"). Values are the lowercase extras and
-  version specifier (e.g. "==1.12.0", "[devel,gcp_api]", "[devel]>=1.8.2, <1.9.2"). To specify a package without
-  pinning it to a version specifier, use the empty string as the value.
-
-* `env_variables` -
-  (Optional)
-  Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes.
-  Environment variable names must match the regular expression `[a-zA-Z_][a-zA-Z0-9_]*`.
-  They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
-  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the following reserved names:
-  ```
-  AIRFLOW_DATABASE_VERSION
-  AIRFLOW_HOME
-  AIRFLOW_SRC_DIR
-  AIRFLOW_WEBSERVER
-  AUTO_GKE
-  CLOUDSDK_METRICS_ENVIRONMENT
-  CLOUD_LOGGING_ONLY
-  COMPOSER_ENVIRONMENT
-  COMPOSER_GKE_LOCATION
-  COMPOSER_GKE_NAME
-  COMPOSER_GKE_ZONE
-  COMPOSER_LOCATION
-  COMPOSER_OPERATION_UUID
-  COMPOSER_PYTHON_VERSION
-  COMPOSER_VERSION
-  CONTAINER_NAME
-  C_FORCE_ROOT
-  DAGS_FOLDER
-  GCP_PROJECT
-  GCP_TENANT_PROJECT
-  GCSFUSE_EXTRACTED
-  GCS_BUCKET
-  GKE_CLUSTER_NAME
-  GKE_IN_TENANT
-  GOOGLE_APPLICATION_CREDENTIALS
-  MAJOR_VERSION
-  MINOR_VERSION
-  PATH
-  PIP_DISABLE_PIP_VERSION_CHECK
-  PORT
-  PROJECT_ID
-  PYTHONPYCACHEPREFIX
-  SQL_DATABASE
-  SQL_HOST
-  SQL_INSTANCE
-  SQL_PASSWORD
-  SQL_PROJECT
-  SQL_REGION
-  SQL_USER
-  ```
-
-* `image_version` -
-(Required) In Composer 1, use a specific Composer 1 version in this parameter. If omitted, the default is the latest version of Composer 2.  
-
-  The version of the software running in the environment. This encapsulates both the version of Cloud Composer
-  functionality and the version of Apache Airflow. It must match the regular expression
-  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
-  The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major
-  version number or 'latest'.
-  The Apache Airflow portion of the image version is a full semantic version that points to one of the
-  supported Apache Airflow versions, or an alias in the form of only major or major.minor versions specified.
-  For more information about Cloud Composer images, see
-  [Cloud Composer version list](https://cloud.google.com/composer/docs/concepts/versioning/composer-versions).
-
-* `python_version` -
-  (Optional, Cloud Composer 1 only)
-  The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes.
-  Can be set to '2' or '3'. If not specified, the default is '3'.
-
-* `scheduler_count` -
-  (Optional, Cloud Composer 1 with Airflow 2 only)
-  The number of schedulers for Airflow.
-
-
-See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. <a name="nested_private_environment_config_c1"></a>The `private_environment_config` block supports:
-
-* `enable_private_endpoint` -
-  If true, access to the public endpoint of the GKE cluster is denied.
-  If this field is set to true, the `ip_allocation_policy.use_ip_aliases` field must
-  also be set to true for Cloud Composer 1 environments.
-
-* `master_ipv4_cidr_block` -
-  (Optional)
-  The IP range in CIDR notation to use for the hosted master network. This range is used
-  for assigning internal IP addresses to the cluster master or set of masters and to the
-  internal load balancer virtual IP. This range must not overlap with any other ranges
-  in use within the cluster's network.
-  If left blank, the default value of is used. See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip#defaults) for default values per region.
-
-* `cloud_sql_ipv4_cidr_block` -
-  (Optional)
-  The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
-
-* `web_server_ipv4_cidr_block` -
-  (Optional, Cloud Composer 1 only)
-  The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from `master_ipv4_cidr_block` and `cloud_sql_ipv4_cidr_block`.
-
-* `enable_privately_used_public_ips` -
-  (Optional)
-  When enabled, IPs from public (non-RFC1918) ranges can be used for
-  `ip_allocation_policy.cluster_ipv4_cidr_block` and `ip_allocation_policy.service_ipv4_cidr_block`.
-
-The `web_server_network_access_control` supports:
-
-* `allowed_ip_range` -
-  A collection of allowed IP ranges with descriptions. Structure is [documented below](#nested_allowed_ip_range_c1).
-
-<a name="nested_allowed_ip_range_c1"></a>The `allowed_ip_range` supports:
-
-* `value` -
-  (Required)
-  IP address or range, defined using CIDR notation, of requests that this rule applies to.
-  Examples: `192.168.1.1` or `192.168.0.0/16` or `2001:db8::/32` or `2001:0db8:0000:0042:0000:8a2e:0370:7334`.
-  IP range prefixes should be properly truncated. For example,
-  `1.2.3.4/24` should be truncated to `1.2.3.0/24`. Similarly, for IPv6, `2001:db8::1/32` should be truncated to `2001:db8::/32`.
-
-* `description` -
-  (Optional)
-  A description of this ip range.
-
-<a name="nested_ip_allocation_policy_c1"></a>The `ip_allocation_policy` block supports:
-
-* `use_ip_aliases` -
-  (Optional, Cloud Composer 1 only)
-  Whether or not to enable Alias IPs in the GKE cluster. If true, a VPC-native cluster is created.
-  Defaults to true if the `ip_allocation_policy` block is present in config.
-
-* `cluster_secondary_range_name` -
-  (Optional)
-  The name of the cluster's secondary range used to allocate IP addresses to pods.
-  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-
-* `services_secondary_range_name` -
-  (Optional)
-  The name of the services' secondary range used to allocate IP addresses to the cluster.
-  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-
-* `cluster_ipv4_cidr_block` -
-  (Optional)
-  The IP address range used to allocate IP addresses to pods in the cluster.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-  Set to blank to have GKE choose a range with the default size.
-  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
-  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
-  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
-  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
-
-* `services_ipv4_cidr_block` -
-  (Optional)
-  The IP address range used to allocate IP addresses in this cluster.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-  Set to blank to have GKE choose a range with the default size.
-  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
-  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
-  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
-  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
-
-<a name="nested_database_config_c1"></a>The `database_config` block supports:
-
-* `machine_type` -
-  (Optional)
-  Optional. Cloud SQL machine type used by Airflow database. It has to be one of: db-n1-standard-2,
-  db-n1-standard-4, db-n1-standard-8 or db-n1-standard-16.
-
-* `Zone` -
-  (Optional)
-  Preferred Cloud SQL database zone.
-
-<a name="nested_web_server_config_c1"></a>The `web_server_config` block supports:
-
-* `machine_type` -
-  (Required)
-  Machine type on which Airflow web server is running. It has to be one of: composer-n1-webserver-2,
-  composer-n1-webserver-4 or composer-n1-webserver-8.
-  Value custom is returned only in response, if Airflow web server parameters were
-  manually changed to a non-standard values.
-
-<a name="nested_encryption_config_c1"></a>The `encryption_config` block supports:
-
-* `kms_key_name` -
-  (Required)
-  Customer-managed Encryption Key available through Google's Key Management Service. It must
-  be the fully qualified resource name,
-  i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
-
-<a name="nested_maintenance_window_c1"></a>The `maintenance_window` block supports:
-* `start_time` -
-  (Required)
-  Start time of the first recurrence of the maintenance window.
-
-* `end_time` -
-  (Required)
-  Maintenance window end time. It is used only to calculate the duration of the maintenance window.
-  The value for end-time must be in the future, relative to 'start_time'.
-
-* `recurrence` -
-  (Required)
-  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
-  The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
-  Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
-
-<a name="nested_master_authorized_networks_config_c1"></a>The `master_authorized_networks_config` block supports:
-* `enabled` -
-  (Required)
-  Whether or not master authorized networks is enabled.
-
-* `cidr_blocks` -
-  `cidr_blocks `define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is [documented below](#nested_cidr_blocks_c1).
-
-<a name="nested_cidr_blocks_c1"></a>The `cidr_blocks` supports:
-
-* `display_name` -
-  (Optional)
-  `display_name` is a field for users to identify CIDR blocks.
-
-* `cidr_block` -
-  (Required)
-  `cidr_block` must be specified in CIDR notation.
-
-## Argument Reference - Cloud Composer 2
-
-The following arguments are supported:
-
-* `name` -
-  (Required)
-  Name of the environment
-
-* `config` -
-  (Optional)
-  Configuration parameters for this environment. Structure is [documented below](#nested_config_c2).
+  Configuration parameters for this environment. Structure is
+  [documented below](#nested_config_gen_3).
 
 * `labels` -
   (Optional)
@@ -858,302 +460,238 @@ The following arguments are supported:
 
 * `storage_config` -
   (Optional)
-  Configuration options for storage used by Composer environment. Structure is [documented below](#nested_storage_config_c2).
+  Configuration options for storage used by the environment. Structure is
+  [documented below](#nested_storage_config_gen_3).
 
-
-<a name="nested_config_c2"></a>The `config` block supports:
+<a name="nested_config_gen_3"></a>The `config` block supports:
 
 * `node_config` -
   (Optional)
-  The configuration used for the Kubernetes Engine cluster. Structure is [documented below](#nested_node_config_c2).
+  The configuration used for the environment's Google Kubernetes Engine
+  cluster. Structure is [documented below](#nested_node_config_gen_3).
 
 * `recovery_config` -
-  (Optional, Cloud Composer 2 only)
-  The configuration settings for recovery. Structure is [documented below](#nested_recovery_config_c2).
+  (Optional)
+  The configuration settings for recovery. Structure is [documented below](#nested_recovery_config_gen_3).
 
 * `software_config` -
   (Optional)
-  The configuration settings for software (Airflow) inside the environment. Structure is
-  [documented below](#nested_software_config_c2).
+  The configuration settings for the Airflow instance that runs inside the
+  environment. Structure is [documented below](#nested_software_config_gen_3).
 
-* `private_environment_config` -
-  (Optional)
-  The configuration used for the Private IP Cloud Composer environment. Structure is [documented below](#nested_private_environment_config_c2).
+* `enable_private_environment` -
+  (Optional, Managed Airflow (Gen 3) only)
+  If true, a private environment will be created.
+
+* `enable_private_builds_only` -
+  (Optional,Managed Airflow (Gen 3) only)
+  If true, builds performed during operations that install Python packages have
+  only private connectivity to Google services. If false, the builds also have
+  access to the internet.
 
 * `encryption_config` -
   (Optional)
-  The encryption options for the Cloud Composer environment and its
+  The encryption options for the Managed Airflow environment and its
   dependencies.
 
 * `maintenance_window` -
   (Optional)
-  The configuration settings for Cloud Composer maintenance windows.
+  The configuration settings for Managed Airflow maintenance windows.
 
 * `workloads_config` -
   (Optional)
-  The Kubernetes workloads configuration for GKE cluster associated with the
-  Cloud Composer environment.
+  Environment resources configuration for the Google Kubernetes engine cluster
+  associated with the Managed Airflow environment.
 
 * `environment_size` -
   (Optional)
   The environment size controls the performance parameters of the managed
-  Cloud Composer infrastructure that includes the Airflow database. Values for
+  Managed Airflow infrastructure that includes the Airflow database. Values for
   environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
   and `ENVIRONMENT_SIZE_LARGE`.
 
-* `resilience_mode` -
-  (Optional, Cloud Composer 2.1.15 or newer only)
-  The resilience mode states whether high resilience is enabled for 
-  the environment or not. Values for resilience mode are `HIGH_RESILIENCE` 
-  for high resilience and `STANDARD_RESILIENCE` for standard
-  resilience.
-
 * `data_retention_config` -
-  (Optional, Cloud Composer 2.0.23 or newer only)
-  Configuration setting for airflow data rentention mechanism. Structure is
-  [documented below](#nested_data_retention_config_c2).
-
-<a name="nested_data_retention_config_c2"></a>The `data_retention_config` block supports:
-* `task_logs_retention_config` - 
   (Optional)
-  The configuration setting for Task Logs. Structure is
-  [documented below](#nested_task_logs_retention_config_c2).
+  Configuration setting for Airflow database retention mechanism. Structure is
+  [documented below](#nested_data_retention_config_gen_3).
 
-<a name="nested_task_logs_retention_config_c2"></a>The `task_logs_retention_config` block supports:
-* `storage_mode` - 
+<a name="nested_data_retention_config_gen_3"></a>The `data_retention_config`
+block supports:
+
+* `airflow_metadata_retention_config` -
   (Optional)
-  The mode of storage for Airflow workers task logs. Values for storage mode are 
-  `CLOUD_LOGGING_ONLY` to only store logs in cloud logging and 
-  `CLOUD_LOGGING_AND_CLOUD_STORAGE` to store logs in cloud logging and cloud storage.
+  The retention policy for the Airflow metadata database. Structure is
+  [documented below](#nested_airflow_metadata_retention_config_gen_3).
 
-* `master_authorized_networks_config` -
+<a name="nested_airflow_metadata_retention_config_gen_3"></a>The
+`airflow_metadata_retention_config` block supports:
+
+* `retention_mode` -
   (Optional)
-  Configuration options for the master authorized networks feature. Enabled
-  master authorized networks will disallow all external traffic to access
-  Kubernetes master through HTTPS except traffic from the given CIDR blocks,
-  Google Compute Engine Public IPs and Google Prod IPs. Structure is
-  [documented below](#nested_master_authorized_networks_config_c2).
+  Retention can be either enabled or disabled. Values for retention_mode are
+  `RETENTION_MODE_ENABLED` to enable retention and `RETENTION_MODE_DISABLED`
+  to disable retention.
 
-<a name="nested_master_authorized_networks_config_c2"></a>The `master_authorized_networks_config` block supports:
-* `enabled` -
-  (Required)
-  Whether or not master authorized networks is enabled.
-
-* `cidr_blocks` -
-  `cidr_blocks `define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is [documented below](#nested_cidr_blocks_c2).
-
-<a name="nested_cidr_blocks_c2"></a>The `cidr_blocks` supports:
-
-* `display_name` -
+* `retention_days` -
   (Optional)
-  `display_name` is a field for users to identify CIDR blocks.
-
-* `cidr_block` -
-  (Required)
-  `cidr_block` must be specified in CIDR notation.
+  How many days data must be retained for.
 
 
-<a name="nested_storage_config_c2"></a>The `storage_config` block supports:
+<a name="nested_storage_config_gen_3"></a>The `storage_config` block supports:
 
 * `bucket` -
   (Required)
   Name of an existing Cloud Storage bucket to be used by the environment.
 
 
-<a name="nested_node_config_c2"></a>The `node_config` block supports:
+<a name="nested_node_config_gen_3"></a>The `node_config` block supports:
 
 * `network` -
   (Optional)
   The Compute Engine network to be used for machine
   communications, specified as a self-link, relative resource name
-  (for example "projects/{project}/global/networks/{network}"), by name.
+  (for example `projects/{project}/global/networks/{network}`), by name.
 
-  The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's
-  project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.
+  The network must belong to the environment's project. If unspecified, the
+  `default` network ID in the environment's project is used. If a
+  Custom Subnet Network is provided, subnetwork must also be provided.
 
 * `subnetwork` -
   (Optional)
   The Compute Engine subnetwork to be used for machine
   communications, specified as a self-link, relative resource name (for example,
-  "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided,
-  network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
+  `projects/{project}/regions/{region}/subnetworks/{subnetwork}`), or by name.
+  If subnetwork is provided, network must also be provided and the subnetwork
+  must belong to the enclosing environment's project and region.
+
+* `composer_network_attachment` -
+  (Optional, Managed Airflow (Gen 3) only)
+  PSC (Private Service Connect) Network entry point. Customers can pre-create
+  the Network Attachment and point Managed Airflow environment to use. It is possible to share network attachment among many environments,
+  provided enough IP addresses are available.
 
 * `service_account` -
-  (Optional)
   The Google Cloud Platform Service Account to be used by the
-  node VMs. If a service account is not specified, the "default"
-  Compute Engine service account is used. Cannot be updated. If given,
-  note that the service account must have `roles/composer.worker`
-  for any GCP resources created under the Cloud Composer Environment.
+  environment to perform operations and run DAGs. Cannot be
+  updated. The service account must have the `roles/composer.worker` role
+  to create the environment. To access other resources in your Google Cloud
+  project, grant extra permissions to access those resources to this service
+  account.
 
 * `tags` -
   (Optional)
-  The list of instance tags applied to all node VMs. Tags are
-  used to identify valid sources or targets for network
+  The list of instance tags applied to all node VMs in the environment's
+  cluster. Tags are used to identify valid sources or targets for network
   firewalls. Each tag within the list must comply with RFC1035.
   Cannot be updated.
 
-* `ip_allocation_policy` -
-  (Optional)
-  Configuration for controlling how IPs are allocated in the GKE cluster.
-  Structure is [documented below](#nested_ip_allocation_policy_c2).
-  Cannot be updated.
+* `composer_internal_ipv4_cidr_block` -
+  (Optional, Managed Airflow (Gen 3) only)
+  /20 IPv4 cidr range that will be used by the environment's internal
+  components. Cannot be updated.
 
-* `enable_ip_masq_agent` -
-  (Optional)
-  IP Masq Agent translates Pod IP addresses to node IP addresses, so that 
-  destinations and services targeted from Airflow DAGs and tasks only receive 
-  packets from node IP addresses instead of Pod IP addresses
-  See the [documentation](https://cloud.google.com/composer/docs/enable-ip-masquerade-agent).
-
-<a name="nested_software_config_c2"></a>The `software_config` block supports:
+<a name="nested_software_config_gen_3"></a>The `software_config` block supports:
 
 * `airflow_config_overrides` -
-  (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
-  separated by a hyphen, for example "core-dags_are_paused_at_creation".
+  (Optional) Apache Airflow configuration options to override.
 
-  Section names must not contain hyphens ("-"), opening square brackets ("["), or closing square brackets ("]").
-  The property name must not be empty and cannot contain "=" or ";". Section and property names cannot contain
-  characters: "." Apache Airflow configuration property names must be written in snake_case. Property values can
-  contain any character, and can be written in any lower/upper case format. Certain Apache Airflow configuration
-  property values are [blacklisted](https://cloud.google.com/composer/docs/concepts/airflow-configurations#airflow_configuration_blacklists),
+  Keys contain section names and Airflow configuration option names,
+  separated by a hyphen, for example: `core-dags_are_paused_at_creation` where
+  `core` is the section and `dags_are_paused_at_creation` is the Airflow
+  configuration option name.
+
+  Section names must not contain hyphens (`-`), opening square brackets (`[`),
+  or closing square brackets (`]`).
+  Option names must not be empty and can't contain `=` or `;` characters.
+  Section and onption names cannot contain `.` characters. Option
+  names must be written in snake_case.
+
+  Values can
+  contain any character, and can be written in any lower or upper case format.
+  Certain Apache Airflow configuration option values are
+  [blocked](https://docs.cloud.google.com/composer/docs/airflow-configurations),
   and cannot be overridden.
 
 * `pypi_packages` -
   (Optional)
   Custom Python Package Index (PyPI) packages to be installed
-  in the environment. Keys refer to the lowercase package name (e.g. "numpy"). Values are the lowercase extras and
-  version specifier (e.g. "==1.12.0", "[devel,gcp_api]", "[devel]>=1.8.2, <1.9.2"). To specify a package without
+  in the environment, in addition to
+  [preinstalled packages](https://docs.cloud.google.com/composer/docs/versions-packages).
+  Keys refer to the lowercase package name (for example: `numpy`). Values are
+  the lowercase extras and version specifier (example: `==1.12.0`,
+  `[devel,gcp_api]`, `[devel]>=1.8.2`, `<1.9.2`). To specify a package without
   pinning it to a version specifier, use the empty string as the value.
 
 * `env_variables` -
   (Optional)
-  Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes.
-  Environment variable names must match the regular expression `[a-zA-Z_][a-zA-Z0-9_]*`.
-  They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
-  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the following reserved names:
-  ```
-  AIRFLOW_HOME
-  C_FORCE_ROOT
-  CONTAINER_NAME
-  DAGS_FOLDER
-  GCP_PROJECT
-  GCS_BUCKET
-  GKE_CLUSTER_NAME
-  SQL_DATABASE
-  SQL_INSTANCE
-  SQL_PASSWORD
-  SQL_PROJECT
-  SQL_REGION
-  SQL_USER
-  ```
+  Additional environment variables to provide to Apache Airflow components of the environment.
+  Environment variable names must match the regular expression
+  `[a-zA-Z_][a-zA-Z0-9_]*`. They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
+  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the
+  [reserved variable names](https://docs.cloud.google.com/composer/docs/composer-3/set-environment-variables#reserved).
 
 * `image_version` -
-(Optional) If omitted, the default is the latest version of Composer 2.
+  Version of Managed Airflow and Apache Airflow to use.
+  If omitted, the
+  [default build of Managed Airflow (Gen 3)](https://docs.cloud.google.com/composer/docs/composer-versions)
+  is used.
 
+  In Managed Airflow (Gen 3), you can only specify `3` as the Managed Airflow
+  portion of the image version. Example: `composer-3-airflow-x.y.z-build.t`.
 
-  The version of the software running in the environment. This encapsulates both the version of Cloud Composer
-  functionality and the version of Apache Airflow. It must match the regular expression
-  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
-  The Cloud Composer portion of the image version is a full semantic version, or an alias in the form of major
-  version number or 'latest'.
-  The Apache Airflow portion of the image version is a full semantic version that points to one of the
-  supported Apache Airflow versions, or an alias in the form of only major or major.minor versions specified.
-  **Important**: In-place upgrade is only available between minor or
-  patch versions of Cloud Composer or Apache Airflow. For example, you can upgrade your environment from
-  `composer-1.16.x` to `composer-1.17.x`, or from `airflow-2.1.x` to `airflow-2.2.x`. You cannot upgrade between
-  major Cloud Composer or Apache Airflow versions (from `1.x.x` to `2.x.x`). To do so, create a new environment.
+  The Apache Airflow portion of the image version is a full semantic version
+  that points to one of the supported Apache Airflow versions, or an alias in
+  the form of only `major`, `major.minor` or `major.minor.patch` versions
+  specified.
+  Like in Managed Airflow (Gen 2) and Managed Airflow (Legacy Gen 1), a given
+  Airflow version is released multiple times in Managed Airflow, with different
+  patches and versions of dependencies. To distinguish between these versions
+  in Managed Airflow (Gen 3), you can optionally specify a build number to pin
+  to a specific Airflow release.
+  Example: `composer-3-airflow-2.6.3-build.4`.
+
+  The image version in Managed Airflow (Gen 3) must match the regular
+  expression:
+  `composer-(([0-9]+)(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-(([0-9]+)((\.[0-9]+)(\.[0-9]+)?)?(-build\.[0-9]+)?)`
+  Example: `composer-3-airflow-2.6.3-build.4`.
+
+  **Important**: In-place upgrade in Managed Airflow (Gen 3) is only available
+  between minor or patch versions of Apache Airflow. You can also upgrade to a
+  different Airflow build within the same version by specifying the build
+  number. For example, you can upgrade your environment from
+  `composer-3-airflow-2.6.x` to `composer-3-airflow-2.9.x`,
+  or from `composer-3-airflow-2.9.3-build.4` to
+  `composer-3-airflow-2.9.3-build.5`.
 
 * `cloud_data_lineage_integration` -
-  (Optional, Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and newer)
+  (Optional)
   The configuration for Cloud Data Lineage integration. Structure is
-  [documented below](#nested_cloud_data_lineage_integration_c2).
+  [documented below](#nested_cloud_data_lineage_integration_gen_3).
 
-<a name="nested_cloud_data_lineage_integration_c2"></a>The `cloud_data_lineage_integration` block supports:
+* `web_server_plugins_mode` -
+  (Optional, Managed Airflow (Gen 3) only)
+  Web server plugins configuration. Can be either `ENABLED` or `DISABLED`.
+  Defaults to `ENABLED`.
+
+<a name="nested_cloud_data_lineage_integration_gen_3"></a>The
+`cloud_data_lineage_integration` block supports:
+
 * `enabled` -
   (Required)
   Whether or not Cloud Data Lineage integration is enabled.
 
-<a name="nested_private_environment_config_c2"></a>See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
-
-* `connection_type` -
-  (Optional, Cloud Composer 2 only)
-  Mode of internal communication within the Composer environment. Must be one
-  of `"VPC_PEERING"` or `"PRIVATE_SERVICE_CONNECT"`.
-
-* `enable_private_endpoint` -
-  If true, access to the public endpoint of the GKE cluster is denied.
-
-* `master_ipv4_cidr_block` -
-  (Optional)
-  The IP range in CIDR notation to use for the hosted master network. This range is used
-  for assigning internal IP addresses to the cluster master or set of masters and to the
-  internal load balancer virtual IP. This range must not overlap with any other ranges
-  in use within the cluster's network.
-  If left blank, the default value of is used. See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip#defaults) for default values per region.
-
-* `cloud_sql_ipv4_cidr_block` -
-  (Optional)
-  The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
-
-* `cloud_composer_network_ipv4_cidr_block"` -
-  (Optional, Cloud Composer 2 only)
-  The CIDR block from which IP range for Cloud Composer Network in tenant project will be reserved. Needs to be disjoint from private_cluster_config.master_ipv4_cidr_block and cloud_sql_ipv4_cidr_block.
-
-* `enable_privately_used_public_ips` -
-  (Optional)
-  When enabled, IPs from public (non-RFC1918) ranges can be used for
-  `ip_allocation_policy.cluster_ipv4_cidr_block` and `ip_allocation_policy.service_ipv4_cidr_block`.
-
-* `cloud_composer_connection_subnetwork` -
-  (Optional)
-  When specified, the environment will use Private Service Connect instead of VPC peerings to connect
-  to Cloud SQL in the Tenant Project, and the PSC endpoint in the Customer Project will use an IP
-  address from this subnetwork. This field is supported for Cloud Composer environments in
-  versions `composer-2.*.*-airflow-*.*.*` and newer.
-
-
-<a name="nested_ip_allocation_policy_c2"></a>The `ip_allocation_policy` block supports:
-
-* `cluster_secondary_range_name` -
-  (Optional)
-  The name of the cluster's secondary range used to allocate IP addresses to pods.
-  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
-
-* `services_secondary_range_name` -
-  (Optional)
-  The name of the services' secondary range used to allocate IP addresses to the cluster.
-  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
-
-* `cluster_ipv4_cidr_block` -
-  (Optional)
-  The IP address range used to allocate IP addresses to pods in the cluster.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-  Set to blank to have GKE choose a range with the default size.
-  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
-  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
-  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
-  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block` but not both.
-
-* `services_ipv4_cidr_block` -
-  (Optional)
-  The IP address range used to allocate IP addresses in this cluster.
-  For Cloud Composer 1 environments, this field is applicable only when `use_ip_aliases` is true.
-  Set to blank to have GKE choose a range with the default size.
-  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
-  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
-  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
-  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
-
-<a name="nested_encryption_config_comp_2"></a>The `encryption_config` block supports:
+<a name="nested_encryption_config_comp_2"></a>The `encryption_config` block
+supports:
 
 * `kms_key_name` -
   (Required)
-  Customer-managed Encryption Key available through Google's Key Management Service. It must
-  be the fully qualified resource name,
-  i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
+  Customer-managed Encryption Key available through Google's Key Management
+  Service. It must be the fully qualified resource name, for example:
+  `projects/example-project-id/locations/example-location/keyRings/example-keyring/cryptoKeys/example-key`.
+  Cannot be updated.
 
-<a name="nested_maintenance_window_comp_2"></a>The `maintenance_window` block supports:
+<a name="nested_maintenance_window_comp_2"></a>The `maintenance_window` block
+supports:
 
 * `start_time` -
   (Required)
@@ -1161,26 +699,30 @@ The following arguments are supported:
 
 * `end_time` -
   (Required)
-  Maintenance window end time. It is used only to calculate the duration of the maintenance window.
-  The value for end-time must be in the future, relative to 'start_time'.
+  Maintenance window end time. It is used only to calculate the duration of the
+  maintenance window.
+  The value for end-time must be in the future, relative to `start_time`.
 
 * `recurrence` -
   (Required)
-  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
-  The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
-  Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
+  Maintenance window recurrence. Format is a subset of
+  [RFC-5545](https://tools.ietf.org/html/rfc5545) `RRULE`.
+  The only allowed values for `FREQ` field are `FREQ=DAILY` and
+  `FREQ=WEEKLY;BYDAY=...`.
+  Example values: `FREQ=WEEKLY;BYDAY=TU,WE`, `FREQ=DAILY`.
 
-<a name="nested_recovery_config_c2"></a>The `recovery_config` block supports:
+<a name="nested_recovery_config_gen_3"></a>The `recovery_config` block supports:
 
 * `scheduled_snapshots_config` -
   (Optional)
-  The recovery configuration settings for the Cloud Composer environment.
+  The recovery configuration settings for the Managed Airflow environment.
 
 The `scheduled_snapshots_config` block supports:
 
 * `enabled` -
   (Optional)
-  When enabled, Cloud Composer periodically saves snapshots of your environment to a Cloud Storage bucket.
+  When enabled, Managed Airflow periodically saves snapshots of your
+  environment to a Cloud Storage bucket.
 
 * `snapshot_location` -
   (Optional)
@@ -1188,11 +730,13 @@ The `scheduled_snapshots_config` block supports:
 
 * `snapshot_creation_schedule` -
   (Optional)
-  Snapshot schedule, in the unix-cron format.
+  Snapshot schedule, in the Unix-cron format.
 
 * `time_zone` -
   (Optional)
-  A time zone for the schedule. This value is a time offset and does not take into account daylight saving time changes. Valid values are from UTC-12 to UTC+12. Examples: UTC, UTC-01, UTC+03.
+  A time zone for the schedule. This value is a time offset and does not take
+  into account daylight saving time changes. Valid values are from UTC-12 to
+  UTC+12. Examples: UTC, UTC-01, UTC+03.
 
 The `workloads_config` block supports:
 
@@ -1202,363 +746,19 @@ The `workloads_config` block supports:
 
 * `triggerer` -
   (Optional)
-  Configuration for resources used by Airflow triggerer.
+  Configuration for resources used by Airflow triggerers.
 
 * `web_server` -
   (Optional)
-  Configuration for resources used by Airflow web server.
-
-* `worker` -
-  (Optional)
-  Configuration for resources used by Airflow workers.
-
-The `scheduler` block supports:
-
-* `cpu` -
-  (Optional)
-  The number of CPUs for a single Airflow scheduler.
-
-* `memory_gb` -
-  (Optional)
-  The amount of memory (GB) for a single Airflow scheduler.
-
-* `storage_gb` -
-  (Optional)
-  The amount of storage (GB) for a single Airflow scheduler.
-
-* `count` -
-  (Optional)
-  The number of schedulers.
-
-The `triggerer` block supports:
-
-* `cpu` -
-  (Required)
-  The number of CPUs for a single Airflow triggerer.
-
-* `memory_gb` -
-  (Required)
-  The amount of memory (GB) for a single Airflow triggerer.
-
-* `count` -
-  (Required)
-  The number of Airflow triggerers.
-
-The `web_server` block supports:
-
-* `cpu` -
-  (Optional)
-  The number of CPUs for the Airflow web server.
-
-* `memory_gb` -
-  (Optional)
-  The amount of memory (GB) for the Airflow web server.
-
-* `storage_gb` -
-  (Optional)
-  The amount of storage (GB) for the Airflow web server.
-
-The `worker` block supports:
-
-* `cpu` -
-  (Optional)
-  The number of CPUs for a single Airflow worker.
-
-* `memory_gb` -
-  (Optional)
-  The amount of memory (GB) for a single Airflow worker.
-
-* `storage_gb`
-  (Optional)
-  The amount of storage (GB) for a single Airflow worker.
-
-* `min_count` -
-  (Optional)
-  The minimum number of Airflow workers that the environment can run. The number of workers in the
-  environment does not go below this number, even if a lower number of workers can handle the load.
-
-* `max_count` -
-  (Optional)
-  The maximum number of Airflow workers that the environment can run. The number of workers in the
-  environment does not go above this number, even if a higher number of workers is required to
-  handle the load.
-
-
-## Argument Reference - Cloud Composer 3
-
-The following arguments are supported:
-
-* `name` -
-  (Required)
-  Name of the environment
-
-* `config` -
-  (Optional)
-  Configuration parameters for this environment. Structure is [documented below](#nested_config_c3).
-
-* `labels` -
-  (Optional)
-  User-defined labels for this environment. The labels map can contain
-  no more than 64 entries. Entries of the labels map are UTF8 strings
-  that comply with the following restrictions:
-  Label keys must be between 1 and 63 characters long and must conform
-  to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
-  Label values must be between 0 and 63 characters long and must
-  conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
-  No more than 64 labels can be associated with a given environment.
-  Both keys and values must be <= 128 bytes in size.
-
-* `region` -
-  (Optional)
-  The location or Compute Engine region for the environment.
-
-* `project` -
-  (Optional) The ID of the project in which the resource belongs.
-  If it is not provided, the provider project is used.
-
-* `storage_config` -
-  (Optional)
-  Configuration options for storage used by Composer environment. Structure is [documented below](#nested_storage_config_c3).
-
-
-<a name="nested_config_c3"></a>The `config` block supports:
-
-* `node_config` -
-  (Optional)
-  The configuration used for the Kubernetes Engine cluster. Structure is [documented below](#nested_node_config_c3).
-
-* `software_config` -
-  (Optional)
-  The configuration settings for software (Airflow) inside the environment. Structure is [documented below](#nested_software_config_c3).
-
-* `enable_private_environment` -
-  (Optional, Cloud Composer 3 only)
-  If true, a private Composer environment will be created.
-
-* `enable_private_builds_only` -
-  (Optional, Cloud Composer 3 only)
-  If true, builds performed during operations that install Python packages have only private connectivity to Google services.
-  If false, the builds also have access to the internet.
-
-* `encryption_config` -
-  (Optional)
-  The encryption options for the Cloud Composer environment and its
-  dependencies.
-
-* `maintenance_window` -
-  (Optional)
-  The configuration settings for Cloud Composer maintenance windows.
-
-* `workloads_config` -
-  (Optional)
-  The Kubernetes workloads configuration for GKE cluster associated with the
-  Cloud Composer environment.
-
-* `environment_size` -
-  (Optional)
-  The environment size controls the performance parameters of the managed
-  Cloud Composer infrastructure that includes the Airflow database. Values for
-  environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
-  and `ENVIRONMENT_SIZE_LARGE`.
-
-* `data_retention_config` -
-  (Optional)
-  Configuration setting for Airflow database retention mechanism. Structure is
-  [documented below](#nested_data_retention_config_c3).
-
-<a name="nested_data_retention_config_c3"></a>The `data_retention_config` block supports:
-* `airflow_metadata_retention_config` - 
-  (Optional)
-  The retention policy for airflow metadata database. Structure is
-  [documented below](#nested_airflow_metadata_retention_config_c3).
-
-<a name="nested_airflow_metadata_retention_config_c3"></a>The `airflow_metadata_retention_config` block supports:
-* `retention_mode` - 
-  (Optional)
-  Retention can be either enabled or disabled. Values for retention_mode are 
-  `RETENTION_MODE_ENABLED` to enable retention and `RETENTION_MODE_DISABLED` 
-  to disable retention.
-* `retention_days` - 
-  (Optional)
-  How many days data should be retained for.
-
-
-<a name="nested_storage_config_c3"></a>The `storage_config` block supports:
-
-* `bucket` -
-  (Required)
-  Name of an existing Cloud Storage bucket to be used by the environment.
-
-
-<a name="nested_node_config_c3"></a>The `node_config` block supports:
-
-* `network` -
-  (Optional)
-  The Compute Engine network to be used for machine
-  communications, specified as a self-link, relative resource name
-  (for example "projects/{project}/global/networks/{network}"), by name.
-
-  The network must belong to the environment's project. If unspecified, the "default" network ID in the environment's
-  project is used. If a Custom Subnet Network is provided, subnetwork must also be provided.
-
-* `subnetwork` -
-  (Optional)
-  The Compute Engine subnetwork to be used for machine
-  communications, specified as a self-link, relative resource name (for example,
-  "projects/{project}/regions/{region}/subnetworks/{subnetwork}"), or by name. If subnetwork is provided,
-  network must also be provided and the subnetwork must belong to the enclosing environment's project and region.
-
-* `composer_network_attachment` -
-  (Optional, Cloud Composer 3 only)
-  PSC (Private Service Connect) Network entry point. Customers can pre-create the Network Attachment 
-  and point Cloud Composer environment to use. It is possible to share network attachment among many environments, 
-  provided enough IP addresses are available.
-
-* `service_account` -
-  (Optional)
-  The Google Cloud Platform Service Account to be used by the
-  node VMs. If a service account is not specified, the "default"
-  Compute Engine service account is used. Cannot be updated. If given,
-  note that the service account must have `roles/composer.worker`
-  for any GCP resources created under the Cloud Composer Environment.
-
-  This field is required for newly created environments.
-
-* `tags` -
-  (Optional)
-  The list of instance tags applied to all node VMs. Tags are
-  used to identify valid sources or targets for network
-  firewalls. Each tag within the list must comply with RFC1035.
-  Cannot be updated.
-
-* `composer_internal_ipv4_cidr_block` -
-  (Optional, Cloud Composer 3 only)
-  /20 IPv4 cidr range that will be used by Composer internal components.
-  Cannot be updated.
-
-<a name="nested_software_config_c3"></a>The `software_config` block supports:
-
-* `airflow_config_overrides` -
-  (Optional) Apache Airflow configuration properties to override. Property keys contain the section and property names,
-  separated by a hyphen, for example "core-dags_are_paused_at_creation".
-
-  Section names must not contain hyphens ("-"), opening square brackets ("["), or closing square brackets ("]").
-  The property name must not be empty and cannot contain "=" or ";". Section and property names cannot contain
-  characters: "." Apache Airflow configuration property names must be written in snake_case. Property values can
-  contain any character, and can be written in any lower/upper case format. Certain Apache Airflow configuration
-  property values are [blacklisted](https://cloud.google.com/composer/docs/concepts/airflow-configurations#airflow_configuration_blacklists),
-  and cannot be overridden.
-
-* `pypi_packages` -
-  (Optional)
-  Custom Python Package Index (PyPI) packages to be installed
-  in the environment. Keys refer to the lowercase package name (e.g. "numpy"). Values are the lowercase extras and
-  version specifier (e.g. "==1.12.0", "[devel,gcp_api]", "[devel]>=1.8.2, <1.9.2"). To specify a package without
-  pinning it to a version specifier, use the empty string as the value.
-
-* `env_variables` -
-  (Optional)
-  Additional environment variables to provide to the Apache Airflow scheduler, worker, and webserver processes.
-  Environment variable names must match the regular expression `[a-zA-Z_][a-zA-Z0-9_]*`.
-  They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
-  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the following reserved names:
-  ```
-  AIRFLOW_HOME
-  C_FORCE_ROOT
-  CONTAINER_NAME
-  DAGS_FOLDER
-  GCP_PROJECT
-  GCS_BUCKET
-  GKE_CLUSTER_NAME
-  SQL_DATABASE
-  SQL_INSTANCE
-  SQL_PASSWORD
-  SQL_PROJECT
-  SQL_REGION
-  SQL_USER
-  ```
-
-* `image_version` -
-  (Required) If omitted, the default is the latest version of Composer 2.
-
-  In Cloud Composer 3, you can only specify 3 in the Cloud Composer portion of the image version. Example: composer-3-airflow-x.y.z-build.t.
-
-  The Apache Airflow portion of the image version is a full semantic version that points to one of the
-  supported Apache Airflow versions, or an alias in the form of only major, major.minor or major.minor.patch versions specified.
-  Like in Composer 1 and 2, a given Airflow version is released multiple times in Composer, with different patches
-  and versions of dependencies. To distinguish between these versions in Composer 3, you can optionally specify a
-  build number to pin to a specific Airflow release.
-  Example: composer-3-airflow-2.6.3-build.4.
-
-  The image version in Composer 3 must match the regular expression:
-  `composer-(([0-9]+)(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-(([0-9]+)((\.[0-9]+)(\.[0-9]+)?)?(-build\.[0-9]+)?)`
-  Example: composer-3-airflow-2.6.3-build.4
-
-  **Important**: In-place upgrade in Composer 3 is only available between minor or patch versions of Apache Airflow.
-  You can also upgrade to a different Airflow build within the same version by specifying the build number.
-  For example, you can upgrade your environment from composer-3-airflow-2.6.x to composer-3-airflow-2.9.x,
-  or from composer-3-airflow-2.9.3-build.4 to composer-3-airflow-2.9.3-build.5.
-
-* `cloud_data_lineage_integration` -
-  (Optional, Cloud Composer environments in versions composer-2.1.2-airflow-*.*.* and later)
-  The configuration for Cloud Data Lineage integration. Structure is
-  [documented below](#nested_cloud_data_lineage_integration_c3).
-
-* `web_server_plugins_mode` -
-  (Optional, Cloud Composer 3 only)
-  Web server plugins configuration. Can be either 'ENABLED' or 'DISABLED'. Defaults to 'ENABLED'.
-
-<a name="nested_cloud_data_lineage_integration_c3"></a>The `cloud_data_lineage_integration` block supports:
-* `enabled` -
-  (Required)
-  Whether or not Cloud Data Lineage integration is enabled.
-
-<a name="nested_encryption_config_comp_2"></a>The `encryption_config` block supports:
-
-* `kms_key_name` -
-  (Required)
-  Customer-managed Encryption Key available through Google's Key Management Service. It must
-  be the fully qualified resource name,
-  i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
-
-<a name="nested_maintenance_window_comp_2"></a>The `maintenance_window` block supports:
-
-* `start_time` -
-  (Required)
-  Start time of the first recurrence of the maintenance window.
-
-* `end_time` -
-  (Required)
-  Maintenance window end time. It is used only to calculate the duration of the maintenance window.
-  The value for end-time must be in the future, relative to 'start_time'.
-
-* `recurrence` -
-  (Required)
-  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
-  The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
-  Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
-
-The `workloads_config` block supports:
-
-* `scheduler` -
-  (Optional)
-  Configuration for resources used by Airflow scheduler.
-
-* `triggerer` -
-  (Optional)
-  Configuration for resources used by Airflow triggerer.
-
-* `web_server` -
-  (Optional)
-  Configuration for resources used by Airflow web server.
+  Configuration for resources used by the Airflow web server.
 
 * `worker` -
   (Optional)
   Configuration for resources used by Airflow workers.
 
 * `dag_processor` -
-  (Optional, Cloud Composer 3 only)
-  Configuration for resources used by DAG processor.
+  (Optional, Managed Airflow (Gen 3) only)
+  Configuration for resources used by Airflow DAG processors.
 
 The `scheduler` block supports:
 
@@ -1622,14 +822,15 @@ The `worker` block supports:
 
 * `min_count` -
   (Optional)
-  The minimum number of Airflow workers that the environment can run. The number of workers in the
-  environment does not go below this number, even if a lower number of workers can handle the load.
+  The minimum number of Airflow workers that the environment can run. The
+  number of workers in the environment does not go below this number, even if a
+  lower number of workers can handle the load.
 
 * `max_count` -
   (Optional)
-  The maximum number of Airflow workers that the environment can run. The number of workers in the
-  environment does not go above this number, even if a higher number of workers is required to
-  handle the load.
+  The maximum number of Airflow workers that the environment can run. The
+  number of workers in the environment does not go above this number, even if a
+  higher number of workers is required to handle the load.
 
 The `dag_processor` block supports:
 
@@ -1649,11 +850,970 @@ The `dag_processor` block supports:
   (Required)
   The number of Airflow DAG processors.
 
+## Argument Reference for Managed Airflow (Gen 2)
+
+The following arguments are supported:
+
+* `name` -
+  (Required)
+  Name of the environment
+
+* `config` -
+  (Optional)
+  Configuration parameters for this environment. Structure is
+  [documented below](#nested_config_gen_2).
+
+* `labels` -
+  (Optional)
+  User-defined labels for this environment. The labels map can contain
+  no more than 64 entries. Entries of the labels map are UTF8 strings
+  that comply with the following restrictions:
+  Label keys must be between 1 and 63 characters long and must conform
+  to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
+  Label values must be between 0 and 63 characters long and must
+  conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
+  No more than 64 labels can be associated with a given environment.
+  Both keys and values must be <= 128 bytes in size.
+
+* `region` -
+  (Optional)
+  The location or Compute Engine region for the environment.
+
+* `project` -
+  (Optional) The ID of the project in which the resource belongs.
+  If it is not provided, the provider project is used.
+
+* `storage_config` -
+  (Optional)
+  Configuration options for storage used by the environment. Structure is
+  [documented below](#nested_storage_config_gen_2).
+
+<a name="nested_config_gen_2"></a>The `config` block supports:
+
+* `node_config` -
+  (Optional)
+  The configuration used for the environment's Google Kubernetes Engine
+  cluster. Structure is [documented below](#nested_node_config_gen_2).
+
+* `recovery_config` -
+  (Optional)
+  The configuration settings for recovery. Structure is [documented below](#nested_recovery_config_gen_2).
+
+* `software_config` -
+  (Optional)
+  The configuration settings for the Airflow instance that runs inside the environment. Structure is
+  [documented below](#nested_software_config_gen_2).
+
+* `private_environment_config` -
+  (Optional)
+  The configuration used for the Private IP Managed Airflow environment. Structure is [documented below](#nested_private_environment_config_gen_2).
+
+* `encryption_config` -
+  (Optional)
+  The encryption options for the Managed Airflow environment and its
+  dependencies.
+
+* `maintenance_window` -
+  (Optional)
+  The configuration settings for Managed Airflow maintenance windows.
+
+* `workloads_config` -
+  (Optional)
+  Environment resources configuration for the Google Kubernetes engine cluster
+  associated with the Managed Airflow environment.
+
+* `environment_size` -
+  (Optional)
+  The environment size controls the performance parameters of the managed
+  Managed Airflow infrastructure that includes the Airflow database. Values for
+  environment size are `ENVIRONMENT_SIZE_SMALL`, `ENVIRONMENT_SIZE_MEDIUM`,
+  and `ENVIRONMENT_SIZE_LARGE`.
+
+* `resilience_mode` -
+  (Optional, Managed Airflow 2.1.15 or later only)
+  The resilience mode states whether high resilience is enabled for
+  the environment or not. Values for resilience mode are `HIGH_RESILIENCE`
+  for high resilience and `STANDARD_RESILIENCE` for standard
+  resilience.
+
+* `data_retention_config` -
+  (Optional, Managed Airflow 2.0.23 or later only)
+  Configuration setting for the data rentention mechanism. Structure is
+  [documented below](#nested_data_retention_config_gen_2).
+
+<a name="nested_data_retention_config_gen_2"></a>The `data_retention_config`
+block supports:
+
+* `task_logs_retention_config` -
+  (Optional)
+  The configuration setting for Task Logs. Structure is
+  [documented below](#nested_task_logs_retention_config_gen_2).
+
+<a name="nested_task_logs_retention_config_gen_2"></a>The
+`task_logs_retention_config` block supports:
+
+* `storage_mode` -
+  (Optional)
+  The mode of storage for Airflow workers task logs. Values for storage mode are
+  `CLOUD_LOGGING_ONLY` to only store logs in Cloud Logging and
+  `CLOUD_LOGGING_AND_CLOUD_STORAGE` to store logs in Cloud Logging and
+  Cloud Storage.
+
+* `master_authorized_networks_config` -
+  (Optional)
+  Configuration options for the authorized networks feature. Enabled
+  authorized networks will disallow all external traffic to access
+  Kubernetes control plane through HTTPS except traffic from the given CIDR
+  blocks, Google Compute Engine Public IPs and Google Prod IPs. Structure is
+  [documented below](#nested_master_authorized_networks_config_gen_2).
+
+<a name="nested_master_authorized_networks_config_gen_2"></a>The
+`master_authorized_networks_config` block supports:
+
+* `enabled` -
+  (Required)
+  Whether or not authorized networks are enabled.
+
+* `cidr_blocks` -
+  `cidr_blocks `define up to 50 external networks that could access Kubernetes
+  control plane through HTTPS. Structure is
+  [documented below](#nested_cidr_blocks_gen_2).
+
+<a name="nested_cidr_blocks_gen_2"></a>The `cidr_blocks` supports:
+
+* `display_name` -
+  (Optional)
+  `display_name` is a field for users to identify CIDR blocks.
+
+* `cidr_block` -
+  (Required)
+  `cidr_block` must be specified in CIDR notation.
+
+<a name="nested_storage_config_gen_2"></a>The `storage_config` block supports:
+
+* `bucket` -
+  (Required)
+  Name of an existing Cloud Storage bucket to be used by the environment.
+
+<a name="nested_node_config_gen_2"></a>The `node_config` block supports:
+
+* `network` -
+  (Optional)
+  The Compute Engine network to be used for machine
+  communications, specified as a self-link, relative resource name
+  (for example `projects/{project}/global/networks/{network}`), by name.
+
+  The network must belong to the environment's project. If unspecified, the
+  `default` network ID in the environment's project is used. If a Custom Subnet
+  Network is provided, subnetwork must also be provided.
+
+* `subnetwork` -
+  (Optional)
+  The Compute Engine subnetwork to be used for machine
+  communications, specified as a self-link, relative resource name (for example,
+  `projects/{project}/regions/{region}/subnetworks/{subnetwork}`), or by name.
+  If subnetwork is provided, network must also be provided and the subnetwork
+  must belong to the enclosing environment's project and region.
+
+* `service_account` -
+  The Google Cloud Platform Service Account to be used by the
+  environment to perform operations and run DAGs. Cannot be
+  updated. The service account must have the `roles/composer.worker` role
+  to create the environment. To access other resources in your Google Cloud
+  project, grant extra permissions to access those resources to this service
+  account.
+
+* `tags` -
+  (Optional)
+  The list of instance tags applied to all node VMs in the environment's
+  cluster. Tags are used to identify valid sources or targets for network
+  firewalls. Each tag within the list must comply with RFC1035.
+  Cannot be updated.
+
+* `ip_allocation_policy` -
+  (Optional)
+  Configuration for controlling how IPs are allocated in the GKE cluster.
+  Structure is [documented below](#nested_ip_allocation_policy_gen_2).
+  Cannot be updated.
+
+* `enable_ip_masq_agent` -
+  (Optional)
+  IP Masq Agent translates Pod IP addresses to node IP addresses, so that
+  destinations and services targeted from Airflow DAGs and tasks only receive
+  packets from node IP addresses instead of Pod IP addresses
+  See the [documentation](https://docs.cloud.google.com/composer/docs/composer-2/enable-ip-masquerade-agent).
+
+<a name="nested_software_config_gen_2"></a>The `software_config` block supports:
+
+* `airflow_config_overrides` -
+  (Optional) Apache Airflow configuration options to override.
+
+  Keys contain section names and Airflow configuration option names,
+  separated by a hyphen, for example: `core-dags_are_paused_at_creation` where
+  `core` is the section and `dags_are_paused_at_creation` is the Airflow
+  configuration option name.
+
+  Section names must not contain hyphens (`-`), opening square brackets (`[`),
+  or closing square brackets (`]`).
+  Option names must not be empty and can't contain `=` or `;` characters.
+  Section and onption names cannot contain `.` characters. Option
+  names must be written in snake_case.
+
+  Values can
+  contain any character, and can be written in any lower or upper case format.
+  Certain Apache Airflow configuration option values are
+  [blocked](https://docs.cloud.google.com/composer/docs/airflow-configurations),
+  and cannot be overridden.
+
+* `pypi_packages` -
+  (Optional)
+  Custom Python Package Index (PyPI) packages to be installed
+  in the environment, in addition to
+  [preinstalled packages](https://docs.cloud.google.com/composer/docs/versions-packages).
+  Keys refer to the lowercase package name (for example: `numpy`). Values are
+  the lowercase extras and version specifier (example: `==1.12.0`,
+  `[devel,gcp_api]`, `[devel]>=1.8.2`, `<1.9.2`). To specify a package without
+  pinning it to a version specifier, use the empty string as the value.
+
+* `env_variables` -
+  (Optional)
+  Additional environment variables to provide to Apache Airflow components of
+  the environment.
+  Environment variable names must match the regular expression
+  `[a-zA-Z_][a-zA-Z0-9_]*`. They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
+  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the
+  [reserved variable names](https://docs.cloud.google.com/composer/docs/composer-3/set-environment-variables#reserved).
+
+* `image_version` -
+  (Required)
+  Version of Managed Airflow and Apache Airflow to use.
+  In Managed Airflow (Gen 2), this parameter is required. If omitted, the
+  [default build of Managed Airflow (Gen 3)](https://docs.cloud.google.com/composer/docs/composer-versions)
+  is used.
+
+  The version the environment. This encapsulates both the version of the
+  Managed Airflow functionality and the version of Apache Airflow. It must
+  match the regular expression
+  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
+  The Managed Airflow portion of the image version is a full semantic version,
+  or an alias in the form of major version number or `latest`.
+  The Apache Airflow portion of the image version is a full semantic version
+  that points to one of the supported Apache Airflow versions, or an alias in
+  the form of only `major` or `major.minor` versions specified.
+
+  **Important**: In-place upgrade is only available between minor or
+  patch versions of Managed Airflow or Apache Airflow. For example, you can
+  upgrade your environment from
+  `composer-2.15.x` to `composer-2.16.x`, or from `airflow-2.9.x` to
+  `airflow-2.10.x`. You cannot upgrade between major Managed Airflow or Apache
+  Airflow versions (from `2.x.x` to `3.x.x`). To do so, create a new
+  environment.
+
+* `cloud_data_lineage_integration` -
+  (Optional, Managed Airflow environments in versions
+  `composer-2.1.2-airflow-*.*.*` and later)
+  The configuration for Cloud Data Lineage integration. Structure is
+  [documented below](#nested_cloud_data_lineage_integration_gen_2).
+
+<a name="nested_cloud_data_lineage_integration_gen_2"></a>The
+`cloud_data_lineage_integration` block supports:
+
+* `enabled` -
+  (Required)
+  Whether or not Cloud Data Lineage integration is enabled.
+
+<a name="nested_private_environment_config_gen_2"></a>See [documentation](https://docs.cloud.google.com/composer/docs/composer-2/configure-private-ip) for
+setting up Private IP environments.
+The `private_environment_config` block supports:
+
+* `connection_type` -
+  (Optional, Managed Airflow (Gen 2) only)
+  Mode of internal communication within the Managed Airflow environment. Must
+  be one of `VPC_PEERING` or `PRIVATE_SERVICE_CONNECT`.
+
+* `enable_private_endpoint` -
+  If true, access to the public endpoint of the environment's
+  Google Kubernetes Enginge cluster is denied.
+
+* `master_ipv4_cidr_block` -
+  (Optional)
+  The IP range in CIDR notation to use for the hosted control plane network.
+  This range is used for assigning internal IP addresses to the cluster control
+  plane or a set of control planes and to the internal load balancer
+  virtual IP. This range must not overlap with any other ranges in use within
+  the cluster's network.
+  If left blank, the default value of is used. See
+  [documentation](https://docs.cloud.google.com/composer/docs/composer-2/configure-private-ip#defaults)
+  for default values per region.
+
+* `cloud_sql_ipv4_cidr_block` -
+  (Optional)
+  The CIDR block from which IP range in the tenant project will be reserved for
+  Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
+
+* `cloud_composer_network_ipv4_cidr_block"` -
+  (Optional, Managed Airflow (Gen 2) only)
+
+  The CIDR block from which IP range for Managed Airflow Network in the tenant
+  project will be reserved. Needs to be disjoint from
+  `private_cluster_config.master_ipv4_cidr_block` and
+  `cloud_sql_ipv4_cidr_block`.
+
+* `enable_privately_used_public_ips` -
+  (Optional)
+  When enabled, IPs from public (non-RFC 1918) ranges can be used for
+  `ip_allocation_policy.cluster_ipv4_cidr_block` and
+  `ip_allocation_policy.service_ipv4_cidr_block`.
+
+* `cloud_composer_connection_subnetwork` -
+  (Optional)
+  When specified, the environment will use Private Service Connect instead of
+  VPC peerings to connect to Cloud SQL in the Tenant Project, and the PSC
+  endpoint in the customer project will use an IP address from this subnetwork.
+  This field is supported for Managed Airflow environments in versions
+  `composer-2.*.*-airflow-*.*.*` and newer.
+
+<a name="nested_ip_allocation_policy_gen_2"></a>The `ip_allocation_policy`
+block supports:
+
+* `cluster_secondary_range_name` -
+  (Optional)
+  The name of the cluster's secondary range used to allocate IP addresses to
+  pods. Specify either `cluster_secondary_range_name` or
+  `cluster_ipv4_cidr_block` but not both.
+
+* `services_secondary_range_name` -
+  (Optional)
+  The name of the services' secondary range used to allocate IP addresses to
+  the cluster. Specify either
+  `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
+
+* `cluster_ipv4_cidr_block` -
+  (Optional)
+  The IP address range used to allocate IP addresses to pods in the cluster.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+  Set to blank to have GKE choose a range with the default size.
+  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
+  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
+  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to
+  use.
+  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block`
+  but not both.
+
+* `services_ipv4_cidr_block` -
+  (Optional)
+  The IP address range used to allocate IP addresses in this cluster.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+  Set to blank to have GKE choose a range with the default size.
+  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
+  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
+  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to
+  use.
+  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block`
+  but not both.
+
+<a name="nested_encryption_config_comp_2"></a>The `encryption_config` block
+supports:
+
+* `kms_key_name` -
+  (Required)
+  Customer-managed Encryption Key available through Google's Key Management
+  Service. It must
+  be the fully qualified resource name, for example:
+  `projects/example-project-id/locations/example-location/keyRings/example-keyring/cryptoKeys/example-key`.
+  Cannot be updated.
+
+<a name="nested_maintenance_window_comp_2"></a>The `maintenance_window` block
+supports:
+
+* `start_time` -
+  (Required)
+  Start time of the first recurrence of the maintenance window.
+
+* `end_time` -
+  (Required)
+  Maintenance window end time. It is used only to calculate the duration of the
+  maintenance window.
+  The value for end-time must be in the future, relative to `start_time`.
+
+* `recurrence` -
+  (Required)
+  Maintenance window recurrence. Format is a subset of
+  [RFC-5545](https://tools.ietf.org/html/rfc5545) `RRULE`.
+  The only allowed values for `FREQ` field are `FREQ=DAILY` and
+  `FREQ=WEEKLY;BYDAY=...`.
+  Example values: `FREQ=WEEKLY;BYDAY=TU,WE`, `FREQ=DAILY`.
+
+<a name="nested_recovery_config_gen_2"></a>The `recovery_config` block supports:
+
+* `scheduled_snapshots_config` -
+  (Optional)
+  The recovery configuration settings for the Managed Airflow environment.
+
+The `scheduled_snapshots_config` block supports:
+
+* `enabled` -
+  (Optional)
+  When enabled, Managed Airflow periodically saves snapshots of your
+  environment to a Cloud Storage bucket.
+
+* `snapshot_location` -
+  (Optional)
+  The URI of a bucket folder where to save the snapshot.
+
+* `snapshot_creation_schedule` -
+  (Optional)
+  Snapshot schedule, in the Unix-cron format.
+
+* `time_zone` -
+  (Optional)
+  A time zone for the schedule. This value is a time offset and does not take
+  into account daylight saving time changes. Valid values are from UTC-12 to
+  UTC+12. Examples: UTC, UTC-01, UTC+03.
+
+The `workloads_config` block supports:
+
+* `scheduler` -
+  (Optional)
+  Configuration for resources used by Airflow schedulers.
+
+* `triggerer` -
+  (Optional)
+  Configuration for resources used by Airflow triggerers.
+
+* `web_server` -
+  (Optional)
+  Configuration for resources used by the Airflow web server.
+
+* `worker` -
+  (Optional)
+  Configuration for resources used by Airflow workers.
+
+The `scheduler` block supports:
+
+* `cpu` -
+  (Optional)
+  The number of CPUs for a single Airflow scheduler.
+
+* `memory_gb` -
+  (Optional)
+  The amount of memory (GB) for a single Airflow scheduler.
+
+* `storage_gb` -
+  (Optional)
+  The amount of storage (GB) for a single Airflow scheduler.
+
+* `count` -
+  (Optional)
+  The number of schedulers.
+
+The `triggerer` block supports:
+
+* `cpu` -
+  (Required)
+  The number of CPUs for a single Airflow triggerer.
+
+* `memory_gb` -
+  (Required)
+  The amount of memory (GB) for a single Airflow triggerer.
+
+* `count` -
+  (Required)
+  The number of Airflow triggerers.
+
+The `web_server` block supports:
+
+* `cpu` -
+  (Optional)
+  The number of CPUs for the Airflow web server.
+
+* `memory_gb` -
+  (Optional)
+  The amount of memory (GB) for the Airflow web server.
+
+* `storage_gb` -
+  (Optional)
+  The amount of storage (GB) for the Airflow web server.
+
+The `worker` block supports:
+
+* `cpu` -
+  (Optional)
+  The number of CPUs for a single Airflow worker.
+
+* `memory_gb` -
+  (Optional)
+  The amount of memory (GB) for a single Airflow worker.
+
+* `storage_gb`
+  (Optional)
+  The amount of storage (GB) for a single Airflow worker.
+
+* `min_count` -
+  (Optional)
+  The minimum number of Airflow workers that the environment can run. The number of workers in the
+  environment does not go below this number, even if a lower number of workers can handle the load.
+
+* `max_count` -
+  (Optional)
+  The maximum number of Airflow workers that the environment can run. The number of workers in the
+  environment does not go above this number, even if a higher number of workers is required to
+  handle the load.
+
+## Argument Reference for Managed Airflow (Legacy Gen 1)
+
+The following arguments are supported:
+
+* `name` -
+  (Required)
+  Name of the environment
+
+* `config` -
+  (Optional)
+  Configuration parameters for this environment.
+  Structure is [documented below](#nested_config_gen_1).
+
+* `labels` -
+  (Optional)
+  User-defined labels for this environment. The labels map can contain
+  no more than 64 entries. Entries of the labels map are UTF8 strings
+  that comply with the following restrictions:
+  Label keys must be between 1 and 63 characters long and must conform
+  to the following regular expression: `[a-z]([-a-z0-9]*[a-z0-9])?`.
+  Label values must be between 0 and 63 characters long and must
+  conform to the regular expression `([a-z]([-a-z0-9]*[a-z0-9])?)?`.
+  No more than 64 labels can be associated with a given environment.
+  Both keys and values must be <= 128 bytes in size.
+
+  **Note**: This field is non-authoritative, and will only manage the labels
+  present in your configuration. Please refer to the field 'effective_labels'
+  for all of the labels present on the resource.
+
+* `terraform_labels` -
+  The combination of labels configured directly on the resource and default labels configured on the provider.
+
+* `effective_labels` -
+  All of labels (key/value pairs) present on the resource in GCP, including the
+  labels configured through Terraform, other clients and services.
+
+* `region` -
+  (Optional)
+  The location or Compute Engine region for the environment.
+
+* `project` -
+  (Optional) The ID of the project in which the resource belongs.
+  If it is not provided, the provider project is used.
+
+<a name="nested_config_gen_1"></a>The `config` block supports:
+
+* `node_count` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The number of nodes in the Kubernetes Engine cluster of the environment.
+
+* `node_config` -
+  (Optional)
+  The configuration used for the environment's Google Kubernetes Engine
+  cluster. Structure is [documented below](#nested_node_config_gen_1).
+
+* `software_config` -
+  (Optional)
+  The configuration settings for the Airflow instance that runs inside the
+  environment. Structure is [documented below](#nested_software_config_gen_1).
+
+* `private_environment_config` -
+  (Optional)
+  The configuration used for the Private IP Managed Airflow environment.
+  Structure is [documented below](#nested_private_environment_config_gen_1).
+
+* `web_server_network_access_control` -
+  The network-level access control policy for the Airflow web server.
+  If unspecified, no network-level access restrictions are applied.
+
+* `database_config` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The configuration settings for Cloud SQL instance used internally
+  by Apache Airflow software.
+
+* `web_server_config` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The configuration settings for the Airflow web server App Engine instance.
+
+* `encryption_config` -
+  (Optional)
+  The encryption options for the environment and its dependencies.
+
+* `maintenance_window` -
+  (Optional, [Beta](../guides/provider_versions.html.markdown))
+  The configuration settings for the maintenance windows.
+
+* `master_authorized_networks_config` -
+  Configuration options for the authorized networks feature. Enabled
+  authorized networks will disallow all external traffic to access
+  Kubernetes control plane through HTTPS except traffic from the given CIDR
+  blocks, Google Compute Engine Public IPs and Google Prod IPs. Structure is
+  [documented below](#nested_master_authorized_networks_config_gen_1).
+
+<a name="nested_master_authorized_networks_config_gen_1"></a>The
+`master_authorized_networks_config` block supports:
+
+* `enabled` -
+  (Required)
+  Whether or not authorized networks are enabled.
+
+* `cidr_blocks` -
+  `cidr_blocks `define up to 50 external networks that could access Kubernetes
+  control plane through HTTPS. Structure is
+  [documented below](#nested_cidr_blocks_gen_2).
+
+<a name="nested_cidr_blocks_gen_2"></a>The `cidr_blocks` supports:
+
+* `display_name` -
+  (Optional)
+  `display_name` is a field for users to identify CIDR blocks.
+
+* `cidr_block` -
+  (Required)
+  `cidr_block` must be specified in CIDR notation.
+
+
+<a name="nested_node_config_gen_1"></a>The `node_config` block supports:
+
+* `zone` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The Compute Engine zone in which to deploy the VMs running the
+  Apache Airflow software, specified as the zone name or
+  relative resource name (e.g. `projects/{project}/zones/{zone}`). Must
+  belong to the enclosing environment's project and region.
+
+* `machine_type` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The Compute Engine machine type used for cluster instances,
+  specified as a name or relative resource name. For example:
+  `projects/{project}/zones/{zone}/machineTypes/{machineType}`. Must belong
+  to the enclosing environment's project and region/zone.
+
+* `network` -
+  (Optional)
+  The Compute Engine network to be used for machine
+  communications, specified as a self-link, relative resource name
+  (for example `projects/{project}/global/networks/{network}`), by name.
+
+  The network must belong to the environment's project. If unspecified, the
+  `default` network ID in the environment's project is used. If a Custom Subnet
+  Network is provided, subnetwork must also be provided.
+
+* `subnetwork` -
+  (Optional)
+  The Compute Engine subnetwork to be used for machine
+  communications, specified as a self-link, relative resource name (for example,
+  `projects/{project}/regions/{region}/subnetworks/{subnetwork}`), or by name.
+  If subnetwork is provided, network must also be provided and the subnetwork
+  must belong to the enclosing environment's project and region.
+
+* `disk_size_gb` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The disk size in GB used for node VMs. Minimum size is 20GB.
+  If unspecified, defaults to 100GB. Cannot be updated.
+
+* `oauth_scopes` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The set of Google API scopes to be made available on all node
+  VMs. Cannot be updated. If empty, defaults to
+  `["https://www.googleapis.com/auth/cloud-platform"]`.
+
+* `service_account` -
+  The Google Cloud Platform Service Account to be used by the
+  environment to perform operations and run DAGs. Cannot be
+  updated. The service account must have the `roles/composer.worker` role
+  to create the environment. To access other resources in your Google Cloud
+  project, grant extra permissions to access those resources to this service
+  account.
+
+* `tags` -
+  (Optional)
+  The list of instance tags applied to all node VMs in the environment's
+  cluster. Tags are used to identify valid sources or targets for network
+  firewalls. Each tag within the list must comply with RFC 1035.
+  Cannot be updated.
+
+* `ip_allocation_policy` -
+  (Optional)
+  Configuration for controlling how IPs are allocated in the GKE cluster.
+  Structure is [documented below](#nested_ip_allocation_policy_gen_1).
+  Cannot be updated.
+
+* `max_pods_per_node` -
+  (Optional, [Beta](../guides/provider_versions.html.markdown),
+  Managed Airflow (Legacy Gen 1) only)
+  The maximum pods per node in the GKE cluster allocated during environment
+  creation. Lowering this value reduces IP address consumption by the
+  environment's GKE cluster. This value can only be set if the environment is
+  VPC-Native. The range of possible values is 8-110, and the default is 32.
+  Cannot be updated.
+
+* `enable_ip_masq_agent` -
+  (Optional)
+  Deploys 'ip-masq-agent' daemon set in the GKE cluster and defines
+  nonMasqueradeCIDRs equals to pod IP range so IP masquerading is used for
+  all destination addresses, except between pods traffic.
+  See the [documentation](https://docs.cloud.google.com/composer/docs/composer-2/enable-ip-masquerade-agent).
+
+<a name="nested_software_config_gen_1"></a>The `software_config` block supports:
+
+* `airflow_config_overrides` -
+  (Optional) Apache Airflow configuration options to override.
+
+  Keys contain section names and Airflow configuration option names,
+  separated by a hyphen, for example: `core-dags_are_paused_at_creation` where
+  `core` is the section and `dags_are_paused_at_creation` is the Airflow
+  configuration option name.
+
+  Section names must not contain hyphens (`-`), opening square brackets (`[`),
+  or closing square brackets (`]`).
+  Option names must not be empty and can't contain `=` or `;` characters.
+  Section and onption names cannot contain `.` characters. Option
+  names must be written in snake_case.
+
+  Values can
+  contain any character, and can be written in any lower or upper case format.
+  Certain Apache Airflow configuration option values are
+  [blocked](https://docs.cloud.google.com/composer/docs/airflow-configurations),
+  and cannot be overridden.
+
+* `pypi_packages` -
+  (Optional)
+  Custom Python Package Index (PyPI) packages to be installed
+  in the environment, in addition to
+  [preinstalled packages](https://docs.cloud.google.com/composer/docs/versions-packages).
+  Keys refer to the lowercase package name (for example: `numpy`). Values are
+  the lowercase extras and version specifier (example: `==1.12.0`,
+  `[devel,gcp_api]`, `[devel]>=1.8.2`, `<1.9.2`). To specify a package without
+  pinning it to a version specifier, use the empty string as the value.
+
+* `env_variables` -
+  (Optional)
+  Additional environment variables to provide to Apache Airflow components of the environment.
+  Environment variable names must match the regular expression
+  `[a-zA-Z_][a-zA-Z0-9_]*`. They cannot specify Apache Airflow software configuration overrides (they cannot match the regular expression
+  `AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+`), and they cannot match any of the
+  [reserved variable names](https://docs.cloud.google.com/composer/docs/composer-3/set-environment-variables#reserved).
+
+* `image_version` -
+  (Required)
+  Version of Managed Airflow and Apache Airflow to use.
+  In Managed Airflow (Legacy Gen 1), this parameter is required. If omitted, the
+  [default build of Managed Airflow (Gen 3)](https://docs.cloud.google.com/composer/docs/composer-versions)
+  is used.
+
+  The version of the software running in the environment. This encapsulates
+  both the version of Managed Airflow functionality and the version of Apache
+  Airflow. It must match the regular expression
+  `composer-([0-9]+(\.[0-9]+\.[0-9]+(-preview\.[0-9]+)?)?|latest)-airflow-([0-9]+(\.[0-9]+(\.[0-9]+)?)?)`.
+  The Managed Airflow portion of the image version is a full semantic version,
+  or an alias in the form of major version number or `latest`.
+  The Apache Airflow portion of the image version is a full semantic version
+  that points to one of the supported Apache Airflow versions, or an alias in
+  the form of only `major` or `major.minor` versions specified.
+
+  For more information about Managed Airflow images, see
+  [Managed Airflow version list](https://docs.cloud.google.com/composer/docs/composer-versions).
+
+* `python_version` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes.
+  Can be set to '2' or '3'. If not specified, the default is '3'.
+
+* `scheduler_count` -
+  (Optional, Managed Airflow (Legacy Gen 1) with Airflow 2 only)
+  The number of schedulers for Airflow.
+
+See
+[documentation](https://docs.cloud.google.com/composer/docs/composer-1/configure-private-ip)
+for setting up private environments.
+<a name="nested_private_environment_config_gen_1"></a>The
+`private_environment_config` block supports:
+
+* `enable_private_endpoint` -
+  If true, access to the public endpoint of the GKE cluster is denied.
+  If this field is set to true, the `ip_allocation_policy.use_ip_aliases` field
+  must also be set to true for Managed Airflow (Legacy Gen 1) environments.
+
+* `master_ipv4_cidr_block` -
+  (Optional)
+  The IP range in CIDR notation to use for the hosted master network. This
+  range is used for assigning internal IP addresses to the cluster master or
+  set of masters and to the internal load balancer virtual IP. This range must
+  not overlap with any other ranges in use within the cluster's network.
+  If left blank, the default value of is used. See
+  [documentation](https://docs.cloud.google.com/composer/docs/composer-1/configure-private-ip#defaults) for default values per region.
+
+* `cloud_sql_ipv4_cidr_block` -
+  (Optional)
+  The CIDR block from which IP range in tenant project will be reserved for
+  Cloud SQL. Needs to be disjoint from `web_server_ipv4_cidr_block`
+
+* `web_server_ipv4_cidr_block` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  The CIDR block from which IP range for web server will be reserved. Needs to
+  be disjoint from `master_ipv4_cidr_block` and `cloud_sql_ipv4_cidr_block`.
+
+* `enable_privately_used_public_ips` -
+  (Optional)
+  When enabled, IPs from public (non-RFC1918) ranges can be used for
+  `ip_allocation_policy.cluster_ipv4_cidr_block` and
+  `ip_allocation_policy.service_ipv4_cidr_block`.
+
+The `web_server_network_access_control` supports:
+
+* `allowed_ip_range` -
+  A collection of allowed IP ranges with descriptions. Structure is
+  [documented below](#nested_allowed_ip_range_gen_1).
+
+<a name="nested_allowed_ip_range_gen_1"></a>The `allowed_ip_range` supports:
+
+* `value` -
+  (Required)
+  IP address or range, defined using CIDR notation, of requests that this rule
+  applies to. Examples: `192.168.1.1` or `192.168.0.0/16` or `2001:db8::/32` or
+  `2001:0db8:0000:0042:0000:8a2e:0370:7334`.
+  IP range prefixes should be properly truncated. For example,
+  `1.2.3.4/24` should be truncated to `1.2.3.0/24`. Similarly, for IPv6,
+  `2001:db8::1/32` should be truncated to `2001:db8::/32`.
+
+* `description` -
+  (Optional)
+  A description of this ip range.
+
+<a name="nested_ip_allocation_policy_gen_1"></a>The `ip_allocation_policy`
+block supports:
+
+* `use_ip_aliases` -
+  (Optional, Managed Airflow (Legacy Gen 1) only)
+  Whether or not to enable Alias IPs in the GKE cluster. If true, a VPC-native
+  cluster is created. Defaults to true if the `ip_allocation_policy` block is
+  present in config.
+
+* `cluster_secondary_range_name` -
+  (Optional)
+  The name of the cluster's secondary range used to allocate IP addresses to
+  pods. Specify either `cluster_secondary_range_name` or
+  `cluster_ipv4_cidr_block` but not both.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+
+* `services_secondary_range_name` -
+  (Optional)
+  The name of the services' secondary range used to allocate IP addresses to
+  the cluster. Specify either `services_secondary_range_name` or
+  `services_ipv4_cidr_block` but not both.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+
+* `cluster_ipv4_cidr_block` -
+  (Optional)
+  The IP address range used to allocate IP addresses to pods in the cluster.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+  Set to blank to have GKE choose a range with the default size.
+  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
+  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
+  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to
+  use.
+  Specify either `cluster_secondary_range_name` or `cluster_ipv4_cidr_block`
+  but not both.
+
+* `services_ipv4_cidr_block` -
+  (Optional)
+  The IP address range used to allocate IP addresses in this cluster.
+  For Managed Airflow (Legacy Gen 1) environments, this field is applicable
+  only when `use_ip_aliases` is true.
+  Set to blank to have GKE choose a range with the default size.
+  Set to /netmask (e.g. /14) to have GKE choose a range with a specific netmask.
+  Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
+  (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to
+  use.
+  Specify either `services_secondary_range_name` or `services_ipv4_cidr_block`
+  but not both.
+
+<a name="nested_database_config_gen_1"></a>The `database_config` block supports:
+
+* `machine_type` -
+  (Optional)
+  Optional. Cloud SQL machine type used by Airflow database. It has to be one
+  of: db-n1-standard-2, db-n1-standard-4, db-n1-standard-8 or db-n1-standard-16.
+
+* `Zone` -
+  (Optional)
+  Preferred Cloud SQL database zone.
+
+<a name="nested_web_server_config_gen_1"></a>The `web_server_config` block
+supports:
+
+* `machine_type` -
+  (Required)
+  Machine type on which Airflow web server is running. It has to be one of:
+  composer-n1-webserver-2, composer-n1-webserver-4 or composer-n1-webserver-8.
+  Value custom is returned only in response, if Airflow web server parameters
+  were manually changed to a non-standard values.
+
+<a name="nested_encryption_config_gen_1"></a>The `encryption_config` block
+supports:
+
+* `kms_key_name` -
+  (Required)
+  Customer-managed Encryption Key available through Google's Key Management
+  Service. It must
+  be the fully qualified resource name, for example:
+  `projects/example-project-id/locations/example-location/keyRings/example-keyring/cryptoKeys/example-key`.
+  Cannot be updated.
+
+<a name="nested_maintenance_window_gen_1"></a>The `maintenance_window` block supports:
+* `start_time` -
+  (Required)
+  Start time of the first recurrence of the maintenance window.
+
+* `end_time` -
+  (Required)
+  Maintenance window end time. It is used only to calculate the duration of the
+  maintenance window.
+  The value for end-time must be in the future, relative to `start_time`.
+
+* `recurrence` -
+  (Required)
+  Maintenance window recurrence. Format is a subset of
+  [RFC-5545](https://tools.ietf.org/html/rfc5545) `RRULE`.
+  The only allowed values for `FREQ` field are `FREQ=DAILY` and
+  `FREQ=WEEKLY;BYDAY=...`.
+  Example values: `FREQ=WEEKLY;BYDAY=TU,WE`, `FREQ=DAILY`.
+
+<a name="nested_master_authorized_networks_config_gen_1"></a>The `master_authorized_networks_config` block supports:
+* `enabled` -
+  (Required)
+  Whether or not master authorized networks is enabled.
+
+* `cidr_blocks` -
+  `cidr_blocks `define up to 50 external networks that could access Kubernetes master through HTTPS. Structure is
+  [documented below](#nested_cidr_blocks_gen_1).
+
+<a name="nested_cidr_blocks_gen_1"></a>The `cidr_blocks` supports:
+
+* `display_name` -
+  (Optional)
+  `display_name` is a field for users to identify CIDR blocks.
+
+* `cidr_block` -
+  (Required)
+  `cidr_block` must be specified in CIDR notation.
+
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are exported:
+In addition to the arguments listed above, the following computed attributes
+are exported:
 
-* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{region}}/environments/{{name}}`
+* `id` - an identifier for the resource with format
+  `projects/{{project}}/locations/{{region}}/environments/{{name}}`
 
 * `config.0.gke_cluster` -
   The Kubernetes Engine cluster used to run this environment.
@@ -1672,7 +1832,7 @@ In addition to the arguments listed above, the following computed attributes are
 ## Timeouts
 
 This resource provides the following
-[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
+[Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
 - `create` - Default is 120 minutes.
 - `update` - Default is 120 minutes.
@@ -1686,7 +1846,9 @@ Environment can be imported using any of these accepted formats:
 * `{{project}}/{{region}}/{{name}}`
 * `{{name}}`
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Environment using one of the formats above. For example:
+In Terraform v1.5.0 and later, use an
+[`import` block](https://developer.hashicorp.com/terraform/language/import) to
+import Environment using one of the formats above. For example:
 
 ```tf
 import {
@@ -1695,7 +1857,9 @@ import {
 }
 ```
 
-When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Environment can be imported using one of the formats above. For example:
+When using the
+[`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import),
+Environment can be imported using one of the formats above. For example:
 
 ```
 $ terraform import google_composer_environment.default projects/{{project}}/locations/{{region}}/environments/{{name}}

--- a/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_user_workloads_secret.html.markdown
@@ -1,13 +1,13 @@
 ---
-subcategory: "Cloud Composer"
+subcategory: "Managed Service for Apache Airflow"
 description: |-
   User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator.
 ---
 
 # google_composer_user_workloads_secret
 
-User workloads Secret used by Airflow tasks that run with Kubernetes Executor or KubernetesPodOperator. 
-Intended for Composer 3 Environments.
+User workloads Secret used by Airflow tasks that run with Kubernetes Executor
+or KubernetesPodOperator. Intended for Managed Airflow (Gen 3) Environments.
 
 ## Example Usage
 


### PR DESCRIPTION
Fixes internal issue 495767958 and updates the documentation for composer_environment

Details:

- Only documentation updates
- Use the new product name (Managed Service for Apache Airflow) and version (Gen 3/2/Legacy 1) o reflect the latest naming changes.
- Add missing recovery_config to Gen 3
- Add missing master_authorized_networks_config for Gen 1
- Fix outdated service_account field description
- Use Gen 3 version as the default and put it first
- Update some field descriptions to make them more clear (image_version, service_account, etc)
- Change docs domain to docs.cloud.google.com and fix broken and outdated links

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
