### PR TITLE
Add support for launch and authorization URLs on workstation_cluster.

### DIFF
--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -65,6 +65,15 @@ examples:
     test_vars_overrides:
       'key_short_name': '"tf-test-key-" + acctest.RandString(t, 10)'
       'value_short_name': '"tf-test-value-" + acctest.RandString(t, 10)'
+samples:
+  - name: "workstation_cluster_urls"
+    primary_resource_id: "default"
+    steps:
+      - name: "workstation_cluster_custom_urls"
+        vars:
+          cluster_id: "custom-urls-cluster"
+        resource_id_vars:
+          cluster_network_name: "workstations-network"
 parameters:
   - name: 'workstationClusterId'
     type: String
@@ -120,6 +129,17 @@ properties:
     type: String
     description: |
       Human-readable name for this resource.
+  - name: 'workstationAuthorizationUrl'
+    type: String
+    default_from_api: true
+    description: |
+      Specifies the redirect URL for unauthorized requests received by workstation VMs in this cluster.
+      Redirects to this endpoint will send a base64 encoded `state` query param containing the target workstation name and original request hostname. The endpoint is responsible for retrieving a token using `GenerateAccessToken` and redirecting back to the original hostname with the token.
+  - name: 'workstationLaunchUrl'
+    type: String
+    description: |
+      Specifies the launch URL for workstations in this cluster. Requests sent to unstarted workstations will be redirected to this URL.
+      Requests redirected to the launch endpoint will be sent with a `workstation` query parameter containing the full workstation resource. The launch endpoint is responsible for starting the workstation, polling it until it reaches `STATE_RUNNING`, and then issuing a redirect to the workstation's host URL.
   - name: 'degraded'
     type: Boolean
     description: |

--- a/mmv1/templates/terraform/samples/services/workstations/workstation_cluster_custom_urls.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/workstations/workstation_cluster_custom_urls.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_workstations_workstation_cluster" "{{$.PrimaryResourceId}}" {
+  workstation_cluster_id = "{{index $.Vars "cluster_id"}}"
+  network                = google_compute_network.default.id
+  subnetwork             = google_compute_subnetwork.default.id
+  location               = "us-central1"
+
+  workstation_authorization_url = "https://workstations.cloud.google.com/ui/auth"
+  workstation_launch_url        = "https://console.cloud.google.com/workstations/launch"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_compute_network" "default" {
+  name                    = "{{index $.ResourceIdVars "cluster_network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "{{index $.ResourceIdVars "cluster_network_name"}}"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.name
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds two new GA fields from the [`google.cloud.workstations.v1.WorkstationCluster`](https://docs.cloud.google.com/workstations/docs/reference/rpc/google.cloud.workstations.v1#google.cloud.workstations.v1.WorkstationCluster) resource:
- `workstation_authorization_url` for configuring an authorization redirect URL for child workstations of a cluster
- `workstation_launch_url` for configuring a redirect URL, e.g. to hold requests issued to an unstarted workstation while it starts

```release-note:enhancement
workstations: added `workstation_authorization_url` and `workstation_launch_url` fields to the `google_workstations_workstation_cluster ` resource.
```
