### PR TITLE
Add support for agent_sandbox_config addon to google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -103,6 +103,7 @@ var (
 		"addons_config.0.slice_controller_config",
 		"addons_config.0.pod_snapshot_config",
 	{{- if ne $.TargetVersionName "ga" }}
+		"addons_config.0.agent_sandbox_config",
 		"addons_config.0.istio_config",
 		"addons_config.0.kalm_config",
 	{{- end }}
@@ -683,6 +684,25 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
+						{{- if ne $.TargetVersionName "ga" }}
+						"agent_sandbox_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `The status of the Agent Sandbox addon. It is disabled by default. Set enabled = true to enable.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:        schema.TypeBool,
+										Required:    true,
+										Description: `Whether the Agent Sandbox feature is enabled.`,
+									},
+								},
+							},
+						},
+						{{- end }}
 					},
 				},
 			},
@@ -5939,6 +5959,16 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 	}
 
 {{ if ne $.TargetVersionName `ga` -}}
+	if v, ok := config["agent_sandbox_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.AgentSandboxConfig = &container.AgentSandboxConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+{{- end }}
+
+{{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.IstioConfig = &container.IstioConfig{
@@ -7646,6 +7676,16 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 	}
 
 {{ if ne $.TargetVersionName `ga` -}}
+	if c.AgentSandboxConfig != nil {
+		result["agent_sandbox_config"] = []map[string]interface{}{
+			{
+				"enabled": c.AgentSandboxConfig.Enabled,
+			},
+		}
+	}
+{{- end }}
+
+{{ if ne $.TargetVersionName `ga` -}}
 	if c.IstioConfig != nil {
 		result["istio_config"] = []map[string]interface{}{
 			{
@@ -9124,6 +9164,30 @@ func clusterAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *sche
 
 	return nil
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func expandAgentSandboxConfig(v interface{}) *container.AgentSandboxConfig {
+    l := v.([]interface{})
+    if len(l) == 0 || l[0] == nil {
+        return nil
+    }
+    raw := l[0].(map[string]interface{})
+    return &container.AgentSandboxConfig{
+        Enabled: raw["enabled"].(bool),
+    }
+}
+
+func flattenAgentSandboxConfig(v *container.AgentSandboxConfig) []interface{} {
+    if v == nil {
+        return nil
+    }
+    return []interface{}{
+        map[string]interface{}{
+            "enabled": v.Enabled,
+        },
+    }
+}
+{{- end }}
 
 func init() {
 	registry.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -13,6 +13,9 @@ cai_asset_name_formats:
   - {{"//container.googleapis.com/projects/{{project}}/locations/{{location}}/clusters/{{name}}"}}
   - {{"//container.googleapis.com/projects/{{project}}/zones/{{location}}/clusters/{{name}}"}}
 fields:
+{{- if ne $.TargetVersionName "ga" }}
+  - api_field: 'addonsConfig.agentSandboxConfig.enabled'
+{{- end }}
   - field: 'addons_config.cloudrun_config.disabled'
     api_field: 'addonsConfig.cloudRunConfig.disabled'
   - field: 'addons_config.cloudrun_config.load_balancer_type'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -285,6 +285,68 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 	})
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccContainerCluster_agentSandbox(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_agentSandbox(clusterName, networkName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "addons_config.0.agent_sandbox_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_agentSandbox(clusterName, networkName, subnetworkName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "addons_config.0.agent_sandbox_config.0.enabled", "false"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_agentSandbox(clusterName, networkName, subnetworkName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  network            = "%s"
+  subnetwork         = "%s"
+
+  addons_config {
+    agent_sandbox_config {
+      enabled = %t
+    }
+  }
+
+  deletion_protection = false
+}
+`, clusterName, networkName, subnetworkName, enabled)
+}
+{{- end }}
+
 func TestAccContainerCluster_withDeletionProtection(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -471,6 +471,9 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
     It is enabled by default;
     set `disabled = true` to disable.
 
+* `agent_sandbox_config` - (Optional, Beta) Configuration for the Agent Sandbox addon. Structure is documented below:
+    * `enabled` - (Required) Whether the Agent Sandbox addon is enabled.
+
 * `http_load_balancing` - (Optional) The status of the HTTP (L7) load balancing
     controller addon, which makes it easy to set up HTTP load balancers for services in a
     cluster. It is enabled by default; set `disabled = true` to disable.


### PR DESCRIPTION
This change adds GKE GA support for the newly promoted `agent_sandbox_config` addon under `addons_config` in the `google_container_cluster` resource.

Specifically:
1. Adds "addons_config.0.agent_sandbox_config" to addonsConfigKeys list.
2. Configures nested schema and type converters (Expanders & Flatteners) in `resource_container_cluster.go.tmpl` to map `agent_sandbox_config` field of type `AgentSandboxConfig`.
3. Adds documentation for `agent_sandbox_config` subfields in `container_cluster.html.markdown`.
4. Adds E2E acceptance test covering resource creation, update (enable/disable), and deletion of `agent_sandbox_config` addon.

Reference: b/512603653

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `agent_sandbox_config` field to `google_container_cluster` resource
```
