### PR TITLE
Switched service dependency generation to use a function

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -2165,6 +2165,21 @@ func (r Resource) TestSampleSetUp(sysfs fs.FS) {
 	}
 }
 
+// TestServiceDependencies returns a map of service names to import aliases that are required
+// by this resource's samples.
+func (r Resource) TestServiceDependencies() map[string]string {
+	deps := map[string]string{}
+	for _, s := range r.TestSamples() {
+		for service, alias := range s.TestServiceDependencies() {
+			if depsAlias, ok := deps[service]; ok && alias != depsAlias {
+				panic(fmt.Sprintf("Conflicting aliases (%s vs %s) for service dependency %s for resource %s", depsAlias, alias, service, r.ApiName))
+			}
+			deps[service] = alias
+		}
+	}
+	return deps
+}
+
 func (r Resource) VersionedProvider(exampleVersion string) bool {
 	var vp string
 	if exampleVersion != "" {

--- a/mmv1/api/resource/sample.go
+++ b/mmv1/api/resource/sample.go
@@ -109,6 +109,24 @@ func (s *Sample) TestSteps() []*Step {
 	})
 }
 
+// TestServiceDependencies returns a map of service names to import aliases that are required
+// by this sample's steps.
+func (s *Sample) TestServiceDependencies() map[string]string {
+	deps := map[string]string{}
+	if len(s.BootstrapIam) > 0 {
+		deps["resourcemanager"] = ""
+	}
+	for _, step := range s.TestSteps() {
+		for service, alias := range step.TestServiceDependencies() {
+			if depsAlias, ok := deps[service]; ok && alias != depsAlias {
+				panic(fmt.Sprintf("Conflicting aliases (%s vs %s) for service dependency %s for sample %s", depsAlias, alias, service, s.Name))
+			}
+			deps[service] = alias
+		}
+	}
+	return deps
+}
+
 func (s *Sample) ResourceType(terraformName string) string {
 	if s.PrimaryResourceType != "" {
 		return s.PrimaryResourceType

--- a/mmv1/api/resource/step.go
+++ b/mmv1/api/resource/step.go
@@ -122,6 +122,24 @@ func (s *Step) TestStepSlug(productName, resourceName string) string {
 	return ret
 }
 
+// TestServiceDependencies returns a map of service names to import aliases that are required
+// by this step.
+func (s *Step) TestServiceDependencies() map[string]string {
+	deps := map[string]string{}
+	for _, val := range s.TestContextVars {
+		if strings.HasPrefix(val, "compute.") {
+			deps["compute"] = ""
+		}
+		if strings.HasPrefix(val, "kms.") {
+			deps["kms"] = ""
+		}
+		if strings.HasPrefix(val, "servicenetworking.") {
+			deps["servicenetworking"] = ""
+		}
+	}
+	return deps
+}
+
 func (s *Step) Validate(rName, sName string) (es []error) {
 	for k := range s.Vars {
 		if _, exists := s.ResourceIdVars[k]; exists {

--- a/mmv1/products/alloydb/Cluster.yaml
+++ b/mmv1/products/alloydb/Cluster.yaml
@@ -78,7 +78,7 @@ examples:
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "alloydb-1")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "alloydb-1")'
     ignore_read_extra:
       - 'deletion_protection'
   - name: 'alloydb_cluster_after_upgrade'
@@ -88,7 +88,7 @@ examples:
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "alloydb-1")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "alloydb-1")'
     ignore_read_extra:
       - 'deletion_protection'
   - name: 'alloydb_cluster_full'
@@ -107,7 +107,7 @@ examples:
       alloydb_instance_name: 'alloydb-instance'
       network_name: 'alloydb-network'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "alloydb-instance-basic")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "alloydb-instance-basic")'
     ignore_read_extra:
       - 'deletion_protection'
       - 'reconciling'

--- a/mmv1/products/eventarc/Pipeline.yaml
+++ b/mmv1/products/eventarc/Pipeline.yaml
@@ -53,7 +53,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'tpgcompute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", tpgcompute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", tpgcompute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
+      'network_attachment_name': 'compute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", compute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", compute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_workflow_destination
     primary_resource_id: primary
     vars:
@@ -70,7 +70,7 @@ examples:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'
     test_vars_overrides:
-      'network_attachment_name': 'tpgcompute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", tpgcompute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", tpgcompute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
+      'network_attachment_name': 'compute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", compute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", compute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_oauth_and_protobuf_format
     primary_resource_id: primary
     vars:
@@ -80,7 +80,7 @@ examples:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'
     test_vars_overrides:
-      'network_attachment_name': 'tpgcompute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", tpgcompute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", tpgcompute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
+      'network_attachment_name': 'compute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", compute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", compute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
   - name: eventarc_pipeline_with_cmek_and_avro_format
     primary_resource_id: primary
     bootstrap_iam:
@@ -93,7 +93,7 @@ examples:
     test_env_vars:
       project_id: 'PROJECT_NAME'
     test_vars_overrides:
-      'network_attachment_name': 'tpgcompute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", tpgcompute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", tpgcompute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
+      'network_attachment_name': 'compute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-pipeline-na", compute.BootstrapSubnet(t, "tf-bootstrap-eventarc-pipeline-subnet", compute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-pipeline-network")))'
       'key_name': 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-eventarc-pipeline-key").CryptoKey.Name'
 parameters:
   - name: location

--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -53,7 +53,7 @@ examples:
       trigger_name: some-trigger
       network_attachment_name: network-attachment
     test_vars_overrides:
-      'network_attachment_name': 'tpgcompute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-trigger-na", tpgcompute.BootstrapSubnet(t, "tf-bootstrap-eventarc-trigger-subnet", tpgcompute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-trigger-network")))'
+      'network_attachment_name': 'compute.BootstrapNetworkAttachment(t, "tf-bootstrap-eventarc-trigger-na", compute.BootstrapSubnet(t, "tf-bootstrap-eventarc-trigger-subnet", compute.BootstrapSharedTestNetwork(t, "tf-bootstrap-eventarc-trigger-network")))'
     test_env_vars:
       project_id: 'PROJECT_NAME'
       service_account: 'SERVICE_ACCT'

--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -58,8 +58,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_autopilot'
@@ -72,8 +72,8 @@ examples:
       subnetwork_name: 'default'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_cmek'
@@ -89,8 +89,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_nslabels'
@@ -105,8 +105,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_full'
@@ -121,8 +121,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_permissive'
@@ -137,8 +137,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_rpo_daily_window'
@@ -153,8 +153,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_backupplan_rpo_weekly_window'
@@ -169,8 +169,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
 parameters:

--- a/mmv1/products/gkebackup/RestorePlan.yaml
+++ b/mmv1/products/gkebackup/RestorePlan.yaml
@@ -57,8 +57,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_rollback_namespace'
@@ -72,8 +72,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_protected_application'
@@ -87,8 +87,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_all_cluster_resources'
@@ -102,8 +102,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_rename_namespace'
@@ -117,8 +117,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_second_transformation'
@@ -132,8 +132,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_gitops_mode'
@@ -147,8 +147,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_restore_order'
@@ -162,8 +162,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
   - name: 'gkebackup_restoreplan_volume_res'
@@ -177,8 +177,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
 parameters:

--- a/mmv1/products/gkehub/Membership.yaml
+++ b/mmv1/products/gkehub/Membership.yaml
@@ -66,8 +66,8 @@ examples:
       project: 'PROJECT_NAME'
       location: 'REGION'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
       # for backward compatible
       name: '"basic" + randomSuffix'
   - name: 'gkehub_membership_basic'
@@ -80,8 +80,8 @@ examples:
       subnetwork_name: 'default'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
       # for backward compatible
       name: '"basic" + randomSuffix'
     oics_vars_overrides:
@@ -98,8 +98,8 @@ examples:
       project: 'PROJECT_NAME'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
       # for backward compatible
       name: '"basic" + randomSuffix'
     oics_vars_overrides:

--- a/mmv1/products/gkehub2/MembershipBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipBinding.yaml
@@ -58,8 +58,8 @@ examples:
       membership_id: 'fmt.Sprintf("tf-test-membership%s", context["random_suffix"])'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
 parameters:

--- a/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
+++ b/mmv1/products/gkehub2/MembershipRBACRoleBinding.yaml
@@ -58,8 +58,8 @@ examples:
       location: 'global'
     test_vars_overrides:
       'deletion_protection': 'false'
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")'
-      'subnetwork_name': 'tpgcompute.BootstrapSubnet(t, "gke-cluster", tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "gke-cluster")'
+      'subnetwork_name': 'compute.BootstrapSubnet(t, "gke-cluster", compute.BootstrapSharedTestNetwork(t, "gke-cluster"))'
     oics_vars_overrides:
       'deletion_protection': 'false'
 parameters:

--- a/mmv1/products/looker/Instance.yaml
+++ b/mmv1/products/looker/Instance.yaml
@@ -84,7 +84,7 @@ examples:
       client_id: 'my-client-id'
       client_secret: 'my-client-secret'
     test_vars_overrides:
-      'address_name': 'tpgcompute.BootstrapSharedTestGlobalAddress(t, "looker-vpc-network-3", tpgcompute.AddressWithPrefixLength(8))'
+      'address_name': 'compute.BootstrapSharedTestGlobalAddress(t, "looker-vpc-network-3", compute.AddressWithPrefixLength(8))'
       'kms_key_name': 'kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
       'network_name': 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "looker-vpc-network-3", servicenetworking.ServiceNetworkWithPrefixLength(8))'
     exclude_docs: true

--- a/mmv1/products/redis/Instance.yaml
+++ b/mmv1/products/redis/Instance.yaml
@@ -69,7 +69,7 @@ examples:
       network_name: 'redis-test-network'
       prevent_destroy: 'true'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "redis-full")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "redis-full")'
       'prevent_destroy': 'false'
     oics_vars_overrides:
       'prevent_destroy': 'false'
@@ -80,7 +80,7 @@ examples:
       network_name: 'redis-test-network'
       prevent_destroy: 'true'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "redis-full-persis")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "redis-full-persis")'
       'prevent_destroy': 'false'
     oics_vars_overrides:
       'prevent_destroy': 'false'
@@ -117,7 +117,7 @@ examples:
       network_name: 'redis-test-network'
       prevent_destroy: 'true'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "redis-mrr")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "redis-mrr")'
       'prevent_destroy': 'false'
     oics_vars_overrides:
       'prevent_destroy': 'false'
@@ -128,7 +128,7 @@ examples:
       network_name: 'redis-test-network'
       prevent_destroy: 'true'
     test_vars_overrides:
-      'network_name': 'tpgcompute.BootstrapSharedTestNetwork(t, "redis-cmek")'
+      'network_name': 'compute.BootstrapSharedTestNetwork(t, "redis-cmek")'
       'prevent_destroy': 'false'
     oics_vars_overrides:
       'prevent_destroy': 'false'

--- a/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
+++ b/mmv1/products/vertexai/IndexEndpointDeployedIndex.yaml
@@ -68,7 +68,7 @@ examples:
       address_name: 'vertex-ai-range'
     test_vars_overrides:
       'network_name': 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
-      'address_name': 'tpgcompute.BootstrapSharedTestGlobalAddress(t, "vpc-network-1", tpgcompute.AddressWithPrefixLength(8))'
+      'address_name': 'compute.BootstrapSharedTestGlobalAddress(t, "vpc-network-1", compute.AddressWithPrefixLength(8))'
   - name: 'vertex_ai_index_endpoint_deployed_index_basic_two'
     primary_resource_id: 'basic_deployed_index'
     vars:
@@ -82,7 +82,7 @@ examples:
       address_name: 'vertex-ai-range'
     test_vars_overrides:
       'network_name': 'servicenetworking.BootstrapSharedServiceNetworkingConnection(t, "vpc-network-1")'
-      'address_name': 'tpgcompute.BootstrapSharedTestGlobalAddress(t, "vpc-network-1", tpgcompute.AddressWithPrefixLength(8))'
+      'address_name': 'compute.BootstrapSharedTestGlobalAddress(t, "vpc-network-1", compute.AddressWithPrefixLength(8))'
   - name: 'vertex_ai_index_endpoint_deployed_index_dedicated_resources'
     primary_resource_id: 'dedicated_resources'
     vars:

--- a/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
@@ -22,16 +22,8 @@ import (
 {{- if $.FirstTestConfig.Sample.BootstrapIam }}
 	"{{ $.ImportPath }}/services/resourcemanager"
 {{- end }}
-{{- range $_, $v := $.FirstTestConfig.Step.TestContextVars }}
-	{{- if hasPrefix $v "tpgcompute." }}
-	tpgcompute "{{ $.ImportPath }}/services/compute"
-	{{- end }}
-	{{- if hasPrefix $v "kms." }}
-	"{{ $.ImportPath }}/services/kms"
-	{{- end }}
-	{{- if hasPrefix $v "servicenetworking." }}
-	"{{ $.ImportPath }}/services/servicenetworking"
-	{{- end }}
+{{- range $service, $alias := $.FirstTestConfig.Step.TestServiceDependencies }}
+	{{ $alias }} "{{ $.ImportPath  }}/services/{{ $service }}"
 {{- end }}
 )
 

--- a/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
@@ -42,23 +42,8 @@ import (
 	"{{ $.ImportPath }}/acctest"
 	"{{ $.ImportPath  }}/envvar"
 	"{{ $.ImportPath  }}/services/{{ lower $.Res.ProductMetadata.Name }}"
-{{ range $s := $.Res.TestSamples }}
-  {{- if $s.BootstrapIam }}
-    "{{ $.ImportPath  }}/services/resourcemanager"
-  {{- end }}
-  {{- range $i, $step := $s.TestSteps }}
-		{{- range $_, $v := $step.TestContextVars }}
-			{{- if hasPrefix $v "tpgcompute." }}
-				tpgcompute "{{ $.ImportPath }}/services/compute"
-			{{- end }}
-			{{- if hasPrefix $v "kms." }}
-				"{{ $.ImportPath }}/services/kms"
-			{{- end }}
-			{{- if hasPrefix $v "servicenetworking." }}
-				"{{ $.ImportPath }}/services/servicenetworking"
-			{{- end }}
-		{{- end }}
-	{{- end }}
+{{- range $service, $alias := $.Res.TestServiceDependencies }}
+	{{ $alias }} "{{ $.ImportPath  }}/services/{{ $service }}"
 {{- end }}
 	"{{ $.ImportPath  }}/tpgresource"
 	transport_tpg "{{ $.ImportPath  }}/transport"


### PR DESCRIPTION
This will make it easier to extend the generation logic in the future - for example, by parsing the HCL text to determine what resources need to be registered for the test to pass.

It turns out that the compute imports don't actually need to be tpgcompute; I had that to match how handwritten things worked, but handwritten tests worked that way because they often included imports of the compute client library. That's not the case in generated tests.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
