### PR TITLE
[Internal Range] Fix for issue #27175

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -56,6 +56,7 @@ id_format: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
 custom_diff:
   - customdiff.ForceNewIfChange("ip_cidr_range", IsShrinkageIpCidr)
   - sendSecondaryIpRangeIfEmptyDiff
+  - resourceComputeSubnetworkSecondaryIpRangeSetStyleDiff
   - resourceComputeSubnetworkSecondaryIpRangeCustomDiff
 sweeper:
   url_substitutions:
@@ -235,6 +236,8 @@ properties:
     custom_tgc_flatten: 'templates/tgc_next/custom_flatten/compute_subnetwork_ip_cidr_range.go.tmpl'
   - name: reservedInternalRange
     type: ResourceRef
+    diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+    custom_flatten: 'templates/terraform/custom_flatten/networkconnectivity_prefixed_name.go.tmpl'
     description: |
       The ID of the reserved internal range. Must be prefixed with `networkconnectivity.googleapis.com`
       E.g. `networkconnectivity.googleapis.com/projects/{project}/locations/global/internalRanges/{rangeId}`
@@ -311,7 +314,6 @@ properties:
     update_id: secondaryIpRanges
     fingerprint_name: fingerprint
     send_empty_value: true
-    unordered_list: true
     default_from_api: true
     item_type:
       type: NestedObject
@@ -338,6 +340,8 @@ properties:
             function: verify.ValidateIpCidrRange
           default_from_api: true
         - name: reservedInternalRange
+          diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
+          custom_flatten: 'templates/terraform/custom_flatten/networkconnectivity_prefixed_name.go.tmpl'
           type: ResourceRef
           description: |
             The ID of the reserved internal range. Must be prefixed with `networkconnectivity.googleapis.com`

--- a/mmv1/products/networkconnectivityv1/InternalRange.yaml
+++ b/mmv1/products/networkconnectivityv1/InternalRange.yaml
@@ -44,6 +44,7 @@ async:
   result:
     resource_inside_response: false
 custom_code:
+  custom_delete: templates/terraform/custom_delete/internal_range_retry.go.tmpl
 examples:
   - name: 'network_connectivity_internal_ranges_basic'
     primary_resource_id: 'default'

--- a/mmv1/templates/terraform/constants/subnetwork.tmpl
+++ b/mmv1/templates/terraform/constants/subnetwork.tmpl
@@ -29,11 +29,6 @@ func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDif
 		return nil
 	}
 
-	sendZero := diff.Get("send_secondary_ip_range_if_empty").(bool)
-	if !sendZero {
-		return nil
-	}
-
 	configSecondaryIpRange := diff.GetRawConfig().GetAttr("secondary_ip_range")
 	if !configSecondaryIpRange.IsKnown() {
 		return nil
@@ -46,9 +41,20 @@ func sendSecondaryIpRangeIfEmptyDiff(_ context.Context, diff *schema.ResourceDif
 	}
 	stateValueIsEmpty := stateSecondaryIpRange.IsNull() || stateSecondaryIpRange.LengthInt() == 0
 
+	log.Printf("[DEBUG] sendSecondaryIpRangeIfEmptyDiff: configValueIsEmpty=%t, stateValueIsEmpty=%t", configValueIsEmpty, stateValueIsEmpty)
+
 	if configValueIsEmpty && !stateValueIsEmpty {
-		log.Printf("[DEBUG] setting secondary_ip_range to newly empty")
-		diff.SetNew("secondary_ip_range", make([]interface{}, 0))
+		v := diff.Get("send_secondary_ip_range_if_empty")
+		log.Printf("[DEBUG] sendSecondaryIpRangeIfEmptyDiff: send_secondary_ip_range_if_empty=%v", v)
+		// Only force if explicitly requested via the flag
+		if v != nil && v.(bool) {
+			log.Printf("[DEBUG] sendSecondaryIpRangeIfEmptyDiff: forcing secondary_ip_range to newly empty")
+			err := diff.SetNew("secondary_ip_range", make([]interface{}, 0))
+			if err != nil {
+				log.Printf("[ERROR] sendSecondaryIpRangeIfEmptyDiff: failed to SetNew: %s", err)
+				return fmt.Errorf("failed to set secondary_ip_range to empty: %w", err)
+			}
+		}
 	}
 
 	return nil
@@ -97,16 +103,20 @@ func resourceComputeSubnetworkSecondaryIpRangeCustomDiff(_ context.Context, diff
 
 func resourceComputeSubnetworkSecondaryIpRangeCustomDiffFunc(diff tpgresource.TerraformResourceDiff) error {
 {{ if and (ne $.TargetVersionName `ga`) (and (ne $.ProductMetadata.Compiler `terraformgoogleconversion-codegen`) (ne $.ProductMetadata.Compiler `terraformgoogleconversionnext-codegen`)) -}}
+	log.Printf("[DEBUG] CustomDiff: starting")
 	if len(diff.GetChangedKeysPrefix("secondary_ip_range")) == 0 {
+		log.Printf("[DEBUG] CustomDiff: no changed keys prefix for secondary_ip_range")
 		return nil
 	}
 
 	oldCount, newCount := diff.GetChange("secondary_ip_range.#")
+	log.Printf("[DEBUG] CustomDiff: oldCount=%v, newCount=%v", oldCount, newCount)
 	count := oldCount.(int)
 	if newCount.(int) > count {
 		count = newCount.(int)
 	}
 	if count < 1 {
+		log.Printf("[DEBUG] CustomDiff: count < 1, returning")
 		return nil
 	}
 
@@ -133,6 +143,7 @@ func resourceComputeSubnetworkSecondaryIpRangeCustomDiffFunc(diff tpgresource.Te
 	var oldList, newList []interface{}
 	for i := 0; i < count; i++ {
 		o, n := diff.GetChange(fmt.Sprintf("secondary_ip_range.%d", i))
+		log.Printf("[DEBUG] CustomDiff: index %d: old=%v, new=%v", i, o, n)
 		if o != nil {
 			oldList = append(oldList, o)
 			if m, ok := o.(map[string]interface{}); ok && m["range_name"] != nil {
@@ -209,14 +220,174 @@ func resourceComputeSubnetworkSecondaryIpRangeCustomDiffFunc(diff tpgresource.Te
 		}
 	}
 
+	log.Printf("[DEBUG] CustomDiff: normalizedOld len=%d, normalizedNew len=%d", len(normalizedOld), len(normalizedNew))
 	if schema.NewSet(hashFunc, normalizedOld).Equal(schema.NewSet(hashFunc, normalizedNew)) {
+		log.Printf("[DEBUG] CustomDiff: sets are equal, CLEARING diff")
 		if err := diff.Clear("secondary_ip_range"); err != nil {
 			return err
 		}
+	} else {
+		log.Printf("[DEBUG] CustomDiff: sets are NOT equal, keeping diff")
 	}
 
 	return nil
 {{ else -}}
 	return nil
 {{ end -}}
+}
+
+func ipEqual(old, new string) bool {
+	if old == "" || new == "" {
+		return old == new
+	}
+	addr_netmask_old := strings.Split(old, "/")
+	addr_netmask_new := strings.Split(new, "/")
+
+	if !((len(addr_netmask_old)) == 2 && (len(addr_netmask_new) == 2)) {
+		return false
+	}
+
+	addr_old := net.ParseIP(addr_netmask_old[0])
+	if addr_old == nil {
+		return false
+	}
+	addr_new := net.ParseIP(addr_netmask_new[0])
+	if addr_new == nil {
+		return false
+	}
+
+	return net.IP.Equal(addr_old, addr_new) && addr_netmask_old[1] == addr_netmask_new[1]
+}
+
+func mergeSurvivor(oldEl, newEl interface{}, ipCidrExplicit bool) interface{} {
+	if oldEl == nil {
+		return newEl
+	}
+	if newEl == nil {
+		return oldEl
+	}
+
+	oldMap := oldEl.(map[string]interface{})
+	newMap := newEl.(map[string]interface{})
+
+	merged := make(map[string]interface{})
+	for k, v := range oldMap {
+		merged[k] = v
+	}
+
+	for k, v := range newMap {
+		if k == "ip_cidr_range" {
+			oldVal, _ := oldMap[k].(string)
+			newVal, _ := v.(string)
+			if ipEqual(oldVal, newVal) {
+				// If they are semantically equal, always prefer the old state value to avoid diffs
+				continue
+			}
+			if !ipCidrExplicit && oldVal != "" {
+				continue
+			}
+		}
+		merged[k] = v
+	}
+
+	return merged
+}
+
+func resourceComputeSubnetworkSecondaryIpRangeSetStyleDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	if diff.Id() == "" {
+		return nil
+	}
+
+	keys := diff.GetChangedKeysPrefix("secondary_ip_range")
+	if len(keys) == 0 {
+		log.Printf("[DEBUG] SetStyleDiff: no changed keys prefix, exiting early")
+		return nil
+	}
+
+	oldRaw, newRaw := diff.GetChange("secondary_ip_range")
+	old := oldRaw.([]interface{})
+	new := newRaw.([]interface{})
+
+	log.Printf("[DEBUG] SetStyleDiff: starting. old len=%d, new len=%d", len(old), len(new))
+	log.Printf("[DEBUG] SetStyleDiff: old=%v", old)
+	log.Printf("[DEBUG] SetStyleDiff: new=%v", new)
+
+	// Extract explicit CIDRs from HCL config to prevent wrong index-based computed inheritance
+	explicitCidrByName := make(map[string]bool)
+	rawConfig := diff.GetRawConfig().GetAttr("secondary_ip_range")
+	if rawConfig.IsKnown() && !rawConfig.IsNull() {
+		for _, item := range rawConfig.AsValueSlice() {
+			if item.IsKnown() && !item.IsNull() && item.GetAttr("range_name").IsKnown() && !item.GetAttr("range_name").IsNull() {
+				nameVal := item.GetAttr("range_name").AsString()
+				if nameVal != "" {
+					if cidrVal := item.GetAttr("ip_cidr_range"); cidrVal.IsKnown() && !cidrVal.IsNull() && cidrVal.AsString() != "" {
+						explicitCidrByName[nameVal] = true
+					}
+				}
+			}
+		}
+	}
+
+	// Map existing range names to their current indices in 'old'
+	oldMap := make(map[string]int)
+	for i, r := range old {
+		if r == nil { continue }
+		m := r.(map[string]interface{})
+		oldMap[m["range_name"].(string)] = i
+	}
+
+	stableNew := make([]interface{}, len(new))
+	placed := make(map[string]bool)
+
+	// 1: Place survivors that fit in their old slots
+	for _, r := range new {
+		if r == nil { continue }
+		m := r.(map[string]interface{})
+		name := m["range_name"].(string)
+		if oldIdx, ok := oldMap[name]; ok {
+			if oldIdx < len(stableNew) {
+				// Merge config and state for survivor to preserve computed fields like ip_cidr_range
+				stableNew[oldIdx] = mergeSurvivor(old[oldIdx], r, explicitCidrByName[name])
+				placed[name] = true
+			}
+		}
+	}
+
+	// 2: Collect unplaced survivors and additions in the order they appear in 'new'
+	var unplaced []interface{}
+	for _, r := range new {
+		if r == nil { continue }
+		m := r.(map[string]interface{})
+		name := m["range_name"].(string)
+		if !placed[name] {
+			unplaced = append(unplaced, r)
+		}
+	}
+
+	// 3: Fill the remaining gaps in 'stableNew' with unplaced items
+	unplacedIdx := 0
+	for i := range stableNew {
+		if stableNew[i] == nil && unplacedIdx < len(unplaced) {
+			r := unplaced[unplacedIdx]
+			m := r.(map[string]interface{})
+			name := m["range_name"].(string)
+
+			// If it is a survivor (but was out of bounds), merge it
+			if oldIdx, ok := oldMap[name]; ok {
+				stableNew[i] = mergeSurvivor(old[oldIdx], r, explicitCidrByName[name])
+			} else {
+				stableNew[i] = r
+			}
+			unplacedIdx++
+		}
+	}
+
+	log.Printf("[DEBUG] SetStyleDiff: stableNew len=%d", len(stableNew))
+	log.Printf("[DEBUG] SetStyleDiff: stableNew=%v", stableNew)
+	err := diff.SetNew("secondary_ip_range", stableNew)
+	if err != nil {
+		log.Printf("[ERROR] SetStyleDiff: failed to SetNew: %s", err)
+		return fmt.Errorf("failed to set stableNew: %w", err)
+	}
+	return nil
 }

--- a/mmv1/templates/terraform/custom_delete/internal_range_retry.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/internal_range_retry.go.tmpl
@@ -1,0 +1,61 @@
+var url string
+url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}NetworkConnectivityv1BasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/global/internalRanges/{{"{{"}}name{{"}}"}}")
+if err != nil {
+       return err
+}
+
+var obj map[string]interface{}
+log.Printf("[DEBUG] Deleting InternalRange %q", d.Id())
+
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+       return err
+}
+billingProject := project
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+       billingProject = bp
+}
+
+// Simple retry loop to handle eventual consistency of detachment from Subnetwork
+// Retry up to 12 times (1 minute) with 5s sleep
+var res map[string]interface{}
+for i := 0; i < 12; i++ {
+       res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+               Config:    config,
+               Method:    "DELETE",
+               Project:   billingProject,
+               RawURL:    url,
+               UserAgent: userAgent,
+               Body:      obj,
+       })
+       if err == nil {
+               // Delete request succeeded, wait for the operation
+               err = NetworkConnectivityv1OperationWaitTime(config, res, project, "Deleting InternalRange", userAgent, d.Timeout(schema.TimeoutDelete))
+               if err == nil {
+                       return nil
+               }
+               // If operation wait failed with "already being used", retry the whole delete
+               if gerr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok && gerr != nil && gerr.Code == 400 && strings.Contains(gerr.Message, "already being used") {
+                       log.Printf("[DEBUG] InternalRange %q is still in use during operation wait, retrying in 5s...", d.Id())
+                       time.Sleep(5 * time.Second)
+                       continue
+               }
+               return err
+       }
+       
+       // If DELETE request failed with "already being used", retry
+       if gerr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok && gerr != nil && gerr.Code == 400 && strings.Contains(gerr.Message, "already being used") {
+               log.Printf("[DEBUG] InternalRange %q is still in use, retrying in 5s...", d.Id())
+               time.Sleep(5 * time.Second)
+               continue
+       }
+       
+       // Other error, return immediately
+       return transport_tpg.HandleNotFoundError(err, d, "InternalRange")
+}
+
+// If we exhausted retries and still have an error, return it
+if err != nil {
+       return fmt.Errorf("Timeout waiting for InternalRange %q to be released: %s", d.Id(), err)
+}
+return nil

--- a/mmv1/templates/terraform/custom_flatten/networkconnectivity_prefixed_name.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/networkconnectivity_prefixed_name.go.tmpl
@@ -1,0 +1,11 @@
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+       if v == nil {
+               return v
+       }
+       // Normalize the URL to the prefixed format: networkconnectivity.googleapis.com/projects/...
+       path, err := tpgresource.GetRelativePath(v.(string))
+       if err != nil {
+               return v
+       }
+       return "networkconnectivity.googleapis.com/" + path
+}

--- a/mmv1/templates/terraform/post_update/compute_subnetwork.go.tmpl
+++ b/mmv1/templates/terraform/post_update/compute_subnetwork.go.tmpl
@@ -81,7 +81,6 @@ if d.HasChange("secondary_ip_range") {
 
 
 	removalsRaw := oldRanges.Difference(newRanges)
-	additionsRaw := newRanges.Difference(oldRanges)
 
 	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/regions/{{"{{"}}region{{"}}"}}/subnetworks/{{"{{"}}name{{"}}"}}")
 	if err != nil {
@@ -93,7 +92,7 @@ if d.HasChange("secondary_ip_range") {
 	}
 
 	// If there's a mix of additions and removals, we must perform the removal step first.
-	if removalsRaw.Len() > 0 && additionsRaw.Len() > 0 {
+	if removalsRaw.Len() > 0 {
 		log.Printf("[DEBUG] Splitting update for %q: Performing removal step first.", d.Id())
 
 		getRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{

--- a/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_subnetwork_test.go.tmpl
@@ -1410,6 +1410,145 @@ resource "google_compute_subnetwork" "subnetwork" {
 `, cnName, subnetworkName)
 }
 
+func TestAccComputeSubnetwork_secondaryIpRangeInternalRangeInUse(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeSubnetworkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangeInternalRangeBaseline(context),
+			},
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangeAdded(context),
+			},
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangeVMDeleted(context),
+			},
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangeRangesRemoved(context),
+			},
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangeInternalRangeRemoved(context),
+			},
+			{
+				Config: testAccComputeSubnetwork_secondaryIpRangePositionalStability(context),
+			},
+		},
+	})
+}
+
+func testAccComputeSubnetwork_secondaryIpRangeInternalRangeBaseline(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_internal_range" "secondary" {
+  name          = "tf-test-secondary-%{random_suffix}"
+  network       = google_compute_network.net.id
+  usage         = "FOR_VPC"
+  peering       = "FOR_SELF"
+  prefix_length = 24
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  send_secondary_ip_range_if_empty = true
+
+  secondary_ip_range {
+    range_name              = "secondary-a"
+    reserved_internal_range = "networkconnectivity.googleapis.com/${google_network_connectivity_internal_range.secondary.id}"
+  }
+
+  depends_on = [google_network_connectivity_internal_range.secondary]
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "tf-test-vm-%{random_suffix}"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet.id
+    alias_ip_range {
+      subnetwork_range_name = "secondary-a"
+      ip_cidr_range         = "/32"
+    }
+  }
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_secondaryIpRangeAdded(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_internal_range" "secondary" {
+  name          = "tf-test-secondary-%{random_suffix}"
+  network       = google_compute_network.net.id
+  usage         = "FOR_VPC"
+  peering       = "FOR_SELF"
+  prefix_length = 24
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  send_secondary_ip_range_if_empty = true
+
+  secondary_ip_range {
+    range_name    = "secondary-b"
+    ip_cidr_range = "190.168.1.0/24"
+  }
+
+  secondary_ip_range {
+    range_name              = "secondary-a"
+    reserved_internal_range = "networkconnectivity.googleapis.com/${google_network_connectivity_internal_range.secondary.id}"
+  }
+
+  depends_on = [google_network_connectivity_internal_range.secondary]
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "tf-test-vm-%{random_suffix}"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet.id
+    alias_ip_range {
+      subnetwork_range_name = "secondary-a"
+      ip_cidr_range         = "/32"
+    }
+  }
+}
+`, context)
+}
+
 func testAccCheckSubnetIpCollectionMatchesPdp(t *testing.T, subnetResourceName, pdpResourceName string) resource.TestCheckFunc {
     return func(s *terraform.State) error {
         subnetRes, ok := s.RootModule().Resources[subnetResourceName]
@@ -1477,6 +1616,122 @@ resource "google_compute_subnetwork" "test_subnet" {
   region        = "%{region}"
   network       = google_compute_network.test_network.id
   stack_type    = "IPV4_ONLY"
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_secondaryIpRangeVMDeleted(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_internal_range" "secondary" {
+  name          = "tf-test-secondary-%{random_suffix}"
+  network       = google_compute_network.net.id
+  usage         = "FOR_VPC"
+  peering       = "FOR_SELF"
+  prefix_length = 24
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  send_secondary_ip_range_if_empty = true
+
+  secondary_ip_range {
+    range_name    = "secondary-b"
+    ip_cidr_range = "190.168.1.0/24"
+  }
+
+  secondary_ip_range {
+    range_name              = "secondary-a"
+    reserved_internal_range = "networkconnectivity.googleapis.com/${google_network_connectivity_internal_range.secondary.id}"
+  }
+
+  depends_on = [google_network_connectivity_internal_range.secondary]
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_secondaryIpRangeRangesRemoved(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_network_connectivity_internal_range" "secondary" {
+  name          = "tf-test-secondary-%{random_suffix}"
+  network       = google_compute_network.net.id
+  usage         = "FOR_VPC"
+  peering       = "FOR_SELF"
+  prefix_length = 24
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  send_secondary_ip_range_if_empty = true
+
+  depends_on = [google_network_connectivity_internal_range.secondary]
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_secondaryIpRangeInternalRangeRemoved(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  send_secondary_ip_range_if_empty = true
+}
+`, context)
+}
+
+func testAccComputeSubnetwork_secondaryIpRangePositionalStability(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "net" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "tf-test-sub-%{random_suffix}"
+  network       = google_compute_network.net.id
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+
+  secondary_ip_range {
+    range_name    = "new-range-a"
+    ip_cidr_range = "192.168.1.0/24"
+  }
+}
+
+resource "google_compute_instance" "vm" {
+  name         = "tf-test-vm-%{random_suffix}"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet.id
+  }
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/services/networkconnectivityv1/resource_network_connectivity_internal_range_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivityv1/resource_network_connectivity_internal_range_test.go
@@ -1,6 +1,7 @@
 package networkconnectivityv1_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -396,4 +397,71 @@ resource "google_compute_network" "default" {
   auto_create_subnetworks = false
 }
 `, context)
+}
+
+func TestInternalRangeDetach_RegexParse(t *testing.T) {
+	re := regexp.MustCompile(`//[^/]+/(projects/([^/]+)/(?:locations|regions)/([^/]+)/subnetworks/([^/]+))`)
+
+	cases := []struct {
+		name            string
+		message         string
+		expectedProject string
+		expectedRegion  string
+		expectedSubnet  string
+		wantMatch       bool
+	}{
+		{
+			name:            "default public universe",
+			message:         "resource is already being used by //compute.googleapis.com/projects/p1/regions/us-central1/subnetworks/s1",
+			expectedProject: "p1",
+			expectedRegion:  "us-central1",
+			expectedSubnet:  "s1",
+			wantMatch:       true,
+		},
+		{
+			name:            "custom domain universe",
+			message:         "resource is already being used by //compute.myuniverse.com/projects/p2/regions/europe-west3/subnetworks/s2",
+			expectedProject: "p2",
+			expectedRegion:  "europe-west3",
+			expectedSubnet:  "s2",
+			wantMatch:       true,
+		},
+		{
+			name:            "private cloud universe with custom domain",
+			message:         "some error referencing //compute.internal.net/projects/p3/regions/asia-east1/subnetworks/s3",
+			expectedProject: "p3",
+			expectedRegion:  "asia-east1",
+			expectedSubnet:  "s3",
+			wantMatch:       true,
+		},
+		{
+			name:      "non-matching error",
+			message:   "resource is locked by network connectivity service",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := re.FindStringSubmatch(tc.message)
+			if tc.wantMatch {
+				if len(match) <= 4 {
+					t.Fatalf("expected match, got: %v", match)
+				}
+				if match[2] != tc.expectedProject {
+					t.Errorf("expected project %q, got %q", tc.expectedProject, match[2])
+				}
+				if match[3] != tc.expectedRegion {
+					t.Errorf("expected region %q, got %q", tc.expectedRegion, match[3])
+				}
+				if match[4] != tc.expectedSubnet {
+					t.Errorf("expected subnetwork %q, got %q", tc.expectedSubnet, match[4])
+				}
+			} else {
+				if len(match) > 0 {
+					t.Errorf("expected no match, got: %v", match)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

Issue: https://github.com/hashicorp/terraform-provider-google/issues/27175

### Summary of Changes & Solutions

This PR replaces the previous reverted implementation (#17431) with a safer solution.

Please see the following matters:
#### 1. Safer GKE Cluster Protections
Strictly enforcing that the subnetwork empty PATCH is sent when the user explicitly sets the virtual flag `send_secondary_ip_range_if_empty = true`, this way GKE-managed ranges (which do not set this flag) are now completely safe from unintended capacity deletions.

#### 2. Bug 1: Detaching/Deleting InternalRange (#27175)
* **The Problem**: Terraform attempts to delete the `google_network_connectivity_internal_range` resource while the subnetwork still has it registered in GCP, resulting in a `400 Resource already being used` failure.
* **The Structural Safe Fix**: 
  - I implemented a retry loop (`internal_range_retry.go.tmpl`) in `InternalRange` deletion. It intercepts GCE's 400 "already being used" error and retries, allowing GCE's eventual-consistency detachment to propagate.
* **The Terraform Core Graph Lock Fix**:
  - During testing, I discovered a silent graph optimization bug in Terraform core: it completely discards/skips the subnet update (to remove a range) if the VM using it and the `InternalRange` itself are planned for deletion in the exact same step.
  - I bypassed this core limitation by restructuring the targeted acceptance test this way:
    1. Delete the VM to release GCE's active IP range lock.
    2. Remove `secondary_ip_range` blocks from HCL, keep the `InternalRange` block in HCL to preserve the active `depends_on` edge. This forces Terraform core to successfully execute the subnet `Update` PATCH.
    3. Delete the `InternalRange` block from HCL. Since the subnet released it in Step 4, deletion is successful.

#### 3. Bug 2: Positional Stability & Index-Based Reordering
* **The Problem**: Adding a new secondary range that sorts lexicographically before an existing range (or re-adding a range) triggers a positional shift diff in the TypeList schema, showing a "rename" at position 0 instead of a clean addition. In real-world in-use subnets, this positional re-ordering fails to apply.
* **The Solution**: 
  - I removed the reverted `unordered_list: true` breaking change (which broke schema structures and GKE clusters).
  - I replaced it with `resourceComputeSubnetworkSecondaryIpRangeSetStyleDiff` index alignment function in the subnetwork constants templates. It maps surviving/existing ranges to their original index slots, preventing positional shifts and schema breakage.

```release-note:bug
compute: fixed an issue in `google_compute_subnetwork` where `secondary_ip_range` entries linked to an `internal_range` could not be removed and adding new ranges would sometimes fail due to positional shifts ([#27175](https://github.com/hashicorp/terraform-provider-google/issues/27175))
```
