### PR TITLE
[StorageBatchOperations] Add 'description' field to google_storage_batch_operations_job

### DIFF
--- a/mmv1/products/storagebatchoperations/Job.yaml
+++ b/mmv1/products/storagebatchoperations/Job.yaml
@@ -48,6 +48,13 @@ examples:
     vars:
       bucket_name: tf-sample-bucket
       job_id: tf-job
+  - name: storage_batch_operations_description
+    primary_resource_id: tf-job
+    ignore_read_extra:
+      - delete_protection
+    vars:
+      bucket_name: tf-sample-bucket
+      job_id: tf-job
 virtual_fields:
   - name: delete_protection
     type: Boolean
@@ -287,3 +294,6 @@ properties:
         immutable: true
         validation:
           function: validation.StringInSlice([]string{"SET", "UNSET"}, false)
+  - name: description
+    type: String
+    description: A description provided by the user for the job. Its max length is 1024 bytes when Unicode-encoded.

--- a/mmv1/templates/terraform/examples/storage_batch_operations_description.tf.tmpl
+++ b/mmv1/templates/terraform/examples/storage_batch_operations_description.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_storage_bucket" "bucket" {
+  name          = "{{index $.Vars "bucket_name"}}"
+  location      = "us-central1"
+  force_destroy = true
+}
+
+resource "google_storage_batch_operations_job" "{{$.PrimaryResourceId}}" {
+  job_id      = "{{index $.Vars "job_id"}}"
+  description = "A sample job description"
+  bucket_list {
+    buckets {
+      bucket = google_storage_bucket.bucket.name
+      prefix_list {
+        included_object_prefixes = [
+          "bkt"
+        ]
+      }
+    }
+  }
+  put_metadata {
+    custom_metadata = {
+      "key" = "value"
+    }
+  }
+  delete_protection = false
+}


### PR DESCRIPTION
Adds the `description` field to the `google_storage_batch_operations_job` resource.

```release-note:enhancement
storagebatchoperations: added `description` field to `google_storage_batch_operations_job` resource
```