### PR TITLE
`kms`: resource identity support for `crypto_key_version` resource

### DIFF
--- a/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
@@ -1,13 +1,10 @@
 
 	config := meta.(*transport_tpg.Config)
 	importId := d.Id()
-	importByIdentity := importId == ""
-	var identityErr error
-	var identity *schema.IdentityData
 	if importId == "" {
-		identity, identityErr = d.Identity()
-		if identityErr != nil || identity == nil {
-			return nil, fmt.Errorf("Error reading import identity: %s", identityErr)
+		identity, err := d.Identity()
+		if err != nil {
+			return nil, fmt.Errorf("Error reading import identity: %s", err)
 		}
 
 		identityName, ok := identity.Get("name").(string)
@@ -27,16 +24,6 @@
 	}
 	if err := d.Set("name", cryptoKeyVersionId.Name); err != nil {
 		return nil, fmt.Errorf("Error setting name: %s", err)
-	}
-
-	if importByIdentity {
-		if identityErr == nil && identity != nil {
-			if err := identity.Set("name", cryptoKeyVersionId.Name); err != nil {
-				return nil, fmt.Errorf("Error setting identity name: %s", err)
-			}
-		} else {
-			log.Printf("[DEBUG] (Import) identity not set: %s", identityErr)
-		}
 	}
 
 	id, err := tpgresource.ReplaceVars(d, config, "{{$.GetIdFormat}}")

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
@@ -1,9 +1,11 @@
 
 	config := meta.(*transport_tpg.Config)
-	identity, identityErr := d.Identity()
-
 	importId := d.Id()
+	importByIdentity := importId == ""
+	var identityErr error
+	var identity *schema.ResourceIdentityData
 	if importId == "" {
+		identity, identityErr = d.Identity()
 		if identityErr != nil || identity == nil {
 			return nil, fmt.Errorf("Error reading import identity: %s", identityErr)
 		}
@@ -27,12 +29,14 @@
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
 
-	if identityErr == nil && identity != nil {
-		if err := identity.Set("name", cryptoKeyVersionId.Name); err != nil {
-			return nil, fmt.Errorf("Error setting identity name: %s", err)
+	if importByIdentity {
+		if identityErr == nil && identity != nil {
+			if err := identity.Set("name", cryptoKeyVersionId.Name); err != nil {
+				return nil, fmt.Errorf("Error setting identity name: %s", err)
+			}
+		} else {
+			log.Printf("[DEBUG] (Import) identity not set: %s", identityErr)
 		}
-	} else {
-		log.Printf("[DEBUG] (Import) identity not set: %s", identityErr)
 	}
 
 	id, err := tpgresource.ReplaceVars(d, config, "{{$.GetIdFormat}}")

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
@@ -3,7 +3,7 @@
 	importId := d.Id()
 	importByIdentity := importId == ""
 	var identityErr error
-	var identity *schema.ResourceIdentityData
+	var identity *schema.IdentityData
 	if importId == "" {
 		identity, identityErr = d.Identity()
 		if identityErr != nil || identity == nil {

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
@@ -25,7 +25,6 @@
 	if err := d.Set("name", cryptoKeyVersionId.Name); err != nil {
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
-
 	id, err := tpgresource.ReplaceVars(d, config, "{{$.GetIdFormat}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)

--- a/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/kms_crypto_key_version.go.tmpl
@@ -1,7 +1,22 @@
 
 	config := meta.(*transport_tpg.Config)
+	identity, identityErr := d.Identity()
 
-	cryptoKeyVersionId, err := parseKmsCryptoKeyVersionId(d.Id(), config)
+	importId := d.Id()
+	if importId == "" {
+		if identityErr != nil || identity == nil {
+			return nil, fmt.Errorf("Error reading import identity: %s", identityErr)
+		}
+
+		identityName, ok := identity.Get("name").(string)
+		if !ok || identityName == "" {
+			return nil, fmt.Errorf("Error reading import identity: missing required identity field \"name\"")
+		}
+
+		importId = identityName
+	}
+
+	cryptoKeyVersionId, err := parseKmsCryptoKeyVersionId(importId, config)
 	if err != nil {
 		return nil, err
 	}
@@ -11,6 +26,15 @@
 	if err := d.Set("name", cryptoKeyVersionId.Name); err != nil {
 		return nil, fmt.Errorf("Error setting name: %s", err)
 	}
+
+	if identityErr == nil && identity != nil {
+		if err := identity.Set("name", cryptoKeyVersionId.Name); err != nil {
+			return nil, fmt.Errorf("Error setting identity name: %s", err)
+		}
+	} else {
+		log.Printf("[DEBUG] (Import) identity not set: %s", identityErr)
+	}
+
 	id, err := tpgresource.ReplaceVars(d, config, "{{$.GetIdFormat}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)

--- a/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
+++ b/mmv1/third_party/terraform/services/kms/resource_kms_crypto_key_version_test.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 )
 
 func TestAccKmsCryptoKeyVersion_basic(t *testing.T) {
@@ -36,6 +37,34 @@ func TestAccKmsCryptoKeyVersion_basic(t *testing.T) {
 			},
 			{
 				Config: testGoogleKmsCryptoKeyVersion_removed(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+		},
+	})
+}
+
+func TestAccKmsCryptoKeyVersion_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	projectOrg := envvar.GetTestOrgFromEnv(t)
+	projectBillingAccount := envvar.GetTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKeyVersion_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				ResourceName:    "google_kms_crypto_key_version.crypto_key_version",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

`crypto_key_version` needed specific logic due to it's custom_import code

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
kms: added resource identity support for `google_kms_crypto_key_version` resource
```
