### PR TITLE
`transport`: add `Resource` in `ListCallOptions`  for refreshing resourceData in listPages

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account.go
@@ -125,6 +125,7 @@ func ListServiceAccounts(config *transport_tpg.Config, project string, callback 
 	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
 		Config:         config,
 		TempData:       d,
+		Resource:       ResourceGoogleServiceAccount(),
 		ListURL:        url,
 		BillingProject: billingProject,
 		UserAgent:      userAgent,

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -202,6 +202,7 @@ func IsApiNotEnabledError(err error) bool {
 type ListPagesOptions struct {
 	Config         *Config
 	TempData       *schema.ResourceData
+	Resource       *schema.Resource
 	ListURL        string
 	BillingProject string
 	UserAgent      string
@@ -250,18 +251,20 @@ func ListPages(opt ListPagesOptions) error {
 			items, ok = res["items"].([]interface{})
 		}
 		if ok {
+			// Capture the seed state once per page. State() returns a snapshot, so reads
+			// here are unaffected by anything the flattener writes on prior iterations.
+			seedState := opt.TempData.State()
 			for _, item := range items {
 				itemMap, ok := item.(map[string]interface{})
 				if !ok {
 					return fmt.Errorf("expected item to be map[string]interface{}, got %T", item)
 				}
 
-				err = opt.Flattener(itemMap, opt.TempData, opt.Config)
-				if err != nil {
+				itemResourceData := opt.Resource.Data(seedState)
+				if err := opt.Flattener(itemMap, itemResourceData, opt.Config); err != nil {
 					return fmt.Errorf("Error flattening instance: %s", err)
 				}
-				err = opt.Callback(opt.TempData)
-				if err != nil {
+				if err := opt.Callback(itemResourceData); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

When reviewing the following PR:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17500#discussion_r3236262375

we run into an issue where the flatteners produced on the target handwritten resource do not overwrite all fields leading to failures on tests and the need to manually integrate the list call on the list resource itself instead of relying on the existing `ListPages`.

Resolving this would be introducing a refresh of the resourceData for every item that's  in the list method response.

each item contains the seedResourceData which contains the list configure values that are set prior to the listPages call.

a new field in `ListCallOptions` is necessary in order to call the resource schema:
```hcl
			seedState := opt.TempData.State() <-- new
			for _, item := range items {
				itemMap, ok := item.(map[string]interface{})
				if !ok {
					return fmt.Errorf("expected item to be map[string]interface{}, got %T", item)
				}

				itemResourceData := opt.Resource.Data(seedState) <-- new
				if err := opt.Flattener(itemMap, itemResourceData, opt.Config); err != nil {
					return fmt.Errorf("Error flattening instance: %s", err)
				}
				if err := opt.Callback(itemResourceData); err != nil {
```

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
