### PR TITLE
feat(ServiceAttachment): add data source for google_compute_service_a…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment.go
@@ -1,0 +1,61 @@
+package compute
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleComputeServiceAttachment() *schema.Resource {
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceComputeServiceAttachment().Schema)
+
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "name")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project", "region")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleComputeServiceAttachmentRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleComputeServiceAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	name := d.Get("name").(string)
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := tpgresource.GetRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := fmt.Sprintf("projects/%s/regions/%s/serviceAttachments/%s", project, region, name)
+	d.SetId(id)
+
+	err = resourceComputeServiceAttachmentRead(d, meta)
+	if err != nil {
+		return err
+	}
+
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_compute_service_attachment",
+		ProductName: "compute",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceGoogleComputeServiceAttachment(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_service_attachment_test.go
@@ -1,0 +1,104 @@
+package compute_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccDataSourceGoogleComputeServiceAttachment_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleComputeServiceAttachment_basic(context),
+				Check: acctest.CheckDataSourceStateMatchesResourceState(
+					"data.google_compute_service_attachment.default",
+					"google_compute_service_attachment.psc_ilb_service_attachment",
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleComputeServiceAttachment_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "psc_ilb_network" {
+  name                    = "tf-test-psc-ilb-network%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
+  name   = "tf-test-psc-ilb-producer-subnetwork%{random_suffix}"
+  region = "us-west2"
+
+  network       = google_compute_network.psc_ilb_network.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "psc_ilb_nat" {
+  name   = "tf-test-psc-ilb-nat%{random_suffix}"
+  region = "us-west2"
+
+  network       = google_compute_network.psc_ilb_network.id
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  ip_cidr_range = "10.1.0.0/16"
+}
+
+resource "google_compute_health_check" "producer_service_health_check" {
+  name = "tf-test-producer-service-health-check%{random_suffix}"
+
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_region_backend_service" "producer_service_backend" {
+  name   = "tf-test-producer-service%{random_suffix}"
+  region = "us-west2"
+
+  health_checks = [google_compute_health_check.producer_service_health_check.id]
+}
+
+resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
+  name   = "tf-test-producer-forwarding-rule%{random_suffix}"
+  region = "us-west2"
+
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.producer_service_backend.id
+  all_ports             = true
+  network               = google_compute_network.psc_ilb_network.name
+  subnetwork            = google_compute_subnetwork.psc_ilb_producer_subnetwork.name
+}
+
+resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
+  name        = "tf-test-psc-ilb-sa%{random_suffix}"
+  region      = "us-west2"
+  description = "A service attachment configured with Terraform"
+
+  enable_proxy_protocol = false
+  connection_preference = "ACCEPT_AUTOMATIC"
+  nat_subnets           = [google_compute_subnetwork.psc_ilb_nat.id]
+  target_service        = google_compute_forwarding_rule.psc_ilb_target_service.id
+}
+
+data "google_compute_service_attachment" "default" {
+  name    = google_compute_service_attachment.psc_ilb_service_attachment.name
+  region  = google_compute_service_attachment.psc_ilb_service_attachment.region
+  project = google_compute_service_attachment.psc_ilb_service_attachment.project
+  depends_on = [
+    google_compute_service_attachment.psc_ilb_service_attachment,
+  ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/compute_service_attachment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_service_attachment.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  A data source to retrieve a service attachment.
+---
+
+# `google_compute_service_attachment`
+
+Get a specific [service attachment](https://cloud.google.com/vpc/docs/configure-private-service-connect-services) within a region. For more information see the
+[official documentation](https://cloud.google.com/vpc/docs/configure-private-service-connect-services)
+and [API](https://cloud.google.com/compute/docs/reference/rest/v1/serviceAttachments/get).
+
+## Example Usage
+
+```hcl
+data "google_compute_service_attachment" "default" {
+  project = "my-project"
+  name    = "my-service-attachment"
+  region  = "us-west2"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the service attachment to retrieve.
+
+---
+
+* `region` - (Optional) The region in which the service attachment resides.
+  If it is not provided, the provider region is used.
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+  If it is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_compute_service_attachment](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_service_attachment#attributes-reference) resource for details of the available attributes.


### PR DESCRIPTION
Add data source for `google_compute_service_attachment`
Should close https://github.com/hashicorp/terraform-provider-google/issues/17122

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_compute_service_attachment`
```

### Acceptance Tests
GA provider:
```
make testacc TEST=./google/services/compute TESTARGS='-run=TestAccDataSourceGoogleComputeServiceAttachment_basic'
sh -c "'/Users/adhi/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/compute -v -run=TestAccDataSourceGoogleComputeServiceAttachment_basic -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceGoogleComputeServiceAttachment_basic
=== PAUSE TestAccDataSourceGoogleComputeServiceAttachment_basic
=== CONT  TestAccDataSourceGoogleComputeServiceAttachment_basic
--- PASS: TestAccDataSourceGoogleComputeServiceAttachment_basic (139.31s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/compute  141.036s
```

Beta provider:
```
make testacc TEST=./google-beta/services/compute TESTARGS='-run=TestAccDataSourceGoogleComputeServiceAttachment_basic'
sh -c "'/Users/adhi/go/src/github.com/hashicorp/terraform-provider-google-beta/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta/services/compute -v -run=TestAccDataSourceGoogleComputeServiceAttachment_basic -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceGoogleComputeServiceAttachment_basic
=== PAUSE TestAccDataSourceGoogleComputeServiceAttachment_basic
=== CONT  TestAccDataSourceGoogleComputeServiceAttachment_basic
--- PASS: TestAccDataSourceGoogleComputeServiceAttachment_basic (133.20s)
PASS
ok      github.com/hashicorp/terraform-provider-google-beta/google-beta/services/compute        135.064s
```