### PR TITLE
feat: promote Dataplex Data Product resources to GA and add service a…

### DIFF
--- a/mmv1/products/dataplex/DataProduct.yaml
+++ b/mmv1/products/dataplex/DataProduct.yaml
@@ -20,7 +20,6 @@ references:
   guides:
     'Introduction to Data Products': 'https://cloud.google.com/dataplex/docs/data-products-overview'
   api: 'https://cloud.google.com/dataplex/docs/reference/rest/v1/projects.locations.dataProducts'
-min_version: beta
 
 base_url: 'projects/{{project}}/locations/{{location}}/dataProducts'
 self_link: 'projects/{{project}}/locations/{{location}}/dataProducts/{{data_product_id}}'
@@ -144,3 +143,6 @@ properties:
             - name: 'googleGroup'
               type: String
               description: 'Email of the Google Group.'
+            - name: 'serviceAccount'
+              type: String
+              description: 'Specifies the email of the producer service account.'

--- a/mmv1/products/dataplex/DataProductDataAsset.yaml
+++ b/mmv1/products/dataplex/DataProductDataAsset.yaml
@@ -19,7 +19,6 @@ references:
   guides:
     'Official Documentation': 'https://docs.cloud.google.com/dataplex/docs/manage-data-products'
   api: 'https://cloud.google.com/dataplex/docs/reference/rest/v1/projects.locations.dataProducts.dataAssets'
-min_version: beta
 
 base_url: 'projects/{{project}}/locations/{{location}}/dataProducts/{{data_product_id}}/dataAssets'
 self_link: 'projects/{{project}}/locations/{{location}}/dataProducts/{{data_product_id}}/dataAssets/{{data_asset_id}}'

--- a/mmv1/templates/terraform/examples/dataplex_data_product_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_data_product_basic.tf.tmpl
@@ -15,5 +15,4 @@ resource "google_dataplex_data_product" "{{$.PrimaryResourceId}}" {
     }
   }
 
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/dataplex_data_product_data_asset_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_data_product_data_asset_basic.tf.tmpl
@@ -14,14 +14,12 @@ resource "google_dataplex_data_product" "example" {
     }
   }
 
-  provider = google-beta
 }
 
 resource "google_bigquery_dataset" "example" {
   project    = "{{index $.TestEnvVars "project_name"}}"
   dataset_id = "tf_test_dataset_%{random_suffix}"
   location   = "us-central1"
-  provider   = google-beta
 }
 
 resource "google_dataplex_data_product_data_asset" "{{$.PrimaryResourceId}}" {
@@ -31,5 +29,4 @@ resource "google_dataplex_data_product_data_asset" "{{$.PrimaryResourceId}}" {
   data_asset_id   = "{{index $.Vars "data_asset_id"}}"
   resource        = "//bigquery.googleapis.com/projects/${google_bigquery_dataset.example.project}/datasets/${google_bigquery_dataset.example.dataset_id}"
 
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/dataplex_data_product_data_asset_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_data_product_data_asset_full.tf.tmpl
@@ -23,14 +23,12 @@ resource "google_dataplex_data_product" "example" {
     }
   }
 
-  provider = google-beta
 }
 
 resource "google_bigquery_dataset" "example" {
   project    = "{{index $.TestEnvVars "project_name"}}"
   dataset_id = "tf_test_dataset_%{random_suffix}"
   location   = "us-central1"
-  provider   = google-beta
 }
 
 resource "google_dataplex_data_product_data_asset" "{{$.PrimaryResourceId}}" {
@@ -55,5 +53,4 @@ resource "google_dataplex_data_product_data_asset" "{{$.PrimaryResourceId}}" {
     iam_roles    = ["roles/bigquery.dataEditor"]
   }
 
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/dataplex_data_product_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataplex_data_product_full.tf.tmpl
@@ -1,3 +1,8 @@
+resource "google_service_account" "test_sa" {
+  account_id   = "tf-test-sa-%{random_suffix}"
+  display_name = "Test Service Account"
+}
+
 resource "google_dataplex_data_product" "{{$.PrimaryResourceId}}" {
   project         = "{{index $.TestEnvVars "project_name"}}"
   location        = "us-central1"
@@ -28,9 +33,8 @@ resource "google_dataplex_data_product" "{{$.PrimaryResourceId}}" {
     group_id     = "scientist"
     display_name = "Data Scientist"
     principal {
-      google_group = "tf-test-scientists-%{random_suffix}@example.com"
+      service_account = google_service_account.test_sa.email
     }
   }
 
-  provider = google-beta
 }

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
@@ -1,6 +1,5 @@
 package dataplex_test
 
-{{- if ne $.TargetVersionName "ga" }}
 import (
 	"testing"
 
@@ -19,7 +18,7 @@ func TestAccDataplexDataProduct_update(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
 				// STEP 1: Initial Creation
@@ -65,8 +64,6 @@ resource "google_dataplex_data_product" "example" {
   data_product_id = "%{data_product_id}"
   display_name    = "initial display name"
   owner_emails    = ["terraform-test@google.com"]
-
-  provider = google-beta
 }
 `, context)
 }
@@ -83,9 +80,6 @@ resource "google_dataplex_data_product" "example" {
   labels = {
     env = "test"
   }
-
-  provider = google-beta
 }
 `, context)
 }
-{{- end }}


### PR DESCRIPTION
### Description
This PR promotes the `google_dataplex_data_product` and `google_dataplex_data_product_data_asset `resources to GA. It removes all `min_version: beta` guards from the YAML configurations and promotes the acceptance tests to the standard `google` provider. Additionally, it introduces support for the `service_account` field in the access group principal, which was recently made public in the API.


### Key Changes
* **GA Promotion**: Removed `min_version: beta` from `DataProduct.yaml` and `DataProductDataAsset.yaml`
* **Service Account Support**: Added the `service_account` property to the access group `principal` configuration in `DataProduct.yaml`.

### Verification Performed
* Local End-to-End tests passed in the **Beta** and **GA** provider.
* Manual verification was performed in the okvidhi-testing project using provider developer overrides. Successful creation and update of the Data Product with a service account principal was verified in the Google Cloud Console.

```release-note:enhancement
dataplex: promoted `google_dataplex_data_product` and `google_dataplex_data_product_data_asset` resources to GA
```

```release-note:enhancement
dataplex: added `service_account` support to `google_dataplex_data_product` access group principals
```
