### PR TITLE
Extend manage-test-failure-ticket to auto-close 50% failing test tickets

### DIFF
--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -106,9 +106,6 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 	gaTestFailuresMap := make(map[string][]bool)
 	betaTestFailuresMap := make(map[string][]bool)
 
-	fmt.Println("Getting test status for past 14 days")
-	fmt.Println("date is", now)
-
 	err = lastNDaysTestNonSuccessMap(provider.GA, 14, now, gcs, gaTestFailuresMap)
 	if err != nil {
 		return err
@@ -183,9 +180,7 @@ func closeResolvedTickets(ctx context.Context, gh *github.Client, label string, 
 }
 
 func lastNDaysTestNonSuccessMap(pVersion provider.Version, n int, now time.Time, gcs CloudstorageClient, testFailuresMap map[string][]bool) error {
-	fmt.Println("Getting test status for past", n, "days")
 	for i := 0; i < n; i++ {
-		fmt.Println("Getting test status for date -", i)
 		date := now.AddDate(0, 0, -i)
 		testInfoList, err := getTestInfoList(pVersion, date, gcs)
 		if err != nil {

--- a/.ci/magician/cmd/manage_test_failure_ticket.go
+++ b/.ci/magician/cmd/manage_test_failure_ticket.go
@@ -42,7 +42,7 @@ var manageTestFailureTicketCmd = &cobra.Command{
 	 It performs the following operations:
 	 1. Lists out GitHub issues with test-failure and forward/review labels.
 	 2. Removes forward/review labels from these issues.
-	 3. Closes 100% test ticket if it starts to pass for 3 days
+	 3. Closes 100% test tickets if they pass for 3 days, and 50% test tickets if they pass for 14 days.
  
 	 The following environment variables are required:
  ` + listMTFTRequiredEnvironmentVariables(),
@@ -102,20 +102,42 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 		}
 	}
 
-	// Get Test status for past 3 days
+	// Get Test status for past 14 days
 	gaTestFailuresMap := make(map[string][]bool)
 	betaTestFailuresMap := make(map[string][]bool)
 
-	lastNDaysTestNonSuccessMap(provider.GA, 3, now, gcs, gaTestFailuresMap)
-	lastNDaysTestNonSuccessMap(provider.Beta, 3, now, gcs, betaTestFailuresMap)
+	fmt.Println("Getting test status for past 14 days")
+	fmt.Println("date is", now)
 
-	// Get 100% failing test tickets
-	opts = &github.IssueListByRepoOptions{
+	err = lastNDaysTestNonSuccessMap(provider.GA, 14, now, gcs, gaTestFailuresMap)
+	if err != nil {
+		return err
+	}
+	err = lastNDaysTestNonSuccessMap(provider.Beta, 14, now, gcs, betaTestFailuresMap)
+	if err != nil {
+		return err
+	}
+
+	err = closeResolvedTickets(ctx, gh, "test-failure-100", 3, gaTestFailuresMap, betaTestFailuresMap)
+	if err != nil {
+		return err
+	}
+
+	err = closeResolvedTickets(ctx, gh, "test-failure-50", 14, gaTestFailuresMap, betaTestFailuresMap)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func closeResolvedTickets(ctx context.Context, gh *github.Client, label string, daysToCheck int, gaTestFailuresMap, betaTestFailuresMap map[string][]bool) error {
+	opts := &github.IssueListByRepoOptions{
 		State:       "open",
-		Labels:      []string{"test-failure-100"},
+		Labels:      []string{label},
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
-	issues, err = ListIssuesWithOpts(ctx, gh, opts)
+	issues, err := ListIssuesWithOpts(ctx, gh, opts)
 	if err != nil {
 		return err
 	}
@@ -133,12 +155,12 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 			continue
 		}
 
-		if shouldCloseTestTicket(tests, gaTestFailuresMap, betaTestFailuresMap) {
+		if shouldCloseTestTicket(tests, gaTestFailuresMap, betaTestFailuresMap, daysToCheck) {
 			shouldCloseTickets = append(shouldCloseTickets, issue.GetNumber())
 		}
 	}
 
-	comment := "All failing tests listed in this ticket have passed in the last three consecutive nightly runs. Closing the ticket."
+	comment := fmt.Sprintf("All failing tests listed in this ticket have passed in the last %d consecutive nightly runs. Closing the ticket.", daysToCheck)
 	for _, ticketNumber := range shouldCloseTickets {
 		fmt.Println("Closing ticket ", ticketNumber)
 		issueComment := &github.IssueComment{
@@ -161,7 +183,9 @@ func execManageTestFailureTicket(now time.Time, gh *github.Client, gcs Cloudstor
 }
 
 func lastNDaysTestNonSuccessMap(pVersion provider.Version, n int, now time.Time, gcs CloudstorageClient, testFailuresMap map[string][]bool) error {
+	fmt.Println("Getting test status for past", n, "days")
 	for i := 0; i < n; i++ {
+		fmt.Println("Getting test status for date -", i)
 		date := now.AddDate(0, 0, -i)
 		testInfoList, err := getTestInfoList(pVersion, date, gcs)
 		if err != nil {
@@ -178,7 +202,7 @@ func lastNDaysTestNonSuccessMap(pVersion provider.Version, n int, now time.Time,
 	return nil
 }
 
-func shouldCloseTestTicket(tests []string, gaTestFailuresMap, betaTestFailuresMap map[string][]bool) bool {
+func shouldCloseTestTicket(tests []string, gaTestFailuresMap, betaTestFailuresMap map[string][]bool, daysToCheck int) bool {
 	for _, test := range tests {
 		gaFailures, foundGaTest := gaTestFailuresMap[test]
 		betaFailures, foundBetaTest := betaTestFailuresMap[test]
@@ -189,15 +213,15 @@ func shouldCloseTestTicket(tests []string, gaTestFailuresMap, betaTestFailuresMa
 		}
 
 		if foundGaTest {
-			for _, fail := range gaFailures {
-				if fail {
+			for i := 0; i < daysToCheck; i++ {
+				if gaFailures[i] {
 					return false
 				}
 			}
 		}
 		if foundBetaTest {
-			for _, fail := range betaFailures {
-				if fail {
+			for i := 0; i < daysToCheck; i++ {
+				if betaFailures[i] {
 					return false
 				}
 			}


### PR DESCRIPTION
Auto-close issues labeled `test-failure-50` after 14 consecutive days of passing tests

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
