### PR TITLE
Added enableVpcScopedDns field for compute Instance

### DIFF
--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -544,6 +544,11 @@ properties:
             projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.
           resource: 'networkAttachment'
           imports: 'selfLink'
+        - name: 'enableVpcScopedDns'
+          type: Boolean
+          immutable: true
+          description: |
+            Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.
   - name: 'scheduling'
     type: NestedObject
     description: Sets the scheduling options for this instance.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -635,6 +635,14 @@ func ResourceComputeInstance() *schema.Resource {
 							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
 
+						"enable_vpc_scoped_dns": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Computed:    true,
+							ForceNew:    true,
+							Description: `Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.`,
+						},
+
 						"parent_nic_name": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -638,7 +638,6 @@ func ResourceComputeInstance() *schema.Resource {
 						"enable_vpc_scoped_dns": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Computed:    true,
 							ForceNew:    true,
 							Description: `Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.`,
 						},

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_meta.yaml.tmpl
@@ -177,6 +177,8 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_meta.yaml.tmpl
@@ -184,6 +184,8 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_meta.yaml.tmpl
@@ -184,6 +184,8 @@ fields:
     field: 'network_interface.network'
   - api_field: 'networkInterfaces.networkAttachment'
     field: 'network_interface.network_attachment'
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -527,6 +527,13 @@ Google Cloud KMS. Only one of kms_key_self_link, rsa_encrypted_key and raw_key m
 							Description:      `The URL of the network attachment that this interface should connect to in the following format: projects/{projectNumber}/regions/{region_name}/networkAttachments/{network_attachment_name}.`,
 						},
 
+						"enable_vpc_scoped_dns": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.`,
+						},
+
 						"parent_nic_name": {
 							Type:        schema.TypeString,
 							Computed:    true,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_meta.yaml.tmpl
@@ -151,6 +151,8 @@ fields:
     api_field: 'properties.networkInterfaces.network'
   - field: 'network_interface.network_attachment'
     api_field: 'properties.networkInterfaces.networkAttachment'
+  - api_field: 'networkInterfaces.enableVpcScopedDns'
+    field: 'network_interface.enable_vpc_scoped_dns'
   - api_field: 'networkInterfaces.parentNicName'
     field: 'network_interface.parent_nic_name'
   - api_field: 'networkInterfaces.vlan'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -5216,6 +5216,43 @@ func TestAccComputeInstance_NetworkAttachmentUpdate(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_NetworkAttachmentVpcScopedDns(t *testing.T) {
+	t.Parallel()
+	suffix := fmt.Sprintf("%s", acctest.RandString(t, 10))
+	envRegion := envvar.GetTestRegionFromEnv()
+	var instance compute.Instance
+
+	providerVersion := "v1"
+
+	testNetworkAttachmentName := fmt.Sprintf("tf-test-network-attachment-%s", suffix)
+
+	// Need to have the full network attachment name in the format project/{project_id}/regions/{region_id}/networkAttachments/{testNetworkAttachmentName}
+	fullFormNetworkAttachmentName := fmt.Sprintf("projects/%s/regions/%s/networkAttachments/%s", envvar.GetTestProjectFromEnv(), envRegion, testNetworkAttachmentName)
+
+	context := map[string]interface{}{
+		"suffix":                  (acctest.RandString(t, 10)),
+		"network_attachment_name": testNetworkAttachmentName,
+		"region":                  envRegion,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders:        map[string]resource.ExternalProvider{"time": {}},
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_networkAttachmentVpcScopedDns(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasNetworkAttachment(&instance, fmt.Sprintf("https://www.googleapis.com/compute/%s/%s", providerVersion, fullFormNetworkAttachmentName)),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_NicStackTypeUpdate(t *testing.T) {
 	t.Parallel()
 	suffix := acctest.RandString(t, 10)
@@ -12686,6 +12723,63 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, suffix, suffix, suffix, region, suffix, region, suffix, region, suffix, region, suffix, region, networkAttachment)
+}
+
+func testAccComputeInstance_networkAttachmentVpcScopedDns(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-11"
+	project = "debian-cloud"
+}
+
+resource "google_compute_network" "consumer_vpc" {
+	name = "tf-test-consumer-network-%{suffix}"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "consumer_subnet" {
+	name          = "tf-test-consumer-subnet-%{suffix}"
+	ip_cidr_range = "10.0.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.consumer_vpc.id
+}
+
+resource "google_compute_network_attachment" "test_network_attachment" {
+	name = "%{network_attachment_name}"
+  region = "us-central1"
+  description = "network attachment 1 description"
+  connection_preference = "ACCEPT_AUTOMATIC"
+
+  subnetworks = [
+    google_compute_subnetwork.consumer_subnet.self_link
+  ]
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "tf-test-instance-%{suffix}"
+	machine_type = "e2-medium"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image = data.google_compute_image.my_image.id
+		}
+	}
+
+	network_interface {
+		network = "default"
+	}
+
+	network_interface {
+		network_attachment = google_compute_network_attachment.test_network_attachment.self_link
+		enable_vpc_scoped_dns = true
+	}
+
+	metadata = {
+		foo = "bar"
+	}
+}
+`, context)
 }
 
 func testAccComputeInstance_nicStackTypeUpdate(suffix, region, stack_type, instance string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -742,6 +742,8 @@ This field is always inherited from its subnetwork.
 
 * `network_interface.0.network_ip` - The internal ip address of the instance, either manually or dynamically assigned.
 
+* `network_interface.0.enable_vpc_scoped_dns` - Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.
+
 * `network_interface.0.parent_nic_name` - Name of the parent network interface of a dynamic network interface.
 
 * `network_interface.0.access_config.0.nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -833,6 +833,8 @@ Referencing an instance template via this attribute prevents Time of Check to Ti
 
 * `tags_fingerprint` - The unique fingerprint of the tags.
 
+* `network_interface.0.enable_vpc_scoped_dns` - Optional. If true, DNS resolution will be enabled over this interface. Only valid with networkAttachment.
+
 * `network_interface.0.parent_nic_name` - Name of the parent network interface of a dynamic network interface.
 
 [1]: /docs/providers/google/r/compute_instance_group_manager.html


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds the field `enable_vpc_scoped_dns` for `google_compute_instance`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `enable_vpc_scoped_dns` field  to `google_compute_instance` resource
```
