### PR TITLE
[TPU] Add autocheckpoint_enabled field to google_tpu_v2_vm

### DIFF
--- a/mmv1/products/tpuv2/Vm.yaml
+++ b/mmv1/products/tpuv2/Vm.yaml
@@ -60,6 +60,12 @@ examples:
     external_providers:
       - random
       - time
+  - name: tpu_v2_vm_autocheckpoint
+    primary_resource_id: tpu
+    min_version: beta
+    vars:
+      vm_name: test-tpu-autochkpt
+    skip_vcr: true
 parameters:
   - name: zone
     type: String
@@ -448,3 +454,6 @@ properties:
             A string used to uniquely distinguish a worker within a TPU node.
           output: true
           min_version: beta
+  - name: autocheckpointEnabled
+    type: Boolean
+    description: Whether Autocheckpoint is enabled.

--- a/mmv1/templates/terraform/examples/tpu_v2_vm_autocheckpoint.tf.tmpl
+++ b/mmv1/templates/terraform/examples/tpu_v2_vm_autocheckpoint.tf.tmpl
@@ -1,0 +1,13 @@
+data "google_tpu_v2_runtime_versions" "available" {
+  provider = google-beta
+}
+
+resource "google_tpu_v2_vm" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+
+  name = "{{index $.Vars "vm_name"}}"
+  zone = "us-central1-c"
+
+  runtime_version = "tpu-vm-tf-2.13.0"
+  autocheckpoint_enabled = true
+}


### PR DESCRIPTION
Adds the `autocheckpoint_enabled` field to the `google_tpu_v2_vm` resource to allow enabling Autocheckpoint on Cloud TPU VM instances.

```release-note:enhancement
tpu: added `autocheckpoint_enabled` field to `google_tpu_v2_vm` resource
```