### PR TITLE
Handle 403/404 on ephemeral SA key deletion

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -259,6 +259,10 @@ func (p *googleEphemeralServiceAccountKey) Close(ctx context.Context, req epheme
 	log.Printf("[DEBUG] Deleting Service Account Key %q\n", data.Name)
 	keys := iambeta.NewClient(p.providerConfig, p.providerConfig.UserAgent).Projects.ServiceAccounts.Keys
 	if _, err := keys.Delete(data.Name).Do(); err != nil {
+		if transport_tpg.IsGoogleApiErrorWithCode(err, 403) || transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+			log.Printf("[DEBUG] Got a 403 or 404 error trying to delete service account key %s, assuming it's already gone: %s", data.Name, err)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error deleting Service Account Key",
 			fmt.Sprintf("Error deleting Service Account Key %q: %s", data.Name, err.Error()),


### PR DESCRIPTION
This change updates close() in ephemeral `google_service_account_key` to ignores 403/404 errors when deleting the resource if the parent service account is already gone, aligning with how [`google_service_account_key`](https://github.com/GoogleCloudPlatform/magic-modules/blob/72e2406eea18da20000161e478b2a68e1651bed2/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_key.go#L237-L247) handles delete.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27362
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27339


<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
resourcemanager: fixed a bug where ephemeral `google_service_account_key` failed on deletion if the parent service account had already been deleted
```
