### PR TITLE
Migrate expandComputeInstanceEncryptionKey / flattenComputeInstanceEncryptionKey to new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1196,29 +1196,29 @@ func flattenNetworkPerformanceConfig(c *compute.NetworkPerformanceConfig) []map[
 	}
 }
 
-func expandComputeInstanceEncryptionKey(d tpgresource.TerraformResourceData) *compute.CustomerEncryptionKey {
+func expandComputeInstanceEncryptionKey(d tpgresource.TerraformResourceData) map[string]interface{} {
 	iek, ok := d.GetOk("instance_encryption_key")
 	if !ok {
 		return nil
 	}
 
 	iekRes := iek.([]interface{})[0].(map[string]interface{})
-	return &compute.CustomerEncryptionKey{
-		KmsKeyName:      	  iekRes["kms_key_self_link"].(string),
-		Sha256:          	  iekRes["sha256"].(string),
-		KmsKeyServiceAccount: iekRes["kms_key_service_account"].(string),
+	return map[string]interface{}{
+		"kmsKeyName":           iekRes["kms_key_self_link"].(string),
+		"sha256":               iekRes["sha256"].(string),
+		"kmsKeyServiceAccount": iekRes["kms_key_service_account"].(string),
 	}
 }
 
-func flattenComputeInstanceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
+func flattenComputeInstanceEncryptionKey(v map[string]interface{}) []map[string]interface{} {
 	if v == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"kms_key_self_link": 	   v.KmsKeyName,
-			"sha256":            	   v.Sha256,
-			"kms_key_service_account": v.KmsKeyServiceAccount,
+			"kms_key_self_link":       v["kmsKeyName"],
+			"sha256":                  v["sha256"],
+			"kms_key_service_account": v["kmsKeyServiceAccount"],
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1886,6 +1886,15 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
 
+	iekMap := expandComputeInstanceEncryptionKey(d)
+	var instanceEncryptionKey *compute.CustomerEncryptionKey
+	if iekMap != nil {
+		instanceEncryptionKey = &compute.CustomerEncryptionKey{}
+		if err := tpgresource.Convert(iekMap, instanceEncryptionKey); err != nil {
+			return nil, fmt.Errorf("Error converting instance_encryption_key: %s", err)
+		}
+	}
+
 	// Create the instance information
 	return &compute.Instance{
 		CanIpForward:               d.Get("can_ip_forward").(bool),
@@ -1916,7 +1925,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		ResourcePolicies:           tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{})),
 		ReservationAffinity:        reservationAffinity,
 		KeyRevocationActionType:    d.Get("key_revocation_action_type").(string),
-		InstanceEncryptionKey:      expandComputeInstanceEncryptionKey(d),
+		InstanceEncryptionKey:      instanceEncryptionKey,
 		{{- if ne $.TargetVersionName `ga` }}
 		EraseWindowsVssSignature:   d.Get("erase_windows_vss_signature").(bool),
 		{{- end }}
@@ -2424,7 +2433,15 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
-	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(instance.InstanceEncryptionKey)); err != nil {
+	var iekMap map[string]interface{}
+	if instance.InstanceEncryptionKey != nil {
+		var err error
+		iekMap, err = tpgresource.ConvertToMap(instance.InstanceEncryptionKey)
+		if err != nil {
+			return fmt.Errorf("Error converting instance_encryption_key: %s", err)
+		}
+	}
+	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(iekMap)); err != nil {
 		return fmt.Errorf("Error setting instance_encryption_key: %s", err)
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1886,11 +1886,11 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
 
-	iekMap := expandComputeInstanceEncryptionKey(d)
+	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)
 	var instanceEncryptionKey *compute.CustomerEncryptionKey
-	if iekMap != nil {
+	if instanceEncryptionKeyMap != nil {
 		instanceEncryptionKey = &compute.CustomerEncryptionKey{}
-		if err := tpgresource.Convert(iekMap, instanceEncryptionKey); err != nil {
+		if err := tpgresource.Convert(instanceEncryptionKeyMap, instanceEncryptionKey); err != nil {
 			return nil, fmt.Errorf("Error converting instance_encryption_key: %s", err)
 		}
 	}
@@ -2433,15 +2433,15 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if err := d.Set("key_revocation_action_type", instance.KeyRevocationActionType); err != nil {
 		return fmt.Errorf("Error setting key_revocation_action_type: %s", err)
 	}
-	var iekMap map[string]interface{}
+	var instanceEncryptionKeyMap map[string]interface{}
 	if instance.InstanceEncryptionKey != nil {
 		var err error
-		iekMap, err = tpgresource.ConvertToMap(instance.InstanceEncryptionKey)
+		instanceEncryptionKeyMap, err = tpgresource.ConvertToMap(instance.InstanceEncryptionKey)
 		if err != nil {
 			return fmt.Errorf("Error converting instance_encryption_key: %s", err)
 		}
 	}
-	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(iekMap)); err != nil {
+	if err := d.Set("instance_encryption_key", flattenComputeInstanceEncryptionKey(instanceEncryptionKeyMap)); err != nil {
 		return fmt.Errorf("Error setting instance_encryption_key: %s", err)
 	}
 

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
@@ -99,7 +99,13 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 	hclData["advanced_machine_features"] = flattenAdvancedMachineFeatures(instance.AdvancedMachineFeatures)
 	hclData["reservation_affinity"] = flattenReservationAffinityTgc(instance.ReservationAffinity)
 	hclData["key_revocation_action_type"] = strings.TrimSuffix(instance.KeyRevocationActionType, "_ON_KEY_REVOCATION")
-	hclData["instance_encryption_key"] = flattenComputeInstanceEncryptionKey(instance.InstanceEncryptionKey)
+	if instance.InstanceEncryptionKey != nil {
+		hclData["instance_encryption_key"] = flattenComputeInstanceEncryptionKey(map[string]interface{}{
+			"kmsKeyName":           instance.InstanceEncryptionKey.KmsKeyName,
+			"sha256":               instance.InstanceEncryptionKey.Sha256,
+			"kmsKeyServiceAccount": instance.InstanceEncryptionKey.KmsKeyServiceAccount,
+		})
+	}
 
 	// TODO: convert details from the boot disk assets (separate disk assets) into initialize_params in cai2hcl?
 	// It needs to integrate the disk assets into instance assets with the resolver.

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -152,6 +152,21 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
 	}
 
+	instanceEncryptionKeyMap := expandComputeInstanceEncryptionKey(d)
+	var instanceEncryptionKey *compute.CustomerEncryptionKey
+	if instanceEncryptionKeyMap != nil {
+		instanceEncryptionKey = &compute.CustomerEncryptionKey{}
+		if v, ok := instanceEncryptionKeyMap["kmsKeyName"].(string); ok {
+			instanceEncryptionKey.KmsKeyName = v
+		}
+		if v, ok := instanceEncryptionKeyMap["sha256"].(string); ok {
+			instanceEncryptionKey.Sha256 = v
+		}
+		if v, ok := instanceEncryptionKeyMap["kmsKeyServiceAccount"].(string); ok {
+			instanceEncryptionKey.KmsKeyServiceAccount = v
+		}
+	}
+
 	// Create the instance information
 	return &compute.Instance{
 		CanIpForward:               d.Get("can_ip_forward").(bool),
@@ -179,7 +194,7 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		ResourcePolicies:           tpgresource.ConvertStringArr(d.Get("resource_policies").([]interface{})),
 		ReservationAffinity:        reservationAffinity,
 		KeyRevocationActionType:    d.Get("key_revocation_action_type").(string),
-		InstanceEncryptionKey:      expandComputeInstanceEncryptionKey(d),
+		InstanceEncryptionKey:      instanceEncryptionKey,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated `expandComputeInstanceEncryptionKey ` and `flattenComputeInstanceEncryptionKey ` functions to use direct HTTP rather than a client library
```
