### PR TITLE
Add custom flattener for errors.details.details in data_loss_preventi…

### DIFF
--- a/mmv1/products/dlp/DiscoveryConfig.yaml
+++ b/mmv1/products/dlp/DiscoveryConfig.yaml
@@ -942,6 +942,7 @@ properties:
             - name: 'details'
               type: Array
               description: A list of messages that carry the error details.
+              custom_flatten: 'templates/terraform/custom_flatten/dlp_discovery_config_error_details.tmpl'
               item_type:
                 type: KeyValuePairs
         - name: 'timestamp'

--- a/mmv1/templates/terraform/custom_flatten/dlp_discovery_config_error_details.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/dlp_discovery_config_error_details.tmpl
@@ -1,0 +1,36 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2024 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	detailsArray := v.([]interface{})
+	for i, raw := range detailsArray {
+		m := raw.(map[string]interface{})
+		if len(m) < 1 {
+			// Do not include empty json objects coming back from the API
+			continue
+		}
+		for k, val := range m {
+			if _, ok := val.(string); !ok {
+				b, err := json.Marshal(v)
+				if err != nil {
+					return err
+				}
+				m[k] = string(b)
+			}
+		}
+		detailsArray[i] = m
+	}
+	return detailsArray
+}


### PR DESCRIPTION
Based fix on https://github.com/GoogleCloudPlatform/magic-modules/pull/12858. We are experiencing the same type of issue with a customer bug. Unfortunately, I am finding it a little hard to repro this locally.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
dlp: fixed error when reading `google_data_loss_prevention_discovery_config` caused by nested error details
```
