### PR TITLE
remove the redundant field in TestAccComputeInterconnectAttachment_l2DedicatedExample

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_attachment_l2_enabled_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_attachment_l2_enabled_test.go
@@ -64,6 +64,7 @@ resource "google_compute_interconnect_attachment" "attachment" {
   interconnect   = google_compute_interconnect.interconnect.id
   type           = "L2_DEDICATED"
   bandwidth      = "BPS_50M"
+  vlan_tag8021q  =  1000
   region         = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/regions/us-east4"
   l2_forwarding {
     appliance_mappings {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_attachment_l2_enabled_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_interconnect_attachment_l2_enabled_test.go
@@ -64,7 +64,6 @@ resource "google_compute_interconnect_attachment" "attachment" {
   interconnect   = google_compute_interconnect.interconnect.id
   type           = "L2_DEDICATED"
   bandwidth      = "BPS_50M"
-  vlan_tag8021q  =  1000
   region         = "https://www.googleapis.com/compute/v1/projects/${data.google_project.project.name}/regions/us-east4"
   l2_forwarding {
     appliance_mappings {
@@ -86,11 +85,6 @@ resource "google_compute_interconnect_attachment" "attachment" {
     }
     default_appliance_ip_address = "10.0.0.4"
     tunnel_endpoint_ip_address   = "172.16.0.1"
-  }
-  lifecycle {
-    ignore_changes = [
-      vlan_tag8021q
-    ]
   }
 }
 `, context)


### PR DESCRIPTION
This PR removes the redundant field in TestAccComputeInterconnectAttachment_l2DedicatedExample.

```release-note:none
```