### PR TITLE
Migrate resource_compute_target_ssl_proxy_test to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
@@ -81,7 +82,7 @@ func testAccCheckComputeTargetSslProxyExists(t *testing.T, n string, proxy *map[
 		config := acctest.GoogleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		url := fmt.Sprintf("%sprojects/%s/global/targetSslProxies/%s", config.ComputeBasePath, config.Project, name)
+		url := fmt.Sprintf("%sprojects/%s/global/targetSslProxies/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), config.Project, name)
 		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_ssl_proxy_test.go.tmpl
@@ -5,17 +5,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
-  "github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func TestAccComputeTargetSslProxy_update(t *testing.T) {
@@ -28,7 +22,7 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 	hc := fmt.Sprintf("tf-test-tssl-%s", acctest.RandString(t, 10))
 
 	resourceSuffix := acctest.RandString(t, 10)
-	var proxy compute.TargetSslProxy
+	var proxy map[string]interface{}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -73,7 +67,7 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetSslProxyExists(t *testing.T, n string, proxy *compute.TargetSslProxy) resource.TestCheckFunc {
+func testAccCheckComputeTargetSslProxyExists(t *testing.T, n string, proxy *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -87,38 +81,53 @@ func testAccCheckComputeTargetSslProxyExists(t *testing.T, n string, proxy *comp
 		config := acctest.GoogleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := compute_tpg.NewClient(config, config.UserAgent).TargetSslProxies.Get(
-			config.Project, name).Do()
+		url := fmt.Sprintf("%sprojects/%s/global/targetSslProxies/%s", config.ComputeBasePath, config.Project, name)
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if found.Name != name {
+		if res["name"] != name {
 			return fmt.Errorf("TargetSslProxy not found")
 		}
 
-		*proxy = *found
+		*proxy = res
 
 		return nil
 	}
 }
 
-func testAccCheckComputeTargetSslProxyHeader(t *testing.T, proxyHeader string, proxy *compute.TargetSslProxy) resource.TestCheckFunc {
+func testAccCheckComputeTargetSslProxyHeader(t *testing.T, proxyHeader string, proxy *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if proxy.ProxyHeader != proxyHeader {
-			return fmt.Errorf("Wrong proxy header. Expected '%s', got '%s'", proxyHeader, proxy.ProxyHeader)
+		if (*proxy)["proxyHeader"] != proxyHeader {
+			return fmt.Errorf("Wrong proxy header. Expected '%s', got '%s'", proxyHeader, (*proxy)["proxyHeader"])
 		}
 		return nil
 	}
 }
 
-func testAccCheckComputeTargetSslProxyHasSslCertificate(t *testing.T, cert string, proxy *compute.TargetSslProxy) resource.TestCheckFunc {
+func testAccCheckComputeTargetSslProxyHasSslCertificate(t *testing.T, cert string, proxy *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 		certURL := fmt.Sprintf(canonicalSslCertificateTemplate, config.Project, cert)
 
-		for _, sslCertificate := range proxy.SslCertificates {
-			if tpgresource.ConvertSelfLinkToV1(sslCertificate) == certURL {
+		sslCertificates, ok := (*proxy)["sslCertificates"].([]interface{})
+		if !ok {
+			return fmt.Errorf("Ssl certificates not found in TargetSslProxy")
+		}
+
+		for _, sslCertificate := range sslCertificates {
+			sslCertificateStr, ok := sslCertificate.(string)
+			if !ok {
+				return fmt.Errorf("Ssl certificate has unexpected type")
+			}
+			if tpgresource.ConvertSelfLinkToV1(sslCertificateStr) == certURL {
 				return nil
 			}
 		}
@@ -127,11 +136,15 @@ func testAccCheckComputeTargetSslProxyHasSslCertificate(t *testing.T, cert strin
 	}
 }
 
-func testAccCheckComputeTargetSslProxyHasCertificateMap(t *testing.T, certificateMap string, proxy *compute.TargetSslProxy) resource.TestCheckFunc {
+func testAccCheckComputeTargetSslProxyHasCertificateMap(t *testing.T, certificateMap string, proxy *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := acctest.GoogleProviderConfig(t)
 		wantCertMapURL := fmt.Sprintf(canonicalCertificateMapTemplate, config.Project, certificateMap)
-		gotCertMapURL := tpgresource.ConvertSelfLinkToV1(proxy.CertificateMap)
+		certificateMapLink, ok := (*proxy)["certificateMap"].(string)
+		if !ok {
+			return fmt.Errorf("certificate map not found in TargetSslProxy")
+		}
+		gotCertMapURL := tpgresource.ConvertSelfLinkToV1(certificateMapLink)
 		if wantCertMapURL != gotCertMapURL {
 			return fmt.Errorf("certificate map not found: got %q, want %q", gotCertMapURL, wantCertMapURL)
 		}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates TestAccComputeTargetSslProxy_update helper functions to use transport_tpg.SendRequest instead of NewClient

```release-note:none
compute: migrated `resource_compute_url_map_test.go.tmpl` test to use direct HTTP rather than a client library
```

