### PR TITLE
container: derive node_pool placement_policy.type from PolicyName on read

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1469,9 +1469,19 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 	}
 
 	if np.PlacementPolicy != nil {
+		// GKE doesn't persist PlacementPolicy.Type on node pools — the
+		// field is accepted on Create/Update but returned as empty on
+		// GET. When PolicyName is set (a custom resource policy is
+		// bound), COMPACT is the only valid value for Type, so derive
+		// it from PolicyName on read to avoid spurious drift / forced
+		// in-place updates on every plan.
+		placementPolicyType := np.PlacementPolicy.Type
+		if placementPolicyType == "" && np.PlacementPolicy.PolicyName != "" {
+			placementPolicyType = "COMPACT"
+		}
 		nodePool["placement_policy"] = []map[string]interface{}{
 			{
-				"type": np.PlacementPolicy.Type,
+				"type": placementPolicyType,
 				"policy_name": np.PlacementPolicy.PolicyName,
 				"tpu_topology": np.PlacementPolicy.TpuTopology,
 			},


### PR DESCRIPTION
### Description

GKE's node-pool API accepts `placementPolicy.type` on Create/Update but returns it as empty on GET — only `policyName` round-trips on refresh. The provider's schema declares `type` as `Required` inside the `placement_policy` block, so when a user (or upstream module) sets `type = "COMPACT"`, the next `terraform refresh` reads back the field as `""` and `terraform plan` reports a perpetual `placement_policy.type: null -> "COMPACT"` diff.

For node pools that have a custom resource policy bound via `policy_name`, in-place updates on this field go through GKE's node-pool-config update path which triggers a **rolling node restart**. Net effect: every `terraform apply` rolls every existing pool with a bound workload-policy, indefinitely, with no actual config change.

This is reproducible on any GKE A4X / GB200 deployment from `cluster-toolkit`'s `gke-a4x` blueprint — `modules/compute/resource-policy` emits `placement_policy.type = "COMPACT"` whenever `workload_policy.type != null`, so every node pool ends up in the drift loop. Observed on a live A4X cluster on 2026-05-19 / 2026-05-20: ~22 min of rolling per pool, per apply, for zero config delta. (Closed cluster-toolkit-side workaround PR [#5691](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5691) in favor of fixing this at the provider layer.)

### Fix

In `flattenNodePool`, when reading back `PlacementPolicy`: if `Type` is empty but `PolicyName` is set, derive `Type = "COMPACT"`. `"COMPACT"` is currently the only valid value for the field when a custom resource policy is bound, so the inference is unambiguous — and it matches what the resource was created/updated with.

```go
placementPolicyType := np.PlacementPolicy.Type
if placementPolicyType == "" && np.PlacementPolicy.PolicyName != "" {
    placementPolicyType = "COMPACT"
}
```

Pools without a bound `policy_name` are unaffected (`Type` stays empty, matching the API).

### Release Note

```release-note:bug
container: fixed perpetual drift on `google_container_node_pool.placement_policy.type` when a custom resource policy is bound. GKE returns the field as empty on GET; the provider now derives `type = "COMPACT"` from `policy_name` on read to match what was set on create/update.
```

### Tests

Existing acceptance tests for `placement_policy` with `policy_name` (e.g. `TestAccContainerNodePool_withWorkloadPolicy*` in the GA test file) cover the read+refresh cycle. The fix preserves the existing behaviour on Create (Type is set), only changes what `flattenNodePool` returns when refreshing an existing pool — so a refresh-then-plan against an already-applied pool should now show no diff.

### Linked issues / PRs

- Internal tracking: voyager-7 cluster's perpetual rolling on every apply.
- Superseded workaround: [GoogleCloudPlatform/cluster-toolkit#5691](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5691) (closed).

Draft for upstream review — happy to address feedback / sign CLA / write a targeted regression test if reviewers want one.