### PR TITLE
Fixed cloud run v1 tests

### DIFF
--- a/mmv1/products/cloudrun/DomainMapping.yaml
+++ b/mmv1/products/cloudrun/DomainMapping.yaml
@@ -44,6 +44,7 @@ custom_code:
   encoder: templates/terraform/encoders/cloud_run_domain_mapping.go.tmpl
   decoder: templates/terraform/decoders/cloud_run.go.tmpl
   constants: templates/terraform/constants/cloud_run_domain_mapping.go.tmpl
+  test_check_destroy: templates/terraform/custom_check_destroy/cloudrun_domain_mapping.go.tmpl
 examples:
   - name: cloud_run_domain_mapping_basic
     primary_resource_id: default

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -55,6 +55,7 @@ custom_code:
   constants: 'templates/terraform/constants/cloud_run_service.go.tmpl'
   encoder: 'templates/terraform/encoders/cloud_run_service.go.tmpl'
   decoder: 'templates/terraform/decoders/cloud_run.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/cloudrun_service.go.tmpl'
 custom_diff:
   - 'revisionNameCustomizeDiff'
 error_retry_predicates:

--- a/mmv1/templates/terraform/custom_check_destroy/cloudrun_domain_mapping.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/cloudrun_domain_mapping.go.tmpl
@@ -1,0 +1,26 @@
+// Delete is eventually-consistent; wait for a moment.
+time.Sleep(10*time.Second)
+
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, fmt.Sprintf("%s%s", transport_tpg.BaseUrl(cloudrun.Product, config), "apis/domains.cloudrun.com/v1/namespaces/{{"{{"}}project}}/domainmappings/{{"{{"}}name{{"}}"}}"))
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:               config,
+	Method:               "GET",
+	Project:              billingProject,
+	RawURL:               url,
+	UserAgent:            config.UserAgent,
+	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsCloudRunCreationConflict},
+})
+if err == nil {
+	return fmt.Errorf("CloudRunDomainMapping still exists at %s", url)
+}

--- a/mmv1/templates/terraform/custom_check_destroy/cloudrun_service.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/cloudrun_service.go.tmpl
@@ -1,0 +1,26 @@
+// Delete is eventually-consistent; wait for a moment.
+time.Sleep(10*time.Second)
+
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(cloudrun.Product, config) + "apis/serving.knative.dev/v1/namespaces/{{"{{"}}project{{"}}"}}/services/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:               config,
+	Method:               "GET",
+	Project:              billingProject,
+	RawURL:               url,
+	UserAgent:            config.UserAgent,
+	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsCloudRunCreationConflict},
+})
+if err == nil {
+	return fmt.Errorf("CloudRunService still exists at %s", url)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

https://github.com/GoogleCloudPlatform/magic-modules/pull/17321 "broke" these tests by fixing URL building for the check_destroy step. The delete is apparently asynchronous, so I've added a short sleep via custom test_check_destroy logic.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
