### PR TITLE
`IAM`: fix resource identity imports for parents with multi-segment URIs

### DIFF
--- a/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
+++ b/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
@@ -49,7 +49,7 @@ func ParseIamResourceIdentity(
 		}
 	}
 
-	if uriRe := buildUriFormatRegexp(rc.UriFormat, len(rc.Params)); uriRe != nil {
+	if uriRe := buildUriFormatRegexp(rc.UriFormat); uriRe != nil {
 		for i := len(rawVals) - 1; i >= 0; i-- {
 			if rawVals[i] == "" {
 				continue
@@ -92,11 +92,8 @@ func ParseIamResourceIdentity(
 	return fmt.Sprintf(rc.UriFormat, args...), nil
 }
 
-func buildUriFormatRegexp(uriFormat string, numParams int) *regexp.Regexp {
+func buildUriFormatRegexp(uriFormat string) *regexp.Regexp {
 	parts := strings.Split(uriFormat, "%s")
-	if len(parts)-1 != numParams {
-		return nil
-	}
 	var sb strings.Builder
 	sb.WriteString("^")
 	for i, part := range parts {

--- a/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
+++ b/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
@@ -2,6 +2,8 @@ package tpgiamresource
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -37,14 +39,34 @@ func ParseIamResourceIdentity(
 	config *transport_tpg.Config,
 	rc IamResourceIdentityConfig,
 ) (string, error) {
-	resolved := make(map[string]string, len(rc.Params))
+	// Collect the raw value supplied for each param from the import identity.
+	rawVals := make([]string, len(rc.Params))
 	for i, p := range rc.Params {
-		var val string
 		if rv, ok := identity.GetOk(p.IdentityKey); ok {
 			if s, ok := rv.(string); ok {
-				val = s
+				rawVals[i] = s
 			}
 		}
+	}
+
+	if uriRe := buildUriFormatRegexp(rc.UriFormat, len(rc.Params)); uriRe != nil {
+		for i := len(rawVals) - 1; i >= 0; i-- {
+			if rawVals[i] == "" {
+				continue
+			}
+			m := uriRe.FindStringSubmatch(rawVals[i])
+			if m != nil && len(m)-1 == len(rc.Params) {
+				for j := range rc.Params {
+					rawVals[j] = m[j+1]
+				}
+				break
+			}
+		}
+	}
+
+	resolved := make(map[string]string, len(rc.Params))
+	for i, p := range rc.Params {
+		val := rawVals[i]
 		if GetDefaultConfigValue := DefaultConfigValueFuncs[p.Key]; GetDefaultConfigValue != nil && val == "" {
 			defaultVal, err := GetDefaultConfigValue(d, config)
 			if err != nil {
@@ -59,9 +81,6 @@ func ParseIamResourceIdentity(
 		if val == "" {
 			return "", fmt.Errorf("import identity is missing attribute %q", p.IdentityKey)
 		}
-		if i == len(rc.Params)-1 {
-			val = tpgresource.GetResourceNameFromSelfLink(val)
-		}
 		resolved[p.Key] = val
 	}
 
@@ -71,4 +90,29 @@ func ParseIamResourceIdentity(
 	}
 
 	return fmt.Sprintf(rc.UriFormat, args...), nil
+}
+
+func buildUriFormatRegexp(uriFormat string, numParams int) *regexp.Regexp {
+	parts := strings.Split(uriFormat, "%s")
+	if len(parts)-1 != numParams {
+		return nil
+	}
+	var sb strings.Builder
+	sb.WriteString("^")
+	for i, part := range parts {
+		sb.WriteString(regexp.QuoteMeta(part))
+		if i < len(parts)-1 {
+			if i == len(parts)-2 {
+				sb.WriteString("(.+)")
+			} else {
+				sb.WriteString("([^/]+)")
+			}
+		}
+	}
+	sb.WriteString("$")
+	re, err := regexp.Compile(sb.String())
+	if err != nil {
+		return nil
+	}
+	return re
 }

--- a/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
+++ b/mmv1/third_party/terraform/tpgiamresource/iam_resource_identity.go
@@ -105,7 +105,10 @@ func buildUriFormatRegexp(uriFormat string, numParams int) *regexp.Regexp {
 			if i == len(parts)-2 {
 				sb.WriteString("(.+)")
 			} else {
-				sb.WriteString("([^/]+)")
+				// Non-final params may themselves contain '/'
+				// (e.g. "organizations/{id}"). Use a non-greedy match so the
+				// literal separator that follows anchors the split.
+				sb.WriteString("(.+?)")
 			}
 		}
 	}


### PR DESCRIPTION
Resource-identity imports for IAM resources (`google_*_iam_member`, etc.) were broken whenever the parent resource's identity attribute carried the full URI (e.g. `projects/my-proj/locations/us-central1/instances/foo`) rather than a bare name.

## Explanation

**Resource:** `google_cloud_run_v2_service_iam_member`
`UriFormat = "projects/%s/locations/%s/services/%s"` (params: `project`, `location`, `name`).

### Before

User runs:
```hcl
import {
  to = google_cloud_run_v2_service_iam_member.foo
  identity = {
    name = "projects/my-proj/locations/us-central1/services/svc-42"
  }
}
```

`ParseIamResourceIdentity` applied `GetResourceNameFromSelfLink` to the last param, collapsing `"projects/my-proj/locations/us-central1/services/svc-42"` → `"svc-42"`. `project` and `location` were empty, so import failed with `"import identity is missing attribute \"project\""` even though the value was right there in the URI.

### After

The function builds a regex from `UriFormat`:

```
^projects/(.+?)/locations/(.+?)/services/(.+)$
```

and matches it against any non-empty identity value. The full URI in `name` matches → captures `["my-proj", "us-central1", "svc-42"]`, which back-fill the empty `project` and `location` slots. Import succeeds.

### Non-greedy detail

Non-final captures use `(.+?)` so they stop at the first literal separator that follows. Greedy `(.+)` would match the **last** occurrence and mis-split paths like `organizations/123/sources/abc` (where the parent itself contains `/`).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
