### PR TITLE
feat: add Terraform IAM support for BigQuery Routines

### DIFF
--- a/mmv1/products/bigquery/Routine.yaml
+++ b/mmv1/products/bigquery/Routine.yaml
@@ -30,6 +30,16 @@ timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: 'google_bigquery_routine'
+  fetch_iam_policy_verb: 'POST'
+  allowed_iam_role: 'roles/bigquery.dataOwner'
+  parent_resource_attribute: 'routine_id'
+  iam_policy_version: '1'
+  import_format:
+    - 'projects/{{project}}/datasets/{{dataset_id}}/routines/{{routine_id}}'
+    - '{{routine_id}}'
 custom_code:
 examples:
   - name: 'bigquery_routine_basic'


### PR DESCRIPTION
  ### Description
  This pull request adds first-class Terraform IAM support for BigQuery Routines (`google_bigquery_routine_iam_policy`, `google_bigquery_routine_iam_binding`, `google_bigquery_routine_iam_member`). 
  
  BigQuery Routines expose standard Resource Manager REST API methods (`POST /bigquery/v2/projects/*/datasets/*/routines/*:setIamPolicy` and `:getIamPolicy`). Following the established pattern for BigQuery Tables, this change leverages MMv1's auto-generation engine by adding the `iam_policy` configuration block to `Routine.yaml`, overriding the requested policy version to `1` to ensure backend API compatibility.
  
  ### Tracking Bug(s)
  * Buganizer: b/362878595, b/399046627
  
  ### Design & API Documentation
  * Design Doc: go/bq-routine-acl, go/bq-iam-wipeout-redesign-extension
  * Public API Reference: https://cloud.google.com/bigquery/docs/reference/rest/v2/routines
  
  ### Acceptance Tests
  * [x] Ran manual E2E verification via local `terraform apply` against test project `spgindia-test-400206`. Successfully established and verified `google_bigquery_routine_iam_binding`.
  * [x] Ran automated E2E acceptance tests (`make testacc TEST=./google/services/bigquery TESTARGS="-run=TestAccBigqueryRoutineIam"`). All E2E test steps (binding, member, policy) passed successfully.
  * [x] Automated VCR presubmit test suite will execute via `@GoogleCloudPlatform/terraform-autotest-contributors`.
  

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigquery: added IAM support (`google_bigquery_routine_iam_policy`, `google_bigquery_routine_iam_binding`, `google_bigquery_routine_iam_member`) for `google_bigquery_routine`
```
  
  
