### PR TITLE
Made TestAccComputeInstanceFromTemplate_DiskForceAttach use two separate disks

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_from_template_test.go.tmpl
@@ -2483,6 +2483,14 @@ resource "google_compute_disk" "foobar" {
   zone  = "us-central1-a"
 }
 
+resource "google_compute_disk" "barbaz" {
+  name  = "%s-2"
+  image = data.google_compute_image.my_image.self_link
+  size  = 10
+  type  = "pd-ssd"
+  zone  = "us-central1-a"
+}
+
 resource "google_compute_instance_template" "foobar" {
   name         = "%s"
   machine_type = "n1-standard-1"  // can't be e2 because of local-ssd
@@ -2520,11 +2528,11 @@ resource "google_compute_instance_from_template" "foobar" {
     force_attach = true
   }
   attached_disk {
-    source       = google_compute_disk.foobar.name
+    source       = google_compute_disk.barbaz.name
     force_attach = true
   }
 }
-`, template, template, instance)
+`, template, template, template, instance)
 }
 
 func testAccComputeInstanceFromTemplate_DiskForceAttach(instance, template string) string {


### PR DESCRIPTION
This is necessary because each disk can only be attached once

Fixed https://github.com/hashicorp/terraform-provider-google/issues/25086

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
