### PR TITLE
`resourceIdentity/MMv1`: skip id values that aren't present in resource schema

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -682,8 +682,9 @@ func (r Resource) IdentityProperties() []*Type {
 		}
 	}
 
+	hasField := map[string]bool{"project": r.HasProject(), "zone": r.HasZone(), "region": r.HasRegion()}
 	for _, field := range []string{"project", "zone", "region"} { // prevents duplicates
-		if slices.Contains(importFormat, field) && !optionalValues[field] {
+		if slices.Contains(importFormat, field) && !optionalValues[field] && hasField[field] {
 			props = append(props, &Type{Name: field, Type: "string"})
 		}
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

When looking into list mmv1 i noticed a bug where an `import_format` can be used despite the values not being present in the resource's schema. 

This adds a check to prevent schema field from being included in identity schema. An example of this is alloydb_user not including project in the resource schema:
https://github.com/GoogleCloudPlatform/magic-modules/blob/59d0a15a26f0edd5272999c5d2efe209cffea033/mmv1/products/alloydb/User.yaml#L22-L28

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
