### PR TITLE
Remove beta restriction for ontapSource field in Backup resource

### DIFF
--- a/mmv1/products/netapp/Backup.yaml
+++ b/mmv1/products/netapp/Backup.yaml
@@ -151,7 +151,6 @@ properties:
       Details of the ONTAP source volume and snapshot.
     required: false
     immutable: true
-    min_version: beta
     properties:
       - name: 'storagePool'
         type: String
@@ -171,6 +170,7 @@ properties:
         description: |
           The UUID of the ONTAP source snapshot.
         immutable: true
+        default_from_api: true
   - name: 'volumeRegion'
     type: String
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
netapp: added `ontap_source` field to `google_netapp_backup` resource (ga)
```

```release-note:enhancement
netapp: marked `ontap_source.snapshot_uuid` field as Computed in `google_netapp_backup` resource (beta)
```
