### PR TITLE
add regions to google_network_connectivity_multicloud_data_transfer_config sweepers

### DIFF
--- a/mmv1/products/networkconnectivity/MulticloudDataTransferConfig.yaml
+++ b/mmv1/products/networkconnectivity/MulticloudDataTransferConfig.yaml
@@ -39,6 +39,13 @@ examples:
     vars:
       config_name: "basic_config"
 
+sweeper:
+  url_substitutions:
+    - region: "europe-west1"
+    - region: "europe-west2"
+    - region: "europe-west3"
+    - region: "europe-west4"
+
 parameters:
   - name: 'location'
     type: String


### PR DESCRIPTION
resources are leaking and causing failures in ci tests such as https://github.com/GoogleCloudPlatform/magic-modules/pull/17528#issuecomment-4443161943

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
