### PR TITLE
compute: add google_compute_cross_site_network list resource

### DIFF
--- a/mmv1/products/compute/CrossSiteNetwork.yaml
+++ b/mmv1/products/compute/CrossSiteNetwork.yaml
@@ -23,6 +23,7 @@ docs:
 base_url: 'projects/{{project}}/global/crossSiteNetworks'
 self_link: 'projects/{{project}}/global/crossSiteNetworks/{{name}}'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds list-resource generation for `google_compute_cross_site_network`.

```release-note:new-list-resource
`google_compute_cross_site_network`
```

<details><summary>Local test output: <code>TestAccComputeCrossSiteNetworkListQuery_generated</code></summary>

```
=== RUN   TestAccComputeCrossSiteNetworkListQuery_generated
=== PAUSE TestAccComputeCrossSiteNetworkListQuery_generated
=== CONT  TestAccComputeCrossSiteNetworkListQuery_generated
--- PASS: TestAccComputeCrossSiteNetworkListQuery_generated (35.37s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/compute 36.783s
```

</details>
