### PR TITLE
`MMv1`: add `project` in query test context map

### DIFF
--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -67,6 +67,10 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 		"{{$n}}": envvar.GetTestRegionFromEnv(),
 		{{- else if eq $n "zone" }}
 		"zone": envvar.GetTestZoneFromEnv(),
+		{{- else if eq $n "project" }}
+		{{- if not (index $step.TestEnvVars "project") }}
+		"project": envvar.GetTestProjectFromEnv(),
+		{{- end }}
 		{{- end }}
 	{{- end }}
 		"random_suffix": randomSuffix,


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We relied on the test_var to provide the PROJECT_NAME, this sets `"project` in the context map to `GetTestProjectFromEnv` in the case where the project test var is not supplied

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
