### PR TITLE
feat(networkservices): add DNS peering config to AgentGateway:

### DIFF
--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -43,6 +43,10 @@ examples:
     primary_resource_id: 'default'
     vars:
       name: 'my-full-agent-gateway'
+      network_name: 'my-gateway-network'
+      subnetwork_name: 'my-gateway-subnetwork'
+      network_attachment_name: 'my-gateway-attachment'
+      dns_zone_name: 'my-gateway-zone'
     test_env_vars:
       project: 'PROJECT_NAME'
   - name: 'network_services_agent_gateway_client_to_agent'
@@ -171,6 +175,35 @@ properties:
             diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
             description: |
               The URI of the Network Attachment resource.
+      - name: 'dnsPeeringConfig'
+        type: NestedObject
+        description: |
+          DNS peering configuration for the AgentGateway. When set, the
+          AgentGateway will resolve queries for the configured `domains` via
+          Cloud DNS in the specified `targetNetwork`.
+        properties:
+          - name: 'domains'
+            type: Array
+            required: true
+            description: |
+              The list of domain names to peer for DNS resolution. Each entry
+              must be a fully qualified domain name ending with a dot
+              (for example, `example.com.`).
+            item_type:
+              type: String
+          - name: 'targetProject'
+            type: String
+            required: true
+            description: |
+              The ID of the project that hosts the target VPC network for DNS
+              peering.
+          - name: 'targetNetwork'
+            type: String
+            required: true
+            diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+            description: |
+              The URI of the target VPC network for DNS peering. Must be of the
+              form `projects/{project}/global/networks/{network}`.
   - name: 'agentGatewayCard'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
@@ -1,3 +1,5 @@
+data "google_project" "project" {}
+
 resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "name"}}"
   location = "us-central1"
@@ -20,6 +22,12 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
     egress {
       network_attachment = google_compute_network_attachment.default.id
     }
+
+    dns_peering_config {
+      domains        = [google_dns_managed_zone.default.dns_name]
+      target_project = data.google_project.project.project_id
+      target_network = google_compute_network.default.id
+    }
   }
 
   depends_on = [google_project_service.agent_registry]
@@ -31,20 +39,36 @@ resource "google_project_service" "agent_registry" {
 }
 
 resource "google_compute_network" "default" {
-  name                    = "net-{{index $.Vars "name"}}"
+  name                    = "{{index $.Vars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "subnet-{{index $.Vars "name"}}"
+  name          = "{{index $.Vars "subnetwork_name"}}"
   region        = "us-central1"
   network       = google_compute_network.default.id
   ip_cidr_range = "10.0.0.0/16"
 }
 
 resource "google_compute_network_attachment" "default" {
-  name                  = "na-{{index $.Vars "name"}}"
+  name                  = "{{index $.Vars "network_attachment_name"}}"
   region                = "us-central1"
-  connection_preference = "ACCEPT_AUTOMATIC"
-  subnetworks           = [google_compute_subnetwork.default.self_link]
+  connection_preference = "ACCEPT_MANUAL"
+
+  subnetworks = [
+    google_compute_subnetwork.default.id,
+  ]
+}
+
+resource "google_dns_managed_zone" "default" {
+  name        = "{{index $.Vars "dns_zone_name"}}"
+  dns_name    = "example.com."
+  description = "Private zone used by AgentGateway DNS peering"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = google_compute_network.default.id
+    }
+  }
 }


### PR DESCRIPTION
Adds the dnsPeeringConfig nested object under privateConnectivity.egress
on google_network_services_agent_gateway, allowing users to specify
domains, targetProject, and targetNetwork so the gateway resolves
queries via Cloud DNS in a peered VPC. 

### Beta Provider Test Log
```
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta/services/networkservices -v -run=TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
=== PAUSE TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
=== CONT  TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
--- PASS: TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample (590.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-google-beta/google-beta/services/networkservices	590.908s
```

### GA Provider Test Log
```
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/networkservices -v -run=TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
=== PAUSE TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
=== CONT  TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample
--- PASS: TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample (712.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/networkservices	713.119s
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
networkservices: added `dns_peering_config` field to `google_network_services_agent_gateway` resource
```
