### PR TITLE
Migrate expandReservationAffinity/flattenReservationAffinity new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1121,7 +1121,7 @@ func hasNodeAffinitiesChanged(oScheduling, newScheduling map[string]interface{})
 	return false
 }
 
-func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.ReservationAffinity, error) {
+func expandReservationAffinity(d tpgresource.TerraformResourceData) (map[string]interface{}, error) {
 	_, ok := d.GetOk("reservation_affinity")
 	if !ok {
 		return nil, nil
@@ -1130,9 +1130,8 @@ func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.Re
 	prefix := "reservation_affinity.0"
 	reservationAffinityType := d.Get(prefix + ".type").(string)
 
-	affinity := compute.ReservationAffinity{
-		ConsumeReservationType: reservationAffinityType,
-		ForceSendFields:        []string{"ConsumeReservationType"},
+	affinity := map[string]interface{}{
+		"consumeReservationType": reservationAffinityType,
 	}
 
 	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
@@ -1142,30 +1141,32 @@ func expandReservationAffinity(d tpgresource.TerraformResourceData) (*compute.Re
 
 	prefix = prefix + ".specific_reservation.0"
 	if hasSpecificReservation {
-		affinity.Key = d.Get(prefix + ".key").(string)
-		affinity.ForceSendFields = append(affinity.ForceSendFields, "Key", "Values")
-
+		affinity["key"] = d.Get(prefix + ".key").(string)
+		values := []interface{}{}
 		for _, v := range d.Get(prefix + ".values").([]interface{}) {
-			affinity.Values = append(affinity.Values, v.(string))
+			values = append(values, v.(string))
 		}
+		affinity["values"] = values
 	}
 
-	return &affinity, nil
+	return affinity, nil
 }
 
-func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[string]interface{} {
+func flattenReservationAffinity(affinity map[string]interface{}) []map[string]interface{} {
 	if affinity == nil {
 		return nil
 	}
 
+	consumeType, _ := affinity["consumeReservationType"].(string)
 	flattened := map[string]interface{}{
-		"type": affinity.ConsumeReservationType,
+		"type": consumeType,
 	}
 
-	if affinity.ConsumeReservationType == "SPECIFIC_RESERVATION" {
+	if consumeType == "SPECIFIC_RESERVATION" {
+		key, _ := affinity["key"].(string)
 		flattened["specific_reservation"] = []map[string]interface{}{{"{{"}}
-			"key":    affinity.Key,
-			"values": affinity.Values,
+			"key":    key,
+			"values": affinity["values"],
 		{{"}}"}}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1888,14 +1888,14 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
-	raMap, err := expandReservationAffinity(d)
+	reservationAffinityMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
 	var reservationAffinity *compute.ReservationAffinity
-	if raMap != nil {
+	if reservationAffinityMap != nil {
 		reservationAffinity = &compute.ReservationAffinity{}
-		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
+		if err := tpgresource.Convert(reservationAffinityMap, reservationAffinity); err != nil {
 			return nil, fmt.Errorf("Error converting reservationAffinity: %s", err)
 		}
 	}
@@ -2449,15 +2449,15 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error setting desired_status: %s", err)
 		}
 	}
-	var raMap map[string]interface{}
+	var reservationAffinityMap map[string]interface{}
 	if instance.ReservationAffinity != nil {
 		var err error
-		raMap, err = tpgresource.ConvertToMap(instance.ReservationAffinity)
+		reservationAffinityMap, err = tpgresource.ConvertToMap(instance.ReservationAffinity)
 		if err != nil {
 			return fmt.Errorf("Error converting reservation_affinity: %s", err)
 		}
 	}
-	if err := d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
+	if err := d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinityMap)); err != nil {
 		return fmt.Errorf("Error setting reservation_affinity: %s", err)
 	}
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1888,9 +1888,16 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
-	reservationAffinity, err := expandReservationAffinity(d)
+	raMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
+	}
+	var reservationAffinity *compute.ReservationAffinity
+	if raMap != nil {
+		reservationAffinity = &compute.ReservationAffinity{}
+		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
+			return nil, fmt.Errorf("Error converting reservationAffinity: %s", err)
+		}
 	}
 
 	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)
@@ -2442,7 +2449,15 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Error setting desired_status: %s", err)
 		}
 	}
-	if err := d.Set("reservation_affinity", flattenReservationAffinity(instance.ReservationAffinity)); err != nil {
+	var raMap map[string]interface{}
+	if instance.ReservationAffinity != nil {
+		var err error
+		raMap, err = tpgresource.ConvertToMap(instance.ReservationAffinity)
+		if err != nil {
+			return fmt.Errorf("Error converting reservation_affinity: %s", err)
+		}
+	}
+	if err := d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
 		return fmt.Errorf("Error setting reservation_affinity: %s", err)
 	}
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1694,9 +1694,16 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
 		}
 	}
-	reservationAffinity, err := expandReservationAffinity(d)
+	raMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return err
+	}
+	var reservationAffinity *compute.ReservationAffinity
+	if raMap != nil {
+		reservationAffinity = &compute.ReservationAffinity{}
+		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
+			return fmt.Errorf("Error converting reservationAffinity: %s", err)
+		}
 	}
 	resourcePolicies := expandInstanceTemplateResourcePolicies(d, "resource_policies")
 
@@ -2250,7 +2257,11 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 
 	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+		raMap, err := tpgresource.ConvertToMap(reservationAffinity)
+		if err != nil {
+			return fmt.Errorf("Error converting reservation_affinity: %s", err)
+		}
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1694,14 +1694,14 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 			return fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
 		}
 	}
-	raMap, err := expandReservationAffinity(d)
+	reservationAffinityMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return err
 	}
 	var reservationAffinity *compute.ReservationAffinity
-	if raMap != nil {
+	if reservationAffinityMap != nil {
 		reservationAffinity = &compute.ReservationAffinity{}
-		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
+		if err := tpgresource.Convert(reservationAffinityMap, reservationAffinity); err != nil {
 			return fmt.Errorf("Error converting reservationAffinity: %s", err)
 		}
 	}
@@ -2257,11 +2257,11 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	}
 
 	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		raMap, err := tpgresource.ConvertToMap(reservationAffinity)
+		reservationAffinityMap, err := tpgresource.ConvertToMap(reservationAffinity)
 		if err != nil {
 			return fmt.Errorf("Error converting reservation_affinity: %s", err)
 		}
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinityMap)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -1787,11 +1787,11 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	}
 
 	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		raMap, err := tpgresource.ConvertToMap(reservationAffinity)
+		reservationAffinityMap, err := tpgresource.ConvertToMap(reservationAffinity)
 		if err != nil {
 			return fmt.Errorf("Error converting reservation_affinity: %s", err)
 		}
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinityMap)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -1446,11 +1446,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 		instanceProperties["advancedMachineFeatures"] = amfMap
 	}
 	if reservationAffinity != nil {
-		raMap, err := tpgresource.ConvertToMap(reservationAffinity)
-		if err != nil {
-			return fmt.Errorf("Error converting reservationAffinity: %s", err)
-		}
-		instanceProperties["reservationAffinity"] = raMap
+		instanceProperties["reservationAffinity"] = reservationAffinity
 	}
 	{{- if ne $.TargetVersionName "ga" }}
 	if len(PartnerMetadata) > 0 {
@@ -1791,7 +1787,11 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	}
 
 	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
-		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+		raMap, err := tpgresource.ConvertToMap(reservationAffinity)
+		if err != nil {
+			return fmt.Errorf("Error converting reservation_affinity: %s", err)
+		}
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(raMap)); err != nil {
 			return fmt.Errorf("Error setting reservation_affinity: %s", err)
 		}
 	}

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -161,8 +161,18 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 	var reservationAffinity *compute.ReservationAffinity
 	if raMap != nil {
 		reservationAffinity = &compute.ReservationAffinity{}
-		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
-			return nil, fmt.Errorf("Error converting reservation_affinity: %s", err)
+		if v, ok := raMap["consumeReservationType"].(string); ok {
+			reservationAffinity.ConsumeReservationType = v
+		}
+		if v, ok := raMap["key"].(string); ok {
+			reservationAffinity.Key = v
+		}
+		if vals, ok := raMap["values"].([]interface{}); ok {
+			for _, v := range vals {
+				if s, ok := v.(string); ok {
+					reservationAffinity.Values = append(reservationAffinity.Values, s)
+				}
+			}
 		}
 	}
 

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -154,9 +154,16 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
-	reservationAffinity, err := expandReservationAffinity(d)
+	raMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
+	}
+	var reservationAffinity *compute.ReservationAffinity
+	if raMap != nil {
+		reservationAffinity = &compute.ReservationAffinity{}
+		if err := tpgresource.Convert(raMap, reservationAffinity); err != nil {
+			return nil, fmt.Errorf("Error converting reservation_affinity: %s", err)
+		}
 	}
 
 	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -154,20 +154,20 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
-	raMap, err := expandReservationAffinity(d)
+	reservationAffinityMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
 	var reservationAffinity *compute.ReservationAffinity
-	if raMap != nil {
+	if reservationAffinityMap != nil {
 		reservationAffinity = &compute.ReservationAffinity{}
-		if v, ok := raMap["consumeReservationType"].(string); ok {
+		if v, ok := reservationAffinityMap["consumeReservationType"].(string); ok {
 			reservationAffinity.ConsumeReservationType = v
 		}
-		if v, ok := raMap["key"].(string); ok {
+		if v, ok := reservationAffinityMap["key"].(string); ok {
 			reservationAffinity.Key = v
 		}
-		if vals, ok := raMap["values"].([]interface{}); ok {
+		if vals, ok := reservationAffinityMap["values"].([]interface{}); ok {
 			for _, v := range vals {
 				if s, ok := v.(string); ok {
 					reservationAffinity.Values = append(reservationAffinity.Values, s)

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -154,26 +154,9 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
-	reservationAffinityMap, err := expandReservationAffinity(d)
+	reservationAffinity, err := expandReservationAffinityTgc(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
-	}
-	var reservationAffinity *compute.ReservationAffinity
-	if reservationAffinityMap != nil {
-		reservationAffinity = &compute.ReservationAffinity{}
-		if v, ok := reservationAffinityMap["consumeReservationType"].(string); ok {
-			reservationAffinity.ConsumeReservationType = v
-		}
-		if v, ok := reservationAffinityMap["key"].(string); ok {
-			reservationAffinity.Key = v
-		}
-		if vals, ok := reservationAffinityMap["values"].([]interface{}); ok {
-			for _, v := range vals {
-				if s, ok := v.(string); ok {
-					reservationAffinity.Values = append(reservationAffinity.Values, s)
-				}
-			}
-		}
 	}
 
 	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)
@@ -658,4 +641,31 @@ func expandSchedulingTgc(v interface{}) (*compute.Scheduling, error) {
 		scheduling.TerminationTime = v.(string)
 	}
 	return scheduling, nil
+}
+
+func expandReservationAffinityTgc(d tpgresource.TerraformResourceData) (*compute.ReservationAffinity, error) {
+	_, ok := d.GetOk("reservation_affinity")
+	if !ok {
+		return nil, nil
+	}
+
+	prefix := "reservation_affinity.0"
+	reservationAffinityType := d.Get(prefix + ".type").(string)
+
+	affinity := &compute.ReservationAffinity{
+		ConsumeReservationType: reservationAffinityType,
+	}
+
+	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
+	if (reservationAffinityType == "SPECIFIC_RESERVATION") != hasSpecificReservation {
+		return nil, fmt.Errorf("specific_reservation must be set when reservation_affinity is SPECIFIC_RESERVATION, and not set otherwise")
+	}
+
+	if hasSpecificReservation {
+		prefix = prefix + ".specific_reservation.0"
+		affinity.Key = d.Get(prefix + ".key").(string)
+		affinity.Values = tpgresource.ConvertStringArr(d.Get(prefix + ".values").([]interface{}))
+	}
+
+	return affinity, nil
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated `expandReservationAffinity` and `flattenReservationAffinity` functions to use direct HTTP rather than a client library
```
