### PR TITLE
Remove url_param_only and add ignore read for Data Transfer Resources.

### DIFF
--- a/mmv1/products/networkconnectivity/Destination.yaml
+++ b/mmv1/products/networkconnectivity/Destination.yaml
@@ -56,7 +56,6 @@ parameters:
     url_param_only: true
     description: |
       The location of the destination.
-
 properties:
   - name: 'name'
     type: String

--- a/mmv1/products/networkconnectivity/Destination.yaml
+++ b/mmv1/products/networkconnectivity/Destination.yaml
@@ -62,7 +62,7 @@ properties:
     type: String
     required: true
     immutable: true
-    url_param_only: true
+    ignore_read: true
     description: |
       The name of the destination.
   - name: 'createTime'

--- a/mmv1/products/networkconnectivity/MulticloudDataTransferConfig.yaml
+++ b/mmv1/products/networkconnectivity/MulticloudDataTransferConfig.yaml
@@ -53,7 +53,7 @@ properties:
     type: String
     required: true
     immutable: true
-    url_param_only: true
+    ignore_read: true
     description: |
       The name of the MulticloudDataTransferConfig resource.
   - name: 'createTime'


### PR DESCRIPTION
Referring PR https://github.com/GoogleCloudPlatform/magic-modules/pull/17114

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkconnectivity: fixed an issue where `google_network_connectivity_multicloud_data_transfer_config` was not recognizing the `name` field as mapping to an API value
```
```release-note:bug
networkconnectivity: fixed an issue where `google_network_connectivity_destination` was not recognizing the `name` field as mapping to an API value
```
