### PR TITLE
tgc-revival: Support node_config.gpudirect_strategy in GKE Node Pools

### DIFF
--- a/mmv1/products/datastream/PrivateConnection.yaml
+++ b/mmv1/products/datastream/PrivateConnection.yaml
@@ -162,12 +162,14 @@ properties:
       - 'psc_interface_config'
     properties:
       - name: 'vpc'
+        is_missing_in_cai: true
         type: String
         description: |
           Fully qualified name of the VPC that Datastream will peer to.
           Format: projects/{project}/global/{networks}/{name}
         required: true
       - name: 'subnet'
+        is_missing_in_cai: true
         type: String
         description: |
           A free subnet for peering. (CIDR of /29)

--- a/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/node_config.go
@@ -484,6 +484,13 @@ func schemaNodeConfig() *schema.Schema {
 					Description: `The name of a Google Compute Engine machine type.`,
 				},
 
+				"gpudirect_strategy": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					ForceNew:    true,
+					Description: `GPUDirect RDMA strategy for the node pool.`,
+				},
+
 				"metadata": {
 					Type:        schema.TypeMap,
 					Optional:    true,
@@ -1445,6 +1452,10 @@ func expandNodeConfig(d tpgresource.TerraformResourceData, prefix string, v inte
 
 	if v, ok := nodeConfig["machine_type"]; ok {
 		nc.MachineType = v.(string)
+	}
+
+	if v, ok := nodeConfig["gpudirect_strategy"]; ok {
+		nc.GpuDirectConfig = expandGpuDirectConfig(v)
 	}
 
 	if v, ok := nodeConfig["guest_accelerator"]; ok {
@@ -2521,6 +2532,7 @@ func flattenNodeConfig(v interface{}, _ interface{}) []map[string]interface{} {
 
 	transformed := map[string]interface{}{
 		"machine_type":                       c["machineType"],
+		"gpudirect_strategy":                 flattenGpuDirectConfig(c["gpuDirectConfig"]),
 		"containerd_config":                  flattenContainerdConfig(c["containerdConfig"]),
 		"disk_size_gb":                       c["diskSizeGb"],
 		"disk_type":                          c["diskType"],
@@ -3594,4 +3606,32 @@ func flattenFastSocket(v interface{}) []map[string]interface{} {
 	}
 
 	return []map[string]interface{}{transformed}
+}
+
+// GPUDirectConfig is currently directly stored as a GpuDirectStrategy string.
+func expandGpuDirectConfig(v interface{}) *container.GPUDirectConfig {
+	if v == nil || v.(string) == "" {
+		return nil
+	}
+
+	return &container.GPUDirectConfig{
+		GpuDirectStrategy: v.(string),
+	}
+}
+
+// GPUDirectConfig currently only has one field, flatten directly to string.
+func flattenGpuDirectConfig(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	c, ok := v.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	strategy, ok := c["gpuDirectStrategy"].(string)
+	if !ok {
+		return ""
+	}
+	return strategy
 }

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// Writes the data into a JSON file test
+// Writes the data into a JSON file
 func writeJSONFile(filename string, data interface{}) error {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Support GKE node pool gpudirect_strategy in GKE Node Pools.

```release-note:none
```