### PR TITLE
Add missing tool types and schema enhancements to google_ces_tool resource

### DIFF
--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -770,13 +770,17 @@ properties:
               See:
               https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata
       - name: filterParameterBehavior
-        type: String
+        type: Enum
         description: |-
           Optional. The filter parameter behavior.
           Possible values:
           FILTER_PARAMETER_BEHAVIOR_UNSPECIFIED
           ALWAYS_INCLUDE
           NEVER_INCLUDE
+        enum_values:
+          - 'FILTER_PARAMETER_BEHAVIOR_UNSPECIFIED'
+          - 'ALWAYS_INCLUDE'
+          - 'NEVER_INCLUDE'
       - name: maxResults
         type: Integer
         description: |-
@@ -902,13 +906,17 @@ properties:
       app/agent developer.
     properties:
       - name: corpusType
-        type: String
+        type: Enum
         description: |-
           Optional. The type of the corpus. Default is FULLY_MANAGED.
           Possible values:
           CORPUS_TYPE_UNSPECIFIED
           USER_OWNED
           FULLY_MANAGED
+        enum_values:
+          - 'CORPUS_TYPE_UNSPECIFIED'
+          - 'USER_OWNED'
+          - 'FULLY_MANAGED'
       - name: name
         type: String
         description: Required. The tool name.
@@ -1540,7 +1548,7 @@ properties:
         type: String
         description: Optional. The description of the widget tool.
       - name: widgetType
-        type: String
+        type: Enum
         description: |-
           Optional. The type of the widget tool. If not specified, the default type will be CUSTOMIZED.
           Possible values:
@@ -1557,6 +1565,20 @@ properties:
           APPOINTMENT_DETAILS
           APPOINTMENT_SCHEDULER
           CONTACT_FORM
+        enum_values:
+          - 'WIDGET_TYPE_UNSPECIFIED'
+          - 'CUSTOM'
+          - 'PRODUCT_CAROUSEL'
+          - 'PRODUCT_DETAILS'
+          - 'QUICK_ACTIONS'
+          - 'PRODUCT_COMPARISON'
+          - 'ADVANCED_PRODUCT_DETAILS'
+          - 'SHORT_FORM'
+          - 'OVERALL_SATISFACTION'
+          - 'ORDER_SUMMARY'
+          - 'APPOINTMENT_DETAILS'
+          - 'APPOINTMENT_SCHEDULER'
+          - 'CONTACT_FORM'
       - name: uiConfig
         type: String
         description: Optional. Configuration for rendering the widget. Represents a JSON object.
@@ -1603,19 +1625,23 @@ properties:
                   docstring.
                 output: true
           - name: mode
-            type: String
+            type: Enum
             description: |-
               Optional. The mode of the data mapping.
               Possible values:
               MODE_UNSPECIFIED
               FIELD_MAPPING
               PYTHON_SCRIPT
+            enum_values:
+              - 'MODE_UNSPECIFIED'
+              - 'FIELD_MAPPING'
+              - 'PYTHON_SCRIPT'
       - name: textResponseConfig
         type: NestedObject
         description: Optional. Configuration for always-included text responses.
         properties:
           - name: type
-            type: String
+            type: Enum
             description: |-
               Optional. The strategy for providing the text response.
               Possible values:
@@ -1623,6 +1649,11 @@ properties:
               NONE
               LLM_GENERATED
               STATIC
+            enum_values:
+              - 'TYPE_UNSPECIFIED'
+              - 'NONE'
+              - 'LLM_GENERATED'
+              - 'STATIC'
           - name: staticText
             type: String
             description: Optional. The static text response to return when type is STATIC.

--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -1400,17 +1400,6 @@ properties:
       - name: pythonCode
         type: String
         description: The Python code to execute for the tool.
-      - name: serviceDirectoryConfig
-        type: NestedObject
-        description: Configuration for tools using Service Directory.
-        properties:
-          - name: service
-            type: String
-            description: |-
-              The name of Service Directory service.
-              Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.
-              Location of the service directory must be the same as the location of the app.
-            required: true
   - name: updateTime
     type: String
     description: Timestamp when the tool was last updated.
@@ -1613,17 +1602,6 @@ properties:
                   The description of the Python function, parsed from the python code's
                   docstring.
                 output: true
-              - name: serviceDirectoryConfig
-                type: NestedObject
-                description: Configuration for tools using Service Directory.
-                properties:
-                  - name: service
-                    type: String
-                    description: |-
-                      The name of Service Directory service.
-                      Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.
-                      Location of the service directory must be the same as the location of the app.
-                    required: true
           - name: mode
             type: String
             description: |-

--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -16,14 +16,13 @@ name: Tool
 description: Description
 docs:
   note: |
-    > [!IMPORTANT]
-    > **Direct Management Restriction for Certain Tool Types:**
-    >
-    > Individual tools of type `openApiTool`, `mcpTool`, `connectorTool`, and `remoteAgentTool` **cannot** be created, updated, or managed directly using the `google_ces_tool` resource. 
-    > 
-    > `openApiTool`, `mcpTool`, and `connectorTool` are dynamically generated at runtime based on their corresponding **toolsets** (configured via the `google_ces_toolset` resource). `remoteAgentTool` represents A2A connections configured externally, and `systemTool` represents pre-defined platform tools managed entirely by Google Cloud.
-    >
-    > Consequently, blocks like `open_api_tool`, `mcp_tool`, `connector_tool`, `remote_agent_tool`, and `system_tool` are marked as **read-only (output-only)** in this resource. They are populated by the server for reference purposes only (e.g., after importing an existing tool into your state) and **cannot** be configured in your Terraform HCL configuration.
+    **Direct Management Restriction for Certain Tool Types:**
+
+    Individual tools of type `openApiTool`, `mcpTool`, `connectorTool`, and `remoteAgentTool` **cannot** be created, updated, or managed directly using the `google_ces_tool` resource.
+
+    `openApiTool`, `mcpTool`, and `connectorTool` are dynamically generated at runtime based on their corresponding **toolsets** (configured via the `google_ces_toolset` resource). `remoteAgentTool` represents A2A connections configured externally, and `systemTool` represents pre-defined platform tools managed entirely by Google Cloud.
+
+    Consequently, blocks like `open_api_tool`, `mcp_tool`, `connector_tool`, `remote_agent_tool`, and `system_tool` are marked as **read-only (output-only)** in this resource. They are populated by the server for reference purposes only (e.g., after importing an existing tool into your state) and **cannot** be configured in your Terraform HCL configuration.
 base_url: projects/{{project}}/locations/{{location}}/apps/{{app}}/tools
 update_mask: true
 self_link:

--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -14,6 +14,16 @@
 ---
 name: Tool
 description: Description
+docs:
+  note: |
+    > [!IMPORTANT]
+    > **Direct Management Restriction for Certain Tool Types:**
+    >
+    > Individual tools of type `openApiTool`, `mcpTool`, `connectorTool`, and `remoteAgentTool` **cannot** be created, updated, or managed directly using the `google_ces_tool` resource. 
+    > 
+    > `openApiTool`, `mcpTool`, and `connectorTool` are dynamically generated at runtime based on their corresponding **toolsets** (configured via the `google_ces_toolset` resource). `remoteAgentTool` represents A2A connections configured externally, and `systemTool` represents pre-defined platform tools managed entirely by Google Cloud.
+    >
+    > Consequently, blocks like `open_api_tool`, `mcp_tool`, `connector_tool`, `remote_agent_tool`, and `system_tool` are marked as **read-only (output-only)** in this resource. They are populated by the server for reference purposes only (e.g., after importing an existing tool into your state) and **cannot** be configured in your Terraform HCL configuration.
 base_url: projects/{{project}}/locations/{{location}}/apps/{{app}}/tools
 update_mask: true
 self_link:
@@ -56,6 +66,27 @@ examples:
       app_display_name: 'my-app'
       tool_id: 'ces_tool_basic4'
       app_id: 'app-id'
+  - name: "ces_tool_agent_basic"
+    primary_resource_id: "ces_tool_agent_basic"
+    vars:
+      tool_display_name: 'ces_tool_agent_basic'
+      app_display_name: 'my-app'
+      tool_id: 'ces_tool_basic5'
+      app_id: 'app-id'
+  - name: "ces_tool_file_search_basic"
+    primary_resource_id: "ces_tool_file_search_basic"
+    vars:
+      tool_display_name: 'ces_tool_file_search_basic'
+      app_display_name: 'my-app'
+      tool_id: 'ces_tool_basic6'
+      app_id: 'app-id'
+  - name: "ces_tool_widget_basic"
+    primary_resource_id: "ces_tool_widget_basic"
+    vars:
+      tool_display_name: 'ces_tool_widget_basic'
+      app_display_name: 'my-app'
+      tool_id: 'ces_tool_basic7'
+      app_id: 'app-id'
 autogen_status: VG9vbA==
 parameters:
   - name: location
@@ -84,6 +115,22 @@ parameters:
     url_param_only: true
     required: true
 properties:
+  - name: agentTool
+    type: NestedObject
+    description: Represents a tool that allows the agent to call another agent.
+    properties:
+      - name: name
+        type: String
+        description: Required. The name of the agent tool.
+        required: true
+      - name: description
+        type: String
+        description: Optional. Description of the tool's purpose.
+      - name: agent
+        type: String
+        description: |-
+          Optional. The resource name of the agent that is the entry point of the tool.
+          Format: projects/{project}/locations/{location}/agents/{agent}
   - name: clientFunction
     type: NestedObject
     description: |-
@@ -375,6 +422,72 @@ properties:
             type: Boolean
             description: Indicate the items in the array must be unique. Only applies
               to TYPE.ARRAY.
+  - name: connectorTool
+    type: NestedObject
+    description: A ConnectorTool allows connections to different integrations.
+    output: true
+    properties:
+      - name: connection
+        type: String
+        description: |-
+          The full resource name of the referenced Integration Connectors Connection. Format: projects/{project}/locations/{location}/connections/{connection}
+        output: true
+      - name: action
+        type: NestedObject
+        description: Action for the tool to use.
+        output: true
+        properties:
+          - name: inputFields
+            type: Array
+            description: Entity fields to use as inputs for the operation.
+            output: true
+            item_type:
+              type: String
+          - name: outputFields
+            type: Array
+            description: Entity fields to return from the operation.
+            output: true
+            item_type:
+              type: String
+          - name: connectionActionId
+            type: String
+            description: ID of a Connection action for the tool to use.
+            output: true
+          - name: entityOperation
+            type: NestedObject
+            description: Entity operation configuration for the tool to use.
+            output: true
+            properties:
+              - name: entityId
+                type: String
+                description: ID of the entity.
+                output: true
+              - name: operation
+                type: String
+                description: |-
+                  Operation to perform on the entity.
+                  Possible values:
+                  OPERATION_TYPE_UNSPECIFIED
+                  LIST
+                  GET
+                  CREATE
+                  UPDATE
+                  DELETE
+                output: true
+      - name: authConfig
+        type: String
+        description: |-
+          Configures how authentication is handled in Integration Connectors. By default, an admin authentication is passed in the Integration Connectors API requests. You can override it with a different end-user authentication config. Note: The Connection must have authentication override enabled in order to specify an EUC configuration here - otherwise, the ConnectorTool creation will fail. See https://cloud.google.com/application-integration/docs/configure-connectors-task#configure-authentication-override for details. Represents a JSON object.
+        output: true
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+      - name: name
+        type: String
+        description: The name of the tool that can be used by the Agent to decide whether to call this ConnectorTool.
+        output: true
+      - name: description
+        type: String
+        description: The description of the tool that can be used by the Agent to decide whether to call this ConnectorTool.
+        output: true
   - name: createTime
     type: String
     description: Timestamp when the tool was created.
@@ -489,6 +602,74 @@ properties:
                             Example: To boost suggestions in languages en or fr:
                             (lang_code: ANY("en", "fr"))
                           required: true
+      - name: dataStoreSource
+        type: NestedObject
+        description: Optional. Search within a single specific DataStore.
+        conflicts:
+          - engineSource
+        properties:
+          - name: filter
+            type: String
+            description: |-
+              Optional. Filter specification for the DataStore.
+              See: https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata
+          - name: dataStore
+            type: NestedObject
+            description: Optional. The data store.
+            properties:
+              - name: connectorConfig
+                type: NestedObject
+                description: The connector config for the data store connection.
+                output: true
+                properties:
+                  - name: collection
+                    type: String
+                    description: Resource name of the collection the data store belongs to.
+                    output: true
+                  - name: collectionDisplayName
+                    type: String
+                    description: Display name of the collection the data store belongs to.
+                    output: true
+                  - name: dataSource
+                    type: String
+                    description: |-
+                      The name of the data source.
+                      Example: `salesforce`, `jira`, `confluence`, `bigquery`.
+                    output: true
+              - name: createTime
+                type: String
+                description: Timestamp when the data store was created.
+                output: true
+              - name: displayName
+                type: String
+                description: The display name of the data store.
+                output: true
+              - name: documentProcessingMode
+                type: String
+                description: |-
+                  The document processing mode for the data store connection.
+                  Only set for PUBLIC_WEB and UNSTRUCTURED data stores.
+                  Possible values:
+                  DOCUMENTS
+                  CHUNKS
+                output: true
+              - name: name
+                type: String
+                description: |-
+                  Full resource name of the DataStore.
+                  Format: projects/{project}/locations/{location}/collections/{collection}/dataStores/{dataStore}
+                required: true
+              - name: type
+                type: String
+                description: |-
+                  The type of the data store. This field is readonly and populated by the
+                  server.
+                  Possible values:
+                  PUBLIC_WEB
+                  UNSTRUCTURED
+                  FAQ
+                  CONNECTOR
+                output: true
       - name: description
         type: String
         description: The tool description.
@@ -497,6 +678,8 @@ properties:
         description: |-
           Configuration for searching within an Engine, potentially targeting
           specific DataStores.
+        conflicts:
+          - dataStoreSource
         properties:
           - name: dataStoreSources
             type: Array
@@ -587,6 +770,14 @@ properties:
               used if 'data_store_sources' is provided.
               See:
               https://cloud.google.com/generative-ai-app-builder/docs/filter-search-metadata
+      - name: filterParameterBehavior
+        type: String
+        description: |-
+          Optional. The filter parameter behavior.
+          Possible values:
+          FILTER_PARAMETER_BEHAVIOR_UNSPECIFIED
+          ALWAYS_INCLUDE
+          NEVER_INCLUDE
       - name: maxResults
         type: Integer
         description: |-
@@ -705,6 +896,32 @@ properties:
       Possible values:
       SYNCHRONOUS
       ASYNCHRONOUS
+  - name: fileSearchTool
+    type: NestedObject
+    description: |-
+      The file search tool allows the agent to search across the files uploaded by the
+      app/agent developer.
+    properties:
+      - name: corpusType
+        type: String
+        description: |-
+          Optional. The type of the corpus. Default is FULLY_MANAGED.
+          Possible values:
+          CORPUS_TYPE_UNSPECIFIED
+          USER_OWNED
+          FULLY_MANAGED
+      - name: name
+        type: String
+        description: Required. The tool name.
+        required: true
+      - name: description
+        type: String
+        description: Optional. The tool description.
+      - name: fileCorpus
+        type: String
+        description: |-
+          Optional. The corpus where files are stored.
+          Format: projects/{project}/locations/{location}/ragCorpora/{rag_corpus}
   - name: generatedSummary
     type: String
     description: |-
@@ -753,6 +970,217 @@ properties:
           A maximum of 20 domains can be specified.
         item_type:
           type: String
+      - name: promptConfig
+        type: NestedObject
+        description: |-
+          Optional. Prompt instructions passed to planner on how the search results should be
+          processed for text and voice.
+        properties:
+          - name: textPrompt
+            type: String
+            description: |-
+              Optional. Defines the prompt used for the system instructions when interacting with the
+              agent in chat conversations. If not set, default prompt will be used.
+          - name: voicePrompt
+            type: String
+            description: |-
+              Optional. Defines the prompt used for the system instructions when interacting with the
+              agent in voice conversations. If not set, default prompt will be used.
+  - name: mcpTool
+    type: NestedObject
+    description: An MCP tool.
+    output: true
+    properties:
+      - name: name
+        type: String
+        description: The name of the MCP tool.
+        output: true
+      - name: nameOverride
+        type: String
+        description: The name override of the MCP tool. This is populated if the name was overridden by a Toolset override.
+        output: true
+      - name: description
+        type: String
+        description: The description of the MCP tool.
+        output: true
+      - name: inputSchema
+        type: String
+        description: The schema of the input arguments of the MCP tool. Represents a JSON object.
+        output: true
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+      - name: outputSchema
+        type: String
+        description: The schema of the output arguments of the MCP tool. Represents a JSON object.
+        output: true
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+      - name: serverAddress
+        type: String
+        description: |-
+          The server address of the MCP server, e.g., "https://example.com/mcp/". If the server is built with the MCP SDK, the url should be suffixed with "/mcp/". Only Streamable HTTP transport based servers are supported. This is the same as the serverAddress in the McpToolset.
+        output: true
+      - name: apiAuthentication
+        type: NestedObject
+        description: Authentication information required to access tools and execute a tool against the MCP server. For API key auth, the API key can only be sent in the request header; sending it via query parameters is not supported.
+        output: true
+        properties:
+          - name: apiKeyConfig
+            type: NestedObject
+            description: Configurations for authentication with API key.
+            output: true
+            properties:
+              - name: apiKeySecretVersion
+                type: String
+                description: |-
+                  The name of the SecretManager secret version resource storing the API key.
+                  Format: `projects/{project}/secrets/{secret}/versions/{version}`
+                  Note: You should grant `roles/secretmanager.secretAccessor` role to the CES
+                  service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+              - name: keyName
+                type: String
+                description: |-
+                  The parameter name or the header name of the API key.
+                  E.g., If the API request is "https://example.com/act?X-Api-Key=", "X-Api-Key" would be the parameter name.
+                output: true
+              - name: requestLocation
+                type: String
+                description: |-
+                  Key location in the request. For API key auth on MCP toolsets,
+                  the API key can only be sent in the request header.
+                  Possible values:
+                  HEADER
+                output: true
+          - name: bearerTokenConfig
+            type: NestedObject
+            description: Configurations for authentication with a bearer token.
+            output: true
+            properties:
+              - name: token
+                type: String
+                description: The bearer token. Must be in the format $context.variables.<name_of_variable>.
+                output: true
+          - name: oauthConfig
+            type: NestedObject
+            description: Configurations for authentication with OAuth.
+            output: true
+            properties:
+              - name: clientId
+                type: String
+                description: The client ID from the OAuth provider.
+                output: true
+              - name: clientSecretVersion
+                type: String
+                description: |-
+                  The name of the SecretManager secret version resource storing the
+                  client secret.
+                  Format: `projects/{project}/secrets/{secret}/versions/{version}`
+                  Note: You should grant `roles/secretmanager.secretAccessor` role to the CES
+                  service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+              - name: oauthGrantType
+                type: String
+                description: |-
+                  OAuth grant types.
+                  Possible values:
+                  CLIENT_CREDENTIAL
+                output: true
+              - name: scopes
+                type: Array
+                description: The OAuth scopes to grant.
+                output: true
+                item_type:
+                  type: String
+              - name: tokenEndpoint
+                type: String
+                description: The token endpoint in the OAuth provider to exchange for an
+                  access token.
+                output: true
+          - name: serviceAccountAuthConfig
+            type: NestedObject
+            description: Configurations for authentication using a custom service account.
+            output: true
+            properties:
+              - name: serviceAccount
+                type: String
+                description: |-
+                  The email address of the service account used for authenticatation. CES
+                  uses this service account to exchange an access token and the access token
+                  is then sent in the `Authorization` header of the request.
+                  The service account must have the
+                  `roles/iam.serviceAccountTokenCreator` role granted to the
+                  CES service agent
+                  `service-<PROJECT-NUMBER>@gcp-sa-ces.iam.gserviceaccount.com`.
+                output: true
+          - name: serviceAgentIdTokenAuthConfig
+            type: NestedObject
+            description: |-
+              Configurations for authentication with [ID
+              token](https://cloud.google.com/docs/authentication/token-types#id) generated
+              from service agent.
+            output: true
+            properties: []
+      - name: tlsConfig
+        type: NestedObject
+        description: The TLS configuration. Includes the custom server certificates that the client should trust.
+        output: true
+        properties:
+          - name: caCerts
+            type: Array
+            description: Specifies a list of allowed custom CA certificates for HTTPS verification.
+            output: true
+            item_type:
+              type: NestedObject
+              properties:
+                - name: cert
+                  type: String
+                  description: |-
+                    The allowed custom CA certificates (in DER format) for
+                    HTTPS verification. This overrides the default SSL trust store. If this
+                    is empty or unspecified, CES will use Google's default trust
+                    store to verify certificates. N.B. Make sure the HTTPS server
+                    certificates are signed with "subject alt name". For instance a
+                    certificate can be self-signed using the following command,
+                    openssl x509 -req -days 200 -in example.com.csr \
+                    -signkey example.com.key \
+                    -out example.com.crt \
+                    -extfile <(printf "\nsubjectAltName='DNS:www.example.com'")
+                  output: true
+                - name: displayName
+                  type: String
+                  description: The name of the allowed custom CA certificates. This can be used to disambiguate the custom CA certificates.
+                  output: true
+      - name: serviceDirectoryConfig
+        type: NestedObject
+        description: Service Directory configuration for VPC-SC, used to resolve service names within a perimeter.
+        output: true
+        properties:
+          - name: service
+            type: String
+            description: |-
+              The name of [Service
+              Directory](https://cloud.google.com/service-directory) service.
+              Format:
+              `projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}`.
+              Location of the service directory must be the same as the location of the
+              app.
+            output: true
+      - name: customHeaders
+        type: KeyValuePairs
+        description: |-
+          The custom headers to send in the request to the MCP server. The values must be in the format `$context.variables.<name_of_variable>` and can be set in the session variables.
+        output: true
+      - name: state
+        type: String
+        description: |-
+          The state of the MCP tool.
+          Possible values:
+          STATE_UNSPECIFIED
+          ACTIVE
+          INACTIVE
+          STALE
+        output: true
   - name: name
     type: String
     description: |-
@@ -973,10 +1401,130 @@ properties:
       - name: pythonCode
         type: String
         description: The Python code to execute for the tool.
+      - name: serviceDirectoryConfig
+        type: NestedObject
+        description: Configuration for tools using Service Directory.
+        properties:
+          - name: service
+            type: String
+            description: |-
+              The name of Service Directory service.
+              Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.
+              Location of the service directory must be the same as the location of the app.
+            required: true
   - name: updateTime
     type: String
     description: Timestamp when the tool was last updated.
     output: true
+  - name: remoteAgentTool
+    type: NestedObject
+    description: Represents a tool that allows the agent to call another remote agent.
+    output: true
+    properties:
+      - name: name
+        type: String
+        description: The name of the tool.
+        output: true
+      - name: description
+        type: String
+        description: The description of the tool.
+        output: true
+      - name: agentCard
+        type: NestedObject
+        description: The agent card of the remote agent that this tool invokes.
+        output: true
+        properties:
+          - name: name
+            type: String
+            description: A human-readable name for the agent.
+            output: true
+          - name: description
+            type: String
+            description: A description of the agent's domain of action/solution space.
+            output: true
+          - name: version
+            type: String
+            description: The version of the agent.
+            output: true
+          - name: supportedInterfaces
+            type: Array
+            description: Ordered list of supported interfaces. The first entry is preferred.
+            output: true
+            item_type:
+              type: NestedObject
+              properties:
+                - name: url
+                  type: String
+                  description: |-
+                    The URL where this interface is available. Must be a valid absolute
+                    HTTPS URL in production.
+                  output: true
+                - name: protocolBinding
+                  type: String
+                  description: |-
+                    The protocol binding supported at this URL. The core ones officially
+                    supported are JSONRPC, GRPC and HTTP+JSON.
+                  output: true
+                - name: tenant
+                  type: String
+                  description: Tenant ID to be used in the request when calling the agent.
+                  output: true
+                - name: protocolVersion
+                  type: String
+                  description: |-
+                    The version of the A2A protocol this interface exposes.
+                    Examples: "0.3", "1.0"
+                  output: true
+          - name: skills
+            type: Array
+            description: |-
+              Skills represent a unit of ability an agent can perform. This may
+              somewhat abstract but represents a more focused set of actions that the agent is highly
+              likely to succeed at.
+            output: true
+            item_type:
+              type: NestedObject
+              properties:
+                - name: id
+                  type: String
+                  description: A unique identifier for the agent's skill.
+                  output: true
+                - name: name
+                  type: String
+                  description: A human-readable name for the skill.
+                  output: true
+                - name: description
+                  type: String
+                  description: A detailed description of the skill.
+                  output: true
+                - name: tags
+                  type: Array
+                  description: A set of keywords describing the skill's capabilities.
+                  output: true
+                  item_type:
+                    type: String
+                - name: examples
+                  type: Array
+                  description: Example prompts or scenarios that this skill can handle.
+                  output: true
+                  item_type:
+                    type: String
+                - name: inputModes
+                  type: Array
+                  description: |-
+                    The set of supported input media types for this skill, overriding the agent's
+                    defaults.
+                  output: true
+                  item_type:
+                    type: String
+                - name: outputModes
+                  type: Array
+                  description: |-
+                    The set of supported output media types for this skill, overriding the agent's
+                    defaults.
+                  output: true
+                  item_type:
+                    type: String
   - name: systemTool
     type: NestedObject
     description: The system tool.
@@ -992,3 +1540,260 @@ properties:
         description: |-
           The name of the system tool.
         output: true
+  - name: widgetTool
+    type: NestedObject
+    description: Represents a widget tool that the agent can invoke.
+    properties:
+      - name: name
+        type: String
+        description: Required. The display name of the widget tool.
+        required: true
+      - name: description
+        type: String
+        description: Optional. The description of the widget tool.
+      - name: widgetType
+        type: String
+        description: |-
+          Optional. The type of the widget tool. If not specified, the default type will be CUSTOMIZED.
+          Possible values:
+          WIDGET_TYPE_UNSPECIFIED
+          CUSTOM
+          PRODUCT_CAROUSEL
+          PRODUCT_DETAILS
+          QUICK_ACTIONS
+          PRODUCT_COMPARISON
+          ADVANCED_PRODUCT_DETAILS
+          SHORT_FORM
+          OVERALL_SATISFACTION
+          ORDER_SUMMARY
+          APPOINTMENT_DETAILS
+          APPOINTMENT_SCHEDULER
+          CONTACT_FORM
+      - name: uiConfig
+        type: String
+        description: Optional. Configuration for rendering the widget. Represents a JSON object.
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        validation:
+          function: 'validation.StringIsJSON'
+        custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+      - name: dataMapping
+        type: NestedObject
+        description: |-
+          Optional. The mapping that defines how data from a source tool is mapped to the
+          widget's input parameters.
+        properties:
+          - name: sourceToolName
+            type: String
+            description: |-
+              Optional. The resource name of the tool that provides the data for the widget (e.g., a search tool or a custom function).
+              Format: projects/{project}/locations/{location}/agents/{agent}/tools/{tool}
+          - name: fieldMappings
+            type: KeyValuePairs
+            description: |-
+              Optional. A map of widget input parameter fields to the corresponding output fields of the source tool.
+              An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+          - name: pythonFunction
+            type: NestedObject
+            description: |-
+              Optional. Configuration for a Python function used to transform the source tool's
+              output into the widget's input format.
+            properties:
+              - name: name
+                type: String
+                description: |-
+                  Optional. The name of the Python function to execute. Must match a Python function
+                  name defined in the python code. Case sensitive. If the name is not
+                  provided, the first function defined in the python code will be used.
+              - name: pythonCode
+                type: String
+                description: Optional. The Python code to execute for the tool.
+              - name: description
+                type: String
+                description: |-
+                  The description of the Python function, parsed from the python code's
+                  docstring.
+                output: true
+              - name: serviceDirectoryConfig
+                type: NestedObject
+                description: Configuration for tools using Service Directory.
+                properties:
+                  - name: service
+                    type: String
+                    description: |-
+                      The name of Service Directory service.
+                      Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.
+                      Location of the service directory must be the same as the location of the app.
+                    required: true
+          - name: mode
+            type: String
+            description: |-
+              Optional. The mode of the data mapping.
+              Possible values:
+              MODE_UNSPECIFIED
+              FIELD_MAPPING
+              PYTHON_SCRIPT
+      - name: textResponseConfig
+        type: NestedObject
+        description: Optional. Configuration for always-included text responses.
+        properties:
+          - name: type
+            type: String
+            description: |-
+              Optional. The strategy for providing the text response.
+              Possible values:
+              TYPE_UNSPECIFIED
+              NONE
+              LLM_GENERATED
+              STATIC
+          - name: staticText
+            type: String
+            description: Optional. The static text response to return when type is STATIC.
+          - name: textResponseInstruction
+            type: String
+            description: |-
+              Optional. Instruction for the LLM on how to generate the text response. Used as
+              the description for the text response parameter if type is LLM_GENERATED.
+      - name: parameters
+        type: NestedObject
+        description: Optional. The input parameters of the widget tool. Represents a Schema object.
+        properties:
+          - name: additionalProperties
+            type: String
+            description: |-
+              Defines the schema for additional properties allowed in an object.
+              The value must be a valid JSON string representing the Schema object.
+              (Note: OpenAPI also allows a boolean, this definition expects a Schema JSON).
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: anyOf
+            type: String
+            description: The instance value should be valid against at least
+              one of the schemas in this list.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: default
+            type: String
+            description: |-
+              Default value of the data. Represents a dynamically typed value
+              which can be either null, a number, a string, a boolean, a struct,
+              or a list of values. The provided default value must be compatible
+              with the defined 'type' and other schema constraints.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: defs
+            type: String
+            description: A map of definitions for use by ref. Only allowed at the root
+              of the schema.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: description
+            type: String
+            description: The description of the data.
+          - name: enum
+            type: Array
+            description: |-
+              Possible values of the element of primitive type with enum format.
+              Examples:
+              1. We can define direction as :
+              {type:STRING, format:enum, enum:["EAST", NORTH", "SOUTH", "WEST"]}
+              2. We can define apartment number as :
+              {type:INTEGER, format:enum, enum:["101", "201", "301"]}
+            item_type:
+              type: String
+          - name: items
+            type: String
+            description: Schema of the elements of Type.ARRAY.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: maxItems
+            type: Integer
+            description: Maximum number of the elements for Type.ARRAY. (int64 format)
+          - name: maximum
+            type: Double
+            description: Maximum value for Type.INTEGER and Type.NUMBER.
+          - name: minItems
+            type: Integer
+            description: Minimum number of the elements for Type.ARRAY. (int64 format)
+          - name: minimum
+            type: Double
+            description: Minimum value for Type.INTEGER and Type.NUMBER.
+          - name: nullable
+            type: Boolean
+            description: Indicates if the value may be null.
+          - name: prefixItems
+            type: String
+            description: Schemas of initial elements of Type.ARRAY.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: properties
+            type: String
+            description: Properties of Type.OBJECT.
+            state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+            custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+            custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+            validation:
+              function: 'validation.StringIsJSON'
+          - name: ref
+            type: String
+            description: |-
+              Allows indirect references between schema nodes. The value should be a
+              valid reference to a child of the root `defs`.
+              For example, the following schema defines a reference to a schema node
+              named "Pet":
+              type: object
+              properties:
+                pet:
+                  ref: #/defs/Pet
+              defs:
+                Pet:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+              The value of the "pet" property is a reference to the schema node
+              named "Pet".
+              See details in
+              https://json-schema.org/understanding-json-schema/structuring.
+          - name: required
+            type: Array
+            description: Required properties of Type.OBJECT.
+            item_type:
+              type: String
+          - name: title
+            type: String
+            description: The title of the schema.
+          - name: type
+            type: String
+            description: |-
+              The type of the data.
+              Possible values:
+              STRING
+              INTEGER
+              NUMBER
+              BOOLEAN
+              OBJECT
+              ARRAY
+            required: true
+          - name: uniqueItems
+            type: Boolean
+            description: Indicate the items in the array must be unique. Only applies
+              to TYPE.ARRAY.

--- a/mmv1/templates/terraform/examples/ces_tool_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_tool_agent_basic.tf.tmpl
@@ -1,0 +1,29 @@
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "{{index $.Vars "app_display_name"}}"
+    app_id       = "{{index $.Vars "app_id"}}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_agent" "target_agent" {
+  agent_id     = "target-agent"
+  location     = "us"
+  app          = google_ces_app.my-app.app_id
+  display_name = "Target Agent"
+  instruction  = "Target agent instruction"
+  llm_agent {}
+}
+
+resource "google_ces_tool" "{{$.PrimaryResourceId}}" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "{{index $.Vars "tool_id"}}"
+    execution_type = "SYNCHRONOUS"
+    agent_tool {
+        name        = "{{index $.Vars "tool_display_name"}}"
+        description = "example-description"
+        agent       = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/agents/${google_ces_agent.target_agent.agent_id}"
+    }
+}

--- a/mmv1/templates/terraform/examples/ces_tool_file_search_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_tool_file_search_basic.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "{{index $.Vars "app_display_name"}}"
+    app_id       = "{{index $.Vars "app_id"}}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "{{$.PrimaryResourceId}}" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "{{index $.Vars "tool_id"}}"
+    execution_type = "SYNCHRONOUS"
+    file_search_tool {
+        name        = "{{index $.Vars "tool_display_name"}}"
+        description = "example-description"
+        corpus_type = "FULLY_MANAGED"
+        file_corpus = "projects/${google_ces_app.my-app.project}/locations/us/ragCorpora/tf-test-mock-corpus"
+    }
+}

--- a/mmv1/templates/terraform/examples/ces_tool_widget_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/ces_tool_widget_basic.tf.tmpl
@@ -1,0 +1,44 @@
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "{{index $.Vars "app_display_name"}}"
+    app_id       = "{{index $.Vars "app_id"}}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "{{$.PrimaryResourceId}}" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "{{index $.Vars "tool_id"}}"
+    execution_type = "SYNCHRONOUS"
+    widget_tool {
+        name        = "{{index $.Vars "tool_display_name"}}"
+        description = "example-description"
+        widget_type = "PRODUCT_CAROUSEL"
+        ui_config = jsonencode({
+            displaySettings = {
+                showHeader = true
+            }
+        })
+        data_mapping {
+            mode = "FIELD_MAPPING"
+            field_mappings = {
+                "key1" = "value1"
+                "key2" = "value2"
+            }
+        }
+        text_response_config {
+            type = "STATIC"
+            static_text = "example-static-text"
+        }
+        parameters {
+            type = "OBJECT"
+            properties = jsonencode({
+                param1 = {
+                    type = "STRING"
+                }
+            })
+        }
+    }
+}

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -640,16 +640,6 @@ func TestAccCESTool_cesToolPythonFunctionBasicExample_update(t *testing.T) {
 
 func testAccCESTool_cesToolPythonFunctionBasicExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_directory_namespace" "basic" {
-  namespace_id = "tf-test-ns-%{random_suffix}"
-  location     = "us-central1"
-}
-
-resource "google_service_directory_service" "basic" {
-  service_id   = "tf-test-svc-%{random_suffix}"
-  namespace    = google_service_directory_namespace.basic.id
-}
-
 resource "google_ces_app" "my-app" {
     location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
@@ -667,9 +657,6 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     python_function {
         name = "example_function"
         python_code = "def example_function() -> int: return 0"
-        service_directory_config {
-            service = google_service_directory_service.basic.id
-        }
     }
 }
 `, context)
@@ -677,16 +664,6 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
 
 func testAccCESTool_cesToolPythonFunctionBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_directory_namespace" "basic" {
-  namespace_id = "tf-test-ns-%{random_suffix}"
-  location     = "us-central1"
-}
-
-resource "google_service_directory_service" "basic" {
-  service_id   = "tf-test-svc-%{random_suffix}"
-  namespace    = google_service_directory_namespace.basic.id
-}
-
 resource "google_ces_app" "my-app" {
     location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
@@ -704,9 +681,6 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     python_function {
         name = "example_function_updated"
         python_code = "def example_function_updated() -> int: return 0"
-        service_directory_config {
-            service = google_service_directory_service.basic.id
-        }
     }
 }
 `, context)
@@ -951,16 +925,6 @@ func TestAccCESTool_cesToolWidgetToolBasicExample_update(t *testing.T) {
 
 func testAccCESTool_cesToolWidgetToolBasicExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_directory_namespace" "basic" {
-  namespace_id = "tf-test-ns-%{random_suffix}"
-  location     = "us-central1"
-}
-
-resource "google_service_directory_service" "basic" {
-  service_id   = "tf-test-svc-%{random_suffix}"
-  namespace    = google_service_directory_namespace.basic.id
-}
-
 resource "google_ces_app" "my-app" {
     location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
@@ -993,9 +957,6 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
             python_function {
                 name        = "transform_function"
                 python_code = "def transform_function(x: int) -> int: return x"
-                service_directory_config {
-                    service = google_service_directory_service.basic.id
-                }
             }
         }
         text_response_config {
@@ -1031,16 +992,6 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
 
 func testAccCESTool_cesToolWidgetToolBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
-resource "google_service_directory_namespace" "basic" {
-  namespace_id = "tf-test-ns-%{random_suffix}"
-  location     = "us-central1"
-}
-
-resource "google_service_directory_service" "basic" {
-  service_id   = "tf-test-svc-%{random_suffix}"
-  namespace    = google_service_directory_namespace.basic.id
-}
-
 resource "google_ces_app" "my-app" {
     location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
@@ -1073,9 +1024,6 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
             python_function {
                 name        = "transform_function_updated"
                 python_code = "def transform_function_updated(x: int) -> int: return x"
-                service_directory_config {
-                    service = google_service_directory_service.basic.id
-                }
             }
         }
         text_response_config {

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -560,6 +560,10 @@ resource "google_ces_tool" "ces_tool_google_search_tool_basic" {
         description     = "example-description"
         exclude_domains = ["example.com", "example2.com"]
         preferred_domains = ["example3.com", "example4.com"]
+        prompt_config {
+            text_prompt = "text-prompt-instruction"
+            voice_prompt = "voice-prompt-instruction"
+        }
     }
 }
 `, context)
@@ -586,6 +590,10 @@ resource "google_ces_tool" "ces_tool_google_search_tool_basic" {
         description     = "example-description-updated"
         exclude_domains = ["example.com", "example2.com"]
         preferred_domains = ["example3.com", "example4.com"]
+        prompt_config {
+            text_prompt = "text-prompt-instruction-updated"
+            voice_prompt = "voice-prompt-instruction-updated"
+        }
     }
 }
 `, context)
@@ -675,3 +683,339 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
 }
 `, context)
 }
+
+func TestAccCESTool_cesToolAgentToolBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCESToolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESTool_cesToolAgentToolBasicExample_full(context),
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_agent_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+			{
+				Config: testAccCESTool_cesToolAgentToolBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_tool.ces_tool_agent_basic", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_agent_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+		},
+	})
+}
+
+func testAccCESTool_cesToolAgentToolBasicExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_agent" "target_agent" {
+  agent_id     = "target-agent-%{random_suffix}"
+  location     = "us"
+  app          = google_ces_app.my-app.app_id
+  display_name = "Target Agent"
+  instruction  = "Target agent instruction"
+  llm_agent {}
+}
+
+resource "google_ces_tool" "ces_tool_agent_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-agent-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    agent_tool {
+        name        = "example-agent-tool%{random_suffix}"
+        description = "example-description"
+        agent       = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/agents/${google_ces_agent.target_agent.agent_id}"
+    }
+}
+`, context)
+}
+
+func testAccCESTool_cesToolAgentToolBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_agent" "target_agent" {
+  agent_id     = "target-agent-%{random_suffix}"
+  location     = "us"
+  app          = google_ces_app.my-app.app_id
+  display_name = "Target Agent"
+  instruction  = "Target agent instruction"
+  llm_agent {}
+}
+
+resource "google_ces_tool" "ces_tool_agent_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-agent-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    agent_tool {
+        name        = "example-agent-tool%{random_suffix}"
+        description = "example-description-updated"
+        agent       = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/agents/${google_ces_agent.target_agent.agent_id}"
+    }
+}
+`, context)
+}
+
+func TestAccCESTool_cesToolFileSearchToolBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCESToolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESTool_cesToolFileSearchToolBasicExample_full(context),
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_file_search_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+			{
+				Config: testAccCESTool_cesToolFileSearchToolBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_tool.ces_tool_file_search_basic", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_file_search_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+		},
+	})
+}
+
+func testAccCESTool_cesToolFileSearchToolBasicExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "ces_tool_file_search_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-filesearch-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    file_search_tool {
+        name        = "example-file-search-tool%{random_suffix}"
+        description = "example-description"
+        corpus_type = "FULLY_MANAGED"
+        file_corpus = "projects/${google_ces_app.my-app.project}/locations/us/ragCorpora/tf-test-corpus-%{random_suffix}"
+    }
+}
+`, context)
+}
+
+func testAccCESTool_cesToolFileSearchToolBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "ces_tool_file_search_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-filesearch-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    file_search_tool {
+        name        = "example-file-search-tool%{random_suffix}"
+        description = "example-description-updated"
+        corpus_type = "FULLY_MANAGED"
+        file_corpus = "projects/${google_ces_app.my-app.project}/locations/us/ragCorpora/tf-test-corpus-%{random_suffix}"
+    }
+}
+`, context)
+}
+
+func TestAccCESTool_cesToolWidgetToolBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCESToolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESTool_cesToolWidgetToolBasicExample_full(context),
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_widget_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+			{
+				Config: testAccCESTool_cesToolWidgetToolBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_tool.ces_tool_widget_basic", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_widget_basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+		},
+	})
+}
+
+func testAccCESTool_cesToolWidgetToolBasicExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "ces_tool_widget_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-widget-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    widget_tool {
+        name        = "example-widget-tool%{random_suffix}"
+        description = "example-description"
+        widget_type = "PRODUCT_CAROUSEL"
+        ui_config = jsonencode({
+            displaySettings = {
+                showHeader = true
+            }
+        })
+        data_mapping {
+            mode = "FIELD_MAPPING"
+            field_mappings = {
+                "key1" = "value1"
+                "key2" = "value2"
+            }
+        }
+        text_response_config {
+            type = "STATIC"
+            static_text = "example-static-text"
+        }
+        parameters {
+            type = "OBJECT"
+            properties = jsonencode({
+                param1 = {
+                    type = "STRING"
+                }
+            })
+        }
+    }
+}
+`, context)
+}
+
+func testAccCESTool_cesToolWidgetToolBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+}
+
+resource "google_ces_tool" "ces_tool_widget_basic" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-widget-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    widget_tool {
+        name        = "example-widget-tool%{random_suffix}"
+        description = "example-description-updated"
+        widget_type = "PRODUCT_CAROUSEL"
+        ui_config = jsonencode({
+            displaySettings = {
+                showHeader = false
+            }
+        })
+        data_mapping {
+            mode = "FIELD_MAPPING"
+            field_mappings = {
+                "key1" = "value1-updated"
+                "key2" = "value2-updated"
+            }
+        }
+        text_response_config {
+            type = "STATIC"
+            static_text = "example-static-text-updated"
+        }
+        parameters {
+            type = "OBJECT"
+            properties = jsonencode({
+                param1 = {
+                    type = "STRING"
+                }
+            })
+        }
+    }
+}
+`, context)
+}
+

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -640,16 +640,27 @@ func TestAccCESTool_cesToolPythonFunctionBasicExample_update(t *testing.T) {
 
 func testAccCESTool_cesToolPythonFunctionBasicExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_service_directory_namespace" "basic" {
+  namespace_id = "tf-test-ns-%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "basic" {
+  service_id   = "tf-test-svc-%{random_suffix}"
+  namespace    = google_service_directory_namespace.basic.id
+}
+
 resource "google_ces_app" "my-app" {
-    location     = "us"
+    location     = "us-central1"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
         time_zone = "America/Los_Angeles"
     }
 }
+
 resource "google_ces_tool" "ces_tool_python_function_basic" {
-    location       = "us"
+    location       = "us-central1"
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -657,7 +668,7 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
         name = "example_function"
         python_code = "def example_function() -> int: return 0"
         service_directory_config {
-            service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+            service = google_service_directory_service.basic.id
         }
     }
 }
@@ -666,16 +677,27 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
 
 func testAccCESTool_cesToolPythonFunctionBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_service_directory_namespace" "basic" {
+  namespace_id = "tf-test-ns-%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "basic" {
+  service_id   = "tf-test-svc-%{random_suffix}"
+  namespace    = google_service_directory_namespace.basic.id
+}
+
 resource "google_ces_app" "my-app" {
-    location     = "us"
+    location     = "us-central1"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
         time_zone = "America/Los_Angeles"
     }
 }
+
 resource "google_ces_tool" "ces_tool_python_function_basic" {
-    location       = "us"
+    location       = "us-central1"
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -683,7 +705,7 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
         name = "example_function_updated"
         python_code = "def example_function_updated() -> int: return 0"
         service_directory_config {
-            service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+            service = google_service_directory_service.basic.id
         }
     }
 }
@@ -929,8 +951,18 @@ func TestAccCESTool_cesToolWidgetToolBasicExample_update(t *testing.T) {
 
 func testAccCESTool_cesToolWidgetToolBasicExample_full(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_service_directory_namespace" "basic" {
+  namespace_id = "tf-test-ns-%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "basic" {
+  service_id   = "tf-test-svc-%{random_suffix}"
+  namespace    = google_service_directory_namespace.basic.id
+}
+
 resource "google_ces_app" "my-app" {
-    location     = "us"
+    location     = "us-central1"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -939,7 +971,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_widget_basic" {
-    location       = "us"
+    location       = "us-central1"
     app            = google_ces_app.my-app.name
     tool_id        = "tf-test-widget-%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -954,15 +986,15 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us-central1/apps/${google_ces_app.my-app.app_id}/tools/source-tool"
             field_mappings = {
                 "key1" = "value1"
             }
             python_function {
                 name        = "transform_function"
-                python_code = "def transform_function(x): return x"
+                python_code = "def transform_function(x: int) -> int: return x"
                 service_directory_config {
-                    service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+                    service = google_service_directory_service.basic.id
                 }
             }
         }
@@ -999,8 +1031,18 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
 
 func testAccCESTool_cesToolWidgetToolBasicExample_update(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_service_directory_namespace" "basic" {
+  namespace_id = "tf-test-ns-%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "basic" {
+  service_id   = "tf-test-svc-%{random_suffix}"
+  namespace    = google_service_directory_namespace.basic.id
+}
+
 resource "google_ces_app" "my-app" {
-    location     = "us"
+    location     = "us-central1"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -1009,7 +1051,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_widget_basic" {
-    location       = "us"
+    location       = "us-central1"
     app            = google_ces_app.my-app.name
     tool_id        = "tf-test-widget-%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -1024,15 +1066,15 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool-updated"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us-central1/apps/${google_ces_app.my-app.app_id}/tools/source-tool-updated"
             field_mappings = {
                 "key1" = "value1-updated"
             }
             python_function {
                 name        = "transform_function_updated"
-                python_code = "def transform_function_updated(x): return x"
+                python_code = "def transform_function_updated(x: int) -> int: return x"
                 service_directory_config {
-                    service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc-updated"
+                    service = google_service_directory_service.basic.id
                 }
             }
         }

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -656,6 +656,9 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     python_function {
         name = "example_function"
         python_code = "def example_function() -> int: return 0"
+        service_directory_config {
+            service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+        }
     }
 }
 `, context)
@@ -679,6 +682,9 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     python_function {
         name = "example_function_updated"
         python_code = "def example_function_updated() -> int: return 0"
+        service_directory_config {
+            service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+        }
     }
 }
 `, context)
@@ -947,23 +953,44 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
             }
         })
         data_mapping {
-            mode = "FIELD_MAPPING"
+            mode             = "FIELD_MAPPING"
+            source_tool_name = "projects/\${google_ces_app.my-app.project}/locations/us/apps/\${google_ces_app.my-app.app_id}/tools/source-tool"
             field_mappings = {
                 "key1" = "value1"
-                "key2" = "value2"
+            }
+            python_function {
+                name        = "transform_function"
+                python_code = "def transform_function(x): return x"
+                service_directory_config {
+                    service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+                }
             }
         }
         text_response_config {
-            type = "STATIC"
-            static_text = "example-static-text"
+            type                      = "STATIC"
+            static_text               = "example-static-text"
+            text_response_instruction = "example-instruction"
         }
         parameters {
-            type = "OBJECT"
-            properties = jsonencode({
-                param1 = {
-                    type = "STRING"
-                }
-            })
+            type                  = "ARRAY"
+            description           = "param-description"
+            title                 = "param-title"
+            nullable              = true
+            min_items             = 1
+            max_items             = 10
+            unique_items          = true
+            minimum               = 1.0
+            maximum               = 100.0
+            required              = ["field1"]
+            enum                  = ["value1", "value2"]
+            default               = jsonencode(["value1"])
+            additional_properties = jsonencode({ type = "STRING" })
+            any_of                = jsonencode([{ type = "STRING" }])
+            defs                  = jsonencode({ def1 = { type = "STRING" } })
+            ref                   = "#/defs/def1"
+            items                 = jsonencode({ type = "STRING" })
+            prefix_items          = jsonencode([{ type = "STRING" }])
+            properties            = jsonencode({ field1 = { type = "STRING" } })
         }
     }
 }
@@ -996,23 +1023,173 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
             }
         })
         data_mapping {
-            mode = "FIELD_MAPPING"
+            mode             = "FIELD_MAPPING"
+            source_tool_name = "projects/\${google_ces_app.my-app.project}/locations/us/apps/\${google_ces_app.my-app.app_id}/tools/source-tool-updated"
             field_mappings = {
                 "key1" = "value1-updated"
-                "key2" = "value2-updated"
+            }
+            python_function {
+                name        = "transform_function_updated"
+                python_code = "def transform_function_updated(x): return x"
+                service_directory_config {
+                    service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc-updated"
+                }
             }
         }
         text_response_config {
-            type = "STATIC"
-            static_text = "example-static-text-updated"
+            type                      = "STATIC"
+            static_text               = "example-static-text-updated"
+            text_response_instruction = "example-instruction-updated"
         }
         parameters {
-            type = "OBJECT"
-            properties = jsonencode({
-                param1 = {
-                    type = "STRING"
-                }
-            })
+            type                  = "ARRAY"
+            description           = "param-description-updated"
+            title                 = "param-title-updated"
+            nullable              = false
+            min_items             = 2
+            max_items             = 20
+            unique_items          = false
+            minimum               = 2.0
+            maximum               = 200.0
+            required              = ["field1"]
+            enum                  = ["value1", "value3"]
+            default               = jsonencode(["value1"])
+            additional_properties = jsonencode({ type = "INTEGER" })
+            any_of                = jsonencode([{ type = "INTEGER" }])
+            defs                  = jsonencode({ def1 = { type = "INTEGER" } })
+            ref                   = "#/defs/def1"
+            items                 = jsonencode({ type = "INTEGER" })
+            prefix_items          = jsonencode([{ type = "INTEGER" }])
+            properties            = jsonencode({ field1 = { type = "INTEGER" } })
+        }
+    }
+}
+`, context)
+}
+
+func TestAccCESTool_cesToolDataStoreSourceBasicExample_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckCESToolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCESTool_cesToolDataStoreSourceBasicExample_full(context),
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_datastore_source",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+			{
+				Config: testAccCESTool_cesToolDataStoreSourceBasicExample_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_ces_tool.ces_tool_datastore_source", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_ces_tool.ces_tool_datastore_source",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"app", "location", "tool_id"},
+			},
+		},
+	})
+}
+
+func testAccCESTool_cesToolDataStoreSourceBasicExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                    = "global"
+  data_store_id               = "tf_test_tool_ds_id%{random_suffix}"
+  display_name                = "tf-test-structured-datastore"
+  industry_vertical           = "GENERIC"
+  content_config              = "NO_CONTENT"
+  solution_types              = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search = false
+}
+
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+    depends_on = [google_discovery_engine_data_store.basic]
+    lifecycle {
+        ignore_changes = [data_store_settings]
+    }
+}
+
+resource "google_ces_tool" "ces_tool_datastore_source" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-ds-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    data_store_tool {
+        name        = "example-ds-tool%{random_suffix}"
+        description = "example-description"
+        filter_parameter_behavior = "ALWAYS_INCLUDE"
+        data_store_source {
+            data_store {
+                name = google_discovery_engine_data_store.basic.name
+            }
+            filter = "example_field: ANY(\"specific_example\")"
+        }
+    }
+}
+`, context)
+}
+
+func testAccCESTool_cesToolDataStoreSourceBasicExample_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_discovery_engine_data_store" "basic" {
+  location                    = "global"
+  data_store_id               = "tf_test_tool_ds_id%{random_suffix}"
+  display_name                = "tf-test-structured-datastore"
+  industry_vertical           = "GENERIC"
+  content_config              = "NO_CONTENT"
+  solution_types              = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search = false
+}
+
+resource "google_ces_app" "my-app" {
+    location     = "us"
+    display_name = "tf-test-my-app%{random_suffix}"
+    app_id       = "tf-test-app-id%{random_suffix}"
+    time_zone_settings {   
+        time_zone = "America/Los_Angeles"
+    }
+    depends_on = [google_discovery_engine_data_store.basic]
+    lifecycle {
+        ignore_changes = [data_store_settings]
+    }
+}
+
+resource "google_ces_tool" "ces_tool_datastore_source" {
+    location       = "us"
+    app            = google_ces_app.my-app.name
+    tool_id        = "tf-test-ds-%{random_suffix}"
+    execution_type = "SYNCHRONOUS"
+    data_store_tool {
+        name        = "example-ds-tool%{random_suffix}"
+        description = "example-description-updated"
+        filter_parameter_behavior = "NEVER_INCLUDE"
+        data_store_source {
+            data_store {
+                name = google_discovery_engine_data_store.basic.name
+            }
+            filter = "example_field: ANY(\"specific_example_updated\")"
         }
     }
 }

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -657,7 +657,7 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
         name = "example_function"
         python_code = "def example_function() -> int: return 0"
         service_directory_config {
-            service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+            service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
         }
     }
 }
@@ -683,7 +683,7 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
         name = "example_function_updated"
         python_code = "def example_function_updated() -> int: return 0"
         service_directory_config {
-            service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+            service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
         }
     }
 }
@@ -954,7 +954,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/\${google_ces_app.my-app.project}/locations/us/apps/\${google_ces_app.my-app.app_id}/tools/source-tool"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool"
             field_mappings = {
                 "key1" = "value1"
             }
@@ -962,7 +962,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
                 name        = "transform_function"
                 python_code = "def transform_function(x): return x"
                 service_directory_config {
-                    service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
+                    service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc"
                 }
             }
         }
@@ -1024,7 +1024,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/\${google_ces_app.my-app.project}/locations/us/apps/\${google_ces_app.my-app.app_id}/tools/source-tool-updated"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool-updated"
             field_mappings = {
                 "key1" = "value1-updated"
             }
@@ -1032,7 +1032,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
                 name        = "transform_function_updated"
                 python_code = "def transform_function_updated(x): return x"
                 service_directory_config {
-                    service = "projects/\${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc-updated"
+                    service = "projects/${google_ces_app.my-app.project}/locations/us/namespaces/ns/services/svc-updated"
                 }
             }
         }

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -651,7 +651,7 @@ resource "google_service_directory_service" "basic" {
 }
 
 resource "google_ces_app" "my-app" {
-    location     = "us-central1"
+    location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -660,7 +660,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_python_function_basic" {
-    location       = "us-central1"
+    location       = "us"
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -688,7 +688,7 @@ resource "google_service_directory_service" "basic" {
 }
 
 resource "google_ces_app" "my-app" {
-    location     = "us-central1"
+    location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -697,7 +697,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_python_function_basic" {
-    location       = "us-central1"
+    location       = "us"
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -962,7 +962,7 @@ resource "google_service_directory_service" "basic" {
 }
 
 resource "google_ces_app" "my-app" {
-    location     = "us-central1"
+    location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -971,7 +971,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_widget_basic" {
-    location       = "us-central1"
+    location       = "us"
     app            = google_ces_app.my-app.name
     tool_id        = "tf-test-widget-%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -986,7 +986,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us-central1/apps/${google_ces_app.my-app.app_id}/tools/source-tool"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool"
             field_mappings = {
                 "key1" = "value1"
             }
@@ -1042,7 +1042,7 @@ resource "google_service_directory_service" "basic" {
 }
 
 resource "google_ces_app" "my-app" {
-    location     = "us-central1"
+    location     = "us"
     display_name = "tf-test-my-app%{random_suffix}"
     app_id       = "tf-test-app-id%{random_suffix}"
     time_zone_settings {   
@@ -1051,7 +1051,7 @@ resource "google_ces_app" "my-app" {
 }
 
 resource "google_ces_tool" "ces_tool_widget_basic" {
-    location       = "us-central1"
+    location       = "us"
     app            = google_ces_app.my-app.name
     tool_id        = "tf-test-widget-%{random_suffix}"
     execution_type = "SYNCHRONOUS"
@@ -1066,7 +1066,7 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
         })
         data_mapping {
             mode             = "FIELD_MAPPING"
-            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us-central1/apps/${google_ces_app.my-app.app_id}/tools/source-tool-updated"
+            source_tool_name = "projects/${google_ces_app.my-app.project}/locations/us/apps/${google_ces_app.my-app.app_id}/tools/source-tool-updated"
             field_mappings = {
                 "key1" = "value1-updated"
             }

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -1018,4 +1018,3 @@ resource "google_ces_tool" "ces_tool_widget_basic" {
 }
 `, context)
 }
-


### PR DESCRIPTION
# Add missing tool types and schema enhancements to google_ces_tool

This PR completes the schema coverage for the `google_ces_tool` resource in Magic Modules to bring it into full parity with the Customer Engagement Suite (CES) REST API. It adds entirely missing customer-managed tool types, exposes read-only platform-managed tool blocks, and resolves several missing attribute gaps in the existing tools.

## Documentation
https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/reference/rest/v1/projects.locations.apps.tools#resource:-tool

## Technical Details
- **Added Missing Tools:**
    - `agentTool`
    - `fileSearchTool`
    - `widgetTool`
- **Exposed Read-Only (Output-Only) Tool Types:**
    - `remoteAgentTool`
    - `connectorTool`
    - `mcpTool`
- **Fixed Gaps in Existing Tools:**
    - Added `promptConfig` with custom `textPrompt` and `voicePrompt` settings to `googleSearchTool`.
    - Added `dataStoreSource` and `filterParameterBehavior` to `dataStoreTool` (with mutual exclusivity `conflicts:` tags configured against `engineSource`).
- **Resource Documentation & Note:**
    - Added a `docs.note` block at the top of `Tool.yaml` detailing the relationship between `google_ces_tool` and `google_ces_toolset`.
    - Created 3 new example templates (`ces_tool_agent_basic.tf.tmpl`, `ces_tool_file_search_basic.tf.tmpl`, and `ces_tool_widget_basic.tf.tmpl`) to showcase the new tools.

## Verification Results
- Code generation successful for both GA and Beta.
- Acceptance tests passed successfully for all newly implemented tools and documentation examples for both GA and beta

```release-note:enhancement
ces: added `agent_tool`, `file_search_tool`, and `widget_tool` support to the `google_ces_tool` resource
```
```release-note:enhancement
ces: added `prompt_config` to `google_search_tool` and `data_store_source` to `data_store_tool` in the `google_ces_tool` resource
```
```release-note:enhancement
ces: exposed `remote_agent_tool`, `connector_tool`, and `mcp_tool` as read-only (output-only) attributes in `google_ces_tool`
```