### PR TITLE
Autogenerate blank service imports for resources in sample HCL

### DIFF
--- a/mmv1/api/product.go
+++ b/mmv1/api/product.go
@@ -72,6 +72,10 @@ type Product struct {
 
 	ClientName string `yaml:"client_name,omitempty"`
 
+	// RepByDefault is if this product should default to REP endpoints if
+	// available. Changing this requires REP to be supported in *ALL* regions
+	RepByDefault bool `yaml:"rep_by_default,omitempty"`
+
 	// The version of the product which is currently being generated.
 	Version *product.Version `yaml:"-"`
 
@@ -81,9 +85,8 @@ type Product struct {
 	// ImportPath contains the prefix used for importing packages in generated files.
 	ImportPath string `yaml:"-"`
 
-	// RepByDefault is if this product should default to REP endpoints if
-	// available. Changing this requires REP to be supported in *ALL* regions
-	RepByDefault bool `yaml:"rep_by_default,omitempty"`
+	// Runtime contains information about the currently-running generation process.
+	Runtime Runtime `yaml:"-"`
 }
 
 func (p *Product) UnmarshalYAML(value *yaml.Node) error {

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -410,6 +410,9 @@ type Resource struct {
 	Parameters []*Type `yaml:"parameters,omitempty"`
 
 	Properties []*Type
+
+	// Runtime contains information about the currently-running generation process.
+	Runtime Runtime `yaml:"-"`
 }
 
 type TestConfig struct {
@@ -2178,13 +2181,18 @@ func (r Resource) TestSampleSetUp(sysfs fs.FS) {
 func (r Resource) TestServiceDependencies() map[string]string {
 	deps := map[string]string{}
 	for _, s := range r.TestSamples() {
-		for service, alias := range s.TestServiceDependencies() {
+		for service, alias := range s.TestServiceDependencies(r.Runtime.ResourcePrefixServiceMap) {
 			if depsAlias, ok := deps[service]; ok && alias != depsAlias {
-				panic(fmt.Sprintf("Conflicting aliases (%s vs %s) for service dependency %s for resource %s", depsAlias, alias, service, r.ApiName))
+				if (alias == "_" && depsAlias == "") || (alias == "" && depsAlias == "_") {
+					deps[service] = ""
+					continue
+				}
+				log.Fatalf("Conflicting aliases (%s vs %s) for service dependency %s for resource %s", depsAlias, alias, service, r.ApiName)
 			}
 			deps[service] = alias
 		}
 	}
+	delete(deps, strings.ToLower(r.ProductMetadata.Name))
 	return deps
 }
 

--- a/mmv1/api/resource/sample.go
+++ b/mmv1/api/resource/sample.go
@@ -15,6 +15,7 @@ package resource
 
 import (
 	"fmt"
+	"log"
 	"slices"
 
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
@@ -111,15 +112,19 @@ func (s *Sample) TestSteps() []*Step {
 
 // TestServiceDependencies returns a map of service names to import aliases that are required
 // by this sample's steps.
-func (s *Sample) TestServiceDependencies() map[string]string {
+func (s *Sample) TestServiceDependencies(resourcePrefixServiceMap map[string]string) map[string]string {
 	deps := map[string]string{}
 	if len(s.BootstrapIam) > 0 {
 		deps["resourcemanager"] = ""
 	}
 	for _, step := range s.TestSteps() {
-		for service, alias := range step.TestServiceDependencies() {
+		for service, alias := range step.TestServiceDependencies(resourcePrefixServiceMap) {
 			if depsAlias, ok := deps[service]; ok && alias != depsAlias {
-				panic(fmt.Sprintf("Conflicting aliases (%s vs %s) for service dependency %s for sample %s", depsAlias, alias, service, s.Name))
+				if (alias == "_" && depsAlias == "") || (alias == "" && depsAlias == "_") {
+					deps[service] = ""
+					continue
+				}
+				log.Fatalf("Conflicting aliases (%s vs %s) for service dependency %s for sample %s", depsAlias, alias, service, s.Name)
 			}
 			deps[service] = alias
 		}

--- a/mmv1/api/resource/sample_test.go
+++ b/mmv1/api/resource/sample_test.go
@@ -1,0 +1,125 @@
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
+)
+
+func TestSample_TestServiceDependencies(t *testing.T) {
+	cases := []struct {
+		name                     string
+		sample                   resource.Sample
+		resourcePrefixServiceMap map[string]string
+		want                     map[string]string
+	}{
+		{
+			name: "empty",
+			sample: resource.Sample{
+				Steps: []*resource.Step{
+					{
+						TestContextVars: map[string]string{},
+						TestHCLText:     "",
+					},
+				},
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want:                     map[string]string{},
+		},
+		{
+			name: "bootstrap iam",
+			sample: resource.Sample{
+				BootstrapIam: []resource.IamMember{
+					{
+						Member: "whatever",
+						Role:   "role",
+					},
+				},
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want: map[string]string{
+				"resourcemanager": "",
+			},
+		},
+		{
+			name: "no conflict",
+			sample: resource.Sample{
+				Steps: []*resource.Step{
+					{
+						TestContextVars: map[string]string{
+							"network": "compute.BootstrapSubnet",
+						},
+						TestHCLText: "",
+					},
+					{
+						TestContextVars: map[string]string{
+							"network": "compute.BootstrapSubnet",
+						},
+						TestHCLText: "",
+					},
+				},
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want: map[string]string{
+				"compute": "",
+			},
+		},
+		{
+			name: "underscore vs empty string conflict",
+			sample: resource.Sample{
+				Steps: []*resource.Step{
+					{
+						TestContextVars: map[string]string{
+							"network": "compute.BootstrapSubnet",
+						},
+						TestHCLText: "",
+					},
+					{
+						TestContextVars: map[string]string{},
+						TestHCLText:     `resource "google_compute_instance"`,
+					},
+				},
+			},
+			resourcePrefixServiceMap: map[string]string{
+				"google_compute_": "compute",
+			},
+			want: map[string]string{
+				"compute": "",
+			},
+		},
+		{
+			name: "merge boostrapped iam",
+			sample: resource.Sample{
+				BootstrapIam: []resource.IamMember{
+					{
+						Member: "whatever",
+						Role:   "role",
+					},
+				},
+				Steps: []*resource.Step{
+					{
+						TestContextVars: map[string]string{},
+						TestHCLText:     `resource "google_project"`,
+					},
+				},
+			},
+			resourcePrefixServiceMap: map[string]string{
+				"google_project": "resourcemanager",
+			},
+			want: map[string]string{
+				"resourcemanager": "",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.sample.TestServiceDependencies(tc.resourcePrefixServiceMap)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("TestServiceDependencies() mismatch (-want +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/api/resource/step.go
+++ b/mmv1/api/resource/step.go
@@ -29,6 +29,8 @@ import (
 	"github.com/golang/glog"
 )
 
+var hclResourceRegexp = regexp.MustCompile(`resource "(?P<resource>google_[^"]+)"`)
+
 type Step struct {
 	Name string `yaml:"name,omitempty"`
 
@@ -124,7 +126,7 @@ func (s *Step) TestStepSlug(productName, resourceName string) string {
 
 // TestServiceDependencies returns a map of service names to import aliases that are required
 // by this step.
-func (s *Step) TestServiceDependencies() map[string]string {
+func (s *Step) TestServiceDependencies(resourcePrefixServiceMap map[string]string) map[string]string {
 	deps := map[string]string{}
 	for _, val := range s.TestContextVars {
 		if strings.HasPrefix(val, "compute.") {
@@ -135,6 +137,26 @@ func (s *Step) TestServiceDependencies() map[string]string {
 		}
 		if strings.HasPrefix(val, "servicenetworking.") {
 			deps["servicenetworking"] = ""
+		}
+	}
+	matches := hclResourceRegexp.FindAllStringSubmatch(s.TestHCLText, -1)
+	resources := map[string]struct{}{}
+	for _, m := range matches {
+		resources[m[1]] = struct{}{}
+	}
+
+	for r, _ := range resources {
+		longestPrefix := ""
+		for prefix, _ := range resourcePrefixServiceMap {
+			if strings.HasPrefix(r, prefix) && len(prefix) > len(longestPrefix) {
+				longestPrefix = prefix
+			}
+		}
+		if longestPrefix != "" {
+			service := resourcePrefixServiceMap[longestPrefix]
+			if _, ok := deps[service]; !ok {
+				deps[service] = "_"
+			}
 		}
 	}
 	return deps

--- a/mmv1/api/resource/step_test.go
+++ b/mmv1/api/resource/step_test.go
@@ -1,0 +1,142 @@
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
+)
+
+func TestStep_TestServiceDependencies(t *testing.T) {
+	cases := []struct {
+		name                     string
+		step                     resource.Step
+		resourcePrefixServiceMap map[string]string
+		want                     map[string]string
+	}{
+		{
+			name: "empty",
+			step: resource.Step{
+				TestContextVars: map[string]string{},
+				TestHCLText:     "",
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want:                     map[string]string{},
+		},
+		{
+			name: "compute bootstrapped",
+			step: resource.Step{
+				TestContextVars: map[string]string{
+					"network": "compute.BootstrapSubnet",
+				},
+				TestHCLText: "",
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want: map[string]string{
+				"compute": "",
+			},
+		},
+		{
+			name: "kms bootstrapped",
+			step: resource.Step{
+				TestContextVars: map[string]string{
+					"kms_key": "kms.BootstrapKMSKey",
+				},
+				TestHCLText: "",
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want: map[string]string{
+				"kms": "",
+			},
+		},
+		{
+			name: "servicenetworking bootstrapped",
+			step: resource.Step{
+				TestContextVars: map[string]string{
+					"network_name": "servicenetworking.BootstrapSharedServiceNetworkingConnection",
+				},
+				TestHCLText: "",
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want: map[string]string{
+				"servicenetworking": "",
+			},
+		},
+		{
+			name: "hcl without prefixes",
+			step: resource.Step{
+				TestContextVars: map[string]string{},
+				TestHCLText: `
+resource "google_compute_instance" "foobar" {
+}
+resource "google_kms_crypto_key" "foobar" {
+}`,
+			},
+			resourcePrefixServiceMap: map[string]string{},
+			want:                     map[string]string{},
+		},
+		{
+			name: "prefixes without hcl",
+			step: resource.Step{
+				TestContextVars: map[string]string{},
+				TestHCLText:     "",
+			},
+			resourcePrefixServiceMap: map[string]string{
+				"google_compute_": "compute",
+				"google_kms_":     "kms",
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "hcl with prefixes",
+			step: resource.Step{
+				TestContextVars: map[string]string{},
+				TestHCLText: `
+resource "google_compute_instance" "foobar" {
+}
+resource "google_kms_crypto_key" "foobar" {
+}`,
+			},
+			resourcePrefixServiceMap: map[string]string{
+				"google_compute_": "compute",
+				"google_kms_":     "kms",
+			},
+			want: map[string]string{
+				"compute": "_",
+				"kms":     "_",
+			},
+		},
+		{
+			name: "hcl with prefixes plus bootstrapped",
+			step: resource.Step{
+				TestContextVars: map[string]string{
+					"network": "compute.BootstrapSubnet",
+					"kms_key": "kms.BootstrapKMSKey",
+				},
+				TestHCLText: `
+resource "google_compute_instance" "foobar" {
+}
+resource "google_kms_crypto_key" "foobar" {
+}`,
+			},
+			resourcePrefixServiceMap: map[string]string{
+				"google_compute_": "compute",
+				"google_kms_":     "kms",
+			},
+			want: map[string]string{
+				"compute": "",
+				"kms":     "",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.step.TestServiceDependencies(tc.resourcePrefixServiceMap)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("TestServiceDependencies() mismatch (-want +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"os"
@@ -9,12 +9,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api"
 	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/product"
+	"github.com/GoogleCloudPlatform/magic-modules/mmv1/api/resource"
 )
 
 func TestResourceMinVersionObj(t *testing.T) {
 	t.Parallel()
-	p := Product{
+	p := api.Product{
 		Name: "test",
 		Versions: []*product.Version{
 			&product.Version{
@@ -34,12 +38,12 @@ func TestResourceMinVersionObj(t *testing.T) {
 
 	cases := []struct {
 		description string
-		obj         Resource
+		obj         api.Resource
 		expected    string
 	}{
 		{
 			description: "resource minVersion is empty",
-			obj: Resource{
+			obj: api.Resource{
 				Name:            "test",
 				MinVersion:      "",
 				ProductMetadata: &p,
@@ -48,7 +52,7 @@ func TestResourceMinVersionObj(t *testing.T) {
 		},
 		{
 			description: "resource minVersion is not empty",
-			obj: Resource{
+			obj: api.Resource{
 				Name:            "test",
 				MinVersion:      "beta",
 				ProductMetadata: &p,
@@ -74,7 +78,7 @@ func TestResourceMinVersionObj(t *testing.T) {
 
 func TestResourceNotInVersion(t *testing.T) {
 	t.Parallel()
-	p := Product{
+	p := api.Product{
 		Name: "test",
 		Versions: []*product.Version{
 			&product.Version{
@@ -94,13 +98,13 @@ func TestResourceNotInVersion(t *testing.T) {
 
 	cases := []struct {
 		description string
-		obj         Resource
+		obj         api.Resource
 		input       *product.Version
 		expected    bool
 	}{
 		{
 			description: "ga is in version if MinVersion is empty",
-			obj: Resource{
+			obj: api.Resource{
 				Name:            "test",
 				MinVersion:      "",
 				ProductMetadata: &p,
@@ -112,7 +116,7 @@ func TestResourceNotInVersion(t *testing.T) {
 		},
 		{
 			description: "ga is not in version if MinVersion is beta",
-			obj: Resource{
+			obj: api.Resource{
 				Name:            "test",
 				MinVersion:      "beta",
 				ProductMetadata: &p,
@@ -142,40 +146,40 @@ func TestResourceServiceVersion(t *testing.T) {
 
 	cases := []struct {
 		description string
-		obj         Resource
+		obj         api.Resource
 		expected    string
 	}{
 		{
 			description: "BaseUrl does not start with a version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl: "test",
 			},
 			expected: "",
 		},
 		{
 			description: "BaseUrl starts with / and does not include a version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl: "/test",
 			},
 			expected: "",
 		},
 		{
 			description: "BaseUrl starts with a version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl: "v3/test",
 			},
 			expected: "v3",
 		},
 		{
 			description: "BaseUrl starts with a / followed by version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl: "/v3/test",
 			},
 			expected: "v3",
 		},
 		{
 			description: "CaiBaseUrl does not start with a version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl:    "apis/serving.knative.dev/v1/namespaces/{{project}}/services",
 				CaiBaseUrl: "projects/{{project}}/locations/{{location}}/services",
 			},
@@ -183,7 +187,7 @@ func TestResourceServiceVersion(t *testing.T) {
 		},
 		{
 			description: "CaiBaseUrl starts with a version",
-			obj: Resource{
+			obj: api.Resource{
 				BaseUrl:    "apis/serving.knative.dev/v1/namespaces/{{project}}/services",
 				CaiBaseUrl: "v1/projects/{{project}}/locations/{{location}}/services",
 			},
@@ -239,34 +243,34 @@ func TestMagicianLocation(t *testing.T) {
 	}
 
 	// Check if package is under mmv1
-	magicianPath := filepath.Join(dir, RELATIVE_MAGICIAN_LOCATION)
+	magicianPath := filepath.Join(dir, api.RELATIVE_MAGICIAN_LOCATION)
 	relPath, err := filepath.Rel(magicianPath, pwd)
 	if err != nil {
 		t.Fatalf("Failed to get relative path: %v", err)
 	}
 	if strings.HasPrefix(relPath, "..") {
-		t.Errorf("Current package is not under %s. Path from magician dir to current dir: %s", RELATIVE_MAGICIAN_LOCATION, relPath)
+		t.Errorf("Current package is not under %s. Path from magician dir to current dir: %s", api.RELATIVE_MAGICIAN_LOCATION, relPath)
 	}
 }
 
 func TestHasPostCreateComputedFields(t *testing.T) {
 	cases := []struct {
 		name, description string
-		resource          Resource
+		resource          api.Resource
 		want              bool
 	}{
 		{
 			name: "no properties",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
 			},
 			want: false,
 		},
 		{
 			name: "no computed properties",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name: "resource",
 					},
@@ -276,9 +280,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "output-only property",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:   "field",
 						Output: true,
@@ -289,9 +293,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "output-only property in id_format",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:   "resource",
 						Output: true,
@@ -302,9 +306,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "output-only property in id_format with ignore_read",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:       "resource",
 						Output:     true,
@@ -316,9 +320,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "default_from_api property",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:           "field",
 						DefaultFromApi: true,
@@ -329,9 +333,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "default_from_api property in id_format",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:           "resource",
 						DefaultFromApi: true,
@@ -342,9 +346,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "default_from_api property in id_format with ignore_read",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:           "resource",
 						DefaultFromApi: true,
@@ -356,9 +360,9 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "converts prop.name to snake case",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource_id}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:   "resourceId",
 						Output: true,
@@ -369,10 +373,10 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 		},
 		{
 			name: "includes fields in self link that aren't in id format",
-			resource: Resource{
+			resource: api.Resource{
 				IdFormat: "projects/{{project}}/resource/{{resource_id}}",
 				SelfLink: "{{name}}",
-				Properties: []*Type{
+				Properties: []*api.Type{
 					{
 						Name:   "name",
 						Output: true,
@@ -398,10 +402,10 @@ func TestHasPostCreateComputedFields(t *testing.T) {
 func TestResourceAddExtraFields(t *testing.T) {
 	t.Parallel()
 
-	createTestResource := func(name, pn string) *Resource {
-		r := &Resource{
+	createTestResource := func(name, pn string) *api.Resource {
+		r := &api.Resource{
 			Name: name,
-			ProductMetadata: &Product{
+			ProductMetadata: &api.Product{
 				Name: "testproduct",
 			},
 		}
@@ -409,8 +413,8 @@ func TestResourceAddExtraFields(t *testing.T) {
 		return r
 	}
 
-	createTestType := func(name, typeStr string, options ...func(*Type)) *Type {
-		t := &Type{
+	createTestType := func(name, typeStr string, options ...func(*api.Type)) *api.Type {
+		t := &api.Type{
 			Name: name,
 			Type: typeStr,
 		}
@@ -418,24 +422,24 @@ func TestResourceAddExtraFields(t *testing.T) {
 			option(t)
 		}
 		if t.ResourceMetadata == nil {
-			t.ResourceMetadata = &Resource{
+			t.ResourceMetadata = &api.Resource{
 				Immutable: false,
 			}
 		}
 		return t
 	}
 
-	withWriteOnly := func(writeOnly bool) func(*Type) {
-		return func(t *Type) { t.WriteOnly = writeOnly }
+	withWriteOnly := func(writeOnly bool) func(*api.Type) {
+		return func(t *api.Type) { t.WriteOnly = writeOnly }
 	}
-	withRequired := func(required bool) func(*Type) {
-		return func(t *Type) { t.Required = required }
+	withRequired := func(required bool) func(*api.Type) {
+		return func(t *api.Type) { t.Required = required }
 	}
-	withDescription := func(desc string) func(*Type) {
-		return func(t *Type) { t.Description = desc }
+	withDescription := func(desc string) func(*api.Type) {
+		return func(t *api.Type) { t.Description = desc }
 	}
-	withProperties := func(props []*Type) func(*Type) {
-		return func(t *Type) { t.Properties = props }
+	withProperties := func(props []*api.Type) func(*api.Type) {
+		return func(t *api.Type) { t.Properties = props }
 	}
 
 	t.Run("WriteOnly property adds companion fields", func(t *testing.T) {
@@ -448,7 +452,7 @@ func TestResourceAddExtraFields(t *testing.T) {
 			withDescription("A password field"),
 		)
 
-		props := []*Type{writeOnlyProp}
+		props := []*api.Type{writeOnlyProp}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 3 {
@@ -496,7 +500,7 @@ func TestResourceAddExtraFields(t *testing.T) {
 			withDescription("A password field"),
 		)
 
-		props := []*Type{writeOnlyProp}
+		props := []*api.Type{writeOnlyProp}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 1 {
@@ -512,13 +516,13 @@ func TestResourceAddExtraFields(t *testing.T) {
 		t.Parallel()
 
 		resource := createTestResource("testresource", "terraform")
-		labelsType := &Type{
+		labelsType := &api.Type{
 			Name:        "labels",
 			Type:        "KeyValueLabels",
 			Description: "Resource labels",
 		}
 
-		props := []*Type{labelsType}
+		props := []*api.Type{labelsType}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 3 {
@@ -567,12 +571,12 @@ func TestResourceAddExtraFields(t *testing.T) {
 		resource := createTestResource("testresource", "terraform")
 		resource.ExcludeAttributionLabel = true
 
-		labelsType := &Type{
+		labelsType := &api.Type{
 			Name: "labels",
 			Type: "KeyValueLabels",
 		}
 
-		props := []*Type{labelsType}
+		props := []*api.Type{labelsType}
 		resource.AddExtraFields(props, nil)
 
 		expectedDiff := "tpgresource.SetLabelsDiffWithoutAttributionLabel"
@@ -585,14 +589,14 @@ func TestResourceAddExtraFields(t *testing.T) {
 		t.Parallel()
 
 		resource := createTestResource("testresource", "terraform")
-		parent := &Type{Name: "metadata"}
+		parent := &api.Type{Name: "metadata"}
 
-		labelsType := &Type{
+		labelsType := &api.Type{
 			Name: "labels",
 			Type: "KeyValueLabels",
 		}
 
-		props := []*Type{labelsType}
+		props := []*api.Type{labelsType}
 		resource.AddExtraFields(props, parent)
 
 		expectedDiff := "tpgresource.SetMetadataLabelsDiff"
@@ -605,13 +609,13 @@ func TestResourceAddExtraFields(t *testing.T) {
 		t.Parallel()
 
 		resource := createTestResource("testresource", "terraform")
-		annotationsType := &Type{
+		annotationsType := &api.Type{
 			Name:        "annotations",
 			Type:        "KeyValueAnnotations",
 			Description: "Resource annotations",
 		}
 
-		props := []*Type{annotationsType}
+		props := []*api.Type{annotationsType}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 2 {
@@ -648,9 +652,9 @@ func TestResourceAddExtraFields(t *testing.T) {
 		resource := createTestResource("testresource", "terraform")
 
 		nestedWriteOnly := createTestType("nestedPassword", "String", withWriteOnly(true))
-		nestedObject := createTestType("config", "NestedObject", withProperties([]*Type{nestedWriteOnly}))
+		nestedObject := createTestType("config", "NestedObject", withProperties([]*api.Type{nestedWriteOnly}))
 
-		props := []*Type{nestedObject}
+		props := []*api.Type{nestedObject}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 1 {
@@ -670,9 +674,9 @@ func TestResourceAddExtraFields(t *testing.T) {
 		t.Parallel()
 
 		resource := createTestResource("testresource", "terraform")
-		emptyNestedObject := createTestType("config", "NestedObject", withProperties([]*Type{}))
+		emptyNestedObject := createTestType("config", "NestedObject", withProperties([]*api.Type{}))
 
-		props := []*Type{emptyNestedObject}
+		props := []*api.Type{emptyNestedObject}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 1 {
@@ -689,7 +693,7 @@ func TestResourceAddExtraFields(t *testing.T) {
 		resource := createTestResource("testresource", "terraform")
 		woProperty := createTestType("passwordWo", "String", withWriteOnly(true))
 
-		props := []*Type{woProperty}
+		props := []*api.Type{woProperty}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 1 {
@@ -707,7 +711,7 @@ func TestResourceAddExtraFields(t *testing.T) {
 		resource := createTestResource("testresource", "terraform")
 		regularProp := createTestType("name", "String", withRequired(true))
 
-		props := []*Type{regularProp}
+		props := []*api.Type{regularProp}
 		result := resource.AddExtraFields(props, nil)
 
 		if len(result) != 1 {
@@ -729,9 +733,9 @@ func TestResourceAddExtraFields(t *testing.T) {
 
 		regularProp := createTestType("name", "String")
 		writeOnlyProp := createTestType("password", "String", withWriteOnly(true))
-		labelsType := &Type{Name: "labels", Type: "KeyValueLabels"}
+		labelsType := &api.Type{Name: "labels", Type: "KeyValueLabels"}
 
-		props := []*Type{regularProp, writeOnlyProp, labelsType}
+		props := []*api.Type{regularProp, writeOnlyProp, labelsType}
 		result := resource.AddExtraFields(props, nil)
 
 		// Should have: name + password + passwordWo + passwordWoVersion + labels + terraformLabels + effectiveLabels = 7
@@ -751,4 +755,132 @@ func TestResourceAddExtraFields(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestSample_TestServiceDependencies(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource api.Resource
+		want     map[string]string
+	}{
+		{
+			name: "empty",
+			resource: api.Resource{
+				ProductMetadata: &api.Product{Name: "Apigee"},
+				Samples: []*resource.Sample{
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{},
+								TestHCLText:     "",
+							},
+						},
+					},
+				},
+				Runtime: api.Runtime{
+					ResourcePrefixServiceMap: map[string]string{},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "no conflict",
+			resource: api.Resource{
+				ProductMetadata: &api.Product{Name: "Apigee"},
+				Samples: []*resource.Sample{
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{
+									"network": "compute.BootstrapSubnet",
+								},
+								TestHCLText: "",
+							},
+						},
+					},
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{
+									"network": "compute.BootstrapSubnet",
+								},
+								TestHCLText: "",
+							},
+						},
+					},
+				},
+				Runtime: api.Runtime{
+					ResourcePrefixServiceMap: map[string]string{},
+				},
+			},
+			want: map[string]string{
+				"compute": "",
+			},
+		},
+		{
+			name: "underscore vs empty string conflict",
+			resource: api.Resource{
+				ProductMetadata: &api.Product{Name: "Apigee"},
+				Samples: []*resource.Sample{
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{
+									"network": "compute.BootstrapSubnet",
+								},
+								TestHCLText: "",
+							},
+						},
+					},
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{},
+								TestHCLText:     `resource "google_compute_instance"`,
+							},
+						},
+					},
+				},
+				Runtime: api.Runtime{
+					ResourcePrefixServiceMap: map[string]string{
+						"google_compute_": "compute",
+					},
+				},
+			},
+			want: map[string]string{
+				"compute": "",
+			},
+		},
+		{
+			name: "remove current product",
+			resource: api.Resource{
+				ProductMetadata: &api.Product{Name: "Compute"},
+				Samples: []*resource.Sample{
+					{
+						Steps: []*resource.Step{
+							{
+								TestContextVars: map[string]string{
+									"network": "compute.BootstrapSubnet",
+								},
+								TestHCLText: "",
+							},
+						},
+					},
+				},
+				Runtime: api.Runtime{
+					ResourcePrefixServiceMap: map[string]string{},
+				},
+			},
+			want: map[string]string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.resource.TestServiceDependencies()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("TestServiceDependencies() mismatch (-want +got:\n%s", diff)
+			}
+		})
+	}
 }

--- a/mmv1/api/runtime.go
+++ b/mmv1/api/runtime.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Google Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// Runtime holds metadata about the current generation runtime.
+type Runtime struct {
+	// ResourcePrefixServiceMap contains entries mapping product resource prefixes (like google_compute_) to
+	// the service package that the resource is in.
+	ResourcePrefixServiceMap map[string]string
+}

--- a/mmv1/loader/loader.go
+++ b/mmv1/loader/loader.go
@@ -102,6 +102,48 @@ func (l *Loader) LoadProducts() {
 	}
 
 	l.Products = l.batchLoadProducts(allProductFiles)
+
+	// Set up ResourcePrefixServiceMap now that all products are loaded.
+	runtime := api.Runtime{
+		// Hardcode a few unusually-named handwritten resources. These are among the oldest resources
+		// in the provider; we shouldn't be adding more to this list.
+		ResourcePrefixServiceMap: map[string]string{
+			"google_project":         "resourcemanager",
+			"google_folder":          "resourcemanager",
+			"google_organization":    "resourcemanager",
+			"google_service_account": "resourcemanager",
+		},
+	}
+	prefixCount := map[string]int{}
+	for _, p := range l.Products {
+		prefix := fmt.Sprintf("google_%s_", p.TerraformName())
+		runtime.ResourcePrefixServiceMap[prefix] = strings.ToLower(p.ApiName)
+		prefixCount[prefix] += 1
+		if prefixCount[prefix] > 1 {
+			delete(runtime.ResourcePrefixServiceMap, prefix)
+		}
+		// Always add resources with legacy_name
+		for _, r := range p.Objects {
+			if r.LegacyName != "" && !strings.HasPrefix(r.LegacyName, prefix) {
+				runtime.ResourcePrefixServiceMap[r.LegacyName] = strings.ToLower(p.ApiName)
+			}
+		}
+	}
+	// For products that share a prefix, add the individual resources instead.
+	for _, p := range l.Products {
+		prefix := fmt.Sprintf("google_%s_", p.TerraformName())
+		if prefixCount[prefix] > 1 {
+			for _, r := range p.Objects {
+				runtime.ResourcePrefixServiceMap[r.TerraformName()] = strings.ToLower(p.ApiName)
+			}
+		}
+	}
+	for _, p := range l.Products {
+		p.Runtime = runtime
+		for _, r := range p.Objects {
+			r.Runtime = runtime
+		}
+	}
 }
 
 func (l *Loader) batchLoadProducts(productNames []string) map[string]*api.Product {

--- a/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/iam_test_file.go.tmpl
@@ -19,10 +19,7 @@ import (
 	"{{ $.ImportPath }}/acctest"
 	"{{ $.ImportPath }}/envvar"
 	"{{ $.ImportPath }}/tpgresource"
-{{- if $.FirstTestConfig.Sample.BootstrapIam }}
-	"{{ $.ImportPath }}/services/resourcemanager"
-{{- end }}
-{{- range $service, $alias := $.FirstTestConfig.Step.TestServiceDependencies }}
+{{- range $service, $alias := ($.FirstTestConfig.Step.TestServiceDependencies $.Runtime.ResourcePrefixServiceMap) }}
 	{{ $alias }} "{{ $.ImportPath  }}/services/{{ $service }}"
 {{- end }}
 )


### PR DESCRIPTION
This will be necessary to ensure that all resources used in a given test file are registered prior to the tests running. While these aren't strictly required at the moment, it won't hurt anything to add these imports, and it'll simplify the future move to remove global registration of all products/resources. It will also make this change easier to review on its own.

cc @SirGitsalot FYI.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
