### PR TITLE
`identity`: add values from import_format in `identitySchema` not in properties list

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -731,6 +731,12 @@ func (r Resource) IdentityProperties() []*Type {
 		if includedValues[field] || field == "project" || field == "zone" || field == "region" {
 			continue
 		}
+		// Avoid creating an identity-only synthetic `name` field when the resource
+		// schema does not define one. This commonly happens with singleton resources
+		// when import format defaults to base_url/{{name}}.
+		if field == "name" {
+			continue
+		}
 		props = append(props, &Type{Name: field, Type: "string", Required: true})
 		includedValues[field] = true
 	}

--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -710,19 +710,29 @@ func (r Resource) IdentityProperties() []*Type {
 		identities = nil
 	}
 	importFormat := r.ExtractIdentifiers(ImportIdFormats(r.ImportFormat, identities, r.BaseUrl)[0])
-	optionalValues := map[string]bool{"project": false, "zone": false, "region": false}
+	includedValues := make(map[string]bool)
 	for _, p := range r.AllProperties() {
-		if slices.Contains(importFormat, google.Underscore(p.Name)) {
+		name := google.Underscore(p.Name)
+		if slices.Contains(importFormat, name) {
 			props = append(props, p)
-			optionalValues[p.Name] = true
+			includedValues[name] = true
 		}
 	}
 
 	hasField := map[string]bool{"project": r.HasProject(), "zone": r.HasZone(), "region": r.HasRegion()}
 	for _, field := range []string{"project", "zone", "region"} { // prevents duplicates
-		if slices.Contains(importFormat, field) && !optionalValues[field] && hasField[field] {
+		if slices.Contains(importFormat, field) && !includedValues[field] && hasField[field] {
 			props = append(props, &Type{Name: field, Type: "string"})
+			includedValues[field] = true
 		}
+	}
+
+	for _, field := range importFormat {
+		if includedValues[field] || field == "project" || field == "zone" || field == "region" {
+			continue
+		}
+		props = append(props, &Type{Name: field, Type: "string", Required: true})
+		includedValues[field] = true
 	}
 
 	if len(r.CustomCode.CustomIdentity) > 0 {

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -884,3 +884,27 @@ func TestSample_TestServiceDependencies(t *testing.T) {
 		})
 	}
 }
+
+func TestIdentityPropertiesIncludesMissingImportIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	r := api.Resource{
+		BaseUrl:      "projects/{{project}}/datasets",
+		ImportFormat: []string{"projects/{{project}}/datasets/{{dataset_id}}"},
+	}
+
+	got := r.IdentityProperties()
+	gotNames := make([]string, 0, len(got))
+	for _, p := range got {
+		gotNames = append(gotNames, p.Name)
+	}
+
+	wantNames := []string{"project", "dataset_id"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("IdentityProperties() names mismatch (-want +got):\n%s", diff)
+	}
+
+	if !got[1].Required {
+		t.Fatalf("dataset_id should be required when synthesized from import format")
+	}
+}

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -908,3 +908,25 @@ func TestIdentityPropertiesIncludesMissingImportIdentifiers(t *testing.T) {
 		t.Fatalf("dataset_id should be required when synthesized from import format")
 	}
 }
+
+func TestIdentityPropertiesSkipsSyntheticNameWhenNotInSchema(t *testing.T) {
+	t.Parallel()
+
+	r := api.Resource{
+		BaseUrl: "projects/{{project}}/locations/{{location}}/encryptionSpec",
+		Parameters: []*api.Type{
+			{Name: "location", Type: "string"},
+		},
+	}
+
+	got := r.IdentityProperties()
+	gotNames := make([]string, 0, len(got))
+	for _, p := range got {
+		gotNames = append(gotNames, p.Name)
+	}
+
+	wantNames := []string{"location", "project"}
+	if diff := cmp.Diff(wantNames, gotNames); diff != "" {
+		t.Fatalf("IdentityProperties() names mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -43,8 +43,6 @@ custom_code:
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
 custom_diff:
   - 'customCollationDiff'
-# exluding resource_identity due to dataset_id field
-exclude_identity_generation: true
 exclude_sweeper: true
 examples:
   - name: 'bigquery_dataset_basic'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

We run into a case in several resources such as dataset where a value within `import_format` is at times a value that is not included in properties list resulting in a value such as `dataset_id` not being included in identity schema. PR resolves this by creating a new Type for the missing value in properties:
```golang
	for _, field := range importFormat {
		if includedValues[field] || field == "project" || field == "zone" || field == "region" {
			continue
		}
		props = append(props, &Type{Name: field, Type: "string", Required: true})
		includedValues[field] = true
	}
```
also included a unit test that replicates this specific edge case

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
