### PR TITLE
fix(bigqueryreservation): clear error when assignment lacks resolvable location

### DIFF
--- a/mmv1/templates/terraform/pre_create/bigquery_reservation_assignment.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/bigquery_reservation_assignment.go.tmpl
@@ -1,20 +1,22 @@
-    if _, ok := d.GetOkExists("location"); !ok {
-        // Extract location from parent reservation.
-        reservation := d.Get("reservation").(string)
+	if _, ok := d.GetOkExists("location"); !ok {
+		reservation := d.Get("reservation").(string)
+		tableRef := regexp.MustCompile("projects/(.+)/locations/(.+)/reservations/(.+)")
+		if parts := tableRef.FindStringSubmatch(reservation); parts != nil {
+			if err := d.Set("location", parts[2]); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf(
+				"`location` is required on google_bigquery_reservation_assignment "+
+					"when `reservation` is given as a bare name (got %q). Either set "+
+					"`location` explicitly on the assignment, or pass `reservation` "+
+					"as the full path `projects/{project}/locations/{location}/"+
+					"reservations/{name}` (typically `google_bigquery_reservation.<x>.id`).",
+				reservation,
+			)
+		}
 
-        tableRef := regexp.MustCompile("projects/(.+)/locations/(.+)/reservations/(.+)")
-        if parts := tableRef.FindStringSubmatch(reservation); parts != nil {
-            err := d.Set("location", parts[2])
-            if err != nil {
-                return err
-            }
-        }
-
-        if strings.Contains(url, "locations//") {
-            // re-compute url now that location must be set
-            url = strings.ReplaceAll(url, "/locations//", "/locations/"+d.Get("location").(string)+"/")
-            if err != nil {
-                return err
-            }
-        }
-    }
+		if strings.Contains(url, "locations//") {
+			url = strings.ReplaceAll(url, "/locations//", "/locations/"+d.Get("location").(string)+"/")
+		}
+	}

--- a/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_assignment_test.go
+++ b/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_assignment_test.go
@@ -1,0 +1,45 @@
+package bigqueryreservation_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccBigqueryReservationReservationAssignment_bareNameWithoutLocation(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBigqueryReservationReservationAssignment_bareNameWithoutLocation(context),
+				ExpectError: regexp.MustCompile("`location` is required"),
+			},
+		},
+	})
+}
+
+func testAccBigqueryReservationReservationAssignment_bareNameWithoutLocation(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_reservation" "test" {
+  name          = "tf-test-reservation-%{random_suffix}"
+  location      = "us-central1"
+  slot_capacity = 0
+  edition       = "ENTERPRISE"
+}
+
+resource "google_bigquery_reservation_assignment" "test" {
+  reservation = google_bigquery_reservation.test.name
+  assignee    = "projects/${google_bigquery_reservation.test.project}"
+  job_type    = "QUERY"
+}
+`, context)
+}


### PR DESCRIPTION
Relates to https://github.com/hashicorp/terraform-provider-google/issues/16905
Relates to https://github.com/hashicorp/terraform-provider-google/issues/27128

## Problem

When `reservation` is a bare name (e.g. `google_bigquery_reservation.x.name`) and `location` is not set, the provider builds a URL with an empty location segment (`/locations//reservations/...`). The API returns a generic `404 "Request couldn't be served"` that gives no indication of what went wrong.

The existing "recovery" code that tries to fix the URL by re-substituting `d.Get("location")` doesn't help — location is still empty at that point because the regex only matches fully-qualified reservation names.

## Reproduction

Tested locally against provider v7.31.0 (`europe-west2`):
<img width="2070" height="1554" alt="image" src="https://github.com/user-attachments/assets/4b95a7c5-5ce7-4bd9-afab-4abce58d64df" />

## Fix

Replace the broken silent-recovery block with a clear error message when the regex doesn't match. Tells the user to either set `location` explicitly or pass `reservation` as the full resource path (`.id` instead of `.name`).

No behaviour change for configs that already work (location set explicitly, or reservation passed as FQN).

## Scope

This is a diagnostic improvement only — it converts a confusing silent 404 into a clear, actionable error message. It does not fix the underlying bare-name vs FQN inconsistency (hashicorp/terraform-provider-google#16905) or the permadiff after import (hashicorp/terraform-provider-google#27128), which would require normalising `reservation` to FQN at plan time.

Happy to raise a follow-up PR for that if there's appetite — would appreciate guidance from maintainers on the preferred approach (diff_suppress + custom expand, or something else).

```release-note:bug
bigqueryreservation: Fixed `google_bigquery_reservation_assignment` returning a confusing 404 error when `reservation` is a bare name and `location` is not set
```
