### PR TITLE
datafusion - added maintenance_policy field to google_data_fusion_instance resource

### DIFF
--- a/mmv1/products/datafusion/Instance.yaml
+++ b/mmv1/products/datafusion/Instance.yaml
@@ -396,6 +396,72 @@ properties:
           enum_values:
             - 'ENABLED'
             - 'DISABLED'
+  - name: 'maintenancePolicy'
+    type: NestedObject
+    description: |
+      Configure the maintenance policy for this instance.
+    properties:
+      - name: 'maintenanceWindow'
+        type: NestedObject
+        description: |
+          The maintenance window of the instance.
+        properties:
+          - name: 'recurringTimeWindow'
+            type: NestedObject
+            description: |
+              The recurring time window of the maintenance window.
+            required: true
+            properties:
+              - name: 'window'
+                type: NestedObject
+                description: |
+                  The window representing the start and end time of recurrences. This field ignores the date components of the provided timestamps. Only the time of day and duration between start and end time are relevant.
+                required: true
+                properties:
+                  - name: 'startTime'
+                    type: String
+                    description: |
+                      The start time of the time window provided in RFC 3339 format.
+                    required: true
+                  - name: 'endTime'
+                    type: String
+                    description: |
+                      The end time of the time window provided in RFC 3339 format.
+                    required: true
+              - name: 'recurrence'
+                type: String
+                description: |
+                  An RRULE with format RFC-5545 for how this window reccurs. They go on for the span of time between the start and end time. The only supported FREQ value is "WEEKLY". To have something repeat every weekday, use: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR".
+                required: true
+
+  - name: 'maintenanceEvents'
+    type: Array
+    description: |
+      The maintenance events for this instance.
+    output: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'startTime'
+          type: String
+          description: |
+            The start time of the maintenance event provided in RFC 3339 format.
+          output: true
+        - name: 'endTime'
+          type: String
+          description: |
+            The end time of the maintenance event provided in RFC 3339 format.
+          output: true
+        - name: 'state'
+          type: Enum
+          description: |
+            The state of the maintenance event.
+          output: true
+          enum_values:
+            - 'STATE_UNSPECIFIED'
+            - 'SCHEDULED'
+            - 'STARTED'
+            - 'COMPLETED'
   - name: 'tags'
     type: KeyValuePairs
     description: |

--- a/mmv1/templates/terraform/pre_update/datafusion_instance_update.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/datafusion_instance_update.go.tmpl
@@ -24,6 +24,10 @@ if d.HasChange("enable_rbac") {
     updateMask = append(updateMask, "enableRbac")
 }
 
+if d.HasChange("maintenance_policy") {
+    updateMask = append(updateMask, "maintenancePolicy")
+}
+
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars
 // won't set it
 

--- a/mmv1/templates/terraform/pre_update/fw_datafusion_instance_update.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/fw_datafusion_instance_update.go.tmpl
@@ -24,6 +24,10 @@ if !plan.EnableRbac.Equal(state.EnableRbac) {
 	updateMask = append(updateMask, "enableRbac")
 }
 
+if !plan.MaintenancePolicy.Equal(state.MaintenancePolicy) {
+	updateMask = append(updateMask, "maintenancePolicy")
+}
+
 
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars
 // won't set it

--- a/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
+++ b/mmv1/third_party/terraform/services/datafusion/resource_data_fusion_instance_test.go
@@ -57,6 +57,17 @@ resource "google_data_fusion_instance" "foobar" {
     accelerator_type = "CDC"
     state = "DISABLED"
   }
+  maintenance_policy {
+    maintenance_window {
+      recurring_time_window {
+        window {
+          start_time = "2027-01-01T00:00:00Z"
+          end_time   = "2027-01-01T04:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      }
+    }
+  }
 }
 `, instanceName)
 }
@@ -79,6 +90,17 @@ resource "google_data_fusion_instance" "foobar" {
   accelerators {
     accelerator_type = "CCAI_INSIGHTS"
     state = "ENABLED"
+  }
+  maintenance_policy {
+    maintenance_window {
+      recurring_time_window {
+        window {
+          start_time = "2027-01-01T01:00:00Z"
+          end_time   = "2027-01-01T05:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      }
+    }
   }
   # Mark for testing to avoid service networking connection usage that is not cleaned up
   options = {
@@ -147,6 +169,19 @@ resource "google_data_fusion_instance" "foobar" {
     label1 = "value1"
     label2 = "value2"
   }
+
+  maintenance_policy {
+    maintenance_window {
+      recurring_time_window {
+        window {
+          start_time = "2027-01-01T00:00:00Z"
+          end_time   = "2027-01-01T04:00:00Z"
+        }
+        recurrence = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
+      }
+    }
+  }
+
   # Mark for testing to avoid service networking connection usage that is not cleaned up
   options = {
   	prober_test_run = "true"


### PR DESCRIPTION

datafusion: added `maintenance_policy` field to `google_data_fusion_instance` resource

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
datafusion: added `maintenance_policy` field to `google_data_fusion_instance` resource
```
