### PR TITLE
Add ontapSource field to Netapp Backup

### DIFF
--- a/mmv1/products/netapp/Backup.yaml
+++ b/mmv1/products/netapp/Backup.yaml
@@ -146,6 +146,32 @@ properties:
       Format: `projects/{{projectId}}/locations/{{location}}/volumes/{{volumename}}/snapshots/{{snapshotname}}``
     required: false
     diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+  - name: 'ontapSource'
+    type: NestedObject
+    description: |
+      Details of the ONTAP source volume and snapshot.
+    required: false
+    immutable: true
+    min_version: beta
+    properties:
+      - name: 'storagePool'
+        type: String
+        description: |
+          Name of the storage pool. This must be specified for creating backups for ONTAP mode volumes.
+          Format: `projects/{{project}}/locations/{{location}}/storagePools/{{storage_pool_id}}`
+        required: true
+        immutable: true
+      - name: 'volumeUuid'
+        type: String
+        description: |
+          The UUID of the ONTAP source volume.
+        required: true
+        immutable: true
+      - name: 'snapshotUuid'
+        type: String
+        description: |
+          The UUID of the ONTAP source snapshot.
+        immutable: true
   - name: 'volumeRegion'
     type: String
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
netapp: added `ontap_source` field to `google_netapp_backup` resource (beta)
```
