### PR TITLE
Revert "Add support for sending AIP-155 requestId query parameter"

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -128,10 +128,6 @@ type Resource struct {
 	// updates. This is typical of newer GCP APIs.
 	UpdateMask bool `yaml:"update_mask,omitempty"`
 
-	// [Optional] If set to true, this resource supports requestId for idempotency.
-	// This is typical of newer GCP APIs complying with AIP-155.
-	SupportsRequestId bool `yaml:"supports_request_id,omitempty"`
-
 	// [Optional] The HTTP verb used during create. Defaults to POST.
 	CreateVerb string `yaml:"create_verb,omitempty"`
 
@@ -819,14 +815,6 @@ func (r Resource) GetAsync() *Async {
 	}
 
 	return r.ProductMetadata.Async
-}
-
-// Returns true if the resource supports requestId for idempotency.
-func (r Resource) HasSupportsRequestId() bool {
-	if r.SupportsRequestId {
-		return true
-	}
-	return false
 }
 
 // Return the resource-specific identity properties, or a best guess of the

--- a/mmv1/products/compute/Network.yaml
+++ b/mmv1/products/compute/Network.yaml
@@ -22,7 +22,6 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networks'
 docs:
 base_url: 'projects/{{project}}/global/networks'
-supports_request_id: true
 has_self_link: true
 immutable: true
 timeouts:

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -379,9 +379,6 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutCreate),
         Headers: headers,
-{{- if $.HasSupportsRequestId }}
-        SendRequestId: {{ $.HasSupportsRequestId }},
-{{- end }}
 {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{- end}}
@@ -1009,9 +1006,6 @@ if len(updateMask) > 0 {
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutUpdate),
 		Headers:   headers,
-{{- if $.HasSupportsRequestId }}
-        SendRequestId: {{ $.HasSupportsRequestId }},
-{{- end }}
 {{-              if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{-             end}}
@@ -1184,9 +1178,6 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
             UserAgent: userAgent,
             Body: obj,
             Timeout: d.Timeout(schema.TimeoutUpdate),
-{{- if $.HasSupportsRequestId }}
-            SendRequestId: {{ $.HasSupportsRequestId }},
-{{- end }}
 {{-                  if $.ErrorRetryPredicates -}}
         	ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{  join $.ErrorRetryPredicates "," -}}{{"}"}},
 {{-                 end}}
@@ -1345,9 +1336,6 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
         Body: obj,
         Timeout: d.Timeout(schema.TimeoutDelete),
         Headers: headers,
-        {{- if $.HasSupportsRequestId }}
-        SendRequestId: {{ $.HasSupportsRequestId }},
-        {{- end }}
         {{- if $.ErrorRetryPredicates }}
         ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{{"{"}}{{- join $.ErrorRetryPredicates "," -}}{{"}"}},
         {{- end }}

--- a/mmv1/third_party/terraform/fwtransport/framework_utils.go
+++ b/mmv1/third_party/terraform/fwtransport/framework_utils.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -75,7 +74,6 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []transport_tpg.RetryErrorPredicateFunc
 	ErrorAbortPredicates []transport_tpg.RetryErrorPredicateFunc
-	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]interface{}, error) {
@@ -102,11 +100,6 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 		opt.Timeout = DefaultRequestTimeout
 	}
 
-	var requestId string
-	if opt.SendRequestId {
-		requestId = uuid.New().String()
-	}
-
 	var res *http.Response
 	err := transport_tpg.Retry(transport_tpg.RetryOptions{
 		RetryFunc: func() error {
@@ -118,11 +111,7 @@ func SendRequest(opt SendRequestOptions, diags *diag.Diagnostics) (map[string]in
 				}
 			}
 
-			queryParams := map[string]string{"alt": "json"}
-			if requestId != "" {
-				queryParams["requestId"] = requestId
-			}
-			u, err := transport_tpg.AddQueryParams(opt.RawURL, queryParams)
+			u, err := transport_tpg.AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"google.golang.org/api/googleapi"
@@ -28,7 +27,6 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []RetryErrorPredicateFunc
 	ErrorAbortPredicates []RetryErrorPredicateFunc
-	SendRequestId        bool
 }
 
 func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
@@ -59,11 +57,6 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 		opt.Timeout = DefaultRequestTimeout
 	}
 
-	var requestId string
-	if opt.SendRequestId {
-		requestId = uuid.New().String()
-	}
-
 	var res *http.Response
 	err := Retry(RetryOptions{
 		RetryFunc: func() error {
@@ -75,11 +68,7 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 				}
 			}
 
-			queryParams := map[string]string{"alt": "json"}
-			if requestId != "" {
-				queryParams["requestId"] = requestId
-			}
-			u, err := AddQueryParams(opt.RawURL, queryParams)
+			u, err := AddQueryParams(opt.RawURL, map[string]string{"alt": "json"})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#17259

```release-note:note
compute: added idempotency support to `google_compute_network` resource by sending `requestId` query parameter (revert)
```

