### PR TITLE
Autoscaler stabilization_period field support

### DIFF
--- a/mmv1/products/compute/Autoscaler.yaml
+++ b/mmv1/products/compute/Autoscaler.yaml
@@ -153,6 +153,16 @@ properties:
           and time the startup process.
         api_name: coolDownPeriodSec
         default_value: 60
+      - name: 'stabilizationPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler waits for load stabilization
+          before making scale-in decisions.
+
+          This might appear as a delay in scaling in but it is an important mechanism
+          for your application to not have fluctuating size due to short term load
+          fluctuations.
+        api_name: stabilizationPeriodSec
       - name: 'mode'
         type: String
         description: |

--- a/mmv1/products/compute/RegionAutoscaler.yaml
+++ b/mmv1/products/compute/RegionAutoscaler.yaml
@@ -132,6 +132,16 @@ properties:
           and time the startup process.
         api_name: coolDownPeriodSec
         default_value: 60
+      - name: 'stabilizationPeriod'
+        type: Integer
+        description: |
+          The number of seconds that the autoscaler waits for load stabilization
+          before making scale-in decisions.
+
+          This might appear as a delay in scaling in but it is an important mechanism
+          for your application to not have fluctuating size due to short term load
+          fluctuations.
+        api_name: stabilizationPeriodSec
       - name: 'mode'
         type: String
         description: |

--- a/mmv1/templates/terraform/examples/autoscaler_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/autoscaler_basic.tf.tmpl
@@ -7,6 +7,7 @@ resource "google_compute_autoscaler" "foobar" {
     max_replicas    = 5
     min_replicas    = 1
     cooldown_period = 60
+    stabilization_period = 300
 
     cpu_utilization {
       target = 0.5

--- a/mmv1/templates/terraform/examples/autoscaler_single_instance.tf.tmpl
+++ b/mmv1/templates/terraform/examples/autoscaler_single_instance.tf.tmpl
@@ -9,6 +9,7 @@ resource "google_compute_autoscaler" "{{$.PrimaryResourceId}}" {
     max_replicas    = 5
     min_replicas    = 1
     cooldown_period = 60
+    stabilization_period = 300
 
     metric {
       name                       = "pubsub.googleapis.com/subscription/num_undelivered_messages"

--- a/mmv1/templates/terraform/examples/region_autoscaler_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_autoscaler_basic.tf.tmpl
@@ -7,6 +7,7 @@ resource "google_compute_region_autoscaler" "{{$.PrimaryResourceId}}" {
     max_replicas    = 5
     min_replicas    = 1
     cooldown_period = 60
+    stabilization_period = 300
 
     cpu_utilization {
       target = 0.5


### PR DESCRIPTION
This PR adds support for `stabilization_period` field to `google_compute_autoscaler` and `google_compute_region_autoscaler` resources.

This filed is GA in compute API.

Fixes b/509493285.

```release-note:enhancement
compute: added `stabilization_period` field to `google_compute_autoscaler` and `google_compute_region_autoscaler` resources
```
