### PR TITLE
Promote PodSnapshotConfig from Beta to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -101,10 +101,10 @@ var (
 		"addons_config.0.parallelstore_csi_driver_config",
 		"addons_config.0.lustre_csi_driver_config",
 		"addons_config.0.slice_controller_config",
+		"addons_config.0.pod_snapshot_config",
 	{{- if ne $.TargetVersionName "ga" }}
 		"addons_config.0.istio_config",
 		"addons_config.0.kalm_config",
-		"addons_config.0.pod_snapshot_config",
 	{{- end }}
 	}
 
@@ -527,6 +527,23 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						"pod_snapshot_config": {
+							Type: schema.TypeList,
+							Optional: true,
+							Computed: true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems: 1,
+							Description: `Configuration for the Pod Snapshot feature.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type: schema.TypeBool,
+										Required: true,
+										Description: `Whether the Pod Snapshot feature is enabled for this cluster.`,
+									},
+								},
+							},
+						},
 						{{- if ne $.TargetVersionName "ga" }}
 						"istio_config": {
 							Type:         schema.TypeList,
@@ -565,23 +582,6 @@ func ResourceContainerCluster() *schema.Resource {
 									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
-									},
-								},
-							},
-						},
-						"pod_snapshot_config": {
-							Type: schema.TypeList,
-							Optional: true,
-							Computed: true,
-							AtLeastOneOf: addonsConfigKeys,
-							MaxItems: 1,
-							Description: `Configuration for the Pod Snapshot feature.`,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"enabled": {
-										Type: schema.TypeBool,
-										Required: true,
-										Description: `Whether the Pod Snapshot feature is enabled for this cluster.`,
 									},
 								},
 							},
@@ -5918,6 +5918,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
     }
 
+	if v, ok := config["pod_snapshot_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.PodSnapshotConfig = &container.PodSnapshotConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 {{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
@@ -5931,14 +5939,6 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 	if v, ok := config["kalm_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.KalmConfig = &container.KalmConfig{
-			Enabled:         addon["enabled"].(bool),
-			ForceSendFields: []string{"Enabled"},
-		}
-	}
-
-	if v, ok := config["pod_snapshot_config"]; ok && len(v.([]interface{})) > 0 {
-		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.PodSnapshotConfig = &container.PodSnapshotConfig{
 			Enabled:         addon["enabled"].(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -7627,6 +7627,13 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 			},
 		}
 	}
+	if c.PodSnapshotConfig != nil {
+		result["pod_snapshot_config"] = []map[string]interface{}{
+			{
+				"enabled": c.PodSnapshotConfig.Enabled,
+			},
+		}
+	}
 
 {{ if ne $.TargetVersionName `ga` -}}
 	if c.IstioConfig != nil {
@@ -7642,14 +7649,6 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		result["kalm_config"] = []map[string]interface{}{
 			{
 				"enabled": c.KalmConfig.Enabled,
-			},
-		}
-	}
-
-	if c.PodSnapshotConfig != nil {
-		result["pod_snapshot_config"] = []map[string]interface{}{
-			{
-				"enabled": c.PodSnapshotConfig.Enabled,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -25,6 +25,7 @@ fields:
   - api_field: 'addonsConfig.gkeBackupAgentConfig.enabled'
   - api_field: 'addonsConfig.horizontalPodAutoscaling.disabled'
   - api_field: 'addonsConfig.httpLoadBalancing.disabled'
+  - api_field: 'addonsConfig.podSnapshotConfig.enabled'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'addonsConfig.istioConfig.auth'
 {{- end }}
@@ -33,7 +34,6 @@ fields:
 {{- end }}
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'addonsConfig.kalmConfig.enabled'
-  - api_field: 'addonsConfig.podSnapshotConfig.enabled'
 {{- end }}
   - api_field: 'addonsConfig.lustreCsiDriverConfig.enableLegacyLustrePort'
   - api_field: 'addonsConfig.lustreCsiDriverConfig.disableMultiNic'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -8202,15 +8202,15 @@ resource "google_container_cluster" "primary" {
     lustre_csi_driver_config {
       enabled = false
     }
+    pod_snapshot_config {
+      enabled = false
+    }
 {{- if ne $.TargetVersionName "ga" }}
     istio_config {
       disabled = true
       auth     = "AUTH_MUTUAL_TLS"
     }
     kalm_config {
-      enabled = false
-    }
-    pod_snapshot_config {
       enabled = false
     }
 {{- end }}
@@ -8291,15 +8291,15 @@ resource "google_container_cluster" "primary" {
       enable_legacy_lustre_port=true
 	  disable_multi_nic=false
     }
+    pod_snapshot_config {
+      enabled = true
+    }
 {{- if ne $.TargetVersionName "ga" }}
     istio_config {
       disabled = false
       auth     = "AUTH_NONE"
     }
     kalm_config {
-      enabled = true
-    }
-    pod_snapshot_config {
       enabled = true
     }
 {{- end }}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -547,7 +547,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
    This flag is required to workaround a port conflict with the gke-metadata-server on GKE nodes.
    * `disable_multi_nic` When set to true, this disables multi-NIC support for the Lustre CSI driver. By default, GKE enables multi-NIC support, which allows the Lustre CSI driver to automatically detect and configure all suitable network interfaces on a node to maximize I/O performance for demanding workloads.
 
-* `pod_snapshot_config` - (Optional, [Beta](../guides/provider_versions.html.markdown)) The status of the Pod Snapshot addon. It is disabled by default. Set `enabled = true` to enable.
+* `pod_snapshot_config` - (Optional) The status of the Pod Snapshot addon. It is disabled by default. Set `enabled = true` to enable.
 
 This example `addons_config` disables two addons:
 


### PR DESCRIPTION
The [GKE Pod Snapshots](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/pod-snapshots) feature is now fully rolled out in `google.golang.org/api`'s v1 version ([ref](https://pkg.go.dev/google.golang.org/api@v0.278.0/container/v1#PodSnapshotConfig)). This change aims to promote the API in the terraform provider from beta to GA.

Internal Ref: b/469789865.
PR implementing the Beta APIs: https://github.com/GoogleCloudPlatform/magic-modules/pull/16096.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `pod_snapshot_config` field to `google_container_cluster` resource (GA)
```
