### PR TITLE
resolve one-time diff with universal deletion policy on existing `google_project_service` resources

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_service.go.tmpl
@@ -240,11 +240,10 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 		if err := d.Set("service", srv); err != nil {
 			return fmt.Errorf("Error setting service: %s", err)
 		}
+		if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
+		    return err
+		}
 		return nil
-	}
-	
-	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
-	    return err
 	}
 	
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -197,21 +197,18 @@ When set to "DELETE", deleting the resource is allowed.
 }
 
 func DeletionPolicyReadDefault(d *schema.ResourceData, config *transport_tpg.Config, resourceDefault string) error {
-	if dpolicy, ok := d.GetOkExists("deletion_policy"); !ok {
+	if _, ok := d.GetOkExists("deletion_policy"); !ok {
 		//prioritize config's value if present
 		if config.DeletionPolicy != "" {
-			log.Printf("[DEBUG] `deletion_policy` detected as not set within resource configuration. Falling back to configured provider default, %s", config.DeletionPolicy)
 			if err := d.Set("deletion_policy", config.DeletionPolicy); err != nil {
 				return fmt.Errorf("Error setting deletion_policy: %s", err)
 			}
 		} else {
-			log.Printf("[DEBUG] `deletion_policy` detected as not set within resource or provider configuration. Falling back to resource default, %s", resourceDefault)
 			if err := d.Set("deletion_policy", resourceDefault); err != nil {
 				return fmt.Errorf("Error setting deletion_policy: %s", err)
 			}
 		}
 	}
-	log.Printf("[DEBUG] `deletion_policy` being set to recorded config value %s", dpolicy.(string))
 	return nil
 }
 

--- a/mmv1/third_party/terraform/tpgresource/utils.go
+++ b/mmv1/third_party/terraform/tpgresource/utils.go
@@ -197,18 +197,21 @@ When set to "DELETE", deleting the resource is allowed.
 }
 
 func DeletionPolicyReadDefault(d *schema.ResourceData, config *transport_tpg.Config, resourceDefault string) error {
-	if _, ok := d.GetOkExists("deletion_policy"); !ok {
+	if dpolicy, ok := d.GetOkExists("deletion_policy"); !ok {
 		//prioritize config's value if present
 		if config.DeletionPolicy != "" {
+			log.Printf("[DEBUG] `deletion_policy` detected as not set within resource configuration. Falling back to configured provider default, %s", config.DeletionPolicy)
 			if err := d.Set("deletion_policy", config.DeletionPolicy); err != nil {
 				return fmt.Errorf("Error setting deletion_policy: %s", err)
 			}
 		} else {
+			log.Printf("[DEBUG] `deletion_policy` detected as not set within resource or provider configuration. Falling back to resource default, %s", resourceDefault)
 			if err := d.Set("deletion_policy", resourceDefault); err != nil {
 				return fmt.Errorf("Error setting deletion_policy: %s", err)
 			}
 		}
 	}
+	log.Printf("[DEBUG] `deletion_policy` being set to recorded config value %s", dpolicy.(string))
 	return nil
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -66,6 +66,8 @@ will be returned if the service to be disabled has usage in last 30 days.
     When set to "ABANDON", the command will remove the resource from Terraform
     management without updating or deleting the resource in the API.
     When set to "DELETE", deleting the resource is allowed.
+    If `disable_on_destroy` is set to `false`, the service will still be enabled when the 
+    Terraform resource is destroyed even if the `deletion_policy` field is set to "DELETE".
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
https://github.com/hashicorp/terraform-provider-google/issues/27469
the logic for setting the value to defaults during read was outside of where this resource assigned values, and was instead a part of the workflow for a resource not being found.


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
resourcemanager: resolved a one-time diff for `deletion_policy` that would occur on existing and imported `google_project_service` resources following upgrading to v7.32.0
```
