### PR TITLE
datacatalog: add RICHTEXT to TagTemplate primitive_type enum (#13597)

### DIFF
--- a/mmv1/products/datacatalog/TagTemplate.yaml
+++ b/mmv1/products/datacatalog/TagTemplate.yaml
@@ -137,6 +137,7 @@ properties:
                 - 'STRING'
                 - 'BOOL'
                 - 'TIMESTAMP'
+                - 'RICHTEXT'
             - name: 'enumType'
               type: NestedObject
               description: |


### PR DESCRIPTION
## Summary

Adds `RICHTEXT` to the allowed enum values of
`google_data_catalog_tag_template.fields.type.primitive_type`. The Data
Catalog v1 API has supported `RICHTEXT` for years (it's listed alongside
`DOUBLE`, `STRING`, `BOOL`, `TIMESTAMP` in the Discovery descriptor for
`GoogleCloudDatacatalogV1FieldType.PrimitiveType`), but the mmv1 schema
omitted it. Users who needed to declare rich-text tag-template fields had
to fall back to hand-rolled `gcloud` calls or imports.

Fixes hashicorp/terraform-provider-google#13597 — see https://github.com/hashicorp/terraform-provider-google/issues/13597

## Why

Data Catalog tag templates can declare fields whose `primitive_type` is
`RICHTEXT` (an HTML-aware longer-form description). This is documented in
the API enum and is observable in the published Discovery doc:

```
.gopath/pkg/mod/google.golang.org/api@v0.278.0/datacatalog/v1/datacatalog-gen.go:
  // PrimitiveType: ...
  // Possible values:
  //   "PRIMITIVE_TYPE_UNSPECIFIED" - The default invalid value for a type.
  //   "DOUBLE" - A double precision number.
  //   "STRING" - An UTF-8 string.
  //   "BOOL" - A boolean value.
  //   "TIMESTAMP" - A timestamp.
  //   "RICHTEXT" - A Richtext description.
  PrimitiveType string `json:"primitiveType,omitempty"`
```

But `mmv1/products/datacatalog/TagTemplate.yaml` only listed four values,
so the generated provider validates `primitive_type` against
`{DOUBLE, STRING, BOOL, TIMESTAMP}` and rejects `RICHTEXT` at plan-time.

**GCP API reference:**
- https://cloud.google.com/data-catalog/docs/reference/rpc/google.cloud.datacatalog.v1#google.cloud.datacatalog.v1.FieldType.PrimitiveType
- https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.tagTemplates#FieldType

## What changed

This change is to a **mmv1-generated** resource. Files touched in
magic-modules:

```
 mmv1/products/datacatalog/TagTemplate.yaml | 1 +
 1 file changed, 1 insertion(+)
```

The downstream regeneration adds `RICHTEXT` to:
- `ValidateEnum([]string{"DOUBLE", "STRING", "BOOL", "TIMESTAMP", "RICHTEXT", ""})`
  in `resource_data_catalog_tag_template.go` (TPG and TPGB), and
- the documented `Possible values` list in the field description.

No expand/flatten logic changes are needed: `primitive_type` is already
round-tripped as an opaque string.

## Edge cases tested

| # | Scenario | Behavior | Verified by |
|---|---|---|---|
| 1 | `primitive_type = "RICHTEXT"` | Accepted at plan-time; rejected before this PR with `expected primitive_type to be one of [DOUBLE STRING BOOL TIMESTAMP]` | Static: regenerated provider, `go build`, `go vet` all clean; the `ValidateEnum` slice now contains `"RICHTEXT"` |
| 2 | Existing values (`DOUBLE`, `STRING`, `BOOL`, `TIMESTAMP`) | Unchanged | Same regenerated `ValidateEnum` slice retains all four |
| 3 | Empty value | Still allowed (computed-from-API) | `ValidateEnum` slice still contains `""` for the unset case |

## Test protocol

| Test | Result | Notes |
|---|---|---|
| `cd mmv1&& go run . --output ../tpg-out --version ga --no-docs` | OK | Regeneration completed without warnings |
| `go build ./google/services/datacatalog/...` (TPG) | OK | clean compile against regenerated source |
| `go vet ./google/services/datacatalog/...` (TPG) | OK | no findings |

This is a **purely additive enum extension** — there is no API call
behavior change, no expand/flatten path change, and no need for live
GCP smoke. The Discovery doc is the authoritative source that the API
already accepts `RICHTEXT`, and the regenerated provider's only diff
versus current main is the addition of the enum value to the validation
slice and to the description string.

## Resources

- Issue: https://github.com/hashicorp/terraform-provider-google/issues/13597
- API enum: `GoogleCloudDatacatalogV1FieldType.PrimitiveType`
  (Discovery doc — vendored Go client at
  `google.golang.org/api/datacatalog/v1`)
- mmv1 file:
  https://github.com/jbbqqf/magic-modules/blob/feat/13597-datacatalog-richtext/mmv1/products/datacatalog/TagTemplate.yaml

## Release notes

```release-note:enhancement
data_catalog: added `RICHTEXT` to allowed values of `primitive_type` on `google_data_catalog_tag_template` fields.
```

## Disclosure

This PR was implemented with assistance from Claude Code as part of a
focused contribution batch on small mmv1 enum gaps. The diff was
reviewed manually against the GCP Data Catalog v1 API Discovery
descriptor (the canonical source for the enum's accepted values). The
regenerated TPG/TPGB provider compiled and vetted cleanly with the new
enum value. Because this is a purely additive validation extension — no
expand/flatten or API-call change — no live smoke was run.

The author (a human) reviewed the diff and the regenerated provider
output before opening this PR.

