### PR TITLE
Add an output-only field for Firebase storage default bucket id

### DIFF
--- a/mmv1/products/firebasestorage/DefaultBucket.yaml
+++ b/mmv1/products/firebasestorage/DefaultBucket.yaml
@@ -54,12 +54,19 @@ properties:
       The resource name of the underlying Google Cloud Storage bucket.
     min_version: "beta"
     output: true
+    custom_flatten: 'templates/terraform/custom_flatten/firebasestorage_bucket.go.tmpl'
     properties:
       - name: "name"
         type: String
         description: |
           The resource name of the bucket in the format
           projects/PROJECT_IDENTIFIER/buckets/BUCKET_ID
+        min_version: "beta"
+        output: true
+      - name: "bucket_id"
+        type: String
+        description: |
+          The last segment of bucket.name.
         min_version: "beta"
         output: true
   - name: "location"

--- a/mmv1/products/firebasestorage/DefaultBucket.yaml
+++ b/mmv1/products/firebasestorage/DefaultBucket.yaml
@@ -63,7 +63,7 @@ properties:
           projects/PROJECT_IDENTIFIER/buckets/BUCKET_ID
         min_version: "beta"
         output: true
-      - name: "bucket_id"
+      - name: "bucketId"
         type: String
         description: |
           The last segment of bucket.name.

--- a/mmv1/templates/terraform/custom_flatten/firebasestorage_bucket.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/firebasestorage_bucket.go.tmpl
@@ -1,0 +1,28 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["name"] = original["name"]
+	if name, ok := original["name"].(string); ok {
+		parts := strings.Split(name, "/")
+		transformed["bucket_id"] = parts[len(parts)-1]
+	}
+	return []interface{}{transformed}
+}


### PR DESCRIPTION
Add an output_only field for Firebase storage default bucket id. This is for convenience so that clients don't have to parse the resource name string.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
firebasestorage: added `bucket.bucket_id` field to `google_firebase_storage_default_bucket` resource (beta)
```
