### PR TITLE
add support for p4sa service account flag in disk and compute restores

### DIFF
--- a/mmv1/products/backupdr/RestoreWorkload.yaml
+++ b/mmv1/products/backupdr/RestoreWorkload.yaml
@@ -136,7 +136,7 @@ properties:
   # --- Target Environments (oneof target_environment) ---
   - name: 'computeInstanceTargetEnvironment'
     type: NestedObject
-    description: 'Optional. The destination environment for GCE VM restoration.'
+    description: 'The destination environment for GCE VM restoration.'
     properties:
       - name: 'project'
         type: String
@@ -146,9 +146,12 @@ properties:
         type: String
         required: true
         description: 'Required. The zone of the Compute Engine instance.'
+      - name: 'useProjectServiceAccount'
+        type: Boolean
+        description: 'If true, use the BackupDR P4SA credentials for same-project restores. Default is false.'
   - name: 'diskTargetEnvironment'
     type: NestedObject
-    description: 'Optional. The destination environment for zonal disk restoration.'
+    description: 'The destination environment for zonal disk restoration.'
     properties:
       - name: 'project'
         type: String
@@ -158,9 +161,12 @@ properties:
         type: String
         required: true
         description: 'Required. Target zone for the disk.'
+      - name: 'useProjectServiceAccount'
+        type: Boolean
+        description: 'If true, use the BackupDR P4SA credentials for same-project restores. Default is false.'
   - name: 'regionDiskTargetEnvironment'
     type: NestedObject
-    description: 'Optional. The destination environment for regional disk restoration.'
+    description: 'The destination environment for regional disk restoration.'
     properties:
       - name: 'project'
         type: String
@@ -176,6 +182,9 @@ properties:
           type: String
         required: true
         description: 'Required. Target URLs of the replica zones for the disk.'
+      - name: 'useProjectServiceAccount'
+        type: Boolean
+        description: 'If true, use the BackupDR P4SA credentials for same-project restores. Default is false.'
   # --- Restore Properties (oneof instance_properties) ---
   - name: 'computeInstanceRestoreProperties'
     type: NestedObject

--- a/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
@@ -95,6 +95,9 @@ if v, ok := d.GetOkExists("compute_instance_target_environment"); ok {
         if val, ok := m["zone"]; ok {
             env["zone"] = val.(string)
         }
+        if val, ok := m["use_project_service_account"]; ok {
+            env["useProjectServiceAccount"] = val.(bool)
+        }
         if len(env) > 0 {
             obj["computeInstanceTargetEnvironment"] = env
         }
@@ -112,6 +115,9 @@ if v, ok := d.GetOkExists("disk_target_environment"); ok {
         }
         if val, ok := m["zone"]; ok {
             env["zone"] = val.(string)
+        }
+        if val, ok := m["use_project_service_account"]; ok {
+            env["useProjectServiceAccount"] = val.(bool)
         }
         if len(env) > 0 {
             obj["diskTargetEnvironment"] = env
@@ -133,6 +139,9 @@ if v, ok := d.GetOkExists("region_disk_target_environment"); ok {
         }
         if zones, ok := m["replica_zones"]; ok {
             env["replicaZones"] = zones
+        }
+        if val, ok := m["use_project_service_account"]; ok {
+            env["useProjectServiceAccount"] = val.(bool)
         }
         if len(env) > 0 {
             obj["regionDiskTargetEnvironment"] = env

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_restore_workload_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_restore_workload_test.go
@@ -209,6 +209,7 @@ resource "google_backup_dr_restore_workload" "restore" {
   compute_instance_target_environment {
     project = "%{project}"
     zone    = "us-central1-a"
+    use_project_service_account = true
   }
 
   compute_instance_restore_properties {
@@ -321,6 +322,7 @@ resource "google_backup_dr_restore_workload" "restore" {
   disk_target_environment {
     project = "%{project}"
     zone    = "us-central1-a"
+    use_project_service_account = true
   }
 
   disk_restore_properties {
@@ -345,6 +347,7 @@ resource "google_backup_dr_restore_workload" "restore" {
   region_disk_target_environment {
     project = "%{project}"
     region  = "us-central1"
+    use_project_service_account = true
     replica_zones = [
       "projects/%{project}/zones/us-central1-a",
       "projects/%{project}/zones/us-central1-b"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
backupdr: Added support for `use_project_service_account` flag in `google_backup_dr_restore_workload` disk and compute restores.
```
Logs: https://paste.googleplex.com/6292196868358144