### PR TITLE
compute: add list resources for disk, image, snapshot

### DIFF
--- a/mmv1/products/compute/Disk.yaml
+++ b/mmv1/products/compute/Disk.yaml
@@ -38,6 +38,7 @@ docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/disks'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/Image.yaml
+++ b/mmv1/products/compute/Image.yaml
@@ -39,6 +39,7 @@ docs:
 base_url: 'projects/{{project}}/global/images'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/Snapshot.yaml
+++ b/mmv1/products/compute/Snapshot.yaml
@@ -36,6 +36,7 @@ base_url: 'projects/{{project}}/global/snapshots'
 has_self_link: true
 create_url: 'PRE_CREATE_REPLACE_ME/createSnapshot'
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds list-resource generation for the following `compute` resources:

- `google_compute_disk`
- `google_compute_image`
- `google_compute_snapshot`

```release-note:new-list-resource
`google_compute_disk`
```

```release-note:new-list-resource
`google_compute_image`
```

```release-note:new-list-resource
`google_compute_snapshot`
```

<details><summary>Local test output</summary>

```
=== RUN   TestAccComputeDiskListQuery_generated
=== RUN   TestAccComputeImageListQuery_generated
=== RUN   TestAccComputeSnapshotListQuery_generated
--- PASS: TestAccComputeDiskListQuery_generated (36.67s)
--- PASS: TestAccComputeSnapshotListQuery_generated (111.54s)
--- PASS: TestAccComputeImageListQuery_generated (123.13s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/compute
```

</details>

> Note: `google_compute_disk_resource_policy_attachment` and `google_compute_region_disk_resource_policy_attachment` were dropped from this PR because the generated query test fails on `"disk" is not a valid template control keyword` — the query test template doesn't auto-populate non-(`project`/`region`/`zone`) path scope parameters into the test context map. A follow-up generator fix similar to #17653 (which added `project`) is needed before those resources can be enabled.
