### PR TITLE
Fixed ApigeeOrganization tests

### DIFF
--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_data_residency_test.tf.tmpl
@@ -22,6 +22,10 @@ resource "time_sleep" "wait_300_seconds" {
   depends_on = [google_project_service.apigee]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   description                = "Terraform-provisioned basic Apigee Org under European Union hosting jurisdiction."
   project_id                 = google_project.project.project_id
@@ -30,10 +34,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   disable_vpc_peering        = true
   depends_on                 = [
     time_sleep.wait_300_seconds,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.tmpl
@@ -16,6 +16,9 @@ resource "time_sleep" "wait_300_seconds" {
   depends_on = [google_project_service.apigee]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
 
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   description         = "Terraform-provisioned basic Apigee Org without VPC Peering."
@@ -24,10 +27,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   disable_vpc_peering = true
   depends_on          = [
     time_sleep.wait_300_seconds,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_test.tf.tmpl
@@ -56,6 +56,10 @@ resource "google_service_networking_connection" "apigee_vpc_connection" {
   depends_on              = [google_project_service.servicenetworking]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   analytics_region   = "us-central1"
   project_id         = google_project.project.project_id
@@ -63,10 +67,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   depends_on         = [
     google_service_networking_connection.apigee_vpc_connection,
     google_project_service.apigee,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_disable_vpc_peering_test.tf.tmpl
@@ -79,6 +79,10 @@ resource "time_sleep" "wait_for_iam" {
   depends_on = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   provider = google-beta
 
@@ -102,10 +106,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
 
   depends_on = [
     time_sleep.wait_for_iam,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_full_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_full_test.tf.tmpl
@@ -115,6 +115,10 @@ resource "time_sleep" "wait_for_iam" {
   depends_on = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   provider = google-beta
 
@@ -139,10 +143,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
     time_sleep.wait_for_iam,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_drz_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_drz_test.tf.tmpl
@@ -119,6 +119,10 @@ resource "time_sleep" "wait_for_iam" {
   depends_on = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   provider = google-beta
 
@@ -134,10 +138,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
     google_service_networking_connection.apigee_vpc_connection,
     google_project_service.apigee,
     time_sleep.wait_for_iam,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_retention_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_retention_test.tf.tmpl
@@ -115,6 +115,10 @@ resource "time_sleep" "wait_for_iam" {
   depends_on = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
+resource "time_sleep" "wait_after_destroy" {
+  destroy_duration = "150s"
+}
+
 resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   provider = google-beta
 
@@ -129,10 +133,6 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
     google_service_networking_connection.apigee_vpc_connection,
     google_project_service.apigee,
     time_sleep.wait_for_iam,
+    time_sleep.wait_after_destroy,
   ]
-}
-
-resource "time_sleep" "wait_after_destroy" {
-  destroy_duration = "150s"
-  depends_on = [google_apigee_organization.{{$.PrimaryResourceId}}]
 }


### PR DESCRIPTION
The dependency order for the wait_after_destroy was backwards (see [docs](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep#delay-destroy-usage)). This fixes it.

Fixed https://github.com/hashicorp/terraform-provider-google/issues/24143. Fixed https://github.com/hashicorp/terraform-provider-google/issues/25281.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
