### PR TITLE
Migrate expandComputeInstanceSourceEncryptionKey / flattenComputeInstanceSourceEncryptionKey to new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1223,33 +1223,33 @@ func flattenComputeInstanceEncryptionKey(v *compute.CustomerEncryptionKey) []map
 	}
 }
 
-func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceData, field string) *compute.CustomerEncryptionKey {
+func expandComputeInstanceSourceEncryptionKey(d tpgresource.TerraformResourceData, field string) map[string]interface{} {
 	cek, ok := d.GetOk(field)
 	if !ok {
 		return nil
 	}
 
 	cekRes := cek.([]interface{})[0].(map[string]interface{})
-	return &compute.CustomerEncryptionKey{
-		RsaEncryptedKey:      cekRes["rsa_encrypted_key"].(string),
-		RawKey:               cekRes["raw_key"].(string),
-		KmsKeyName:           cekRes["kms_key_self_link"].(string),
-		Sha256:               cekRes["sha256"].(string),
-		KmsKeyServiceAccount: cekRes["kms_key_service_account"].(string),
+	return map[string]interface{}{
+		"rsaEncryptedKey":      cekRes["rsa_encrypted_key"].(string),
+		"rawKey":               cekRes["raw_key"].(string),
+		"kmsKeyName":           cekRes["kms_key_self_link"].(string),
+		"sha256":               cekRes["sha256"].(string),
+		"kmsKeyServiceAccount": cekRes["kms_key_service_account"].(string),
 	}
 }
 
-func flattenComputeInstanceSourceEncryptionKey(v *compute.CustomerEncryptionKey) []map[string]interface{} {
+func flattenComputeInstanceSourceEncryptionKey(v map[string]interface{}) []map[string]interface{} {
 	if v == nil {
 		return nil
 	}
 	return []map[string]interface{}{
 		{
-			"rsa_encrypted_key":       v.RsaEncryptedKey,
-			"raw_key":                 v.RawKey,
-			"kms_key_self_link":       v.KmsKeyName,
-			"sha256":                  v.Sha256,
-			"kms_key_service_account": v.KmsKeyServiceAccount,
+			"rsa_encrypted_key":       v["rsaEncryptedKey"],
+			"raw_key":                 v["rawKey"],
+			"kms_key_self_link":       v["kmsKeyName"],
+			"sha256":                  v["sha256"],
+			"kms_key_service_account": v["kmsKeyServiceAccount"],
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -4275,10 +4275,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_image_encryption_key"); ok {
-			siKey := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_image_encryption_key")
-			if siKey != nil {
+			sourceImageEncryptionKeyMap := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_image_encryption_key")
+			if sourceImageEncryptionKeyMap != nil {
 				disk.InitializeParams.SourceImageEncryptionKey = &compute.CustomerEncryptionKey{}
-				if err := tpgresource.Convert(siKey, disk.InitializeParams.SourceImageEncryptionKey); err != nil {
+				if err := tpgresource.Convert(sourceImageEncryptionKeyMap, disk.InitializeParams.SourceImageEncryptionKey); err != nil {
 					return nil, fmt.Errorf("Error converting source_image_encryption_key: %s", err)
 				}
 			}
@@ -4294,10 +4294,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"); ok {
-			ssKey := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_snapshot_encryption_key")
-			if ssKey != nil {
+			sourceSnapshotEncryptionKeyMap := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_snapshot_encryption_key")
+			if sourceSnapshotEncryptionKeyMap != nil {
 				disk.InitializeParams.SourceSnapshotEncryptionKey = &compute.CustomerEncryptionKey{}
-				if err := tpgresource.Convert(ssKey, disk.InitializeParams.SourceSnapshotEncryptionKey); err != nil {
+				if err := tpgresource.Convert(sourceSnapshotEncryptionKeyMap, disk.InitializeParams.SourceSnapshotEncryptionKey); err != nil {
 					return nil, fmt.Errorf("Error converting source_snapshot_encryption_key: %s", err)
 				}
 			}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -4275,7 +4275,13 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_image_encryption_key"); ok {
-			disk.InitializeParams.SourceImageEncryptionKey = expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_image_encryption_key")
+			siKey := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_image_encryption_key")
+			if siKey != nil {
+				disk.InitializeParams.SourceImageEncryptionKey = &compute.CustomerEncryptionKey{}
+				if err := tpgresource.Convert(siKey, disk.InitializeParams.SourceImageEncryptionKey); err != nil {
+					return nil, fmt.Errorf("Error converting source_image_encryption_key: %s", err)
+				}
+			}
 		}
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.snapshot"); ok {
@@ -4288,7 +4294,13 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 		}
 
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.source_snapshot_encryption_key"); ok {
-			disk.InitializeParams.SourceSnapshotEncryptionKey = expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_snapshot_encryption_key")
+			ssKey := expandComputeInstanceSourceEncryptionKey(d, "boot_disk.0.initialize_params.0.source_snapshot_encryption_key")
+			if ssKey != nil {
+				disk.InitializeParams.SourceSnapshotEncryptionKey = &compute.CustomerEncryptionKey{}
+				if err := tpgresource.Convert(ssKey, disk.InitializeParams.SourceSnapshotEncryptionKey); err != nil {
+					return nil, fmt.Errorf("Error converting source_snapshot_encryption_key: %s", err)
+				}
+			}
 		}
 
 		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.labels"); ok {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated `expandComputeInstanceSourceEncryptionKey ` and `flattenComputeInstanceSourceEncryptionKey ` functions to use direct HTTP rather than a client library
```
