### PR TITLE
Update agent config, add recursive output-only marking to autogen

### DIFF
--- a/.agents/agents/autogen/config.yaml
+++ b/.agents/agents/autogen/config.yaml
@@ -20,7 +20,7 @@ custom_agent:
         7. Check if the resource should go in the beta or GA provider based on the OpenAPI spec and any other guides you can find
         8. Generate the downstream provider
         9. Verify that the new resources and tests are present
-        10. Run the acceptance tests and verify that they pass
+        10. Run the acceptance tests and verify that they pass. The user must provide you credentials and project variables, if they did not, prompt them for it. A sample invokation is `make testacc TEST=./google-beta/services/product TESTARGS='-run=TestAcc<Product><Resource>'`
         
     - title: "Report Format"
       content: "You must return a clear, human-readable Markdown report explaining whether resource generation and testing succeeded or failed, and if it failed, what discrepancy was found."

--- a/.agents/agents/autogen/config.yaml
+++ b/.agents/agents/autogen/config.yaml
@@ -20,7 +20,7 @@ custom_agent:
         7. Check if the resource should go in the beta or GA provider based on the OpenAPI spec and any other guides you can find
         8. Generate the downstream provider
         9. Verify that the new resources and tests are present
-        10. Run the acceptance tests and verify that they pass. The user must provide you credentials and project variables, if they did not, prompt them for it. A sample invokation is `make testacc TEST=./google-beta/services/product TESTARGS='-run=TestAcc<Product><Resource>'`
+        10. Run the acceptance tests and verify that they pass. The user must provide you credentials and project variables, if they did not, prompt them for it. A sample invocation is `make testacc TEST=./google-beta/services/product TESTARGS='-run=TestAcc<Product><Resource>'`
         
     - title: "Report Format"
       content: "You must return a clear, human-readable Markdown report explaining whether resource generation and testing succeeded or failed, and if it failed, what discrepancy was found."

--- a/mmv1/openapi_generate/parser.go
+++ b/mmv1/openapi_generate/parser.go
@@ -630,7 +630,27 @@ func WriteObject(name string, obj *openapi3.SchemaRef, objType openapi3.Types, u
 		field.Immutable = true
 	}
 
+	if field.Output {
+		makeOutputOnly(&field)
+	}
+
 	return field
+}
+
+func makeOutputOnly(t *api.Type) {
+	if t == nil {
+		return
+	}
+	t.Output = true
+	for _, p := range t.Properties {
+		makeOutputOnly(p)
+	}
+	if t.ItemType != nil {
+		makeOutputOnly(t.ItemType)
+	}
+	if t.ValueType != nil {
+		makeOutputOnly(t.ValueType)
+	}
 }
 
 func buildProperties(props openapi3.Schemas, required []string, seenRefs map[string]bool, seenPointers map[*openapi3.Schema]bool) []*api.Type {

--- a/mmv1/openapi_generate/parser_test.go
+++ b/mmv1/openapi_generate/parser_test.go
@@ -29,8 +29,8 @@ func TestMapType(t *testing.T) {
 	if mmObject.KeyName == "" || mmObject.Type != "Map" {
 		t.Error("Failed to parse map type")
 	}
-	if len(mmObject.ValueType.Properties) != 5 {
-		t.Errorf("Expected 5 properties, found %d", len(mmObject.ValueType.Properties))
+	if len(mmObject.ValueType.Properties) != 6 {
+		t.Errorf("Expected 6 properties, found %d", len(mmObject.ValueType.Properties))
 	}
 
 	var recursivePet *api.Type
@@ -83,3 +83,90 @@ func TestFindResources(t *testing.T) {
 		t.Error("Singleton update should be found")
 	}
 }
+
+func TestReadOnlyPropagation(t *testing.T) {
+	_ = NewOpenapiParser("/fake", "/fake")
+	ctx := t.Context()
+	loader := &openapi3.Loader{Context: ctx, IsExternalRefsAllowed: true}
+	doc, err := loader.LoadFromData(testData)
+	if err != nil {
+		t.Fatalf("Could not load data %s", err)
+	}
+	err = doc.Validate(ctx)
+	if err != nil {
+		t.Fatalf("Could not validate data %s", err)
+	}
+
+	petSchema := doc.Paths.Map()["/pets"].Post.RequestBody.Value.Content["application/json"].Schema
+	mmObject := WriteObject("pet", petSchema, propType(petSchema), false, make(map[string]bool), make(map[*openapi3.Schema]bool))
+
+	var readOnlyObject *api.Type
+	for _, p := range mmObject.ValueType.Properties {
+		if p.Name == "readOnlyObject" {
+			readOnlyObject = p
+			break
+		}
+	}
+
+	if readOnlyObject == nil {
+		t.Fatal("Failed to find readOnlyObject property")
+	}
+
+	if !readOnlyObject.Output {
+		t.Error("Expected readOnlyObject to have Output=true")
+	}
+
+	// Check nested string property
+	var nameProp *api.Type
+	var nestedProp *api.Type
+	var arrayNestedProp *api.Type
+	for _, p := range readOnlyObject.Properties {
+		switch p.Name {
+		case "name":
+			nameProp = p
+		case "nested":
+			nestedProp = p
+		case "arrayNested":
+			arrayNestedProp = p
+		}
+	}
+
+	if nameProp == nil || !nameProp.Output {
+		t.Errorf("Expected property 'name' under 'readOnlyObject' to be parsed and have Output=true, got: %+v", nameProp)
+	}
+
+	if nestedProp == nil || !nestedProp.Output {
+		t.Errorf("Expected property 'nested' under 'readOnlyObject' to be parsed and have Output=true, got: %+v", nestedProp)
+	} else {
+		var subNameProp *api.Type
+		for _, p := range nestedProp.Properties {
+			if p.Name == "subName" {
+				subNameProp = p
+				break
+			}
+		}
+		if subNameProp == nil || !subNameProp.Output {
+			t.Errorf("Expected 'subName' under 'nested' to have Output=true, got: %+v", subNameProp)
+		}
+	}
+
+	if arrayNestedProp == nil || !arrayNestedProp.Output {
+		t.Errorf("Expected property 'arrayNested' under 'readOnlyObject' to be parsed and have Output=true, got: %+v", arrayNestedProp)
+	} else {
+		if arrayNestedProp.ItemType == nil || !arrayNestedProp.ItemType.Output {
+			t.Errorf("Expected 'ItemType' of 'arrayNested' to have Output=true, got: %+v", arrayNestedProp.ItemType)
+		} else {
+			var itemSubNameProp *api.Type
+			for _, p := range arrayNestedProp.ItemType.Properties {
+				if p.Name == "itemSubName" {
+					itemSubNameProp = p
+					break
+				}
+			}
+			if itemSubNameProp == nil || !itemSubNameProp.Output {
+				t.Errorf("Expected 'itemSubName' under 'arrayNested.ItemType' to have Output=true, got: %+v", itemSubNameProp)
+			}
+		}
+	}
+}
+

--- a/mmv1/openapi_generate/parser_test.go
+++ b/mmv1/openapi_generate/parser_test.go
@@ -169,4 +169,3 @@ func TestReadOnlyPropagation(t *testing.T) {
 		}
 	}
 }
-

--- a/mmv1/openapi_generate/test_data/test_api.yaml
+++ b/mmv1/openapi_generate/test_data/test_api.yaml
@@ -237,6 +237,24 @@ components:
             $ref: "#/components/schemas/Food"
         recursivePet:
           $ref: "#/components/schemas/Pet"
+        readOnlyObject:
+          readOnly: true
+          type: object
+          properties:
+            name:
+              type: string
+            nested:
+              type: object
+              properties:
+                subName:
+                  type: string
+            arrayNested:
+              type: array
+              items:
+                type: object
+                properties:
+                  itemSubName:
+                    type: string
     Food:
       required:
         - name


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

No user-facing changes. Output-only should be inherited as it's needed in TF. Small update to trigger acctest in autogen agent

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
