### PR TITLE
Migrate expandNetworkPerformanceConfig / flattenNetworkPerformanceConfig new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1137,7 +1137,7 @@ func flattenReservationAffinity(affinity *compute.ReservationAffinity) []map[str
 	return []map[string]interface{}{flattened}
 }
 
-func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (*compute.NetworkPerformanceConfig, error) {
+func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (map[string]interface{}, error) {
 	configs, ok := d.GetOk("network_performance_config")
 	if !ok {
 		return nil, nil
@@ -1152,8 +1152,8 @@ func expandNetworkPerformanceConfig(d tpgresource.TerraformResourceData, config 
 		return nil, nil
 	}
 	npc := npcSlice[0].(map[string]interface{})
-	return &compute.NetworkPerformanceConfig{
-		TotalEgressBandwidthTier: npc["total_egress_bandwidth_tier"].(string),
+	return map[string]interface{}{
+		"totalEgressBandwidthTier": npc["total_egress_bandwidth_tier"].(string),
 	}, nil
 }
 
@@ -1185,13 +1185,13 @@ func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeatu
 	return result
 }
 
-func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[string]interface{} {
+func flattenNetworkPerformanceConfig(c map[string]interface{}) []map[string]interface{} {
 	if c == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"total_egress_bandwidth_tier": c.TotalEgressBandwidthTier,
+			"total_egress_bandwidth_tier": c["totalEgressBandwidthTier"],
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1872,9 +1872,16 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network interfaces: %s", err)
 	}
-	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
+	npcMap, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network performance config: %s", err)
+	}
+	var networkPerformanceConfig *compute.NetworkPerformanceConfig
+	if npcMap != nil {
+		networkPerformanceConfig = &compute.NetworkPerformanceConfig{}
+		if err := tpgresource.Convert(npcMap, networkPerformanceConfig); err != nil {
+			return nil, fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
+		}
 	}
 	accels, err := expandInstanceGuestAccelerators(d, config)
 	if err != nil {
@@ -2166,7 +2173,15 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("machine_type", tpgresource.GetResourceNameFromSelfLink(instance.MachineType)); err != nil {
 		return fmt.Errorf("Error setting machine_type: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)); err != nil {
+	var npcMap map[string]interface{}
+	if instance.NetworkPerformanceConfig != nil {
+		var err error
+		npcMap, err = tpgresource.ConvertToMap(instance.NetworkPerformanceConfig)
+		if err != nil {
+			return fmt.Errorf("Error converting network_performance_config: %s", err)
+		}
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
 	// Set the networks

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1683,9 +1683,16 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
+	npcMap, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil
+	}
+	var networkPerformanceConfig *compute.NetworkPerformanceConfig
+	if npcMap != nil {
+		networkPerformanceConfig = &compute.NetworkPerformanceConfig{}
+		if err := tpgresource.Convert(npcMap, networkPerformanceConfig); err != nil {
+			return fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
+		}
 	}
 	reservationAffinity, err := expandReservationAffinity(d)
 	if err != nil {
@@ -2149,7 +2156,15 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceTemplate.Properties.NetworkPerformanceConfig)); err != nil {
+	var npcMap map[string]interface{}
+	if instanceTemplate.Properties.NetworkPerformanceConfig != nil {
+		var err error
+		npcMap, err = tpgresource.ConvertToMap(instanceTemplate.Properties.NetworkPerformanceConfig)
+		if err != nil {
+			return fmt.Errorf("Error converting network_performance_config: %s", err)
+		}
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
 	if instanceTemplate.Properties.NetworkInterfaces != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -1421,11 +1421,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 		instanceProperties["metadata"] = metadataMap
 	}
 	if networkPerformanceConfig != nil {
-		npcMap, err := tpgresource.ConvertToMap(networkPerformanceConfig)
-		if err != nil {
-			return fmt.Errorf("Error converting networkPerformanceConfig: %s", err)
-		}
-		instanceProperties["networkPerformanceConfig"] = npcMap
+		instanceProperties["networkPerformanceConfig"] = networkPerformanceConfig
 	}
 	if tags := resourceInstanceTags(d); tags != nil {
 		tagsMap, err := tpgresource.ConvertToMap(tags)
@@ -1708,7 +1704,15 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 	if err = d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
 	}
-	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(instanceTemplate.Properties.NetworkPerformanceConfig)); err != nil {
+	var npcMap map[string]interface{}
+	if instanceTemplate.Properties.NetworkPerformanceConfig != nil {
+		var err error
+		npcMap, err = tpgresource.ConvertToMap(instanceTemplate.Properties.NetworkPerformanceConfig)
+		if err != nil {
+			return fmt.Errorf("Error converting network_performance_config: %s", err)
+		}
+	}
+	if err := d.Set("network_performance_config", flattenNetworkPerformanceConfig(npcMap)); err != nil {
 		return err
 	}
 	if instanceTemplate.Properties.NetworkInterfaces != nil {

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
@@ -59,7 +59,11 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 		hclData["can_ip_forward"] = instance.CanIpForward
 	}
 	hclData["machine_type"] = tpgresource.GetResourceNameFromSelfLink(instance.MachineType)
-	hclData["network_performance_config"] = flattenNetworkPerformanceConfig(instance.NetworkPerformanceConfig)
+	if instance.NetworkPerformanceConfig != nil {
+		hclData["network_performance_config"] = flattenNetworkPerformanceConfig(map[string]interface{}{
+			"totalEgressBandwidthTier": instance.NetworkPerformanceConfig.TotalEgressBandwidthTier,
+		})
+	}
 
 	// Set the networks
 	networkInterfaces, _, _, err := flattenNetworkInterfacesTgc(instance.NetworkInterfaces, project)

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -137,9 +137,16 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating network interfaces: %s", err)
 	}
 
-	networkPerformanceConfig, err := expandNetworkPerformanceConfig(d, config)
+	networkPerformanceConfigMap, err := expandNetworkPerformanceConfig(d, config)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating network performance config: %s", err)
+	}
+	var networkPerformanceConfig *compute.NetworkPerformanceConfig
+	if networkPerformanceConfigMap != nil {
+		networkPerformanceConfig = &compute.NetworkPerformanceConfig{}
+		if v, ok := networkPerformanceConfigMap["totalEgressBandwidthTier"].(string); ok {
+			networkPerformanceConfig.TotalEgressBandwidthTier = v
+		}
 	}
 
 	accels, err := expandInstanceGuestAccelerators(d, config)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated functions for `network_performance_config` field in `google_compute_instance`, `google_compute_region_instance_template` and `google_compute_instance_template` resources to use direct HTTP rather than a client library
```
