### PR TITLE
Moved SetupProjectsAndGetAccessToken to a dedicated package

### DIFF
--- a/mmv1/third_party/terraform/acctest/provider_test_utils.go
+++ b/mmv1/third_party/terraform/acctest/provider_test_utils.go
@@ -1,0 +1,108 @@
+package acctest
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/provider"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var TestAccProviders map[string]*schema.Provider
+var testAccProvider *schema.Provider
+
+func init() {
+	configs = make(map[string]*transport_tpg.Config)
+	sources = make(map[string]VcrSource)
+	testAccProvider = provider.Provider()
+	TestAccProviders = map[string]*schema.Provider{
+		"google": testAccProvider,
+	}
+}
+
+// GoogleProviderConfig returns a configured SDKv2 provider.
+// This function is typically used in CheckDestroy functions in acceptance tests. The provider client is used to make GET requests to check a resource is destroyed.
+// Either a preexisting configured SDKv2 provider for the given test name is returned, or a new one is configured with empty (but non-nil) terraform.ResourceConfig
+func GoogleProviderConfig(t *testing.T) *transport_tpg.Config {
+	configsLock.RLock()
+	config, ok := configs[t.Name()]
+	configsLock.RUnlock()
+	if ok {
+		return config
+	}
+
+	sdkProvider := provider.Provider()
+	rc := terraform.ResourceConfig{}
+
+	// `universe_domain` must be specified through config (i.e. unlike most provider settings there's no environment variable), and we check the value matches the credentials during provider initilization
+	// In the test environment we seed the value through a test-only environment variable, and we need to pre-seed a value in ResourceConfig as if it was in config to pass the check
+	universeDomain := envvar.GetTestUniverseDomainFromEnv(t)
+	if universeDomain != "" && universeDomain != "googleapis.com" {
+		rc.Config = make(map[string]interface{})
+		rc.Config["universe_domain"] = universeDomain
+	}
+	sdkProvider.Configure(context.Background(), &rc)
+	return sdkProvider.Meta().(*transport_tpg.Config)
+}
+
+func AccTestPreCheck(t *testing.T) {
+	if v := os.Getenv("GOOGLE_CREDENTIALS_FILE"); v != "" {
+		creds, err := ioutil.ReadFile(v)
+		if err != nil {
+			t.Fatalf("Error reading GOOGLE_CREDENTIALS_FILE path: %s", err)
+		}
+		os.Setenv("GOOGLE_CREDENTIALS", string(creds))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.CredsEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.CredsEnvVars, ", "))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.ProjectEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ProjectEnvVars, ", "))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.RegionEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.RegionEnvVars, ", "))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.ZoneEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ZoneEnvVars, ", "))
+	}
+}
+
+// AccTestPreCheck_AdcCredentialsOnly is a PreCheck function for acceptance tests that use ADCs when
+func AccTestPreCheck_AdcCredentialsOnly(t *testing.T) {
+	if v := os.Getenv("GOOGLE_CREDENTIALS_FILE"); v != "" {
+		t.Log("Ignoring GOOGLE_CREDENTIALS_FILE; acceptance test doesn't use credentials other than ADCs")
+	}
+
+	// Fail on set creds
+	if v := envvar.MultiEnvSearch(envvar.CredsEnvVarsExcludingAdcs()); v != "" {
+		t.Fatalf("This acceptance test only uses ADCs, so all of %s must be unset", strings.Join(envvar.CredsEnvVarsExcludingAdcs(), ", "))
+	}
+
+	// Fail on ADC ENV not set
+	if v := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); v == "" {
+		t.Fatalf("GOOGLE_APPLICATION_CREDENTIALS must be set for acceptance tests that are dependent on ADCs")
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.ProjectEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ProjectEnvVars, ", "))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.RegionEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.RegionEnvVars, ", "))
+	}
+
+	if v := envvar.MultiEnvSearch(envvar.ZoneEnvVars); v == "" {
+		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ZoneEnvVars, ", "))
+	}
+}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
 {{ if ne $.TargetVersionName `ga` -}}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
@@ -252,7 +253,7 @@ func testAccFwProvider_UserProjectOverride(t *testing.T) {
 	pid := "tf-test-" + acctest.RandString(t, 10)
 
 	config := transport_tpg.BootstrapConfig(t)
-	accessToken, err := acctest.SetupProjectsAndGetAccessToken(org, billing, pid, "firebase", config)
+	accessToken, err := ptu.SetupProjectsAndGetAccessToken(org, billing, pid, "firebase", config)
 	if err != nil || accessToken == "" {
 		if err == nil {
 			t.Fatal("error when setting up projects and retrieving access token: access token is an empty string")
@@ -263,7 +264,7 @@ func testAccFwProvider_UserProjectOverride(t *testing.T) {
 	context := map[string]interface{}{
 		"user_project_override": false, // changed in config functions
 		"access_token":          accessToken,
-		"project_2":             pid + "-2", // acctest.SetupProjectsAndGetAccessToken creates project 1 with id = `pid`, and 2 = `pid` + "-2"
+		"project_2":             pid + "-2", // ptu.SetupProjectsAndGetAccessToken creates project 1 with id = `pid`, and 2 = `pid` + "-2"
 		"random_suffix":         acctest.RandString(t, 5),
 	}
 

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 {{ if ne $.TargetVersionName `ga` -}}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
+	ptu "github.com/hashicorp/terraform-provider-google/google/provider/testutils"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 {{- end }}
 )

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
@@ -9,9 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
 {{ if ne $.TargetVersionName `ga` -}}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 {{- end }}
 )

--- a/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
+++ b/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
@@ -243,7 +244,7 @@ data "google_provider_config_sdk" "default" {}
 func testAccProviderUserProjectOverride(t *testing.T) {
 	// Test cannot run in VCR mode due to use of aliases
 	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
-	// And also due to the resources made out of band in acctest.SetupProjectsAndGetAccessToken
+	// And also due to the resources made out of band in ptu.SetupProjectsAndGetAccessToken
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
@@ -253,7 +254,7 @@ func testAccProviderUserProjectOverride(t *testing.T) {
 	topicName := "tf-test-topic-" + acctest.RandString(t, 10)
 
 	config := transport_tpg.BootstrapConfig(t)
-	accessToken, err := acctest.SetupProjectsAndGetAccessToken(org, billing, pid, "pubsub", config)
+	accessToken, err := ptu.SetupProjectsAndGetAccessToken(org, billing, pid, "pubsub", config)
 	if err != nil || accessToken == "" {
 		if err == nil {
 			t.Fatal("error when setting up projects and retrieving access token: access token is an empty string")
@@ -291,7 +292,7 @@ func testAccProviderUserProjectOverride(t *testing.T) {
 func testAccProviderIndirectUserProjectOverride(t *testing.T) {
 	// Test cannot run in VCR mode due to use of aliases
 	// See: https://github.com/hashicorp/terraform-provider-google/issues/20019
-	// And also due to the resources made out of band in acctest.SetupProjectsAndGetAccessToken
+	// And also due to the resources made out of band in ptu.SetupProjectsAndGetAccessToken
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
@@ -300,7 +301,7 @@ func testAccProviderIndirectUserProjectOverride(t *testing.T) {
 	pid := "tf-test-" + acctest.RandString(t, 10)
 
 	config := transport_tpg.BootstrapConfig(t)
-	accessToken, err := acctest.SetupProjectsAndGetAccessToken(org, billing, pid, "cloudkms", config)
+	accessToken, err := ptu.SetupProjectsAndGetAccessToken(org, billing, pid, "cloudkms", config)
 	if err != nil || accessToken == "" {
 		if err == nil {
 			t.Fatal("error when setting up projects and retrieving access token: access token is an empty string")

--- a/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
+++ b/mmv1/third_party/terraform/provider/provider_user_project_override_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	ptu "github.com/hashicorp/terraform-provider-google/google/provider/test_utils"
+	ptu "github.com/hashicorp/terraform-provider-google/google/provider/testutils"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 

--- a/mmv1/third_party/terraform/provider/test_utils/test_utils.go.tmpl
+++ b/mmv1/third_party/terraform/provider/test_utils/test_utils.go.tmpl
@@ -1,17 +1,6 @@
-package acctest
+package test_utils
 
 import (
-	"context"
-	"io/ioutil"
-	"os"
-	"strings"
-	"testing"
-
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"fmt"
 	"time"
 
@@ -20,7 +9,6 @@ import (
 	"google.golang.org/api/iamcredentials/v1"
 	"google.golang.org/api/serviceusage/v1"
 
-	"github.com/hashicorp/terraform-provider-google/google/provider"
 	tpgcloudbilling "github.com/hashicorp/terraform-provider-google/google/services/cloudbilling"
 	"github.com/hashicorp/terraform-provider-google/google/services/iambeta"
 	tpgiamcredentials "github.com/hashicorp/terraform-provider-google/google/services/iamcredentials"
@@ -31,98 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
-
-var TestAccProviders map[string]*schema.Provider
-var testAccProvider *schema.Provider
-
-func init() {
-	configs = make(map[string]*transport_tpg.Config)
-	sources = make(map[string]VcrSource)
-	testAccProvider = provider.Provider()
-	TestAccProviders = map[string]*schema.Provider{
-		"google": testAccProvider,
-	}
-}
-
-// GoogleProviderConfig returns a configured SDKv2 provider.
-// This function is typically used in CheckDestroy functions in acceptance tests. The provider client is used to make GET requests to check a resource is destroyed.
-// Either a preexisting configured SDKv2 provider for the given test name is returned, or a new one is configured with empty (but non-nil) terraform.ResourceConfig
-func GoogleProviderConfig(t *testing.T) *transport_tpg.Config {
-	configsLock.RLock()
-	config, ok := configs[t.Name()]
-	configsLock.RUnlock()
-	if ok {
-		return config
-	}
-
-	sdkProvider := provider.Provider()
-	rc := terraform.ResourceConfig{}
-
-	// `universe_domain` must be specified through config (i.e. unlike most provider settings there's no environment variable), and we check the value matches the credentials during provider initilization
-	// In the test environment we seed the value through a test-only environment variable, and we need to pre-seed a value in ResourceConfig as if it was in config to pass the check
-	universeDomain := envvar.GetTestUniverseDomainFromEnv(t)
-	if universeDomain != "" && universeDomain != "googleapis.com" {
-		rc.Config = make(map[string]interface{})
-		rc.Config["universe_domain"] = universeDomain
-	}
-	sdkProvider.Configure(context.Background(), &rc)
-	return sdkProvider.Meta().(*transport_tpg.Config)
-}
-
-func AccTestPreCheck(t *testing.T) {
-	if v := os.Getenv("GOOGLE_CREDENTIALS_FILE"); v != "" {
-		creds, err := ioutil.ReadFile(v)
-		if err != nil {
-			t.Fatalf("Error reading GOOGLE_CREDENTIALS_FILE path: %s", err)
-		}
-		os.Setenv("GOOGLE_CREDENTIALS", string(creds))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.CredsEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.CredsEnvVars, ", "))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.ProjectEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ProjectEnvVars, ", "))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.RegionEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.RegionEnvVars, ", "))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.ZoneEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ZoneEnvVars, ", "))
-	}
-}
-
-// AccTestPreCheck_AdcCredentialsOnly is a PreCheck function for acceptance tests that use ADCs when
-func AccTestPreCheck_AdcCredentialsOnly(t *testing.T) {
-	if v := os.Getenv("GOOGLE_CREDENTIALS_FILE"); v != "" {
-		t.Log("Ignoring GOOGLE_CREDENTIALS_FILE; acceptance test doesn't use credentials other than ADCs")
-	}
-
-	// Fail on set creds
-	if v := envvar.MultiEnvSearch(envvar.CredsEnvVarsExcludingAdcs()); v != "" {
-		t.Fatalf("This acceptance test only uses ADCs, so all of %s must be unset", strings.Join(envvar.CredsEnvVarsExcludingAdcs(), ", "))
-	}
-
-	// Fail on ADC ENV not set
-	if v := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); v == "" {
-		t.Fatalf("GOOGLE_APPLICATION_CREDENTIALS must be set for acceptance tests that are dependent on ADCs")
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.ProjectEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ProjectEnvVars, ", "))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.RegionEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.RegionEnvVars, ", "))
-	}
-
-	if v := envvar.MultiEnvSearch(envvar.ZoneEnvVars); v == "" {
-		t.Fatalf("One of %s must be set for acceptance tests", strings.Join(envvar.ZoneEnvVars, ", "))
-	}
-}
 
 func SetupProjectsAndGetAccessToken(org, billing, pid, service string, config *transport_tpg.Config) (string, error) {
 	// Create project-1 and project-2

--- a/mmv1/third_party/terraform/provider/testutils/testutils.go.tmpl
+++ b/mmv1/third_party/terraform/provider/testutils/testutils.go.tmpl
@@ -1,4 +1,4 @@
-package test_utils
+package testutils
 
 import (
 	"fmt"


### PR DESCRIPTION
After some consideration, I ended up going with this solution. I'm not sure the helper function is structured in a way that makes the most sense - it should probably be using bootstrap functions rather than hand-coding creation of test projects. But I don't want to try to untangle that right now. Even if I did, it would still have dependencies on specific services.

So, to keep everything from becoming dependent on those services, I put this code in a separate package. I nested it inside google/provider/ rather than creating a google/provider_test_utils directory because it felt nicer.

This is making me wonder if we'll want to move all the bootstrap_test_utils files into sub-packages as well, since they also introduce dependencies in the main package that didn't otherwise need to exist... I wish I'd thought of that before starting that whole migration! But we're still better off than we were before, and we can do that migration more easily going forward if we want to.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
