### PR TITLE
`storage`: add `SetResourceIdentityAttributes` in update

### DIFF
--- a/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
+++ b/mmv1/third_party/terraform/services/storage/resource_storage_bucket.go.tmpl
@@ -1207,7 +1207,10 @@ func resourceStorageBucketUpdate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(res.Id)
 
-	return nil
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"name":    res.Name,
+		"project": d.Get("project").(string),
+	})
 }
 
 func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27595
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27596

This slipped through due to the missing identity error only existing in older versions of terraform.

In an attempt to reproduce i got no error on terraform version 1.14.0

however when downgrading to 1.5.7 i get the following:
```console
󰀵 mau  …/󰲋 /Scratch/storage_bucket_identity_bug   12:30   envchain GCLOUD terraform apply
google_storage_bucket.bucket: Refreshing state... [id=storage-identity-bucket]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # google_storage_bucket.bucket will be updated in-place
  ~ resource "google_storage_bucket" "bucket" {
      ~ force_destroy               = true -> false
        id                          = "storage-identity-bucket"
        name                        = "storage-identity-bucket"
        # (17 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

google_storage_bucket.bucket: Modifying... [id=storage-identity-bucket]
╷
│ Error: Missing Resource Identity After Update: The Terraform provider unexpectedly returned no resource identity after having no errors in the resource update. This is always a problem with the provider and should be reported to the provider developer
│ 
│   with google_storage_bucket.bucket,
│   on main.tf line 1, in resource "google_storage_bucket" "bucket":
│    1: resource "google_storage_bucket" "bucket" {
│ 
╵

```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
storage: fixed missing identity error when updating values in `google_storage_bucket`
```
