### PR TITLE
cloudbuild: add automap_substitutions to Trigger build options and steps (#18279)

### DIFF
--- a/mmv1/products/cloudbuild/Trigger.yaml
+++ b/mmv1/products/cloudbuild/Trigger.yaml
@@ -1012,6 +1012,12 @@ properties:
                 If `allowFailure` is also specified, this field will take precedence.
               item_type:
                 type: Integer
+            - name: 'automapSubstitutions'
+              type: Boolean
+              description: |
+                Option to include built-in and custom substitutions as env variables for this build step.
+                This option will override the global option in BuildOption.
+              send_empty_value: true
       - name: 'artifacts'
         type: NestedObject
         description: |
@@ -1203,6 +1209,11 @@ properties:
               Option to specify whether or not to apply bash style string operations to the substitutions.
 
               NOTE this is always enabled for triggered builds and cannot be overridden in the build configuration file.
+            send_empty_value: true
+          - name: 'automapSubstitutions'
+            type: Boolean
+            description: |
+              Option to include built-in and custom substitutions as env variables for all build steps.
             send_empty_value: true
           - name: 'logStreamingOption'
             type: Enum


### PR DESCRIPTION
## Summary

Adds `automap_substitutions` to the `google_cloudbuild_trigger` resource at both
the `build.options` level (global, applies to all build steps) and the
`build.step` level (per-step, overrides the global value).

Fixes hashicorp/terraform-provider-google#18279 — see https://github.com/hashicorp/terraform-provider-google/issues/18279

## Why

Cloud Build's `BuildOptions.automapSubstitutions` and
`BuildStep.automapSubstitutions` instruct Cloud Build to expose the built-in
and user-defined substitutions (e.g. `_FOO`, `$REPO_NAME`, etc.) as
environment variables inside the build container, removing the need to
manually wire each substitution as `env = ["_FOO=$_FOO"]` per step. Issue
#18279 has 11 reactions and several follow-up "+1"-style messages. The
field has been generally available in the Cloud Build REST API since 2022.

**GCP API reference:**
- BuildOptions.automapSubstitutions: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#BuildOptions
- BuildStep.automapSubstitutions: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#BuildStep

## What changed

This is a magic-modules-generated resource. The change is a pure additive
schema change in `mmv1/products/cloudbuild/Trigger.yaml`:

```
 mmv1/products/cloudbuild/Trigger.yaml | 11 +++++++++++
 1 file changed, 11 insertions(+)
```

Two new fields:

* `build.options.automap_substitutions` (`Boolean`, optional, `send_empty_value: true`)
* `build.step[*].automap_substitutions` (`Boolean`, optional, `send_empty_value: true`)

Both map cleanly to `automapSubstitutions` in the API JSON. The choice of
`send_empty_value: true` mirrors the existing `dynamic_substitutions` field
right next to the new options-level field, so users who explicitly set the
flag to `false` get the value sent to the API rather than dropped.

## Edge cases tested

| # | Scenario | HCL excerpt | Expected | Verified by |
|---|---|---|---|---|
| 1 | Default — field omitted | `# automap_substitutions absent` | Trigger plans cleanly with no automap field on the wire (legacy behaviour preserved). | Plan-only smoke (`SMOKE_PLAN_ONLY=1`); plan succeeds on AFTER. |
| 2 | Build options-level on | `options { automap_substitutions = true }` plus `substitutions = { _FOO = "bar" }` | Plan includes `automapSubstitutions: true` under `build.options`. | Plan-only smoke; AFTER plan ok. |
| 3 | Per-step override | One step with `automap_substitutions = true`, one with `false`, plus `options.automap_substitutions = false` | Each step's value is sent independently and overrides the build-level option. | Plan-only smoke; AFTER plan ok. |

## Test protocol

| Test | Result | Notes |
|---|---|---|
| `make build OUTPUT_PATH=$TPG VERSION=ga` | ok | regenerates `resource_cloudbuild_trigger.go` with both flatten/expand wired |
| `make build OUTPUT_PATH=$TPGB VERSION=beta` | ok | identical regen for the -beta provider |
| `go build ./...` (TPG, TPGB) | ok | no new symbols undefined |
| `go vet ./google/services/cloudbuild/...` | ok | clean |
| **Live BEFORE / AFTER smoke (plan-only)** | 🟢 GREEN | BEFORE plan fails on `An argument named "automap_substitutions" is not expected here.`; AFTER plan succeeds for all three scenarios. See note below on why apply was deferred. |

### Why plan-only and not apply

I tried apply against `gcp-masterclasses` with three different trigger
shapes (`trigger_template` / `pubsub_config` / `webhook_config`) — every
attempt was rejected by the Cloud Build API with a generic
`googleapi: Error 400: Request contains an invalid argument.` independent
of whether `automap_substitutions` was present. The same shapes also fail
on the BEFORE binary built from `origin/main`, which tells me the rejection
is unrelated to this PR (the project is missing prerequisite setup —
Cloud Source Repositories API is disabled, no GitHub repo connection,
webhook/secret IAM propagation, etc.). Since this PR adds two pure-
additive boolean fields whose API names (`automapSubstitutions`) are
verified present in the discovery doc (`cloudbuild/v1/cloudbuild-api.json`)
and in the vendored Go client (`cloudbuild-gen.go` lines 1196 and 1350),
plan-only — which proves the schema accepts/rejects the input correctly —
is the right verification level here.

A reviewer with a properly-configured Cloud Build sandbox (CSR enabled,
or a GitHub-connected repo, or a working webhook trigger) can apply the
smoke `main.tf` end-to-end and confirm the field round-trips through
`gcloud builds triggers describe`.

### Reproduction

```bash
# magic-modules side
git fetch fork feat/18279-cloudbuild-trigger-automap
git checkout feat/18279-cloudbuild-trigger-automap
make build OUTPUT_PATH=$TPG VERSION=ga
make build OUTPUT_PATH=$TPGB VERSION=beta

# verify generated provider
grep -n automap_substitutions \
  $TPG/google/services/cloudbuild/resource_cloudbuild_trigger.go

# live smoke (plan-only)
GCP_PROJECT=<sandbox> SMOKE_PLAN_ONLY=1 \
  SMOKE_TPG_ROOT=$TPG SMOKE_TF=/path/to/smoke/main.tf \
  ./scripts/smoke-tpg.sh
```

Expected: 🟢 GREEN (BEFORE: plan_failed, AFTER: plan_ok).

## Resources

- Original issue: https://github.com/hashicorp/terraform-provider-google/issues/18279
- Cloud Build REST `BuildOptions`: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#BuildOptions
- Cloud Build REST `BuildStep`: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#BuildStep
- Terraform docs page: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger

## Release notes

```release-note:enhancement
cloudbuild: added `automap_substitutions` to `build_options` and `step` blocks of `google_cloudbuild_trigger`.
```

## Disclosure

This PR was implemented with assistance from Claude Code as part of a
focused contribution batch on hand-written resources. The diff was
reviewed manually against the GCP API documentation linked above. The
live before/after smoke harness exercised the schema parsing end-to-end
in plan mode against the author's sandbox project; apply was deferred for
the reasons explained above and the missing coverage is called out
explicitly so a maintainer can decide whether to ask for an apply-mode
re-run before merge.

