### PR TITLE
Re-enable networkPerformanceConfig test

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -848,10 +848,6 @@ func TestAccContainerCluster_inTransitEncryptionConfig(t *testing.T) {
 func TestAccContainerCluster_networkPerformanceConfig(t *testing.T) {
 	t.Parallel()
 
-	// Skip in VCR until the test issue is resolved
-	// https://github.com/hashicorp/terraform-provider-google/issues/24850
-	acctest.SkipIfVcr(t)
-
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)


### PR DESCRIPTION
re-enable failed test in https://github.com/hashicorp/terraform-provider-google/issues/24850

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: none

```
