### PR TITLE
`iam_binding`: set `ResourceIdentity` when members are nil

### DIFF
--- a/mmv1/third_party/terraform/tpgiamresource/resource_iam_binding.go
+++ b/mmv1/third_party/terraform/tpgiamresource/resource_iam_binding.go
@@ -247,6 +247,17 @@ func resourceIamBindingRead(newUpdaterFunc NewResourceIamUpdaterFunc, parentSpec
 			if err := d.Set("members", nil); err != nil {
 				return fmt.Errorf("Error setting members: %s", err)
 			}
+			if parentResourceIdentityParser != nil {
+				identity, err := d.Identity()
+				if err != nil {
+					return err
+				}
+				conditionTitle := ""
+				if eBinding.Condition != nil {
+					conditionTitle = eBinding.Condition.Title
+				}
+				setIamBindingResourceIdentity(identity, d, parentSpecificSchema, eBinding.Role, conditionTitle)
+			}
 			return nil
 		} else {
 			if err := d.Set("role", binding.Role); err != nil {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

ResourceIdentity was only being set when matching binding was found, leaving the case of noMembers not covered resulting in missing identity error in VCR. This resolves the failing test we see currently:
```console
Error recording tests:
error running go: exit status 1
stdout:
=== RUN   TestAccProjectIamBinding_noMembers
=== PAUSE TestAccProjectIamBinding_noMembers
=== CONT  TestAccProjectIamBinding_noMembers
    resource_google_project_iam_binding_test.go:231: Step 3/3 error running import: exit status 1
        
        Error: Missing Resource Identity After Read: The Terraform provider unexpectedly returned no resource identity after having no errors in the resource read. This is always a problem with the provider and should be reported to the provider developer
        
        
--- FAIL: TestAccProjectIamBinding_noMembers (61.63s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-google-beta/google-beta/services/resourcemanager	61.709s
FAIL
stderr:
```

follow-up to https://github.com/GoogleCloudPlatform/magic-modules/pull/17587

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
