### PR TITLE
`terraform.go`: add `hasEligibleExample()` method

### DIFF
--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -200,17 +200,20 @@ func (t *Terraform) GenerateResourceMetadataFile(object api.Resource, targetFile
 	templateData.GenerateMetadataFile(targetFilePath, object)
 }
 
-func (t *Terraform) GenerateResourceTestsLegacy(object api.Resource, templateData TemplateData, outputFolder string) {
-	eligibleExample := false
+func (t *Terraform) hasEligibleExample(object api.Resource) bool {
 	for _, example := range object.Examples {
-		if !example.ExcludeTest {
-			if object.ProductMetadata.VersionObjOrClosest(t.Product.Version.Name).CompareTo(object.ProductMetadata.VersionObjOrClosest(example.MinVersion)) >= 0 {
-				eligibleExample = true
-				break
-			}
+		if example.ExcludeTest {
+			continue
+		}
+		if object.ProductMetadata.VersionObjOrClosest(t.Product.Version.Name).CompareTo(object.ProductMetadata.VersionObjOrClosest(example.MinVersion)) >= 0 {
+			return true
 		}
 	}
-	if !eligibleExample {
+	return false
+}
+
+func (t *Terraform) GenerateResourceTestsLegacy(object api.Resource, templateData TemplateData, outputFolder string) {
+	if !t.hasEligibleExample(object) {
 		return
 	}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

we do a check for an eligible example in list_resource generations. to prevent duplicate code we can move this in it's own method so that the logic can be shared across list and regular resources.

Here's the exact place in list_resource generation would use the `hasEligibleExample()` method:
https://github.com/GoogleCloudPlatform/magic-modules/pull/17368/changes#diff-3c988d71e717231071510844d318daa430f9a1f128117c0bb7b16f4ef0c2c44cR273-R292

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
