### PR TITLE
feat: Add datasource google_oracle_database_goldengate_deployment_types

### DIFF
--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types.go
@@ -1,0 +1,184 @@
+package oracledatabase
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceOracleDatabaseGoldengateDeploymentTypes() *schema.Resource {
+	dsSchema := map[string]*schema.Schema{
+		"project": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The ID of the project in which the resource is located. If it is not provided, the provider project is used.",
+		},
+		"location": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The location of the resource.",
+		},
+		"goldengate_deployment_types": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The name of the Goldengate Deployment Type resource.",
+					},
+					"deployment_type": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The deployment type of the Goldengate Deployment Type resource.",
+					},
+					"category": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The category of the Goldengate Deployment Type resource.",
+					},
+					"connection_types": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Description: "The connection types of the Goldengate Deployment Type resource.",
+					},
+					"display_name": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The display name of the Goldengate Deployment Type resource.",
+					},
+					"ogg_version": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The OGG version of the Goldengate Deployment Type resource.",
+					},
+					"source_technologies": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Description: "The source technologies of the Goldengate Deployment Type resource.",
+					},
+					"target_technologies": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Description: "The target technologies of the Goldengate Deployment Type resource.",
+					},
+					"supported_capabilities": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
+						Description: "The supported capabilities of the Goldengate Deployment Type resource.",
+					},
+					"supported_technologies_url": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The supported technologies URL of the Goldengate Deployment Type resource.",
+					},
+					"default_username": {
+						Type:        schema.TypeString,
+						Computed:    true,
+						Description: "The default username of the Goldengate Deployment Type resource.",
+					},
+				},
+			},
+		},
+	}
+	return &schema.Resource{
+		Read:   DataSourceOracleDatabaseGoldengateDeploymentTypesRead,
+		Schema: dsSchema,
+	}
+}
+
+func DataSourceOracleDatabaseGoldengateDeploymentTypesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+	url, err := tpgresource.ReplaceVars(d, config, "{{OracleDatabaseBasePath}}projects/{{project}}/locations/{{location}}/goldengateDeploymentTypes")
+	if err != nil {
+		return err
+	}
+	billingProject := ""
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for GoldengateDeploymentTypes: %s", err)
+	}
+	billingProject = project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error reading GoldengateDeploymentTypes: %s", err)
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("goldengate_deployment_types", flattenGoldengateDeploymentTypes(res["goldengateDeploymentTypes"], d, config)); err != nil {
+		return fmt.Errorf("Error setting goldengate_deployment_types: %s", err)
+	}
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/goldengateDeploymentTypes")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func flattenGoldengateDeploymentTypes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0)
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"name":                       original["name"],
+			"deployment_type":            original["deploymentType"],
+			"category":                   original["category"],
+			"connection_types":           original["connectionTypes"],
+			"display_name":               original["displayName"],
+			"ogg_version":                original["oggVersion"],
+			"source_technologies":        original["sourceTechnologies"],
+			"target_technologies":        original["targetTechnologies"],
+			"supported_capabilities":     original["supportedCapabilities"],
+			"supported_technologies_url": original["supportedTechnologiesUrl"],
+			"default_username":           original["defaultUsername"],
+		})
+	}
+
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_oracle_database_goldengate_deployment_types",
+		ProductName: "oracledatabase",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceOracleDatabaseGoldengateDeploymentTypes(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_goldengate_deployment_types_test.go
@@ -1,0 +1,35 @@
+package oracledatabase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccOracleDatabaseGoldengateDeploymentTypes_basic(t *testing.T) {
+	t.Parallel()
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOracleDatabaseGoldengateDeploymentTypesConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_goldengate_deployment_types.my_deployment_types", "goldengate_deployment_types.#"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_goldengate_deployment_types.my_deployment_types", "goldengate_deployment_types.0.deployment_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOracleDatabaseGoldengateDeploymentTypesConfig() string {
+	return fmt.Sprintf(`
+data "google_oracle_database_goldengate_deployment_types" "my_deployment_types" {
+	location = "us-east4"
+	project  = "oci-terraform-testing-prod"
+}
+`)
+}

--- a/mmv1/third_party/terraform/website/docs/d/oracle_database_goldengate_deployment_types.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/oracle_database_goldengate_deployment_types.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Oracle Database"
+description: |-
+  List all GoldenGate Deployment Types in a location.
+---
+
+# google_oracle_database_goldengate_deployment_types
+
+List all GoldenGate Deployment Types in a location.
+
+For more information see the
+[API](https://cloud.google.com/oracle/database/docs/reference/rest/v1/projects.locations.goldengateDeploymentTypes).
+
+## Example Usage
+
+```hcl
+data "google_oracle_database_goldengate_deployment_types" "my_deployment_types" {
+  location = "us-east4"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of resource.
+
+* `project` - (Optional) The project to which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes reference
+
+The following attributes are exported:
+
+* `goldengate_deployment_types` - List of GoldenGate Deployment Types. Structure is [documented below](#nested_goldengate_deployment_types).
+
+<a name="nested_goldengate_deployment_types"></a> The `goldengate_deployment_types` block supports:
+
+* `name` - The name of the GoldenGate Deployment Type resource. Format: `projects/{project}/locations/{location}/goldenGateDeploymentTypes/{golden_gate_deployment_type}`
+
+* `deployment_type` - The deployment type of the GoldenGate Deployment Type resource.
+
+* `category` - The category of the GoldenGate Deployment Type resource.
+
+* `connection_types` - The connection types of the GoldenGate Deployment Type resource.
+
+* `display_name` - The display name of the GoldenGate Deployment Type resource.
+
+* `ogg_version` - The OGG version of the GoldenGate Deployment Type resource.
+
+* `source_technologies` - The source technologies of the GoldenGate Deployment Type resource.
+
+* `target_technologies` - The target technologies of the GoldenGate Deployment Type resource.
+
+* `supported_capabilities` - The supported capabilities of the GoldenGate Deployment Type resource.
+
+* `supported_technologies_url` - The supported technologies URL of the GoldenGate Deployment Type resource.
+
+* `default_username` - The default username of the GoldenGate Deployment Type resource.


### PR DESCRIPTION
Part of https://github.com/hashicorp/terraform-provider-google/issues/27423


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-datasource
`google_oracle_database_goldengate_deployment_types`
```
