### PR TITLE
tgc-revival: narrow the files to run tgc integration tests in CI

### DIFF
--- a/.ci/magician/cmd/test_tgc_integration.go
+++ b/.ci/magician/cmd/test_tgc_integration.go
@@ -107,8 +107,8 @@ func shouldRunTests(changedFiles []string) bool {
 		}
 
 		// Handle pkg/services/ and its exceptions
-		if strings.HasPrefix(file, "pkg/services/") {
-			if strings.HasSuffix(file, "_cai2hcl.go") || strings.HasSuffix(file, "_tfplan2cai.go") {
+		if strings.HasPrefix(file, "pkg/") {
+			if strings.HasPrefix(file, "pkg/cai2hcl/") || strings.HasPrefix(file, "pkg/tfplan2cai/") || strings.HasPrefix(file, "pkg/caiasset/") {
 				return true
 			}
 			continue

--- a/.ci/magician/cmd/test_tgc_integration_test.go
+++ b/.ci/magician/cmd/test_tgc_integration_test.go
@@ -51,13 +51,28 @@ func TestShouldRunTests(t *testing.T) {
 			expected:     false,
 		},
 		{
-			name:         "pkg/services cai2hcl file (exception)",
+			name:         "pkg/services cai2hcl file (no longer exception)",
 			changedFiles: []string{"pkg/services/compute/compute_disk_cai2hcl.go"},
+			expected:     false,
+		},
+		{
+			name:         "pkg/services tfplan2cai file (no longer exception)",
+			changedFiles: []string{"pkg/services/compute/compute_disk_tfplan2cai.go"},
+			expected:     false,
+		},
+		{
+			name:         "pkg/cai2hcl file",
+			changedFiles: []string{"pkg/cai2hcl/converters/convert_resource.go"},
 			expected:     true,
 		},
 		{
-			name:         "pkg/services tfplan2cai file (exception)",
-			changedFiles: []string{"pkg/services/compute/compute_disk_tfplan2cai.go"},
+			name:         "pkg/tfplan2cai file",
+			changedFiles: []string{"pkg/tfplan2cai/converters/cai/convert.go"},
+			expected:     true,
+		},
+		{
+			name:         "pkg/caiasset file",
+			changedFiles: []string{"pkg/caiasset/asset.go"},
 			expected:     true,
 		},
 		{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Run the tgc integration tests for the tgc core logic changes in `/pkg` package.

That means that only the changes to core TGC logic, tests, and new resource will trigger the integration tests. It will reduce the noise to most PRs, as no actions are taken in those unrelated PRs.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
