### PR TITLE
compute: add name_prefix to google_compute_managed_ssl_certificate (#8889)

### DIFF
--- a/mmv1/products/compute/ManagedSslCertificate.yaml
+++ b/mmv1/products/compute/ManagedSslCertificate.yaml
@@ -40,6 +40,15 @@ docs:
     certificates may entail some downtime while the certificate provisions.
 
     In conclusion: Be extremely cautious.
+  optional_properties: |
+    * `name_prefix` - (Optional) Creates a unique name beginning with the
+     specified prefix. Conflicts with `name`. Max length is 54 characters.
+     Prefixes with lengths longer than 37 characters will use a shortened
+     UUID that will be more prone to collisions.
+     Resulting name for a `name_prefix` <= 37 characters:
+     `name_prefix` + YYYYmmddHHSSssss + 8 digit incremental counter
+     Resulting name for a `name_prefix` 38 - 54 characters:
+     `name_prefix` + YYmmdd + 3 digit incremental counter
 base_url: 'projects/{{project}}/global/sslCertificates'
 has_self_link: true
 immutable: true
@@ -65,6 +74,7 @@ async:
 collection_url_key: 'items'
 custom_code:
   constants: 'templates/terraform/constants/compute_managed_ssl_certificate.go.tmpl'
+  extra_schema_entry: 'templates/terraform/extra_schema_entry/ssl_certificate.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'managed_ssl_certificate_basic'
@@ -80,11 +90,15 @@ examples:
     test_vars_overrides:
       # for backward compatible
       dns_zone_name: '"dnszone" + randomSuffix'
+    ignore_read_extra:
+      - 'name_prefix'
   - name: 'managed_ssl_certificate_recreation'
     primary_resource_id: 'cert'
     external_providers: ["random", "time"]
     # Random provider
     skip_vcr: true
+    ignore_read_extra:
+      - 'name_prefix'
 parameters:
 properties:
   - name: 'creationTimestamp'
@@ -111,6 +125,8 @@ properties:
       character, which cannot be a dash.
 
       These are in the same namespace as the managed SSL certificates.
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/name_or_name_prefix.go.tmpl'
   - name: 'managed'
     type: NestedObject
     description: |


### PR DESCRIPTION
## Summary

Adds `name_prefix` support to `google_compute_managed_ssl_certificate`,
mirroring the existing `name_prefix` on `google_compute_ssl_certificate`.
Users practising cert rotation typically need to recreate certs with
stable prefixes (so the new cert exists side-by-side with the old before
swap), and they want Terraform to generate the unique trailing suffix
automatically. Without `name_prefix`, they must use `random_id`
workarounds or imperative wrappers.

Fixes hashicorp/terraform-provider-google#8889 — see https://github.com/hashicorp/terraform-provider-google/issues/8889

## Why

The user-managed `google_compute_ssl_certificate` already supports
`name_prefix` via a shared `extra_schema_entry` and `custom_expand`
(`mmv1/templates/terraform/extra_schema_entry/ssl_certificate.tmpl` and
`mmv1/templates/terraform/custom_expand/name_or_name_prefix.go.tmpl`).
The Google-managed variant has the same lifecycle constraint
(certificates are immutable, must be rotated by replacement) and the
same underlying API resource (`compute#sslCertificate`) — so the same
prefix-generation logic applies as-is.

**GCP API reference:**
- https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates
- https://cloud.google.com/load-balancing/docs/ssl-certificates

## What changed

This change is to a **mmv1-generated** resource. Files touched in
magic-modules:

```
 mmv1/products/compute/ManagedSslCertificate.yaml | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)
```

The YAML edits:
1. Added a `docs.optional_properties` entry documenting `name_prefix` (same
   wording as `SslCertificate.yaml`).
2. Added `extra_schema_entry: 'templates/terraform/extra_schema_entry/ssl_certificate.tmpl'`
   to the `custom_code` block (which already had a `constants` entry).
3. Added `default_from_api: true` and `custom_expand: '.../name_or_name_prefix.go.tmpl'`
   to the `name` property — same shape as the `name` field on `SslCertificate.yaml`.
4. Added `ignore_read_extra: ['name_prefix']` to both examples (matches the
   pattern from `SslCertificate.yaml`'s examples — `name_prefix` is a
   client-side-only field with no read counterpart).

## Edge cases tested

| # | Scenario | HCL excerpt | Expected | Verified by |
|---|---|---|---|---|
| 1 | `name` set, `name_prefix` unset | `name = "my-cert"` | Existing behavior unchanged | Regen schema diff: `name` is still `Optional+Computed`, `ConflictsWith: []string{"name_prefix"}` |
| 2 | `name_prefix` set, `name` unset | `name_prefix = "rotation-"` | `name` computed by `id.PrefixedUniqueId(prefix)` | `custom_expand` template emits the same logic as `SslCertificate` (`prefix > 37 → ReducedPrefixedUniqueId`, else `id.PrefixedUniqueId`) |
| 3 | Both set | `name = "x"; name_prefix = "y-"` | Plan-time error from `ConflictsWith` validator | The shared `ssl_certificate.tmpl` schema entry has `ConflictsWith: []string{"name"}` |
| 4 | `name_prefix` exceeds 54 chars | `name_prefix = strings.Repeat("a", 55)` | Plan-time validation error | Shared `ValidateFunc` rejects len > 54 |

## Test protocol

| Test | Result | Notes |
|---|---|---|
| YAML lint (`go run mmv1/. --output ... --version ga --no-docs`) | OK | Regeneration completed cleanly |
| `go build ./google/services/compute/...` (TPG) | OK | full compute service compiles |
| `go vet ./google/services/compute/...` (TPG) | OK | no new findings (3 pre-existing unreachable-code warnings in firewall_policy files are unchanged by this PR) |
| Generated schema includes `name_prefix` field | OK | grep'd `resource_compute_managed_ssl_certificate.go` after regen — confirms `name_prefix` schema entry, `ConflictsWith: []string{"name"}`, and the expand-name handler |
| Generated `name` field is computed-from-prefix | OK | `expandComputeManagedSslCertificateName` follows the shared template: returns `name` when set, else `id.PrefixedUniqueId(name_prefix)`, else `id.UniqueId()` |

This is a **purely additive client-side schema extension** (the API
already accepts whatever name the client supplies — there is no API-side
change). Live smoke is therefore not strictly necessary for confidence,
and Google-managed cert provisioning is slow/expensive (30-min create
timeout) which makes it costly. The static evidence is identical to
what's been used for the user-managed `SslCertificate` `name_prefix` for
years.

## Resources

- Issue: https://github.com/hashicorp/terraform-provider-google/issues/8889
- Sibling resource (already supports `name_prefix`):
  https://github.com/jbbqqf/magic-modules/blob/main/mmv1/products/compute/SslCertificate.yaml
- mmv1 file:
  https://github.com/jbbqqf/magic-modules/blob/feat/8889-managed-ssl-cert-name-prefix/mmv1/products/compute/ManagedSslCertificate.yaml

## Release notes

```release-note:enhancement
compute: added `name_prefix` argument to `google_compute_managed_ssl_certificate`.
```

## Disclosure

This PR was implemented with assistance from Claude Code. The diff was
modeled on the existing `SslCertificate.yaml` `name_prefix` wiring — a
well-tested pattern that's been in the provider for years — and the
regenerated provider compiled and vetted cleanly. The author (a human)
reviewed the diff and the regenerated schema before opening this PR.

