### PR TITLE
Switched to generation of bootstrap dependencies

### DIFF
--- a/docs/content/test/test.md
+++ b/docs/content/test/test.md
@@ -109,14 +109,14 @@ An **acceptance test** verifies that a resource can be created, updated, and des
              network_name: "example-network"
            # test_vars_overrides contains literal overrides for variables in tests.
            test_vars_overrides:
-             network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
+             network_name: 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
          # Subsequent steps define update configurations.
          - name: "pubsub_topic_full"
            resource_id_vars:
              resource_name: "example-resource"
              network_name: "example-network"
            test_vars_overrides:
-             network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
+             network_name: 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
            # vars should ONLY be used for fields that vary between steps.
            # Fields that stay constant across steps should be hardcoded in the .tf.tmpl file.
            vars: 
@@ -126,7 +126,7 @@ An **acceptance test** verifies that a resource can be created, updated, and des
              resource_name: "example-resource"
              network_name: "example-network"
            test_vars_overrides:
-             network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
+             network_name: 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "pubsub-topic-network-config")'
            vars:
              display_name: "Updated Display Name" # The new value for the updatable field
    ```
@@ -291,7 +291,7 @@ Tests within the legacy `examples` generator are configured directly on the reso
        # a shared network for your product to avoid test failures due to limits
        # on the default network.
        test_vars_overrides:
-         network_name: 'acctest.BootstrapSharedServiceNetworkingConnection(t, "PRODUCT-RESOURCE-network-config")'
+         network_name: 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "PRODUCT-RESOURCE-network-config")'
        # Set min_version: beta if the resource is not beta-only and any beta-only fields are being tested.
        min_version: beta
    ```
@@ -347,16 +347,20 @@ samples:
         resource_id_vars:
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'acctest.BootstrapKMSKey(t).CryptoKey.Name'
+          kms_key_name: 'kms.BootstrapKMSKey(t).CryptoKey.Name'
 ```
 {{< /tab >}}
 {{< tab "Handwritten" >}}
 ```go
+import (
+  "github.com/hashicorp/terraform-provider-google/google/services/kms"
+)
+
 func TestAccProductResource_update(t *testing.T) {
    t.Parallel()
 
    context := map[string]interface{}{
-      "kms": acctest.BootstrapKMSKey(t).CryptoKey.Name,
+      "kms": kms.BootstrapKMSKey(t).CryptoKey.Name,
       // other variables
    }
    // rest of test
@@ -406,13 +410,13 @@ samples:
 ```go
 // Project-level IAM
 import (
-  "github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 )
 
 func TestAccProductResource_update(t *testing.T) {
     t.Parallel()
 
-    acctest.BootstrapIamMembers(t, []acctest.IamMember{
+    resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
         {
             Member: "serviceAccount:service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com",
             Role:   "roles/cloudkms.cryptoKeyEncrypterDecrypter",
@@ -424,14 +428,14 @@ func TestAccProductResource_update(t *testing.T) {
 ```go
 // Org-level IAM
 import (
-  "github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
-  "github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 )
 
 func TestAccProductResource_update(t *testing.T) {
     t.Parallel()
 
-    acctest.BootstrapIamMembers(t, []acctest.IamMember{
+    resourcemanager.BootstrapIamMembers(t, []resourcemanager.IamMember{
         {
             Member: "serviceAccount:service-org-{organization_id}@gcp-sa-osconfig.iam.gserviceaccount.com",
             Role:   "roles/osconfig.serviceAgent",
@@ -471,20 +475,24 @@ samples:
           network_name: 'default'
           subnetwork_name: 'default'
         test_vars_overrides:
-          network_name: 'acctest.BootstrapSharedTestNetwork(t, "network-identifier")'
-          subnetwork_name: 'acctest.BootstrapSubnet(t, "subnet-identifier", acctest.BootstrapSharedTestNetwork(t, "network-identifier"))'
+          network_name: 'tpgcompute.BootstrapSharedTestNetwork(t, "network-identifier")'
+          subnetwork_name: 'tpgcompute.BootstrapSubnet(t, "subnet-identifier", tpgcompute.BootstrapSharedTestNetwork(t, "network-identifier"))'
 ```
 {{< /tab >}}
 {{< tab "Handwritten" >}}
 ```go
+import (
+  tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+)
+
 func TestAccProductResource_update(t *testing.T) {
    t.Parallel()
 
    networkName := 
    subnetName := 
    context := map[string]interface{}{
-      "network_name": acctest.BootstrapSharedTestNetwork(t, "network-identifier"),
-      "subnetwork_name": acctest.BootstrapSubnet(t, "subnet-identifier", acctest.BootstrapSharedTestNetwork(t, "network-identifier")),
+      "network_name": tpgcompute.BootstrapSharedTestNetwork(t, "network-identifier"),
+      "subnetwork_name": tpgcompute.BootstrapSubnet(t, "subnet-identifier", tpgcompute.BootstrapSharedTestNetwork(t, "network-identifier")),
       // other variables
    }
    // rest of test
@@ -502,8 +510,8 @@ import (
 
 
   "github.com/hashicorp/terraform-plugin-testing/helper/resource"
-  "github.com/hashicorp/terraform-provider-google-beta/google-beta/acctest"
-  "github.com/hashicorp/terraform-provider-google-beta/google-beta/envvar"
+  "github.com/hashicorp/terraform-provider-google/google/acctest"
+  "github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 func TestAccProductResourceName_update(t *testing.T) {
 	t.Parallel()

--- a/mmv1/products/alloydb/Backup.yaml
+++ b/mmv1/products/alloydb/Backup.yaml
@@ -40,7 +40,6 @@ async:
     resource_inside_response: false
 custom_code:
   encoder: 'templates/terraform/encoders/alloydb_backup.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'alloydb_backup_basic'

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -59,7 +59,6 @@ custom_code:
   pre_create: 'templates/terraform/pre_create/alloydb_cluster.go.tmpl'
   pre_update: 'templates/terraform/pre_update/alloydb_cluster.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/alloydb_cluster.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_servicenetworking.go.tmpl'
 deletion_policy_default: "DEFAULT"
 deletion_policy_custom_docs: true
 # Skipping the sweeper because we need to force-delete clusters.

--- a/mmv1/products/alloydb/Instance.yaml
+++ b/mmv1/products/alloydb/Instance.yaml
@@ -50,7 +50,6 @@ custom_code:
   pre_create: 'templates/terraform/pre_create/alloydb_instance.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/alloydb_instance.go.tmpl'
   custom_import: 'templates/terraform/custom_import/alloydb_instance.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 # Skipping the sweeper because instances will be deleted during cluster sweeps
 exclude_sweeper: true
 # exluding resource_identity due to custom_import

--- a/mmv1/products/alloydb/User.yaml
+++ b/mmv1/products/alloydb/User.yaml
@@ -34,7 +34,6 @@ autogen_async: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/alloydb_user.go.tmpl'
   pre_update: 'templates/terraform/pre_update/alloydb_user.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 # Skipping the sweeper because instances will be deleted during cluster sweeps
 exclude_sweeper: true
 # exluding resource_identity due to custom_import

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -53,7 +53,6 @@ iam_policy:
 custom_code:
   constants: 'templates/terraform/constants/artifact_registry_repository.go.tmpl'
   encoder: 'templates/terraform/encoders/location_from_region.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us-central1"

--- a/mmv1/products/backupdr/BackupVault.yaml
+++ b/mmv1/products/backupdr/BackupVault.yaml
@@ -39,7 +39,6 @@ async:
     resource_inside_response: true
 custom_code:
   pre_delete: 'templates/terraform/pre_delete/backup_dr_backup_vault.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'backup_dr_backup_vault_simple'

--- a/mmv1/products/bigquery/Job.yaml
+++ b/mmv1/products/bigquery/Job.yaml
@@ -46,7 +46,6 @@ async:
 custom_code:
   constants: 'templates/terraform/constants/bigquery_job.go.tmpl'
   encoder: 'templates/terraform/encoders/bigquery_job.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 # exluding resource_identity due to dataset_id field
 exclude_identity_generation: true
 schema_version: 1

--- a/mmv1/products/bigqueryconnection/Connection.yaml
+++ b/mmv1/products/bigqueryconnection/Connection.yaml
@@ -43,7 +43,6 @@ iam_policy:
     - '{{connection_id}}'
 custom_code:
   encoder: 'templates/terraform/encoders/bigquery_connection.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "US"

--- a/mmv1/products/cloudfunctions2/Function.yaml
+++ b/mmv1/products/cloudfunctions2/Function.yaml
@@ -55,7 +55,6 @@ iam_policy:
 custom_code:
   constants: 'templates/terraform/constants/cloudfunctions2_function.go.tmpl'
   encoder: 'templates/terraform/encoders/cloudfunctions2_runtime_update_policy.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 taint_resource_on_failed_create: true
 sweeper:
   url_substitutions:

--- a/mmv1/products/colab/NotebookExecution.yaml
+++ b/mmv1/products/colab/NotebookExecution.yaml
@@ -34,7 +34,6 @@ import_format:
 include_in_tgc_next: true
 custom_code:
   post_create: 'templates/terraform/post_create/colab_notebook_execution.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'colab_notebook_execution_basic'
     primary_resource_id: 'notebook-execution'

--- a/mmv1/products/colab/Runtime.yaml
+++ b/mmv1/products/colab/Runtime.yaml
@@ -33,7 +33,6 @@ custom_code:
   post_create: 'templates/terraform/post_create/colab_runtime.go.tmpl'
   custom_update: 'templates/terraform/custom_update/colab_runtime.go.tmpl'
   constants: 'templates/terraform/constants/colab_runtime.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'colab_runtime_basic'
     primary_resource_id: 'runtime'

--- a/mmv1/products/colab/RuntimeTemplate.yaml
+++ b/mmv1/products/colab/RuntimeTemplate.yaml
@@ -44,7 +44,6 @@ iam_policy:
     - '{{runtime_template}}'
 include_in_tgc_next: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'colab_runtime_template_basic'
     primary_resource_id: 'runtime-template'

--- a/mmv1/products/colab/Schedule.yaml
+++ b/mmv1/products/colab/Schedule.yaml
@@ -34,7 +34,6 @@ custom_code:
   post_create: 'templates/terraform/post_create/colab_schedule.go.tmpl'
   post_update: 'templates/terraform/post_update/colab_schedule.go.tmpl'
   constants: 'templates/terraform/constants/colab_schedule.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   identifier_field: 'displayName'
 examples:

--- a/mmv1/products/dataproc/Batch.yaml
+++ b/mmv1/products/dataproc/Batch.yaml
@@ -42,7 +42,6 @@ include_in_tgc_next: true
 custom_code:
   decoder: templates/terraform/decoders/cloud_dataproc_batch.go.tmpl
   constants: templates/terraform/constants/cloud_dataproc_batch.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
   tgc_ignore_terraform_decoder: true
 examples:
   - name: dataproc_batch_spark

--- a/mmv1/products/dataproc/SessionTemplate.yaml
+++ b/mmv1/products/dataproc/SessionTemplate.yaml
@@ -32,7 +32,6 @@ import_format:
   - '{{name}}'
 custom_code:
   custom_import: 'templates/terraform/custom_import/set_id_name_with_slashes.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 collection_url_key: 'sessionTemplates'
 examples:
   - name: 'dataproc_session_templates_jupyter'

--- a/mmv1/products/datastream/Stream.yaml
+++ b/mmv1/products/datastream/Stream.yaml
@@ -46,7 +46,6 @@ custom_code:
   pre_update: 'templates/terraform/pre_update/datastream_stream.go.tmpl'
   post_update: 'templates/terraform/post_update/datastream_stream.go.tmpl'
   post_import: 'templates/terraform/post_import/datastream_stream.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 include_in_tgc_next: true
 tgc_tests:
   - name: 'TestAccDatastreamStream_mongoDb'

--- a/mmv1/products/discoveryengine/CmekConfig.yaml
+++ b/mmv1/products/discoveryengine/CmekConfig.yaml
@@ -47,7 +47,6 @@ async:
     resource_inside_response: true
 custom_code:
   update_encoder: 'templates/terraform/update_encoder/discoveryengine_cmekconfig_kmskey.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   url_substitutions:
     - location: "us"

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -45,7 +45,6 @@ async:
   result:
     resource_inside_response: false
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   dependencies:
     - 'google_discovery_engine_chat_engine'

--- a/mmv1/products/eventarc/Channel.yaml
+++ b/mmv1/products/eventarc/Channel.yaml
@@ -32,7 +32,6 @@ async:
     resource_inside_response: true
 autogen_async: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 description: |
  The Eventarc Channel resource
 error_retry_predicates:

--- a/mmv1/products/eventarc/Pipeline.yaml
+++ b/mmv1/products/eventarc/Pipeline.yaml
@@ -28,7 +28,6 @@ references:
 description: |
   The Eventarc Pipeline resource
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_and_kms.go.tmpl'
 async:
   actions: ['create', 'update', 'delete']
   operation:

--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -40,7 +40,6 @@ sweeper:
     - region: "us-central1"
     - region: "europe-west1"
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_and_kms.go.tmpl'
 examples:
   - name: eventarc_trigger_with_cloud_run_destination
     primary_resource_id: primary

--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -44,7 +44,6 @@ iam_policy:
     - 'projects/{{project}}/locations/{{location}}/backupPlans/{{name}}'
     - '{{name}}'
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute.go.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'gkebackup_backupplan_basic'

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -44,7 +44,6 @@ iam_policy:
     - 'projects/{{project}}/locations/{{location}}/restorePlans/{{name}}'
     - '{{name}}'
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute.go.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'gkebackup_restoreplan_all_namespaces'

--- a/mmv1/products/gkehub/Membership.yaml
+++ b/mmv1/products/gkehub/Membership.yaml
@@ -49,7 +49,6 @@ iam_policy:
     - '{{membership_id}}'
 custom_code:
   constants: 'templates/terraform/constants/gke_hub_membership_diff.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute.go.tmpl'
 include_in_tgc_next: true
 # Skip sweeper gen since this is a child resource.
 exclude_sweeper: true

--- a/mmv1/products/gkehub2/MembershipBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipBinding.yaml
@@ -42,7 +42,6 @@ async:
   result:
     resource_inside_response: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute.go.tmpl'
 # Skip sweeper gen since this is a child resource.
 exclude_sweeper: true
 examples:

--- a/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
@@ -42,7 +42,6 @@ async:
   result:
     resource_inside_response: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute.go.tmpl'
 # Skip sweeper gen since this is a child resource.
 exclude_sweeper: true
 examples:

--- a/mmv1/products/integrations/Client.yaml
+++ b/mmv1/products/integrations/Client.yaml
@@ -37,7 +37,6 @@ timeouts:
 custom_code:
   decoder: 'templates/terraform/decoders/integrations_client.go.tmpl'
   pre_create: 'templates/terraform/pre_create/integrations_client.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 exclude_sweeper: true
 examples:
   - name: 'integrations_client_basic'

--- a/mmv1/products/logging/FolderSettings.yaml
+++ b/mmv1/products/logging/FolderSettings.yaml
@@ -42,7 +42,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'logging_folder_settings_all'
     primary_resource_id: 'example'

--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -128,7 +128,6 @@ virtual_fields:
     exclude: true
 custom_code:
   pre_delete: templates/terraform/pre_delete/looker_instance.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_kms_servicenetworking.go.tmpl'
 parameters:
   - name: 'region'
     type: String

--- a/mmv1/products/lustre/Instance.yaml
+++ b/mmv1/products/lustre/Instance.yaml
@@ -35,7 +35,6 @@ sweeper:
     - location: "us-central1-a"
     - location: "us-central1-c"
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 examples:
   - name: lustre_instance_basic
     primary_resource_id: 'instance'

--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -38,7 +38,6 @@ async:
   result:
     resource_inside_response: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'managedkafka_cluster_basic'
     primary_resource_id: 'example'

--- a/mmv1/products/memcache/Instance.yaml
+++ b/mmv1/products/memcache/Instance.yaml
@@ -33,7 +33,6 @@ autogen_async: true
 include_in_tgc_next: true
 custom_code:
   pre_delete: templates/terraform/pre_delete/memcache_instance.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 examples:
   - name: memcache_instance_basic
     primary_resource_id: instance

--- a/mmv1/products/memorystore/Instance.yaml
+++ b/mmv1/products/memorystore/Instance.yaml
@@ -44,7 +44,6 @@ custom_code:
   encoder: 'templates/terraform/encoders/memorystore_instance.go.tmpl'
   decoder: 'templates/terraform/decoders/memorystore_instance.go.tmpl'
   constants: 'templates/terraform/constants/memorystore_instance.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'memorystore_instance_basic'
     primary_resource_id: 'instance-basic'

--- a/mmv1/products/metastore/Service.yaml
+++ b/mmv1/products/metastore/Service.yaml
@@ -50,7 +50,6 @@ iam_policy:
     - 'projects/{{project}}/locations/{{location}}/services/{{service_id}}'
     - '{{service_id}}'
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'dataproc_metastore_service_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/netapp/Backup.yaml
+++ b/mmv1/products/netapp/Backup.yaml
@@ -61,7 +61,6 @@ async:
 exclude_sweeper: true
 include_in_tgc_next: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 examples:
   - name: 'netapp_backup'
     primary_resource_id: 'test_backup'

--- a/mmv1/products/netapp/StoragePool.yaml
+++ b/mmv1/products/netapp/StoragePool.yaml
@@ -67,7 +67,6 @@ async:
 include_in_tgc_next: true
 custom_code:
   pre_update: 'templates/terraform/pre_update/netapp_storagepool.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 # Skipping the sweeper since we need to sweep multiple regions
 exclude_sweeper: true
 examples:

--- a/mmv1/products/netapp/Volume.yaml
+++ b/mmv1/products/netapp/Volume.yaml
@@ -51,7 +51,6 @@ custom_code:
   pre_delete: 'templates/terraform/pre_delete/netapp_volume_force_delete.go.tmpl'
   pre_update: 'templates/terraform/pre_update/netapp_volume_update.go.tmpl'
   constants: 'templates/terraform/constants/netapp_volume.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 deletion_policy_default: "DEFAULT"
 deletion_policy_custom_docs: true
 examples:

--- a/mmv1/products/netapp/VolumeQuotaRule.yaml
+++ b/mmv1/products/netapp/VolumeQuotaRule.yaml
@@ -41,7 +41,6 @@ async:
   result:
     resource_inside_response: false
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 # Skipping the sweeper since we need to sweep multiple regions
 exclude_sweeper: true
 examples:

--- a/mmv1/products/netapp/VolumeReplication.yaml
+++ b/mmv1/products/netapp/VolumeReplication.yaml
@@ -61,7 +61,6 @@ custom_code:
   post_delete: 'templates/terraform/post_delete/netapp_volume_replication_delete_destination_volume.go.tmpl'
   post_update: 'templates/terraform/post_update/netapp_volume_replication_mirror_state.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/netapp_volume_replication_stop_before_delete.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 examples:
   - name: 'netapp_volume_replication_create'
     primary_resource_id: 'test_replication'

--- a/mmv1/products/netapp/VolumeSnapshot.yaml
+++ b/mmv1/products/netapp/VolumeSnapshot.yaml
@@ -46,7 +46,6 @@ async:
     resource_inside_response: false
 include_in_tgc_next: true
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 # Skipping the sweeper since we need to sweep multiple regions
 exclude_sweeper: true
 examples:

--- a/mmv1/products/netapp/kmsconfig.yaml
+++ b/mmv1/products/netapp/kmsconfig.yaml
@@ -54,7 +54,6 @@ async:
 include_in_tgc_next: true
 custom_code:
   post_create: 'templates/terraform/post_create/KMS_Verify.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 # Skipping the sweeper since we need to sweep multiple regions
 exclude_sweeper: true
 examples:

--- a/mmv1/products/notebooks/Instance.yaml
+++ b/mmv1/products/notebooks/Instance.yaml
@@ -56,7 +56,6 @@ custom_code:
   update_encoder: 'templates/terraform/update_encoder/notebooks_instance.go.tmpl'
   post_create: 'templates/terraform/post_create/notebooks_instance.go.tmpl'
   post_update: 'templates/terraform/post_update/notebooks_instance.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 schema_version: 1
 state_upgraders: true
 sweeper:

--- a/mmv1/products/observability/FolderSettings.yaml
+++ b/mmv1/products/observability/FolderSettings.yaml
@@ -28,7 +28,6 @@ update_mask: true
 
 custom_code:
   pre_create: templates/terraform/pre_create/observability_folder_settings.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 import_format:
   - 'folders/{{folder}}/locations/{{location}}/settings'
 

--- a/mmv1/products/observability/OrganizationSettings.yaml
+++ b/mmv1/products/observability/OrganizationSettings.yaml
@@ -28,7 +28,6 @@ autogen_async: true
 
 custom_code:
   pre_create: templates/terraform/pre_create/observability_organization_settings.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 import_format:
   - 'organizations/{{organization}}/locations/{{location}}/settings'
 

--- a/mmv1/products/observability/ProjectSettings.yaml
+++ b/mmv1/products/observability/ProjectSettings.yaml
@@ -30,7 +30,6 @@ update_mask: true
 
 custom_code:
   pre_create: templates/terraform/pre_create/observability_project_settings.go.tmpl
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 
 async:
   operation:

--- a/mmv1/products/parametermanager/Parameter.yaml
+++ b/mmv1/products/parametermanager/Parameter.yaml
@@ -31,7 +31,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'parameter_config_basic'
     primary_resource_id: 'parameter-basic'

--- a/mmv1/products/parametermanager/ParameterVersion.yaml
+++ b/mmv1/products/parametermanager/ParameterVersion.yaml
@@ -90,7 +90,6 @@ examples:
       parameter_id: '"parameter" + randomSuffix'
 custom_code:
   custom_import: 'templates/terraform/custom_import/parameter_manager_parameter_version.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 exclude_identity_generation: true
 parameters:
   - name: 'parameter'

--- a/mmv1/products/parametermanagerregional/RegionalParameter.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameter.yaml
@@ -32,7 +32,6 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'regional_parameter_basic'
     primary_resource_id: 'regional-parameter-basic'

--- a/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
+++ b/mmv1/products/parametermanagerregional/RegionalParameterVersion.yaml
@@ -77,7 +77,6 @@ examples:
 custom_code:
   pre_create: 'templates/terraform/pre_create/parameter_manager_regional_parameter_version.go.tmpl'
   custom_import: 'templates/terraform/custom_import/parameter_manager_regional_parameter_version.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 # exluding resource_identity due to custom_import
 exclude_identity_generation: true
 parameters:

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -49,7 +49,6 @@ iam_policy:
   example_config_body: 'templates/terraform/iam/example_config_body/privateca_ca_pool.tf.tmpl'
 custom_code:
   tgc_decoder: 'templates/tgc_next/decoders/privateca_capool.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'privateca_capool_basic'
     primary_resource_id: 'default'

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -54,7 +54,6 @@ custom_code:
   pre_delete: 'templates/terraform/pre_delete/privateca_authority_disable.go.tmpl'
   post_import: 'templates/terraform/post_import/privateca_import.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/privateca_certificate_authority.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 custom_diff:
   - 'resourcePrivateCaCACustomDiff'
 examples:

--- a/mmv1/products/redis/Cluster.yaml
+++ b/mmv1/products/redis/Cluster.yaml
@@ -119,7 +119,6 @@ include_in_tgc_next: true
 custom_code:
   encoder: 'templates/terraform/encoders/redis_cluster.go.tmpl'
   decoder: 'templates/terraform/decoders/redis_cluster.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
   tgc_ignore_terraform_decoder: true
 sweeper:
   ensure_value:

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -41,7 +41,6 @@ async:
 custom_code:
   extra_schema_entry: 'templates/terraform/extra_schema_entry/redis_instance.tmpl'
   constants: 'templates/terraform/constants/redis_instance.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_servicenetworking.go.tmpl'
   encoder: 'templates/terraform/encoders/redis_location_id_for_fallback_zone.go.tmpl'
   decoder: 'templates/terraform/decoders/redis_instance.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/redis_instance.go.tmpl'

--- a/mmv1/products/resourcemanager/Lien.yaml
+++ b/mmv1/products/resourcemanager/Lien.yaml
@@ -46,7 +46,6 @@ nested_query:
   modify_by_patch: false
 custom_code:
   constants: 'templates/terraform/constants/resourcemanager_lien.go.tmpl'
-  test_constants: 'templates/terraform/constants/resourcemanager_lien.go.tpml'
   decoder: 'templates/terraform/decoders/avoid_meaningless_project_update.tmpl'
   pre_delete: 'templates/terraform/pre_delete/modify_delete_url.tmpl'
   post_import: 'templates/terraform/post_import/lien_import.tmpl'

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -43,7 +43,6 @@ custom_code:
   constants: 'templates/terraform/constants/secret_manager_secret.go.tmpl'
   pre_update: 'templates/terraform/pre_update/secret_manager_secret.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/secret_manager_secret.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 custom_diff:
   - 'secretManagerSecretAutoCustomizeDiff'
 examples:

--- a/mmv1/products/secretmanagerregional/RegionalSecret.yaml
+++ b/mmv1/products/secretmanagerregional/RegionalSecret.yaml
@@ -44,7 +44,6 @@ iam_policy:
 custom_code:
   pre_update: 'templates/terraform/pre_update/secret_manager_regional_secret.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/regional_secret.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 include_in_tgc_next: true
 examples:
   - name: 'regional_secret_config_basic'

--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -53,7 +53,6 @@ iam_policy:
     - '{{instance_id}}'
 custom_code:
   pre_delete: 'templates/terraform/pre_delete/securesourcemanager_deletion_policy.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 deletion_policy_default: "PREVENT"
 examples:
   - name: 'secure_source_manager_instance_basic'

--- a/mmv1/products/vertexai/Featurestore.yaml
+++ b/mmv1/products/vertexai/Featurestore.yaml
@@ -46,7 +46,6 @@ iam_policy:
   min_version: 'beta'
 custom_code:
   pre_delete: 'templates/terraform/pre_delete/vertex_ai_force_delete.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 exclude_sweeper: true
 examples:
   - name: 'vertex_ai_featurestore'

--- a/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
+++ b/mmv1/products/vertexai/FeaturestoreEntitytype.yaml
@@ -56,7 +56,6 @@ custom_code:
   pre_create: 'templates/terraform/constants/vertex_ai_featurestore_entitytype.go.tmpl'
   pre_delete: 'templates/terraform/constants/vertex_ai_featurestore_entitytype.go.tmpl'
   custom_import: 'templates/terraform/custom_import/vertex_ai_featurestore_entitytype.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 exclude_sweeper: true
 examples:
   - name: 'vertex_ai_featurestore_entitytype'

--- a/mmv1/products/vertexai/Index.yaml
+++ b/mmv1/products/vertexai/Index.yaml
@@ -37,7 +37,6 @@ async:
     resource_inside_response: true
 custom_code:
   custom_update: 'templates/terraform/custom_update/vertex_ai_index.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   identifier_field: 'displayName'
 examples:

--- a/mmv1/products/vertexai/IndexEndpoint.yaml
+++ b/mmv1/products/vertexai/IndexEndpoint.yaml
@@ -37,8 +37,6 @@ async:
     resource_inside_response: true
 sweeper:
   identifier_field: 'displayName'
-custom_code:
-  test_constants: 'templates/terraform/test_constants/import_kms_servicenetworking.go.tmpl'
 examples:
   - name: 'vertex_ai_index_endpoint'
     primary_resource_id: 'index_endpoint'

--- a/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
@@ -52,7 +52,6 @@ custom_code:
   decoder: 'templates/terraform/decoders/vertex_ai_index_endpoint_deployed_index.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/vertex_ai_index_endpoint_deployed_index.go.tmpl'
   custom_import: 'templates/terraform/custom_import/vertex_ai_index_endpoint_deployed_index.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_tpgcompute_servicenetworking.go.tmpl'
 # exluding resource_identity due to custom_import
 exclude_identity_generation: true
 examples:

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -140,7 +140,6 @@ examples:
 custom_code:
   pre_delete: 'templates/terraform/pre_delete/reasoning_engine_deletion_policy.go.tmpl'
   post_update: 'templates/terraform/post_update/sleep_10s.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 virtual_fields:
   - name: 'deletion_policy'
     description: |

--- a/mmv1/products/vertexai/Tensorboard.yaml
+++ b/mmv1/products/vertexai/Tensorboard.yaml
@@ -37,7 +37,6 @@ async:
     resource_inside_response: true
 custom_code:
   custom_import: 'templates/terraform/custom_import/vertex_ai_tensorboard_import.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 examples:
   - name: 'vertex_ai_tensorboard'
     primary_resource_id: 'tensorboard'

--- a/mmv1/products/vpcaccess/Connector.yaml
+++ b/mmv1/products/vpcaccess/Connector.yaml
@@ -46,7 +46,6 @@ custom_code:
   constants: 'templates/terraform/constants/vpc_access_connector.go.tmpl'
   pre_update: 'templates/terraform/pre_update/vpc_access_connector_instances.go.tmpl'
   tgc_ignore_terraform_decoder: true
-  test_constants: 'templates/terraform/test_constants/import_servicenetworking.go.tmpl'
 custom_diff:
   - 'customdiff.ForceNewIfChange("min_instances", isInstanceShrinkage)'
   - 'customdiff.ForceNewIfChange("max_instances", isInstanceShrinkage)'

--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -52,7 +52,6 @@ custom_code:
   post_create: 'templates/terraform/post_create/workbench_instance.go.tmpl'
   pre_update: 'templates/terraform/pre_update/workbench_instance.go.tmpl'
   post_update: 'templates/terraform/post_update/workbench_instance.go.tmpl'
-  test_constants: 'templates/terraform/test_constants/import_kms.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us-central1-a"

--- a/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
@@ -22,6 +22,17 @@ import (
 {{- if $.FirstTestConfig.Sample.BootstrapIam }}
 	"{{ $.ImportPath }}/services/resourcemanager"
 {{- end }}
+{{- range $_, $v := $.FirstTestConfig.Step.TestContextVars }}
+	{{- if hasPrefix $v "tpgcompute." }}
+	tpgcompute "{{ $.ImportPath }}/services/compute"
+	{{- end }}
+	{{- if hasPrefix $v "kms." }}
+	"{{ $.ImportPath }}/services/kms"
+	{{- end }}
+	{{- if hasPrefix $v "servicenetworking." }}
+	"{{ $.ImportPath }}/services/servicenetworking"
+	{{- end }}
+{{- end }}
 )
 
 {{if $.CustomCode.TestConstants -}} 

--- a/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
@@ -44,8 +44,20 @@ import (
 {{ range $s := $.Res.TestSamples }}
   {{- if $s.BootstrapIam }}
     "{{ $.ImportPath  }}/services/resourcemanager"
-    {{ break }}
   {{- end }}
+  {{- range $i, $step := $s.TestSteps }}
+		{{- range $_, $v := $step.TestContextVars }}
+			{{- if hasPrefix $v "tpgcompute." }}
+				tpgcompute "{{ $.ImportPath }}/services/compute"
+			{{- end }}
+			{{- if hasPrefix $v "kms." }}
+				"{{ $.ImportPath }}/services/kms"
+			{{- end }}
+			{{- if hasPrefix $v "servicenetworking." }}
+				"{{ $.ImportPath }}/services/servicenetworking"
+			{{- end }}
+		{{- end }}
+	{{- end }}
 {{- end }}
 	"{{ $.ImportPath  }}/tpgresource"
 	transport_tpg "{{ $.ImportPath  }}/transport"

--- a/mmv1/templates/terraform/test_constants/import_kms.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_kms.go.tmpl
@@ -1,5 +1,0 @@
-import (
-	"{{ $.ImportPath }}/services/kms"
-)
-
-var _ = kms.Product

--- a/mmv1/templates/terraform/test_constants/import_kms_servicenetworking.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_kms_servicenetworking.go.tmpl
@@ -1,9 +1,0 @@
-import (
-    "{{ $.ImportPath }}/services/kms"
-    "{{ $.ImportPath }}/services/servicenetworking"
-)
-
-var (
-    _ = kms.Product
-    _ = servicenetworking.Product
-)

--- a/mmv1/templates/terraform/test_constants/import_servicenetworking.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_servicenetworking.go.tmpl
@@ -1,3 +1,0 @@
-import (
-	"{{ $.ImportPath }}/services/servicenetworking"
-)

--- a/mmv1/templates/terraform/test_constants/import_tpgcompute.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_tpgcompute.go.tmpl
@@ -1,3 +1,0 @@
-import (
-	tpgcompute "{{ $.ImportPath }}/services/compute"
-)

--- a/mmv1/templates/terraform/test_constants/import_tpgcompute_and_kms.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_tpgcompute_and_kms.go.tmpl
@@ -1,6 +1,0 @@
-import (
-    tpgcompute "{{ $.ImportPath }}/services/compute"
-    "{{ $.ImportPath }}/services/kms"
-)
-
-var _ = kms.Product

--- a/mmv1/templates/terraform/test_constants/import_tpgcompute_kms_servicenetworking.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_tpgcompute_kms_servicenetworking.go.tmpl
@@ -1,7 +1,0 @@
-import (
-    tpgcompute "{{ $.ImportPath }}/services/compute"
-    "{{ $.ImportPath }}/services/kms"
-    "{{ $.ImportPath }}/services/servicenetworking"
-)
-
-var _ = kms.Product

--- a/mmv1/templates/terraform/test_constants/import_tpgcompute_servicenetworking.go.tmpl
+++ b/mmv1/templates/terraform/test_constants/import_tpgcompute_servicenetworking.go.tmpl
@@ -1,4 +1,0 @@
-import (
-    tpgcompute "{{ $.ImportPath }}/services/compute"
-    "{{ $.ImportPath }}/services/servicenetworking"
-)


### PR DESCRIPTION
I just brute-forced this with test_constants to get the initial set of changes through; now I'm circling back to clean up & make this be generated. This still isn't a general solution, but I'm also not sure how we'd set one up. Leaving that as a future problem; in the meantime, test_constants can still fill the gap.

I also updated the relevant docs.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
