### PR TITLE
Add terraform support for biglake hive catalogs

### DIFF
--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -12,11 +12,9 @@
 # limitations under the License.
 
 ---
-# API resource name
 name: 'HiveCatalog'
-# Resource description for the provider documentation.
 description: |
-  RESOURCE_DESCRIPTION
+  Hive Catalogs in Biglake Metastore
 references:
   guides:
    # Link to quickstart in the API's Guides section. 
@@ -26,71 +24,41 @@ references:
   api: 'API_REFERENCE_URL'
 # Marks the resource as beta-only. Ensure a beta version block is present in
 # provider.yaml.
-min_version: beta
-
-# URL for the resource's standard List method. https://google.aip.dev/132
-# Terraform field names enclosed in double curly braces are replaced with
-# the field values from the resource at runtime.
+# min_version: beta
 base_url: 'hive/v1beta/projects/{{project}}/catalogs'
-# URL for the resource's standard Get method. https://google.aip.dev/131
-# Terraform field names enclosed in double curly braces are replaced with
-# the field values from the resource at runtime.
-self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog_id}}'
-
-# If true, the resource and all its fields are considered immutable - that is,
-# only creatable, not updatable. Individual fields can override this if they
-# have a custom update method in the API.
+self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{name}}'
 immutable: false
-
-# URL for the resource's standard Create method, including query parameters.
-# https://google.aip.dev/133
-# Terraform field names enclosed in double curly braces are replaced with
-# the field values from the resource at runtime.
-create_url: 'hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{catalog_id}}&primary_location={{primary_location}}'
-
-# Overrides the URL for the resource's standard Update method. (If unset, the
-# self_link URL is used by default.) https://google.aip.dev/134
-# Terraform field names enclosed in double curly braces are replaced with
-# the field values from the resource at runtime.
-# update_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
-# The HTTP verb used to update a resource. Allowed values: :POST, :PUT, :PATCH. Default: :PUT.
+create_url: 'hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{name}}&primary_location={{primary_location}}'
 update_verb: 'PATCH'
-# If true, the resource sets an `updateMask` query parameter listing modified
-# fields when updating the resource. If false, it does not.
 update_mask: true
 
-# If true, code for handling long-running operations is generated along with
-# the resource. If false, that code is not generated.
-autogen_async: true
-# Sets parameters for handling operations returned by the API.
-async:
-  # Overrides which API calls return operations. Default: ['create',
-  # 'update', 'delete']
-  # actions: ['create', 'update', 'delete']
-  operation:
-    base_url: '{{op_id}}'
-
-# The IAM policy is shared with IcebergCatalog.
+# The IAM policy is shared with Iceberg Catalog (biglakeiceberg).
 iam_policy:
-  base_url: 'v1/projects/{{project}}/catalogs/{{catalog_id}}'
-  parent_resource_attribute: 'catalog_id'
+  base_url: 'v1/projects/{{project}}/catalogs/{{name}}'
+  parent_resource_attribute: 'name'
   method_name_separator: ":"
   fetch_iam_policy_verb: 'GET'
   import_format:
-    - 'projects/{{project}}/catalogs/{{catalog_id}}'
-    - '{{catalog_id}}'
+    - 'projects/{{project}}/catalogs/{{name}}'
+    - '{{name}}'
   allowed_iam_role: 'roles/biglake.editor'
 examples:
   - name: 'biglake_hive_catalog'
     primary_resource_id: 'my_hive_catalog'
     vars:
-      catalog_id: 'my_hive_catalog'
+      name: 'my_hive_catalog'
     test_env_vars:
       GOOGLE_BILLING_PROJECT: 'PROJECT'
       USER_PROJECT_OVERRIDE: 'true'
-    min_version: beta
+  - name: 'biglake_hive_catalog_full'
+    primary_resource_id: 'my_hive_catalog'
+    vars:
+      name: 'my_hive_catalog'
+    test_env_vars:
+      GOOGLE_BILLING_PROJECT: 'PROJECT'
+      USER_PROJECT_OVERRIDE: 'true'
 parameters:
-  - name: 'catalog_id'
+  - name: 'name'
     type: String
     required: true
     immutable: true
@@ -107,12 +75,8 @@ parameters:
       a BigLake-supported location, and it should be proximate to the remote
       catalog's location.
 properties:
-  - name: name
-    type: String
-    description: The full resource name returned by the API.
-    ignore_read: true
-    output: true
   - name: 'location_uri'
+    api_name: 'locationUri'
     type: String
     required: true
     description: | 
@@ -122,10 +86,12 @@ properties:
     description: |
       Description of the Hive catalog.
   - name: 'create_time'
+    api_name: 'createTime'
     type: String
     description: Output only. The creation time of the catalog.
     output: true
   - name: 'update_time'
+    api_name: 'updateTime'
     type: String
     description: Output only. The update time of the catalog.
     output: true

--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -1,0 +1,156 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# API resource name
+name: 'HiveCatalog'
+# Resource description for the provider documentation.
+description: |
+  RESOURCE_DESCRIPTION
+references:
+  guides:
+   # Link to quickstart in the API's Guides section. 
+    'QUICKSTART_TITLE': 'QUICKSTART_URL'
+  # Link to the REST API reference for the resource. For example,
+  # https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.backups
+  api: 'API_REFERENCE_URL'
+# Marks the resource as beta-only. Ensure a beta version block is present in
+# provider.yaml.
+min_version: beta
+
+# URL for the resource's standard List method. https://google.aip.dev/132
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+base_url: 'hive/v1beta/projects/{{project}}/catalogs'
+# URL for the resource's standard Get method. https://google.aip.dev/131
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{catalog_id}}'
+
+# If true, the resource and all its fields are considered immutable - that is,
+# only creatable, not updatable. Individual fields can override this if they
+# have a custom update method in the API.
+immutable: false
+
+# URL for the resource's standard Create method, including query parameters.
+# https://google.aip.dev/133
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+create_url: 'hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{catalog_id}}&primary_location={{primary_location}}'
+
+# Overrides the URL for the resource's standard Update method. (If unset, the
+# self_link URL is used by default.) https://google.aip.dev/134
+# Terraform field names enclosed in double curly braces are replaced with
+# the field values from the resource at runtime.
+# update_url: 'projects/{{project}}/locations/{{location}}/resourcenames/{{name}}'
+# The HTTP verb used to update a resource. Allowed values: :POST, :PUT, :PATCH. Default: :PUT.
+update_verb: 'PATCH'
+# If true, the resource sets an `updateMask` query parameter listing modified
+# fields when updating the resource. If false, it does not.
+update_mask: true
+
+# If true, code for handling long-running operations is generated along with
+# the resource. If false, that code is not generated.
+autogen_async: true
+# Sets parameters for handling operations returned by the API.
+async:
+  # Overrides which API calls return operations. Default: ['create',
+  # 'update', 'delete']
+  # actions: ['create', 'update', 'delete']
+  operation:
+    base_url: '{{op_id}}'
+
+# The IAM policy is shared with IcebergCatalog.
+iam_policy:
+  base_url: 'v1/projects/{{project}}/catalogs/{{catalog_id}}'
+  parent_resource_attribute: 'catalog_id'
+  method_name_separator: ":"
+  fetch_iam_policy_verb: 'GET'
+  import_format:
+    - 'projects/{{project}}/catalogs/{{catalog_id}}'
+    - '{{catalog_id}}'
+  allowed_iam_role: 'roles/biglake.editor'
+examples:
+  - name: 'biglake_hive_catalog'
+    primary_resource_id: 'my_hive_catalog'
+    vars:
+      catalog_id: 'my_hive_catalog'
+    test_env_vars:
+      GOOGLE_BILLING_PROJECT: 'PROJECT'
+      USER_PROJECT_OVERRIDE: 'true'
+    min_version: beta
+parameters:
+  - name: 'catalog_id'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Name of the Hive Catalog.
+  - name: 'primary_location'
+    type: String
+    url_param_only: true
+    immutable: true
+    required: true
+    description: |
+      The primary location for mirroring the remote catalog metadata. It must be
+      a BigLake-supported location, and it should be proximate to the remote
+      catalog's location.
+properties:
+  - name: name
+    type: String
+    description: The full resource name returned by the API.
+    ignore_read: true
+    output: true
+  - name: 'location_uri'
+    type: String
+    required: true
+    description: | 
+      Cloud Storage location path where the catalog data will be stored. Format: gs://bucket/path/to/catalog
+  - name: 'description'
+    type: String
+    description: |
+      Description of the Hive catalog.
+  - name: 'create_time'
+    type: String
+    description: Output only. The creation time of the catalog.
+    output: true
+  - name: 'update_time'
+    type: String
+    description: Output only. The update time of the catalog.
+    output: true
+  - name: 'replicas'
+    type: Array
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'region'
+          type: String
+          description: The region of the replica, e.g., `us-east1`.
+          output: true
+        - name: 'state'
+          type: Enum
+          description: If the catalog is replicated to multiple regions, this enum
+            describes the current state of the replica. STATE_UNSPECIFIED - The replica
+            state is unknown. STATE_PRIMARY - The replica is the writable primary.
+            STATE_PRIMARY_IN_PROGRESS - The replica has been recently assigned as
+            the primary, but not all databases are writeable yet. STATE_SECONDARY -
+            The replica is a read-only secondary replica.
+          output: true
+          enum_values:
+            - 'STATE_UNSPECIFIED'
+            - 'STATE_PRIMARY'
+            - 'STATE_PRIMARY_IN_PROGRESS'
+            - 'STATE_SECONDARY'
+    description: Output only. The replicas for the catalog metadata.
+    output: true

--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -73,7 +73,7 @@ properties:
     api_name: 'locationUri'
     type: String
     required: true
-    description: | 
+    description: |
       Cloud Storage location path where the catalog data will be stored. Format: gs://bucket/path/to/catalog
   - name: 'description'
     type: String

--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -17,14 +17,8 @@ description: |
   Hive Catalogs in Biglake Metastore
 references:
   guides:
-   # Link to quickstart in the API's Guides section. 
-    'QUICKSTART_TITLE': 'QUICKSTART_URL'
-  # Link to the REST API reference for the resource. For example,
-  # https://cloud.google.com/alloydb/docs/reference/rest/v1/projects.locations.backups
-  api: 'API_REFERENCE_URL'
-# Marks the resource as beta-only. Ensure a beta version block is present in
-# provider.yaml.
-# min_version: beta
+    'QUICKSTART_TITLE': 'https://docs.cloud.google.com/lakehouse/docs/about-spark-hive-metastore'
+min_version: beta
 base_url: 'hive/v1beta/projects/{{project}}/catalogs'
 self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{name}}'
 immutable: false
@@ -50,7 +44,7 @@ examples:
     test_env_vars:
       GOOGLE_BILLING_PROJECT: 'PROJECT'
       USER_PROJECT_OVERRIDE: 'true'
-  - name: 'biglake_hive_catalog_full'
+  - name: 'biglake_hive_catalog_full_args'
     primary_resource_id: 'my_hive_catalog'
     vars:
       name: 'my_hive_catalog'

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'BiglakeHive'
+legacy_name: 'biglake'
+display_name: 'Biglake'
+versions:
+  - name: 'beta'
+    base_url: 'https://biglake.googleapis.com/'
+scopes:
+  - 'https://www.googleapis.com/auth/bigquery'
+  - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -16,7 +16,7 @@ name: 'BiglakeHive'
 legacy_name: 'biglake'
 display_name: 'Biglake'
 versions:
-  - name: 'beta'
+  - name: 'ga'
     base_url: 'https://biglake.googleapis.com/'
 scopes:
   - 'https://www.googleapis.com/auth/bigquery'

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -16,8 +16,6 @@ name: 'BiglakeHive'
 legacy_name: 'biglake'
 display_name: 'Biglake'
 versions:
-  - name: 'ga'
-    base_url: 'https://biglake.googleapis.com/'
   - name: 'beta'
     base_url: 'https://biglake.googleapis.com/'
 scopes:

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -18,6 +18,8 @@ display_name: 'Biglake'
 versions:
   - name: 'ga'
     base_url: 'https://biglake.googleapis.com/'
+  - name: 'beta'
+    base_url: 'https://biglake.googleapis.com/'
 scopes:
   - 'https://www.googleapis.com/auth/bigquery'
   - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -16,6 +16,8 @@ name: 'BiglakeHive'
 legacy_name: 'biglake'
 display_name: 'Biglake'
 versions:
+  - name: 'ga'
+    base_url: 'https://biglake.googleapis.com/'
   - name: 'beta'
     base_url: 'https://biglake.googleapis.com/'
 scopes:

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
+  name          = "{{index $.Vars "catalog_id"}}"
+  location      = "us-central1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+  provider = google-beta
+}
+
+resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
+    catalog_id = "{{index $.Vars "catalog_id"}}"
+    primary_location="us-central1"
+    location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+    description="terraform test hive catalog"
+    depends_on = [
+      google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
+    ]
+    provider = google-beta
+}

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
@@ -3,6 +3,7 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
+  provider = google-beta
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
@@ -12,4 +13,5 @@ resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
     depends_on = [
       google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
     ]
+    provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
@@ -9,6 +9,7 @@ resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
     name = "{{index $.Vars "name"}}"
     primary_location="us-central1"
     location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+    description="terraform test hive catalog"
     depends_on = [
       google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
     ]

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog_full_args.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog_full_args.tf.tmpl
@@ -3,6 +3,7 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
+  provider = google-beta
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
@@ -13,4 +14,5 @@ resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
     depends_on = [
       google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
     ]
+    provider = google-beta
 }

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -91,6 +91,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Biglake",
         "path" to "./google-beta/services/biglake"
     ),
+    "biglakehive" to mapOf(
+        "name" to "biglakehive",
+        "displayName" to "BiglakeHive",
+        "path" to "./google-beta/services/biglakehive"
+    ),
     "biglakeiceberg" to mapOf(
         "name" to "biglakeiceberg",
         "displayName" to "BiglakeIceberg",

--- a/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
+++ b/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
@@ -1,0 +1,98 @@
+package biglakehive_test
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"google.golang.org/api/googleapi"
+)
+
+var (
+	_ = fmt.Sprintf
+	_ = log.Print
+	_ = strconv.Atoi
+	_ = strings.Trim
+	_ = time.Now
+	_ = resource.TestMain
+	_ = terraform.NewState
+	_ = envvar.TestEnvVar
+	_ = tpgresource.SetLabels
+	_ = transport_tpg.Config{}
+	_ = googleapi.Error{}
+)
+
+func TestAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"name":          "tf_test_my_hive_catalog" + randomSuffix,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckBiglakeHiveHiveCatalogDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBiglakeHiveHiveCatalog_biglakeHiveCatalogExample(context),
+			},
+			{
+				ResourceName:            "google_biglake_hive_catalog.my_hive_catalog",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "primary_location"},
+			},
+			{
+				Config: testAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_biglake_hive_catalog.my_hive_catalog", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:       "google_biglake_hive_catalog.my_hive_catalog",
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				ImportStateKind:    resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
+func testAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_storage_bucket" "bucket_for_my_hive_catalog" {
+  name          = "%{name}"
+  location      = "us-central1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_biglake_hive_catalog" "my_hive_catalog" {
+    name = google_storage_bucket.bucket_for_my_hive_catalog.name
+	primary_location="us-central1"
+    location_uri="gs://%{name}"
+    description="terraform test hive catalog updated"
+    depends_on = [
+      google_storage_bucket.bucket_for_my_hive_catalog
+    ]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
+++ b/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go
@@ -83,6 +83,7 @@ resource "google_storage_bucket" "bucket_for_my_hive_catalog" {
   location      = "us-central1"
   force_destroy = true
   uniform_bucket_level_access = true
+  provider = google-beta
 }
 
 resource "google_biglake_hive_catalog" "my_hive_catalog" {
@@ -93,6 +94,7 @@ resource "google_biglake_hive_catalog" "my_hive_catalog" {
     depends_on = [
       google_storage_bucket.bucket_for_my_hive_catalog
     ]
+	provider = google-beta
 }
 `, context)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27576

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_biglake_hive_catalog`
```