### PR TITLE
Made ReplaceVars error if it fails to replace with non-empty values

### DIFF
--- a/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/examples/base_configs/test_file.go.tmpl
@@ -163,11 +163,6 @@ func testAccCheck{{ $.Res.ResourceName }}DestroyProducer(t *testing.T) func(s *t
 		if err != nil {
 			return err
 		}
-{{- if $.Res.ProductMetadata.Version.RepEnabled }}
-		if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-			return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-		}
-{{- end }}
 
 		billingProject := ""
 

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -296,11 +296,6 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-    if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-    }
-{{- end }}
 
     log.Printf("[DEBUG] Creating new {{ $.Name -}}: %#v", obj)
 {{- if $.NestedQuery -}}
@@ -556,11 +551,6 @@ func resource{{ $.ResourceName -}}PollRead(d *schema.ResourceData, meta interfac
         if err != nil {
             return nil, err
         }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-        if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-            return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-        }
-{{- end }}
 
         billingProject := ""
 
@@ -652,11 +642,6 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     if err != nil {
         return err
     }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-    if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-    }
-{{- end }}
 
     billingProject := ""
 
@@ -908,11 +893,6 @@ func resource{{ $.ResourceName -}}Update(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-    if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-        return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-    }
-{{- end }}
 
     log.Printf("[DEBUG] Updating {{ $.Name }} %q: %#v", d.Id(), obj)
 	headers := make(http.Header)
@@ -1011,11 +991,6 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         if err != nil {
             return err
         }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-        if strings.Contains(getUrl, "{{"{{"}}location{{"}}"}}") {
-            return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", getUrl)
-        }
-{{- end }}
 {{		                if $.SupportsIndirectUserProjectOverride -}}
         if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
             billingProject = parts[1]
@@ -1098,11 +1073,6 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         if err != nil {
             return err
         }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-        if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-            return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-        }
-{{- end }}
 
         headers := make(http.Header)
 {{                  if $.CustomCode.PreUpdate -}}
@@ -1229,11 +1199,6 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     if err != nil {
         return err
     }
-{{- if $.ProductMetadata.Version.RepEnabled }}
-    if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-		return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-    }
-{{- end }}
     {{/*If the deletion of the object requires sending a request body, the custom code will set 'obj' */}}
     var obj map[string]interface{}
     {{- if and $.NestedQuery $.NestedQuery.ModifyByPatch }}

--- a/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
@@ -195,11 +195,6 @@ func testAccCheck{{ $.Res.ResourceName }}DestroyProducer(t *testing.T) func(s *t
 		if err != nil {
 			return err
 		}
-{{- if $.Res.ProductMetadata.Version.RepEnabled }}
-		if strings.Contains(url, "{{"{{"}}location{{"}}"}}") {
-			return fmt.Errorf("failed to qualify endpoint for a resource with a regionalized endpoint %s", url)
-		}
-{{- end }}
 
 		billingProject := ""
 

--- a/mmv1/third_party/terraform/fwresource/field_helpers.go
+++ b/mmv1/third_party/terraform/fwresource/field_helpers.go
@@ -120,10 +120,16 @@ func ReplaceVarsForFrameworkTest(config *transport_tpg.Config, rs *terraform.Res
 			return f.String()
 		}
 
-		return ""
+		return s
 	}
 
-	return re.ReplaceAllStringFunc(linkTmpl, replaceFunc), nil
+	ret := re.ReplaceAllStringFunc(linkTmpl, replaceFunc)
+
+	if re.MatchString(ret) {
+		return "", fmt.Errorf("Unreplaced value found: %s", ret)
+	}
+
+	return ret, nil
 }
 
 func FlattenStringEmptyToNull(configuredValue types.String, apiValue string) types.String {

--- a/mmv1/third_party/terraform/fwtransport/framework_utils.go
+++ b/mmv1/third_party/terraform/fwtransport/framework_utils.go
@@ -318,6 +318,8 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 					} else {
 						return fmt.Sprintf("%v", v.ValueString())
 					}
+				} else {
+					return ""
 				}
 			}
 		} else {
@@ -346,6 +348,8 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 					} else {
 						return fmt.Sprintf("%v", v.ValueString())
 					}
+				} else {
+					return ""
 				}
 			}
 		}

--- a/mmv1/third_party/terraform/fwtransport/framework_utils.go
+++ b/mmv1/third_party/terraform/fwtransport/framework_utils.go
@@ -172,7 +172,7 @@ type DefaultVars struct {
 }
 
 func ReplaceVars(ctx context.Context, req interface{}, diags *diag.Diagnostics, data DefaultVars, config *transport_tpg.Config, linkTmpl string) string {
-	return ReplaceVarsRecursive(ctx, req, diags, data, config, linkTmpl, false, 0)
+	return ReplaceVarsRecursive(ctx, req, diags, data, config, linkTmpl, false)
 }
 
 // relaceVarsForId shortens variables by running them through GetResourceNameFromSelfLink
@@ -184,30 +184,29 @@ func ReplaceVars(ctx context.Context, req interface{}, diags *diag.Diagnostics, 
 // access_level: accessPolicies/foo/accessLevels/bar
 // becomes accessPolicies/foo/accessLevels/bar
 func ReplaceVarsForId(ctx context.Context, req interface{}, diags *diag.Diagnostics, data DefaultVars, config *transport_tpg.Config, linkTmpl string) string {
-	return ReplaceVarsRecursive(ctx, req, diags, data, config, linkTmpl, true, 0)
+	return ReplaceVarsRecursive(ctx, req, diags, data, config, linkTmpl, true)
 }
 
-// ReplaceVars must be done recursively because there are baseUrls that can contain references to regions
-// (eg cloudrun service) there aren't any cases known for 2+ recursion but we will track a run away
-// substitution as 10+ calls to allow for future use cases.
-func ReplaceVarsRecursive(ctx context.Context, req interface{}, diags *diag.Diagnostics, data DefaultVars, config *transport_tpg.Config, linkTmpl string, shorten bool, depth int) string {
-	if depth > 10 {
-		diags.AddError("url building error", "Recursive substitution detected.")
-	}
-
+// ReplaceVarsRecursive runs replacement twice, then returns an error if any replacements remain
+// undone. We currently support two rounds of replacement because some {{ProductBasePath}} replacements
+// will contain `{{location}}` fields or similar; however, we're working to remove {{ProductBasePath}}
+// replacement, at which point a single round of replacement would be sufficient.
+func ReplaceVarsRecursive(ctx context.Context, req interface{}, diags *diag.Diagnostics, data DefaultVars, config *transport_tpg.Config, linkTmpl string, shorten bool) string {
 	// https://github.com/google/re2/wiki/Syntax
 	re := regexp.MustCompile("{{([%[:word:]]+)}}")
 	f := BuildReplacementFunc(ctx, re, req, diags, data, config, linkTmpl, shorten)
 	if diags.HasError() {
 		return ""
 	}
-	final := re.ReplaceAllStringFunc(linkTmpl, f)
+	ret := re.ReplaceAllStringFunc(linkTmpl, f)
+	ret = re.ReplaceAllStringFunc(ret, f)
 
-	if re.Match([]byte(final)) {
-		return ReplaceVarsRecursive(ctx, req, diags, data, config, final, shorten, depth+1)
+	if re.MatchString(ret) {
+		diags.AddError("url building error", fmt.Sprintf("Unreplaced value found: %s", ret))
+		return ""
 	}
 
-	return final
+	return ret
 }
 
 // This function replaces references to Terraform properties (in the form of {{var}}) with their value in Terraform
@@ -215,7 +214,7 @@ func ReplaceVarsRecursive(ctx context.Context, req interface{}, diags *diag.Diag
 // This function supports URL-encoding the result by prepending '%' to the field name e.g. {{%var}}
 func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{}, diags *diag.Diagnostics, data DefaultVars, config *transport_tpg.Config, linkTmpl string, shorten bool) func(string) string {
 	var project, region, zone string
-	var projectID types.String
+	var projectIDAttribute types.String
 
 	if strings.Contains(linkTmpl, "{{project}}") {
 		project = fwresource.GetProjectFramework(data.Project, types.StringValue(config.Project), diags).ValueString()
@@ -227,27 +226,29 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 		}
 	}
 
+	projectID := ""
 	if strings.Contains(linkTmpl, "{{project_id_or_project}}") {
 		var diagInfo diag.Diagnostics
 		switch req.(type) {
 		case resource.CreateRequest:
 			pReq := req.(resource.CreateRequest)
-			diagInfo = pReq.Plan.GetAttribute(ctx, path.Root("project_id"), &projectID)
+			diagInfo = pReq.Plan.GetAttribute(ctx, path.Root("project_id"), &projectIDAttribute)
 		case resource.UpdateRequest:
 			pReq := req.(resource.UpdateRequest)
-			diagInfo = pReq.Plan.GetAttribute(ctx, path.Root("project_id"), &projectID)
+			diagInfo = pReq.Plan.GetAttribute(ctx, path.Root("project_id"), &projectIDAttribute)
 		case resource.ReadRequest:
 			sReq := req.(resource.ReadRequest)
-			diagInfo = sReq.State.GetAttribute(ctx, path.Root("project_id"), &projectID)
+			diagInfo = sReq.State.GetAttribute(ctx, path.Root("project_id"), &projectIDAttribute)
 		case resource.DeleteRequest:
 			sReq := req.(resource.DeleteRequest)
-			diagInfo = sReq.State.GetAttribute(ctx, path.Root("project_id"), &projectID)
+			diagInfo = sReq.State.GetAttribute(ctx, path.Root("project_id"), &projectIDAttribute)
 		}
 		diags.Append(diagInfo...)
 		if diags.HasError() {
 			return nil
 		}
-		if projectID.ValueString() != "" {
+		projectID = projectIDAttribute.ValueString()
+		if projectID != "" {
 			project = fwresource.GetProjectFramework(data.Project, types.StringValue(config.Project), diags).ValueString()
 			if diags.HasError() {
 				return nil
@@ -255,7 +256,7 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 		}
 		if shorten {
 			project = strings.TrimPrefix(project, "projects/")
-			projectID = types.StringValue(strings.TrimPrefix(projectID.ValueString(), "projects/"))
+			projectID = strings.TrimPrefix(projectID, "projects/")
 		}
 	}
 
@@ -280,21 +281,15 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 	}
 
 	f := func(s string) string {
-
 		m := re.FindStringSubmatch(s)[1]
-		if m == "project" {
+		switch {
+		case m == "project_id_or_project" && projectID != "":
+			return projectID
+		case (m == "project" || m == "project_id_or_project") && project != "":
 			return project
-		}
-		if m == "project_id_or_project" {
-			if projectID.ValueString() != "" {
-				return projectID.ValueString()
-			}
-			return project
-		}
-		if m == "region" {
+		case m == "region" && region != "":
 			return region
-		}
-		if m == "zone" {
+		case m == "zone" && zone != "":
 			return zone
 		}
 		if string(m[0]) == "%" {
@@ -367,7 +362,7 @@ func BuildReplacementFunc(ctx context.Context, re *regexp.Regexp, req interface{
 				return f.String()
 			}
 		}
-		return ""
+		return s
 	}
 
 	return f

--- a/mmv1/third_party/terraform/tpgresource/resource_test_utils.go
+++ b/mmv1/third_party/terraform/tpgresource/resource_test_utils.go
@@ -191,10 +191,16 @@ func ReplaceVarsForTest(config *transport_tpg.Config, rs *terraform.ResourceStat
 			return f.String()
 		}
 
-		return ""
+		return s
 	}
 
-	return re.ReplaceAllStringFunc(linkTmpl, replaceFunc), nil
+	ret := re.ReplaceAllStringFunc(linkTmpl, replaceFunc)
+
+	if re.MatchString(ret) {
+		return "", fmt.Errorf("Unreplaced value found: %s", ret)
+	}
+
+	return ret, nil
 }
 
 // These methods are required by some mappers but we don't actually have (or need)

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -788,6 +788,8 @@ func BuildReplacementFunc(re *regexp.Regexp, d TerraformResourceData, config *tr
 			v, ok := d.GetOkExists(m[1:])
 			if ok {
 				return url.PathEscape(fmt.Sprintf("%v", v))
+			} else if v != nil {
+				return ""
 			}
 		} else {
 			v, ok := d.GetOkExists(m)
@@ -797,6 +799,8 @@ func BuildReplacementFunc(re *regexp.Regexp, d TerraformResourceData, config *tr
 				} else {
 					return fmt.Sprintf("%v", v)
 				}
+			} else if v != nil {
+				return ""
 			}
 		}
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -682,7 +682,7 @@ func IsEmptyValue(v reflect.Value) bool {
 }
 
 func ReplaceVars(d TerraformResourceData, config *transport_tpg.Config, linkTmpl string) (string, error) {
-	return ReplaceVarsRecursive(d, config, linkTmpl, false, 0)
+	return ReplaceVarsRecursive(d, config, linkTmpl, false)
 }
 
 // relaceVarsForId shortens variables by running them through GetResourceNameFromSelfLink
@@ -694,30 +694,28 @@ func ReplaceVars(d TerraformResourceData, config *transport_tpg.Config, linkTmpl
 // access_level: accessPolicies/foo/accessLevels/bar
 // becomes accessPolicies/foo/accessLevels/bar
 func ReplaceVarsForId(d TerraformResourceData, config *transport_tpg.Config, linkTmpl string) (string, error) {
-	return ReplaceVarsRecursive(d, config, linkTmpl, true, 0)
+	return ReplaceVarsRecursive(d, config, linkTmpl, true)
 }
 
-// ReplaceVars must be done recursively because there are baseUrls that can contain references to regions
-// (eg cloudrun service) there aren't any cases known for 2+ recursion but we will track a run away
-// substitution as 10+ calls to allow for future use cases.
-func ReplaceVarsRecursive(d TerraformResourceData, config *transport_tpg.Config, linkTmpl string, shorten bool, depth int) (string, error) {
-	if depth > 10 {
-		return "", errors.New("Recursive substitution detected")
-	}
-
+// ReplaceVarsRecursive runs replacement twice, then returns an error if any replacements remain
+// undone. We currently support two rounds of replacement because some {{ProductBasePath}} replacements
+// will contain `{{location}}` fields or similar; however, we're working to remove {{ProductBasePath}}
+// replacement, at which point a single round of replacement would be sufficient.
+func ReplaceVarsRecursive(d TerraformResourceData, config *transport_tpg.Config, linkTmpl string, shorten bool) (string, error) {
 	// https://github.com/google/re2/wiki/Syntax
 	re := regexp.MustCompile("{{([%[:word:]]+)}}")
 	f, err := BuildReplacementFunc(re, d, config, linkTmpl, shorten)
 	if err != nil {
 		return "", err
 	}
-	final := re.ReplaceAllStringFunc(linkTmpl, f)
+	ret := re.ReplaceAllStringFunc(linkTmpl, f)
+	ret = re.ReplaceAllStringFunc(ret, f)
 
-	if re.Match([]byte(final)) {
-		return ReplaceVarsRecursive(d, config, final, shorten, depth+1)
+	if re.MatchString(ret) {
+		return "", fmt.Errorf("Unreplaced value found: %s", ret)
 	}
 
-	return final, nil
+	return ret, nil
 }
 
 // This function replaces references to Terraform properties (in the form of {{var}}) with their value in Terraform
@@ -775,21 +773,15 @@ func BuildReplacementFunc(re *regexp.Regexp, d TerraformResourceData, config *tr
 	}
 
 	f := func(s string) string {
-
 		m := re.FindStringSubmatch(s)[1]
-		if m == "project" {
+		switch {
+		case m == "project_id_or_project" && projectID != "":
+			return projectID
+		case (m == "project" || m == "project_id_or_project") && project != "":
 			return project
-		}
-		if m == "project_id_or_project" {
-			if projectID != "" {
-				return projectID
-			}
-			return project
-		}
-		if m == "region" {
+		case m == "region" && region != "":
 			return region
-		}
-		if m == "zone" {
+		case m == "zone" && zone != "":
 			return zone
 		}
 		if string(m[0]) == "%" {
@@ -820,7 +812,7 @@ func BuildReplacementFunc(re *regexp.Regexp, d TerraformResourceData, config *tr
 				return f.String()
 			}
 		}
-		return ""
+		return s
 	}
 
 	return f, nil


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/17321#discussion_r3184609932

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
provider: changed behavior of URL building to error if a value is missing (instead of using an empty string). This will more clearly surface bugs in URL building.
```
