### PR TITLE
Add google_ces_security_settings resource (Beta)

### DIFF
--- a/mmv1/products/ces/SecuritySettings.yaml
+++ b/mmv1/products/ces/SecuritySettings.yaml
@@ -1,0 +1,89 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'SecuritySettings'
+description: |
+  Security settings for a location in Customer Engagement Suite.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/customer-engagement-ai/docs'
+  api: 'https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/rest/v1beta/SecuritySettings'
+base_url: 'projects/{{project}}/locations/{{location}}/securitySettings'
+self_link: 'projects/{{project}}/locations/{{location}}/securitySettings'
+create_verb: 'PATCH'
+update_verb: 'PATCH'
+update_mask: true
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/securitySettings'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+exclude_delete: true
+exclude_sweeper: true
+min_version: beta
+examples:
+  - name: 'ces_security_settings_basic'
+    primary_resource_id: 'security_settings'
+    vars:
+      # Simple resource, no dynamic vars needed other than project/location
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    description: |
+      The location of the security settings.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: 'name'
+    type: String
+    description: |
+      Identifier. The unique identifier of the security settings.
+      Format: projects/{project}/locations/{location}/securitySettings
+    output: true
+  - name: 'endpointControlPolicy'
+    type: NestedObject
+    description: |
+      Optional. Endpoint control related settings.
+    properties:
+      - name: 'enforcementScope'
+        type: Enum
+        description: |
+          Optional. The scope in which this policy's allowedOrigins list is enforced.
+        enum_values:
+          - 'ENFORCEMENT_SCOPE_UNSPECIFIED'
+          - 'VPCSC_ONLY'
+          - 'ALWAYS'
+      - name: 'allowedOrigins'
+        type: Array
+        description: |
+          Optional. The allowed HTTP(s) origins that tools in the App are able to directly call.
+        item_type:
+          type: String
+  - name: 'createTime'
+    type: String
+    description: |
+      Output only. Timestamp when the security settings were created.
+    output: true
+  - name: 'updateTime'
+    type: String
+    description: |
+      Output only. Timestamp when the security settings were last updated.
+    output: true
+  - name: 'etag'
+    type: String
+    description: |
+      Output only. Etag of the resource.
+    output: true

--- a/mmv1/products/ces/SecuritySettings.yaml
+++ b/mmv1/products/ces/SecuritySettings.yaml
@@ -36,8 +36,7 @@ min_version: beta
 examples:
   - name: 'ces_security_settings_basic'
     primary_resource_id: 'security_settings'
-    vars:
-      # Simple resource, no dynamic vars needed other than project/location
+    exclude_test: true
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/templates/terraform/examples/ces_security_settings_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_security_settings_basic.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_ces_security_settings" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  location = "us"
+
+  endpoint_control_policy {
+    enforcement_scope = "ALWAYS"
+    allowed_origins   = ["https://example.com", "https://google.com"]
+  }
+}
+

--- a/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ces_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckCESSecuritySettingsDestroyNoOp,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_full(context),
+			},
+			{
+				ResourceName:            "google_ces_security_settings.security_settings",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+			{
+				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_security_settings.security_settings", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_security_settings.security_settings",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}
+
+func testAccCheckCESSecuritySettingsDestroyNoOp(s *terraform.State) error {
+	return nil
+}
+
+func testAccCESSecuritySettings_cesSecuritySettingsExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_security_settings" "security_settings" {
+  provider = google-beta
+  location = "us"
+
+  endpoint_control_policy {
+    enforcement_scope = "ALWAYS"
+    allowed_origins   = ["https://example.com", "https://google.com"]
+  }
+}
+`, context)
+}
+
+func testAccCESSecuritySettings_cesSecuritySettingsExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_security_settings" "security_settings" {
+  provider = google-beta
+  location = "us"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
@@ -14,7 +14,9 @@
 package ces_test
 
 import (
+	"log"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -37,7 +39,16 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		CheckDestroy:             testAccCheckCESSecuritySettingsDestroyNoOp,
 		Steps: []resource.TestStep{
+			// Step 1: Spin up the project and enable the main CES wrapper API
 			{
+				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_projectAndService(context),
+			},
+			// Step 2: Wait 30s in Go for regional endpoints to initialize, then apply the settings
+			{
+				PreConfig: func() {
+					log.Printf("[DEBUG] Waiting 30 seconds for CES regional endpoint propagation on new project...")
+					time.Sleep(30 * time.Second)
+				},
 				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_full(context),
 			},
 			{
@@ -46,6 +57,7 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "project"},
 			},
+			// Step 3: Update the settings (testing standard allowed origins update)
 			{
 				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_update(context),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -66,6 +78,25 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 
 func testAccCheckCESSecuritySettingsDestroyNoOp(s *terraform.State) error {
 	return nil
+}
+
+func testAccCESSecuritySettings_cesSecuritySettingsExample_projectAndService(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider        = google-beta
+  project_id      = "tf-test-project-%{random_suffix}"
+  name            = "tf-test-project-%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "ces" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = "ces.googleapis.com"
+}
+`, context)
 }
 
 func testAccCESSecuritySettings_cesSecuritySettingsExample_full(context map[string]interface{}) string {

--- a/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
@@ -20,13 +20,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(t, 10),
+		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -41,7 +44,7 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 				ResourceName:            "google_ces_security_settings.security_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "project"},
 			},
 			{
 				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_update(context),
@@ -55,7 +58,7 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 				ResourceName:            "google_ces_security_settings.security_settings",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"location"},
+				ImportStateVerifyIgnore: []string{"location", "project"},
 			},
 		},
 	})
@@ -67,23 +70,64 @@ func testAccCheckCESSecuritySettingsDestroyNoOp(s *terraform.State) error {
 
 func testAccCESSecuritySettings_cesSecuritySettingsExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider        = google-beta
+  project_id      = "tf-test-project-%{random_suffix}"
+  name            = "tf-test-project-%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "ces" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = "ces.googleapis.com"
+}
+
 resource "google_ces_security_settings" "security_settings" {
   provider = google-beta
+  project  = google_project.project.project_id
   location = "us"
 
   endpoint_control_policy {
     enforcement_scope = "ALWAYS"
     allowed_origins   = ["https://example.com", "https://google.com"]
   }
+
+  depends_on = [google_project_service.ces]
 }
 `, context)
 }
 
 func testAccCESSecuritySettings_cesSecuritySettingsExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project" "project" {
+  provider        = google-beta
+  project_id      = "tf-test-project-%{random_suffix}"
+  name            = "tf-test-project-%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "ces" {
+  provider = google-beta
+  project  = google_project.project.project_id
+  service  = "ces.googleapis.com"
+}
+
 resource "google_ces_security_settings" "security_settings" {
   provider = google-beta
+  project  = google_project.project.project_id
   location = "us"
+
+  endpoint_control_policy {
+    enforcement_scope = "VPCSC_ONLY"
+    allowed_origins   = ["https://google.com"]
+  }
+
+  depends_on = [google_project_service.ces]
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_security_settings_test.go
@@ -1,26 +1,10 @@
-// Copyright 2026 Google Inc.
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package ces_test
 
 import (
-	"log"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
@@ -37,18 +21,11 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckCESSecuritySettingsDestroyNoOp,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
 		Steps: []resource.TestStep{
-			// Step 1: Spin up the project and enable the main CES wrapper API
 			{
-				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_projectAndService(context),
-			},
-			// Step 2: Wait 30s in Go for regional endpoints to initialize, then apply the settings
-			{
-				PreConfig: func() {
-					log.Printf("[DEBUG] Waiting 30 seconds for CES regional endpoint propagation on new project...")
-					time.Sleep(30 * time.Second)
-				},
 				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_full(context),
 			},
 			{
@@ -57,7 +34,6 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"location", "project"},
 			},
-			// Step 3: Update the settings (testing standard allowed origins update)
 			{
 				Config: testAccCESSecuritySettings_cesSecuritySettingsExample_update(context),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -74,29 +50,6 @@ func TestAccCESSecuritySettings_cesSecuritySettingsExample_update(t *testing.T) 
 			},
 		},
 	})
-}
-
-func testAccCheckCESSecuritySettingsDestroyNoOp(s *terraform.State) error {
-	return nil
-}
-
-func testAccCESSecuritySettings_cesSecuritySettingsExample_projectAndService(context map[string]interface{}) string {
-	return acctest.Nprintf(`
-resource "google_project" "project" {
-  provider        = google-beta
-  project_id      = "tf-test-project-%{random_suffix}"
-  name            = "tf-test-project-%{random_suffix}"
-  org_id          = "%{org_id}"
-  billing_account = "%{billing_account}"
-  deletion_policy = "DELETE"
-}
-
-resource "google_project_service" "ces" {
-  provider = google-beta
-  project  = google_project.project.project_id
-  service  = "ces.googleapis.com"
-}
-`, context)
 }
 
 func testAccCESSecuritySettings_cesSecuritySettingsExample_full(context map[string]interface{}) string {
@@ -116,6 +69,12 @@ resource "google_project_service" "ces" {
   service  = "ces.googleapis.com"
 }
 
+resource "time_sleep" "wait_enable_service" {
+  provider        = time
+  create_duration = "30s"
+  depends_on      = [google_project_service.ces]
+}
+
 resource "google_ces_security_settings" "security_settings" {
   provider = google-beta
   project  = google_project.project.project_id
@@ -126,7 +85,7 @@ resource "google_ces_security_settings" "security_settings" {
     allowed_origins   = ["https://example.com", "https://google.com"]
   }
 
-  depends_on = [google_project_service.ces]
+  depends_on = [time_sleep.wait_enable_service]
 }
 `, context)
 }
@@ -148,6 +107,12 @@ resource "google_project_service" "ces" {
   service  = "ces.googleapis.com"
 }
 
+resource "time_sleep" "wait_enable_service" {
+  provider        = time
+  create_duration = "30s"
+  depends_on      = [google_project_service.ces]
+}
+
 resource "google_ces_security_settings" "security_settings" {
   provider = google-beta
   project  = google_project.project.project_id
@@ -158,7 +123,7 @@ resource "google_ces_security_settings" "security_settings" {
     allowed_origins   = ["https://google.com"]
   }
 
-  depends_on = [google_project_service.ces]
+  depends_on = [time_sleep.wait_enable_service]
 }
 `, context)
 }


### PR DESCRIPTION
# Add support for Customer Engagement Suite SecuritySettings (Beta)

This PR adds a new resource `google_ces_security_settings` to support managing location-level Security Settings in the Customer Engagement Suite (CES) product.

## Documentation
* API Reference: [SecuritySettings](https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/rest/v1beta/SecuritySettings)

## Rationale
Conversational agent tools in Customer Engagement Suite require a location-level `SecuritySettings` configuration to control which HTTP(s) origins they are allowed to directly call (via Endpoint Control Policies). This resource allows managing these security settings declaratively.

---

## Technical Details & Rough Edges

### 1. Singleton Lifecycle handling
* **PATCH-only verbs**: Since this is a location singleton created automatically by the backend, both creation and updates are configured to use `PATCH` (with `update_mask: true`).
* **State-only delete (`exclude_delete: true`)**: The API does not support `DELETE` for this singleton. The provider cleanly drops the resource from the local Terraform state on destroy without hitting REST errors.

### 2. CI Concurrency Isolation & Dynamic Project Test (Why I used custom tests)
* **Parallel Checkout Safety**: Because this is a location singleton in a shared test project, multiple CI checks running in parallel will collide on the single `us` region and cause flaky/intermittent test failures.
* **Implementation**: 
  * Marked the basic example `ces_security_settings_basic` in `SecuritySettings.yaml` as docs-only (`exclude_test: true`) to avoid CI leaks.
  * Replaced it with a **handwritten Go update test** (`ces_security_settings_test.go`) that dynamically spins up a fresh project (`google_project`), enables `ces.googleapis.com`, and applies `google_ces_security_settings`. This ensures complete concurrency isolation in parallel runners.
  * Added a **30-second HCL `time_sleep` resource** after enabling the API to cleanly wait for the implicit backend sub-APIs and IAM policies to propagate, completely avoiding 403 Permission Denied errors.
  * Declared the `"time"` provider inside the test's `ExternalProviders` block to ensure clean and seamless dependency locking during Go execution.
  * The test verifies a standard resource update lifecycle (allowed origins A -> B) in the isolated project. Deleting the dynamic project on test exit automatically destroys the location singleton.


---

## Verification Results
* Code generation successful for `google-beta` provider.
* Acceptance test `TestAccCESSecuritySettings_cesSecuritySettingsExample_update` executed and successfully **PASSED**.
* Verified that the location security settings are correctly created in Step 1 and successfully updated in-place in Step 3.

```release-note:new-resource
`google_ces_security_settings` (beta)
```