### PR TITLE
tgc-revival: Add google_cloud_ids_endpoint to TGC and fix test auto-discovery bug

### DIFF
--- a/mmv1/products/cloudids/Endpoint.yaml
+++ b/mmv1/products/cloudids/Endpoint.yaml
@@ -19,19 +19,19 @@ references:
   guides:
   api: 'https://cloud.google.com/intrusion-detection-system/docs/configuring-ids'
 docs:
-id_format: 'projects/{{project}}/locations/{{location}}/endpoints/{{name}}'
 base_url: 'projects/{{project}}/locations/{{location}}/endpoints'
 self_link: 'projects/{{project}}/locations/{{location}}/endpoints/{{name}}'
 create_url: 'projects/{{project}}/locations/{{location}}/endpoints?endpointId={{name}}'
-update_verb: 'PATCH'
 update_mask: true
+update_verb: 'PATCH'
+id_format: 'projects/{{project}}/locations/{{location}}/endpoints/{{name}}'
 import_format:
   - 'projects/{{project}}/locations/{{location}}/endpoints/{{name}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
-autogen_async: true
+exclude_sweeper: true
 async:
   actions: ['create', 'delete', 'update']
   type: 'OpAsync'
@@ -39,8 +39,9 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true
+autogen_async: true
+include_in_tgc_next: true
 custom_code:
-exclude_sweeper: true
 examples:
   - name: 'cloudids_endpoint'
     primary_resource_id: 'example-endpoint'

--- a/mmv1/products/compute/InterconnectAttachment.yaml
+++ b/mmv1/products/compute/InterconnectAttachment.yaml
@@ -276,6 +276,9 @@ properties:
       using PARTNER type this will be managed upstream.
     immutable: true
     default_from_api: true
+    # This field is not returned in the CAI asset for L2_DEDICATED attachment types.
+    # This could be an API issue, as the field is not in the API response as well.
+    is_missing_in_cai: true
   - name: 'ipsecInternalAddresses'
     type: Array
     description: |

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -465,7 +465,7 @@ func (tgc TerraformGoogleConversionNext) addTestsFromHandwrittenTests(object *ap
 		if errors.Is(err, os.ErrNotExist) {
 			if strings.HasSuffix(handwrittenTestFilePath, ".tmpl") {
 				log.Printf("no handwritten test file found at %s", handwrittenTestFilePath)
-				return nil
+				return tgc.addTestsByTestNameMatch(object)
 			}
 			handwrittenTestFilePath += ".tmpl"
 			data, err = fs.ReadFile(tgc.templateFS, handwrittenTestFilePath)


### PR DESCRIPTION
This PR adds support for the `google_cloud_ids_endpoint` resource in TGC next, and fixes an early exit bug in the code generator's handwritten test auto-discovery.

```release-note:none

```