### PR TITLE
 Add terminal_storage_class and per_unit_storage_throughput fields.

### DIFF
--- a/mmv1/products/hypercomputecluster/Cluster.yaml
+++ b/mmv1/products/hypercomputecluster/Cluster.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google Inc.
+# Copyright 2026 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -597,6 +597,13 @@ properties:
                       type: Boolean
                       required: true
                       description: Enables Auto-class feature.
+                    - name: terminalStorageClass
+                      type: String
+                      description: |-
+                        Terminal storage class of the autoclass bucket
+                        Possible values:
+                        NEARLINE
+                        ARCHIVE
                 - name: bucket
                   type: String
                   required: true
@@ -717,6 +724,14 @@ properties:
                   description: |-
                     Name of the Managed Lustre instance to create, in the format
                     `projects/{project}/locations/{location}/instances/{instance}`
+                - name: perUnitStorageThroughput
+                  type: String
+                  description: |-
+                    Throughput of the instance in MB/s/TiB. Valid values are 125, 250,
+                    500, 1000. See [Performance tiers and maximum storage
+                    capacities](https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers)
+                    for more information.
+                  immutable: true
         - name: filestore
           type: NestedObject
           description: A reference to a [Filestore](https://cloud.google.com/filestore) instance.

--- a/mmv1/products/hypercomputecluster/product.yaml
+++ b/mmv1/products/hypercomputecluster/product.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Google Inc.
+# Copyright 2026 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -513,7 +513,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         bucket = "bucket-new-2-%{random_suffix}"
         autoclass {
           enabled = true
-					terminal_storage_class = "NEARLINE"
+          terminal_storage_class = "NEARLINE"
         }
         hierarchical_namespace {
           enabled = false

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -513,6 +513,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         bucket = "bucket-new-2-%{random_suffix}"
         autoclass {
           enabled = true
+					terminal_storage_class = "NEARLINE"
         }
         hierarchical_namespace {
           enabled = false
@@ -543,6 +544,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         description = "Lustre instance created via Terraform"
         filesystem = "lustrefs"
         lustre = "projects/${local.project_id}/locations/us-central1-a/instances/lustre-%{random_suffix}"
+				per_unit_storage_throughput = "1000"
       }
     }
   }

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -544,7 +544,7 @@ resource "google_hypercomputecluster_cluster" "cluster" {
         description = "Lustre instance created via Terraform"
         filesystem = "lustrefs"
         lustre = "projects/${local.project_id}/locations/us-central1-a/instances/lustre-%{random_suffix}"
-				per_unit_storage_throughput = "1000"
+          per_unit_storage_throughput = "1000"
       }
     }
   }


### PR DESCRIPTION
Add Terraform support for `terminal_storage_class` and `per_unit_storage_throughput`.


```release-note:enhancement
hypercomputecluster: added `terminal_storage_class` and `per_unit_storage_throughput` fields to the `google_hypercomputecluster_cluster` resource
```
