### PR TITLE
Migrate flattenGuestAccelerators, resourceInstanceTags functions in compute_instance_helpers.go.tmpl to use direct HTTP rather than a client library   service/compute-instances

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -997,32 +997,49 @@ func serviceAccountsToInterface(serviceAccounts []*compute.ServiceAccount) []int
 	return result
 }
 
-func flattenGuestAccelerators(accelerators []*compute.AcceleratorConfig) []map[string]interface{} {
-	acceleratorsSchema := make([]map[string]interface{}, len(accelerators))
-	for i, accelerator := range accelerators {
-		acceleratorsSchema[i] = map[string]interface{}{
-			"count": accelerator.AcceleratorCount,
-			"type":  accelerator.AcceleratorType,
+func flattenGuestAccelerators(accelerators []interface{}) []map[string]interface{} {
+	acceleratorsSchema := make([]map[string]interface{}, 0, len(accelerators))
+	for _, raw := range accelerators {
+		accelerator, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
 		}
+		acceleratorsSchema = append(acceleratorsSchema, map[string]interface{}{
+			"count": accelerator["acceleratorCount"],
+			"type":  accelerator["acceleratorType"],
+		})
 	}
 	return acceleratorsSchema
 }
 
-func resourceInstanceTags(d tpgresource.TerraformResourceData) *compute.Tags {
-	// Calculate the tags
-	var tags *compute.Tags
-	if v := d.Get("tags"); v != nil {
-		vs := v.(*schema.Set)
-		tags = new(compute.Tags)
-		tags.Items = make([]string, vs.Len())
-		for i, v := range vs.List() {
-			tags.Items[i] = v.(string)
+// guestAcceleratorsToInterface adapts typed []*compute.AcceleratorConfig decoded
+// from an Apiary response into the []interface{} form accepted by
+// flattenGuestAccelerators.
+func guestAcceleratorsToInterface(accelerators []*compute.AcceleratorConfig) []interface{} {
+	result := make([]interface{}, len(accelerators))
+	for i, a := range accelerators {
+		result[i] = map[string]interface{}{
+			"acceleratorCount": a.AcceleratorCount,
+			"acceleratorType":  a.AcceleratorType,
 		}
-
-		tags.Fingerprint = d.Get("tags_fingerprint").(string)
 	}
+	return result
+}
 
-	return tags
+func resourceInstanceTags(d tpgresource.TerraformResourceData) map[string]interface{} {
+	v := d.Get("tags")
+	if v == nil {
+		return nil
+	}
+	vs := v.(*schema.Set)
+	items := make([]string, vs.Len())
+	for i, v := range vs.List() {
+		items[i] = v.(string)
+	}
+	return map[string]interface{}{
+		"items":       items,
+		"fingerprint": d.Get("tags_fingerprint").(string),
+	}
 }
 
 func expandShieldedVmConfigs(d tpgresource.TerraformResourceData) map[string]interface{} {

--- a/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
+++ b/mmv1/third_party/terraform/services/compute/data_source_google_compute_instance.go
@@ -157,7 +157,7 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	err = d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators))
+	err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instance.GuestAccelerators)))
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1907,6 +1907,15 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
+	tagsMap := resourceInstanceTags(d)
+	var tags *compute.Tags
+	if tagsMap != nil {
+		tags = &compute.Tags{}
+		if err := tpgresource.Convert(tagsMap, tags); err != nil {
+			return nil, fmt.Errorf("Error converting tags: %s", err)
+		}
+	}
+
 	reservationAffinityMap, err := expandReservationAffinity(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating reservation affinity: %s", err)
@@ -1941,7 +1950,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		Name:                       d.Get("name").(string),
 		NetworkInterfaces:          networkInterfaces,
 		NetworkPerformanceConfig:   networkPerformanceConfig,
-		Tags:                       resourceInstanceTags(d),
+		Tags:                       tags,
 		Params:                     params,
 		Labels:                     tpgresource.ExpandEffectiveLabels(d),
 		ServiceAccounts:            expandServiceAccountsTyped(d.Get("service_account").([]interface{})),
@@ -2429,7 +2438,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	}
 {{- end }}
 
-	if err := d.Set("guest_accelerator", flattenGuestAccelerators(instance.GuestAccelerators)); err != nil {
+	if err := d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instance.GuestAccelerators))); err != nil {
 		return fmt.Errorf("Error setting guest_accelerator: %s", err)
 	}
 	var shieldedVmConfigMap map[string]interface{}
@@ -2742,15 +2751,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 {{ end }}
 	if d.HasChange("tags") {
-		tags := resourceInstanceTags(d)
-		tagsV1 := &compute.Tags{}
-		if err := tpgresource.Convert(tags, tagsV1); err != nil {
-			return err
-		}
-		tagsBody, err := tpgresource.ConvertToMap(tagsV1)
-		if err != nil {
-			return fmt.Errorf("Error converting tags: %s", err)
-		}
+		tagsBody := resourceInstanceTags(d)
 		url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}/setTags")
 		if err != nil {
 			return fmt.Errorf("Error generating URL: %s", err)

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1716,6 +1716,15 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	}
 	resourcePolicies := expandInstanceTemplateResourcePolicies(d, "resource_policies")
 
+	tagsMap := resourceInstanceTags(d)
+	var tags *compute.Tags
+	if tagsMap != nil {
+		tags = &compute.Tags{}
+		if err := tpgresource.Convert(tagsMap, tags); err != nil {
+			return fmt.Errorf("Error converting tags: %s", err)
+		}
+	}
+
 	instanceProperties := &compute.InstanceProperties{
 		CanIpForward:               d.Get("can_ip_forward").(bool),
 		Description:                d.Get("instance_description").(string),
@@ -1731,7 +1740,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		NetworkPerformanceConfig:   networkPerformanceConfig,
 		Scheduling:                 scheduling,
 		ServiceAccounts:            expandServiceAccountsTyped(d.Get("service_account").([]interface{})),
-		Tags:                       resourceInstanceTags(d),
+		Tags:                       tags,
 		AdvancedMachineFeatures:    expandAdvancedMachineFeatures(d),
 		ResourcePolicies:           resourcePolicies,
 		ReservationAffinity:        reservationAffinity,
@@ -2261,7 +2270,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		}
 	}
 	if instanceTemplate.Properties.GuestAccelerators != nil {
-		if err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceTemplate.Properties.GuestAccelerators)); err != nil {
+		if err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instanceTemplate.Properties.GuestAccelerators))); err != nil {
 			return fmt.Errorf("Error setting guest_accelerator: %s", err)
 		}
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -1417,11 +1417,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 	if networkPerformanceConfig != nil {
 		instanceProperties["networkPerformanceConfig"] = networkPerformanceConfig
 	}
-	if tags := resourceInstanceTags(d); tags != nil {
-		tagsMap, err := tpgresource.ConvertToMap(tags)
-		if err != nil {
-			return fmt.Errorf("Error converting tags: %s", err)
-		}
+	if tagsMap := resourceInstanceTags(d); tagsMap != nil {
 		instanceProperties["tags"] = tagsMap
 	}
 	if cic := expandConfidentialInstanceConfig(d); cic != nil {
@@ -1751,7 +1747,7 @@ func resourceComputeRegionInstanceTemplateRead(d *schema.ResourceData, meta inte
 		}
 	}
 	if instanceTemplate.Properties.GuestAccelerators != nil {
-		if err = d.Set("guest_accelerator", flattenGuestAccelerators(instanceTemplate.Properties.GuestAccelerators)); err != nil {
+		if err = d.Set("guest_accelerator", flattenGuestAccelerators(guestAcceleratorsToInterface(instanceTemplate.Properties.GuestAccelerators))); err != nil {
 			return fmt.Errorf("Error setting guest_accelerator: %s", err)
 		}
 	}

--- a/mmv1/third_party/tgc/services/compute/compute_instance.go.tmpl
+++ b/mmv1/third_party/tgc/services/compute/compute_instance.go.tmpl
@@ -144,6 +144,15 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating guest accelerators: %s", err)
 	}
 
+	tagsMap := resourceInstanceTags(d)
+	var tags *compute.Tags
+	if tagsMap != nil {
+		tags = &compute.Tags{}
+		if err := tpgresource.Convert(tagsMap, tags); err != nil {
+			return nil, fmt.Errorf("Error converting tags: %s", err)
+		}
+	}
+
 	// Create the instance information
 	instance := &compute.Instance{
 		CanIpForward:            d.Get("can_ip_forward").(bool),
@@ -154,7 +163,7 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		Name:                    d.Get("name").(string),
 		Zone:                    d.Get("zone").(string),
 		NetworkInterfaces:       networkInterfaces,
-		Tags:                    resourceInstanceTags(d),
+		Tags:                    tags,
 		Labels:                  tpgresource.ExpandLabels(d),
 		ServiceAccounts:         expandServiceAccountsTyped(d.Get("service_account").([]interface{})),
 		GuestAccelerators:       accels,

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -168,6 +168,15 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		}
 	}
 
+	tagsMap := resourceInstanceTags(d)
+	var tags *compute.Tags
+	if tagsMap != nil {
+		tags = &compute.Tags{
+			Items:       tagsMap["items"].([]string),
+			Fingerprint: tagsMap["fingerprint"].(string),
+		}
+	}
+
 	// Create the instance information
 	instance := &compute.Instance{
 		CanIpForward:             d.Get("can_ip_forward").(bool),
@@ -179,7 +188,7 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		Zone:                     d.Get("zone").(string),
 		NetworkInterfaces:        networkInterfaces,
 		NetworkPerformanceConfig: networkPerformanceConfig,
-		Tags:                     resourceInstanceTags(d),
+		Tags:                     tags,
 		Params:                   params,
 		Labels:                   tpgresource.ExpandLabels(d),
 		ServiceAccounts:          expandServiceAccountsTyped(d.Get("service_account").([]interface{})),


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
migrated compute_instance_helpers interfaces
```
