### PR TITLE
retry Cloud Scheduler 409 sync mutate cannot be queued

### DIFF
--- a/mmv1/products/cloudscheduler/Job.yaml
+++ b/mmv1/products/cloudscheduler/Job.yaml
@@ -30,6 +30,8 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+error_retry_predicates:
+  - is409SyncMutateCannotBeQueuedError
 custom_code:
   constants: 'templates/terraform/constants/scheduler.tmpl'
   encoder: 'templates/terraform/encoders/cloud_scheduler.go.tmpl'

--- a/mmv1/products/cloudscheduler/Job.yaml
+++ b/mmv1/products/cloudscheduler/Job.yaml
@@ -31,7 +31,7 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 error_retry_predicates:
-  - is409SyncMutateCannotBeQueuedError
+  - transport_tpg.Is409SyncMutateCannotBeQueuedError
 custom_code:
   constants: 'templates/terraform/constants/scheduler.tmpl'
   encoder: 'templates/terraform/encoders/cloud_scheduler.go.tmpl'

--- a/mmv1/templates/terraform/constants/scheduler.tmpl
+++ b/mmv1/templates/terraform/constants/scheduler.tmpl
@@ -87,3 +87,14 @@ func validateHttpHeaders() schema.SchemaValidateFunc {
 		return
 	}
 }
+
+func is409SyncMutateCannotBeQueuedError(err error) (bool, string) {
+	if err == nil {
+		return false, ""
+	}
+	errStr := err.Error()
+	if strings.Contains(errStr, "Error 409") && strings.Contains(errStr, "sync mutate calls cannot be queued") {
+		return true, "sync mutate calls cannot be queued"
+	}
+	return false, ""
+}

--- a/mmv1/templates/terraform/constants/scheduler.tmpl
+++ b/mmv1/templates/terraform/constants/scheduler.tmpl
@@ -87,14 +87,3 @@ func validateHttpHeaders() schema.SchemaValidateFunc {
 		return
 	}
 }
-
-func is409SyncMutateCannotBeQueuedError(err error) (bool, string) {
-	if err == nil {
-		return false, ""
-	}
-	errStr := err.Error()
-	if strings.Contains(errStr, "Error 409") && strings.Contains(errStr, "sync mutate calls cannot be queued") {
-		return true, "sync mutate calls cannot be queued"
-	}
-	return false, ""
-}

--- a/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/services/cloudscheduler"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
 func TestAccCloudSchedulerJob_schedulerPausedExample(t *testing.T) {
@@ -123,4 +124,35 @@ resource "google_cloud_scheduler_job" "job" {
   }
 }
 `, context)
+}
+
+func TestUnitCloudSchedulerJob_Is409SyncMutateCannotBeQueuedError(t *testing.T) {
+	cases := map[string]struct {
+		Err      error
+		Expected bool
+	}{
+		"sync mutate cannot be queued error": {
+			Err:      fmt.Errorf("googleapi: Error 409: sync mutate calls cannot be queued"),
+			Expected: true,
+		},
+		"operation in progress error": {
+			Err:      fmt.Errorf("googleapi: Error 409: operationInProgress"),
+			Expected: false,
+		},
+		"generic error": {
+			Err:      fmt.Errorf("some generic error"),
+			Expected: false,
+		},
+		"nil error": {
+			Err:      nil,
+			Expected: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		retry, _ := transport_tpg.Is409SyncMutateCannotBeQueuedError(tc.Err)
+		if retry != tc.Expected {
+			t.Fatalf("bad: %s, expected %t got %t", tn, tc.Expected, retry)
+		}
+	}
 }

--- a/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
+++ b/mmv1/third_party/terraform/services/cloudscheduler/resource_cloud_scheduler_job_test.go
@@ -1,6 +1,7 @@
 package cloudscheduler_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -712,3 +712,15 @@ func IsDataplex1PEntryNotFoundError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+// Retry on Cloud Scheduler 'Sync Mutate Cannot Be Queued'
+func Is409SyncMutateCannotBeQueuedError(err error) (bool, string) {
+	if err == nil {
+		return false, ""
+	}
+	errStr := err.Error()
+	if strings.Contains(errStr, "Error 409") && strings.Contains(errStr, "sync mutate calls cannot be queued") {
+		return true, "sync mutate calls cannot be queued"
+	}
+	return false, ""
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.


Cloud Scheduler can return "409: sync mutate calls cannot be queued" if there are simultaneous calls to the same resource, or if there is a delete too soon after a create.  These should succeed after retires.  This PR marks this error as retryable.

```release-note:enhancement
cloudscheudler: added retries for the Cloud Scheduler "409: sync mutate calls cannot be queued" error on Scheduler's Job resource mutations.
```
