### PR TITLE
tgc-revival: fix RegionInstantSnapshot tests

### DIFF
--- a/mmv1/products/compute/RegionInstantSnapshot.yaml
+++ b/mmv1/products/compute/RegionInstantSnapshot.yaml
@@ -52,6 +52,7 @@ sweeper:
   url_substitutions:
     - region: "us-central1"
 include_in_tgc_next: true
+cai_resource_kind: InstantSnapshot
 examples:
   - name: 'region_instant_snapshot_basic'
     primary_resource_id: 'default'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```
--- FAIL: TestAccComputeRegionInstantSnapshot (2.88s)
    --- FAIL: TestAccComputeRegionInstantSnapshot/TestAccComputeRegionInstantSnapshot_resourceManagerTags (2.88s)
        --- FAIL: TestAccComputeRegionInstantSnapshot/TestAccComputeRegionInstantSnapshot_resourceManagerTags/step1 (0.00s)
            assert_test_files.go:117: TestAccComputeRegionInstantSnapshot_resourceManagerTags_step1: Starting test with retry logic.
            assert_test_files.go:92: TestAccComputeRegionInstantSnapshot_resourceManagerTags_step1: Test for the primary resource google_compute_region_instant_snapshot.foobar begins.
panic: runtime error: slice bounds out of range [9:7] [recovered, repanicked]

```

I have modified `RegionInstantSnapshot.yaml` in Magic Modules to add `cai_resource_kind: InstantSnapshot`, which will ensure that both zonal and regional instant snapshots are grouped under the `compute.googleapis.com/InstantSnapshot` CAI asset type.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
