### PR TITLE
Migrated compute_instance_helpers.go.tmpl partially to use transport_tpg.SendRequest

### DIFF
--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -267,6 +267,7 @@ func (tgc TerraformGoogleConversionNext) CopyCommonFiles(outputFolder string, ge
 		"pkg/tpgresource/regional_utils.go":       "third_party/terraform/tpgresource/regional_utils.go",
 		"pkg/tpgresource/field_helpers.go":        "third_party/terraform/tpgresource/field_helpers.go",
 		"pkg/tpgresource/service_scope.go":        "third_party/terraform/tpgresource/service_scope.go",
+		"pkg/tpgresource/convert.go":              "third_party/terraform/tpgresource/convert.go",
 		"pkg/verify/validation.go":                "third_party/terraform/verify/validation.go",
 		"pkg/verify/path_or_contents.go":          "third_party/terraform/verify/path_or_contents.go",
 		"pkg/version/version.go":                  "third_party/terraform/version/version.go",

--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -185,8 +185,12 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 	}
 
 	if v, ok := original["on_instance_stop_action"]; ok {
-		transformedOnInstanceStopAction, err := expandComputeOnInstanceStopAction(v)
+		transformedOnInstanceStopActionRaw, err := expandComputeOnInstanceStopAction(v)
 		if err != nil {
+			return nil, err
+		}
+		var transformedOnInstanceStopAction *compute.SchedulingOnInstanceStopAction
+		if err := tpgresource.Convert(transformedOnInstanceStopActionRaw, &transformedOnInstanceStopAction); err != nil {
 			return nil, err
 		}
 		scheduling.OnInstanceStopAction = transformedOnInstanceStopAction
@@ -223,8 +227,12 @@ func expandScheduling(v interface{}) (*compute.Scheduling, error) {
 	}
 
 	if v, ok := original["preemption_notice_duration"]; ok {
-		transformedPreemptionNoticeDuration, err := expandComputePreemptionNoticeDuration(v)
+		transformedPreemptionNoticeDurationRaw, err := expandComputePreemptionNoticeDuration(v)
 		if err != nil {
+			return nil, err
+		}
+		var transformedPreemptionNoticeDuration *compute.Duration
+		if err := tpgresource.Convert(transformedPreemptionNoticeDurationRaw, &transformedPreemptionNoticeDuration); err != nil {
 			return nil, err
 		}
 		scheduling.PreemptionNoticeDuration = transformedPreemptionNoticeDuration
@@ -279,22 +287,22 @@ func expandComputeMaxRunDurationSeconds(v interface{}) (interface{}, error) {
 	return v, nil
 }
 
-func expandComputeOnInstanceStopAction(v interface{}) (*compute.SchedulingOnInstanceStopAction, error){
+func expandComputeOnInstanceStopAction(v interface{}) (interface{}, error) {
 	l := v.([]interface{})
-	onInstanceStopAction := compute.SchedulingOnInstanceStopAction{}
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
 	}
 	raw := l[0]
 	original := raw.(map[string]interface{})
-	
+	transformed := make(map[string]interface{})
+
 	if d, ok := original["discard_local_ssd"]; ok {
-		onInstanceStopAction.DiscardLocalSsd = d.(bool)
+		transformed["discardLocalSsd"] = d.(bool)
 	} else {
 		return nil, nil
 	}
 
-	return &onInstanceStopAction, nil	
+	return transformed, nil
 }
 
 func expandComputeLocalSsdRecoveryTimeout(v interface{}) (*compute.Duration, error) {
@@ -489,24 +497,24 @@ func flattenGracefulShutdownMaxDuration(v *compute.Duration) []interface{} {
 	return []interface{}{transformed}
 }
 
-func expandComputePreemptionNoticeDuration(v interface{}) (*compute.Duration, error) {
+func expandComputePreemptionNoticeDuration(v interface{}) (interface{}, error) {
 	l := v.([]interface{})
-	duration := compute.Duration{}
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
 	}
 	raw := l[0]
 	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
 	if transformedNanos, ok := original["nanos"]; ok && transformedNanos != nil {
-		duration.Nanos = int64(transformedNanos.(int))
+		transformed["nanos"] = int64(transformedNanos.(int))
 	}
 
 	if transformedSeconds, ok := original["seconds"]; ok && transformedSeconds != nil {
-		duration.Seconds = int64(transformedSeconds.(int))
+		transformed["seconds"] = int64(transformedSeconds.(int))
 	}
 
-	return &duration, nil
+	return transformed, nil
 }
 
 func flattenComputePreemptionNoticeDuration(v *compute.Duration) []interface{} {

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -599,8 +599,12 @@ func expandSchedulingTgc(v interface{}) (*compute.Scheduling, error) {
 	}
 
 	if v, ok := original["on_instance_stop_action"]; ok {
-		transformedOnInstanceStopAction, err := expandComputeOnInstanceStopAction(v)
+		transformedOnInstanceStopActionRaw, err := expandComputeOnInstanceStopAction(v)
 		if err != nil {
+			return nil, err
+		}
+		var transformedOnInstanceStopAction *compute.SchedulingOnInstanceStopAction
+		if err := tpgresource.Convert(transformedOnInstanceStopActionRaw, &transformedOnInstanceStopAction); err != nil {
 			return nil, err
 		}
 		scheduling.OnInstanceStopAction = transformedOnInstanceStopAction


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: Migrated compute_instance_helpers.go.tmpl partially to use transport_tpg.SendRequest. Methods: expandComputeOnInstanceStopAction, expandComputePreemptionNoticeDuration
```
