### PR TITLE
[ContactCenterInsights] Add support for CMEK EncryptionSpec

### DIFF
--- a/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
+++ b/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
@@ -62,7 +62,6 @@ examples:
     primary_resource_id: "my-encryption-spec"
     min_version: "beta"
     exclude_import_test: true
-    skip_vcr: true
     vars:
       project_id: 'my-proj'
       kms_keyring: 'my-keyring'

--- a/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
+++ b/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'EncryptionSpec'
+description: |
+  Initializes a location-level encryption key specification.
+references:
+  guides:
+    'Official Documentation': 'https://docs.cloud.google.com/contact-center/insights/docs/cmek'
+  api: 'https://docs.cloud.google.com/contact-center/insights/docs/reference/rest/v1/projects.locations.encryptionSpec'
+
+base_url: 'projects/{{project}}/locations/{{location}}/encryptionSpec'
+self_link: 'projects/{{project}}/locations/{{location}}/encryptionSpec'
+
+create_url: 'projects/{{project}}/locations/{{location}}/encryptionSpec:initialize'
+
+exclude_delete: true
+immutable: true
+
+async:
+  actions: ['create']
+  operation:
+    base_url: '{{op_id}}'
+
+custom_code:
+  pre_create: 'templates/terraform/pre_create/contactcenterinsights_encryption_spec_pre_create.go.tmpl'
+  pre_read: 'templates/terraform/pre_create/contactcenterinsights_set_endpoint.go.tmpl'
+
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    ignore_read: true
+    url_param_only: true
+    description: |
+      The location in which the encryptionSpec is to be initialized.
+
+properties:
+  - name: 'kmsKey'
+    type: String
+    required: true
+    immutable: true
+    description: |
+      The name of customer-managed encryption key that is used to secure a resource and its sub-resources.
+      If empty, the resource is secured by the default Google encryption key.
+      Only the key in the same location as this resource is allowed to be used for encryption.
+      Format: projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{key}
+
+examples:
+  - name: "contact_center_insights_encryption_spec_basic"
+    primary_resource_id: "my-encryption-spec"
+    min_version: "beta"
+    exclude_import_test: true
+    vars:
+      project_id: 'my-proj'
+      kms_keyring: 'my-keyring'
+      kms_key: 'my-key'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_acct: 'BILLING_ACCT'
+    external_providers:
+      - "time"

--- a/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
+++ b/mmv1/products/contactcenterinsights/EncryptionSpec.yaml
@@ -62,6 +62,7 @@ examples:
     primary_resource_id: "my-encryption-spec"
     min_version: "beta"
     exclude_import_test: true
+    skip_vcr: true
     vars:
       project_id: 'my-proj'
       kms_keyring: 'my-keyring'

--- a/mmv1/templates/terraform/examples/contact_center_insights_encryption_spec_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/contact_center_insights_encryption_spec_basic.tf.tmpl
@@ -17,6 +17,7 @@ resource "google_project_service" "contactcenterinsights" {
   provider = google-beta
   project  = google_project.project.project_id
   service  = "contactcenterinsights.googleapis.com"
+  depends_on = [google_project_service.cloudkms]
 }
 
 resource "time_sleep" "wait_enable_service_api" {

--- a/mmv1/templates/terraform/examples/contact_center_insights_encryption_spec_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/contact_center_insights_encryption_spec_basic.tf.tmpl
@@ -1,0 +1,71 @@
+resource "google_project" "project" {
+  provider        = google-beta
+  project_id      = "{{index $.Vars "project_id"}}"
+  name            = "{{index $.Vars "project_id"}}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_acct"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "cloudkms" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = "cloudkms.googleapis.com"
+}
+
+resource "google_project_service" "contactcenterinsights" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = "contactcenterinsights.googleapis.com"
+}
+
+resource "time_sleep" "wait_enable_service_api" {
+  depends_on = [
+    google_project_service.cloudkms,
+    google_project_service.contactcenterinsights
+  ]
+  create_duration = "30s"
+}
+
+resource "google_project_service_identity" "gcp_sa" {
+  provider   = google-beta
+  service    = "contactcenterinsights.googleapis.com"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_enable_service_api]
+}
+
+resource "time_sleep" "wait_create_sa" {
+  depends_on      = [google_project_service_identity.gcp_sa]
+  create_duration = "30s"
+}
+
+resource "google_kms_key_ring" "keyring" {
+  provider   = google-beta
+  name       = "{{index $.Vars "kms_keyring"}}"
+  location   = "us-east1"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_enable_service_api]
+}
+
+resource "google_kms_crypto_key" "key" {
+  provider = google-beta
+  name     = "{{index $.Vars "kms_key"}}"
+  key_ring = google_kms_key_ring.keyring.id
+  purpose  = "ENCRYPT_DECRYPT"
+}
+
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  provider      = google-beta
+  crypto_key_id = google_kms_crypto_key.key.id
+  member        = "${replace(google_project_service_identity.gcp_sa.member, "@gcp-sa-contactcenterinsights.iam", "@gcp-sa-ccai-cmek.iam")}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  depends_on    = [time_sleep.wait_create_sa]
+}
+
+resource "google_contact_center_insights_encryption_spec" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  location = "us-east1"
+  kms_key  = google_kms_crypto_key.key.id
+  depends_on = [google_kms_crypto_key_iam_member.crypto_key]
+}

--- a/mmv1/templates/terraform/pre_create/contactcenterinsights_encryption_spec_pre_create.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/contactcenterinsights_encryption_spec_pre_create.go.tmpl
@@ -1,0 +1,20 @@
+location := d.Get("location").(string)
+universeDomain := config.UniverseDomain
+
+if universeDomain != "" && universeDomain != "googleapis.com" {
+  url = strings.Replace(url, "googleapis.com", universeDomain, 1)
+}
+
+if strings.HasPrefix(url, "https://contactcenterinsights") {
+    if location != "" && location != "us-central1" {
+        url = strings.Replace(url, "https://contactcenterinsights", fmt.Sprintf("https://%s-contactcenterinsights", location), 1)
+    }
+}
+
+// Wrap kmsKey in encryption_spec for creation
+if kmsKey, ok := obj["kmsKey"]; ok {
+    obj["encryption_spec"] = map[string]interface{}{
+        "kms_key": kmsKey,
+    }
+    delete(obj, "kmsKey")
+}

--- a/mmv1/templates/terraform/pre_create/contactcenterinsights_set_endpoint.go.tmpl
+++ b/mmv1/templates/terraform/pre_create/contactcenterinsights_set_endpoint.go.tmpl
@@ -1,0 +1,12 @@
+location := d.Get("location").(string)
+universeDomain := config.UniverseDomain
+
+if universeDomain != "" && universeDomain != "googleapis.com" {
+  url = strings.Replace(url, "googleapis.com", universeDomain, 1)
+}
+
+if strings.HasPrefix(url, "https://contactcenterinsights") {
+    if location != "" && location != "us-central1" {
+        url = strings.Replace(url, "https://contactcenterinsights", fmt.Sprintf("https://%s-contactcenterinsights", location), 1)
+    }
+}

--- a/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
+++ b/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
@@ -3,6 +3,7 @@ package contactcenterinsights
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -44,6 +45,12 @@ func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
 	// See: https://docs.cloud.google.com/contact-center/insights/docs/regionalization
 	if location == "us-central1" {
 		url = fmt.Sprintf("https://contactcenterinsights.googleapis.com/v1/%s", w.CommonOperationWaiter.Op.Name)
+	}
+
+	// Handle custom universe domain
+	universeDomain := w.Config.UniverseDomain
+	if universeDomain != "" && universeDomain != "googleapis.com" {
+		url = strings.Replace(url, "googleapis.com", universeDomain, 1)
 	}
 
 	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
+++ b/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
@@ -24,7 +24,7 @@ func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
 	if w == nil {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
-	
+
 	// Extract location from operation name (e.g., projects/.../locations/us-east1/operations/...)
 	location := ""
 	if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(w.CommonOperationWaiter.Op.Name); parts != nil {
@@ -39,7 +39,7 @@ func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
 
 	// Construct the regional endpoint URL
 	url := fmt.Sprintf("https://%s-contactcenterinsights.googleapis.com/v1/%s", location, w.CommonOperationWaiter.Op.Name)
-	
+
 	// For historical reasons, us-central1 acts as the global endpoint and does not use a prefix.
 	// See: https://docs.cloud.google.com/contact-center/insights/docs/regionalization
 	if location == "us-central1" {

--- a/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
+++ b/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
@@ -1,0 +1,71 @@
+package contactcenterinsights
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type ContactCenterInsightsOperationWaiter struct {
+	Config    *transport_tpg.Config
+	UserAgent string
+	Project   string
+	tpgresource.CommonOperationWaiter
+}
+
+func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
+	if w == nil {
+		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
+	}
+	// Returns the proper get.
+	location := ""
+	if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(w.CommonOperationWaiter.Op.Name); parts != nil {
+		location = parts[1]
+	} else {
+		return nil, fmt.Errorf(
+			"Saw %s when the op name is expected to contains location %s",
+			w.CommonOperationWaiter.Op.Name,
+			"projects/{{project}}/locations/{{location}}/...",
+		)
+	}
+
+	url := fmt.Sprintf("https://%s-contactcenterinsights.googleapis.com/v1/%s", location, w.CommonOperationWaiter.Op.Name)
+	if location == "us-central1" {
+		url = fmt.Sprintf("https://contactcenterinsights.googleapis.com/v1/%s", w.CommonOperationWaiter.Op.Name)
+	}
+
+	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    w.Config,
+		Method:    "GET",
+		Project:   w.Project,
+		RawURL:    url,
+		UserAgent: w.UserAgent,
+	})
+}
+
+func createContactCenterInsightsWaiter(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string) (*ContactCenterInsightsOperationWaiter, error) {
+	w := &ContactCenterInsightsOperationWaiter{
+		Config:    config,
+		UserAgent: userAgent,
+		Project:   project,
+	}
+	if err := w.CommonOperationWaiter.SetOp(op); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func ContactCenterInsightsOperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
+	if val, ok := op["name"]; !ok || val == "" {
+		// This was a synchronous call - there is no operation to wait for.
+		return nil
+	}
+	w, err := createContactCenterInsightsWaiter(config, op, project, activity, userAgent)
+	if err != nil {
+		return err
+	}
+	return tpgresource.OperationWait(w, activity, timeout, config.PollInterval)
+}

--- a/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
+++ b/mmv1/third_party/terraform/services/contactcenterinsights/contactcenterinsights_operation.go
@@ -16,11 +16,16 @@ type ContactCenterInsightsOperationWaiter struct {
 	tpgresource.CommonOperationWaiter
 }
 
+// QueryOp is handwritten because Contact Center Insights requires regional endpoints
+// for non-global regions. We need to extract the location from the operation name
+// and construct the correct regional URL. The default Magic Modules generator
+// does not support this dynamic endpoint switching based on operation name.
 func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
 	if w == nil {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
-	// Returns the proper get.
+	
+	// Extract location from operation name (e.g., projects/.../locations/us-east1/operations/...)
 	location := ""
 	if parts := regexp.MustCompile(`locations\/([^\/]*)\/`).FindStringSubmatch(w.CommonOperationWaiter.Op.Name); parts != nil {
 		location = parts[1]
@@ -32,7 +37,11 @@ func (w *ContactCenterInsightsOperationWaiter) QueryOp() (interface{}, error) {
 		)
 	}
 
+	// Construct the regional endpoint URL
 	url := fmt.Sprintf("https://%s-contactcenterinsights.googleapis.com/v1/%s", location, w.CommonOperationWaiter.Op.Name)
+	
+	// For historical reasons, us-central1 acts as the global endpoint and does not use a prefix.
+	// See: https://docs.cloud.google.com/contact-center/insights/docs/regionalization
 	if location == "us-central1" {
 		url = fmt.Sprintf("https://contactcenterinsights.googleapis.com/v1/%s", w.CommonOperationWaiter.Op.Name)
 	}


### PR DESCRIPTION
# Add support for Contact Center Insights CMEK EncryptionSpec

This PR adds a new resource `google_contact_center_insights_encryption_spec` to support Customer-Managed Encryption Keys (CMEK) in Contact Center Insights.

## Documentation
https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/cmek#create

## Rationale
Contact Center Insights requires a location-level initialization of CMEK keys before they can be used for resources in that location. This resource supports that operation via the `:initialize` custom method.

## Technical Details
- **Custom Endpoint Handling:** Contact Center Insights requires regional endpoints for non-global regions (e.g., `us-east1-contactcenterinsights.googleapis.com`). Added custom code in `pre_create` and `pre_read` hooks to handle this dynamically based on location.
- **Response Flattening:** The API response for `GetEncryptionSpec` returns a flat structure (`{kmsKey: "..."}`), while the `initialize` request requires it wrapped in `encryption_spec`. Handled this by modeling properties as flat in YAML and using a `pre_create` hook to wrap them for the creation request.
- **Beta Only Test:** The automated test depends on `google_project_service_identity` to create the service account, which is a Beta-only resource. Hence, the test is restricted to the Beta provider.

## Verification Results
- Code generation successful for both GA and Beta.
- Acceptance test `TestAccContactCenterInsightsEncryptionSpec_contactCenterInsightsEncryptionSpecBasicExample` passed successfully in the Beta provider repository.

```release-note:new-resource
`google_contact_center_insights_encryption_spec`
```