### PR TITLE
add is_missing_in_cai attribute to encryption key fields in compute

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -124,6 +124,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        is_missing_in_cai: true
       - name: 'sha256'
         type: String
         description: |
@@ -243,6 +244,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        is_missing_in_cai: true
         # TODO Change to ResourceRef once KMS is in Magic Modules
       - name: 'kmsKeySelfLink'
         type: String

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -174,6 +174,7 @@ properties:
           RFC 4648 base64 to either encrypt or decrypt this resource.
         ignore_read: true
         sensitive: true
+        is_missing_in_cai: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |
@@ -181,6 +182,7 @@ properties:
           RFC 4648 base64 to either encrypt or decrypt this resource.
         ignore_read: true
         sensitive: true
+        is_missing_in_cai: true
   - name: 'labels'
     type: KeyValueLabels
     description: Labels to apply to this Image.
@@ -287,12 +289,14 @@ properties:
       - name: 'rawKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
       - name: 'rsaEncryptedKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit
           customer-supplied encryption key to either encrypt or decrypt
@@ -337,12 +341,14 @@ properties:
       - name: 'rawKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
       - name: 'rsaEncryptedKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit
           customer-supplied encryption key to either encrypt or decrypt
@@ -460,12 +466,14 @@ properties:
       - name: 'rawKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
       - name: 'rsaEncryptedKey'
         type: String
         sensitive: true
+        is_missing_in_cai: true
         description: |
           Specifies an RFC 4648 base64 encoded, RSA-wrapped 2048-bit
           customer-supplied encryption key to either encrypt or decrypt

--- a/mmv1/products/compute/MachineImage.yaml
+++ b/mmv1/products/compute/MachineImage.yaml
@@ -116,6 +116,8 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         min_version: beta
+        sensitive: true
+        is_missing_in_cai: true
       - name: sha256
         type: String
         description: |

--- a/mmv1/products/compute/RegionDisk.yaml
+++ b/mmv1/products/compute/RegionDisk.yaml
@@ -237,6 +237,7 @@ properties:
           Specifies a 256-bit customer-supplied encryption key, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        is_missing_in_cai: true
         # TODO Change to ResourceRef once KMS is in Magic Modules
       - name: 'kmsKeyName'
         type: String

--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -121,6 +121,7 @@ parameters:
           RFC 4648 base64 to either encrypt or decrypt this resource.
         ignore_read: true
         sensitive: true
+        is_missing_in_cai: true
         custom_flatten: 'templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.tmpl'
       - name: 'rsaEncryptedKey'
         type: String
@@ -129,6 +130,7 @@ parameters:
           RFC 4648 base64 to either encrypt or decrypt this resource.
         ignore_read: true
         sensitive: true
+        is_missing_in_cai: true
       - name: 'sha256'
         type: String
         description: |
@@ -162,12 +164,14 @@ parameters:
           RFC 4648 base64 to either encrypt or decrypt this resource.
         # The docs list this field but it is never returned.
         sensitive: true
+        is_missing_in_cai: true
       - name: 'rsaEncryptedKey'
         type: String
         description: |
           Specifies an encryption key stored in Google Cloud KMS, encoded in
           RFC 4648 base64 to either encrypt or decrypt this resource.
         sensitive: true
+        is_missing_in_cai: true
       - name: 'kmsKeySelfLink'
         type: String
         description: |


### PR DESCRIPTION
Add is_missing_in_cai attribute to encryption key fields in compute.  This prevents the user-provided raw encryption key to be exported to Google Cloud Asset Inventory (CAI) during Terraform's CAI export process. CAI is frequently used, and exporting encryption keys into asset inventory pipelines defeats the purpose of Customer Suppled Encryption Keys (CSEK).

```release-note:bug
compute: add is_missing_in_cai attribute to encryption key fields in compute resources
```
