### PR TITLE
Migrate resource_project_usage_export_bucket.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_project_usage_export_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_project_usage_export_bucket.go.tmpl
@@ -11,12 +11,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceProjectUsageBucket() *schema.Resource {
@@ -64,7 +58,7 @@ func ResourceProjectUsageBucket() *schema.Resource {
 
 func resourceProjectUsageBucketRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -74,12 +68,24 @@ func resourceProjectUsageBucketRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	p, err := NewClient(config, userAgent).Projects.Get(project).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = fmt.Sprintf("%sprojects/%s", url, project)
+	p, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Project data for project %s", project))
 	}
 
-	if p.UsageExportLocation == nil {
+	usageExportLocation, ok := p["usageExportLocation"].(map[string]interface{})
+	if !ok || usageExportLocation == nil {
 		log.Printf("[WARN] Removing usage export location resource %s because it's not enabled server-side.", project)
 		d.SetId("")
 		return nil
@@ -88,10 +94,10 @@ func resourceProjectUsageBucketRead(d *schema.ResourceData, meta interface{}) er
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("prefix", p.UsageExportLocation.ReportNamePrefix); err != nil {
+	if err := d.Set("prefix", usageExportLocation["reportNamePrefix"]); err != nil {
 		return fmt.Errorf("Error setting prefix: %s", err)
 	}
-	if err := d.Set("bucket_name", p.UsageExportLocation.BucketName); err != nil {
+	if err := d.Set("bucket_name", usageExportLocation["bucketName"]); err != nil {
 		return fmt.Errorf("Error setting bucket_name: %s", err)
 	}
 	return nil
@@ -99,7 +105,7 @@ func resourceProjectUsageBucketRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceProjectUsageBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -109,10 +115,25 @@ func resourceProjectUsageBucketCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	op, err := NewClient(config, userAgent).Projects.SetUsageExportBucket(project, &compute.UsageExportLocation{
-		ReportNamePrefix: d.Get("prefix").(string),
-		BucketName:       d.Get("bucket_name").(string),
-	}).Do()
+	body := map[string]interface{}{
+		"reportNamePrefix": d.Get("prefix").(string),
+		"bucketName":       d.Get("bucket_name").(string),
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = fmt.Sprintf("%sprojects/%s/setUsageExportBucket", url, project)
+	op, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      body,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
 	if err != nil {
 		return err
 	}
@@ -132,7 +153,7 @@ func resourceProjectUsageBucketCreate(d *schema.ResourceData, meta interface{}) 
 
 func resourceProjectUsageBucketDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
-	userAgent, err :=  tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
 	if err != nil {
 		return err
 	}
@@ -142,7 +163,19 @@ func resourceProjectUsageBucketDelete(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	op, err := NewClient(config, userAgent).Projects.SetUsageExportBucket(project, nil).Do()
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	url = fmt.Sprintf("%sprojects/%s/setUsageExportBucket", url, project)
+	op, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Timeout:   d.Timeout(schema.TimeoutDelete),
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates `ResourceProjectUsageBucket` resource to use transport_tpg.SendRequest instead of NewClient

```release-note:none
```
