### PR TITLE
feat: google ces deployment Add missing securitySettings fields to we…

### DIFF
--- a/mmv1/products/ces/Deployment.yaml
+++ b/mmv1/products/ces/Deployment.yaml
@@ -29,6 +29,12 @@ examples:
       app_display_name: my-app
       app_id: app-id
       deployment_display_name: my-deployment
+  - name: ces_deployment_full
+    primary_resource_id: my-deployment
+    vars:
+      app_display_name: my-app
+      app_id: app-id
+      deployment_display_name: my-deployment
 parameters:
   - name: location
     type: String
@@ -69,6 +75,8 @@ properties:
           TWILIO
           GOOGLE_TELEPHONY_PLATFORM
           CONTACT_CENTER_AS_A_SERVICE
+          FIVE9
+          CONTACT_CENTER_INTEGRATION
       - name: disableBargeInControl
         type: Boolean
         description: |-
@@ -103,21 +111,47 @@ properties:
             description: |-
               The modality of the web widget.
               Possible values:
-              UNKNOWN_MODALITY
+              MODALITY_UNSPECIFIED
               CHAT_AND_VOICE
               VOICE_ONLY
               CHAT_ONLY
+              CHAT_VOICE_AND_VIDEO
           - name: theme
             type: String
             description: |-
               The theme of the web widget.
               Possible values:
-              UNKNOWN_THEME
+              THEME_UNSPECIFIED
               LIGHT
               DARK
           - name: webWidgetTitle
             type: String
             description: The title of the web widget.
+          - name: securitySettings
+            type: NestedObject
+            description: The security settings of the web widget.
+            properties:
+              - name: enablePublicAccess
+                type: Boolean
+                description: |-
+                  Indicates whether public access to the web widget is enabled. If true, the web widget will be publicly accessible. If false, the web widget must be integrated with your own authentication and authorization system to return valid credentials for accessing the CES agent.
+                send_empty_value: true
+              - name: enableOriginCheck
+                type: Boolean
+                description: |-
+                  Indicates whether origin check for the web widget is enabled. If true, the web widget will check the origin of the website that loads the web widget and only allow it to be loaded in the same origin or any of the allowed origins.
+                send_empty_value: true
+              - name: allowedOrigins
+                type: Array
+                description: |-
+                  The origins that are allowed to host the web widget. An origin is defined by RFC 6454. If empty, all origins are allowed. A maximum of 100 origins is allowed. Example: "https://example.com"
+                item_type:
+                  type: String
+              - name: enableRecaptcha
+                type: Boolean
+                description: |-
+                  Indicates whether reCAPTCHA verification for the web widget is enabled.
+                send_empty_value: true
   - name: createTime
     type: String
     description: Timestamp when this deployment was created.

--- a/mmv1/templates/terraform/examples/ces_deployment_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_deployment_full.tf.tmpl
@@ -1,0 +1,34 @@
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "{{index $.Vars "app_display_name"}}"
+    app_id       = "{{index $.Vars "app_id"}}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+resource "google_ces_deployment" "{{$.PrimaryResourceId}}" {
+    location     = "us"
+    display_name = "{{index $.Vars "deployment_display_name"}}"
+    app          = google_ces_app.my-app.name
+    app_version  = "projects/example-project/locations/us/apps/example-app/versions/example-version"
+    channel_profile {
+        channel_type = "API"
+        disable_barge_in_control = true
+        disable_dtmf = true
+        persona_property {
+            persona = "CHATTY"
+        }
+        profile_id = "temp_profile_id"
+        web_widget_config {
+            modality = "CHAT_AND_VOICE"
+            theme = "DARK"
+            web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = true
+                enable_origin_check = true
+                allowed_origins = ["https://example.com", "https://test.com"]
+                enable_recaptcha = true
+            }
+        }
+    }
+}

--- a/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_deployment_test.go
@@ -74,6 +74,12 @@ resource "google_ces_deployment" "my-deployment" {
             modality = "CHAT_AND_VOICE"
             theme = "DARK"
             web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = true
+                enable_origin_check = true
+                allowed_origins = ["https://example.com", "https://test.com"]
+                enable_recaptcha = true
+            }
         }
     }
 }
@@ -107,6 +113,12 @@ resource "google_ces_deployment" "my-deployment" {
             modality = "CHAT_ONLY"
             theme = "LIGHT"
             web_widget_title = "temp_webwidget_title"
+            security_settings {
+                enable_public_access = false
+                enable_origin_check = false
+                allowed_origins = ["https://updated.com"]
+                enable_recaptcha = false
+            }
         }
     }
 }


### PR DESCRIPTION
# Add missing securitySettings fields to webWidgetConfig in ces_deployment

This PR adds missing fields to `web_widget_config` in the `google_ces_deployment` resource to match the REST API, and fixes some discrepancies in existing fields.

## Documentation
https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/rest/v1/ChannelProfile#ChannelProfile.WebWidgetConfig

## Rationale
The `web_widget_config` in `google_ces_deployment` had limited support compared to the REST API. Specifically, `securitySettings` and its sub-fields were missing, which are needed for configuring allowed origins and reCAPTCHA.

## Technical Details
- **Added Fields:** Added `securitySettings` with `enablePublicAccess`, `enableOriginCheck`, `allowedOrigins`, and `enableRecaptcha` to `Deployment.yaml`.
- **Fixed Discrepancies:**
    - Updated `channelType` to include missing values: `FIVE9` and `CONTACT_CENTER_INTEGRATION`.
    - Updated `modality` to use `MODALITY_UNSPECIFIED` and add `CHAT_VOICE_AND_VIDEO`.
    - Updated `theme` to use `THEME_UNSPECIFIED`.
- **Boolean Handling:** Used `send_empty_value: true` for boolean fields to ensure `false` values are propagated to the API.
- **Testing:**
    - Created a new example file `ces_deployment_full.tf.tmpl` to showcase the new fields.
    - Updated `ces_deployment_test.go` to include update tests for the new fields, specifically testing toggling from true to false.

## Verification Results
- Code generation successful for both GA and Beta.
- Acceptance tests passed successfully in both GA and Beta providers.
- Manual verification in a test project confirmed that the fields are correctly stored in the backend.

```release-note:enhancement
ces: added `security_settings` field to `google_ces_deployment` resource
```
```release-note:bug
ces: updated supported values for `channel_type`, `modality`, and `theme` in `google_ces_deployment`
```