### PR TITLE
Added short sleep to google_chronicle_rule test_check_destroy

### DIFF
--- a/mmv1/products/chronicle/Rule.yaml
+++ b/mmv1/products/chronicle/Rule.yaml
@@ -53,6 +53,7 @@ examples:
 
 custom_code:
   pre_delete: 'templates/terraform/pre_delete/chronicle_rule.go.tmpl'
+  test_check_destroy: 'templates/terraform/custom_check_destroy/chronicle_rule.go.tmpl'
 
 virtual_fields:
   - name: 'deletion_policy'

--- a/mmv1/templates/terraform/custom_check_destroy/chronicle_rule.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/chronicle_rule.go.tmpl
@@ -1,0 +1,25 @@
+// Delete is eventually-consistent; wait for a moment.
+time.Sleep(10*time.Second)
+
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, fmt.Sprintf("%s%s", transport_tpg.BaseUrl(chronicle.Product, config), "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/rules/{{"{{"}}rule_id{{"}}"}}"))
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err == nil {
+	return fmt.Errorf("ChronicleRule still exists at %s", url)
+}


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/27300 (TestAccChronicleRule_chronicleRuleBasicExample_update)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
