### PR TITLE
tgc-revival: add Tgc networkmanagement resource

### DIFF
--- a/mmv1/products/networkmanagement/ConnectivityTest.yaml
+++ b/mmv1/products/networkmanagement/ConnectivityTest.yaml
@@ -13,6 +13,7 @@
 
 ---
 name: ConnectivityTest
+include_in_tgc_next: true
 description: |
   A connectivity test are a static analysis of your resource configurations
   that enables you to evaluate connectivity to and from Google Cloud

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -124,15 +124,17 @@ func (tgc TerraformGoogleConversionNext) GenerateResource(object api.Resource, t
 		log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
 	}
 
+	fileNamePrefix := tgc.ResourceGoFilename(object)
+
 	converters := []string{"tfplan2cai", "cai2hcl"}
 	for _, converter := range converters {
 		templatePath := fmt.Sprintf("templates/tgc_next/%s/resource_converter.go.tmpl", converter)
-		targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_%s_%s.go", productName, google.Underscore(object.Name), converter))
+		targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_%s.go", fileNamePrefix, converter))
 		templateData.GenerateTGCResourceFile(templatePath, targetFilePath, object)
 	}
 
 	templatePath := "templates/tgc_next/services/resource.go.tmpl"
-	fileName := fmt.Sprintf("%s_%s.go", productName, google.Underscore(object.Name))
+	fileName := fmt.Sprintf("%s.go", fileNamePrefix)
 	targetFilePath := path.Join(targetFolder, fileName)
 	templateData.GenerateTGCResourceFile(templatePath, targetFilePath, object)
 	tgc.replaceImportPath(targetFolder, fileName)
@@ -157,7 +159,7 @@ func (tgc *TerraformGoogleConversionNext) GenerateResourceTests(object api.Resou
 	if err := os.MkdirAll(targetFolder, os.ModePerm); err != nil {
 		log.Println(fmt.Errorf("error creating parent directory %v: %v", targetFolder, err))
 	}
-	targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_%s_generated_test.go", productName, google.Underscore(object.Name)))
+	targetFilePath := path.Join(targetFolder, fmt.Sprintf("%s_generated_test.go", tgc.ResourceGoFilename(object)))
 	templateData.GenerateTGCNextTestFile(targetFilePath, object)
 	return nil
 }


### PR DESCRIPTION
Fixed TGC generator to construct generated resource filenames using `tgc.ResourceGoFilename(object)` instead of `google.Underscore(object.Name)` during service code generation in TGC next. This ensures resources like `ConnectivityTest` (which has `filename_override: connectivity_test_resource`) generate correct file names, preventing compilation issues due to incorrect `_test.go` filename suffix.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
