### PR TITLE
move private connectivity tests to us-west1

### DIFF
--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
 	display_name          = "dbms_pc"
-	location              = "us-central1"
+	location              = "us-central2"
 	private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
 	labels = {

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
 	display_name          = "dbms_pc"
-	location              = "us-central2"
+	location              = "us-west1"
 	private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
 	labels = {

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
 	display_name          = "dbms_pc"
-	location              = "us-central1"
+	location              = "us-central2"
 	private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
 	labels = {

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
@@ -29,6 +29,6 @@ resource "google_compute_network" "default" {
 resource "google_compute_subnetwork" "default" {
   name          = "{{index $.Vars "subnetwork_name"}}"
   ip_cidr_range = "10.0.0.0/16"
-  region        = "us-central1"
+  region        = "us-west1"
   network       = google_compute_network.default.id
 }

--- a/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
+++ b/mmv1/templates/terraform/examples/database_migration_service_private_connection_psc.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_database_migration_service_private_connection" "{{$.PrimaryResourceId}}" {
 	display_name          = "dbms_pc"
-	location              = "us-central2"
+	location              = "us-west1"
 	private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
 	labels = {
@@ -16,7 +16,7 @@ resource "google_database_migration_service_private_connection" "{{$.PrimaryReso
 
 resource "google_compute_network_attachment" "default" {
   name                  = "{{index $.Vars "attachment_name"}}"
-  region                = "us-central1"
+  region                = "us-west1"
   connection_preference = "ACCEPT_AUTOMATIC"
   subnetworks           = [resource.google_compute_subnetwork.default.id]
 }

--- a/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
     display_name          = "Connection profile"
-    location              = "us-central2"
+    region                = "us-west1"
     private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
     labels = {
@@ -30,7 +30,7 @@ resource "google_compute_network" "default" {
 
 resource "google_compute_subnetwork" "default" {
     name   = "{{index $.Vars "subnetwork_name"}}"
-    region = "us-central1"
+    region = "us-west1"
 
     network       = google_compute_network.default.id
     ip_cidr_range = "10.0.0.0/16"

--- a/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
 
 resource "google_compute_network_attachment" "default" {
     name                  = "{{index $.Vars "network_attachment_name"}}"
-    region                = "us-central2"
+    region                = "us-west1"
     description           = "basic network attachment description"
     connection_preference = "ACCEPT_AUTOMATIC"
 

--- a/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
     display_name          = "Connection profile"
-    region                = "us-west1"
+    location              = "us-west1"
     private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
     labels = {

--- a/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_private_connection_psc_interface.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
     display_name          = "Connection profile"
-    location              = "us-central1"
+    location              = "us-central2"
     private_connection_id = "{{index $.Vars "private_connection_id"}}"
 
     labels = {
@@ -14,7 +14,7 @@ resource "google_datastream_private_connection" "{{$.PrimaryResourceId}}" {
 
 resource "google_compute_network_attachment" "default" {
     name                  = "{{index $.Vars "network_attachment_name"}}"
-    region                = "us-central1"
+    region                = "us-central2"
     description           = "basic network attachment description"
     connection_preference = "ACCEPT_AUTOMATIC"
 

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_private_connection.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_private_connection.tf
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_datastream_private_connection" "default" {
     display_name          = "Connection profile"
-    location              = "us-central1"
+    location              = "us-west1"
     private_connection_id = "pc-connection"
 
     labels = {

--- a/mmv1/third_party/tgc/tests/data/example_google_datastream_private_connection.tf
+++ b/mmv1/third_party/tgc/tests/data/example_google_datastream_private_connection.tf
@@ -13,7 +13,7 @@ provider "google" {
 
 resource "google_datastream_private_connection" "default" {
     display_name          = "Connection profile"
-    location              = "us-west1"
+    location              = "us-central1"
     private_connection_id = "pc-connection"
 
     labels = {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

max upper quota for "PrivateConnectionsPerProjectAndRegion" is 5, we were at 6 tests using us-central 1

moved both dbms resources using a private connectivity resource to us-west1, and one datastream to it to create a small buffer

fixes https://github.com/hashicorp/terraform-provider-google/issues/27340

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
