### PR TITLE
Migrate resource compute instance from machine image and test to use …

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image.go.tmpl
@@ -11,12 +11,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceComputeInstanceFromMachineImage() *schema.Resource {
@@ -147,23 +141,52 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
+	// Force send all top-level fields that have been set in case they're overridden to zero values.
+	// Initialize ForceSendFields to empty so we don't get things that the instance resource
+	// always force-sends.
+	instance.ForceSendFields = []string{}
+	for f, s := range computeInstanceFromMachineImageSchema() {
+		// It seems that GetOkExists always returns true for sets.
+		// TODO: confirm this and file issue against Terraform core.
+		// In the meantime, don't force send sets.
+		if s.Type == schema.TypeSet {
+			continue
+		}
+
+		if _, exists := d.GetOkExists(f); exists {
+			// Assume for now that all fields are exact snake_case versions of the API fields.
+			// This won't necessarily always be true, but it serves as a good approximation and
+			// can be adjusted later as we discover issues.
+			instance.ForceSendFields = append(instance.ForceSendFields,  tpgresource.SnakeToPascalCase(f))
+		}
+	}
+
+	instanceBytes, err := json.Marshal(instance)
+	if err != nil {
+		return fmt.Errorf("Error marshaling instance: %s", err)
+	}
+	var instanceBody map[string]interface{}
+	if err = json.Unmarshal(instanceBytes, &instanceBody); err != nil {
+		return fmt.Errorf("Error processing instance body: %s", err)
+	}
+
 	sa := d.Get("service_account").([]interface{})
 	if len(sa) == 0 {
 		// ServiceAccount is required when the image is from a different project
-		accounts := make([]*compute.ServiceAccount, 1)
-		accounts[0] = &compute.ServiceAccount{
-			Email:  "default",
-			Scopes: nil,
+		instanceBody["serviceAccounts"] = []map[string]interface{}{
+			{
+				"email":  "default",
+				"scopes": nil,
+			},
 		}
-		instance.ServiceAccounts = accounts
 	}
 
 	src := d.Get("source_machine_image").(string)
-	instance.SourceMachineImage = src
+	instanceBody["sourceMachineImage"] = src
 
 	// Add source machine image encryption key if specified
 	if encryptionKey := expandSourceMachineImageEncryptionKey(d); encryptionKey != nil {
-		instance.SourceMachineImageEncryptionKey = encryptionKey
+		instanceBody["sourceMachineImageEncryptionKey"] = encryptionKey
 	}
 
 	tpl, err := tpgresource.ParseMachineImageFieldValue(src, d, config)
@@ -187,54 +210,23 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 		return err
 	}
 
-	instance.Disks, err = adjustInstanceFromMachineImageDisks(d, config, miRes, project)
+	disks, err := adjustInstanceFromMachineImageDisks(d, config, miRes, project)
 	if err != nil {
 		return err
 	}
+	instanceBody["disks"] = disks
 
 	// when we make the original call to expandComputeInstance expandScheduling is called, which sets default values.
 	// However, we want the values to be read from the machine image instead.
 	if _, hasSchedule := d.GetOk("scheduling"); !hasSchedule {
 		if srcProps, ok := miRes["sourceInstanceProperties"].(map[string]interface{}); ok {
 			if schedulingRaw, ok := srcProps["scheduling"]; ok {
-				schedBytes, _ := json.Marshal(schedulingRaw)
-				var sched compute.Scheduling
-				if jsonErr := json.Unmarshal(schedBytes, &sched); jsonErr == nil {
-					instance.Scheduling = &sched
-				}
+				instanceBody["scheduling"] = schedulingRaw
 			}
 		}
 	}
 
-	// Force send all top-level fields that have been set in case they're overridden to zero values.
-	// Initialize ForceSendFields to empty so we don't get things that the instance resource
-	// always force-sends.
-	instance.ForceSendFields = []string{}
-	for f, s := range computeInstanceFromMachineImageSchema() {
-		// It seems that GetOkExists always returns true for sets.
-		// TODO: confirm this and file issue against Terraform core.
-		// In the meantime, don't force send sets.
-		if s.Type == schema.TypeSet {
-			continue
-		}
-
-		if _, exists := d.GetOkExists(f); exists {
-			// Assume for now that all fields are exact snake_case versions of the API fields.
-			// This won't necessarily always be true, but it serves as a good approximation and
-			// can be adjusted later as we discover issues.
-			instance.ForceSendFields = append(instance.ForceSendFields,  tpgresource.SnakeToPascalCase(f))
-		}
-	}
-
 	log.Printf("[INFO] Requesting instance creation")
-	instanceBytes, err := json.Marshal(instance)
-	if err != nil {
-		return fmt.Errorf("Error marshaling instance: %s", err)
-	}
-	var instanceBody map[string]interface{}
-	if err = json.Unmarshal(instanceBytes, &instanceBody); err != nil {
-		return fmt.Errorf("Error processing instance body: %s", err)
-	}
 	insertURL := fmt.Sprintf("%sprojects/%s/zones/%s/instances", transport_tpg.BaseUrl(Product, config), project, z)
 	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
@@ -249,7 +241,8 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 	}
 
 	// Store the ID now
-	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
+	instanceName, _ := instanceBody["name"].(string)
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instanceName))
 
 	// Wait for the operation to complete
 	err = ComputeOperationWaitTime(config, res, project,
@@ -265,8 +258,8 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 
 // Instances have disks spread across multiple schema properties. This function
 // ensures that overriding one of these properties does not override the others.
-func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transport_tpg.Config, miRes map[string]interface{}, project string) ([]*compute.AttachedDisk, error) {
-	disks := []*compute.AttachedDisk{}
+func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transport_tpg.Config, miRes map[string]interface{}, project string) ([]interface{}, error) {
+	disks := []interface{}{}
 
 	var miDisks []interface{}
 	if srcProps, ok := miRes["sourceInstanceProperties"].(map[string]interface{}); ok {
@@ -280,7 +273,11 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 		if err != nil {
 			return nil, err
 		}
-		disks = append(disks, bootDisk)
+		bdMap, err := attachedDiskToMap(bootDisk)
+		if err != nil {
+			return nil, err
+		}
+		disks = append(disks, bdMap)
 	} else {
 		// boot disk was not overridden, so use the one from the machine image
 		for _, rawDisk := range miDisks {
@@ -292,10 +289,10 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 				autoDelete, _ := disk["autoDelete"].(bool)
 				diskType, _ := disk["type"].(string)
 				deviceName, _ := disk["deviceName"].(string)
-				newdisk := &compute.AttachedDisk{
-					AutoDelete: autoDelete,
-					Type:       diskType,
-					DeviceName: deviceName,
+				newdisk := map[string]interface{}{
+					"autoDelete": autoDelete,
+					"type":       diskType,
+					"deviceName": deviceName,
 				}
 				disks = append(disks, newdisk)
 				break
@@ -308,7 +305,13 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 		if err != nil {
 			return nil, err
 		}
-		disks = append(disks, scratchDisks...)
+		for _, sd := range scratchDisks {
+			sdMap, err := attachedDiskToMap(sd)
+			if err != nil {
+				return nil, err
+			}
+			disks = append(disks, sdMap)
+		}
 	} else {
 		// scratch disks were not overridden, so use the ones from the machine image
 		for _, rawDisk := range miDisks {
@@ -320,10 +323,10 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 			if diskType == "SCRATCH" {
 				autoDelete, _ := disk["autoDelete"].(bool)
 				deviceName, _ := disk["deviceName"].(string)
-				newdisk := &compute.AttachedDisk{
-					AutoDelete: autoDelete,
-					Type:       "SCRATCH",
-					DeviceName: deviceName,
+				newdisk := map[string]interface{}{
+					"autoDelete": autoDelete,
+					"type":       "SCRATCH",
+					"deviceName": deviceName,
 				}
 				disks = append(disks, newdisk)
 			}
@@ -339,7 +342,11 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 				return nil, err
 			}
 
-			disks = append(disks, disk)
+			dMap, err := attachedDiskToMap(disk)
+			if err != nil {
+				return nil, err
+			}
+			disks = append(disks, dMap)
 		}
 	} else {
 		// attached disks were not overridden, so use the ones from the machine image
@@ -353,10 +360,10 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 			if !isBoot && diskType != "SCRATCH" {
 				autoDelete, _ := disk["autoDelete"].(bool)
 				deviceName, _ := disk["deviceName"].(string)
-				newdisk := &compute.AttachedDisk{
-					AutoDelete: autoDelete,
-					Type:       diskType,
-					DeviceName: deviceName,
+				newdisk := map[string]interface{}{
+					"autoDelete": autoDelete,
+					"type":       diskType,
+					"deviceName": deviceName,
 				}
 				disks = append(disks, newdisk)
 			}
@@ -366,7 +373,19 @@ func adjustInstanceFromMachineImageDisks(d *schema.ResourceData, config *transpo
 	return disks, nil
 }
 
-func expandSourceMachineImageEncryptionKey(d tpgresource.TerraformResourceData) *compute.CustomerEncryptionKey {
+func attachedDiskToMap(disk interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(disk)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func expandSourceMachineImageEncryptionKey(d tpgresource.TerraformResourceData) map[string]interface{} {
 	if v, ok := d.GetOk("source_machine_image_encryption_key"); !ok || v == nil {
 		return nil
 	}
@@ -375,56 +394,64 @@ func expandSourceMachineImageEncryptionKey(d tpgresource.TerraformResourceData) 
 	if len(encryptionKeyList) == 0 || encryptionKeyList[0] == nil {
 		return nil
 	}
-	
+
 	encryptionKeyMap := encryptionKeyList[0].(map[string]interface{})
-	encryptionKey := &compute.CustomerEncryptionKey{}
-	
+	encryptionKey := map[string]interface{}{}
+
 	if rawKey, ok := encryptionKeyMap["raw_key"]; ok && rawKey != "" {
-		encryptionKey.RawKey = rawKey.(string)
+		encryptionKey["rawKey"] = rawKey.(string)
 	}
-	
+
 	if rsaKey, ok := encryptionKeyMap["rsa_encrypted_key"]; ok && rsaKey != "" {
-		encryptionKey.RsaEncryptedKey = rsaKey.(string)
+		encryptionKey["rsaEncryptedKey"] = rsaKey.(string)
 	}
-	
+
 	if kmsKey, ok := encryptionKeyMap["kms_key_name"]; ok && kmsKey != "" {
-		encryptionKey.KmsKeyName = kmsKey.(string)
+		encryptionKey["kmsKeyName"] = kmsKey.(string)
 	}
-	
+
 	if kmsKeyServiceAccount, ok := encryptionKeyMap["kms_key_service_account"]; ok && kmsKeyServiceAccount != "" {
-		encryptionKey.KmsKeyServiceAccount = kmsKeyServiceAccount.(string)
+		encryptionKey["kmsKeyServiceAccount"] = kmsKeyServiceAccount.(string)
 	}
-	
+
+	if len(encryptionKey) == 0 {
+		return nil
+	}
+
 	return encryptionKey
 }
 
-func flattenSourceMachineImageEncryptionKey(key *compute.CustomerEncryptionKey) []map[string]interface{} {
+func flattenSourceMachineImageEncryptionKey(key map[string]interface{}) []map[string]interface{} {
 	if key == nil {
 		return nil
 	}
-	
+
 	m := map[string]interface{}{}
-	
-	if key.RawKey != "" {
-		m["raw_key"] = key.RawKey
+
+	if rawKey, ok := key["rawKey"].(string); ok && rawKey != "" {
+		m["raw_key"] = rawKey
 	}
-	
-	if key.RsaEncryptedKey != "" {
-		m["rsa_encrypted_key"] = key.RsaEncryptedKey
+
+	if rsaKey, ok := key["rsaEncryptedKey"].(string); ok && rsaKey != "" {
+		m["rsa_encrypted_key"] = rsaKey
 	}
-	
-	if key.KmsKeyName != "" {
-		m["kms_key_name"] = key.KmsKeyName
+
+	if kmsKey, ok := key["kmsKeyName"].(string); ok && kmsKey != "" {
+		m["kms_key_name"] = kmsKey
 	}
-	
-	if key.KmsKeyServiceAccount != "" {
-		m["kms_key_service_account"] = key.KmsKeyServiceAccount
+
+	if kmsKeyServiceAccount, ok := key["kmsKeyServiceAccount"].(string); ok && kmsKeyServiceAccount != "" {
+		m["kms_key_service_account"] = kmsKeyServiceAccount
 	}
-	
-	if key.Sha256 != "" {
-		m["sha256"] = key.Sha256
+
+	if sha256, ok := key["sha256"].(string); ok && sha256 != "" {
+		m["sha256"] = sha256
 	}
-	
+
+	if len(m) == 0 {
+		return nil
+	}
+
 	return []map[string]interface{}{m}
 }
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_machine_image_test.go.tmpl
@@ -50,7 +50,11 @@ func TestAccComputeInstanceFromMachineImage_maxRunDuration(t *testing.T) {
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	generatedInstanceName := fmt.Sprintf("tf-test-generated-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_machine_image.foobar"
-	var expectedMaxRunDuration = map[string]interface{}{"nanos": float64(123), "seconds": "60"}
+	// Define in testAccComputeInstanceFromMachineImage_maxRunDuration
+	expectedMaxRunDuration := map[string]interface{}{
+		"nanos":   float64(123),
+		"seconds": "60",
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -139,7 +143,10 @@ func TestAccComputeInstanceFromMachineImage_localSsdRecoveryTimeout(t *testing.T
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	generatedInstanceName := fmt.Sprintf("tf-test-generated-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_machine_image.foobar"
-	var expectedLocalSsdRecoveryTimeout = map[string]interface{}{"nanos": float64(0), "seconds": "3600"}
+	expectedLocalSsdRecoveryTimeout := map[string]interface{}{
+		"nanos":   float64(0),
+    "seconds": "3600",
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -164,7 +171,10 @@ func TestAccComputeInstanceFromMachineImageWithOverride_localSsdRecoveryTimeout(
 	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
 	generatedInstanceName := fmt.Sprintf("tf-test-generated-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_machine_image.foobar"
-	var expectedLocalSsdRecoveryTimeout = map[string]interface{}{"nanos": float64(0), "seconds": "7200"}
+	expectedLocalSsdRecoveryTimeout := map[string]interface{}{
+		"nanos":   float64(0),
+    "seconds": "7200",
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -191,14 +201,9 @@ func TestAccComputeInstanceFromMachineImageWithOverride_partnerMetadata(t *testi
 	generatedInstanceName := fmt.Sprintf("tf-test-generated-%s", acctest.RandString(t, 10))
 	resourceName := "google_compute_instance_from_machine_image.foobar"
 	var namespace = "test.compute.googleapis.com"
-	expectedPartnerMetadata := make(map[string]map[string]interface{})
-	expectedPartnerMetadata[namespace] = map[string]interface{}{
-		"entries": map[string]interface{}{
-			"key1": "value1",
-			"key2": float64(2),
-			"key3": map[string]interface{}{
-				"key31": "value31",
-			},
+	expectedPartnerMetadata := map[string]interface{}{
+		namespace: map[string]interface{}{
+			"entries": `{"key1": "value1", "key2": 2,"key3": {"key31":"value31"}}`,
 		},
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -1,6 +1,7 @@
 package compute_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -21,13 +22,13 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/compute/v1"
 {{- else }}
 	compute "google.golang.org/api/compute/v0.beta"
 {{- end }}
-	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestMinCpuPlatformDiffSuppress(t *testing.T) {
@@ -5588,10 +5589,10 @@ func testAccCheckComputeInstanceExists(t *testing.T, n string, instance interfac
 		panic("Attempted to check existence of Instance that was nil.")
 	}
 
-	return testAccCheckComputeInstanceExistsInProject(t, n, envvar.GetTestProjectFromEnv(), instance.(*map[string]interface{}))
+	return testAccCheckComputeInstanceExistsInProject(t, n, envvar.GetTestProjectFromEnv(), instance)
 }
 
-func testAccCheckComputeInstanceExistsInProject(t *testing.T, n, p string, instance *map[string]interface{}) resource.TestCheckFunc {
+func testAccCheckComputeInstanceExistsInProject(t *testing.T, n, p string, instance interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -5603,9 +5604,13 @@ func testAccCheckComputeInstanceExistsInProject(t *testing.T, n, p string, insta
 		}
 
 		config := acctest.GoogleProviderConfig(t)
-		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s", transport_tpg.BaseUrl(tpgcompute.Product, config), p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
+		url := fmt.Sprintf("%sprojects/%s/zones/%s/instances/%s",
+			transport_tpg.BaseUrl(tpgcompute.Product, config), p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"])
 		{{- if ne $.TargetVersionName "ga" }}
-		url = fmt.Sprintf("%s?view=FULL", url)
+		url, queryErr := transport_tpg.AddQueryParams(url, map[string]string{"view": "FULL"})
+		if queryErr != nil {
+			return queryErr
+		}
 		{{- end }}
 		found, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
@@ -5618,12 +5623,26 @@ func testAccCheckComputeInstanceExistsInProject(t *testing.T, n, p string, insta
 			return err
 		}
 
-		name, _ := found["name"].(string)
-		if name != rs.Primary.Attributes["name"] {
+		if gotName, _ := found["name"].(string); gotName != rs.Primary.Attributes["name"] {
 			return fmt.Errorf("Instance not found")
 		}
 
-		*instance = found
+		switch dst := instance.(type) {
+		case *compute.Instance:
+			b, err := json.Marshal(found)
+			if err != nil {
+				return fmt.Errorf("Error marshaling instance: %s", err)
+			}
+			var inst compute.Instance
+			if err := json.Unmarshal(b, &inst); err != nil {
+				return fmt.Errorf("Error unmarshaling instance: %s", err)
+			}
+			*dst = inst
+		case *map[string]interface{}:
+			*dst = found
+		default:
+			return fmt.Errorf("unsupported instance type %T", instance)
+		}
 
 		return nil
 	}
@@ -5785,26 +5804,47 @@ func testAccCheckComputeResourcePolicy(instance *map[string]interface{}, schedul
 	}
 }
 
-func testAccCheckComputeInstanceMaxRunDuration(instance *map[string]interface{}, instanceMaxRunDurationWant map[string]interface{}) resource.TestCheckFunc {
+func testAccCheckComputeInstanceMaxRunDuration(instance *map[string]interface{}, instanceMaxRunDurationWant interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance == nil || *instance == nil {
 			return fmt.Errorf("instance is nil")
 		}
-		scheduling, ok := (*instance)["scheduling"].(map[string]interface{})
+		instMap, err := convertToInstanceMap(instance)
+		if err != nil {
+			return fmt.Errorf("error converting instance: %s", err)
+		}
+		sched, ok := instMap["scheduling"].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("no scheduling")
 		}
-		mrd, ok := scheduling["maxRunDuration"].(map[string]interface{})
+		gotMRD, ok := sched["maxRunDuration"].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("no maxRunDuration")
 		}
-
-		if !reflect.DeepEqual(mrd, instanceMaxRunDurationWant) {
-			return fmt.Errorf("got the wrong instance max run duration action: have: %#v; want: %#v", mrd, instanceMaxRunDurationWant)
+		wantMRD, err := convertToInstanceMap(instanceMaxRunDurationWant)
+		if err != nil {
+			return fmt.Errorf("error converting want: %s", err)
+		}
+		if !reflect.DeepEqual(gotMRD, wantMRD) {
+			return fmt.Errorf("got the wrong instance max run duration action: have: %#v; want: %#v", gotMRD, wantMRD)
 		}
 
 		return nil
 	}
+}
+
+// convertToInstanceMap normalizes a typed compute struct or a map[string]interface{}
+// into a map representation via JSON roundtrip, so helpers can work with either input.
+func convertToInstanceMap(v interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func testAccCheckComputeInstanceHasAvailabilityDomain(instance *map[string]interface{}, availabilityDomain int64) resource.TestCheckFunc {
@@ -5826,22 +5866,29 @@ func testAccCheckComputeInstanceHasAvailabilityDomain(instance *map[string]inter
 	}
 }
 
-func testAccCheckComputeInstanceLocalSsdRecoveryTimeout(instance *map[string]interface{}, instanceLocalSsdRecoveryTiemoutWant map[string]interface{}) resource.TestCheckFunc {
+func testAccCheckComputeInstanceLocalSsdRecoveryTimeout(instance *map[string]interface{}, instanceLocalSsdRecoveryTiemoutWant interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance == nil || *instance == nil {
 			return fmt.Errorf("instance is nil")
 		}
-		scheduling, ok := (*instance)["scheduling"].(map[string]interface{})
+		instMap, err := convertToInstanceMap(instance)
+		if err != nil {
+			return fmt.Errorf("error converting instance: %s", err)
+		}
+		sched, ok := instMap["scheduling"].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("no scheduling")
 		}
-		got, ok := scheduling["localSsdRecoveryTimeout"].(map[string]interface{})
+		gotLSRT, ok := sched["localSsdRecoveryTimeout"].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("no localSsdRecoveryTimeout")
 		}
-
-		if !reflect.DeepEqual(got, instanceLocalSsdRecoveryTiemoutWant) {
-			return fmt.Errorf("got the wrong instance local ssd recovery timeout action: have: %#v; want: %#v", got, instanceLocalSsdRecoveryTiemoutWant)
+		wantLSRT, err := convertToInstanceMap(instanceLocalSsdRecoveryTiemoutWant)
+		if err != nil {
+			return fmt.Errorf("error converting want: %s", err)
+		}
+		if !reflect.DeepEqual(gotLSRT, wantLSRT) {
+			return fmt.Errorf("got the wrong instance local ssd recovery timeout action: have: %#v; want: %#v", gotLSRT, wantLSRT)
 		}
 
 		return nil
@@ -5849,29 +5896,72 @@ func testAccCheckComputeInstanceLocalSsdRecoveryTimeout(instance *map[string]int
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
-func testAccCheckComputeInstancePartnerMetadata(instance *map[string]interface{}, expectedPartnerMetadata map[string]map[string]interface{}) resource.TestCheckFunc {
+func testAccCheckComputeInstancePartnerMetadata(instance *map[string]interface{}, expectedPartnerMetadata interface{}) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance == nil || *instance == nil {
 			return fmt.Errorf("instance is nil")
 		}
-		partnerMetadata, ok := (*instance)["partnerMetadata"].(map[string]interface{})
+		instMap, err := convertToInstanceMap(instance)
+		if err != nil {
+			return fmt.Errorf("error converting instance: %s", err)
+		}
+		gotPartnerMetadata, ok := instMap["partnerMetadata"].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("no partner metadata")
 		}
+		wantPartnerMetadata, err := convertToInstanceMap(expectedPartnerMetadata)
+		if err != nil {
+			return fmt.Errorf("error converting want: %s", err)
+		}
 		expectedPartnerMetadataMap := make(map[string]interface{})
 		acutalPartnerMetadataMap := make(map[string]interface{})
-		for key, value := range partnerMetadata {
-			entry, _ := value.(map[string]interface{})
-			acutalPartnerMetadataMap[key] = entry["entries"]
+		for key, value := range gotPartnerMetadata {
+			entries, ok := value.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			rawEntries, ok := entries["entries"]
+			if !ok {
+				continue
+			}
+			acutalPartnerMetadataMap[key] = normalizeEntries(rawEntries)
 		}
-		for key, value := range expectedPartnerMetadata {
-			expectedPartnerMetadataMap[key] = value["entries"]
+		for key, value := range wantPartnerMetadata {
+			entries, ok := value.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			rawEntries, ok := entries["entries"]
+			if !ok {
+				continue
+			}
+			expectedPartnerMetadataMap[key] = normalizeEntries(rawEntries)
 		}
 		if !reflect.DeepEqual(acutalPartnerMetadataMap, expectedPartnerMetadataMap) {
 			return fmt.Errorf("got the wrong instance partne metadata action: have: %+v; want: %+v", acutalPartnerMetadataMap, expectedPartnerMetadataMap)
 		}
 		return nil
 
+	}
+}
+
+// normalizeEntries decodes raw JSON entries (string or json.RawMessage) into a map for comparison.
+func normalizeEntries(raw interface{}) interface{} {
+	switch v := raw.(type) {
+	case string:
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(v), &m); err == nil {
+			return m
+		}
+		return v
+	case []byte:
+		var m map[string]interface{}
+		if err := json.Unmarshal(v, &m); err == nil {
+			return m
+		}
+		return string(v)
+	default:
+		return v
 	}
 }
 {{- end }}
@@ -6540,10 +6630,20 @@ func testAccCheckComputeInstanceHasShieldedVmConfig(instance *map[string]interfa
 	}
 }
 
-func testAccCheckComputeInstanceHasConfidentialInstanceConfig(instance *map[string]interface{}, EnableConfidentialCompute bool, ConfidentialInstanceType string) resource.TestCheckFunc {
+func testAccCheckComputeInstanceHasConfidentialInstanceConfig(instance interface{}, EnableConfidentialCompute bool, ConfidentialInstanceType string) resource.TestCheckFunc {
 
 	return func(s *terraform.State) error {
-		cic, _ := (*instance)["confidentialInstanceConfig"].(map[string]interface{})
+		if instance == nil {
+			return fmt.Errorf("instance is nil")
+		}
+		instMap, err := convertToInstanceMap(instance)
+		if err != nil {
+			return fmt.Errorf("error converting instance: %s", err)
+		}
+		cic, ok := instMap["confidentialInstanceConfig"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("no confidentialInstanceConfig")
+		}
 		gotEnable, _ := cic["enableConfidentialCompute"].(bool)
 		if gotEnable != EnableConfidentialCompute {
 			return fmt.Errorf("Wrong ConfidentialInstanceConfig EnableConfidentialCompute: expected %t, got, %t", EnableConfidentialCompute, gotEnable)


### PR DESCRIPTION
…transport_tpg

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_instance_from_machine_image` data source to use direct HTTP rather than a client library
```
