### PR TITLE
discoveryengine: add aclEnabled to google_discovery_engine_data_store (#19566)

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -177,6 +177,17 @@ properties:
       - 'NO_CONTENT'
       - 'CONTENT_REQUIRED'
       - 'PUBLIC_WEBSITE'
+  - name: 'aclEnabled'
+    type: Boolean
+    description: |
+      Immutable. Whether data in the DataStore has ACL information. If set to true,
+      the source data must have ACL. ACL will be ingested when data is ingested by
+      DocumentService.ImportDocuments methods. When ACL is enabled for the DataStore,
+      Document can't be accessed by calling DocumentService.GetDocument or
+      DocumentService.ListDocuments. Currently ACL is only supported in the GENERIC
+      industry vertical with non-PUBLIC_WEBSITE content config.
+    required: false
+    immutable: true
   - name: 'advancedSiteSearchConfig'
     type: NestedObject
     description: |


### PR DESCRIPTION
## Summary

Adds the `acl_enabled` field to `google_discovery_engine_data_store`, exposing the existing `DataStore.aclEnabled` API capability so users can ingest ACL-aware document collections through Terraform.

Fixes hashicorp/terraform-provider-google#19566

## Why

Vertex AI Search supports per-document access control. Customers using Vertex AI Search for enterprise content need to indicate at DataStore creation time that incoming documents will carry ACL metadata, otherwise `DocumentService.ImportDocuments` rejects ACL-bearing payloads. This field is exposed and documented on the v1 API but was not surfaced by the provider.

**GCP API reference:**
- DataStore resource: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.dataStores#DataStore.FIELDS.acl_enabled

## What changed

This change is to a magic-modules-generated resource. mmv1 file touched:

```
mmv1/products/discoveryengine/DataStore.yaml | 11 +++++++++++
1 file changed, 11 insertions(+)
```

The new field is `Optional + Immutable` (matches API contract — `aclEnabled` is set at DataStore creation and not mutable thereafter, per `discoveryengine-gen.go` in `google.golang.org/api@v0.278.0`).

## Edge cases tested

| # | Scenario | HCL excerpt | Expected | Verified by |
|---|---|---|---|---|
| 1 | Default (field unset) | `# acl_enabled omitted` | Field absent from API request, DataStore created with default (false) | static (additive schema) |
| 2 | Explicitly `false` | `acl_enabled = false` | Field sent as `false`; equivalent to default | static (additive schema) |
| 3 | Explicitly `true` | `acl_enabled = true` | Field sent as `true`; ACL ingestion enabled | static (additive schema) |
| 4 | Update attempt | `acl_enabled = true` then change to `false` | Plan shows ForceNew (resource recreation) | `immutable: true` in mmv1 |

This is a pure additive schema change with no behavior change for existing users (default omits the field, matching prior behavior). No live smoke was run because the gap is "field absent from schema" — `make iterate` validates YAML lint, codegen, build, and unit tests on both providers.

## Resources

- Issue: https://github.com/hashicorp/terraform-provider-google/issues/19566
- API: https://cloud.google.com/generative-ai-app-builder/docs/reference/rest/v1/projects.locations.collections.dataStores

## Release notes

```release-note:enhancement
discoveryengine: added `acl_enabled` argument to `google_discovery_engine_data_store`.
```

## Disclosure

This PR was implemented with assistance from Claude Code. The mmv1 schema change was reviewed manually against the GCP REST API documentation and the vendored Go API client (`google.golang.org/api@v0.278.0/discoveryengine/v1/discoveryengine-gen.go`).

