### PR TITLE
`list-MMv1`: add `name` fallback for `DisplayName` setting

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -746,9 +746,15 @@ func (r Resource) ListResultDisplayNameKeyStrings() []string {
 	if slices.ContainsFunc(r.RootProperties(), func(p *Type) bool { return p.Name == "display_name" }) {
 		keys = append(keys, "display_name")
 	}
+	if slices.ContainsFunc(r.RootProperties(), func(p *Type) bool { return p.Name == "name" }) {
+		keys = append(keys, "name")
+	}
 	markers := regexp.MustCompile(`\{\{(\w+)\}\}`).FindAllStringSubmatch(r.IdFormat, -1)
 	if len(markers) > 0 {
-		keys = append(keys, markers[len(markers)-1][1])
+		tail := markers[len(markers)-1][1]
+		if !slices.Contains(keys, tail) {
+			keys = append(keys, tail)
+		}
 	}
 	return keys
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Ran into the failing error in https://github.com/GoogleCloudPlatform/magic-modules/pull/17699#issuecomment-4522383104

this is due to us relying on the value from `base_url`, this is fine for most resources but in the case of secret the preferred key is `name`. We now have a fallback to check for `displayName, name, {{LastBaseURLValue}}`

We getting passing when generating the list resource with the changes found in this PR
<img width="2624" height="522" alt="image" src="https://github.com/user-attachments/assets/5834247a-aea0-4920-8605-d99e8c425351" />


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
