### PR TITLE
Add sipConfig to ConversationProfile in Dialogflow

### DIFF
--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -676,16 +676,11 @@ properties:
     name: 'sipConfig'
     description: |
       Configuration for SIP.
-    min_version: beta
     properties:
       - type: Boolean
         name: 'createConversationOnTheFly'
         description: |
           Asks Dialogflow Telephony to create the conversation provided in the SIP header on the fly when the call comes in.
-      - type: Boolean
-        name: 'useMultiSdpPorts'
-        description: |
-          Uses multiple ports, each for one SDP media connection.
       - type: Boolean
         name: 'inactiveStart'
         description: |
@@ -702,10 +697,6 @@ properties:
         name: 'keepConversationRunning'
         description: |
           Keeps the conversation running even if the call is disconnected.
-      - type: Boolean
-        name: 'useProgress'
-        description: |
-          Use 183 Progress instead of 180 Ringing during SDP negotiation.
       - type: Array
         name: 'copyInboundCallLegHeaders'
         description: |

--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -38,6 +38,7 @@ custom_code:
   pre_delete: 'templates/terraform/pre_create/dialogflow_set_endpoint.go.tmpl'
   post_create: 'templates/terraform/post_create/set_computed_name.tmpl'
   custom_import: 'templates/terraform/custom_import/self_link_as_name_set_project_and_location.go.tmpl'
+  test_check_destroy: 'templates/terraform/test_check_destroy/dialogflow_conversation_profile.go.tmpl'
 exclude_sweeper: true
 examples:
   - name: 'dialogflow_conversation_profile_basic'
@@ -674,6 +675,7 @@ properties:
               - SSML_VOICE_GENDER_NEUTRAL
   - type: NestedObject
     name: 'sipConfig'
+    min_version: beta
     description: |
       Configuration for SIP.
     properties:
@@ -681,10 +683,12 @@ properties:
         name: 'createConversationOnTheFly'
         description: |
           Asks Dialogflow Telephony to create the conversation provided in the SIP header on the fly when the call comes in.
+        send_empty_value: true
       - type: Boolean
         name: 'inactiveStart'
         description: |
           Starts the conversation with inactive SDP directives
+        send_empty_value: true
       - type: String
         name: 'maxAudioRecordingDuration'
         description: |
@@ -693,10 +697,12 @@ properties:
         name: 'allowVirtualAgentInteraction'
         description: |
           Allows interactions with a Dialogflow virtual agent even if the call is connected for SIPREC purposes.
+        send_empty_value: true
       - type: Boolean
         name: 'keepConversationRunning'
         description: |
           Keeps the conversation running even if the call is disconnected.
+        send_empty_value: true
       - type: Array
         name: 'copyInboundCallLegHeaders'
         description: |
@@ -707,6 +713,7 @@ properties:
         name: 'ignoreReinviteMediaDirection'
         description: |
           Ignores any media direction in the reINVITE SDP offer. Reuse the previous media direction.
+        send_empty_value: true
   - type: NestedObject
     name: 'newRecognitionResultNotificationConfig'
     description: |

--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -60,13 +60,13 @@ parameters:
     type: String
     url_param_only: true
     description: |
-      desc
+      The location of the conversation profile.
     required: true
 properties:
   - name: 'name'
     type: String
     description: |
-      name
+      Identifier. The unique identifier of this conversation profile.
     output: true
   - name: 'displayName'
     type: String
@@ -213,7 +213,7 @@ properties:
                     - type: NestedObject
                       name: 'sections'
                       description: |
-                        he customized sections chosen to return when requesting a summary of a conversation.
+                        The customized sections chosen to return when requesting a summary of a conversation.
                       properties:
                         - type: Array
                           name: 'sectionTypes'
@@ -243,7 +243,7 @@ properties:
                           name: 'agent'
                           required: true
                           description: |
-                            he name of a Dialogflow virtual agent used for end user side intent detection and suggestion. Format: projects/<Project ID>/locations/<Location ID>/agent.
+                            The name of a Dialogflow virtual agent used for end user side intent detection and suggestion. Format: projects/<Project ID>/locations/<Location ID>/agent.
                         - type: NestedObject
                           name: 'humanAgentSideConfig'
                           description: |
@@ -388,7 +388,7 @@ properties:
                     - type: NestedObject
                       name: 'sections'
                       description: |
-                        he customized sections chosen to return when requesting a summary of a conversation.
+                        The customized sections chosen to return when requesting a summary of a conversation.
                       properties:
                         - type: Array
                           name: 'sectionTypes'
@@ -444,7 +444,7 @@ properties:
                           name: 'agent'
                           required: true
                           description: |
-                            he name of a Dialogflow virtual agent used for end user side intent detection and suggestion. Format: projects/<Project ID>/locations/<Location ID>/agent.
+                            The name of a Dialogflow virtual agent used for end user side intent detection and suggestion. Format: projects/<Project ID>/locations/<Location ID>/agent.
                         - type: NestedObject
                           name: 'humanAgentSideConfig'
                           description: |
@@ -495,7 +495,7 @@ properties:
       - type: NestedObject
         name: 'messageAnalysisConfig'
         description: |
-          desc
+          Configuration for analyzing conversation messages.
         properties:
           - type: Boolean
             name: 'enableEntityExtraction'
@@ -600,7 +600,7 @@ properties:
           - AUDIO_ENCODING_AMR
           - AUDIO_ENCODING_AMR_WB
           - AUDIO_ENCODING_OGG_OPUS
-          - AUDIOENCODING_SPEEX_WITH_HEADER_BYTE
+          - AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE
       - type: Integer
         name: 'sampleRateHertz'
         description: |
@@ -617,7 +617,7 @@ properties:
       - type: Boolean
         name: 'useTimeoutBasedEndpointing'
         description: |
-          Use timeout based endpointing, interpreting endpointer sensitivy as seconds of timeout value.
+          Use timeout based endpointing, interpreting endpointer sensitivity as seconds of timeout value.
   - type: String
     name: 'languageCode'
     description: |
@@ -706,7 +706,7 @@ properties:
       - type: Boolean
         name: 'ignoreReinviteMediaDirection'
         description: |
-          Ingores any media direction in the reINVITE SDP offer. Reuse the previous media direction.
+          Ignores any media direction in the reINVITE SDP offer. Reuse the previous media direction.
   - type: NestedObject
     name: 'newRecognitionResultNotificationConfig'
     description: |

--- a/mmv1/products/dialogflow/ConversationProfile.yaml
+++ b/mmv1/products/dialogflow/ConversationProfile.yaml
@@ -673,6 +673,50 @@ properties:
               - SSML_VOICE_GENDER_FEMALE
               - SSML_VOICE_GENDER_NEUTRAL
   - type: NestedObject
+    name: 'sipConfig'
+    description: |
+      Configuration for SIP.
+    min_version: beta
+    properties:
+      - type: Boolean
+        name: 'createConversationOnTheFly'
+        description: |
+          Asks Dialogflow Telephony to create the conversation provided in the SIP header on the fly when the call comes in.
+      - type: Boolean
+        name: 'useMultiSdpPorts'
+        description: |
+          Uses multiple ports, each for one SDP media connection.
+      - type: Boolean
+        name: 'inactiveStart'
+        description: |
+          Starts the conversation with inactive SDP directives
+      - type: String
+        name: 'maxAudioRecordingDuration'
+        description: |
+          Max duration for audio recording. Overrides the default value of 15 min. Max value is 8 hours.
+      - type: Boolean
+        name: 'allowVirtualAgentInteraction'
+        description: |
+          Allows interactions with a Dialogflow virtual agent even if the call is connected for SIPREC purposes.
+      - type: Boolean
+        name: 'keepConversationRunning'
+        description: |
+          Keeps the conversation running even if the call is disconnected.
+      - type: Boolean
+        name: 'useProgress'
+        description: |
+          Use 183 Progress instead of 180 Ringing during SDP negotiation.
+      - type: Array
+        name: 'copyInboundCallLegHeaders'
+        description: |
+          List of inbound call leg headers to be copied to outbound call legs created later.
+        item_type:
+          type: String
+      - type: Boolean
+        name: 'ignoreReinviteMediaDirection'
+        description: |
+          Ingores any media direction in the reINVITE SDP offer. Reuse the previous media direction.
+  - type: NestedObject
     name: 'newRecognitionResultNotificationConfig'
     description: |
       Optional. Configuration for publishing transcription intermediate results. Event will be sent in format of ConversationEvent. If configured, the following information will be populated as ConversationEvent Pub/Sub message attributes: - "participant_id" - "participantRole" - "message_id"

--- a/mmv1/templates/terraform/examples/dialogflow_conversation_profile_beta_bidi.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dialogflow_conversation_profile_beta_bidi.tf.tmpl
@@ -1,11 +1,15 @@
 resource "google_dialogflow_conversation_profile" "bidi_profile" {
   provider = google-beta
   display_name = "{{index $.Vars "profile_name"}}"
-  location     = "global"
+  location     = "europe-west1"
   language_code = "en-US"
   use_bidi_streaming = true
   automated_agent_config {
     agent = google_ces_app.ces_app_for_agent.id
+  }
+  sip_config {
+    allow_virtual_agent_interaction = true
+    create_conversation_on_the_fly = true
   }
 }
 

--- a/mmv1/templates/terraform/test_check_destroy/dialogflow_conversation_profile.go.tmpl
+++ b/mmv1/templates/terraform/test_check_destroy/dialogflow_conversation_profile.go.tmpl
@@ -1,0 +1,35 @@
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, fmt.Sprintf("%s%s", transport_tpg.BaseUrl(dialogflow.Product, config), "{{"{{"}}name{{"}}"}}"))
+if err != nil {
+	return err
+}
+
+billingProject := ""
+
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+location := rs.Primary.Attributes["location"]
+universeDomain := config.UniverseDomain
+
+if universeDomain != "" && universeDomain != "googleapis.com" {
+	url = strings.Replace(url, "googleapis.com", universeDomain, 1)
+}
+
+if strings.HasPrefix(url, "https://dialogflow") {
+	if location != "" && location != "global" {
+		url = strings.Replace(url, "https://dialogflow", fmt.Sprintf("https://%s-dialogflow", location), 1)
+	}
+}
+
+_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "GET",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: config.UserAgent,
+})
+if err == nil {
+	return fmt.Errorf("DialogflowConversationProfile still exists at %s", url)
+}

--- a/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_conversation_profile_test.go
+++ b/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_conversation_profile_test.go
@@ -496,3 +496,96 @@ func testAccDialogflowConversationProfile_dialogflowRegional(context map[string]
 	}
 `, context)
 }
+
+func TestAccDialogflowConversationProfile_sipConfig(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"profile_name":  "tf-test-dialogflow-profile-" + randomSuffix,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckDialogflowConversationProfileDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowConversationProfile_sipConfigStep1(context),
+			},
+			{
+				Config: testAccDialogflowConversationProfile_sipConfigStep2(context),
+			},
+			{
+				Config: testAccDialogflowConversationProfile_sipConfigStep3(context),
+			},
+			{
+				Config: testAccDialogflowConversationProfile_sipConfigStep4(context),
+			},
+		},
+	})
+}
+
+func testAccDialogflowConversationProfile_sipConfigStep1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_conversation_profile" "profile" {
+  provider = google-beta
+  display_name = "%{profile_name}"
+  location = "europe-west1"
+  language_code = "en-US"
+}
+`, context)
+}
+
+func testAccDialogflowConversationProfile_sipConfigStep2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_conversation_profile" "profile" {
+  provider = google-beta
+  display_name = "%{profile_name}"
+  location = "europe-west1"
+  language_code = "en-US"
+  sip_config {
+    create_conversation_on_the_fly = true
+    inactive_start = true
+    max_audio_recording_duration = "300s"
+    allow_virtual_agent_interaction = true
+    keep_conversation_running = true
+    copy_inbound_call_leg_headers = ["X-Header-1"]
+    ignore_reinvite_media_direction = true
+  }
+}
+`, context)
+}
+
+func testAccDialogflowConversationProfile_sipConfigStep3(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_conversation_profile" "profile" {
+  provider = google-beta
+  display_name = "%{profile_name}"
+  location = "europe-west1"
+  language_code = "en-US"
+  sip_config {
+    create_conversation_on_the_fly = true
+    inactive_start = true
+    max_audio_recording_duration = "600s"
+    allow_virtual_agent_interaction = true
+    keep_conversation_running = true
+    copy_inbound_call_leg_headers = ["X-Header-1", "X-Header-2"]
+    ignore_reinvite_media_direction = true
+  }
+}
+`, context)
+}
+
+func testAccDialogflowConversationProfile_sipConfigStep4(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_dialogflow_conversation_profile" "profile" {
+  provider = google-beta
+  display_name = "%{profile_name}"
+  location = "europe-west1"
+  language_code = "en-US"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_conversation_profile_test.go
+++ b/mmv1/third_party/terraform/services/dialogflow/resource_dialogflow_conversation_profile_test.go
@@ -516,13 +516,33 @@ func TestAccDialogflowConversationProfile_sipConfig(t *testing.T) {
 				Config: testAccDialogflowConversationProfile_sipConfigStep1(context),
 			},
 			{
+				ResourceName:      "google_dialogflow_conversation_profile.profile",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccDialogflowConversationProfile_sipConfigStep2(context),
+			},
+			{
+				ResourceName:      "google_dialogflow_conversation_profile.profile",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccDialogflowConversationProfile_sipConfigStep3(context),
 			},
 			{
-				Config: testAccDialogflowConversationProfile_sipConfigStep4(context),
+				ResourceName:      "google_dialogflow_conversation_profile.profile",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDialogflowConversationProfile_sipConfigStep1(context),
+			},
+			{
+				ResourceName:      "google_dialogflow_conversation_profile.profile",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -567,25 +587,9 @@ resource "google_dialogflow_conversation_profile" "profile" {
   location = "europe-west1"
   language_code = "en-US"
   sip_config {
-    create_conversation_on_the_fly = true
-    inactive_start = true
     max_audio_recording_duration = "600s"
-    allow_virtual_agent_interaction = true
-    keep_conversation_running = true
     copy_inbound_call_leg_headers = ["X-Header-1", "X-Header-2"]
-    ignore_reinvite_media_direction = true
   }
-}
-`, context)
-}
-
-func testAccDialogflowConversationProfile_sipConfigStep4(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_dialogflow_conversation_profile" "profile" {
-  provider = google-beta
-  display_name = "%{profile_name}"
-  location = "europe-west1"
-  language_code = "en-US"
 }
 `, context)
 }


### PR DESCRIPTION
Added sipConfig nested object with its fields to ConversationProfile resource. Updated example to use sipConfig and location europe-west1 (more realistic location for SIP related integrations)


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dialogflow: added `sip_config` field to `google_dialogflow_conversation_profile` resource (beta)
```

```release-note:bug
dialogflow: corrected `AUDIOENCODING_SPEEX_WITH_HEADER_BYTE` ENUM value to `AUDIO_ENCODING_SPEEX_WITH_HEADER_BYTE` for `audio_encoding` field in `google_dialogflow_conversation_profile` resource
```
