### PR TITLE
compute: add list resources for firewall, subnetwork, global_address

### DIFF
--- a/mmv1/products/compute/Firewall.yaml
+++ b/mmv1/products/compute/Firewall.yaml
@@ -38,6 +38,7 @@ docs:
 base_url: 'projects/{{project}}/global/firewalls'
 has_self_link: true
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/GlobalAddress.yaml
+++ b/mmv1/products/compute/GlobalAddress.yaml
@@ -27,6 +27,7 @@ docs:
 base_url: 'projects/{{project}}/global/addresses'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -44,6 +44,7 @@ references:
 base_url: projects/{{project}}/regions/{{region}}/subnetworks
 immutable: true
 has_self_link: true
+generate_list_resource: true
 bypass_clientside_update_check: true
 collection_url_key: items
 iam_policy:


### PR DESCRIPTION
Adds list-resource generation for the following `compute` resources:

- `google_compute_firewall`
- `google_compute_subnetwork`
- `google_compute_global_address`

```release-note:new-list-resource
`google_compute_firewall`
```

```release-note:new-list-resource
`google_compute_subnetwork`
```

```release-note:new-list-resource
`google_compute_global_address`
```

<details><summary>Local test output</summary>

```
--- PASS: TestAccComputeGlobalAddressListQuery_generated (36.07s)
--- PASS: TestAccComputeSubnetworkListQuery_generated (100.27s)
--- PASS: TestAccComputeFirewallListQuery_generated (204.28s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/compute 205.702s
```

</details>
