### PR TITLE
Fixed DocumentAI flakey tests

### DIFF
--- a/mmv1/products/documentai/Processor.yaml
+++ b/mmv1/products/documentai/Processor.yaml
@@ -27,6 +27,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  test_check_destroy: 'templates/terraform/custom_check_destroy/documentai_schema.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us"

--- a/mmv1/products/documentai/Processor.yaml
+++ b/mmv1/products/documentai/Processor.yaml
@@ -27,7 +27,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  test_check_destroy: 'templates/terraform/custom_check_destroy/documentai_schema.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/documentai_processor.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us"

--- a/mmv1/products/documentai/Schema.yaml
+++ b/mmv1/products/documentai/Schema.yaml
@@ -26,6 +26,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+custom_code:
+  test_check_destroy: 'templates/terraform/custom_check_destroy/documentai_schema.go.tmpl'
 examples:
   - name: 'documentai_schema'
     primary_resource_id: 'schema'

--- a/mmv1/templates/terraform/custom_check_destroy/documentai_processor.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/documentai_processor.go.tmpl
@@ -1,0 +1,25 @@
+// Delete is eventually consistent; wait for a moment.
+time.Sleep(10*time.Second)
+
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(documentai.Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/processors/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err == nil {
+	return fmt.Errorf("DocumentAIProcessor still exists at %s", url)
+}

--- a/mmv1/templates/terraform/custom_check_destroy/documentai_schema.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/documentai_schema.go.tmpl
@@ -1,0 +1,25 @@
+// Delete is eventually consistent; wait for a moment.
+time.Sleep(10*time.Second)
+
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(documentai.Product, config)+"projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/schemas/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err == nil {
+	return fmt.Errorf("DocumentAISchema still exists at %s", url)
+}


### PR DESCRIPTION
Added a short sleep to test_check_destroy.

https://github.com/GoogleCloudPlatform/magic-modules/pull/17321 "broke" these tests by fixing the URL computation in test check destroy. I'm not able to reproduce the failure locally but I'm hopeful that adding a short sleep will help here (similar to https://github.com/GoogleCloudPlatform/magic-modules/pull/17465, which I _was_ able to reproduce.)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
