### PR TITLE
Limited VCR test results to 100 to avoid exceeding GH comment length limit

### DIFF
--- a/.ci/gcb-pr-downstream-generation-and-test.yml
+++ b/.ci/gcb-pr-downstream-generation-and-test.yml
@@ -264,7 +264,7 @@ steps:
         - $COMMIT_SHA
         - $BUILD_ID
         - $PROJECT_ID
-        - "23"  # Build step
+        - "22"  # Build step
         - "true"
 
     - name: 'gcr.io/graphite-docker-images/go-plus'

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -50,7 +50,7 @@
 
 Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
 
-{{ if gt (len .ReplayingResult.FailedTests) 100 -}}
+{{ if gt (len .ReplayingResult.FailedTests) 5 -}}
 More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the full list.
 {{- else -}}
 <details>

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -51,7 +51,7 @@
 Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
 
 {{ if gt (len .ReplayingResult.FailedTests) 1 -}}
-More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build]({{$.BuildStepUrl}}) to see the full list.
+More than 100 tests failed in replaying; this is too many to display on GitHub. View the [Cloud Build logs]({{$.BuildStepUrl}}) to see the full list.
 {{- else -}}
 <details>
 <summary>Click here to see the affected tests</summary>
@@ -77,4 +77,4 @@ More than 100 tests failed in replaying; this is too many to display on GitHub. 
 {{ end }}
 {{ end }}
 
-View the [build log](https://storage.cloud.google.com/{{.LogBucket}}/{{.Version}}/refs/heads/{{.Head}}/artifacts/{{.BuildID}}/build-log/replaying_test.log)
+View the [replaying VCR build log](https://storage.cloud.google.com/{{.LogBucket}}/{{.Version}}/refs/heads/{{.Head}}/artifacts/{{.BuildID}}/build-log/replaying_test.log)

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -50,7 +50,7 @@
 
 Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
 
-{{ if gt (len .ReplayingResult.FailedTests) 1 -}}
+{{ if gt (len .ReplayingResult.FailedTests) 100 -}}
 More than 100 tests failed in replaying; this is too many to display on GitHub. View the [Cloud Build logs]({{$.BuildStepUrl}}) to see the full list.
 {{- else -}}
 <details>

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -50,7 +50,7 @@
 
 Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
 
-{{ if gt (len .ReplayingResult.FailedTests) 5 -}}
+{{ if gt (len .ReplayingResult.FailedTests) 1 -}}
 More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the full list.
 {{- else -}}
 <details>

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -51,7 +51,7 @@
 Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
 
 {{ if gt (len .ReplayingResult.FailedTests) 1 -}}
-More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the full list.
+More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build]({{$.BuildStepUrl}}) to see the full list.
 {{- else -}}
 <details>
 <summary>Click here to see the affected tests</summary>

--- a/.ci/magician/cmd/templates/vcr/post_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/post_replay.tmpl
@@ -47,11 +47,18 @@
 
 {{ if gt (len .ReplayingResult.FailedTests) 0 }}
 #### Action taken
+
+Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.
+
+{{ if gt (len .ReplayingResult.FailedTests) 100 -}}
+More than 100 tests failed in replaying; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the full list.
+{{- else -}}
 <details>
-<summary>Found {{len .ReplayingResult.FailedTests}} affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Click here to see the affected tests</summary>
+<summary>Click here to see the affected tests</summary>
 
 {{range .ReplayingResult.FailedTests}}{{. | printf "* %s\n"}}{{end}}
 </details>
+{{- end }}
 {{ else }}
 {{ if .ReplayingErr }}
 > [!CAUTION]

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -3,7 +3,7 @@
 **Step 2: Recording Mode**
 
 {{ if gt (len .TestRows) 1 -}}
-More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build]({{$.BuildStepUrl}}) to see the result summary.
+More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [Cloud Build logs]({{$.BuildStepUrl}}) to see the result summary.
 {{- else -}}
 {{template "RecordReplayRows" .}}
 {{- end}}
@@ -32,4 +32,4 @@ More than 100 tests ran in recording mode; this is too many to display on GitHub
 {{ color "green" "**All tests passed!**" }}
 {{ end }}
 
-View the [build log]({{.LogBaseUrl}}/build-log/recording_test.log) or the [debug logs folder]({{.BrowseLogBaseUrl}}/recording) for detailed results.
+View the [recording VCR build log]({{.LogBaseUrl}}/build-log/recording_test.log) or the [debug logs folder]({{.BrowseLogBaseUrl}}/recording) for detailed results.

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -2,7 +2,7 @@
 
 **Step 2: Recording Mode**
 
-{{ if gt (len .TestRows) 1 -}}
+{{ if gt (len .TestRows) 100 -}}
 More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [Cloud Build logs]({{$.BuildStepUrl}}) to see the result summary.
 {{- else -}}
 {{template "RecordReplayRows" .}}

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -2,7 +2,7 @@
 
 **Step 2: Recording Mode**
 
-{{ if gt (len .TestRows) 100 -}}
+{{ if gt (len .TestRows) 5 -}}
 More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the result summary.
 {{- else -}}
 {{template "RecordReplayRows" .}}

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -2,11 +2,11 @@
 
 **Step 2: Recording Mode**
 
-| Recording Mode | Replaying Rerun | Test Name |
-| :--- | :--- | :--- |
-{{range .TestRows -}}
-| {{symbol .RecordingStatus}}{{if .RecordingErrorUrl}}&nbsp;[Error]({{.RecordingErrorUrl}}){{end}}{{if .RecordingLogUrl}}{{if .RecordingErrorUrl}}&nbsp;·&nbsp;{{else}}&nbsp;{{end}}[Log]({{.RecordingLogUrl}}){{end}} | {{symbol .ReplayingAfterRecordingStatus}}{{if .ReplayingAfterRecordingErrorUrl}}&nbsp;[Error]({{.ReplayingAfterRecordingErrorUrl}}){{end}}{{if .ReplayingAfterRecordingLogUrl}}{{if .ReplayingAfterRecordingErrorUrl}}&nbsp;·&nbsp;{{else}}&nbsp;{{end}}[Log]({{.ReplayingAfterRecordingLogUrl}}){{end}} | {{.DisplayName}} |
-{{end}}
+{{ if gt (len .TestRows) 100 -}}
+More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the result summary.
+{{- else -}}
+{{template "RecordReplayRows" .}}
+{{- end}}
 
 {{ if or (gt (len .ReplayingAfterRecordingResult.FailedTests) 0) (gt (len .RecordingResult.FailedTests) 0) .HasTerminatedTests .RecordingErr (gt (len .NotRunBetaTests) 0) (gt (len .NotRunGATests) 0) }}
 > [!CAUTION]

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -3,7 +3,7 @@
 **Step 2: Recording Mode**
 
 {{ if gt (len .TestRows) 1 -}}
-More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the result summary.
+More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build]({{$.BuildStepUrl}}) to see the result summary.
 {{- else -}}
 {{template "RecordReplayRows" .}}
 {{- end}}

--- a/.ci/magician/cmd/templates/vcr/record_replay.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay.tmpl
@@ -2,7 +2,7 @@
 
 **Step 2: Recording Mode**
 
-{{ if gt (len .TestRows) 5 -}}
+{{ if gt (len .TestRows) 1 -}}
 More than 100 tests ran in recording mode; this is too many to display on GitHub. View the [build](http://console.cloud.google.com/cloud-build/builds/${{$.BuildID}}) to see the result summary.
 {{- else -}}
 {{template "RecordReplayRows" .}}

--- a/.ci/magician/cmd/templates/vcr/record_replay_rows.tmpl
+++ b/.ci/magician/cmd/templates/vcr/record_replay_rows.tmpl
@@ -1,0 +1,7 @@
+{{define "RecordReplayRows" -}}
+| Recording Mode | Replaying Rerun | Test Name |
+| :--- | :--- | :--- |
+{{range .TestRows -}}
+| {{symbol .RecordingStatus}}{{if .RecordingErrorUrl}}&nbsp;[Error]({{.RecordingErrorUrl}}){{end}}{{if .RecordingLogUrl}}{{if .RecordingErrorUrl}}&nbsp;·&nbsp;{{else}}&nbsp;{{end}}[Log]({{.RecordingLogUrl}}){{end}} | {{symbol .ReplayingAfterRecordingStatus}}{{if .ReplayingAfterRecordingErrorUrl}}&nbsp;[Error]({{.ReplayingAfterRecordingErrorUrl}}){{end}}{{if .ReplayingAfterRecordingLogUrl}}{{if .ReplayingAfterRecordingErrorUrl}}&nbsp;·&nbsp;{{else}}&nbsp;{{end}}[Log]({{.ReplayingAfterRecordingLogUrl}}){{end}} | {{.DisplayName}} |
+{{end}}
+{{- end -}}

--- a/.ci/magician/cmd/test_eap_vcr.go
+++ b/.ci/magician/cmd/test_eap_vcr.go
@@ -276,7 +276,7 @@ func execTestEAPVCR(changeNumber, genPath, kokoroArtifactsDir string, rnr ExecRu
 			Version:                       provider.Private.String(),
 			Head:                          head,
 		}
-		recordReplayComment, err := formatRecordReplay(recordReplayData)
+		recordReplayComment, err := formatRecordReplay(recordReplayData, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("error formatting record replay comment: %w", err)
 		}

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -706,7 +706,7 @@ func formatComment(filename string, tmplText string, data any) (string, error) {
 }
 
 func formatPostReplay(data postReplay, w io.Writer) (string, error) {
-	if len(data.ReplayingResult.FailedTests) > 5 {
+	if len(data.ReplayingResult.FailedTests) > 1 {
 		fmt.Fprintln(w, "Failed replaying tests:")
 		for _, t := range data.ReplayingResult.FailedTests {
 			fmt.Fprintln(w, "* "+t)
@@ -716,7 +716,7 @@ func formatPostReplay(data postReplay, w io.Writer) (string, error) {
 }
 
 func formatRecordReplay(data recordReplay, w io.Writer) (string, error) {
-	if len(data.TestRows) > 5 {
+	if len(data.TestRows) > 1 {
 		tmpl := parseTemplate("record_replay_rows.tmpl", recordReplayRowsTmplText+`{{ template "RecordReplayRows" . }}`)
 		sb := new(strings.Builder)
 		err := tmpl.Execute(sb, data)

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -71,6 +71,7 @@ type postReplay struct {
 	Version          string
 	Head             string
 	BuildID          string
+	BuildStepUrl     string
 }
 
 type VCRTestTableRow struct {
@@ -94,6 +95,7 @@ type recordReplay struct {
 	Version                       string
 	Head                          string
 	BuildID                       string
+	BuildStepUrl                  string
 	LogBaseUrl                    string
 	BrowseLogBaseUrl              string
 	NotRunBetaTests               []string
@@ -229,8 +231,8 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		return fmt.Errorf("error fetching cassettes: %w", err)
 	}
 
-	buildStatusTargetURL := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s;step=%s?project=%s", buildID, buildStep, projectID)
-	if err := gh.PostBuildStatus(prNumber, "VCR-test", "pending", buildStatusTargetURL, mmCommitSha); err != nil {
+	buildStepUrl := fmt.Sprintf("https://console.cloud.google.com/cloud-build/builds;region=global/%s;step=%s?project=%s", buildID, buildStep, projectID)
+	if err := gh.PostBuildStatus(prNumber, "VCR-test", "pending", buildStepUrl, mmCommitSha); err != nil {
 		return fmt.Errorf("error posting pending status: %w", err)
 	}
 
@@ -249,13 +251,13 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		return fmt.Errorf("error uploading replaying logs: %w", err)
 	}
 
-	if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
+	if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
 		return fmt.Errorf("error handling panics: %w", err)
 	} else if hasPanics {
 		return nil
 	}
 
-	if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStatusTargetURL, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
+	if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
 		return fmt.Errorf("error handling build failures: %w", err)
 	} else if hasBuildFailures {
 		return nil
@@ -278,6 +280,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		Version:          provider.Beta.String(),
 		Head:             newBranch,
 		BuildID:          buildID,
+		BuildStepUrl:     buildStepUrl,
 	}
 
 	comment, err := formatPostReplay(postReplayData, os.Stdout)
@@ -321,13 +324,13 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			return fmt.Errorf("error uploading recording logs: %w", err)
 		}
 
-		if hasPanics, err := handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
+		if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
 			return fmt.Errorf("error handling panics: %w", err)
 		} else if hasPanics {
 			return nil
 		}
 
-		if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStatusTargetURL, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
+		if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
 			return fmt.Errorf("error handling build failures: %w", err)
 		} else if hasBuildFailures {
 			return nil
@@ -385,6 +388,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			Version:                       provider.Beta.String(),
 			Head:                          newBranch,
 			BuildID:                       buildID,
+			BuildStepUrl:                  buildStepUrl,
 			NotRunBetaTests:               notRunBeta,
 			NotRunGATests:                 notRunGa,
 		}
@@ -401,7 +405,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		}
 	}
 
-	if err := gh.PostBuildStatus(prNumber, "VCR-test", testState, buildStatusTargetURL, mmCommitSha); err != nil {
+	if err := gh.PostBuildStatus(prNumber, "VCR-test", testState, buildStepUrl, mmCommitSha); err != nil {
 		return fmt.Errorf("error posting build status: %w", err)
 	}
 	return nil
@@ -549,7 +553,7 @@ func runReplaying(runFullVCR bool, version provider.Version, services map[string
 	return result, testDirs, replayingErr
 }
 
-func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
+func handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
 	if len(result.Panics) > 0 {
 		comment := "> [!CAUTION]\n"
 		comment += "> **Panic occurred during VCR tests**\n>\n"
@@ -574,7 +578,7 @@ func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, r
 		if err := appendVCRResultToDiffComment(prNumber, comment, gh, rnr); err != nil {
 			return true, fmt.Errorf("error appending comment: %v", err)
 		}
-		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStatusTargetURL, mmCommitSha); err != nil {
+		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStepUrl, mmCommitSha); err != nil {
 			return true, fmt.Errorf("error posting failure status: %v", err)
 		}
 		return true, nil
@@ -582,7 +586,7 @@ func handlePanics(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, r
 	return false, nil
 }
 
-func handleBuildFailures(prNumber, buildID, buildStatusTargetURL, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
+func handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
 	if len(result.BuildFailures) > 0 {
 		comment := "> [!CAUTION]\n"
 		comment += "> **Build Failure during VCR tests**\n>\n"
@@ -610,7 +614,7 @@ func handleBuildFailures(prNumber, buildID, buildStatusTargetURL, mmCommitSha st
 		if err := appendVCRResultToDiffComment(prNumber, comment, gh, rnr); err != nil {
 			return true, fmt.Errorf("error appending comment: %v", err)
 		}
-		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStatusTargetURL, mmCommitSha); err != nil {
+		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStepUrl, mmCommitSha); err != nil {
 			return true, fmt.Errorf("error posting failure status: %v", err)
 		}
 		return true, nil

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -710,7 +710,7 @@ func formatComment(filename string, tmplText string, data any) (string, error) {
 }
 
 func formatPostReplay(data postReplay, w io.Writer) (string, error) {
-	if len(data.ReplayingResult.FailedTests) > 1 {
+	if len(data.ReplayingResult.FailedTests) > 100 {
 		fmt.Fprintln(w, "Failed replaying tests:")
 		for _, t := range data.ReplayingResult.FailedTests {
 			fmt.Fprintln(w, "* "+t)
@@ -720,7 +720,7 @@ func formatPostReplay(data postReplay, w io.Writer) (string, error) {
 }
 
 func formatRecordReplay(data recordReplay, w io.Writer) (string, error) {
-	if len(data.TestRows) > 1 {
+	if len(data.TestRows) > 100 {
 		tmpl := parseTemplate("record_replay_rows.tmpl", recordReplayRowsTmplText+`{{ template "RecordReplayRows" . }}`)
 		sb := new(strings.Builder)
 		err := tmpl.Execute(sb, data)

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -706,7 +706,7 @@ func formatComment(filename string, tmplText string, data any) (string, error) {
 }
 
 func formatPostReplay(data postReplay, w io.Writer) (string, error) {
-	if len(data.ReplayingResult.FailedTests) > 100 {
+	if len(data.ReplayingResult.FailedTests) > 5 {
 		fmt.Fprintln(w, "Failed replaying tests:")
 		for _, t := range data.ReplayingResult.FailedTests {
 			fmt.Fprintln(w, "* "+t)
@@ -716,7 +716,7 @@ func formatPostReplay(data postReplay, w io.Writer) (string, error) {
 }
 
 func formatRecordReplay(data recordReplay, w io.Writer) (string, error) {
-	if len(data.TestRows) > 100 {
+	if len(data.TestRows) > 5 {
 		tmpl := parseTemplate("record_replay_rows.tmpl", recordReplayRowsTmplText+`{{ template "RecordReplayRows" . }}`)
 		sb := new(strings.Builder)
 		err := tmpl.Execute(sb, data)

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -28,6 +29,8 @@ var (
 	postReplayTmplText string
 	//go:embed templates/vcr/record_replay.tmpl
 	recordReplayTmplText string
+	//go:embed templates/vcr/record_replay_rows.tmpl
+	recordReplayRowsTmplText string
 )
 
 var ttvRequiredEnvironmentVariables = [...]string{
@@ -277,7 +280,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		BuildID:          buildID,
 	}
 
-	comment, err := formatPostReplay(postReplayData)
+	comment, err := formatPostReplay(postReplayData, os.Stdout)
 	if err != nil {
 		return fmt.Errorf("error formatting post replay comment: %w", err)
 	}
@@ -385,7 +388,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			NotRunBetaTests:               notRunBeta,
 			NotRunGATests:                 notRunGa,
 		}
-		recordReplayComment, err := formatRecordReplay(recordReplayData)
+		recordReplayComment, err := formatRecordReplay(recordReplayData, os.Stdout)
 		if err != nil {
 			return fmt.Errorf("error formatting record replay comment: %w", err)
 		}
@@ -675,7 +678,7 @@ func init() {
 	rootCmd.AddCommand(testTerraformVCRCmd)
 }
 
-func formatComment(fileName string, tmplText string, data any) (string, error) {
+func parseTemplate(filename string, tmplText string) *template.Template {
 	funcs := template.FuncMap{
 		"join":         strings.Join,
 		"add":          func(i, j int) int { return i + j },
@@ -685,30 +688,50 @@ func formatComment(fileName string, tmplText string, data any) (string, error) {
 		"symbol":       symbol,
 		"contains":     contains,
 	}
-	tmpl, err := template.New(fileName).Funcs(funcs).Parse(tmplText)
+	tmpl, err := template.New(filename).Funcs(funcs).Parse(tmplText)
 	if err != nil {
-		panic(fmt.Sprintf("Unable to parse %s: %s", fileName, err))
+		panic(fmt.Sprintf("Unable to parse %s: %s", filename, err))
 	}
+	return tmpl
+}
+
+func formatComment(filename string, tmplText string, data any) (string, error) {
+	tmpl := parseTemplate(filename, tmplText)
 	sb := new(strings.Builder)
-	err = tmpl.Execute(sb, data)
+	err := tmpl.Execute(sb, data)
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(sb.String()), nil
 }
 
-func formatPostReplay(data postReplay) (string, error) {
+func formatPostReplay(data postReplay, w io.Writer) (string, error) {
+	if len(data.ReplayingResult.FailedTests) > 100 {
+		fmt.Fprintln(w, "Failed replaying tests:")
+		for _, t := range data.ReplayingResult.FailedTests {
+			fmt.Fprintln(w, "* "+t)
+		}
+	}
 	return formatComment("post_replay.tmpl", postReplayTmplText, data)
 }
 
-func formatRecordReplay(data recordReplay) (string, error) {
+func formatRecordReplay(data recordReplay, w io.Writer) (string, error) {
+	if len(data.TestRows) > 100 {
+		tmpl := parseTemplate("record_replay_rows.tmpl", recordReplayRowsTmplText+`{{ template "RecordReplayRows" . }}`)
+		sb := new(strings.Builder)
+		err := tmpl.Execute(sb, data)
+		if err != nil {
+			return "", err
+		}
+		fmt.Fprintln(w, strings.TrimSpace(sb.String()))
+	}
 	logBasePath := fmt.Sprintf("%s/%s/refs/heads/%s/artifacts/%s", data.LogBucket, data.Version, data.Head, data.BuildID)
 	if data.BuildID == "" {
 		logBasePath = fmt.Sprintf("%s/%s/refs/heads/%s", data.LogBucket, data.Version, data.Head)
 	}
 	data.LogBaseUrl = fmt.Sprintf("https://storage.cloud.google.com/%s", logBasePath)
 	data.BrowseLogBaseUrl = fmt.Sprintf("https://console.cloud.google.com/storage/browser/%s", logBasePath)
-	return formatComment("record_replay.tmpl", recordReplayTmplText, data)
+	return formatComment("record_replay.tmpl", recordReplayRowsTmplText+recordReplayTmplText, data)
 }
 
 func contains(slice []string, item string) bool {

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -465,7 +465,7 @@ func TestWithoutReplayFailedTests(t *testing.T) {
 			wantContains: []string{
 				"> [!CAUTION]",
 				"🔴 Errors occurred during REPLAYING mode. Please check the build log for details.",
-				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+				"View the [replaying VCR build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
 			},
 		},
 		{
@@ -478,7 +478,7 @@ func TestWithoutReplayFailedTests(t *testing.T) {
 			},
 			wantContains: []string{
 				"🟢 **All tests passed in Replaying mode! No Recording was needed.**",
-				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
+				"View the [replaying VCR build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/replaying_test.log)",
 			},
 		},
 	}
@@ -571,7 +571,7 @@ func TestRecordReplay(t *testing.T) {
 				"| ❌&nbsp;[Error](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_build/e_recording_test.log)&nbsp;·&nbsp;[Log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording/e.log) | - | TestAcc_e |",
 
 				"Please address these issues to complete your PR",
-				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug logs folder](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording) for detailed results.",
+				"View the [recording VCR build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug logs folder](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording) for detailed results.",
 			},
 		},
 		{
@@ -609,7 +609,7 @@ func TestRecordReplay(t *testing.T) {
 				"| ✅&nbsp;[Log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording/b.log) | ✅ | TestAcc_b |",
 				"| ✅&nbsp;[Log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording/c.log) | ✅ | TestAcc_c |",
 				"🟢 **All tests passed!**",
-				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug logs folder](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording) for detailed results.",
+				"View the [recording VCR build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug logs folder](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording) for detailed results.",
 			},
 		},
 		{

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -291,7 +291,7 @@ func TestAnalyticsComment(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatPostReplay(tc.data)
+			got, err := formatPostReplay(tc.data, new(strings.Builder))
 			if err != nil {
 				t.Fatalf("Failed to format comment: %v", err)
 			}
@@ -363,7 +363,7 @@ func TestNonExercisedTestsComment(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatPostReplay(tc.data)
+			got, err := formatPostReplay(tc.data, new(strings.Builder))
 			if err != nil {
 				t.Fatalf("Failed to format comment: %v", err)
 			}
@@ -377,10 +377,16 @@ func TestNonExercisedTestsComment(t *testing.T) {
 }
 
 func TestWithReplayFailedTests(t *testing.T) {
+	manyFailedTests := make([]string, 101)
+	for i := range manyFailedTests {
+		manyFailedTests[i] = "TestAccAlloydbBackup_alloydbBackupFullTestNewExample"
+	}
 	tests := []struct {
-		name         string
-		data         postReplay
-		wantContains []string
+		name               string
+		data               postReplay
+		wantContains       []string
+		wantNotContains    []string
+		wantStdoutContains []string
 	}{
 		{
 			name: "with failed tests",
@@ -391,18 +397,38 @@ func TestWithReplayFailedTests(t *testing.T) {
 			},
 			wantContains: []string{
 				"#### Action taken",
+				"Found 2 affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit.",
 				"<details>",
-				"<summary>Found 2 affected test(s) by replaying old test recordings. Starting RECORDING based on the most recent commit. Click here to see the affected tests</summary>",
+				"<summary>Click here to see the affected tests</summary>",
 				"* a",
 				"* b",
 				"</details>",
 				"[Learn how VCR tests work](https://googlecloudplatform.github.io/magic-modules/develop/test/test/)",
 			},
 		},
+		{
+			name: "Too many failed tests",
+			data: postReplay{
+				ReplayingResult: vcr.Result{
+					FailedTests: manyFailedTests,
+				},
+				RunFullVCR: true,
+			},
+			wantContains: []string{
+				"More than 100 tests failed in replaying; this is too many to display on GitHub.",
+			},
+			wantNotContains: []string{manyFailedTests[0]},
+			wantStdoutContains: []string{
+				"Failed replaying tests",
+				manyFailedTests[0],
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatPostReplay(tc.data)
+			sb := new(strings.Builder)
+			got, err := formatPostReplay(tc.data, sb)
+			gotStdout := sb.String()
 			if err != nil {
 				t.Fatalf("Failed to format comment: %v", err)
 			}
@@ -410,6 +436,12 @@ func TestWithReplayFailedTests(t *testing.T) {
 				if !strings.Contains(got, wc) {
 					t.Errorf("formatPostReplay() returned %q, which does not contain %q", got, wc)
 				}
+			}
+			for _, s := range tc.wantNotContains {
+				assert.NotContains(t, got, s)
+			}
+			for _, s := range tc.wantStdoutContains {
+				assert.Contains(t, gotStdout, s)
 			}
 		})
 	}
@@ -452,7 +484,7 @@ func TestWithoutReplayFailedTests(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatPostReplay(tc.data)
+			got, err := formatPostReplay(tc.data, new(strings.Builder))
 			if err != nil {
 				t.Fatalf("Failed to format comment: %v", err)
 			}
@@ -466,10 +498,21 @@ func TestWithoutReplayFailedTests(t *testing.T) {
 }
 
 func TestRecordReplay(t *testing.T) {
+	manyRows := make([]VCRTestTableRow, 101)
+	for i := range manyRows {
+		manyRows[i] = VCRTestTableRow{
+			DisplayName:                   "TestAcc_a",
+			RecordingStatus:               "Passed",
+			RecordingLogUrl:               "https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording/a.log",
+			ReplayingAfterRecordingStatus: "Passed",
+		}
+	}
 	tests := []struct {
-		name         string
-		data         recordReplay
-		wantContains []string
+		name               string
+		data               recordReplay
+		wantContains       []string
+		wantNotContains    []string
+		wantStdoutContains []string
 	}{
 		{
 			name: "ReplayingAfterRecordingResult has failed tests",
@@ -569,15 +612,44 @@ func TestRecordReplay(t *testing.T) {
 				"View the [build log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/build-log/recording_test.log) or the [debug logs folder](https://console.cloud.google.com/storage/browser/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording) for detailed results.",
 			},
 		},
+		{
+			name: "Too many rows",
+			data: recordReplay{
+				TestRows:           manyRows,
+				AllRecordingPassed: true,
+				BuildID:            "build-123",
+				Head:               "auto-pr-123",
+				Version:            provider.Beta.String(),
+				LogBucket:          "ci-vcr-logs",
+			},
+			wantContains: []string{
+				"More than 100 tests ran in recording mode; this is too many to display on GitHub.",
+			},
+			wantNotContains: []string{
+				manyRows[0].DisplayName,
+			},
+			wantStdoutContains: []string{
+				"| Recording Mode | Replaying Rerun | Test Name |",
+				"| ✅&nbsp;[Log](https://storage.cloud.google.com/ci-vcr-logs/beta/refs/heads/auto-pr-123/artifacts/build-123/recording/a.log) | ✅ | TestAcc_a |",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := formatRecordReplay(tc.data)
+			sb := new(strings.Builder)
+			got, err := formatRecordReplay(tc.data, sb)
+			gotStdout := sb.String()
 			if err != nil {
 				t.Fatalf("Failed to format comment: %v", err)
 			}
-			for _, wc := range tc.wantContains {
-				assert.Contains(t, got, wc)
+			for _, s := range tc.wantContains {
+				assert.Contains(t, got, s)
+			}
+			for _, s := range tc.wantNotContains {
+				assert.NotContains(t, got, s)
+			}
+			for _, s := range tc.wantStdoutContains {
+				assert.Contains(t, gotStdout, s)
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
@@ -9,6 +9,7 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// FORCE compute VCR run
 func DataSourceGoogleComputeDisk() *schema.Resource {
 
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeDisk().Schema)

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_disk.go
@@ -9,7 +9,6 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
-// FORCE compute VCR run
 func DataSourceGoogleComputeDisk() *schema.Resource {
 
 	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeDisk().Schema)


### PR DESCRIPTION
Most PRs won't exceed this limit; exceeding it usually means something has gone wrong. So, it should be okay to add a little friction to avoid the larger problem of failing the VCR build completely because of the comment length.

I opted not to add an explicit comment about this usually indicating a problem; I think that we can probably expect that reviewers will know that.

The lists of failures in the linked cloud build logs are a bit tricky to find - search for `TestAccComputeInstanceFromTemplate_DiskForceAttach`. It will be easier if there are 100+.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
