### PR TITLE
`CI`: explcitly check children of google/services in `teamcity-diff-services-check` workflow

### DIFF
--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
             # Create lists of service packages in providers. Need to cd into repos where go.mod is to do this command.
             cd ${GOOGLE_REPO_PATH}
-            go list -f '{{.Name}}' ${GOOGLE_REPO_PATH}/google/services/... > $GITHUB_WORKSPACE/provider_services_ga.txt
+            go list -e -f '{{.Name}}' ${GOOGLE_REPO_PATH}/google/services/* > $GITHUB_WORKSPACE/provider_services_ga.txt
             cd ${GOOGLE_BETA_REPO_PATH}
-            go list -f '{{.Name}}' ${GOOGLE_BETA_REPO_PATH}/google-beta/services/... > $GITHUB_WORKSPACE/provider_services_beta.txt
+            go list -e -f '{{.Name}}' ${GOOGLE_BETA_REPO_PATH}/google-beta/services/* > $GITHUB_WORKSPACE/provider_services_beta.txt
 
             # Run tool to compare service packages in the providers vs those listed in TeamCity config files
             cd $GITHUB_WORKSPACE

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -54,9 +54,9 @@ jobs:
         run: |
           # Create lists of service packages in providers. Need to cd into repos where go.mod is to do this command.
           cd ${GOOGLE_REPO_PATH}
-          go list -f '{{.Name}}' ${GOOGLE_REPO_PATH}/google/services/... > $GITHUB_WORKSPACE/provider_services_ga.txt
+          go list -e -f '{{.Name}}' ${GOOGLE_REPO_PATH}/google/services/* > $GITHUB_WORKSPACE/provider_services_ga.txt
           cd ${GOOGLE_BETA_REPO_PATH}
-          go list -f '{{.Name}}' ${GOOGLE_BETA_REPO_PATH}/google-beta/services/... > $GITHUB_WORKSPACE/provider_services_beta.txt
+          go list -e -f '{{.Name}}' ${GOOGLE_BETA_REPO_PATH}/google-beta/services/* > $GITHUB_WORKSPACE/provider_services_beta.txt
 
           # Run tool to compare service packages in the providers vs those listed in TeamCity config files
           cd $GITHUB_WORKSPACE


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

got an email warning us about teamcity services mismatch where the diff was being caused by a `client` service. This has been failing for about two weeks now:
- https://github.com/GoogleCloudPlatform/magic-modules/actions/workflows/teamcity-services-diff-check-weekly.yml

There is no service called client so after some digging it comes from the GHA recursively going through directories within `[google|google-beta]/services`, the introduction of:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17355

caused  `client` to appear in the diff check.

Fix is to explicitly check within the children of `[google|google-beta]/services` and not recursing down further. 

`-e` is set to ignore `stderr` that appear when a package isn't found within a directory, this cause the `provider_services_*.txt` to not be generated successfully: adding the `-e` resolved this
```console
󰀵 mau  …/terraform-provider-google   main $!?⇣   v1.26.1   11:48   cd /Users/mau/Dev/terraform-provider-google && go list -f '{{.Name}}' ./google/services/* > /Users/mau/Dev/magic-modules/provider_services_ga.txt
no Go files in /Users/mau/Dev/terraform-provider-google/google/services/VCR_PATH_TEST
no Go files in /Users/mau/Dev/terraform-provider-google/google/services/billing
no Go files in /Users/mau/Dev/terraform-provider-google/google/services/corebilling
no Go files in /Users/mau/Dev/terraform-provider-google/google/services/recaptcha
no Go files in /Users/mau/Dev/terraform-provider-google/google/services/resourcemanager3
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
