### PR TITLE
Migrate expandComputeInstanceGuestOsFeatures / flattenComputeInstanceGuestOsFeatures to new API

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1161,26 +1161,28 @@ func flattenComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
-	features, ok := v.([]*compute.GuestOsFeature)
+	features, ok := v.([]interface{})
 	if !ok {
 		return nil
 	}
 	var result []interface{}
-	for _, feature := range features {
-		if feature != nil && feature.Type != "" {
-			result = append(result, feature.Type)
+	for _, raw := range features {
+		if m, ok := raw.(map[string]interface{}); ok {
+			if t, ok := m["type"].(string); ok && t != "" {
+				result = append(result, t)
+			}
 		}
 	}
 	return result
 }
 
-func expandComputeInstanceGuestOsFeatures(v interface{}) []*compute.GuestOsFeature {
+func expandComputeInstanceGuestOsFeatures(v interface{}) []interface{} {
 	if v == nil {
 		return nil
 	}
-	var result []*compute.GuestOsFeature
+	var result []interface{}
 	for _, feature := range v.([]interface{}) {
-		result = append(result, &compute.GuestOsFeature{Type: feature.(string)})
+		result = append(result, map[string]interface{}{"type": feature.(string)})
 	}
 	return result
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -4186,9 +4186,9 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.guest_os_features"); ok {
-		gofSlice := expandComputeInstanceGuestOsFeatures(v)
-		disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(gofSlice))
-		for i, raw := range gofSlice {
+		guestOsFeaturesSlice := expandComputeInstanceGuestOsFeatures(v)
+		disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(guestOsFeaturesSlice))
+		for i, raw := range guestOsFeaturesSlice {
 			disk.GuestOsFeatures[i] = &compute.GuestOsFeature{}
 			if m, ok := raw.(map[string]interface{}); ok && m != nil {
 				if err := tpgresource.Convert(m, disk.GuestOsFeatures[i]); err != nil {
@@ -4350,10 +4350,10 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 }
 
 func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config *transport_tpg.Config) []map[string]interface{} {
-	gofSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
+	guestOsFeaturesSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
 	for _, f := range disk.GuestOsFeatures {
 		if f != nil && f.Type != "" {
-			gofSlice = append(gofSlice, map[string]interface{}{"type": f.Type})
+			guestOsFeaturesSlice = append(guestOsFeaturesSlice, map[string]interface{}{"type": f.Type})
 		}
 	}
 	result := map[string]interface{}{
@@ -4361,7 +4361,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config 
 		"device_name": disk.DeviceName,
 		"mode":        disk.Mode,
 		"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
-		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(gofSlice),
+		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(guestOsFeaturesSlice),
 		"force_attach": d.Get("boot_disk.0.force_attach"),
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
 		// originally specified to avoid diffs.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -4186,7 +4186,16 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.guest_os_features"); ok {
-		disk.GuestOsFeatures = expandComputeInstanceGuestOsFeatures(v)
+		gofSlice := expandComputeInstanceGuestOsFeatures(v)
+		disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(gofSlice))
+		for i, raw := range gofSlice {
+			disk.GuestOsFeatures[i] = &compute.GuestOsFeature{}
+			if m, ok := raw.(map[string]interface{}); ok && m != nil {
+				if err := tpgresource.Convert(m, disk.GuestOsFeatures[i]); err != nil {
+					return nil, fmt.Errorf("Error converting guest_os_features: %s", err)
+				}
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_raw"); ok {
@@ -4341,12 +4350,18 @@ func expandBootDisk(d *schema.ResourceData, config *transport_tpg.Config, projec
 }
 
 func flattenBootDisk(d *schema.ResourceData, disk *compute.AttachedDisk, config *transport_tpg.Config) []map[string]interface{} {
+	gofSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
+	for _, f := range disk.GuestOsFeatures {
+		if f != nil && f.Type != "" {
+			gofSlice = append(gofSlice, map[string]interface{}{"type": f.Type})
+		}
+	}
 	result := map[string]interface{}{
 		"auto_delete": disk.AutoDelete,
 		"device_name": disk.DeviceName,
 		"mode":        disk.Mode,
 		"source":      tpgresource.ConvertSelfLinkToV1(disk.Source),
-		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(disk.GuestOsFeatures),
+		"guest_os_features":       flattenComputeInstanceGuestOsFeatures(gofSlice),
 		"force_attach": d.Get("boot_disk.0.force_attach"),
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
 		// originally specified to avoid diffs.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1593,7 +1593,16 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 		}
 
 		if v, ok := d.GetOk(prefix + ".guest_os_features"); ok {
-			disk.GuestOsFeatures = expandComputeInstanceGuestOsFeatures(v.([]interface{}))
+			gofSlice := expandComputeInstanceGuestOsFeatures(v.([]interface{}))
+			disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(gofSlice))
+			for i, raw := range gofSlice {
+				disk.GuestOsFeatures[i] = &compute.GuestOsFeature{}
+				if m, ok := raw.(map[string]interface{}); ok && m != nil {
+					if err := tpgresource.Convert(m, disk.GuestOsFeatures[i]); err != nil {
+						return nil, fmt.Errorf("Error converting guest_os_features: %s", err)
+					}
+				}
+			}
 		}
 
 		if v, ok := d.GetOk(prefix + ".architecture"); ok {
@@ -1877,6 +1886,12 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		diskMap["disk_encryption_key"] = encryption
 	}
 
+	gofSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
+	for _, f := range disk.GuestOsFeatures {
+		if f != nil && f.Type != "" {
+			gofSlice = append(gofSlice, map[string]interface{}{"type": f.Type})
+		}
+	}
 	diskMap["auto_delete"] = disk.AutoDelete
 	diskMap["boot"] = disk.Boot
 	diskMap["device_name"] = disk.DeviceName
@@ -1884,7 +1899,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 	diskMap["source"] = tpgresource.ConvertSelfLinkToV1(disk.Source)
 	diskMap["mode"] = disk.Mode
 	diskMap["type"] = disk.Type
-	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(disk.GuestOsFeatures)
+	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(gofSlice)
 	diskMap["architecture"] = configDisk["architecture"]
 
 	return diskMap, nil

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1593,9 +1593,9 @@ func buildDisks(d *schema.ResourceData, config *transport_tpg.Config) ([]*comput
 		}
 
 		if v, ok := d.GetOk(prefix + ".guest_os_features"); ok {
-			gofSlice := expandComputeInstanceGuestOsFeatures(v.([]interface{}))
-			disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(gofSlice))
-			for i, raw := range gofSlice {
+			guestOsFeaturesSlice := expandComputeInstanceGuestOsFeatures(v.([]interface{}))
+			disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(guestOsFeaturesSlice))
+			for i, raw := range guestOsFeaturesSlice {
 				disk.GuestOsFeatures[i] = &compute.GuestOsFeature{}
 				if m, ok := raw.(map[string]interface{}); ok && m != nil {
 					if err := tpgresource.Convert(m, disk.GuestOsFeatures[i]); err != nil {
@@ -1886,10 +1886,10 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 		diskMap["disk_encryption_key"] = encryption
 	}
 
-	gofSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
+	guestOsFeaturesSlice := make([]interface{}, 0, len(disk.GuestOsFeatures))
 	for _, f := range disk.GuestOsFeatures {
 		if f != nil && f.Type != "" {
-			gofSlice = append(gofSlice, map[string]interface{}{"type": f.Type})
+			guestOsFeaturesSlice = append(guestOsFeaturesSlice, map[string]interface{}{"type": f.Type})
 		}
 	}
 	diskMap["auto_delete"] = disk.AutoDelete
@@ -1899,7 +1899,7 @@ func flattenDisk(disk *compute.AttachedDisk, configDisk map[string]any, defaultP
 	diskMap["source"] = tpgresource.ConvertSelfLinkToV1(disk.Source)
 	diskMap["mode"] = disk.Mode
 	diskMap["type"] = disk.Type
-	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(gofSlice)
+	diskMap["guest_os_features"] = flattenComputeInstanceGuestOsFeatures(guestOsFeaturesSlice)
 	diskMap["architecture"] = configDisk["architecture"]
 
 	return diskMap, nil

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -311,7 +311,16 @@ func expandBootDisk(d tpgresource.TerraformResourceData, config *transport_tpg.C
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.guest_os_features"); ok {
-		disk.GuestOsFeatures = expandComputeInstanceGuestOsFeatures(v)
+		guestOsFeaturesSlice := expandComputeInstanceGuestOsFeatures(v)
+		disk.GuestOsFeatures = make([]*compute.GuestOsFeature, len(guestOsFeaturesSlice))
+		for i, raw := range guestOsFeaturesSlice {
+			disk.GuestOsFeatures[i] = &compute.GuestOsFeature{}
+			if m, ok := raw.(map[string]interface{}); ok && m != nil {
+				if t, ok := m["type"].(string); ok {
+					disk.GuestOsFeatures[i].Type = t
+				}
+			}
+		}
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_raw"); ok {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: migrated `expandComputeInstanceGuestOsFeatures ` and `flattenComputeInstanceGuestOsFeatures ` functions to use direct HTTP rather than a client library
```
