### PR TITLE
Migrate resource_compute_ssl_policy_test.go.tmpl to new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -203,7 +204,7 @@ func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *map[s
 
 		name := rs.Primary.Attributes["name"]
 
-		url := fmt.Sprintf("%sprojects/%s/global/sslPolicies/%s", transport_tpg.BaseUrl(Product, config), project, name)
+		url := fmt.Sprintf("%sprojects/%s/global/sslPolicies/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), project, name)
 		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",

--- a/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
@@ -3,23 +3,17 @@ package compute_test
 import (
 	"fmt"
 	"testing"
-	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	compute_tpg "github.com/hashicorp/terraform-provider-google/google/services/compute"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccComputeSslPolicy_update(t *testing.T) {
 	t.Parallel()
 
-	var sslPolicy compute.SslPolicy
+	var sslPolicy map[string]interface{}
 	sslPolicyName := fmt.Sprintf("test-ssl-policy-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -98,7 +92,7 @@ func TestAccComputeSslPolicy_update(t *testing.T) {
 func TestAccComputeSslPolicy_update_to_custom(t *testing.T) {
 	t.Parallel()
 
-	var sslPolicy compute.SslPolicy
+	var sslPolicy map[string]interface{}
 	sslPolicyName := fmt.Sprintf("test-ssl-policy-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -145,7 +139,7 @@ func TestAccComputeSslPolicy_update_to_custom(t *testing.T) {
 func TestAccComputeSslPolicy_update_from_custom(t *testing.T) {
 	t.Parallel()
 
-	var sslPolicy compute.SslPolicy
+	var sslPolicy map[string]interface{}
 	sslPolicyName := fmt.Sprintf("test-ssl-policy-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -189,7 +183,7 @@ func TestAccComputeSslPolicy_update_from_custom(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *compute.SslPolicy) resource.TestCheckFunc {
+func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *map[string]interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -209,17 +203,23 @@ func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *compu
 
 		name := rs.Primary.Attributes["name"]
 
-		found, err := compute_tpg.NewClient(config, config.UserAgent).SslPolicies.Get(
-			project, name).Do()
+		url := fmt.Sprintf("%sprojects/%s/global/sslPolicies/%s", config.ComputeBasePath, project, name)
+		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
 		if err != nil {
 			return fmt.Errorf("Error Reading SSL Policy %s: %s", name, err)
 		}
 
-		if found.Name != name {
+		if found["name"].(string) != name {
 			return fmt.Errorf("SSL Policy not found")
 		}
 
-		*sslPolicy = *found
+		*sslPolicy = found
 
 		return nil
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_ssl_policy_test.go
@@ -203,7 +203,7 @@ func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *map[s
 
 		name := rs.Primary.Attributes["name"]
 
-		url := fmt.Sprintf("%sprojects/%s/global/sslPolicies/%s", config.ComputeBasePath, project, name)
+		url := fmt.Sprintf("%sprojects/%s/global/sslPolicies/%s", transport_tpg.BaseUrl(Product, config), project, name)
 		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "GET",


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated `resource_compute_ssl_policy_test.` file to use direct HTTP rather than a client library
```
