### PR TITLE
mark encryption keys as immutable and sensitive across compute and backupdr resources

### DIFF
--- a/mmv1/products/backupdr/RestoreWorkload.yaml
+++ b/mmv1/products/backupdr/RestoreWorkload.yaml
@@ -303,13 +303,16 @@ properties:
             - name: 'diskEncryptionKey'
               type: NestedObject
               description: 'Optional. Encrypts or decrypts a disk using a customer-supplied encryption key.'
+              immutable: true
               properties:
                 - name: 'rawKey'
                   type: String
                   description: 'Optional. Specifies a 256-bit customer-supplied encryption key.'
+                  sensitive: true
                 - name: 'rsaEncryptedKey'
                   type: String
                   description: 'Optional. RSA-wrapped 2048-bit customer-supplied encryption key.'
+                  sensitive: true
                 - name: 'kmsKeyName'
                   type: String
                   description: 'Optional. The name of the encryption key that is stored in Google Cloud KMS.'
@@ -360,11 +363,14 @@ properties:
       - name: 'instanceEncryptionKey'
         type: NestedObject
         description: 'Optional. Encrypts suspended data for an instance with a customer-managed encryption key.'
+        immutable: true
         properties:
           - name: 'rawKey'
             type: String
+            sensitive: true
           - name: 'rsaEncryptedKey'
             type: String
+            sensitive: true
           - name: 'kmsKeyName'
             type: String
           - name: 'kmsKeyServiceAccount'
@@ -708,11 +714,14 @@ properties:
       - name: 'diskEncryptionKey'
         type: NestedObject
         description: 'Optional. Encrypts the disk using a customer-supplied encryption key.'
+        immutable: true
         properties:
           - name: 'rawKey'
             type: String
+            sensitive: true
           - name: 'rsaEncryptedKey'
             type: String
+            sensitive: true
           - name: 'kmsKeyName'
             type: String
           - name: 'kmsKeyServiceAccount'

--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -123,6 +123,7 @@ properties:
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
+        sensitive: true
       - name: 'sha256'
         type: String
         description: |
@@ -241,6 +242,7 @@ properties:
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
+        sensitive: true
         # TODO Change to ResourceRef once KMS is in Magic Modules
       - name: 'kmsKeySelfLink'
         type: String

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -152,6 +152,7 @@ properties:
       After you encrypt an image with a customer-supplied key, you must
       provide the same key if you use the image later (e.g. to create a
       disk from the image)
+    immutable: true
     properties:
       - name: 'kmsKeySelfLink'
         type: String
@@ -283,6 +284,7 @@ properties:
     description: |
       The customer-supplied encryption key of the source disk. Required if
       the source disk is protected by a customer-supplied encryption key.
+    immutable: true
     properties:
       - name: 'rawKey'
         type: String
@@ -333,6 +335,7 @@ properties:
     description: |
       The customer-supplied encryption key of the source image. Required if
       the source image is protected by a customer-supplied encryption key.
+    immutable: true
     properties:
       - name: 'rawKey'
         type: String
@@ -456,6 +459,7 @@ properties:
     description: |
       The customer-supplied encryption key of the source snapshot. Required if
       the source snapshot is protected by a customer-supplied encryption key.
+    immutable: true
     properties:
       - name: 'rawKey'
         type: String

--- a/mmv1/products/compute/Instance.yaml
+++ b/mmv1/products/compute/Instance.yaml
@@ -110,6 +110,7 @@ properties:
           description: |
             Encrypts or decrypts a disk using a customer-supplied
             encryption key.
+          immutable: true
           properties:
             - name: 'rawKey'
               type: String
@@ -117,12 +118,14 @@ properties:
                 Specifies a 256-bit customer-supplied encryption key,
                 encoded in RFC 4648 base64 to either encrypt or decrypt
                 this resource.
+              sensitive: true
             - name: 'rsaEncryptedKey'
               type: String
               description: |
                 Specifies an RFC 4648 base64 encoded, RSA-wrapped
                 2048-bit customer-supplied encryption key to either
                 encrypt or decrypt this resource.
+              sensitive: true
             - name: 'sha256'
               type: String
               description: |
@@ -210,6 +213,7 @@ properties:
                 encryption keys, so you cannot create disks for
                 instances in a managed instance group if the source
                 images are encrypted with your own keys.
+              immutable: true
               properties:
                 - name: 'rawKey'
                   type: String
@@ -217,6 +221,7 @@ properties:
                     Specifies a 256-bit customer-supplied encryption
                     key, encoded in RFC 4648 base64 to either encrypt
                     or decrypt this resource.
+                  sensitive: true
                 - name: 'sha256'
                   type: String
                   description: |

--- a/mmv1/products/compute/MachineImage.yaml
+++ b/mmv1/products/compute/MachineImage.yaml
@@ -109,6 +109,7 @@ properties:
       provide the same key if you use the machine image later (e.g. to create a
       instance from the image)
     min_version: beta
+    immutable: true
     properties:
       - name: rawKey
         type: String
@@ -116,6 +117,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         min_version: beta
+        sensitive: true
       - name: sha256
         type: String
         description: |

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -173,6 +173,7 @@ properties:
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
+        sensitive: true
         # TODO Change to ResourceRef once KMS is in Magic Modules
       - name: 'kmsKeyName'
         type: String

--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -113,6 +113,7 @@ parameters:
       If you do not provide an encryption key when creating the snapshot,
       then the snapshot will be encrypted using an automatically generated
       key and you do not need to provide a key to use the snapshot later.
+    immutable: true
     properties:
       - name: 'rawKey'
         type: String
@@ -154,6 +155,7 @@ parameters:
       if the source snapshot is protected by a customer-supplied encryption
       key.
     ignore_read: true
+    immutable: true
     properties:
       - name: 'rawKey'
         type: String


### PR DESCRIPTION
```release-note:bug
compute: mark encryption keys as immutable and sensitive across compute and backupdr resources
```
