### PR TITLE
tgc-revival: Mark postQuantumKeyExchange as is_missing_in_cai: true for SslPolicy and RegionSslPolicy

### DIFF
--- a/mmv1/products/compute/RegionSslPolicy.yaml
+++ b/mmv1/products/compute/RegionSslPolicy.yaml
@@ -14,7 +14,6 @@
 ---
 name: 'RegionSslPolicy'
 api_resource_type_kind: SslPolicy
-kind: 'compute#sslPolicy'
 description: |
   Represents a Regional SSL policy. SSL policies give you the ability to control the
   features of SSL that your SSL proxy or HTTPS load balancer negotiates.
@@ -26,10 +25,14 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/sslPolicies'
 has_self_link: true
 update_verb: 'PATCH'
+collection_url_key: 'items'
+kind: 'compute#sslPolicy'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+custom_diff:
+  - 'regionSslPolicyCustomizeDiff'
 async:
   actions: ['create', 'delete', 'update']
   type: 'OpAsync'
@@ -37,12 +40,9 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: false
-collection_url_key: 'items'
 include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/region_ssl_policy.tmpl'
-custom_diff:
-  - 'regionSslPolicyCustomizeDiff'
 examples:
   - name: 'region_ssl_policy_basic'
     primary_resource_id: 'region-ssl-policy'
@@ -140,6 +140,7 @@ properties:
       type: String
   - name: 'postQuantumKeyExchange'
     type: Enum
+    is_missing_in_cai: true
     description: |
       One of `DEFAULT`, `ENABLED`, or `DEFERRED`. Controls whether the load balancer negotiates
       X25519MLKEM768 key exchange when clients advertise support for it.

--- a/mmv1/products/compute/SslPolicy.yaml
+++ b/mmv1/products/compute/SslPolicy.yaml
@@ -13,7 +13,6 @@
 
 ---
 name: 'SslPolicy'
-kind: 'compute#sslPolicy'
 description: |
   Represents a SSL policy. SSL policies give you the ability to control the
   features of SSL that your SSL proxy or HTTPS load balancer negotiates.
@@ -25,10 +24,14 @@ docs:
 base_url: 'projects/{{project}}/global/sslPolicies'
 has_self_link: true
 update_verb: 'PATCH'
+collection_url_key: 'items'
+kind: 'compute#sslPolicy'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+custom_diff:
+  - 'sslPolicyCustomizeDiff'
 async:
   actions: ['create', 'delete', 'update']
   type: 'OpAsync'
@@ -36,13 +39,10 @@ async:
     base_url: '{{op_id}}'
   result:
     resource_inside_response: false
-collection_url_key: 'items'
 include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/ssl_policy.tmpl'
   update_encoder: 'templates/terraform/update_encoder/ssl_policy.tmpl'
-custom_diff:
-  - 'sslPolicyCustomizeDiff'
 examples:
   - name: 'ssl_policy_basic'
     primary_resource_id: 'prod-ssl-policy'
@@ -134,6 +134,7 @@ properties:
       type: String
   - name: 'postQuantumKeyExchange'
     type: Enum
+    is_missing_in_cai: true
     description: |
       One of `DEFAULT`, `ENABLED`, or `DEFERRED`. Controls whether the load balancer
       negotiates X25519MLKEM768 key exchange when clients advertise support for it.


### PR DESCRIPTION
Fix integration test failures for google_compute_ssl_policy and google_compute_region_ssl_policy caused by postQuantumKeyExchange being missing in CAI asset data.

```release-note:none

```