### PR TITLE
Fixed cloudbilling tests

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/billing_project_info.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/billing_project_info.go.tmpl
@@ -5,7 +5,7 @@
 
 config := acctest.GoogleProviderConfig(t)
 
-url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}CoreBillingBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/billingInfo")
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(cloudbilling.Product, config)+"projects/{{"{{"}}project{{"}}"}}/billingInfo")
 if err != nil {
   return err
 }


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/27287. Fixed https://github.com/hashicorp/terraform-provider-google/issues/27283.

The tests are working fine except for failing to find the cloudbilling product while checking if the resource was destroyed.

This failure is a little surprising to me, because the rest of the test works fine (which would only be possible if the registry were working as expected.) But in any case, we can change this custom_code template to reference the product directly (which is what the generated code would do, and which will avoid the registration question altogether).

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
