### PR TITLE
`project_service`: move deletion policy prior to services list set

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -232,6 +232,10 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	}
 	servicesList := servicesRaw.(map[string]struct{})
 
+	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
+		return err
+	}
+
 	srv := d.Get("service").(string)
 	if _, ok := servicesList[srv]; ok {
 		if err := d.Set("project", project); err != nil {
@@ -241,12 +245,7 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("Error setting service: %s", err)
 		}
 		return nil
-	}
-	
-	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
-	    return err
-	}
-	
+	}	
 
 	log.Printf("[DEBUG] service %s not in enabled services for project %s, removing from state", srv, project)
 	d.SetId("")


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

When rebasing https://github.com/GoogleCloudPlatform/magic-modules/pull/17297 i noticed the inclusion of `deletion_policy` when running the [ResourceIdentity test](https://github.com/GoogleCloudPlatform/magic-modules/pull/17297#issuecomment-4491072941) resulting in the field itself being missing when performing an import:
```hcl
=== CONT  TestAccProjectService_importBlockWithResourceIdentity
    resource_google_project_service_test.go:197: Step 2/2 error running import: importing resource google_project_service.ps: expected a no-op import operation, got ["update"] action with plan 
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # google_project_service.ps will be updated in-place
          # (will be imported first)
          ~ resource "google_project_service" "ps" {
              + deletion_policy = "DELETE"
                id              = "ci-test-project-188019/iam.googleapis.com"
                project         = "ci-test-project-188019"
                service         = "iam.googleapis.com"
            }
        
        Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccProjectService_importBlockWithResourceIdentity (20.67s)
```

This looks to be due to the import being [returned on nil when `servicesList[srv]` is non-empty](https://github.com/GoogleCloudPlatform/magic-modules/blob/f05008204c7168e67242d4f373de823507dda00b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl#L235-L248)

I've moved the DeletionPolicyDefault prior to this and it looks to resolve it on the PR, unless there was an exact reason why it should be set after looping through the `servicesList` we should be good to merge to unblock the project service list PR


See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
