### PR TITLE
Added allservices package that imports all services

### DIFF
--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -505,7 +505,28 @@ func (t Terraform) getCommonCopyFiles(versionName string, generateCode, generate
 	// save the folder name to foldersCopiedToGoogleDir
 	var foldersCopiedToGoogleDir []string
 	if generateCode {
-		foldersCopiedToGoogleDir = []string{"third_party/terraform/services", "third_party/terraform/acctest", "third_party/terraform/sweeper", "third_party/terraform/provider", "third_party/terraform/registry", "third_party/terraform/tpgdclresource", "third_party/terraform/tpgiamresource", "third_party/terraform/tpgresource", "third_party/terraform/transport", "third_party/terraform/fwmodels", "third_party/terraform/fwprovider", "third_party/terraform/fwtransport", "third_party/terraform/fwresource", "third_party/terraform/fwutils", "third_party/terraform/fwvalidators", "third_party/terraform/verify", "third_party/terraform/envvar", "third_party/terraform/functions", "third_party/terraform/test-fixtures"}
+		foldersCopiedToGoogleDir = []string{
+			"third_party/terraform/acctest",
+			"third_party/terraform/allservices",
+			"third_party/terraform/envvar",
+			"third_party/terraform/functions",
+			"third_party/terraform/fwmodels",
+			"third_party/terraform/fwprovider",
+			"third_party/terraform/fwresource",
+			"third_party/terraform/fwtransport",
+			"third_party/terraform/fwutils",
+			"third_party/terraform/fwvalidators",
+			"third_party/terraform/provider",
+			"third_party/terraform/registry",
+			"third_party/terraform/services",
+			"third_party/terraform/sweeper",
+			"third_party/terraform/test-fixtures",
+			"third_party/terraform/tpgdclresource",
+			"third_party/terraform/tpgiamresource",
+			"third_party/terraform/tpgresource",
+			"third_party/terraform/transport",
+			"third_party/terraform/verify",
+		}
 	}
 	googleDir := "google"
 	if versionName != "ga" {
@@ -622,7 +643,25 @@ func (t Terraform) getCommonCompileFiles(versionName string) map[string]string {
 
 	// Case 2: When compile all of files except .tmpl in a folder to the google directory of downstream repository,
 	// save the folder name to foldersCopiedToGoogleDir
-	foldersCompiledToGoogleDir := []string{"third_party/terraform/services", "third_party/terraform/acctest", "third_party/terraform/sweeper", "third_party/terraform/provider", "third_party/terraform/tpgdclresource", "third_party/terraform/tpgiamresource", "third_party/terraform/tpgresource", "third_party/terraform/transport", "third_party/terraform/fwmodels", "third_party/terraform/fwprovider", "third_party/terraform/fwtransport", "third_party/terraform/fwresource", "third_party/terraform/verify", "third_party/terraform/envvar", "third_party/terraform/functions", "third_party/terraform/test-fixtures"}
+	foldersCompiledToGoogleDir := []string{
+		"third_party/terraform/acctest",
+		"third_party/terraform/allservices",
+		"third_party/terraform/envvar",
+		"third_party/terraform/functions",
+		"third_party/terraform/fwmodels",
+		"third_party/terraform/fwprovider",
+		"third_party/terraform/fwresource",
+		"third_party/terraform/fwtransport",
+		"third_party/terraform/provider",
+		"third_party/terraform/services",
+		"third_party/terraform/sweeper",
+		"third_party/terraform/test-fixtures",
+		"third_party/terraform/tpgdclresource",
+		"third_party/terraform/tpgiamresource",
+		"third_party/terraform/tpgresource",
+		"third_party/terraform/transport",
+		"third_party/terraform/verify",
+	}
 	googleDir := "google"
 	if versionName != "ga" {
 		googleDir = fmt.Sprintf("google-%s", versionName)

--- a/mmv1/third_party/terraform/allservices/allservices.go.tmpl
+++ b/mmv1/third_party/terraform/allservices/allservices.go.tmpl
@@ -1,0 +1,10 @@
+// Package allservices imports all services in the provider. This greatly increases build time and should only be used
+// in cases where access to all services is truly required.
+package allservices
+
+import (
+	// Register products/resources
+	{{- range $product := $.Products }}
+	_ "github.com/hashicorp/terraform-provider-google/google/services/{{ $product.ApiName }}"
+	{{- end }}
+)

--- a/mmv1/third_party/terraform/allservices/allservices_test.go
+++ b/mmv1/third_party/terraform/allservices/allservices_test.go
@@ -1,4 +1,4 @@
-package acctest_test
+package allservices_test
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	fwtypes "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/allservices"
 	"github.com/hashicorp/terraform-provider-google/google/fwprovider"
 	"github.com/hashicorp/terraform-provider-google/google/provider"
 	"github.com/hashicorp/terraform-provider-google/google/registry"


### PR DESCRIPTION
This is necessary to make importing all services an explicit choice. This will replace provider_register_services, which imports all services as a side effect of importing the provider package. It's in a separate PR so that the diff processor can run properly on the switchover PR. (Without this change, it fails to compile because allservices doesn't exist.)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
