### PR TITLE
identityplatform: add IAM resources for Tenant (#18809)

### DIFF
--- a/mmv1/products/identityplatform/Tenant.yaml
+++ b/mmv1/products/identityplatform/Tenant.yaml
@@ -32,6 +32,14 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  fetch_iam_policy_verb: 'POST'
+  parent_resource_attribute: 'tenant'
+  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
+  import_format:
+    - 'projects/{{project}}/tenants/{{tenant}}'
+    - '{{tenant}}'
 examples:
   - name: 'identity_platform_tenant_basic'
     primary_resource_id: 'tenant'


### PR DESCRIPTION
## Summary

Adds `google_identity_platform_tenant_iam_binding`, `google_identity_platform_tenant_iam_member`, and `google_identity_platform_tenant_iam_policy` by enabling the `iam_policy` block on the `Tenant` mmv1 resource.

Fixes hashicorp/terraform-provider-google#18809 — see https://github.com/hashicorp/terraform-provider-google/issues/18809

## Why

Today, granting access to Identity Platform multi-tenancy resources requires giving service accounts project-wide IAM roles, since per-tenant IAM is only available through the Cloud Console. This forces users into an over-permissioned setup. The `identitytoolkit.googleapis.com` v2 API explicitly supports `setIamPolicy` / `getIamPolicy` / `testIamPermissions` on the `projects/{project}/tenants/{tenant}` resource, so wiring it through mmv1 is straightforward.

**GCP API reference:**
- https://cloud.google.com/identity-platform/docs/multi-tenancy-access-control
- https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects.tenants/setIamPolicy
- https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects.tenants/getIamPolicy

## What changed

mmv1 schema-only change. Adds `iam_policy:` block to `mmv1/products/identityplatform/Tenant.yaml`:

```yaml
iam_policy:
  method_name_separator: ':'
  fetch_iam_policy_verb: 'POST'
  parent_resource_attribute: 'tenant'
  example_config_body: 'templates/terraform/iam/iam_attributes.go.tmpl'
  import_format:
    - 'projects/{{project}}/tenants/{{tenant}}'
    - '{{tenant}}'
```

`fetch_iam_policy_verb: 'POST'` matches the API discovery (`getIamPolicy` is a POST in the discovery doc, like all v2 IAM endpoints on identitytoolkit).

## Test protocol

| Test | Result |
|---|---|
| `make build OUTPUT_PATH=... VERSION=ga PRODUCT=identityplatform` | PASS — generates `iam_identity_platform_tenant.go` and `iam_identity_platform_tenant_generated_test.go` |
| `go vet ./google/services/identityplatform/...` | PASS |
| `go build ./...` (full TPG) | PASS |

The mmv1 generator produces the standard IAM trio (`*_iam_binding`, `*_iam_member`, `*_iam_policy`) plus generated acceptance tests. The acceptance tests run during the standard CI matrix on this PR.

### Edge cases tested by the auto-generated test

The generated `iam_identity_platform_tenant_generated_test.go` covers (per the standard mmv1 IAM template):

| # | Scenario | Verified by |
|---|---|---|
| 1 | `_iam_member` add and remove | generated TestAcc |
| 2 | `_iam_binding` add, update members list | generated TestAcc |
| 3 | `_iam_policy` set, replace, import | generated TestAcc |

## Resources

- Original issue: https://github.com/hashicorp/terraform-provider-google/issues/18809
- GCP API documentation:
  - https://cloud.google.com/identity-platform/docs/multi-tenancy-access-control
  - https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects.tenants/setIamPolicy
- Vendored discovery doc snippet (verified locally): `identitytoolkit.projects.tenants.getIamPolicy` (POST) and `setIamPolicy` (POST) at `projects/{p}/tenants/{t}:setIamPolicy`.

## Release notes

```release-note:new-resource
`google_identity_platform_tenant_iam_policy`
```

```release-note:new-resource
`google_identity_platform_tenant_iam_binding`
```

```release-note:new-resource
`google_identity_platform_tenant_iam_member`
```

## Disclosure

This PR was implemented with assistance from Claude Code as part of a focused contribution batch. The `iam_policy` block format was reviewed against existing precedents (`identitytoolkit`-style resources are similar to `iambeta/WorkloadIdentityPool.yaml`, both POST-based getIamPolicy). The generated code (`iam_identity_platform_tenant.go`) was reviewed and `go vet` + full TPG build pass. No live smoke was run for this purely additive mmv1 schema change; CI's acceptance tests on this PR will exercise the generated IAM resources end-to-end.

