### PR TITLE
`appengine`: bump to `nodejs22` to resolve 400 errors

### DIFF
--- a/mmv1/templates/terraform/examples/app_engine_application_url_dispatch_rules_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_application_url_dispatch_rules_basic.tf.tmpl
@@ -15,7 +15,7 @@ resource "google_app_engine_application_url_dispatch_rules" "{{$.PrimaryResource
 resource "google_app_engine_standard_app_version" "admin_v3" {
   version_id = "v3"
   service    = "admin"
-  runtime    = "nodejs20"
+  runtime    = "nodejs22"
 
   entrypoint {
     shell = "node ./app.js"

--- a/mmv1/templates/terraform/examples/app_engine_service_network_settings.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_service_network_settings.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_app_engine_standard_app_version" "internalapp" {
   service = "internalapp"
   delete_service_on_destroy = true
 
-  runtime = "nodejs20"
+  runtime = "nodejs22"
   entrypoint {
     shell = "node ./app.js"
   }

--- a/mmv1/templates/terraform/examples/app_engine_service_split_traffic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_service_split_traffic.tf.tmpl
@@ -14,7 +14,7 @@ resource "google_app_engine_standard_app_version" "liveapp_v1" {
   service = "liveapp"
   delete_service_on_destroy = true
 
-  runtime = "nodejs20"
+  runtime = "nodejs22"
   entrypoint {
     shell = "node ./app.js"
   }
@@ -33,7 +33,7 @@ resource "google_app_engine_standard_app_version" "liveapp_v2" {
   service = "liveapp"
   noop_on_destroy = true
 
-  runtime = "nodejs20"
+  runtime = "nodejs22"
   entrypoint {
     shell = "node ./app.js"
   }

--- a/mmv1/templates/terraform/examples/app_engine_standard_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_standard_app_version.tf.tmpl
@@ -18,7 +18,7 @@ resource "google_project_iam_member" "storage_viewer" {
 resource "google_app_engine_standard_app_version" "{{$.PrimaryResourceId}}" {
   version_id = "v1"
   service    = "myapp"
-  runtime    = "nodejs20"
+  runtime    = "nodejs22"
 
   entrypoint {
     shell = "node ./app.js"
@@ -55,7 +55,7 @@ resource "google_app_engine_standard_app_version" "{{$.PrimaryResourceId}}" {
 resource "google_app_engine_standard_app_version" "myapp_v2" {
   version_id      = "v2"
   service         = "myapp"
-  runtime         = "nodejs20"
+  runtime         = "nodejs22"
   app_engine_apis = true
 
   entrypoint {

--- a/mmv1/templates/terraform/examples/iap_app_engine_service.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iap_app_engine_service.tf.tmpl
@@ -37,7 +37,7 @@ resource "google_app_engine_standard_app_version" "version" {
   project         = google_app_engine_application.app.project
   version_id      = "v2"
   service         = "default"
-  runtime         = "nodejs20"
+  runtime         = "nodejs22"
   noop_on_destroy = true
 
   // TODO: Removed basic scaling once automatic_scaling refresh behavior is fixed.

--- a/mmv1/templates/terraform/examples/iap_app_engine_version.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iap_app_engine_version.tf.tmpl
@@ -12,7 +12,7 @@ resource "google_storage_bucket_object" "object" {
 resource "google_app_engine_standard_app_version" "version" {
   version_id      = "%{random_suffix}"
   service         = "default"
-  runtime         = "nodejs20"
+  runtime         = "nodejs22"
   noop_on_destroy = false
 
   entrypoint {

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_service_network_settings_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_service_network_settings_test.go
@@ -58,7 +58,7 @@ resource "google_app_engine_standard_app_version" "app" {
   service = "app-%{random_suffix}"
   delete_service_on_destroy = true
 
-  runtime = "nodejs20"
+  runtime = "nodejs22"
   entrypoint {
     shell = "node ./app.js"
   }
@@ -98,7 +98,7 @@ resource "google_app_engine_standard_app_version" "app" {
   service = "app-%{random_suffix}"
   delete_service_on_destroy = true
 
-  runtime = "nodejs20"
+  runtime = "nodejs22"
   entrypoint {
     shell = "node ./app.js"
   }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We've been running into tests failing in nightly due to being on a nodejs version that is not allowed anymore, resolving the failures involves bumping to `nodejs22`

```console
=== CONT  TestAccAppEngineStandardAppVersion_appEngineStandardAppVersionExample
    resource_app_engine_standard_app_version_generated_test.go:71: Step 1/3 error: Error running apply: exit status 1
        Error: Error creating StandardAppVersion: googleapi: Error 400: Error(s) encountered validating runtime. Runtime nodejs20 is end of support and no longer allowed. Please use the latest Node.js runtime for App Engine Standard..
          with google_app_engine_standard_app_version.myapp_v1,
          on terraform_plugin_test.tf line 29, in resource "google_app_engine_standard_app_version" "myapp_v1":
          29: resource "google_app_engine_standard_app_version" "myapp_v1" {
        Error: Error creating StandardAppVersion: googleapi: Error 400: Error(s) encountered validating runtime. Runtime nodejs20 is end of support and no longer allowed. Please use the latest Node.js runtime for App Engine Standard..
          with google_app_engine_standard_app_version.myapp_v2,
          on terraform_plugin_test.tf line 66, in resource "google_app_engine_standard_app_version" "myapp_v2":
          66: resource "google_app_engine_standard_app_version" "myapp_v2" {
--- FAIL: TestAccAppEngineStandardAppVersion_appEngineStandardAppVersionExample (40.31s)
```

Fixes around ~20 failing tests that were detected within the [last week](https://github.com/hashicorp/terraform-provider-google/issues?q=is%3Aissue+is%3Aopen+label%3Atest-failure+created%3A%3E%3D%40today-7d)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
