### PR TITLE
`fix`: remove `firebasestorage` import in `firebaserules_release_generated_test.go.tmpl`

### DIFF
--- a/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
@@ -13,6 +13,7 @@ import (
 {{- if ne $.TargetVersionName "ga" }}
 	_ "github.com/hashicorp/terraform-provider-google/google/services/firebasestorage"
 {{- end }}
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/firebaserules"
 	dcl "github.com/hashicorp/terraform-provider-google/google/tpgdclresource"
 )

--- a/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-{{- if ne $.TargetVersionName "ga" }}
 	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
+{{- if ne $.TargetVersionName "ga" }}
+	_ "github.com/hashicorp/terraform-provider-google/google/services/firebasestorage"
 {{- end }}
-	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/firebaserules"
 	dcl "github.com/hashicorp/terraform-provider-google/google/tpgdclresource"
 )

--- a/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/firebasestorage"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/firebaserules"
 	dcl "github.com/hashicorp/terraform-provider-google/google/tpgdclresource"

--- a/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/firebaserules/resource_firebaserules_release_generated_test.go.tmpl
@@ -9,7 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+{{- if ne $.TargetVersionName "ga" }}
 	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
+{{- end }}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/firebaserules"
 	dcl "github.com/hashicorp/terraform-provider-google/google/tpgdclresource"


### PR DESCRIPTION
We've been getting build errors within `firebaserules` service due to:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17646/changes

<img width="2698" height="1232" alt="image" src="https://github.com/user-attachments/assets/6d8b1868-ab82-4851-8fe4-d8cce06ac0eb" />

This only applies to the test file as an import of firebasestorage was being applied despite it not existing anymore. Removing this resolves the build error we've been seeing in [TeamCity nightly](https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS_GOOGLE_PACKAGE_FIREBASERULES/670162)

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
