### PR TITLE
Converted provider_test.go.tmpl to provider_test.go

### DIFF
--- a/mmv1/third_party/terraform/provider/provider_test.go
+++ b/mmv1/third_party/terraform/provider/provider_test.go
@@ -2,19 +2,19 @@ package provider_test
 
 import (
 	"fmt"
-	"regexp"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/provider"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
@@ -250,7 +250,7 @@ func TestAccProviderInvalidRepConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckComputeAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderInvalidRepConfig(),
+				Config:      testAccProviderInvalidRepConfig(),
 				ExpectError: regexp.MustCompile("conflict between prefer_global_endpoints and prefer_regional_endpoints"),
 			},
 		},
@@ -325,7 +325,7 @@ func testAccCheckComputeAddressDestroyProducer(t *testing.T) func(s *terraform.S
 
 			config := acctest.GoogleProviderConfig(t)
 
-			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/addresses/{{"{{"}}name{{"}}"}}")
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/addresses/{{name}}")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Looking through the [history](https://github.com/GoogleCloudPlatform/magic-modules/commits/main/mmv1/third_party/terraform/provider/provider_test.go.tmpl) of this file, it hasn't really needed to be a tmpl file since the Ruby -> Go conversion. While not urgent, might as well simplify.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
