### PR TITLE
Remove redundant Zones.Get from resourceComputeInstanceCreate

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2016,12 +2016,6 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Loading zone: %s", z)
-	zone, err := NewClient(config, userAgent).Zones.Get(
-		project, z).Do()
-	if err != nil {
-		return fmt.Errorf("Error loading zone '%s': %s", z, err)
-	}
 
 	instance, err := expandComputeInstance(project, d, config)
 	if err != nil {
@@ -2081,7 +2075,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 
 	if val, ok := d.GetOk("desired_status"); ok {
 		if val.(string) != "RUNNING" {
-			err = changeInstanceStatusOnCreation(config, d, project, zone.Name, val.(string), userAgent)
+			err = changeInstanceStatusOnCreation(config, d, project, z, val.(string), userAgent)
 			if err != nil {
 				return fmt.Errorf("Error changing instance status after creation: %s", err)
 			}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

The `Zones.Get` call in `resourceComputeInstanceCreate` was only used to obtain the canonical zone name, which is already the value returned by `tpgresource.GetZone(d, config)`. Drop the call and pass the string `z` directly to `changeInstanceStatusOnCreation`.

Part of an ongoing partial migration of `resource_compute_instance.go.tmpl` from the Apiary client library to direct HTTP. Patterns follow #17536.

```release-note:none
```
