### PR TITLE
Migrate resource_compute_url_map_test.go.tmpl to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_url_map_test.go.tmpl
@@ -3,8 +3,10 @@ package compute_test
 import (
 	"fmt"
 	"testing"
+
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	"github.com/hashicorp/terraform-provider-google/google/services/compute"
+  tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -164,13 +166,19 @@ func testAccCheckComputeUrlMapExists(t *testing.T, n string) resource.TestCheckF
 		config := acctest.GoogleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := compute.NewClient(config, config.UserAgent).UrlMaps.Get(
-			config.Project, name).Do()
+		url := fmt.Sprintf("%sprojects/%s/global/urlMaps/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), config.Project, name)
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if found.Name != name {
+		if found["name"] != name {
 			return fmt.Errorf("Url map not found")
 		}
 		return nil


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates testAccCheckComputeUrlMapExists function to use transport_tpg.SendRequest instead of NewClient

```release-note:none
compute: migrated `resource_compute_url_map_test.go.tmpl` test to use direct HTTP rather than a client library
```
