### PR TITLE
`bigquery`: fix `TestAccBigQueryDataset_collationUpdate`

### DIFF
--- a/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
@@ -31,17 +31,11 @@ func validateDefaultTableExpirationMs(v interface{}, k string) (ws []string, err
 }
 
 func customCollationDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// 1. Check if the configuration is explicitly set to an empty string.
-	// We use GetRawConfig to see what the user actually wrote,
-	// before the SDK "fills in" computed values.
+	// Use raw config so we can distinguish an explicit "" from an omitted value.
 	conf := d.GetRawConfig()
 	if !conf.IsNull() && conf.GetAttr("default_collation").IsKnown() && !conf.GetAttr("default_collation").IsNull() {
 		val := conf.GetAttr("default_collation").AsString()
-
-		// 2. If config is "", but the state (old value) is NOT "", force an update.
-		old, _ := d.GetChange("default_collation")
-		if old != "" && val == "" {
-			// THIS is what goes inside the block:
+		if val == "" && d.HasChange("default_collation") {
 			if err := d.SetNew("default_collation", ""); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We've been getting [failures](https://hashicorp.teamcity.com/test/8347509247226202175?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_NIGHTLYTESTS) due to the collation diff failing when going from a value to a `""` value.

```console
------- Stdout: -------
=== RUN   TestAccBigQueryDataset_collationUpdate
=== PAUSE TestAccBigQueryDataset_collationUpdate
=== CONT  TestAccBigQueryDataset_collationUpdate
    resource_bigquery_dataset_test.go:592: Step 3/4 error: Check failed: Check 1/2 error: Check 1/1 error: google_bigquery_dataset.test: Attribute 'default_collation' expected "", got "und:ci"
--- FAIL: TestAccBigQueryDataset_collationUpdate (17.44s)
FAIL
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
