### PR TITLE
Add field to control propagation of Firebase AI Logic Prompt Templates

### DIFF
--- a/mmv1/products/firebaseailogic/PromptTemplate.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplate.yaml
@@ -24,11 +24,12 @@ references:
   api: 'https://firebase.google.com/docs/reference/ai-logic/rest/v1beta/projects.locations.templates'
 update_mask: true
 self_link: projects/{{project}}/locations/{{location}}/templates/{{template_id}}
-create_url: projects/{{project}}/locations/{{location}}/templates?promptTemplateId={{template_id}}
+create_url: projects/{{project}}/locations/{{location}}/templates?promptTemplateId={{template_id}}&regionalPropagationDisabled={{regional_propagation_disabled}}
+update_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}?regionalPropagationDisabled={{regional_propagation_disabled}}
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/templates/{{template_id}}
-delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}
+delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}?regionalPropagationDisabled={{regional_propagation_disabled}}
 autogen_async: false
 autogen_status: UHJvbXB0VGVtcGxhdGU=
 parameters:
@@ -37,6 +38,14 @@ parameters:
     required: true
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
+    url_param_only: true
+  - name: regional_propagation_disabled
+    type: Boolean
+    default_value: false
+    description: |-
+      For the `global` location only. If true, the write operation (create,
+      update, or delete) will apply to the global region only. Otherwise, the
+      operation will also propagate to all applicable regions.
     url_param_only: true
 properties:
   - name: templateId
@@ -93,6 +102,11 @@ examples:
     primary_resource_id: file
     vars:
       template_id: 'file-template'
+  - name: firebaseailogic_prompt_template_global_only
+    min_version: beta
+    primary_resource_id: global_only
+    vars:
+      template_id: 'global-only-template'
   - name: firebaseailogic_prompt_template_basic
     min_version: beta
     primary_resource_id: basic

--- a/mmv1/products/firebaseailogic/PromptTemplate.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplate.yaml
@@ -42,7 +42,7 @@ parameters:
     description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
     immutable: true
     url_param_only: true
-  - name: regional_propagation_disabled
+  - name: regionalPropagationDisabled
     type: Boolean
     description: |-
       For the `global` location only. If true, the write operation (create,

--- a/mmv1/products/firebaseailogic/PromptTemplate.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplate.yaml
@@ -24,13 +24,16 @@ references:
   api: 'https://firebase.google.com/docs/reference/ai-logic/rest/v1beta/projects.locations.templates'
 update_mask: true
 self_link: projects/{{project}}/locations/{{location}}/templates/{{template_id}}
-create_url: projects/{{project}}/locations/{{location}}/templates?promptTemplateId={{template_id}}&regionalPropagationDisabled={{regional_propagation_disabled}}
-update_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}?regionalPropagationDisabled={{regional_propagation_disabled}}
+create_url: projects/{{project}}/locations/{{location}}/templates?promptTemplateId={{template_id}}
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/templates/{{template_id}}
-delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}?regionalPropagationDisabled={{regional_propagation_disabled}}
+delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}
 autogen_async: false
+custom_code:
+  pre_create: 'templates/terraform/pre_create/firebase_ai_logic_prompt_template.go.tmpl'
+  pre_update: 'templates/terraform/pre_update/firebase_ai_logic_prompt_template.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/firebase_ai_logic_prompt_template.go.tmpl'
 autogen_status: UHJvbXB0VGVtcGxhdGU=
 parameters:
   - name: location
@@ -41,7 +44,6 @@ parameters:
     url_param_only: true
   - name: regional_propagation_disabled
     type: Boolean
-    default_value: false
     description: |-
       For the `global` location only. If true, the write operation (create,
       update, or delete) will apply to the global region only. Otherwise, the

--- a/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
@@ -68,6 +68,7 @@ parameters:
       apply to the global region only. Otherwise, the operation will also
       propagate to all applicable regions.
     url_param_only: true
+    immutable: true
 properties:
   - name: name
     type: String

--- a/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
@@ -33,9 +33,14 @@ examples:
       template_id: 'lock-template'
     test_env_vars:
       project_id: PROJECT_NAME
-create_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=true
+  - name: firebaseailogic_prompt_template_lock_global_only
+    min_version: beta
+    primary_resource_id: global_only_lock
+    vars:
+      template_id: 'global-only-lock-template'
+create_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=true&regionalPropagationDisabled={{regional_propagation_disabled}}
 create_verb: POST
-delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=false
+delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=false&regionalPropagationDisabled={{regional_propagation_disabled}}
 delete_verb: POST
 custom_code:
   # We read the PromptTemplate to verify it is locked
@@ -55,6 +60,14 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+  - name: regional_propagation_disabled
+    type: Boolean
+    default_value: false
+    description: |-
+      For the `global` location only. If true, the modifyLock operation will
+      apply to the global region only. Otherwise, the operation will also
+      propagate to all applicable regions.
+    url_param_only: true
 properties:
   - name: name
     type: String

--- a/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
@@ -38,11 +38,13 @@ examples:
     primary_resource_id: global_only_lock
     vars:
       template_id: 'global-only-lock-template'
-create_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=true&regionalPropagationDisabled={{regional_propagation_disabled}}
+create_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=true
 create_verb: POST
-delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=false&regionalPropagationDisabled={{regional_propagation_disabled}}
+delete_url: projects/{{project}}/locations/{{location}}/templates/{{template_id}}:modifyLock?locked=false
 delete_verb: POST
 custom_code:
+  pre_create: 'templates/terraform/pre_create/firebase_ai_logic_prompt_template_lock.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/firebase_ai_logic_prompt_template_lock.go.tmpl'
   # We read the PromptTemplate to verify it is locked
   post_read: 'templates/terraform/post_read/firebase_ai_logic_prompt_template_lock.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/firebase_ai_logic_prompt_template_lock.go.tmpl'
@@ -62,7 +64,6 @@ parameters:
     immutable: true
   - name: regional_propagation_disabled
     type: Boolean
-    default_value: false
     description: |-
       For the `global` location only. If true, the modifyLock operation will
       apply to the global region only. Otherwise, the operation will also

--- a/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
+++ b/mmv1/products/firebaseailogic/PromptTemplateLock.yaml
@@ -62,7 +62,7 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
-  - name: regional_propagation_disabled
+  - name: regionalPropagationDisabled
     type: Boolean
     description: |-
       For the `global` location only. If true, the modifyLock operation will

--- a/mmv1/templates/terraform/examples/firebaseailogic_prompt_template_global_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebaseailogic_prompt_template_global_only.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_firebase_ai_logic_prompt_template" "global_only" {
+  provider = google-beta
+  location = "global"
+  template_id = "{{index $.Vars "template_id"}}"
+  regional_propagation_disabled = true
+  template_string = file("test-fixtures/hello_world.prompt")
+}

--- a/mmv1/templates/terraform/examples/firebaseailogic_prompt_template_lock_global_only.tf.tmpl
+++ b/mmv1/templates/terraform/examples/firebaseailogic_prompt_template_lock_global_only.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_firebase_ai_logic_prompt_template" "global_only" {
+  provider = google-beta
+  location = "global"
+  template_id = "{{index $.Vars "template_id"}}"
+  template_string = <<EOF
+---
+model: googleai/gemini-1.5-flash
+---
+Hello World
+EOF
+}
+
+resource "google_firebase_ai_logic_prompt_template_lock" "global_only_lock" {
+  provider = google-beta
+  location = google_firebase_ai_logic_prompt_template.global_only.location
+  template_id = google_firebase_ai_logic_prompt_template.global_only.template_id
+  regional_propagation_disabled = true
+}

--- a/mmv1/templates/terraform/pre_create/firebase_ai_logic_prompt_template.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/firebase_ai_logic_prompt_template.go.tmpl
@@ -1,0 +1,6 @@
+if d.Get("regional_propagation_disabled").(bool) {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"regionalPropagationDisabled": "true"})
+    if err != nil {
+        return err
+    }
+}

--- a/mmv1/templates/terraform/pre_create/firebase_ai_logic_prompt_template_lock.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/firebase_ai_logic_prompt_template_lock.go.tmpl
@@ -1,0 +1,6 @@
+if d.Get("regional_propagation_disabled").(bool) {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"regionalPropagationDisabled": "true"})
+    if err != nil {
+        return err
+    }
+}

--- a/mmv1/templates/terraform/pre_delete/firebase_ai_logic_prompt_template.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/firebase_ai_logic_prompt_template.go.tmpl
@@ -1,0 +1,6 @@
+if d.Get("regional_propagation_disabled").(bool) {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"regionalPropagationDisabled": "true"})
+    if err != nil {
+        return err
+    }
+}

--- a/mmv1/templates/terraform/pre_delete/firebase_ai_logic_prompt_template_lock.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/firebase_ai_logic_prompt_template_lock.go.tmpl
@@ -1,0 +1,6 @@
+if d.Get("regional_propagation_disabled").(bool) {
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"regionalPropagationDisabled": "true"})
+    if err != nil {
+        return err
+    }
+}

--- a/mmv1/templates/terraform/pre_update/firebase_ai_logic_prompt_template.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/firebase_ai_logic_prompt_template.go.tmpl
@@ -1,0 +1,6 @@
+if d.Get("regional_propagation_disabled").(bool) {
+	url, err = transport_tpg.AddQueryParams(url, map[string]string{"regionalPropagationDisabled": "true"})
+	if err != nil {
+		return err
+	}
+}

--- a/mmv1/third_party/terraform/services/firebaseailogic/resource_firebase_ai_logic_prompt_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaseailogic/resource_firebase_ai_logic_prompt_template_test.go.tmpl
@@ -58,7 +58,7 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdate(t 
 				ResourceName:            "google_firebase_ai_logic_prompt_template.updating",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 			{
 				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context, "Hello from Updated Version 2"),
@@ -67,7 +67,7 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdate(t 
 				ResourceName:            "google_firebase_ai_logic_prompt_template.updating",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 		},
 	})
@@ -100,7 +100,7 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateComplexUp
 				ResourceName:            "google_firebase_ai_logic_prompt_template.complex",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 			{
 				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateComplexUpdateExample(context, "Updated Name", "gemini-1.5-flash", "Hello V1"),
@@ -112,7 +112,7 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateComplexUp
 				ResourceName:            "google_firebase_ai_logic_prompt_template.complex",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 			{
 				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateComplexUpdateExample(context, "Final Name", "gemini-2.0-flash", "Hello V2"),
@@ -125,7 +125,7 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateComplexUp
 				ResourceName:            "google_firebase_ai_logic_prompt_template.complex",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 		},
 	})
@@ -243,7 +243,7 @@ func TestAccFirebaseAILogicPromptTemplate_regional(t *testing.T) {
 				ResourceName:            "google_firebase_ai_logic_prompt_template.regional",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/firebaseailogic/resource_firebase_ai_logic_prompt_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaseailogic/resource_firebase_ai_logic_prompt_template_test.go.tmpl
@@ -52,7 +52,8 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdate(t 
 		CheckDestroy: testAccCheckFirebaseAILogicPromptTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context, "Hello from Version 1"),
+				// Create template with regional propagation. This creates the template in all regions.
+				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context, "Hello from Version 1", false),
 			},
 			{
 				ResourceName:            "google_firebase_ai_logic_prompt_template.updating",
@@ -61,7 +62,8 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdate(t 
 				ImportStateVerifyIgnore: []string{"location", "regional_propagation_disabled"},
 			},
 			{
-				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context, "Hello from Updated Version 2"),
+				// Update template without propagation. This updates the template in "global" only.
+				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context, "Hello from Updated Version 2", false),
 			},
 			{
 				ResourceName:            "google_firebase_ai_logic_prompt_template.updating",
@@ -148,24 +150,32 @@ func TestAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedUpd
 		CheckDestroy: testAccCheckFirebaseAILogicPromptTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context, "Hello V1"),
+				// Create template, then lock without regional propagation. This locks the template in "global" only.
+				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context, "Hello V1", true),
 			},
 			{
-				Config:      testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context, "Hello V2"),
+				// Lock template with propagation. This locks the template in all regions.
+				Config: testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context, "Hello V1", false),
+			},
+			{
+				// Template is locked; updating its content should fail.
+				Config:      testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context, "Hello V2", false),
 				ExpectError: regexp.MustCompile("(?s)Error updating PromptTemplate.*Precondition check failed"),
 			},
 		},
 	})
 }
 
-func testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context map[string]interface{}, message string) string {
+func testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateUpdateExample(context map[string]interface{}, message string, regionalPropagationDisabled bool) string {
 	context["template_message"] = message
+	context["regional_propagation_disabled"] = regionalPropagationDisabled
 	return acctest.Nprintf(`
 resource "google_firebase_ai_logic_prompt_template" "updating" {
   provider = google-beta
   project  = "%{project_id}"
   location = "global"
   template_id = "tf-test-update-%{random_suffix}"
+  regional_propagation_disabled = %{regional_propagation_disabled}
   template_string = <<EOF
 ---
 model: googleai/gemini-2.0-flash
@@ -197,8 +207,9 @@ EOF
 `, context)
 }
 
-func testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context map[string]interface{}, message string) string {
+func testAccFirebaseAILogicPromptTemplate_firebaseailogicPromptTemplateLockedExample(context map[string]interface{}, message string, regionalPropagationDisabled bool) string {
 	context["template_message"] = message
+	context["regional_propagation_disabled"] = regionalPropagationDisabled
 	return acctest.Nprintf(`
 resource "google_firebase_ai_logic_prompt_template" "locked" {
   provider = google-beta
@@ -218,6 +229,7 @@ resource "google_firebase_ai_logic_prompt_template_lock" "locked_lock" {
   project  = google_firebase_ai_logic_prompt_template.locked.project
   location = google_firebase_ai_logic_prompt_template.locked.location
   template_id = google_firebase_ai_logic_prompt_template.locked.template_id
+  regional_propagation_disabled = %{regional_propagation_disabled}
 }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds an optional boolean field `regional_propagation_disabled` to the PromptTemplate and PromptTemplateLock resources. By default, any operation on a PromptTemplate in the `global` location is replicated on all Cloud regions where possible. This new field allows expert users to disable that behavior if they want to work with PromptTemplates in `global` only.

Part of http://b/496979779

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
firebaseailogic: added `regional_propagation_disabled` field to `google_firebase_ai_logic_prompt_template` and `google_firebase_ai_logic_prompt_template_lock` resources (beta)
```
