### PR TITLE
tgc-revival: Mark resolveSubnetMask as is_missing_in_cai in Subnetwork

### DIFF
--- a/mmv1/products/compute/Subnetwork.yaml
+++ b/mmv1/products/compute/Subnetwork.yaml
@@ -591,6 +591,7 @@ properties:
     description: |
       'Configures subnet mask resolution for this subnetwork.'
     immutable: true
+    is_missing_in_cai: true
     enum_values:
       - ARP_ALL_RANGES
       - ARP_PRIMARY_RANGE


### PR DESCRIPTION
Mark resolveSubnetMask as is_missing_in_cai in Subnetwork to stabilize TGC integration tests

```release-note:none
```