### PR TITLE
apigee: send zero values for `ip_header_index` in `google_apigee_environment`

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -239,3 +239,4 @@ properties:
             description: |
               The index of the ip in the header. Positive indices 0, 1, 2, 3 chooses indices from the left (first ips). Negative indices -1, -2, -3 chooses indices from the right (last ips).
             required: true
+            send_empty_value: true

--- a/mmv1/templates/terraform/examples/apigee_environment_client_ip_resolution_config_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_client_ip_resolution_config_test.tf.tmpl
@@ -75,7 +75,7 @@ resource "google_apigee_environment" "{{$.PrimaryResourceId}}" {
   client_ip_resolution_config {
     header_index_algorithm {
       ip_header_name = "X-Forwarded-For"
-      ip_header_index = 1
+      ip_header_index = 0
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/27493

Because the field represents a zero-based index on a comma-separated list, such as an IP list in an HTTP request header (e.g., `X-Forwarded-For`), it is essential that index `0` will be sent to the API and not be ignored.

We encountered this limitation, and as a workaround, we are currently forced to rewrite the header in our external load balancer as follows: `some-header:1.1.1.1,${observed_client_ip}`, where `1.1.1.1` serves as a placeholder to bypass the index issue. In Apigee, we then set `ip_header_index=1` to work around this provider-specific limitation.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
apigee: send zero values for `ip_header_index` in `google_apigee_environment`
```
