### PR TITLE
Add network resources validation in cluster director

### DIFF
--- a/mmv1/products/hypercomputecluster/Cluster.yaml
+++ b/mmv1/products/hypercomputecluster/Cluster.yaml
@@ -179,6 +179,7 @@ properties:
     output: true
   - name: networkResources
     type: Map
+    required: true
     description: |-
       Network resources available to the cluster. Must contain at most one value.
       Keys specify the ID of the network resource by which it can be referenced

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -2,6 +2,7 @@ package hypercomputecluster_test
 
 import (
 	"testing"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -785,6 +786,81 @@ resource "google_hypercomputecluster_cluster" "cluster" {
       partitions {
         id = "partition"
         node_set_ids = ["nodeset1"]
+      }
+      default_partition = "partition"
+    }
+  }
+}
+`, context)
+}
+
+func TestAccHypercomputeclusterCluster_networkValidation(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 3),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccHypercomputeclusterCluster_missingNetwork(context),
+				ExpectError: regexp.MustCompile("network_resources: At least one network_resources entry must be specified for cluster creation"),
+			},
+		},
+	})
+}
+
+func testAccHypercomputeclusterCluster_missingNetwork(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+locals {
+  project_id = data.google_project.project.name
+}
+
+resource "google_hypercomputecluster_cluster" "cluster" {
+  cluster_id                  = "tf%{random_suffix}"
+  location                    = "us-central1"
+  description                 = "Cluster Director instance created through Terraform - Missing Network"
+  compute_resources {
+    id = "compute-spot"
+    config {
+      new_spot_instances {
+        machine_type = "n2-standard-2"
+        zone = "us-central1-a"
+        termination_action = "STOP"
+      }
+    }
+  }
+  orchestrator {
+    slurm {
+      login_nodes {
+        machine_type = "n2-standard-2"
+        count = 1
+        zone = "us-central1-a"
+        boot_disk {
+          size_gb = "100"
+          type = "pd-balanced"
+        }
+      }
+      node_sets {
+        id = "nodeset"
+        compute_id = "compute-spot"
+        static_node_count = 1
+        compute_instance {
+          boot_disk {
+            size_gb = "100"
+            type = "pd-balanced"
+          }
+        }
+      }
+      partitions {
+        id = "partition"
+        node_set_ids = ["nodeset"]
       }
       default_partition = "partition"
     }

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -1,8 +1,8 @@
 package hypercomputecluster_test
 
 import (
-	"testing"
 	"regexp"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -806,11 +806,11 @@ func TestAccHypercomputeclusterCluster_networkValidation(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHypercomputeclusterCluster_missingNetwork(context),
+				Config:      testAccHypercomputeclusterCluster_missingNetwork(context),
 				ExpectError: regexp.MustCompile(`Insufficient network_resources blocks`),
 			},
 			{
-				Config: testAccHypercomputeclusterCluster_emptyNetwork(context),
+				Config:      testAccHypercomputeclusterCluster_emptyNetwork(context),
 				ExpectError: regexp.MustCompile(`The argument "id" is required, but no definition was found`),
 			},
 		},

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -798,7 +798,7 @@ func TestAccHypercomputeclusterCluster_networkValidation(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 3),
+		"random_suffix": acctest.RandString(t, 8),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -827,7 +827,7 @@ locals {
 }
 
 resource "google_hypercomputecluster_cluster" "cluster" {
-  cluster_id  = "tf-miss-%{random_suffix}"
+  cluster_id  = "tf%{random_suffix}"
   location    = "us-central1"
   project     = local.project_id
   description = "Cluster Director instance created through Terraform - Missing Network"
@@ -884,7 +884,7 @@ locals {
 }
 
 resource "google_hypercomputecluster_cluster" "cluster" {
-  cluster_id  = "tf-empty-%{random_suffix}"
+  cluster_id  = "tf%{random_suffix}"
   location    = "us-central1"
   project     = local.project_id
   description = "Cluster Director instance created through Terraform - Empty Network Block"

--- a/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
+++ b/mmv1/third_party/terraform/services/hypercomputecluster/resource_hypercomputecluster_cluster_test.go
@@ -806,8 +806,12 @@ func TestAccHypercomputeclusterCluster_networkValidation(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccHypercomputeclusterCluster_missingNetwork(context),
-				ExpectError: regexp.MustCompile("network_resources: At least one network_resources entry must be specified for cluster creation"),
+				Config: testAccHypercomputeclusterCluster_missingNetwork(context),
+				ExpectError: regexp.MustCompile(`Insufficient network_resources blocks`),
+			},
+			{
+				Config: testAccHypercomputeclusterCluster_emptyNetwork(context),
+				ExpectError: regexp.MustCompile(`The argument "id" is required, but no definition was found`),
 			},
 		},
 	})
@@ -819,20 +823,21 @@ data "google_project" "project" {
 }
 
 locals {
-  project_id = data.google_project.project.name
+  project_id = data.google_project.project.project_id
 }
 
 resource "google_hypercomputecluster_cluster" "cluster" {
-  cluster_id                  = "tf%{random_suffix}"
-  location                    = "us-central1"
-  description                 = "Cluster Director instance created through Terraform - Missing Network"
+  cluster_id  = "tf-miss-%{random_suffix}"
+  location    = "us-central1"
+  project     = local.project_id
+  description = "Cluster Director instance created through Terraform - Missing Network"
+
   compute_resources {
     id = "compute-spot"
     config {
       new_spot_instances {
         machine_type = "n2-standard-2"
-        zone = "us-central1-a"
-        termination_action = "STOP"
+        zone         = "us-central1-a"
       }
     }
   }
@@ -840,26 +845,86 @@ resource "google_hypercomputecluster_cluster" "cluster" {
     slurm {
       login_nodes {
         machine_type = "n2-standard-2"
-        count = 1
-        zone = "us-central1-a"
+        count        = 1
+        zone         = "us-central1-a"
         boot_disk {
           size_gb = "100"
-          type = "pd-balanced"
+          type    = "pd-balanced"
         }
       }
       node_sets {
-        id = "nodeset"
-        compute_id = "compute-spot"
+        id                = "nodeset"
+        compute_id        = "compute-spot"
         static_node_count = 1
         compute_instance {
           boot_disk {
             size_gb = "100"
-            type = "pd-balanced"
+            type    = "pd-balanced"
           }
         }
       }
       partitions {
-        id = "partition"
+        id           = "partition"
+        node_set_ids = ["nodeset"]
+      }
+      default_partition = "partition"
+    }
+  }
+}
+`, context)
+}
+
+func testAccHypercomputeclusterCluster_emptyNetwork(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {
+}
+
+locals {
+  project_id = data.google_project.project.project_id
+}
+
+resource "google_hypercomputecluster_cluster" "cluster" {
+  cluster_id  = "tf-empty-%{random_suffix}"
+  location    = "us-central1"
+  project     = local.project_id
+  description = "Cluster Director instance created through Terraform - Empty Network Block"
+
+  network_resources {
+  }
+
+  compute_resources {
+    id = "compute-spot"
+    config {
+      new_spot_instances {
+        machine_type = "n2-standard-2"
+        zone         = "us-central1-a"
+      }
+    }
+  }
+  orchestrator {
+    slurm {
+      login_nodes {
+        machine_type = "n2-standard-2"
+        count        = 1
+        zone         = "us-central1-a"
+        boot_disk {
+          size_gb = "100"
+          type    = "pd-balanced"
+        }
+      }
+      node_sets {
+        id                = "nodeset"
+        compute_id        = "compute-spot"
+        static_node_count = 1
+        compute_instance {
+          boot_disk {
+            size_gb = "100"
+            type    = "pd-balanced"
+          }
+        }
+      }
+      partitions {
+        id           = "partition"
         node_set_ids = ["nodeset"]
       }
       default_partition = "partition"


### PR DESCRIPTION
**feat: Add network_resources validation for Cluster Director**

This change adds a pre-create validation to ensure the `network_resources` field is set and not empty when  resource for Cluster Director. 

Fixes b/495546305

```release-note:enhancement
clusterdirector: Added validation to require at least one `network_resources` block during creation of cluster resource
```