### PR TITLE
Made custom endpoints fields always be defined on the provider

### DIFF
--- a/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider.go.tmpl
@@ -216,6 +216,17 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
                     transport_tpg.CustomEndpointValidator(),
                 },
             },
+
+            // Generated Products. Although these will only be _populated_ for registered products, they
+            // must always be present to match the ProviderModel struct.
+            {{- range $product := $.Products }}
+            "{{ underscore $product.Name }}_custom_endpoint": &schema.StringAttribute{
+                Optional:     true,
+                Validators: []validator.String{
+                    transport_tpg.CustomEndpointValidator(),
+                },
+            },
+            {{- end }}
         },
         Blocks: map[string]schema.Block{
             "batching": schema.ListNestedBlock{
@@ -259,14 +270,6 @@ func (p *FrameworkProvider) Schema(_ context.Context, _ provider.SchemaRequest, 
             },
         },
     }
-	for _, p := range registry.ListProducts() {
-        resp.Schema.Attributes[p.CustomEndpointField] = &schema.StringAttribute{
-            Optional:     true,
-            Validators: []validator.String{
-                transport_tpg.CustomEndpointValidator(),
-            },
-        }
-	}
 }
 
 // Configure prepares the metadata/'meta' required for data sources and resources to function.

--- a/mmv1/third_party/terraform/provider/provider.go.tmpl
+++ b/mmv1/third_party/terraform/provider/provider.go.tmpl
@@ -214,6 +214,16 @@ func Provider() *schema.Provider {
 				Optional:     true,
 				ValidateFunc: ValidateCustomEndpoint,
 			},
+
+			// Generated Products. Although these will only be _populated_ for registered products, they
+			// must always be present to match the FW provider's schema (which must match its ProviderModel struct.)
+			{{- range $product := $.Products }}
+			"{{ underscore $product.Name }}_custom_endpoint": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: ValidateCustomEndpoint,
+			},
+			{{- end }}
 		},
 
 		ProviderMetaSchema: map[string]*schema.Schema{
@@ -226,14 +236,6 @@ func Provider() *schema.Provider {
 		DataSourcesMap: registry.DatasourceMap(),
 {{- end }}
 		ResourcesMap: registry.ResourceMap(),
-	}
-
-	for _, p := range registry.ListProducts() {
-		provider.Schema[p.CustomEndpointField] = &schema.Schema{
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: ValidateCustomEndpoint,
-		}
 	}
 
 	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {


### PR DESCRIPTION
Although the various products may not be registered, we have to make the fields _available_ because they're present on the framework provider's ProviderModel.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
