### PR TITLE
Add skeleton for RPC support

### DIFF
--- a/mmv1/api/product/version.go
+++ b/mmv1/api/product/version.go
@@ -31,6 +31,11 @@ type Version struct {
 	BaseUrl          string `yaml:"base_url"`
 	Name             string
 	RepUrl           string `yaml:"rep_url,omitempty"`
+
+	// EXPERIMENTAL: RPC settings are not fully implemented, and should not be
+	// used at this time.
+	RPCAddress string `yaml:"rpc_address,omitempty"`
+	RPCPackage string `yaml:"rpc_package,omitempty"`
 }
 
 func (v *Version) Validate(pName string) {

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -366,6 +366,14 @@ type Resource struct {
 	// ====================
 	TGCResource `yaml:",inline"`
 
+	// EXPERIMENTAL: RPC settings are not fully implemented, and should not be
+	// used at this time.
+	RPCService      string `yaml:"rpc_service,omitempty"`
+	RPCCreateMethod string `yaml:"rpc_create_method,omitempty"`
+	RPCReadMethod   string `yaml:"rpc_read_method,omitempty"`
+	RPCUpdateMethod string `yaml:"rpc_update_method,omitempty"`
+	RPCDeleteMethod string `yaml:"rpc_delete_method,omitempty"`
+
 	CustomCode resource.CustomCode `yaml:"custom_code,omitempty"`
 
 	// Examples in documentation. Backed by generated tests, and have

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -370,9 +370,17 @@ func resource{{ $.ResourceName -}}Create(d *schema.ResourceData, meta interface{
 {{- if $.CustomCode.PreCreate }}
     {{ customTemplate $ $.CustomCode.PreCreate false -}}
 {{- end}}
+{{- if $.RPCCreateMethod }}
+    res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+        Config: config,
+        Product: "{{ $.ProductMetadata.Name -}}",
+        RPCService: "{{ $.RPCService -}}",
+        Method: "{{ $.RPCCreateMethod -}}",
+{{- else }}
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
         Method: "{{ upper $.CreateVerb -}}",
+{{- end}}
         Project: billingProject,
         RawURL: url,
         UserAgent: userAgent,
@@ -615,9 +623,17 @@ func resource{{ $.ResourceName -}}PollRead(d *schema.ResourceData, meta interfac
             return nil, err
         }
 
+{{ if $.RPCReadMethod -}}
+        res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+            Config: config,
+            Product: "{{ $.ProductMetadata.Name -}}",
+            RPCService: "{{ $.RPCService -}}",
+            Method: "{{ $.RPCReadMethod -}}",
+{{- else }}
         res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
             Config: config,
             Method: "{{ upper $.ReadVerb -}}",
+{{- end}}
             Project: billingProject,
             RawURL: url,
             UserAgent: userAgent,
@@ -710,9 +726,17 @@ func resource{{ $.ResourceName -}}Read(d *schema.ResourceData, meta interface{})
     {{- if $.CustomCode.PreRead }}
         {{ customTemplate $ $.CustomCode.PreRead false -}}
     {{- end }}
+{{- if $.RPCReadMethod }}
+    res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+        Config: config,
+        Product: "{{ $.ProductMetadata.Name -}}",
+        RPCService: "{{ $.RPCService -}}",
+        Method: "{{ $.RPCReadMethod -}}",
+{{- else }}
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
         Method: "{{ upper $.ReadVerb -}}",
+{{- end}}
         Project: billingProject,
         RawURL: url,
         UserAgent: userAgent,
@@ -997,9 +1021,17 @@ func resource{{ $.ResourceName -}}Update(d *schema.ResourceData, meta interface{
 // if updateMask is empty we are not updating anything so skip the post
 if len(updateMask) > 0 {
 {{-             end}}
+{{- if $.RPCUpdateMethod }}
+    res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+        Config: config,
+        Product: "{{ $.ProductMetadata.Name -}}",
+        RPCService: "{{ $.RPCService -}}",
+        Method: "{{ $.RPCUpdateMethod -}}",
+{{- else }}
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
         Method: "{{ $.UpdateVerb -}}",
+{{- end}}
         Project: billingProject,
         RawURL: url,
         UserAgent: userAgent,
@@ -1078,9 +1110,17 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         billingProject = bp
         }
 
+{{ if $.RPCReadMethod -}}
+        getRes, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+            Config: config,
+            Product: "{{ $.ProductMetadata.Name -}}",
+            RPCService: "{{ $.RPCService -}}",
+            Method: "{{ $.RPCReadMethod -}}",
+{{- else }}
         getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
             Config: config,
             Method: "{{ upper $.ReadVerb -}}",
+{{- end}}
             Project: billingProject,
             RawURL: getUrl,
             UserAgent: userAgent,
@@ -1170,9 +1210,17 @@ if d.HasChange("{{ join ($.PropertyNamesToStrings (index $CustomUpdateProps $gro
         billingProject = bp
         }
 
+{{ if $.RPCUpdateMethod -}}
+        res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+            Config: config,
+            Product: "{{ $.ProductMetadata.Name -}}",
+            RPCService: "{{ $.RPCService -}}",
+            Method: "{{ $.RPCUpdateMethod -}}",
+{{- else }}
         res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
             Config: config,
             Method: "{{ $group.UpdateVerb }}",
+{{- end}}
             Project: billingProject,
             RawURL: url,
             UserAgent: userAgent,
@@ -1327,9 +1375,17 @@ func resource{{ $.ResourceName }}Delete(d *schema.ResourceData, meta interface{}
     {{- end }}
 
     log.Printf("[DEBUG] Deleting {{ $.Name }} %q", d.Id())
+{{- if $.RPCDeleteMethod }}
+    res, err := transport_tpg.SendRequestRPC(transport_tpg.SendRequestOptions{
+        Config: config,
+        Product: "{{ $.ProductMetadata.Name -}}",
+        RPCService: "{{ $.RPCService -}}",
+        Method: "{{ $.RPCDeleteMethod -}}",
+{{- else }}
     res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config: config,
         Method: "{{ camelize $.DeleteVerb "upper" -}}",
+{{- end}}
         Project: billingProject,
         RawURL: url,
         UserAgent: userAgent,

--- a/mmv1/third_party/terraform/transport/config.go.tmpl
+++ b/mmv1/third_party/terraform/transport/config.go.tmpl
@@ -177,6 +177,12 @@ func ExpandExternalCredentialsConfig(v interface{}) (*ExternalCredentials, error
 	return config, nil
 }
 
+type RPCClient struct {
+	ProxyAddress string
+	Address      string
+	Package      string
+}
+
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
@@ -219,6 +225,8 @@ type Config struct {
 
 	PreferGlobalEndpoints bool
 	PreferRegionalEndpoints bool
+
+	RPCClients map[string]*RPCClient
 }
 
 var DefaultClientScopes = []string{
@@ -370,6 +378,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 		c.PollInterval = 10 * time.Second
 	}
 
+	c.setRPCClients()
 
 	// gRPC Logging setup
 	logger := logrus.StandardLogger()
@@ -513,6 +522,21 @@ func (c *Config) getTokenSource(ctx context.Context, clientScopes []string, init
 		return nil, fmt.Errorf("%s", err)
 	}
 	return creds.TokenSource, nil
+}
+
+func (c *Config) setRPCClients() {
+	c.RPCClients = make(map[string]*RPCClient)
+	{{- range $product := $.Products }}
+	{{- if ne $product.Version.RPCAddress "" }}
+	c.RPCClients["{{ $product.Name }}"] = &RPCClient{
+		ProxyAddress: envvar.MultiEnvDefault([]string{
+			"TF_HTTP_RPC_PROXY_ADDRESS",
+		}, "http://192.168.1.7:80").(string),
+		Address: "{{ $product.Version.RPCAddress }}",
+		Package: "{{ $product.Version.RPCPackage }}",
+	}
+	{{- end }}
+	{{- end }}
 }
 
 // StaticTokenSource is used to be able to identify static token sources without reflection.

--- a/mmv1/third_party/terraform/transport/transport.go
+++ b/mmv1/third_party/terraform/transport/transport.go
@@ -27,6 +27,9 @@ type SendRequestOptions struct {
 	Headers              http.Header
 	ErrorRetryPredicates []RetryErrorPredicateFunc
 	ErrorAbortPredicates []RetryErrorPredicateFunc
+	// RPC related opts
+	Product    string
+	RPCService string
 }
 
 func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
@@ -113,6 +116,110 @@ func SendRequest(opt SendRequestOptions) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	if err := json.NewDecoder(res.Body).Decode(&result); err != nil {
 		return nil, err
+	}
+
+	return result, nil
+}
+
+func SendRequestRPC(opt SendRequestOptions) (map[string]interface{}, error) {
+	if opt.Config == nil || opt.Config.Client == nil {
+		return nil, fmt.Errorf("http client is nil for request to rpc proxy")
+	}
+	if opt.Product == "" || opt.Config.RPCClients[opt.Product] == nil {
+		return nil, fmt.Errorf("rpc client is nil for request to rpc proxy; product is %q", opt.Product)
+	}
+
+	reqHeaders := opt.Headers
+	if reqHeaders == nil {
+		reqHeaders = make(http.Header)
+	}
+	reqHeaders.Set("User-Agent", opt.UserAgent)
+	reqHeaders.Set("Content-Type", "application/json")
+
+	if opt.Timeout == 0 {
+		opt.Timeout = DefaultRequestTimeout
+	}
+
+	var res *http.Response
+	err := Retry(RetryOptions{
+		RetryFunc: func() error {
+			var reqJsonStr string
+			if opt.Body != nil {
+				b, err := json.Marshal(opt.Body)
+				if err != nil {
+					return err
+				}
+				reqJsonStr = string(b)
+			}
+
+			reqBody := map[string]interface{}{
+				"targetAddress": opt.Config.RPCClients[opt.Product].Address,
+				"packageName":   opt.Config.RPCClients[opt.Product].Package,
+				"serviceName":   opt.RPCService,
+				"methodName":    opt.Method,
+				"requestJson":   reqJsonStr,
+			}
+
+			var buf bytes.Buffer
+			if reqBody != nil {
+				err := json.NewEncoder(&buf).Encode(reqBody)
+				if err != nil {
+					return err
+				}
+			}
+
+			req, err := http.NewRequest("POST", opt.Config.RPCClients[opt.Product].ProxyAddress+"/handleRPC", &buf)
+			if err != nil {
+				return err
+			}
+
+			req.Header = reqHeaders
+			res, err = opt.Config.Client.Do(req)
+			if err != nil {
+				return err
+			}
+
+			if err := googleapi.CheckResponse(res); err != nil {
+				googleapi.CloseBody(res)
+				return err
+			}
+
+			return nil
+		},
+		Timeout:              opt.Timeout,
+		ErrorRetryPredicates: opt.ErrorRetryPredicates,
+		ErrorAbortPredicates: opt.ErrorAbortPredicates,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if res == nil {
+		return nil, fmt.Errorf("Unable to parse server response. This is most likely a terraform problem, please file a bug at https://github.com/hashicorp/terraform-provider-google/issues.")
+	}
+
+	// The defer call must be made outside of the retryFunc otherwise it's closed too soon.
+	defer googleapi.CloseBody(res)
+
+	// 204 responses will have no body, so we're going to error with "EOF" if we
+	// try to parse it. Instead, we can just return nil.
+	if res.StatusCode == 204 {
+		return nil, nil
+	}
+	var proxyResult map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&proxyResult); err != nil {
+		return nil, err
+	}
+
+	if errMsg, ok := proxyResult["errorMessage"].(string); ok && errMsg != "" {
+		return nil, fmt.Errorf("RPC proxy returned error: %s", errMsg)
+	}
+
+	var result map[string]interface{}
+	if respJsonStr, ok := proxyResult["responseJson"].(string); ok && respJsonStr != "" {
+		if err := json.Unmarshal([]byte(respJsonStr), &result); err != nil {
+			return nil, fmt.Errorf("Failed to unmarshal responseJson from proxy: %v", err)
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds a skeleton for fields that would be used for RPC calls. They are implemented with an experimental HTTP proxy to support an initial round of internal testing.

Note: these fields are not yet intended to be used by contributors!

(One other note: these changes have not been fully end-to-end tested internally, but we've done some basic validation of behavior which looked good)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
