### PR TITLE
Migrate compute instance flatten functions from Apiary structs to maps

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -19,6 +19,16 @@ import (
 {{- end }}
 )
 
+// toFloat64 safely converts a JSON-unmarshaled interface{} value to float64.
+// JSON numbers are always float64 after json.Unmarshal, so this handles nil safely.
+func toFloat64(v interface{}) float64 {
+	if v == nil {
+		return 0
+	}
+	f, _ := v.(float64)
+	return f
+}
+
 func instanceSchedulingNodeAffinitiesElemSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -77,6 +87,34 @@ func flattenAliasIpRange(d *schema.ResourceData, ranges []*compute.AliasIpRange,
 	return sorted
 }
 
+func flattenAliasIpRangeFromMap(d *schema.ResourceData, ranges []interface{}, i int) []map[string]interface{} {
+	prefix := fmt.Sprintf("network_interface.%d", i)
+
+	configData := []map[string]interface{}{}
+	for _, item := range d.Get(prefix + ".alias_ip_range").([]interface{}) {
+		configData = append(configData, item.(map[string]interface{}))
+	}
+
+	apiData := make([]map[string]interface{}, 0, len(ranges))
+	for _, rangeRaw := range ranges {
+		r, ok := rangeRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		apiData = append(apiData, map[string]interface{}{
+			"ip_cidr_range":         r["ipCidrRange"],
+			"subnetwork_range_name": r["subnetworkRangeName"],
+		})
+	}
+
+	//permadiff fix
+	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "ip_cidr_range")
+	if err != nil {
+		return apiData
+	}
+	return sorted
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 func flattenIpv6AliasRange(d *schema.ResourceData, ranges []*compute.AliasIpRange, i int) []map[string]interface{} {
 	prefix := fmt.Sprintf("network_interface.%d", i)
@@ -91,6 +129,34 @@ func flattenIpv6AliasRange(d *schema.ResourceData, ranges []*compute.AliasIpRang
 		apiData = append(apiData, map[string]interface{}{
 			"ip_cidr_range":         ipRange.IpCidrRange,
 			"subnetwork_range_name": ipRange.SubnetworkRangeName,
+		})
+	}
+
+	//permadiff fix
+	sorted, err := tpgresource.SortMapsByConfigOrder(configData, apiData, "ip_cidr_range")
+	if err != nil {
+		return apiData
+	}
+	return sorted
+}
+
+func flattenIpv6AliasRangeFromMap(d *schema.ResourceData, ranges []interface{}, i int) []map[string]interface{} {
+	prefix := fmt.Sprintf("network_interface.%d", i)
+
+	configData := []map[string]interface{}{}
+	for _, item := range d.Get(prefix + ".alias_ipv6_range").([]interface{}) {
+		configData = append(configData, item.(map[string]interface{}))
+	}
+
+	apiData := make([]map[string]interface{}, 0, len(ranges))
+	for _, rangeRaw := range ranges {
+		r, ok := rangeRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		apiData = append(apiData, map[string]interface{}{
+			"ip_cidr_range":         r["ipCidrRange"],
+			"subnetwork_range_name": r["subnetworkRangeName"],
 		})
 	}
 
@@ -379,113 +445,136 @@ func expandGracefulShutdownMaxDuration(v interface{}) (*compute.Duration, error)
 }
 {{ end }}
 
-func flattenScheduling(resp *compute.Scheduling) []map[string]interface{} {
+func flattenScheduling(resp map[string]interface{}) []map[string]interface{} {
+	if resp == nil {
+		return nil
+	}
 	schedulingMap := map[string]interface{}{
-		"on_host_maintenance":         resp.OnHostMaintenance,
-		"preemptible":                 resp.Preemptible,
-		"min_node_cpus":               resp.MinNodeCpus,
-		"provisioning_model":          resp.ProvisioningModel,
-		"instance_termination_action": resp.InstanceTerminationAction,
-		"availability_domain":         resp.AvailabilityDomain,
-		"termination_time":            resp.TerminationTime,
+		"on_host_maintenance":         resp["onHostMaintenance"],
+		"preemptible":                 resp["preemptible"],
+		"min_node_cpus":               int64(toFloat64(resp["minNodeCpus"])),
+		"provisioning_model":          resp["provisioningModel"],
+		"instance_termination_action": resp["instanceTerminationAction"],
+		"availability_domain":         int64(toFloat64(resp["availabilityDomain"])),
+		"termination_time":            resp["terminationTime"],
 	}
 
-	if resp.AutomaticRestart != nil {
-		schedulingMap["automatic_restart"] = *resp.AutomaticRestart
+	if v, ok := resp["automaticRestart"].(bool); ok {
+		schedulingMap["automatic_restart"] = v
 	}
 
-	if resp.MaxRunDuration != nil {
-		schedulingMap["max_run_duration"] = flattenComputeMaxRunDuration(resp.MaxRunDuration)
+	if v, ok := resp["maxRunDuration"].(map[string]interface{}); ok && v != nil {
+		schedulingMap["max_run_duration"] = flattenComputeMaxRunDuration(v)
 	}
 
-	if resp.OnInstanceStopAction != nil {
-		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(resp.OnInstanceStopAction)
+	if v, ok := resp["onInstanceStopAction"].(map[string]interface{}); ok && v != nil {
+		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(v)
 	}
 
 {{ if ne $.TargetVersionName `ga` -}}
-	schedulingMap["skip_guest_os_shutdown"] = resp.SkipGuestOsShutdown
+	schedulingMap["skip_guest_os_shutdown"] = resp["skipGuestOsShutdown"]
 
-	if resp.HostErrorTimeoutSeconds != 0 {
-		schedulingMap["host_error_timeout_seconds"] = resp.HostErrorTimeoutSeconds
+	if v, ok := resp["hostErrorTimeoutSeconds"]; ok && v != nil {
+		schedulingMap["host_error_timeout_seconds"] = int64(toFloat64(v))
 	}
 
-	if resp.MaintenanceInterval != "" {
-		schedulingMap["maintenance_interval"] = resp.MaintenanceInterval
+	if v, ok := resp["maintenanceInterval"].(string); ok && v != "" {
+		schedulingMap["maintenance_interval"] = v
 	}
 
-	if resp.GracefulShutdown != nil {
-		schedulingMap["graceful_shutdown"] = flattenGracefulShutdown(resp.GracefulShutdown)
+	if v, ok := resp["gracefulShutdown"].(map[string]interface{}); ok && v != nil {
+		schedulingMap["graceful_shutdown"] = flattenGracefulShutdown(v)
 	}
 
-	if resp.PreemptionNoticeDuration != nil {
-		schedulingMap["preemption_notice_duration"] = flattenComputePreemptionNoticeDuration(resp.PreemptionNoticeDuration)
+	if v, ok := resp["preemptionNoticeDuration"].(map[string]interface{}); ok && v != nil {
+		schedulingMap["preemption_notice_duration"] = flattenComputePreemptionNoticeDuration(v)
 	}
 {{- end }}
 
-	if resp.LocalSsdRecoveryTimeout != nil {
-		schedulingMap["local_ssd_recovery_timeout"] = flattenComputeLocalSsdRecoveryTimeout(resp.LocalSsdRecoveryTimeout)
+	if v, ok := resp["localSsdRecoveryTimeout"].(map[string]interface{}); ok && v != nil {
+		schedulingMap["local_ssd_recovery_timeout"] = flattenComputeLocalSsdRecoveryTimeout(v)
 	}
 
 	nodeAffinities := schema.NewSet(schema.HashResource(instanceSchedulingNodeAffinitiesElemSchema()), nil)
-	for _, na := range resp.NodeAffinities {
-		nodeAffinities.Add(map[string]interface{}{
-			"key":      na.Key,
-			"operator": na.Operator,
-			"values":   schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(na.Values)),
-		})
+	if nas, ok := resp["nodeAffinities"].([]interface{}); ok {
+		for _, naRaw := range nas {
+			na, ok := naRaw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			var values []interface{}
+			if v, ok := na["values"].([]interface{}); ok {
+				values = v
+			}
+			strValues := make([]string, 0, len(values))
+			for _, v := range values {
+				if s, ok := v.(string); ok {
+					strValues = append(strValues, s)
+				}
+			}
+			nodeAffinities.Add(map[string]interface{}{
+				"key":      na["key"],
+				"operator": na["operator"],
+				"values":   schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(strValues)),
+			})
+		}
 	}
 	schedulingMap["node_affinities"] = nodeAffinities
 
 	return []map[string]interface{}{schedulingMap}
 }
 
-func flattenComputeMaxRunDuration(v *compute.Duration) []interface{} {
+func flattenComputeMaxRunDuration(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["nanos"] = v.Nanos
-	transformed["seconds"] = v.Seconds
+	transformed["nanos"] = int64(toFloat64(v["nanos"]))
+	transformed["seconds"] = int64(toFloat64(v["seconds"]))
 	return []interface{}{transformed}
 }
 
-func flattenOnInstanceStopAction(v *compute.SchedulingOnInstanceStopAction) []interface{} {
+func flattenOnInstanceStopAction(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["discard_local_ssd"] = v.DiscardLocalSsd
+	transformed["discard_local_ssd"] = v["discardLocalSsd"]
 	return []interface{}{transformed}
 }
 
-func flattenComputeLocalSsdRecoveryTimeout(v *compute.Duration) []interface{} {
+func flattenComputeLocalSsdRecoveryTimeout(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["nanos"] = v.Nanos
-	transformed["seconds"] = v.Seconds
+	transformed["nanos"] = int64(toFloat64(v["nanos"]))
+	transformed["seconds"] = int64(toFloat64(v["seconds"]))
 	return []interface{}{transformed}
 }
 
 {{ if ne $.TargetVersionName `ga` -}}
-func flattenGracefulShutdown(v *compute.SchedulingGracefulShutdown) []interface{} {
+func flattenGracefulShutdown(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["enabled"] = v.Enabled
-	transformed["max_duration"] = flattenGracefulShutdownMaxDuration(v.MaxDuration)
+	transformed["enabled"] = v["enabled"]
+	if md, ok := v["maxDuration"].(map[string]interface{}); ok && md != nil {
+		transformed["max_duration"] = flattenGracefulShutdownMaxDuration(md)
+	} else {
+		transformed["max_duration"] = nil
+	}
 	return []interface{}{transformed}
 }
 
-func flattenGracefulShutdownMaxDuration(v *compute.Duration) []interface{} {
+func flattenGracefulShutdownMaxDuration(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["nanos"] = v.Nanos
-	transformed["seconds"] = v.Seconds
+	transformed["nanos"] = int64(toFloat64(v["nanos"]))
+	transformed["seconds"] = int64(toFloat64(v["seconds"]))
 	return []interface{}{transformed}
 }
 
@@ -509,125 +598,185 @@ func expandComputePreemptionNoticeDuration(v interface{}) (*compute.Duration, er
 	return &duration, nil
 }
 
-func flattenComputePreemptionNoticeDuration(v *compute.Duration) []interface{} {
+func flattenComputePreemptionNoticeDuration(v map[string]interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
 	transformed := make(map[string]interface{})
-	transformed["nanos"] = v.Nanos
-	transformed["seconds"] = v.Seconds
+	transformed["nanos"] = int64(toFloat64(v["nanos"]))
+	transformed["seconds"] = int64(toFloat64(v["seconds"]))
 	return []interface{}{transformed}
 }
 {{- end }}
 
-func flattenAccessConfigs(accessConfigs []*compute.AccessConfig) ([]map[string]interface{}, string) {
-	flattened := make([]map[string]interface{}, len(accessConfigs))
+func flattenAccessConfigs(accessConfigs []interface{}) ([]map[string]interface{}, string) {
+	flattened := make([]map[string]interface{}, 0, len(accessConfigs))
 	natIP := ""
-	for i, ac := range accessConfigs {
-		flattened[i] = map[string]interface{}{
-			"nat_ip":       ac.NatIP,
-			"network_tier": ac.NetworkTier,
+	for _, acRaw := range accessConfigs {
+		ac, ok := acRaw.(map[string]interface{})
+		if !ok {
+			continue
 		}
-		if ac.SetPublicPtr {
-			flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
+		natIPVal, _ := ac["natIP"].(string)
+		entry := map[string]interface{}{
+			"nat_ip":       natIPVal,
+			"network_tier": ac["networkTier"],
+		}
+		if setPublicPtr, ok := ac["setPublicPtr"].(bool); ok && setPublicPtr {
+			entry["public_ptr_domain_name"] = ac["publicPtrDomainName"]
 		}
 		if natIP == "" {
-			natIP = ac.NatIP
+			natIP = natIPVal
 		}
 		{{- if ne $.TargetVersionName "ga" }}
-		if ac.SecurityPolicy != "" {
-			flattened[i]["security_policy"] = ac.SecurityPolicy
+		if sp, ok := ac["securityPolicy"].(string); ok && sp != "" {
+			entry["security_policy"] = sp
 		}
 		{{- end }}
+		flattened = append(flattened, entry)
 	}
 	return flattened, natIP
 }
 
-func flattenIpv6AccessConfigs(ipv6AccessConfigs []*compute.AccessConfig) []map[string]interface{} {
-	flattened := make([]map[string]interface{}, len(ipv6AccessConfigs))
-	for i, ac := range ipv6AccessConfigs {
-		flattened[i] = map[string]interface{}{
-			"network_tier": ac.NetworkTier,
+func flattenIpv6AccessConfigs(ipv6AccessConfigs []interface{}) []map[string]interface{} {
+	flattened := make([]map[string]interface{}, 0, len(ipv6AccessConfigs))
+	for _, acRaw := range ipv6AccessConfigs {
+		ac, ok := acRaw.(map[string]interface{})
+		if !ok {
+			continue
 		}
-		flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
-		flattened[i]["external_ipv6"] = ac.ExternalIpv6
-		flattened[i]["external_ipv6_prefix_length"] = strconv.FormatInt(ac.ExternalIpv6PrefixLength, 10)
-		flattened[i]["name"] = ac.Name
+		prefixLen := int64(toFloat64(ac["externalIpv6PrefixLength"]))
+		entry := map[string]interface{}{
+			"network_tier":                ac["networkTier"],
+			"public_ptr_domain_name":      ac["publicPtrDomainName"],
+			"external_ipv6":               ac["externalIpv6"],
+			"external_ipv6_prefix_length": strconv.FormatInt(prefixLen, 10),
+			"name":                        ac["name"],
+		}
 		{{- if ne $.TargetVersionName "ga" }}
-		if ac.SecurityPolicy != "" {
-			flattened[i]["security_policy"] = ac.SecurityPolicy
+		if sp, ok := ac["securityPolicy"].(string); ok && sp != "" {
+			entry["security_policy"] = sp
 		}
 		{{- end }}
+		flattened = append(flattened, entry)
 	}
 	return flattened
 }
 
-func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Config, networkInterfaces []*compute.NetworkInterface) ([]map[string]interface{}, string, string, string, error) {
-	flattened := make([]map[string]interface{}, len(networkInterfaces))
+func flattenNetworkInterfaces(d *schema.ResourceData, config *transport_tpg.Config, networkInterfaces []interface{}) ([]map[string]interface{}, string, string, string, error) {
+	flattened := make([]map[string]interface{}, 0, len(networkInterfaces))
 	var region, internalIP, externalIP string
 
-	for i, iface := range networkInterfaces {
+	for i, ifaceRaw := range networkInterfaces {
+		iface, ok := ifaceRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var accessConfigsRaw []interface{}
+		if v, ok := iface["accessConfigs"].([]interface{}); ok {
+			accessConfigsRaw = v
+		}
 		var ac []map[string]interface{}
-		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
+		ac, externalIP = flattenAccessConfigs(accessConfigsRaw)
 
-		subnet, err := tpgresource.ParseSubnetworkFieldValue(iface.Subnetwork, d, config)
+		subnetwork, _ := iface["subnetwork"].(string)
+		subnet, err := tpgresource.ParseSubnetworkFieldValue(subnetwork, d, config)
 		if err != nil {
 			return nil, "", "", "", err
 		}
 		region = subnet.Region
 
-		flattened[i] = map[string]interface{}{
-			"network_ip":          iface.NetworkIP,
-			"network":             tpgresource.ConvertSelfLinkToV1(iface.Network),
-			"parent_nic_name":     iface.ParentNicName,
-			"vlan":                iface.Vlan,
-			"subnetwork":          tpgresource.ConvertSelfLinkToV1(iface.Subnetwork),
+		var aliasIpv6Ranges []interface{}
+		{{ if ne $.TargetVersionName `ga` -}}
+		if v, ok := iface["aliasIpv6Ranges"].([]interface{}); ok {
+			aliasIpv6Ranges = v
+		}
+		{{- end }}
+		_ = aliasIpv6Ranges
+
+		networkIP, _ := iface["networkIP"].(string)
+		network, _ := iface["network"].(string)
+		parentNicName, _ := iface["parentNicName"].(string)
+		vlan := int64(toFloat64(iface["vlan"]))
+		nicType, _ := iface["nicType"].(string)
+		stackType, _ := iface["stackType"].(string)
+		ipv6Address, _ := iface["ipv6Address"].(string)
+		queueCount := int64(toFloat64(iface["queueCount"]))
+		internalIpv6PrefixLength := int64(toFloat64(iface["internalIpv6PrefixLength"]))
+		igmpQuery, _ := iface["igmpQuery"].(string)
+
+		var ipv6AccessConfigsRaw []interface{}
+		if v, ok := iface["ipv6AccessConfigs"].([]interface{}); ok {
+			ipv6AccessConfigsRaw = v
+		}
+
+		var aliasIpRangesRaw []interface{}
+		if v, ok := iface["aliasIpRanges"].([]interface{}); ok {
+			aliasIpRangesRaw = v
+		}
+
+		entry := map[string]interface{}{
+			"network_ip":          networkIP,
+			"network":             tpgresource.ConvertSelfLinkToV1(network),
+			"parent_nic_name":     parentNicName,
+			"vlan":                vlan,
+			"subnetwork":          tpgresource.ConvertSelfLinkToV1(subnetwork),
 			"subnetwork_project":  subnet.Project,
 			"access_config":       ac,
-			"alias_ip_range":      flattenAliasIpRange(d, iface.AliasIpRanges, i),
+			"alias_ip_range":      flattenAliasIpRangeFromMap(d, aliasIpRangesRaw, i),
 			{{ if ne $.TargetVersionName `ga` -}}
-			"alias_ipv6_range":     flattenIpv6AliasRange(d, iface.AliasIpv6Ranges, i),
+			"alias_ipv6_range":     flattenIpv6AliasRangeFromMap(d, aliasIpv6Ranges, i),
 			{{- end }}
-			"nic_type":            iface.NicType,
-			"stack_type":          iface.StackType,
-			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
-			"ipv6_address":        iface.Ipv6Address,
-			"queue_count":         iface.QueueCount,
-			"internal_ipv6_prefix_length": iface.InternalIpv6PrefixLength,
-			"igmp_query":          iface.IgmpQuery,
+			"nic_type":            nicType,
+			"stack_type":          stackType,
+			"ipv6_access_config":  flattenIpv6AccessConfigs(ipv6AccessConfigsRaw),
+			"ipv6_address":        ipv6Address,
+			"queue_count":         queueCount,
+			"internal_ipv6_prefix_length": internalIpv6PrefixLength,
+			"igmp_query":          igmpQuery,
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
 		// same flattening code for both resource types, so we avoid trying to
 		// set the name field when it's not set at the GCE end.
-		if iface.Name != "" {
-			flattened[i]["name"] = iface.Name
+		if name, ok := iface["name"].(string); ok && name != "" {
+			entry["name"] = name
 		}
 		{{- if ne $.TargetVersionName "ga" }}
-		if iface.MacAddress != "" {
-			flattened[i]["mac_address"] = iface.MacAddress
+		if macAddress, ok := iface["macAddress"].(string); ok && macAddress != "" {
+			entry["mac_address"] = macAddress
 		}
 		{{- end }}
 		if internalIP == "" {
-			internalIP = iface.NetworkIP
+			internalIP = networkIP
 		}
 
-		if iface.NetworkAttachment != "" {
-			networkAttachment, err := tpgresource.GetRelativePath(iface.NetworkAttachment)
+		if networkAttachment, ok := iface["networkAttachment"].(string); ok && networkAttachment != "" {
+			relPath, err := tpgresource.GetRelativePath(networkAttachment)
 			if err != nil {
 				return nil, "", "", "", err
 			}
-			flattened[i]["network_attachment"] = networkAttachment
+			entry["network_attachment"] = relPath
 		}
 
 		{{ if ne $.TargetVersionName `ga` -}}
 		// the security_policy for a network_interface is found in one of its accessConfigs.
-		if len(iface.AccessConfigs) > 0 && iface.AccessConfigs[0].SecurityPolicy != "" {
-			flattened[i]["security_policy"] = iface.AccessConfigs[0].SecurityPolicy
-		} else if len(iface.Ipv6AccessConfigs) > 0 && iface.Ipv6AccessConfigs[0].SecurityPolicy != "" {
-			flattened[i]["security_policy"] = iface.Ipv6AccessConfigs[0].SecurityPolicy
+		if len(accessConfigsRaw) > 0 {
+			if ac0, ok := accessConfigsRaw[0].(map[string]interface{}); ok {
+				if sp, ok := ac0["securityPolicy"].(string); ok && sp != "" {
+					entry["security_policy"] = sp
+				}
+			}
+		}
+		if entry["security_policy"] == nil && len(ipv6AccessConfigsRaw) > 0 {
+			if iac0, ok := ipv6AccessConfigsRaw[0].(map[string]interface{}); ok {
+				if sp, ok := iac0["securityPolicy"].(string); ok && sp != "" {
+					entry["security_policy"] = sp
+				}
+			}
 		}
 		{{- end }}
+		flattened = append(flattened, entry)
 	}
 	return flattened, region, internalIP, externalIP, nil
 }
@@ -740,13 +889,26 @@ func expandNetworkInterfaces(d tpgresource.TerraformResourceData, config *transp
 	return ifaces, nil
 }
 
-func flattenServiceAccounts(serviceAccounts []*compute.ServiceAccount) []map[string]interface{} {
-	result := make([]map[string]interface{}, len(serviceAccounts))
-	for i, serviceAccount := range serviceAccounts {
-		result[i] = map[string]interface{}{
-			"email":  serviceAccount.Email,
-			"scopes": schema.NewSet(tpgresource.StringScopeHashcode, tpgresource.ConvertStringArrToInterface(serviceAccount.Scopes)),
+func flattenServiceAccounts(serviceAccounts []interface{}) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(serviceAccounts))
+	for _, saRaw := range serviceAccounts {
+		sa, ok := saRaw.(map[string]interface{})
+		if !ok {
+			continue
 		}
+		email, _ := sa["email"].(string)
+		var scopes []string
+		if v, ok := sa["scopes"].([]interface{}); ok {
+			for _, s := range v {
+				if str, ok := s.(string); ok {
+					scopes = append(scopes, str)
+				}
+			}
+		}
+		result = append(result, map[string]interface{}{
+			"email":  email,
+			"scopes": schema.NewSet(tpgresource.StringScopeHashcode, tpgresource.ConvertStringArrToInterface(scopes)),
+		})
 	}
 	return result
 }
@@ -768,13 +930,17 @@ func expandServiceAccounts(configs []interface{}) []*compute.ServiceAccount {
 	return accounts
 }
 
-func flattenGuestAccelerators(accelerators []*compute.AcceleratorConfig) []map[string]interface{} {
-	acceleratorsSchema := make([]map[string]interface{}, len(accelerators))
-	for i, accelerator := range accelerators {
-		acceleratorsSchema[i] = map[string]interface{}{
-			"count": accelerator.AcceleratorCount,
-			"type":  accelerator.AcceleratorType,
+func flattenGuestAccelerators(accelerators []interface{}) []map[string]interface{} {
+	acceleratorsSchema := make([]map[string]interface{}, 0, len(accelerators))
+	for _, accRaw := range accelerators {
+		acc, ok := accRaw.(map[string]interface{})
+		if !ok {
+			continue
 		}
+		acceleratorsSchema = append(acceleratorsSchema, map[string]interface{}{
+			"count": int64(toFloat64(acc["acceleratorCount"])),
+			"type":  acc["acceleratorType"],
+		})
 	}
 	return acceleratorsSchema
 }
@@ -822,14 +988,14 @@ func expandConfidentialInstanceConfig(d tpgresource.TerraformResourceData) *comp
 	}
 }
 
-func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *compute.ConfidentialInstanceConfig) []map[string]interface{} {
+func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig map[string]interface{}) []map[string]interface{} {
 	if ConfidentialInstanceConfig == nil {
 		return nil
 	}
 
 	return []map[string]interface{}{{"{{"}}
-		"enable_confidential_compute": ConfidentialInstanceConfig.EnableConfidentialCompute,
-		"confidential_instance_type": ConfidentialInstanceConfig.ConfidentialInstanceType,
+		"enable_confidential_compute": ConfidentialInstanceConfig["enableConfidentialCompute"],
+		"confidential_instance_type": ConfidentialInstanceConfig["confidentialInstanceType"],
 	{{"}}"}}
 }
 
@@ -849,29 +1015,32 @@ func expandAdvancedMachineFeatures(d tpgresource.TerraformResourceData) *compute
 	}
 }
 
-func flattenAdvancedMachineFeatures(AdvancedMachineFeatures *compute.AdvancedMachineFeatures) []map[string]interface{} {
+func flattenAdvancedMachineFeatures(AdvancedMachineFeatures map[string]interface{}) []map[string]interface{} {
 	if AdvancedMachineFeatures == nil {
 		return nil
 	}
 	return []map[string]interface{}{{"{{"}}
-		"enable_nested_virtualization": AdvancedMachineFeatures.EnableNestedVirtualization,
-		"threads_per_core":             AdvancedMachineFeatures.ThreadsPerCore,
-		"turbo_mode":                   AdvancedMachineFeatures.TurboMode,
-		"visible_core_count":           AdvancedMachineFeatures.VisibleCoreCount,
-		"performance_monitoring_unit":  AdvancedMachineFeatures.PerformanceMonitoringUnit,
-		"enable_uefi_networking":       AdvancedMachineFeatures.EnableUefiNetworking,
+		"enable_nested_virtualization": AdvancedMachineFeatures["enableNestedVirtualization"],
+		"threads_per_core":             int64(toFloat64(AdvancedMachineFeatures["threadsPerCore"])),
+		"turbo_mode":                   AdvancedMachineFeatures["turboMode"],
+		"visible_core_count":           int64(toFloat64(AdvancedMachineFeatures["visibleCoreCount"])),
+		"performance_monitoring_unit":  AdvancedMachineFeatures["performanceMonitoringUnit"],
+		"enable_uefi_networking":       AdvancedMachineFeatures["enableUefiNetworking"],
 	{{"}}"}}
 }
 
-func flattenShieldedVmConfig(shieldedVmConfig *compute.ShieldedInstanceConfig) []map[string]bool {
+func flattenShieldedVmConfig(shieldedVmConfig map[string]interface{}) []map[string]bool {
 	if shieldedVmConfig == nil {
 		return nil
 	}
+	enableSecureBoot, _ := shieldedVmConfig["enableSecureBoot"].(bool)
+	enableVtpm, _ := shieldedVmConfig["enableVtpm"].(bool)
+	enableIntegrityMonitoring, _ := shieldedVmConfig["enableIntegrityMonitoring"].(bool)
 
 	return []map[string]bool{{"{{"}}
-		"enable_secure_boot":          shieldedVmConfig.EnableSecureBoot,
-		"enable_vtpm":                 shieldedVmConfig.EnableVtpm,
-		"enable_integrity_monitoring": shieldedVmConfig.EnableIntegrityMonitoring,
+		"enable_secure_boot":          enableSecureBoot,
+		"enable_vtpm":                 enableVtpm,
+		"enable_integrity_monitoring": enableIntegrityMonitoring,
 	{{"}}"}}
 }
 
@@ -885,12 +1054,12 @@ func expandDisplayDevice(d tpgresource.TerraformResourceData) *compute.DisplayDe
 	}
 }
 
-func flattenEnableDisplay(displayDevice *compute.DisplayDevice) interface{} {
+func flattenEnableDisplay(displayDevice map[string]interface{}) interface{} {
 	if displayDevice == nil {
 		return nil
 	}
 
-	return displayDevice.EnableDisplay
+	return displayDevice["enableDisplay"]
 }
 
 // Node affinity updates require a reboot
@@ -1118,19 +1287,29 @@ func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.Re
 	return &affinity, nil
 }
 
-func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[string]interface{} {
+func flattenReservationAffinity(affinity map[string]interface{}) []map[string]interface{} {
 	if affinity == nil {
 		return nil
 	}
 
+	consumeReservationType, _ := affinity["consumeReservationType"].(string)
 	flattened := map[string]interface{}{
-		"type": affinity.ConsumeReservationType,
+		"type": consumeReservationType,
 	}
 
-	if affinity.ConsumeReservationType == "SPECIFIC_RESERVATION" {
+	if consumeReservationType == "SPECIFIC_RESERVATION" {
+		key, _ := affinity["key"].(string)
+		var values []string
+		if v, ok := affinity["values"].([]interface{}); ok {
+			for _, val := range v {
+				if s, ok := val.(string); ok {
+					values = append(values, s)
+				}
+			}
+		}
 		flattened["specific_reservation"] = []map[string]interface{}{{"{{"}}
-			"key":    affinity.Key,
-			"values": affinity.Values,
+			"key":    key,
+			"values": values,
 		{{"}}"}}
 	}
 
@@ -1174,6 +1353,23 @@ func flattenComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
 	return result
 }
 
+func flattenComputeInstanceGuestOsFeaturesFromMap(features []interface{}) []interface{} {
+	if features == nil {
+		return nil
+	}
+	var result []interface{}
+	for _, featureRaw := range features {
+		feature, ok := featureRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, ok := feature["type"].(string); ok && t != "" {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
 func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeature {
 	if v == nil {
 		return nil
@@ -1185,13 +1381,13 @@ func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeatu
 	return result
 }
 
-func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[string]interface{} {
+func flattenNetworkPerformanceConfig(c map[string]interface{}) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"total_egress_bandwidth_tier": c.TotalEgressBandwidthTier,
+			"total_egress_bandwidth_tier": c["totalEgressBandwidthTier"],
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
@@ -56,9 +56,19 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting hostname: %s", err)
 	}
 
+	// Convert instance to map for flatten functions that now accept maps.
+	instanceMap, err := tpgresource.ConvertToMap(instance)
+	if err != nil {
+		return fmt.Errorf("Error converting instance to map: %s", err)
+	}
+
 	// Set the networks
 	// Use the first external IP found for the default connection info.
-	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, instance.NetworkInterfaces)
+	var networkInterfacesRaw []interface{}
+	if v, ok := instanceMap["networkInterfaces"].([]interface{}); ok {
+		networkInterfacesRaw = v
+	}
+	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 	if err != nil {
 		return err
 	}
@@ -143,17 +153,29 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	err = d.Set("service_account", flattenServiceAccounts(instance.ServiceAccounts))
+	var serviceAccountsRaw []interface{}
+	if v, ok := instanceMap["serviceAccounts"].([]interface{}); ok {
+		serviceAccountsRaw = v
+	}
+	err = d.Set("service_account", flattenServiceAccounts(serviceAccountsRaw))
 	if err != nil {
 		return err
 	}
 
-	err = d.Set("scheduling", flattenScheduling(instance.Scheduling))
+	var schedulingMap map[string]interface{}
+	if v, ok := instanceMap["scheduling"].(map[string]interface{}); ok {
+		schedulingMap = v
+	}
+	err = d.Set("scheduling", flattenScheduling(schedulingMap))
 	if err != nil {
 		return err
 	}
 
-	err = d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators))
+	var guestAcceleratorsRaw []interface{}
+	if v, ok := instanceMap["guestAccelerators"].([]interface{}); ok {
+		guestAcceleratorsRaw = v
+	}
+	err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsRaw))
 	if err != nil {
 		return err
 	}
@@ -163,12 +185,20 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	err = d.Set("shielded_instance_config", flattenShieldedVmConfig(instance.ShieldedInstanceConfig))
+	var shieldedMap map[string]interface{}
+	if v, ok := instanceMap["shieldedInstanceConfig"].(map[string]interface{}); ok {
+		shieldedMap = v
+	}
+	err = d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedMap))
 	if err != nil {
 		return err
 	}
 
-	err = d.Set("enable_display", flattenEnableDisplay(instance.DisplayDevice))
+	var displayMap map[string]interface{}
+	if v, ok := instanceMap["displayDevice"].(map[string]interface{}); ok {
+		displayMap = v
+	}
+	err = d.Set("enable_display", flattenEnableDisplay(displayMap))
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
@@ -80,6 +80,36 @@ func flattenMetadataBeta(metadata *compute.Metadata) map[string]string {
 	return metadataMap
 }
 
+// flattenMetadataBetaFromMap flattens metadata from a map[string]interface{} returned
+// by the REST API (json.Unmarshal). The metadata format has "items" as a list of
+// {"key": ..., "value": ...} objects.
+func flattenMetadataBetaFromMap(metadata map[string]interface{}) map[string]string {
+	metadataMap := make(map[string]string)
+	if metadata == nil {
+		return metadataMap
+	}
+	items, ok := metadata["items"].([]interface{})
+	if !ok {
+		return metadataMap
+	}
+	for _, itemRaw := range items {
+		item, ok := itemRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		key, _ := item["key"].(string)
+		value, _ := item["value"].(string)
+		metadataMap[key] = value
+	}
+	return metadataMap
+}
+
+// convertPartnerMetadataFromMap converts partner metadata from the map form
+// returned by the REST API (after JSON unmarshal).
+func convertPartnerMetadataFromMap(pm map[string]interface{}) map[string]interface{} {
+	return pm
+}
+
 // This function differs from flattenMetadataBeta only in that it takes
 // compute.metadata rather than compute.metadata as an argument. It should
 // be removed in favour of flattenMetadataBeta if/when all resources using it get

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2166,12 +2166,23 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(instance.MachineType)); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)); err != nil {
+	// Convert the full instance to a map once and reuse for all flatten calls.
+	niJSON, err := tpgresource.ConvertToMap(instance)
+	if err != nil {
+		return fmt.Errorf("Error converting instance to map: %s", err)
+	}
+	var npcMap map[string]interface{}
+	if v, ok := niJSON["networkPerformanceConfig"].(map[string]interface{}); ok {
+		npcMap = v
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
-	// Set the networks
-	// Use the first external IP found for the default connection info.
-	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, instance.NetworkInterfaces)
+	var networkInterfacesRaw []interface{}
+	if v, ok := niJSON["networkInterfaces"].([]interface{}); ok {
+		networkInterfacesRaw = v
+	}
+	networkInterfaces, _, internalIP, externalIP, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 	if err != nil {
 		return err
 	}
@@ -2331,7 +2342,12 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 
 	zone := tpgresource.GetResourceNameFromSelfLink(instance.Zone)
 
-	if err := d.Set("service_account", flattenServiceAccounts(instance.ServiceAccounts)); err != nil {
+	// Use the already-converted map for service accounts, scheduling, etc.
+	var serviceAccountsRaw []interface{}
+	if v, ok := niJSON["serviceAccounts"].([]interface{}); ok {
+		serviceAccountsRaw = v
+	}
+	if err := d.Set("service_account", flattenServiceAccounts(serviceAccountsRaw)); err != nil {
 		return fmt.Errorf("Error setting service_account: %s", err)
 	}
 	if err := d.Set("attached_disk", ads); err != nil {
@@ -2341,14 +2357,18 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error setting scratch_disk: %s", err)
 	}
 
+	var schedulingMap map[string]interface{}
+	if v, ok := niJSON["scheduling"].(map[string]interface{}); ok {
+		schedulingMap = v
+	}
 {{ if eq $.TargetVersionName `ga` -}}
-	if err := d.Set("scheduling", flattenScheduling(instance.Scheduling)); err != nil {
+	if err := d.Set("scheduling", flattenScheduling(schedulingMap)); err != nil {
 		return fmt.Errorf("Error setting scheduling: %s", err)
 	}
 {{ else -}}
 	// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
 	// To avoid diff, we need to set the value from the state not from API response.
-	scheduling := flattenScheduling(instance.Scheduling)
+	scheduling := flattenScheduling(schedulingMap)
 	if nanos, ok := d.GetOk("scheduling.0.graceful_shutdown.0.max_duration.0.nanos"); ok {
 		graceful_shutdown := scheduling[0]["graceful_shutdown"].([]interface{})[0].(map[string]interface{})
 		max_duration := graceful_shutdown["max_duration"].([]interface{})[0].(map[string]interface{})
@@ -2362,13 +2382,25 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 {{- end }}
 
-	if err := d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators)); err != nil {
+	var guestAcceleratorsRaw []interface{}
+	if v, ok := niJSON["guestAccelerators"].([]interface{}); ok {
+		guestAcceleratorsRaw = v
+	}
+	if err := d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsRaw)); err != nil {
 		return fmt.Errorf("Error setting guest_accelerator: %s", err)
 	}
-	if err := d.Set("shielded_instance_config", flattenShieldedVmConfig(instance.ShieldedInstanceConfig)); err != nil {
+	var shieldedMap map[string]interface{}
+	if v, ok := niJSON["shieldedInstanceConfig"].(map[string]interface{}); ok {
+		shieldedMap = v
+	}
+	if err := d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedMap)); err != nil {
 		return fmt.Errorf("Error setting shielded_instance_config: %s", err)
 	}
-	if err := d.Set("enable_display", flattenEnableDisplay(instance.DisplayDevice)); err != nil {
+	var displayMap map[string]interface{}
+	if v, ok := niJSON["displayDevice"].(map[string]interface{}); ok {
+		displayMap = v
+	}
+	if err := d.Set("enable_display", flattenEnableDisplay(displayMap)); err != nil {
 		return fmt.Errorf("Error setting enable_display: %s", err)
 	}
 	if err := d.Set("cpu_platform", instance.CpuPlatform); err != nil {
@@ -2407,10 +2439,18 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("current_status", instance.Status); err != nil {
 		return fmt.Errorf("Error setting current_status: %s", err)
 	}
-	if err := d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(instance.ConfidentialInstanceConfig)); err != nil {
+	var cicMap map[string]interface{}
+	if v, ok := niJSON["confidentialInstanceConfig"].(map[string]interface{}); ok {
+		cicMap = v
+	}
+	if err := d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(cicMap)); err != nil {
 		return fmt.Errorf("Error setting confidential_instance_config: %s", err)
 	}
-	if err := d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(instance.AdvancedMachineFeatures)); err != nil {
+	var amfMap map[string]interface{}
+	if v, ok := niJSON["advancedMachineFeatures"].(map[string]interface{}); ok {
+		amfMap = v
+	}
+	if err := d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(amfMap)); err != nil {
 		return fmt.Errorf("Error setting advanced_machine_features: %s", err)
 	}
 	if d.Get("desired_status") != "" {
@@ -2418,7 +2458,11 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error setting desired_status: %s", err)
 		}
 	}
-	if err := d.Set("reservation_affinity", flattenReservationAffinity(instance.ReservationAffinity)); err != nil {
+	var raMap map[string]interface{}
+	if v, ok := niJSON["reservationAffinity"].(map[string]interface{}); ok {
+		raMap = v
+	}
+	if err := d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
 		return fmt.Errorf("Error setting reservation_affinity: %s", err)
 	}
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1822,18 +1822,17 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 	return dc
 }
 
-func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultProject string) (map[string]interface{}, error) {
+func flattenDisk(disk map[string]interface{}, configDisk map[string]any, defaultProject string) (map[string]interface{}, error) {
 	diskMap := make(map[string]interface{})
-
 
 	// These values are not returned by the API, so we copy them from the config.
 	diskMap["source_image_encryption_key"] = configDisk["source_image_encryption_key"]
 	diskMap["source_snapshot"] = configDisk["source_snapshot"]
 	diskMap["source_snapshot_encryption_key"] = configDisk["source_snapshot_encryption_key"]
 
-	if disk.InitializeParams != nil {
-		if disk.InitializeParams.SourceImage != "" {
-			path, err := resolveImageRefToRelativeURI(defaultProject, disk.InitializeParams.SourceImage)
+	if initParams, ok := disk["initializeParams"].(map[string]interface{}); ok && initParams != nil {
+		if sourceImage, ok := initParams["sourceImage"].(string); ok && sourceImage != "" {
+			path, err := resolveImageRefToRelativeURI(defaultProject, sourceImage)
 			if err != nil {
 				return nil, errwrap.Wrapf("Error expanding source image input to relative URI: {{"{{"}}err{{"}}"}}", err)
 			}
@@ -1841,32 +1840,35 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		} else {
 			diskMap["source_image"] = ""
 		}
-		diskMap["disk_type"] = disk.InitializeParams.DiskType
-		diskMap["provisioned_iops"] = disk.InitializeParams.ProvisionedIops
-		diskMap["provisioned_throughput"] = disk.InitializeParams.ProvisionedThroughput
-		diskMap["disk_name"] = disk.InitializeParams.DiskName
-		diskMap["labels"] = disk.InitializeParams.Labels
+		diskMap["disk_type"] = initParams["diskType"]
+		diskMap["provisioned_iops"] = int64(toFloat64(initParams["provisionedIops"]))
+		diskMap["provisioned_throughput"] = int64(toFloat64(initParams["provisionedThroughput"]))
+		diskMap["disk_name"] = initParams["diskName"]
+		diskMap["labels"] = initParams["labels"]
 		// The API does not return a disk size value for scratch disks. They are largely only one size,
-		// so we can assume that size here. Prefer disk.DiskSizeGb over the deprecated
-		// disk.InitializeParams.DiskSizeGb.
-		if disk.DiskSizeGb == 0 && disk.InitializeParams.DiskSizeGb == 0 && disk.Type == "SCRATCH" {
+		// so we can assume that size here. Prefer disk.diskSizeGb over the deprecated
+		// initializeParams.diskSizeGb.
+		diskSizeGb := int64(toFloat64(disk["diskSizeGb"]))
+		initDiskSizeGb := int64(toFloat64(initParams["diskSizeGb"]))
+		diskType, _ := disk["type"].(string)
+		if diskSizeGb == 0 && initDiskSizeGb == 0 && diskType == "SCRATCH" {
 			diskMap["disk_size_gb"] = DEFAULT_SCRATCH_DISK_SIZE_GB
-		} else if disk.DiskSizeGb != 0 {
-			diskMap["disk_size_gb"] = disk.DiskSizeGb
+		} else if diskSizeGb != 0 {
+			diskMap["disk_size_gb"] = diskSizeGb
 		} else {
-			diskMap["disk_size_gb"] = disk.InitializeParams.DiskSizeGb
+			diskMap["disk_size_gb"] = initDiskSizeGb
 		}
-		diskMap["resource_policies"] = disk.InitializeParams.ResourcePolicies
-		diskMap["resource_manager_tags"] = disk.InitializeParams.ResourceManagerTags
-		if disk.InitializeParams.StoragePool != "" {
-    		diskMap["storage_pool"] = tpgresource.GetResourceNameFromSelfLink(disk.InitializeParams.StoragePool)
+		diskMap["resource_policies"] = initParams["resourcePolicies"]
+		diskMap["resource_manager_tags"] = initParams["resourceManagerTags"]
+		if storagePool, ok := initParams["storagePool"].(string); ok && storagePool != "" {
+			diskMap["storage_pool"] = tpgresource.GetResourceNameFromSelfLink(storagePool)
 		}
 	}
 
-	if disk.DiskEncryptionKey != nil {
+	if diskEncKey, ok := disk["diskEncryptionKey"].(map[string]interface{}); ok && diskEncKey != nil {
 		encryption := make([]map[string]interface{}, 1)
 		encryption[0] = make(map[string]interface{})
-		encryption[0]["kms_key_self_link"] = disk.DiskEncryptionKey.KmsKeyName
+		encryption[0]["kms_key_self_link"] = diskEncKey["kmsKeyName"]
 		if diskEncryptionKey, ok := configDisk["disk_encryption_key"].([]interface{}); ok && len(diskEncryptionKey) > 0 {
 			if encryptionKeyMap, ok := diskEncryptionKey[0].(map[string]interface{}); ok {
 				if kmsSa, ok := encryptionKeyMap["kms_key_service_account"].(string); ok && kmsSa != "" {
@@ -1877,14 +1879,20 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		diskMap["disk_encryption_key"] = encryption
 	}
 
-	diskMap["auto_delete"] = disk.AutoDelete
-	diskMap["boot"] = disk.Boot
-	diskMap["device_name"] = disk.DeviceName
-	diskMap["interface"] = disk.Interface
-	diskMap["source"] = tpgresource.ConvertSelfLinkToV1(disk.Source)
-	diskMap["mode"] = disk.Mode
-	diskMap["type"] = disk.Type
-	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(disk.GuestOsFeatures)
+	diskMap["auto_delete"], _ = disk["autoDelete"].(bool)
+	diskMap["boot"], _ = disk["boot"].(bool)
+	diskMap["device_name"] = disk["deviceName"]
+	diskMap["interface"] = disk["interface"]
+	source, _ := disk["source"].(string)
+	diskMap["source"] = tpgresource.ConvertSelfLinkToV1(source)
+	diskMap["mode"] = disk["mode"]
+	diskType, _ := disk["type"].(string)
+	diskMap["type"] = diskType
+	var guestOsFeatures []interface{}
+	if v, ok := disk["guestOsFeatures"].([]interface{}); ok {
+		guestOsFeatures = v
+	}
+	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeaturesFromMap(guestOsFeatures)
 	diskMap["architecture"] = configDisk["architecture"]
 
 	return diskMap, nil
@@ -1927,15 +1935,17 @@ func reorderDisks(configDisks []interface{}, apiDisks []map[string]interface{}) 
 			continue
 		}
 		disk := d.(map[string]interface{})
-		if v := disk["device_name"]; v.(string) != "" {
-			disksByDeviceName[v.(string)] = i
-		} else if v := disk["type"]; v.(string) == "SCRATCH" {
-			iface := disk["interface"].(string)
+		deviceName, _ := disk["device_name"].(string)
+		diskType, _ := disk["type"].(string)
+		if deviceName != "" {
+			disksByDeviceName[deviceName] = i
+		} else if diskType == "SCRATCH" {
+			iface, _ := disk["interface"].(string)
 			scratchDisksByInterface[iface] = append(scratchDisksByInterface[iface], i)
-		} else if v := disk["source"]; v.(string) != "" {
-			attachedDisksBySource[v.(string)] = i
-		} else if v := disk["disk_name"]; v.(string) != "" {
-			attachedDisksByDiskName[v.(string)] = i
+		} else if v, _ := disk["source"].(string); v != "" {
+			attachedDisksBySource[v] = i
+		} else if v, _ := disk["disk_name"].(string); v != "" {
+			attachedDisksByDiskName[v] = i
 		} else {
 			attachedDisksByCharacteristics = append(attachedDisksByCharacteristics, i)
 		}
@@ -1943,35 +1953,40 @@ func reorderDisks(configDisks []interface{}, apiDisks []map[string]interface{}) 
 
 	// Align the disks, going from the most specific criteria to the least.
 	for _, apiDisk := range apiDisks {
+		apiDiskBoot, _ := apiDisk["boot"].(bool)
+		apiDiskDeviceName, _ := apiDisk["device_name"].(string)
+		apiDiskType, _ := apiDisk["type"].(string)
+		apiDiskIface, _ := apiDisk["interface"].(string)
+		apiDiskSource, _ := apiDisk["source"].(string)
+
 		// 1. This resource only works if the boot disk is the first one (which should be fixed
 		//	  separately), so put the boot disk first.
-		if apiDisk["boot"].(bool) {
+		if apiDiskBoot {
 			result[0] = apiDisk
 
 			// 2. All disks have a unique device name
-		} else if i, ok := disksByDeviceName[apiDisk["device_name"].(string)]; ok {
+		} else if i, ok := disksByDeviceName[apiDiskDeviceName]; ok {
 			result[i] = apiDisk
 
 			// 3. Scratch disks are all the same except device name and interface, so match them by
 			//    interface.
-		} else if apiDisk["type"].(string) == "SCRATCH" {
-			iface := apiDisk["interface"].(string)
-			indexes := scratchDisksByInterface[iface]
+		} else if apiDiskType == "SCRATCH" {
+			indexes := scratchDisksByInterface[apiDiskIface]
 			if len(indexes) > 0 {
 				result[indexes[0]] = apiDisk
-				scratchDisksByInterface[iface] = indexes[1:]
+				scratchDisksByInterface[apiDiskIface] = indexes[1:]
 			} else {
 				result = append(result, apiDisk)
 			}
 
 			// 4. Each attached disk will have a different source, so match by that.
-		} else if i, ok := attachedDisksBySource[apiDisk["source"].(string)]; ok {
+		} else if i, ok := attachedDisksBySource[apiDiskSource]; ok {
 			result[i] = apiDisk
 
 			// 5. If a disk was created for this resource via initializeParams, it will have a
 			//    unique name.
-		} else if v, ok := apiDisk["disk_name"]; ok && attachedDisksByDiskName[v.(string)] != 0 {
-			result[attachedDisksByDiskName[v.(string)]] = apiDisk
+		} else if diskName, _ := apiDisk["disk_name"].(string); diskName != "" && attachedDisksByDiskName[diskName] != 0 {
+			result[attachedDisksByDiskName[diskName]] = apiDisk
 
 			// 6. If no unique keys exist on this disk, then use a combination of its remaining
 			//    characteristics to see whether it matches exactly.
@@ -2004,10 +2019,14 @@ func reorderDisks(configDisks []interface{}, apiDisks []map[string]interface{}) 
 	return ds
 }
 
-func flattenDisks(disks []*compute.AttachedDisk, d *schema.ResourceData, defaultProject string) ([]map[string]interface{}, error) {
+func flattenDisks(disks []interface{}, d *schema.ResourceData, defaultProject string) ([]map[string]interface{}, error) {
 	apiDisks := make([]map[string]interface{}, len(disks))
 
-	for i, disk := range disks {
+	for i, diskRaw := range disks {
+		disk, ok := diskRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
 		configDisk := d.Get(fmt.Sprintf("disk.%d", i)).(map[string]any)
 		apiDisk, err := flattenDisk(disk, configDisk, defaultProject)
 		if err != nil {
@@ -2045,15 +2064,25 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("Instance Template %q", d.Get("name").(string)))
 	}
+
+	// Convert to map for flatten functions.
+	itMap, err := tpgresource.ConvertToMap(instanceTemplate)
+	if err != nil {
+		return fmt.Errorf("Error converting instance template to map: %s", err)
+	}
+	propertiesRaw, _ := itMap["properties"]
+	properties, _ := propertiesRaw.(map[string]interface{})
+	if properties == nil {
+		properties = map[string]interface{}{}
+	}
+
 	// Set the metadata fingerprint if there is one.
-	if instanceTemplate.Properties.Metadata != nil {
-		if err = d.Set("metadata_fingerprint", instanceTemplate.Properties.Metadata.Fingerprint); err != nil {
+	if metadata, ok := properties["metadata"].(map[string]interface{}); ok && metadata != nil {
+		if err = d.Set("metadata_fingerprint", metadata["fingerprint"]); err != nil {
 			return fmt.Errorf("Error setting metadata_fingerprint: %s", err)
 		}
 
-		md := instanceTemplate.Properties.Metadata
-
-		_md := flattenMetadataBeta(md)
+		_md := flattenMetadataBetaFromMap(metadata)
 
 		if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
 			if err = d.Set("metadata_startup_script", script); err != nil {
@@ -2073,8 +2102,9 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}
-	if instanceTemplate.Properties.PartnerMetadata != nil {
-		partnerMetadata, err := flattenPartnerMetadata(convertPartnerMetadataFromCompute(instanceTemplate.Properties.PartnerMetadata))
+	if partnerMetadataRaw, ok := properties["partnerMetadata"].(map[string]interface{}); ok && partnerMetadataRaw != nil {
+		partnerMetadataConverted := convertPartnerMetadataFromMap(partnerMetadataRaw)
+		partnerMetadata, err := flattenPartnerMetadata(partnerMetadataConverted)
 		if err != nil {
 			return fmt.Errorf("Error parsing partner metadata: %s", err)
 		}
@@ -2085,8 +2115,8 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	{{- end }}
 
 	// Set the tags fingerprint if there is one.
-	if instanceTemplate.Properties.Tags != nil {
-		if err = d.Set("tags_fingerprint", instanceTemplate.Properties.Tags.Fingerprint); err != nil {
+	if tags, ok := properties["tags"].(map[string]interface{}); ok && tags != nil {
+		if err = d.Set("tags_fingerprint", tags["fingerprint"]); err != nil {
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
 	} else {
@@ -2094,16 +2124,24 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.Labels != nil {
-		if err := tpgresource.SetLabels(instanceTemplate.Properties.Labels, d, "labels"); err != nil {
+	if labels, ok := properties["labels"].(map[string]interface{}); ok && labels != nil {
+		labelStrMap := make(map[string]string, len(labels))
+		for k, v := range labels {
+			labelStrMap[k] = v.(string)
+		}
+		if err := tpgresource.SetLabels(labelStrMap, d, "labels"); err != nil {
 			return fmt.Errorf("Error setting labels: %s", err)
 		}
-	}
-	if err := tpgresource.SetLabels(instanceTemplate.Properties.Labels, d, "terraform_labels"); err != nil {
-		return fmt.Errorf("Error setting terraform_labels: %s", err)
-	}
-	if err := d.Set("effective_labels", instanceTemplate.Properties.Labels); err != nil {
-		return fmt.Errorf("Error setting effective_labels: %s", err)
+		if err := tpgresource.SetLabels(labelStrMap, d, "terraform_labels"); err != nil {
+			return fmt.Errorf("Error setting terraform_labels: %s", err)
+		}
+		if err := d.Set("effective_labels", labelStrMap); err != nil {
+			return fmt.Errorf("Error setting effective_labels: %s", err)
+		}
+	} else {
+		if err := tpgresource.SetLabels(map[string]string{}, d, "terraform_labels"); err != nil {
+			return fmt.Errorf("Error setting terraform_labels: %s", err)
+		}
 	}
 	if err = d.Set("self_link", instanceTemplate.SelfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
@@ -2117,8 +2155,8 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	if err = d.Set("name", instanceTemplate.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if instanceTemplate.Properties.Disks != nil {
-		disks, err := flattenDisks(instanceTemplate.Properties.Disks, d, project)
+	if disksRaw, ok := properties["disks"].([]interface{}); ok && disksRaw != nil {
+		disks, err := flattenDisks(disksRaw, d, project)
 		if err != nil {
 			return fmt.Errorf("error flattening disks: %s", err)
 		}
@@ -2129,31 +2167,35 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	if err = d.Set("description", instanceTemplate.Description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	if err = d.Set("machine_type", instanceTemplate.Properties.MachineType); err != nil {
+	if err = d.Set("machine_type", properties["machineType"]); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	if err = d.Set("min_cpu_platform", instanceTemplate.Properties.MinCpuPlatform); err != nil {
+	if err = d.Set("min_cpu_platform", properties["minCpuPlatform"]); err != nil {
 		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
 	}
 
-	if err = d.Set("can_ip_forward", instanceTemplate.Properties.CanIpForward); err != nil {
+	if err = d.Set("can_ip_forward", properties["canIpForward"]); err != nil {
 		return fmt.Errorf("Error setting can_ip_forward: %s", err)
 	}
 
-	if err = d.Set("instance_description", instanceTemplate.Properties.Description); err != nil {
+	if err = d.Set("instance_description", properties["description"]); err != nil {
 		return fmt.Errorf("Error setting instance_description: %s", err)
 	}
-	if err = d.Set("key_revocation_action_type", instanceTemplate.Properties.KeyRevocationActionType); err != nil {
+	if err = d.Set("key_revocation_action_type", properties["keyRevocationActionType"]); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceTemplate.Properties.NetworkPerformanceConfig)); err != nil {
+	var npcMap map[string]interface{}
+	if v, ok := properties["networkPerformanceConfig"].(map[string]interface{}); ok {
+		npcMap = v
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
-	if instanceTemplate.Properties.NetworkInterfaces != nil {
-		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
+	if networkInterfacesRaw, ok := properties["networkInterfaces"].([]interface{}); ok && networkInterfacesRaw != nil {
+		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 		if err != nil {
 			return err
 		}
@@ -2167,8 +2209,8 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 			}
 		}
 	}
-	if instanceTemplate.Properties.Scheduling != nil {
-		scheduling := flattenScheduling(instanceTemplate.Properties.Scheduling)
+	if schedulingRaw, ok := properties["scheduling"].(map[string]interface{}); ok && schedulingRaw != nil {
+		scheduling := flattenScheduling(schedulingRaw)
 {{ if ne $.TargetVersionName `ga` }}
 		// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
 		// To avoid diff, we need to set the value from the state not from API response.
@@ -2185,57 +2227,65 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error setting scheduling: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.Tags != nil {
-		if err = d.Set("tags", instanceTemplate.Properties.Tags.Items); err != nil {
-			return fmt.Errorf("Error setting tags: %s", err)
+	if tags, ok := properties["tags"].(map[string]interface{}); ok && tags != nil {
+		if items, ok := tags["items"].([]interface{}); ok {
+			strItems := make([]string, 0, len(items))
+			for _, v := range items {
+				if s, ok := v.(string); ok {
+					strItems = append(strItems, s)
+				}
+			}
+			if err = d.Set("tags", strItems); err != nil {
+				return fmt.Errorf("Error setting tags: %s", err)
+			}
 		}
 	} else {
 		if err = d.Set("tags", nil); err != nil {
 			return fmt.Errorf("Error setting empty tags: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.ServiceAccounts != nil {
-		if err = d.Set("service_account", flattenServiceAccounts(instanceTemplate.Properties.ServiceAccounts)); err != nil {
+	if serviceAccountsRaw, ok := properties["serviceAccounts"].([]interface{}); ok && serviceAccountsRaw != nil {
+		if err = d.Set("service_account", flattenServiceAccounts(serviceAccountsRaw)); err != nil {
 			return fmt.Errorf("Error setting service_account: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.GuestAccelerators != nil {
-		if err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceTemplate.Properties.GuestAccelerators)); err != nil {
+	if guestAcceleratorsRaw, ok := properties["guestAccelerators"].([]interface{}); ok && guestAcceleratorsRaw != nil {
+		if err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsRaw)); err != nil {
 			return fmt.Errorf("Error setting guest_accelerator: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.ShieldedInstanceConfig != nil {
-		if err = d.Set("shielded_instance_config", flattenShieldedVmConfig(instanceTemplate.Properties.ShieldedInstanceConfig)); err != nil {
+	if shieldedRaw, ok := properties["shieldedInstanceConfig"].(map[string]interface{}); ok && shieldedRaw != nil {
+		if err = d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedRaw)); err != nil {
 			return fmt.Errorf("Error setting shielded_instance_config: %s", err)
 		}
 	}
 
-	if instanceTemplate.Properties.ConfidentialInstanceConfig != nil {
-		if err = d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(instanceTemplate.Properties.ConfidentialInstanceConfig)); err != nil {
+	if cicRaw, ok := properties["confidentialInstanceConfig"].(map[string]interface{}); ok && cicRaw != nil {
+		if err = d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(cicRaw)); err != nil {
 			return fmt.Errorf("Error setting confidential_instance_config: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.AdvancedMachineFeatures != nil {
-		if err = d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(instanceTemplate.Properties.AdvancedMachineFeatures)); err != nil {
+	if amfRaw, ok := properties["advancedMachineFeatures"].(map[string]interface{}); ok && amfRaw != nil {
+		if err = d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(amfRaw)); err != nil {
 			return fmt.Errorf("Error setting advanced_machine_features: %s", err)
 		}
 	}
 {{- if ne $.TargetVersionName "ga" }}
-	if instanceTemplate.Properties.DisplayDevice != nil {
-		if err = d.Set("enable_display", flattenEnableDisplay(instanceTemplate.Properties.DisplayDevice)); err != nil {
+	if ddRaw, ok := properties["displayDevice"].(map[string]interface{}); ok && ddRaw != nil {
+		if err = d.Set("enable_display", flattenEnableDisplay(ddRaw)); err != nil {
 			return fmt.Errorf("Error setting enable_display: %s", err)
 		}
 	}
 {{- end }}
 
-	if instanceTemplate.Properties.ResourcePolicies != nil {
-		if err = d.Set("resource_policies", instanceTemplate.Properties.ResourcePolicies); err != nil {
+	if resourcePoliciesRaw, ok := properties["resourcePolicies"].([]interface{}); ok && resourcePoliciesRaw != nil {
+		if err = d.Set("resource_policies", resourcePoliciesRaw); err != nil {
 			return fmt.Errorf("Error setting resource_policies: %s", err)
 		}
 	}
 
-	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+	if raRaw, ok := properties["reservationAffinity"].(map[string]interface{}); ok && raRaw != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(raRaw)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -16,12 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 	"github.com/hashicorp/terraform-provider-google/google/verify"
-
-{{ if eq $.TargetVersionName `ga` }}
-	"google.golang.org/api/compute/v1"
-{{- else }}
-	compute "google.golang.org/api/compute/v0.beta"
-{{- end }}
 )
 
 func ResourceComputeRegionInstanceTemplate() *schema.Resource {
@@ -1584,7 +1578,7 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 		return transport_tpg.HandleNotFoundError(err, d, fmt.Sprintf("ComputeRegionInstanceTemplate %q", d.Id()))
 	}
 
-	// Extract id (uint64) and selfLink before JSON roundtrip.
+	// Extract id (uint64) and selfLink directly from the response map.
 	var numericId string
 	switch v := res["id"].(type) {
 	case string:
@@ -1595,27 +1589,24 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 		numericId = fmt.Sprintf("%v", v)
 	}
 	selfLink, _ := res["selfLink"].(string)
-	delete(res, "id")
+	if v, ok := res["name"].(string); ok {
+		name = v
+	}
+	description, _ := res["description"].(string)
+	creationTimestamp, _ := res["creationTimestamp"].(string)
 
-	resBytes, err := json.Marshal(res)
-	if err != nil {
-		return fmt.Errorf("Error marshaling instance template response: %s", err)
+	properties, _ := res["properties"].(map[string]interface{})
+	if properties == nil {
+		properties = map[string]interface{}{}
 	}
-	var instanceTemplate compute.InstanceTemplate
-	if err := json.Unmarshal(resBytes, &instanceTemplate); err != nil {
-		return fmt.Errorf("Error parsing instance template response: %s", err)
-	}
-	instanceTemplate.SelfLink = selfLink
 
 	// Set the metadata fingerprint if there is one.
-	if instanceTemplate.Properties.Metadata != nil {
-		if err = d.Set("metadata_fingerprint", instanceTemplate.Properties.Metadata.Fingerprint); err != nil {
+	if metadata, ok := properties["metadata"].(map[string]interface{}); ok && metadata != nil {
+		if err = d.Set("metadata_fingerprint", metadata["fingerprint"]); err != nil {
 			return fmt.Errorf("Error setting metadata_fingerprint: %s", err)
 		}
 
-		md := instanceTemplate.Properties.Metadata
-
-		_md := flattenMetadataBeta(md)
+		_md := flattenMetadataBetaFromMap(metadata)
 
 		if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
 			if err = d.Set("metadata_startup_script", script); err != nil {
@@ -1635,8 +1626,9 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	}
 
 	{{ if ne $.TargetVersionName `ga` -}}
-	if instanceTemplate.Properties.PartnerMetadata != nil {
-		partnerMetadata, err := flattenPartnerMetadata(convertPartnerMetadataFromCompute(instanceTemplate.Properties.PartnerMetadata))
+	if partnerMetadataRaw, ok := properties["partnerMetadata"].(map[string]interface{}); ok && partnerMetadataRaw != nil {
+		partnerMetadataConverted := convertPartnerMetadataFromMap(partnerMetadataRaw)
+		partnerMetadata, err := flattenPartnerMetadata(partnerMetadataConverted)
 		if err != nil {
 			return fmt.Errorf("Error parsing partner metadata: %s", err)
 		}
@@ -1647,8 +1639,8 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	{{- end }}
 
 	// Set the tags fingerprint if there is one.
-	if instanceTemplate.Properties.Tags != nil {
-		if err = d.Set("tags_fingerprint", instanceTemplate.Properties.Tags.Fingerprint); err != nil {
+	if tags, ok := properties["tags"].(map[string]interface{}); ok && tags != nil {
+		if err = d.Set("tags_fingerprint", tags["fingerprint"]); err != nil {
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
 	} else {
@@ -1656,28 +1648,36 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error setting tags_fingerprint: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.Labels != nil {
-		if err := tpgresource.SetLabels(instanceTemplate.Properties.Labels, d, "labels"); err != nil {
+	if labels, ok := properties["labels"].(map[string]interface{}); ok && labels != nil {
+		labelStrMap := make(map[string]string, len(labels))
+		for k, v := range labels {
+			labelStrMap[k] = v.(string)
+		}
+		if err := tpgresource.SetLabels(labelStrMap, d, "labels"); err != nil {
 			return fmt.Errorf("Error setting labels: %s", err)
 		}
+		if err := tpgresource.SetLabels(labelStrMap, d, "terraform_labels"); err != nil {
+			return fmt.Errorf("Error setting terraform_labels: %s", err)
+		}
+		if err := d.Set("effective_labels", labelStrMap); err != nil {
+			return fmt.Errorf("Error setting effective_labels: %s", err)
+		}
+	} else {
+		if err := tpgresource.SetLabels(map[string]string{}, d, "terraform_labels"); err != nil {
+			return fmt.Errorf("Error setting terraform_labels: %s", err)
+		}
 	}
-	if err := tpgresource.SetLabels(instanceTemplate.Properties.Labels, d, "terraform_labels"); err != nil {
-		return fmt.Errorf("Error setting terraform_labels: %s", err)
-	}
-	if err := d.Set("effective_labels", instanceTemplate.Properties.Labels); err != nil {
-		return fmt.Errorf("Error setting effective_labels: %s", err)
-	}
-	if err = d.Set("self_link", instanceTemplate.SelfLink); err != nil {
+	if err = d.Set("self_link", selfLink); err != nil {
 		return fmt.Errorf("Error setting self_link: %s", err)
 	}
-	if err := d.Set("creation_timestamp", instanceTemplate.CreationTimestamp); err != nil {
+	if err := d.Set("creation_timestamp", creationTimestamp); err != nil {
 		return fmt.Errorf("Error setting creation_timestamp: %s", err)
 	}
-	if err = d.Set("name", instanceTemplate.Name); err != nil {
+	if err = d.Set("name", name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}
-	if instanceTemplate.Properties.Disks != nil {
-		disks, err := flattenDisks(instanceTemplate.Properties.Disks, d, project)
+	if disksRaw, ok := properties["disks"].([]interface{}); ok && disksRaw != nil {
+		disks, err := flattenDisks(disksRaw, d, project)
 		if err != nil {
 			return fmt.Errorf("error flattening disks: %s", err)
 		}
@@ -1685,34 +1685,38 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error setting disk: %s", err)
 		}
 	}
-	if err = d.Set("description", instanceTemplate.Description); err != nil {
+	if err = d.Set("description", description); err != nil {
 		return fmt.Errorf("Error setting description: %s", err)
 	}
-	if err = d.Set("machine_type", instanceTemplate.Properties.MachineType); err != nil {
+	if err = d.Set("machine_type", properties["machineType"]); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	if err = d.Set("min_cpu_platform", instanceTemplate.Properties.MinCpuPlatform); err != nil {
+	if err = d.Set("min_cpu_platform", properties["minCpuPlatform"]); err != nil {
 		return fmt.Errorf("Error setting min_cpu_platform: %s", err)
 	}
 
-	if err = d.Set("can_ip_forward", instanceTemplate.Properties.CanIpForward); err != nil {
+	if err = d.Set("can_ip_forward", properties["canIpForward"]); err != nil {
 		return fmt.Errorf("Error setting can_ip_forward: %s", err)
 	}
 
-	if err = d.Set("instance_description", instanceTemplate.Properties.Description); err != nil {
+	if err = d.Set("instance_description", properties["description"]); err != nil {
 		return fmt.Errorf("Error setting instance_description: %s", err)
 	}
-	if err = d.Set("key_revocation_action_type", instanceTemplate.Properties.KeyRevocationActionType); err != nil {
+	if err = d.Set("key_revocation_action_type", properties["keyRevocationActionType"]); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceTemplate.Properties.NetworkPerformanceConfig)); err != nil {
+	var npcMap map[string]interface{}
+	if v, ok := properties["networkPerformanceConfig"].(map[string]interface{}); ok {
+		npcMap = v
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
-	if instanceTemplate.Properties.NetworkInterfaces != nil {
-		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
+	if networkInterfacesRaw, ok := properties["networkInterfaces"].([]interface{}); ok && networkInterfacesRaw != nil {
+		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, networkInterfacesRaw)
 		if err != nil {
 			return err
 		}
@@ -1726,8 +1730,8 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 			}
 		}
 	}
-	if instanceTemplate.Properties.Scheduling != nil {
-		scheduling := flattenScheduling(instanceTemplate.Properties.Scheduling)
+	if schedulingRaw, ok := properties["scheduling"].(map[string]interface{}); ok && schedulingRaw != nil {
+		scheduling := flattenScheduling(schedulingRaw)
 {{ if ne $.TargetVersionName `ga` }}
 		// Workaroud: API doesn't update the scheduling.graceful_shutdown.max_duration.nanos field.
 		// To avoid diff, we need to set the value from the state not from API response.
@@ -1744,57 +1748,65 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error setting scheduling: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.Tags != nil {
-		if err = d.Set("tags", instanceTemplate.Properties.Tags.Items); err != nil {
-			return fmt.Errorf("Error setting tags: %s", err)
+	if tags, ok := properties["tags"].(map[string]interface{}); ok && tags != nil {
+		if items, ok := tags["items"].([]interface{}); ok {
+			strItems := make([]string, 0, len(items))
+			for _, v := range items {
+				if s, ok := v.(string); ok {
+					strItems = append(strItems, s)
+				}
+			}
+			if err = d.Set("tags", strItems); err != nil {
+				return fmt.Errorf("Error setting tags: %s", err)
+			}
 		}
 	} else {
 		if err = d.Set("tags", nil); err != nil {
 			return fmt.Errorf("Error setting empty tags: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.ServiceAccounts != nil {
-		if err = d.Set("service_account", flattenServiceAccounts(instanceTemplate.Properties.ServiceAccounts)); err != nil {
+	if serviceAccountsRaw, ok := properties["serviceAccounts"].([]interface{}); ok && serviceAccountsRaw != nil {
+		if err = d.Set("service_account", flattenServiceAccounts(serviceAccountsRaw)); err != nil {
 			return fmt.Errorf("Error setting service_account: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.GuestAccelerators != nil {
-		if err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceTemplate.Properties.GuestAccelerators)); err != nil {
+	if guestAcceleratorsRaw, ok := properties["guestAccelerators"].([]interface{}); ok && guestAcceleratorsRaw != nil {
+		if err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsRaw)); err != nil {
 			return fmt.Errorf("Error setting guest_accelerator: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.ShieldedInstanceConfig != nil {
-		if err = d.Set("shielded_instance_config", flattenShieldedVmConfig(instanceTemplate.Properties.ShieldedInstanceConfig)); err != nil {
+	if shieldedRaw, ok := properties["shieldedInstanceConfig"].(map[string]interface{}); ok && shieldedRaw != nil {
+		if err = d.Set("shielded_instance_config", flattenShieldedVmConfig(shieldedRaw)); err != nil {
 			return fmt.Errorf("Error setting shielded_instance_config: %s", err)
 		}
 	}
 
-	if instanceTemplate.Properties.ConfidentialInstanceConfig != nil {
-		if err = d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(instanceTemplate.Properties.ConfidentialInstanceConfig)); err != nil {
+	if cicRaw, ok := properties["confidentialInstanceConfig"].(map[string]interface{}); ok && cicRaw != nil {
+		if err = d.Set("confidential_instance_config", flattenConfidentialInstanceConfig(cicRaw)); err != nil {
 			return fmt.Errorf("Error setting confidential_instance_config: %s", err)
 		}
 	}
-	if instanceTemplate.Properties.AdvancedMachineFeatures != nil {
-		if err = d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(instanceTemplate.Properties.AdvancedMachineFeatures)); err != nil {
+	if amfRaw, ok := properties["advancedMachineFeatures"].(map[string]interface{}); ok && amfRaw != nil {
+		if err = d.Set("advanced_machine_features", flattenAdvancedMachineFeatures(amfRaw)); err != nil {
 			return fmt.Errorf("Error setting advanced_machine_features: %s", err)
 		}
 	}
 {{- if ne $.TargetVersionName "ga" }}
-	if instanceTemplate.Properties.DisplayDevice != nil {
-		if err = d.Set("enable_display", flattenEnableDisplay(instanceTemplate.Properties.DisplayDevice)); err != nil {
+	if ddRaw, ok := properties["displayDevice"].(map[string]interface{}); ok && ddRaw != nil {
+		if err = d.Set("enable_display", flattenEnableDisplay(ddRaw)); err != nil {
 			return fmt.Errorf("Error setting enable_display: %s", err)
 		}
 	}
 {{- end }}
 
-	if instanceTemplate.Properties.ResourcePolicies != nil {
-		if err = d.Set("resource_policies", instanceTemplate.Properties.ResourcePolicies); err != nil {
+	if resourcePoliciesRaw, ok := properties["resourcePolicies"].([]interface{}); ok && resourcePoliciesRaw != nil {
+		if err = d.Set("resource_policies", resourcePoliciesRaw); err != nil {
 			return fmt.Errorf("Error setting resource_policies: %s", err)
 		}
 	}
 
-	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+	if raRaw, ok := properties["reservationAffinity"].(map[string]interface{}); ok && raRaw != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(raRaw)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance.go
@@ -1,6 +1,7 @@
 package compute
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/registry"
@@ -12,6 +13,22 @@ import (
 
 	"google.golang.org/api/compute/v1"
 )
+
+// structToMap converts an Apiary struct to map[string]interface{} via JSON roundtrip.
+func structToMap(v interface{}) map[string]interface{} {
+	b, _ := json.Marshal(v)
+	var m map[string]interface{}
+	json.Unmarshal(b, &m)
+	return m
+}
+
+// structToSlice converts an Apiary slice to []interface{} via JSON roundtrip.
+func structToSlice(v interface{}) []interface{} {
+	b, _ := json.Marshal(v)
+	var s []interface{}
+	json.Unmarshal(b, &s)
+	return s
+}
 
 func init() {
 	registry.Schema{
@@ -1463,15 +1480,18 @@ func flattenSchedulingTgc(resp *compute.Scheduling) []map[string]interface{} {
 	}
 
 	if resp.MaxRunDuration != nil {
-		schedulingMap["max_run_duration"] = flattenComputeMaxRunDuration(resp.MaxRunDuration)
+		mrdMap := structToMap(resp.MaxRunDuration)
+		schedulingMap["max_run_duration"] = flattenComputeMaxRunDuration(mrdMap)
 	}
 
 	if resp.OnInstanceStopAction != nil {
-		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(resp.OnInstanceStopAction)
+		oisaMap := structToMap(resp.OnInstanceStopAction)
+		schedulingMap["on_instance_stop_action"] = flattenOnInstanceStopAction(oisaMap)
 	}
 
 	if resp.LocalSsdRecoveryTimeout != nil {
-		schedulingMap["local_ssd_recovery_timeout"] = flattenComputeLocalSsdRecoveryTimeout(resp.LocalSsdRecoveryTimeout)
+		lsrtMap := structToMap(resp.LocalSsdRecoveryTimeout)
+		schedulingMap["local_ssd_recovery_timeout"] = flattenComputeLocalSsdRecoveryTimeout(lsrtMap)
 	}
 
 	if len(schedulingMap) == 0 {
@@ -1486,8 +1506,11 @@ func flattenNetworkInterfacesTgc(networkInterfaces []*compute.NetworkInterface, 
 	var internalIP, externalIP string
 
 	for i, iface := range networkInterfaces {
+		acSlice := structToSlice(iface.AccessConfigs)
+		ipv6Slice := structToSlice(iface.Ipv6AccessConfigs)
+
 		var ac []map[string]interface{}
-		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
+		ac, externalIP = flattenAccessConfigs(acSlice)
 
 		flattened[i] = map[string]interface{}{
 			"network_ip":                  iface.NetworkIP,
@@ -1495,7 +1518,7 @@ func flattenNetworkInterfacesTgc(networkInterfaces []*compute.NetworkInterface, 
 			"alias_ip_range":              flattenAliasIpRangeTgc(iface.AliasIpRanges),
 			"nic_type":                    iface.NicType,
 			"stack_type":                  iface.StackType,
-			"ipv6_access_config":          flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
+			"ipv6_access_config":          flattenIpv6AccessConfigs(ipv6Slice),
 			"ipv6_address":                iface.Ipv6Address,
 			"network":                     tpgresource.ConvertSelfLinkToV1(iface.Network),
 			"subnetwork":                  tpgresource.ConvertSelfLinkToV1(iface.Subnetwork),

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
@@ -59,7 +59,8 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 		hclData["can_ip_forward"] = instance.CanIpForward
 	}
 	hclData["machine_type"] = tpgresource.GetResourceNameFromSelfLink(instance.MachineType)
-	hclData["network_performance_config"] = flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)
+	npcMap := structToMap(instance.NetworkPerformanceConfig)
+	hclData["network_performance_config"] = flattenNetworkPerformanceConfig(npcMap)
 
 	// Set the networks
 	networkInterfaces, _, _, err := flattenNetworkInterfacesTgc(instance.NetworkInterfaces, project)
@@ -83,8 +84,10 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 
 	hclData["scheduling"] = flattenSchedulingTgc(instance.Scheduling)
 	hclData["guest_accelerator"] = flattenGuestAcceleratorsTgc(instance.GuestAccelerators)
-	hclData["shielded_instance_config"] = flattenShieldedVmConfig(instance.ShieldedInstanceConfig)
-	hclData["enable_display"] = flattenEnableDisplay(instance.DisplayDevice)
+	sicMap := structToMap(instance.ShieldedInstanceConfig)
+	hclData["shielded_instance_config"] = flattenShieldedVmConfig(sicMap)
+	ddMap := structToMap(instance.DisplayDevice)
+	hclData["enable_display"] = flattenEnableDisplay(ddMap)
 	hclData["min_cpu_platform"] = instance.MinCpuPlatform
 
 	// Only convert the field when its value is not default false
@@ -95,8 +98,10 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 	hclData["name"] = instance.Name
 	hclData["description"] = instance.Description
 	hclData["hostname"] = instance.Hostname
-	hclData["confidential_instance_config"] = flattenConfidentialInstanceConfig(instance.ConfidentialInstanceConfig)
-	hclData["advanced_machine_features"] = flattenAdvancedMachineFeatures(instance.AdvancedMachineFeatures)
+	cicMap := structToMap(instance.ConfidentialInstanceConfig)
+	hclData["confidential_instance_config"] = flattenConfidentialInstanceConfig(cicMap)
+	amfMap := structToMap(instance.AdvancedMachineFeatures)
+	hclData["advanced_machine_features"] = flattenAdvancedMachineFeatures(amfMap)
 	hclData["reservation_affinity"] = flattenReservationAffinityTgc(instance.ReservationAffinity)
 	hclData["key_revocation_action_type"] = strings.TrimSuffix(instance.KeyRevocationActionType, "_ON_KEY_REVOCATION")
 	hclData["instance_encryption_key"] = flattenComputeInstanceEncryptionKey(instance.InstanceEncryptionKey)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: Migrate compute instance flatten functions from Apiary structs to maps
```
