### PR TITLE
compute: add filter argument to google_compute_forwarding_rules data source (#20052)

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rules.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rules.go
@@ -26,6 +26,12 @@ func DataSourceGoogleComputeForwardingRules() *schema.Resource {
 				Optional: true,
 			},
 
+			"filter": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `A filter expression that filters resources listed in the response, in the form documented at https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules/list. Example: "labels.env:prod".`,
+			},
+
 			"rules": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -54,10 +60,19 @@ func dataSourceGoogleComputeForwardingRulesRead(d *schema.ResourceData, meta int
 		return err
 	}
 
+	filter, _ := d.Get("filter").(string)
+
 	id := fmt.Sprintf("projects/%s/regions/%s/forwardingRules", project, region)
+	if filter != "" {
+		id = fmt.Sprintf("%s/filter=%s", id, filter)
+	}
 	d.SetId(id)
 
-	forwardingRulesAggregatedList, err := NewClient(config, userAgent).ForwardingRules.List(project, region).Do()
+	listCall := NewClient(config, userAgent).ForwardingRules.List(project, region)
+	if filter != "" {
+		listCall = listCall.Filter(filter)
+	}
+	forwardingRulesAggregatedList, err := listCall.Do()
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Forwarding Rules Not Found : %s", project))
 	}
@@ -98,6 +113,10 @@ func dataSourceGoogleComputeForwardingRulesRead(d *schema.ResourceData, meta int
 
 	if err := d.Set("region", region); err != nil {
 		return fmt.Errorf("Error setting the region: %s", err)
+	}
+
+	if err := d.Set("filter", filter); err != nil {
+		return fmt.Errorf("Error setting the filter: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Adds a `filter` argument to the `google_compute_forwarding_rules` data
source, mirroring the `filter` query parameter supported by the
underlying `compute.forwardingRules.list` REST API. Without it, users
who want to enumerate forwarding rules for a specific label, network,
target type, or load-balancing scheme have to fetch every rule in the
region and filter in HCL with `for_each + tomap` workarounds.

Fixes hashicorp/terraform-provider-google#20052 — see https://github.com/hashicorp/terraform-provider-google/issues/20052

## Why

The Compute Engine `ForwardingRules.list` API exposes a `filter` query
parameter that uses the documented Google filter syntax
(`labels.env:prod`, `network eq ".*/my-vpc"`, etc.). The vendored Go
client has had `(*ForwardingRulesListCall).Filter(string)` for years
(see `google.golang.org/api/compute/v1/compute2-gen.go`), but the
Terraform data source schema only exposed `project` / `region` / `rules`
— so users couldn't take advantage of server-side filtering, and large
GCP projects (hundreds of forwarding rules) saw both unnecessary API
load and inefficient state plans.

**GCP API reference:**
- https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules/list
- https://cloud.google.com/sdk/gcloud/reference/topic/filters (general filter expression syntax)

## What changed

This change is to a **hand-written** Terraform data source (whose source
of truth lives in magic-modules `mmv1/third_party/...`). Files touched:

```
 .../data_source_google_compute_forwarding_rules.go | 21 ++++++++++++++++++++-
 1 file changed, 20 insertions(+), 1 deletion(-)
```

Three small edits in
`mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rules.go`:
1. Added a `filter` `Optional` `TypeString` schema entry with a
   description pointing to the API docs.
2. In the `Read` function, retrieved the user-supplied filter, included
   it in the data source ID (so distinct filter expressions produce
   distinct IDs), and applied it via `listCall.Filter(filter)` only
   when non-empty.
3. Set the resolved filter back into state at the end of `Read` (mirrors
   the existing pattern for `project` / `region`).

## Edge cases tested

| # | Scenario | HCL excerpt | Expected | Verified by |
|---|---|---|---|---|
| 1 | `filter` unset (default) | `# filter omitted` | Unchanged behavior — ID is `projects/.../regions/.../forwardingRules`, every rule in the region returned | Static: the `if filter != ""` guard skips both the ID suffix and the `Filter()` call |
| 2 | `filter = "labels.env:prod"` | `filter = "labels.env:prod"` | Server-side filtered list | Vendored client has `(*ForwardingRulesListCall).Filter(string)`; the data source now wires it |
| 3 | `filter` with regex syntax | `filter = "name eq \".*-prod-.*\""` | Server-side regex filter | Same path as scenario 2; the API accepts the documented filter syntax verbatim |
| 4 | Two data-source instances with different filters | one with `filter=...env:prod`, one with `filter=...env:dev` | Distinct IDs, no state collision | The ID now includes `/filter=<expr>` when set |

## Test protocol

| Test | Result | Notes |
|---|---|---|
| `cd mmv1 && go run . --output ... --version ga --no-docs` | OK | Regeneration completed cleanly |
| `go build ./google/services/compute/...` (TPG) | OK | full compute service compiles |
| `go vet ./google/services/compute/...` (TPG) | OK | only pre-existing unreachable-code warnings in `*_firewall_policy_with_rules.go` (unchanged by this PR) |
| Generated source contains `filter` schema entry and `Filter(filter)` call | OK | grep'd `data_source_google_compute_forwarding_rules.go` after regen — confirmed |

This is **purely additive** (data source only — no resource lifecycle
implications): omitting `filter` reproduces the exact previous
behavior. The only risk surface is the server's reaction to an invalid
filter expression, and that surface is identical to what
`(*ForwardingRulesListCall).Filter(...)` already provides — i.e. the
caller gets the same `400 Bad Request` they'd get from `gcloud compute
forwarding-rules list --filter=...`.

## Resources

- Issue: https://github.com/hashicorp/terraform-provider-google/issues/20052
- API method (with `filter` param):
  https://cloud.google.com/compute/docs/reference/rest/v1/forwardingRules/list
- mmv1 source file:
  https://github.com/jbbqqf/magic-modules/blob/feat/20052-forwarding-rules-filter/mmv1/third_party/terraform/services/compute/data_source_google_compute_forwarding_rules.go

## Release notes

```release-note:enhancement
compute: added `filter` argument to the `google_compute_forwarding_rules` data source.
```

## Disclosure

This PR was implemented with assistance from Claude Code. The diff was
modeled on the existing `filter` patterns used by other data sources
(e.g. `google_compute_instances`) and the vendored Go client's
`Filter()` builder. The regenerated provider compiled and vetted
cleanly. The author (a human) reviewed the diff and the regenerated
data source before opening this PR.

