### PR TITLE
Prepend migrated legacy examples to resource samples

### DIFF
--- a/mmv1/loader/loader.go
+++ b/mmv1/loader/loader.go
@@ -347,7 +347,7 @@ func (l *Loader) loadResource(product *api.Product, baseResourcePath string, ove
 
 	// Convert Examples to Samples in memory after overrides are applied
 	if len(resource.Examples) > 0 {
-
+		var convertedSamples []*apiresource.Sample
 		for _, e := range resource.Examples {
 			// Create an in-memory custom wrapper over the fs for legacy template files
 			if e.ConfigPath == "" {
@@ -383,8 +383,9 @@ func (l *Loader) loadResource(product *api.Product, baseResourcePath string, ove
 				TGCSkipTest:         e.TGCSkipTest,
 				Steps:               steps,
 			}
-			resource.Samples = append(resource.Samples, sample)
+			convertedSamples = append(convertedSamples, sample)
 		}
+		resource.Samples = append(convertedSamples, resource.Samples...)
 		resource.Examples = nil
 	}
 


### PR DESCRIPTION
Ensures that legacy examples converted to samples (in-memory) are prepended and ordered before any newly added samples. 

Since the generator uses the first example to generate any iam/datasource/list resource - this is to ensure any new samples added won't change what config is used to generate those tests before the migration is fully completed.


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
