### PR TITLE
Correct description of the cluster field in RestorePlan

### DIFF
--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -223,7 +223,7 @@ properties:
   - name: 'cluster'
     type: String
     description: |
-      The source cluster from which Restores will be created via this RestorePlan.
+      The name of the target cluster to which you want to Restore via this RestorePlan.
     required: true
     immutable: true
   - name: 'restoreConfig'


### PR DESCRIPTION
### Description
To avoid confusion from treating the "source cluster" as the backup cluster, this PR updates the `cluster` field description in the `RestorePlan` configuration. 

This change aligns the description with the error message on docs.cloud.google.com, which clarifies it as: "the name of the target cluster to which you want to restore the backup".

### References
Fixes b/509846441

**Release Note Template for Downstream PRs**
```release-note:none
```
