### PR TITLE
storage: add MMv1 list resources

### DIFF
--- a/mmv1/products/storage/HmacKey.yaml
+++ b/mmv1/products/storage/HmacKey.yaml
@@ -34,6 +34,7 @@ self_link: 'projects/{{project}}/hmacKeys/{{access_id}}'
 create_url: 'projects/{{project}}/hmacKeys?serviceAccountEmail={{service_account_email}}'
 # technically updatable, but implemented as custom update for new fingerprint support
 immutable: true
+generate_list_resource: true
 import_format:
   - 'projects/{{project}}/hmacKeys/{{access_id}}'
 timeouts:


### PR DESCRIPTION
Adds list-resource generation for the following storage resources:

- `google_storage_hmac_key`

```release-note:new-list-resource
`google_storage_hmac_key`
```

<details><summary>Local test output</summary>

```
--- PASS: TestAccStorageHmacKeyListQuery_generated (29.41s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/storage  30.972s
```

</details>
