### PR TITLE
`datastream`: fix `TestAccDatastreamConnectionProfile_datastreamConnectionProfileFullExample`

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -74,9 +74,6 @@ examples:
     primary_resource_id: 'default'
     vars:
       connection_profile_id: 'my-profile'
-      # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/12410
-    ignore_read_extra:
-      - 'forward_ssh_connectivity.0.password'
   - name: 'datastream_connection_profile_postgres'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/templates/terraform/examples/datastream_connection_profile_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/datastream_connection_profile_full.tf.tmpl
@@ -7,13 +7,6 @@ resource "google_datastream_connection_profile" "{{$.PrimaryResourceId}}" {
 		bucket    = "my-bucket"
 		root_path = "/path"
 	}
-
-	forward_ssh_connectivity {
-		hostname = "google.com"
-		username = "my-user"
-		port     = 8022
-		password = "swordfish"
-	}
 	labels = {
 		key = "value"
 	}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

sometime around january 24th the api does not accept `forward_ssh_connectivity` block when using `gcs_profile`. We can confirm this by reviewing the gcs_profile section in the datastream connection profile [guide](https://docs.cloud.google.com/datastream/docs/create-connection-profiles#cp4cloudstorage). There is no mention of ssh tunnel which can be found in other profile types such as SQL server

Fixes https://github.com/hashicorp/terraform-provider-google/issues/25578

investigation came from reviewing [TeamCity Build Nighly test for datastream](https://hashicorp.teamcity.com/test/8347509247226202175?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS&expandedTest=build%3A%28id%3A664986%29%2Cid%3A2000000051)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
