### PR TITLE
Support deletion for CryptoKey and CryptoKeyVersion

### DIFF
--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,9 @@
+KMS: Schema Addition & Test Prep for deletion policy
+
+This is part 1 of a two-part change for the next major release to implement KMS hard-deletion.
+PR 2 will follow with the actual delete logic.
+
+- Added deletionPolicy property to CryptoKeyVersion.yaml with default DELETE.
+- Updated existing acceptance tests to use deletion_policy = DESTROY to avoid teardown failures.
+- Added new test for DESTROY_SCHEDULED state transition.
+- Fixed pre_update template to handle simultaneous updates safely and ensure state refresh.

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: 'CryptoKey'
+deletion_policy_exclude: true
 description: |
   A `CryptoKey` represents a logical key that can be used for cryptographic operations.
 
@@ -175,6 +176,8 @@ properties:
       `DELETE` is the default and requires all versions to be permanently deleted first.
       `DESTROY` will destroy all versions and abandon the key in state (legacy behavior).
     default_value: "DELETE"
+    url_param_only: true
+    ignore_read: true
   - name: 'keyAccessJustificationsPolicy'
     type: NestedObject
     description: |

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -17,11 +17,9 @@ description: |
   A `CryptoKey` represents a logical key that can be used for cryptographic operations.
 
 
-  ~> **Note:** CryptoKeys cannot be deleted from Google Cloud Platform.
-  Destroying a Terraform-managed CryptoKey will remove it from state
-  and delete all CryptoKeyVersions, rendering the key unusable, but *will
-  not delete the resource from the project.* When Terraform destroys these keys,
-  any data previously encrypted with these keys will be irrecoverable.
+  ~> **Note:** By default, deleting a Terraform-managed CryptoKey will attempt to permanently delete it from Google Cloud Platform if all its child versions have been permanently deleted.
+  If you want to preserve the key resource in GCP while rendering it unusable (legacy Terraform behavior), set `deletion_policy` to `DESTROY`.
+  When Terraform destroys these keys or their versions, any data previously encrypted with them will be irrecoverable.
   For this reason, it is strongly recommended that you add
   [lifecycle](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle)
   hooks to the resource to prevent accidental destruction.
@@ -170,6 +168,13 @@ properties:
       The resource name is in the format "projects/*/locations/*/ekmConnections/*" and only applies to "EXTERNAL_VPC" keys.
     immutable: true
     default_from_api: true
+  - name: 'deletionPolicy'
+    type: String
+    description: |
+      The deletion policy for the CryptoKey.
+      `DELETE` is the default and requires all versions to be permanently deleted first.
+      `DESTROY` will destroy all versions and abandon the key in state (legacy behavior).
+    default_value: "DELETE"
   - name: 'keyAccessJustificationsPolicy'
     type: NestedObject
     description: |

--- a/mmv1/products/kms/CryptoKey.yaml
+++ b/mmv1/products/kms/CryptoKey.yaml
@@ -173,9 +173,9 @@ properties:
     type: String
     description: |
       The deletion policy for the CryptoKey.
-      `DELETE` is the default and requires all versions to be permanently deleted first.
-      `DESTROY` will destroy all versions and abandon the key in state (legacy behavior).
-    default_value: "DELETE"
+      - 'SCHEDULE_DESTROY' (Default): Destroy all versions and abandon the key in state (legacy behavior).
+      - 'DELETE': Requires all versions to be permanently deleted first, then deletes the CryptoKey.
+    default_value: "SCHEDULE_DESTROY"
     url_param_only: true
     ignore_read: true
   - name: 'keyAccessJustificationsPolicy'

--- a/mmv1/products/kms/CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/CryptoKeyVersion.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: 'CryptoKeyVersion'
+deletion_policy_exclude: true
 description: |
   A `CryptoKeyVersion` represents an individual cryptographic key, and the associated key material.
 
@@ -69,6 +70,8 @@ properties:
       - 'DELETE' (Default): When the resource block is removed from configuration, the provider will verify the resource state is DESTROYED and call the permanent delete API endpoint. If the resource has not completed its scheduled destruction period, the Terraform destroy operation will fail and return an error.
       - 'DESTROY': When the resource block is removed from configuration, the provider will call the destroy API endpoint to schedule the key for destruction, and then immediately drop the resource from the Terraform state. The API resource itself is not permanently removed.
     default_value: 'DELETE'
+    url_param_only: true
+    ignore_read: true
   - name: 'state'
     type: Enum
     description: |

--- a/mmv1/products/kms/CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/CryptoKeyVersion.yaml
@@ -62,6 +62,13 @@ properties:
     description: |
       The resource name for this CryptoKeyVersion.
     output: true
+  - name: 'deletionPolicy'
+    type: String
+    description: |
+      The deletion policy for the CryptoKeyVersion.
+      - 'DELETE' (Default): When the resource block is removed from configuration, the provider will verify the resource state is DESTROYED and call the permanent delete API endpoint. If the resource has not completed its scheduled destruction period, the Terraform destroy operation will fail and return an error.
+      - 'DESTROY': When the resource block is removed from configuration, the provider will call the destroy API endpoint to schedule the key for destruction, and then immediately drop the resource from the Terraform state. The API resource itself is not permanently removed.
+    default_value: 'DELETE'
   - name: 'state'
     type: Enum
     description: |

--- a/mmv1/products/kms/CryptoKeyVersion.yaml
+++ b/mmv1/products/kms/CryptoKeyVersion.yaml
@@ -67,9 +67,9 @@ properties:
     type: String
     description: |
       The deletion policy for the CryptoKeyVersion.
-      - 'DELETE' (Default): When the resource block is removed from configuration, the provider will verify the resource state is DESTROYED and call the permanent delete API endpoint. If the resource has not completed its scheduled destruction period, the Terraform destroy operation will fail and return an error.
-      - 'DESTROY': When the resource block is removed from configuration, the provider will call the destroy API endpoint to schedule the key for destruction, and then immediately drop the resource from the Terraform state. The API resource itself is not permanently removed.
-    default_value: 'DELETE'
+      - 'SCHEDULE_DESTROY' (Default): When the resource block is removed from configuration, the provider will call the destroy API endpoint to schedule the key for destruction, and then immediately drop the resource from the Terraform state. The API resource itself is not permanently removed (legacy behavior).
+      - 'DELETE': When the resource block is removed from configuration, the provider will verify the resource state is DESTROYED and call the permanent delete API endpoint. If the resource has not completed its scheduled destruction period, the Terraform destroy operation will fail and return an error.
+    default_value: 'SCHEDULE_DESTROY'
     url_param_only: true
     ignore_read: true
   - name: 'state'

--- a/mmv1/templates/terraform/custom_delete/kms_crypto_key.tmpl
+++ b/mmv1/templates/terraform/custom_delete/kms_crypto_key.tmpl
@@ -5,7 +5,7 @@
 
 	policy := d.Get("deletion_policy").(string)
 
-	if policy == "DESTROY" {
+	if policy == "SCHEDULE_DESTROY" || policy == "" {
 		if err := clearCryptoKeyVersions(cryptoKeyId, userAgent, config); err != nil {
 			return err
 		}
@@ -16,7 +16,7 @@
 		}
 		d.SetId("")
 		return nil
-	} else if policy == "DELETE" || policy == "" {
+	} else if policy == "DELETE" {
 		if err := checkCryptoKeyVersionsEmpty(cryptoKeyId, userAgent, config); err != nil {
 			return err
 		}

--- a/mmv1/templates/terraform/custom_delete/kms_crypto_key.tmpl
+++ b/mmv1/templates/terraform/custom_delete/kms_crypto_key.tmpl
@@ -3,23 +3,31 @@
 		return err
 	}
 
-	log.Printf(`
-[WARNING] KMS CryptoKey resources cannot be deleted from GCP. The CryptoKey %s will be removed from Terraform state,
-and all its CryptoKeyVersions will be destroyed, but it will still be present in the project.`, cryptoKeyId.CryptoKeyId())
+	policy := d.Get("deletion_policy").(string)
 
-	// Delete all versions of the key
-	if err := clearCryptoKeyVersions(cryptoKeyId, userAgent, config); err != nil {
-		return err
-	}
-
-	// Make sure automatic key rotation is disabled if set
-	if d.Get("rotation_period") != "" {
-		if err := disableCryptoKeyRotation(cryptoKeyId, userAgent, config); err != nil {
-			return fmt.Errorf(
-				"While cryptoKeyVersions were cleared, Terraform was unable to disable automatic rotation of key due to an error: %s."+
-					"Please retry or manually disable automatic rotation to prevent creation of a new version of this key.", err)
+	if policy == "DESTROY" {
+		if err := clearCryptoKeyVersions(cryptoKeyId, userAgent, config); err != nil {
+			return err
 		}
-	}
+		if d.Get("rotation_period").(string) != "" {
+			if err := disableCryptoKeyRotation(cryptoKeyId, userAgent, config); err != nil {
+				return err
+			}
+		}
+		d.SetId("")
+		return nil
+	} else if policy == "DELETE" || policy == "" {
+		if err := checkCryptoKeyVersionsEmpty(cryptoKeyId, userAgent, config); err != nil {
+			return err
+		}
 
-	d.SetId("")
-	return nil
+		// Call the final DELETE method for the CryptoKey
+		if err := deleteCryptoKey(cryptoKeyId, d, userAgent, config); err != nil {
+			return err
+		}
+
+		d.SetId("")
+		return nil
+	} else {
+		return fmt.Errorf("Unsupported deletion_policy: %s", policy)
+	}

--- a/mmv1/templates/terraform/custom_delete/kms_crypto_key_version.tmpl
+++ b/mmv1/templates/terraform/custom_delete/kms_crypto_key_version.tmpl
@@ -1,13 +1,27 @@
     
-    cryptoKeyVersionId, err := parseKmsCryptoKeyVersionId(d.Id(), config)
-    if err != nil {
-        return err
-    }
-    if cryptoKeyVersionId == nil {
-        return nil
-    }
-    if err := deleteCryptoKeyVersions(cryptoKeyVersionId, d, userAgent, config); err != nil { 
-        return nil
-    }
-    d.SetId("")
-	return nil
+	cryptoKeyVersionId, err := parseKmsCryptoKeyVersionId(d.Id(), config)
+	if err != nil {
+		return err
+	}
+	if cryptoKeyVersionId == nil {
+		return nil
+	}
+	policy := d.Get("deletion_policy").(string)
+
+	// Handle the legacy "DESTROY" behavior first
+	if policy == "DESTROY" {
+		if err := destroyCryptoKeyVersion(cryptoKeyVersionId, d, userAgent, config); err != nil {
+			return err
+		}
+		d.SetId("")
+		return nil
+	} else if policy == "" || policy == "DELETE" {
+		// Proceed with the "DELETE" workflow
+		if err := deleteCryptoKeyVersion(cryptoKeyVersionId, d, userAgent, config); err != nil {
+			return err
+		}
+		d.SetId("")
+		return nil
+	} else {
+		return fmt.Errorf("Unsupported deletion_policy: %s", policy)
+	}

--- a/mmv1/templates/terraform/custom_delete/kms_crypto_key_version.tmpl
+++ b/mmv1/templates/terraform/custom_delete/kms_crypto_key_version.tmpl
@@ -8,14 +8,14 @@
 	}
 	policy := d.Get("deletion_policy").(string)
 
-	// Handle the legacy "DESTROY" behavior first
-	if policy == "DESTROY" {
+	// Handle the legacy behavior first (default)
+	if policy == "SCHEDULE_DESTROY" || policy == "" {
 		if err := destroyCryptoKeyVersion(cryptoKeyVersionId, d, userAgent, config); err != nil {
 			return err
 		}
 		d.SetId("")
 		return nil
-	} else if policy == "" || policy == "DELETE" {
+	} else if policy == "DELETE" {
 		// Proceed with the "DELETE" workflow
 		if err := deleteCryptoKeyVersion(cryptoKeyVersionId, d, userAgent, config); err != nil {
 			return err

--- a/mmv1/templates/terraform/pre_update/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/kms_crypto_key_version.go.tmpl
@@ -12,6 +12,49 @@ if d.HasChange("external_protection_level_options") {
 		newUpdateMask = append(newUpdateMask, "externalProtectionLevelOptions.ekmConnectionKeyPath")
 	}
 }
+
+// Intercept state change to DESTROY_SCHEDULED or handle invalid restore
+if d.HasChange("state") {
+	oldState, newState := d.GetChange("state")
+	oldStateStr, ok1 := oldState.(string)
+	newStateStr, ok2 := newState.(string)
+	
+	if ok1 && ok2 {
+		if newStateStr == "DESTROY_SCHEDULED" {
+			if len(newUpdateMask) > 1 {
+				return fmt.Errorf("Cannot combine state change to DESTROY_SCHEDULED with updates to other fields: %v", newUpdateMask)
+			}
+			
+			// Safe URL construction (Fix brittle split)
+			destroyUrl := strings.Split(url, "?")[0] + ":destroy"
+			
+			// Resolve billing project safely
+			billingProject, err := tpgresource.GetBillingProject(d, config)
+			if err != nil {
+				return err
+			}
+			
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   billingProject,
+				RawURL:    destroyUrl,
+				UserAgent: userAgent,
+			})
+			if err != nil {
+				return fmt.Errorf("Error scheduling destroy: %s", err)
+			}
+			
+			// Return Read to update state after destroy (Fix state refresh)
+			return resourceKMSCryptoKeyVersionRead(d, meta)
+		}
+		
+		if oldStateStr == "DESTROY_SCHEDULED" && (newStateStr == "ENABLED" || newStateStr == "DISABLED") {
+			return fmt.Errorf("Restoring a CryptoKeyVersion from DESTROY_SCHEDULED via state change is not supported in this version. Please use the gcloud CLI or Cloud Console to restore.")
+		}
+	}
+}
+
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars
 // won't set it
 url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(newUpdateMask, ",")})

--- a/mmv1/templates/terraform/pre_update/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/kms_crypto_key_version.go.tmpl
@@ -25,24 +25,12 @@ if d.HasChange("state") {
 				return fmt.Errorf("Cannot combine state change to DESTROY_SCHEDULED with updates to other fields: %v", newUpdateMask)
 			}
 			
-			// Safe URL construction (Fix brittle split)
-			destroyUrl := strings.Split(url, "?")[0] + ":destroy"
-			
-			// Resolve billing project safely
-			billingProject, err := tpgresource.GetBillingProject(d, config)
+			ckvId, err := parseKmsCryptoKeyVersionId(d.Id(), config)
 			if err != nil {
 				return err
 			}
-			
-			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-				Config:    config,
-				Method:    "POST",
-				Project:   billingProject,
-				RawURL:    destroyUrl,
-				UserAgent: userAgent,
-			})
-			if err != nil {
-				return fmt.Errorf("Error scheduling destroy: %s", err)
+			if err := destroyCryptoKeyVersion(ckvId, d, userAgent, config); err != nil {
+				return err
 			}
 			
 			// Return Read to update state after destroy (Fix state refresh)

--- a/mmv1/third_party/terraform/services/kms/kms_utils.go
+++ b/mmv1/third_party/terraform/services/kms/kms_utils.go
@@ -259,7 +259,7 @@ func clearCryptoKeyVersions(cryptoKeyId *KmsCryptoKeyId, userAgent string, confi
 	return nil
 }
 
-func deleteCryptoKeyVersions(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema.ResourceData, userAgent string, config *transport_tpg.Config) error {
+func destroyCryptoKeyVersion(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema.ResourceData, userAgent string, config *transport_tpg.Config) error {
 	versionsClient := NewClient(config, userAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
 	request := &cloudkms.DestroyCryptoKeyVersionRequest{}
 	destroyCall := versionsClient.Destroy(cryptoKeyVersionId.Name, request)
@@ -271,6 +271,90 @@ func deleteCryptoKeyVersions(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schem
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ID %s", cryptoKeyVersionId.Name))
 	}
 
+	return nil
+}
+
+func deleteCryptoKeyVersion(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema.ResourceData, userAgent string, config *transport_tpg.Config) error {
+	// GET the resource to check its state before attempting to delete.
+	versionsClient := NewClient(config, userAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
+	getCkvCall := versionsClient.Get(cryptoKeyVersionId.Name)
+	if config.UserProjectOverride {
+		getCkvCall.Header().Set("X-Goog-User-Project", cryptoKeyVersionId.CryptoKeyId.KeyRingId.Project)
+	}
+	ckvResponse, err := getCkvCall.Do()
+	if err != nil {
+		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("CryptoKeyVersion %q", d.Id()))
+	}
+
+	// Check if the resource is in a state that allows for permanent deletion.
+	switch ckvResponse.State {
+	case "DESTROYED", "GENERATION_FAILED", "IMPORT_FAILED":
+		// Proceed with the "DELETE" (hard-delete) workflow
+		deleteUrl := config.KMSBasePath + cryptoKeyVersionId.Name
+		
+		_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   cryptoKeyVersionId.CryptoKeyId.KeyRingId.Project,
+			RawURL:    deleteUrl,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			if transport_tpg.IsNotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("Error deleting CryptoKeyVersion: %s", err)
+		}
+		return nil
+	case "DESTROY_SCHEDULED":
+		return fmt.Errorf("CryptoKeyVersion %q is scheduled for destruction. Please wait for the destruction period to complete before removing the resource from your configuration.", d.Id())
+	default:
+		return fmt.Errorf(
+			"CryptoKeyVersion %q cannot be deleted directly because it is in state %q. "+
+			"Please follow the two-step deletion process: first, set the 'state' "+
+			"field of the resource to 'DESTROY_SCHEDULED' and wait for the scheduled "+
+			"destruction period to complete before removing the resource from your configuration.",
+			d.Id(), ckvResponse.State)
+	}
+}
+
+func checkCryptoKeyVersionsEmpty(cryptoKeyId *KmsCryptoKeyId, userAgent string, config *transport_tpg.Config) error {
+	versionsClient := NewClient(config, userAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
+	listCall := versionsClient.List(cryptoKeyId.CryptoKeyId()).PageSize(1)
+	if config.UserProjectOverride {
+		listCall.Header().Set("X-Goog-User-Project", cryptoKeyId.KeyRingId.Project)
+	}
+	versionsResponse, err := listCall.Do()
+	if err != nil {
+		if transport_tpg.IsNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+
+	if len(versionsResponse.CryptoKeyVersions) > 0 || versionsResponse.NextPageToken != "" {
+		return fmt.Errorf("CryptoKey cannot be deleted because it still contains CryptoKeyVersions. All versions must be permanently deleted first.")
+	}
+	return nil
+}
+
+func deleteCryptoKey(cryptoKeyId *KmsCryptoKeyId, d *schema.ResourceData, userAgent string, config *transport_tpg.Config) error {
+	deleteUrl := config.KMSBasePath + cryptoKeyId.CryptoKeyId()
+	
+	_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "DELETE",
+		Project:   cryptoKeyId.KeyRingId.Project,
+		RawURL:    deleteUrl,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		if transport_tpg.IsNotFoundError(err) {
+			return nil
+		}
+		return fmt.Errorf("Error deleting CryptoKey: %s", err)
+	}
+	
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/kms/kms_utils.go
+++ b/mmv1/third_party/terraform/services/kms/kms_utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-google/google/registry"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
 
@@ -290,8 +291,8 @@ func deleteCryptoKeyVersion(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema
 	switch ckvResponse.State {
 	case "DESTROYED", "GENERATION_FAILED", "IMPORT_FAILED":
 		// Proceed with the "DELETE" (hard-delete) workflow
-		deleteUrl := config.KMSBasePath + cryptoKeyVersionId.Name
-		
+		deleteUrl := transport_tpg.BaseUrl(registry.GetProduct("kms"), config) + cryptoKeyVersionId.Name
+
 		_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    config,
 			Method:    "DELETE",
@@ -300,7 +301,7 @@ func deleteCryptoKeyVersion(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema
 			UserAgent: userAgent,
 		})
 		if err != nil {
-			if transport_tpg.IsNotFoundError(err) {
+			if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 				return nil
 			}
 			return fmt.Errorf("Error deleting CryptoKeyVersion: %s", err)
@@ -311,9 +312,9 @@ func deleteCryptoKeyVersion(cryptoKeyVersionId *kmsCryptoKeyVersionId, d *schema
 	default:
 		return fmt.Errorf(
 			"CryptoKeyVersion %q cannot be deleted directly because it is in state %q. "+
-			"Please follow the two-step deletion process: first, set the 'state' "+
-			"field of the resource to 'DESTROY_SCHEDULED' and wait for the scheduled "+
-			"destruction period to complete before removing the resource from your configuration.",
+				"Please follow the two-step deletion process: first, set the 'state' "+
+				"field of the resource to 'DESTROY_SCHEDULED' and wait for the scheduled "+
+				"destruction period to complete before removing the resource from your configuration.",
 			d.Id(), ckvResponse.State)
 	}
 }
@@ -326,7 +327,7 @@ func checkCryptoKeyVersionsEmpty(cryptoKeyId *KmsCryptoKeyId, userAgent string, 
 	}
 	versionsResponse, err := listCall.Do()
 	if err != nil {
-		if transport_tpg.IsNotFoundError(err) {
+		if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 			return nil
 		}
 		return err
@@ -339,8 +340,8 @@ func checkCryptoKeyVersionsEmpty(cryptoKeyId *KmsCryptoKeyId, userAgent string, 
 }
 
 func deleteCryptoKey(cryptoKeyId *KmsCryptoKeyId, d *schema.ResourceData, userAgent string, config *transport_tpg.Config) error {
-	deleteUrl := config.KMSBasePath + cryptoKeyId.CryptoKeyId()
-	
+	deleteUrl := transport_tpg.BaseUrl(registry.GetProduct("kms"), config) + cryptoKeyId.CryptoKeyId()
+
 	_, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 		Config:    config,
 		Method:    "DELETE",
@@ -349,12 +350,12 @@ func deleteCryptoKey(cryptoKeyId *KmsCryptoKeyId, d *schema.ResourceData, userAg
 		UserAgent: userAgent,
 	})
 	if err != nil {
-		if transport_tpg.IsNotFoundError(err) {
+		if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
 			return nil
 		}
 		return fmt.Errorf("Error deleting CryptoKey: %s", err)
 	}
-	
+
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
@@ -498,6 +498,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DELETE"
   labels = {
     key = "value"
   }
@@ -531,7 +532,6 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
-  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -564,7 +564,6 @@ resource "google_kms_crypto_key" "crypto_key" {
   name            = "%s"
   key_ring        = google_kms_key_ring.key_ring.id
   rotation_period = "%s"
-  deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod)
 }
@@ -593,7 +592,6 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
-  deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -623,7 +621,6 @@ resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
   purpose  = "ASYMMETRIC_SIGN"
-  deletion_policy = "DESTROY"
 
   version_template {
     algorithm = "%s"
@@ -707,7 +704,6 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
-  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -754,7 +750,6 @@ resource "google_kms_crypto_key" "crypto_key" {
   provider = google-beta
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
-  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -882,6 +877,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DELETE"
   skip_initial_version_creation = true
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_test.go.tmpl
@@ -3,6 +3,7 @@ package kms_test
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
@@ -473,6 +474,37 @@ func testAccCheckGoogleKmsCryptoKeyRotationDisabled(t *testing.T, projectId, loc
 	}
 }
 
+func testGoogleKmsCryptoKey_deleteFailureConfig(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+  project = google_project.acceptance.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = google_kms_key_ring.key_ring.id
+  labels = {
+    key = "value"
+  }
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
 // This test runs in its own project, otherwise the test project would start to get filled
 // with undeletable resources
 func testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
@@ -499,6 +531,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -531,6 +564,7 @@ resource "google_kms_crypto_key" "crypto_key" {
   name            = "%s"
   key_ring        = google_kms_key_ring.key_ring.id
   rotation_period = "%s"
+  deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod)
 }
@@ -559,6 +593,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -588,6 +623,7 @@ resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
   purpose  = "ASYMMETRIC_SIGN"
+  deletion_policy = "DESTROY"
 
   version_template {
     algorithm = "%s"
@@ -671,6 +707,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -717,6 +754,7 @@ resource "google_kms_crypto_key" "crypto_key" {
   provider = google-beta
   name     = "%s"
   key_ring = google_kms_key_ring.key_ring.id
+  deletion_policy = "DESTROY"
   labels = {
     key = "value"
   }
@@ -757,6 +795,94 @@ resource "google_kms_crypto_key" "crypto_key" {
   }
   skip_initial_version_creation = true
   import_only = true
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func TestAccKmsCryptoKey_deleteSuccess(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKey_skipVersion(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation", "labels", "terraform_labels"},
+			},
+			{
+				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKmsCryptoKey_deleteFailure(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKey_deleteFailureConfig(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				Config:      testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				ExpectError: regexp.MustCompile("CryptoKey cannot be deleted because it still contains CryptoKeyVersions"),
+			},
+			{
+				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+		},
+	})
+}
+
+func testGoogleKmsCryptoKey_skipVersion(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+  project = google_project.acceptance.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = google_kms_key_ring.key_ring.id
+  skip_initial_version_creation = true
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
@@ -244,6 +244,7 @@ func TestAccKmsCryptoKeyVersion_externalProtectionLevelOptionsVpc(t *testing.T) 
 	})
 }
 
+// TODO: Consider renaming this to testGoogleKmsCryptoKeyVersion_legacy as it tests the legacy destroy behavior.
 func testGoogleKmsCryptoKeyVersion_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -275,6 +276,8 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -314,6 +317,8 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -381,6 +386,8 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -419,6 +426,8 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 		prevent_destroy = true
 	}
 	state       = "ENABLED"
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -458,6 +467,8 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 		prevent_destroy = %s
 	}
 	state = "%s"
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, preventDestroy, state)
 }
@@ -512,6 +523,8 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 	external_protection_level_options {
 		external_key_uri = %s
 	}
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, keyUri)
 }
@@ -603,6 +616,69 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 	external_protection_level_options {
 		ekm_connection_key_path = %s
 	}
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
 }
 `, projectId, ekmConnectionName, keyRingName, cryptoKeyName, keyPath)
+}
+
+func TestAccKmsCryptoKeyVersion_destroyScheduled(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKeyVersion_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				Config: testGoogleKmsCryptoKeyVersion_destroyScheduled(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_kms_crypto_key_version.crypto_key_version", "state", "DESTROY_SCHEDULED"),
+				),
+			},
+		},
+	})
+}
+
+func testGoogleKmsCryptoKeyVersion_destroyScheduled(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+	deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name     = "%s"
+	key_ring = google_kms_key_ring.key_ring.id
+}
+
+resource "google_kms_crypto_key_version" "crypto_key_version" {
+	crypto_key = google_kms_crypto_key.crypto_key.id
+	state      = "DESTROY_SCHEDULED"
+	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "DESTROY"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
@@ -3,6 +3,7 @@ package kms_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -11,7 +12,9 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 )
 
 func TestAccKmsCryptoKeyVersion_basic(t *testing.T) {
@@ -679,6 +682,155 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 	state      = "DESTROY_SCHEDULED"
 	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
 	deletion_policy = "DESTROY"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func TestAccKmsCryptoKeyVersion_delete(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKeyVersion_deleteCreate(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				Config: testGoogleKmsCryptoKeyVersion_deleteSchedule(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_kms_crypto_key_version.crypto_key_version", "state", "DESTROY_SCHEDULED"),
+					func(s *terraform.State) error {
+						config := acctest.GoogleProviderConfig(t)
+						versionsClient := kms.NewClient(config, config.UserAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
+						
+						rs, ok := s.RootModule().Resources["google_kms_crypto_key_version.crypto_key_version"]
+						if !ok {
+							return fmt.Errorf("Not found: google_kms_crypto_key_version.crypto_key_version")
+						}
+						id := rs.Primary.ID
+						
+						err := resource.Retry(20*time.Second, func() *resource.RetryError {
+							res, err := versionsClient.Get(id).Do()
+							if err != nil {
+								return resource.NonRetryableError(err)
+							}
+							if res.State == "DESTROYED" {
+								return nil
+							}
+							return resource.RetryableError(fmt.Errorf("waiting for CryptoKeyVersion to be DESTROYED, current state: %s", res.State))
+						})
+						return err
+					},
+				),
+			},
+			{
+				Config: testGoogleKmsCryptoKeyVersion_deleteRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+		},
+	})
+}
+
+func testGoogleKmsCryptoKeyVersion_deleteCreate(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+	deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name     = "%s"
+	key_ring = google_kms_key_ring.key_ring.id
+	destroy_scheduled_duration = "0s"
+}
+
+resource "google_kms_crypto_key_version" "crypto_key_version" {
+	crypto_key = google_kms_crypto_key.crypto_key.id
+	deletion_policy = "DELETE"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKeyVersion_deleteSchedule(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+	deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name     = "%s"
+	key_ring = google_kms_key_ring.key_ring.id
+	destroy_scheduled_duration = "0s"
+}
+
+resource "google_kms_crypto_key_version" "crypto_key_version" {
+	crypto_key = google_kms_crypto_key.crypto_key.id
+	state      = "DESTROY_SCHEDULED"
+	deletion_policy = "DELETE"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKeyVersion_deleteRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+	deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name     = "%s"
+	key_ring = google_kms_key_ring.key_ring.id
+	destroy_scheduled_duration = "0s"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
@@ -2,8 +2,8 @@ package kms_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -12,9 +12,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/secretmanager"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
-	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 )
 
 func TestAccKmsCryptoKeyVersion_basic(t *testing.T) {
@@ -279,8 +277,6 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -320,8 +316,6 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -389,8 +383,6 @@ resource "google_kms_crypto_key" "crypto_key" {
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -429,8 +421,6 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 		prevent_destroy = true
 	}
 	state       = "ENABLED"
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -470,8 +460,6 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 		prevent_destroy = %s
 	}
 	state = "%s"
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, preventDestroy, state)
 }
@@ -526,8 +514,6 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 	external_protection_level_options {
 		external_key_uri = %s
 	}
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, keyUri)
 }
@@ -619,8 +605,6 @@ resource "google_kms_crypto_key_version" "crypto_key_version" {
 	external_protection_level_options {
 		ekm_connection_key_path = %s
 	}
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
 }
 `, projectId, ekmConnectionName, keyRingName, cryptoKeyName, keyPath)
 }
@@ -680,8 +664,8 @@ resource "google_kms_crypto_key" "crypto_key" {
 resource "google_kms_crypto_key_version" "crypto_key_version" {
 	crypto_key = google_kms_crypto_key.crypto_key.id
 	state      = "DESTROY_SCHEDULED"
-	// Explicitly set to "DESTROY" to avoid failing teardown in acceptance tests.
-	deletion_policy = "DESTROY"
+	// Explicitly set to "SCHEDULE_DESTROY" to avoid failing teardown in acceptance tests.
+	deletion_policy = "SCHEDULE_DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
@@ -706,32 +690,15 @@ func TestAccKmsCryptoKeyVersion_delete(t *testing.T) {
 				Config: testGoogleKmsCryptoKeyVersion_deleteSchedule(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_kms_crypto_key_version.crypto_key_version", "state", "DESTROY_SCHEDULED"),
-					func(s *terraform.State) error {
-						config := acctest.GoogleProviderConfig(t)
-						versionsClient := kms.NewClient(config, config.UserAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
-
-						rs, ok := s.RootModule().Resources["google_kms_crypto_key_version.crypto_key_version"]
-						if !ok {
-							return fmt.Errorf("Not found: google_kms_crypto_key_version.crypto_key_version")
-						}
-						id := rs.Primary.ID
-
-						err := resource.Retry(20*time.Second, func() *resource.RetryError {
-							res, err := versionsClient.Get(id).Do()
-							if err != nil {
-								return resource.NonRetryableError(err)
-							}
-							if res.State == "DESTROYED" {
-								return nil
-							}
-							return resource.RetryableError(fmt.Errorf("waiting for CryptoKeyVersion to be DESTROYED, current state: %s", res.State))
-						})
-						return err
-					},
 				),
 			},
 			{
-				Config: testGoogleKmsCryptoKeyVersion_deleteRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Config:      testGoogleKmsCryptoKeyVersion_deleteRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				ExpectError: regexp.MustCompile("is scheduled for destruction"),
+			},
+			{
+				// Escape hatch to reset policy to SCHEDULE_DESTROY so automated test teardown succeeds
+				Config: testGoogleKmsCryptoKeyVersion_deleteScheduleCleanup(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 			},
 		},
 	})
@@ -761,7 +728,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
 	name     = "%s"
 	key_ring = google_kms_key_ring.key_ring.id
-	destroy_scheduled_duration = "0s"
+	destroy_scheduled_duration = "86400s"
 }
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
@@ -795,7 +762,7 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
 	name     = "%s"
 	key_ring = google_kms_key_ring.key_ring.id
-	destroy_scheduled_duration = "0s"
+	destroy_scheduled_duration = "86400s"
 }
 
 resource "google_kms_crypto_key_version" "crypto_key_version" {
@@ -830,7 +797,43 @@ resource "google_kms_key_ring" "key_ring" {
 resource "google_kms_crypto_key" "crypto_key" {
 	name     = "%s"
 	key_ring = google_kms_key_ring.key_ring.id
-	destroy_scheduled_duration = "0s"
+	destroy_scheduled_duration = "86400s"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKeyVersion_deleteScheduleCleanup(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+	deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = google_project_service.acceptance.project
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name                       = "%s"
+	key_ring                   = google_kms_key_ring.key_ring.id
+	destroy_scheduled_duration = "86400s"
+}
+
+resource "google_kms_crypto_key_version" "crypto_key_version" {
+	crypto_key      = google_kms_crypto_key.crypto_key.id
+	state           = "DESTROY_SCHEDULED"
+	// Revert to legacy escape hatch so automated test teardown succeeds!
+	deletion_policy = "SCHEDULE_DESTROY"
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
@@ -709,13 +709,13 @@ func TestAccKmsCryptoKeyVersion_delete(t *testing.T) {
 					func(s *terraform.State) error {
 						config := acctest.GoogleProviderConfig(t)
 						versionsClient := kms.NewClient(config, config.UserAgent).Projects.Locations.KeyRings.CryptoKeys.CryptoKeyVersions
-						
+
 						rs, ok := s.RootModule().Resources["google_kms_crypto_key_version.crypto_key_version"]
 						if !ok {
 							return fmt.Errorf("Not found: google_kms_crypto_key_version.crypto_key_version")
 						}
 						id := rs.Primary.ID
-						
+
 						err := resource.Retry(20*time.Second, func() *resource.RetryError {
 							res, err := versionsClient.Get(id).Do()
 							if err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.
-->

This PR introduces the hard-deletion feature for both `google_kms_crypto_key` and `google_kms_crypto_key_version` resources in Cloud KMS in a safe, backwards-compatible manner.

### Key Changes:
- Added `deletion_policy` to `CryptoKey` and `CryptoKeyVersion` schemas.
- Implemented `SCHEDULE_DESTROY` (Default) policy: Emulates the legacy behavior by scheduling destruction of version material and removing the resource from state without calling the final API delete. This ensures existing user configurations do not break.
- Implemented `DELETE` (Opt-in) policy: Requires all child versions to be permanently deleted first, then attempts to hard-delete the resource via the API.
- Refactored `kms_utils.go` to extract validation logic and handle race conditions during deletion.
- Added comprehensive tests for both success and failure scenarios.

### Release Notes
```release-note:enhancement
kms: added `deletion_policy` field to `google_kms_crypto_key` and `google_kms_crypto_key_version` resources to allow opt-in permanent deletion
```