### PR TITLE
Migrate resource_compute_target_pool_test to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_target_pool_test.go.tmpl
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/services/compute"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
 )
 
 func TestAccComputeTargetPool_basic(t *testing.T) {
@@ -148,8 +148,14 @@ func testAccCheckComputeTargetPoolDestroyProducer(t *testing.T) func(s *terrafor
 				continue
 			}
 
-			_, err := compute.NewClient(config, config.UserAgent).TargetPools.Get(
-				config.Project, config.Region, rs.Primary.Attributes["name"]).Do()
+			url := fmt.Sprintf("%sprojects/%s/regions/%s/targetPools/%s", config.ComputeBasePath, config.Project, config.Region, rs.Primary.Attributes["name"])
+			_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				Project:   config.Project,
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
 			if err == nil {
 				return fmt.Errorf("TargetPool still exists")
 			}
@@ -172,13 +178,19 @@ func testAccCheckComputeTargetPoolExists(t *testing.T, n string) resource.TestCh
 
 		config := acctest.GoogleProviderConfig(t)
 
-		found, err := compute.NewClient(config, config.UserAgent).TargetPools.Get(
-			config.Project, config.Region, rs.Primary.Attributes["name"]).Do()
+		url := fmt.Sprintf("%sprojects/%s/regions/%s/targetPools/%s", config.ComputeBasePath, config.Project, config.Region, rs.Primary.Attributes["name"])
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   config.Project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.Attributes["name"] {
+		if found["name"] != rs.Primary.Attributes["name"] {
 			return fmt.Errorf("TargetPool not found")
 		}
 


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

This change migrates TestAccComputeTargetPool_basic and helper methods to use transport_tpg.SendRequest instead of NewClient

```release-note:note
compute: migrated `resource_compute_target_pool_test.go.tmpl` test to use direct HTTP rather than a client library
```
