### PR TITLE
Set up sweeping for networkconnectivity destination

### DIFF
--- a/mmv1/products/networkconnectivity/Destination.yaml
+++ b/mmv1/products/networkconnectivity/Destination.yaml
@@ -41,6 +41,13 @@ examples:
       config_name: "basic-config"
       destination_name: "basic-destination"
 
+sweeper:
+  parent:
+    resource_type: "google_network_connectivity_multicloud_data_transfer_config"
+    child_field: "multicloud_data_transfer_config"
+    parent_field: "name"
+    parent_field_extract_name: true
+
 parameters:
   - name: 'multicloudDataTransferConfig'
     type: String


### PR DESCRIPTION
This is necessary because otherwise deletions persist and prevent deletion of multicloud_data_transfer_config. There can only be one multicloud_data_transfer_config per region, so this can cause test failures. (For example, https://github.com/GoogleCloudPlatform/magic-modules/pull/17612#issuecomment-4482602330)

I've run the sweeper locally successfully for the VCR test project.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
