### PR TITLE
secretmanager: add MMv1 list resources

### DIFF
--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -39,6 +39,7 @@ iam_policy:
   parent_resource_attribute: 'secret_id'
   iam_conditions_request_type: 'QUERY_PARAM_NESTED'
 include_in_tgc_next: true
+generate_list_resource: true
 custom_code:
   constants: 'templates/terraform/constants/secret_manager_secret.go.tmpl'
   pre_update: 'templates/terraform/pre_update/secret_manager_secret.go.tmpl'


### PR DESCRIPTION
Adds list-resource generation for the following secretmanager resources:

- `google_secret_manager_secret`

```release-note:new-list-resource
`google_secret_manager_secret`
```

<details><summary>Local test output</summary>

```
--- ci-required ---
TestAccSecretManagerSecretListQuery_generated: could not run locally — missing GOOGLE_CREDENTIALS.
The generated test is included in the PR and must be validated by CI (modular-magician).
```

</details>

## CI-Required Resources

The following resources could not be tested locally due to missing GCP credentials. Their generated tests are included and must pass in CI:

| Resource | Reason |
|---|---|
| `google_secret_manager_secret` | Missing `GOOGLE_CREDENTIALS` / ADC in local environment |

> **Note for reviewers:** The generated code compiles successfully (`go build ./...` passed). The list-query acceptance test requires live GCP credentials and is expected to pass in the CI environment run by modular-magician.