### PR TITLE
Extended chronicle_rule sleep during test_check_destroy

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/chronicle_rule.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/chronicle_rule.go.tmpl
@@ -1,5 +1,5 @@
 // Delete is eventually-consistent; wait for a moment.
-time.Sleep(10*time.Second)
+time.Sleep(30*time.Second)
 
 config := acctest.GoogleProviderConfig(t)
 url, err := tpgresource.ReplaceVarsForTest(config, rs, fmt.Sprintf("%s%s", transport_tpg.BaseUrl(chronicle.Product, config), "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/instances/{{"{{"}}instance{{"}}"}}/rules/{{"{{"}}rule_id{{"}}"}}"))


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/17505

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
