### PR TITLE
[TpuV2] Add 'provisioning_model' field to google_tpu_v2_queued_resource

### DIFF
--- a/mmv1/products/tpuv2/QueuedResource.yaml
+++ b/mmv1/products/tpuv2/QueuedResource.yaml
@@ -57,6 +57,15 @@ examples:
     test_env_vars:
       project: PROJECT_NAME
     skip_vcr: true
+  - name: tpu_v2_queued_resource_provisioning_options
+    primary_resource_id: qr
+    min_version: beta
+    vars:
+      qr_name: test-qr
+      tpu_name: test-tpu
+    test_env_vars:
+      project: PROJECT_NAME
+    skip_vcr: true
 parameters:
   - name: zone
     type: String
@@ -155,3 +164,11 @@ properties:
                       description: |
                         Specifies networking queue count for TPU VM instance's network interface.
                       immutable: true
+  - name: provisioningModel
+    type: Enum
+    description: The provisioning model for the resource.
+    enum_values:
+      - STANDARD
+      - SPOT
+      - RESERVATION_BOUND
+      - FLEX_START

--- a/mmv1/templates/terraform/examples/tpu_v2_queued_resource_provisioning_options.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_queued_resource_provisioning_options.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_tpu_v2_queued_resource" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  name    = "{{index $.Vars "qr_name"}}"
+  zone    = "us-central1-c"
+  project = "{{index $.TestEnvVars "project"}}"
+
+  tpu {
+    node_spec {
+      parent  = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1-c"
+      node_id = "{{index $.Vars "tpu_name"}}"
+      node {
+        runtime_version  = "tpu-vm-tf-2.13.0"
+        accelerator_type = "v2-8"
+        description      = "Text description of the TPU."
+      }
+    }
+  }
+
+  provisioning_model = "SPOT"
+}


### PR DESCRIPTION
This PR adds the `provisioning_model` field to the `google_tpu_v2_queued_resource` resource. It also includes an acceptance test to verify the creation of the resource with this new field.

```release-note:enhancement
tpu: added `provisioning_model` field to `google_tpu_v2_queued_resource` resource (beta)
```