### PR TITLE
Feat: add excluded projects and folders examples in google compute organization security policy association resource

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicyAssociation.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicyAssociation.yaml
@@ -48,6 +48,12 @@ examples:
       short_name: "my-short-name"
     test_env_vars:
       org_id: 'ORG_TARGET'
+  - name: 'organization_security_policy_association_excluded'
+    primary_resource_id: 'policy'
+    vars:
+      short_name: "my-short-name-excluded"
+    test_env_vars:
+      org_id: 'ORG_TARGET'
 parameters:
   - name: 'policyId'
     type: String

--- a/mmv1/templates/terraform/examples/organization_security_policy_association_excluded.tf.tmpl
+++ b/mmv1/templates/terraform/examples/organization_security_policy_association_excluded.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_folder" "security_policy_target" {
+  display_name        = "tf-test-secpol-%{random_suffix}"
+  parent              = "organizations/{{index $.TestEnvVars "org_id"}}"
+  deletion_protection = false
+}
+
+resource "google_compute_organization_security_policy" "policy" {
+  short_name = "tf-test%{random_suffix}"
+  parent     = google_folder.security_policy_target.name
+  type       = "CLOUD_ARMOR"
+}
+
+resource "google_compute_organization_security_policy_association" "{{$.PrimaryResourceId}}" {
+  name          = "tf-test%{random_suffix}"
+  attachment_id = "organizations/{{index $.TestEnvVars "org_id"}}"
+  policy_id     = google_compute_organization_security_policy.policy.id
+
+  excluded_projects = [
+    "projects/2000000002",
+    "projects/3000000003"
+  ]
+  excluded_folders = [
+    "folders/4000000004",
+    "folders/5000000005"
+  ]
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Hello Folks, this PR is to create a example to how to use a excluded_projects and excluded_folders on google_compute_organization_security_policy_association resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: added `excluded_projects` and `excluded_folders` example to `google_compute_organization_security_policy_association` resource
```
