### PR TITLE
monitoring: clarify comparison enum doc for alert policy (#16862)

### DIFF
--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -638,14 +638,19 @@ properties:
             - name: 'comparison'
               type: Enum
               description: |
-                The comparison to apply between the time
-                series (indicated by filter and aggregation)
-                and the threshold (indicated by
-                threshold_value). The comparison is applied
-                on each time series, with the time series on
-                the left-hand side and the threshold on the
-                right-hand side. Only COMPARISON_LT and
-                COMPARISON_GT are supported currently.
+                The comparison to apply between the time series
+                (indicated by filter and aggregation) and the threshold
+                (indicated by threshold_value). The comparison is
+                applied on each time series, with the time series on
+                the left-hand side and the threshold on the right-hand
+                side.
+
+                The Cloud Monitoring API only supports `COMPARISON_LT`
+                and `COMPARISON_GT` for metric-threshold conditions; the
+                other values are kept in the schema for backward
+                compatibility with imported state but will be rejected
+                by the API. See
+                https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#MetricThreshold.
               required: true
               enum_values:
                 - 'COMPARISON_GT'
@@ -1058,14 +1063,20 @@ properties:
                 - name: 'comparison'
                   type: Enum
                   description: |
-                    The comparison to apply between the time
-                    series (indicated by filter and aggregation)
-                    and the threshold (indicated by
-                    threshold_value). The comparison is applied
-                    on each time series, with the time series on
-                    the left-hand side and the threshold on the
-                    right-hand side. Only COMPARISON_LT and
-                    COMPARISON_GT are supported currently.
+                    The comparison to apply between the time series
+                    (indicated by filter and aggregation) and the
+                    threshold (indicated by threshold_value). The
+                    comparison is applied on each time series, with
+                    the time series on the left-hand side and the
+                    threshold on the right-hand side.
+
+                    The Cloud Monitoring API only supports
+                    `COMPARISON_LT` and `COMPARISON_GT` for SQL
+                    row-count thresholds; the other values are kept
+                    in the schema for backward compatibility with
+                    imported state but will be rejected by the API.
+                    See
+                    https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#MetricThreshold.
                   enum_values:
                     - 'COMPARISON_GT'
                     - 'COMPARISON_GE'


### PR DESCRIPTION
## Summary

Documentation fix on `google_monitoring_alert_policy`. The Cloud Monitoring API only supports `COMPARISON_LT` and `COMPARISON_GT` for `condition_threshold.comparison` and `conditions[].condition_sql.row_count_test.comparison`, but the registry docs presents all six enum values without clearly flagging the API limitation, so users set `COMPARISON_GE` (and friends) and get an API error back.

Fixes hashicorp/terraform-provider-google#16862 — see https://github.com/hashicorp/terraform-provider-google/issues/16862

## Why

The maintainer (`shuyama1`) acknowledged this in 2023:
> Sorry for the misleading documentation. Looks like the API only supports `COMPARISON_LT` and `COMPARISON_GT` currently ([API doc](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#MetricThreshold)). We'll correct the documentation for available values.

…but the doc cleanup was never shipped. Users continue to hit the same trap (the latest comment on the issue, with screenshot, is from 2025).

This PR rewords the field descriptions to lead with the API limitation and link the canonical reference, so the registry doc is unambiguous. The enum value list is intentionally left intact so already-imported state that happens to contain non-LT/GT values doesn't error out at parse time; the API remains the authoritative gate.

**GCP API reference:**
- https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#MetricThreshold

## What changed

mmv1 source — single file:

```
 mmv1/products/monitoring/AlertPolicy.yaml | 27 +++++++++++++++++----------
```

Two `comparison` field descriptions are reworded:
- `conditions[].condition_threshold.comparison`
- `conditions[].condition_sql.row_count_test.comparison`

The downstream impact after regeneration is registry-doc text only — `Description` strings on the schema. No validation change, no plan/apply behavior change.

## Edge cases tested

| # | Scenario | HCL excerpt | Expected | Verified by |
|---|---|---|---|---|
| 1 | LT/GT (supported) | `comparison = "COMPARISON_LT"` | Plan + apply succeed (unchanged from today) | static — no path change |
| 2 | GE/LE/EQ/NE (unsupported) | `comparison = "COMPARISON_GE"` | Plan succeeds (validation passes), API returns the same error as today | static — enum_values list intentionally kept |
| 3 | Imported state with non-LT/GT value | preexisting `tfstate` with `COMPARISON_GE` | Plan/refresh does not error at parse time | enum_values list intentionally kept |

## Test protocol

| Test | Result | Notes |
|---|---|---|
| YAML well-formedness review | pass | both `comparison` blocks rewritten consistently |
| API premise | confirmed | linked Monitoring REST docs and maintainer ack |

This is a **doc-only** change (description text). No live smoke was run because the change does not alter plan/apply behavior, validation, or payload shape — it only changes the doc string surfaced in the registry. The reviewer can compare before/after by re-rendering the registry doc page from the regenerated provider.

## Resources

- Original issue: https://github.com/hashicorp/terraform-provider-google/issues/16862
- API reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies#MetricThreshold
- Terraform provider docs page: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy

## Release notes

```release-note:none
```

## Disclosure

This PR was implemented with assistance from Claude Code as part of a focused contribution batch. The diff was reviewed manually against the GCP API documentation linked above. The author (a human) reviewed the diff and the API-premise check before opening this PR.

