### PR TITLE
apigee: populate sharedflow_deployment fields in Read

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -3,6 +3,7 @@ package apigee
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -152,6 +153,23 @@ func resourceApigeeSharedflowDeploymentRead(d *schema.ResourceData, meta interfa
 		return err
 	}
 
+	// org_id is not returned by the API; it is derived from the resource ID
+	// (set by Create or by the import parser) and stays in state untouched.
+	if err := d.Set("environment", flattenApigeeSharedflowDeploymentEnvironment(res["environment"], d, config)); err != nil {
+		return fmt.Errorf("Error reading SharedflowDeployment: %s", err)
+	}
+	// The API uses `apiProxy` for both API proxy and shared flow deployments
+	// to identify the deployed artifact.
+	if err := d.Set("sharedflow_id", flattenApigeeSharedflowDeploymentSharedflowId(res["apiProxy"], d, config)); err != nil {
+		return fmt.Errorf("Error reading SharedflowDeployment: %s", err)
+	}
+	if err := d.Set("revision", flattenApigeeSharedflowDeploymentRevision(res["revision"], d, config)); err != nil {
+		return fmt.Errorf("Error reading SharedflowDeployment: %s", err)
+	}
+	if err := d.Set("service_account", flattenApigeeSharedflowDeploymentServiceAccount(res["serviceAccount"], d, config)); err != nil {
+		return fmt.Errorf("Error reading SharedflowDeployment: %s", err)
+	}
+
 	return nil
 }
 
@@ -286,7 +304,19 @@ func flattenApigeeSharedflowDeploymentRevision(v interface{}, d *schema.Resource
 }
 
 func flattenApigeeSharedflowDeploymentServiceAccount(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
-	return v
+	// The Apigee API may return service accounts as a full resource name
+	// (e.g. "projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com")
+	// while the schema documents (and Create accepts) the bare email form.
+	// Strip the prefix when present so a Read after a Create using the bare
+	// email does not show drift.
+	if v == nil {
+		return v
+	}
+	s, ok := v.(string)
+	if !ok {
+		return v
+	}
+	return strings.TrimPrefix(s, "projects/-/serviceAccounts/")
 }
 
 func init() {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
@@ -135,11 +135,18 @@ resource "google_apigee_sharedflow" "test_apigee_sharedflow" {
   depends_on      = [google_apigee_organization.apigee_org]
 }
 
+resource "google_service_account" "sharedflow_sa" {
+  account_id   = "tf-test-sf-sa%{random_suffix}"
+  display_name = "TF Test Sharedflow SA"
+  project      = google_project.project.project_id
+}
+
 resource "google_apigee_sharedflow_deployment" "sharedflow_deployment_test" {
-  environment = google_apigee_environment.apigee_environment.name
-  org_id = google_apigee_sharedflow.test_apigee_sharedflow.org_id
-  revision = google_apigee_sharedflow.test_apigee_sharedflow.revision[length(google_apigee_sharedflow.test_apigee_sharedflow.revision)-1]
-  sharedflow_id = google_apigee_sharedflow.test_apigee_sharedflow.name
+  environment     = google_apigee_environment.apigee_environment.name
+  org_id          = google_apigee_sharedflow.test_apigee_sharedflow.org_id
+  revision        = google_apigee_sharedflow.test_apigee_sharedflow.revision[length(google_apigee_sharedflow.test_apigee_sharedflow.revision)-1]
+  sharedflow_id   = google_apigee_sharedflow.test_apigee_sharedflow.name
+  service_account = google_service_account.sharedflow_sa.email
 }
 `, context)
 }


### PR DESCRIPTION
## Summary

The Read function for `google_apigee_sharedflow_deployment` fetched the deployment from the API but never copied the response into Terraform state. As a result `service_account` always read back as null, and because `service_account` is `ForceNew` this caused destructive resource replacement after `terraform import` whenever the user's HCL declared a non-empty `service_account` matching what was actually deployed.

This PR populates `environment`, `sharedflow_id` (from the `apiProxy` response field, since the API uses `apiProxy` for both API proxy and shared flow deployments), `revision`, and `service_account` in state from the GET response.

It also strips the `projects/-/serviceAccounts/` prefix that the API may return on `serviceAccount`, so a Read after a Create using the bare-email form (which the schema documents and `Create` accepts) shows no drift.

The existing acceptance test now sets a `service_account` on the deployment so the existing `ImportStateVerify` step actually exercises the field; previously it did not because no `service_account` was set.

`org_id` is intentionally not re-set in Read because the API does not return it; it remains in state from the resource ID (which is set by Create or by the import parser).

Fixes hashicorp/terraform-provider-google#25332

## Release Note

```release-note:bug
apigee: fixed forced replacement when importing `google_apigee_sharedflow_deployment` resource, where `service_account` read as null  
```