### PR TITLE
`docs`: update identity block link

### DIFF
--- a/mmv1/templates/terraform/list_resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/list_resource.html.markdown.tmpl
@@ -49,6 +49,6 @@ Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
 
 ## Results
 
-By default each result includes **resource identity** for [`{{$.TerraformName}}`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/{{$.TerraformName}}) (see [Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)).
+By default each result includes **resource identity** for [`{{$.TerraformName}}`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/{{$.TerraformName}}) (see [Resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity)).
 
 With `include_resource = true` on the `list` block, results also include the full resource-style attributes documented for the managed [`{{$.TerraformName}}` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/{{$.TerraformName}}#attributes-reference).

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -209,7 +209,7 @@ This resource does not support import.
 * `{{replaceAll $idFormat "%" "" }}`
 {{- end }}
 
-In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/resources/identities) to import {{$.Name}} using identity values. For example:
+In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/block/import#identity) to import {{$.Name}} using identity values. For example:
 
 ```tf
 import {

--- a/mmv1/third_party/terraform/website/docs/guides/using_list_resources_with_terraform_query.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/using_list_resources_with_terraform_query.html.markdown
@@ -85,7 +85,7 @@ The following are **core Terraform** features; see the HashiCorp language docs f
 * **`config { ... }`** — Provider-specific arguments; each list resource documents its supported
   attributes.
 * **`include_resource`** — When `true`, results include full resource-shaped data in addition to
-  [resource identity](https://developer.hashicorp.com/terraform/language/resources/identities).
+  [resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity).
   When unset/false, identity is returned by default.
 * **`limit`** — Maximum number of results (default `100` per Terraform documentation).
 * **`count` / `for_each`** — Meta-arguments for multiple queries, same idea as for managed resources.

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_service_account.html.markdown
@@ -40,7 +40,7 @@ Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
 ## Results
 
 By default each result includes **resource identity** for `google_service_account` (see
-[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+[Resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity)):
 
 * `email` - Service account email (required for identity).
 * `project` - Project ID when applicable.

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -241,7 +241,7 @@ $ terraform import google_project_iam_member.default "{{project_id}} roles/viewe
 
 #### Import via resource identity
 
-`google_project_iam_member` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/resources/identities) (Terraform 1.12+):
+`google_project_iam_member` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity) (Terraform 1.12+):
 
 ```tf
 import {
@@ -284,7 +284,7 @@ terraform import google_project_iam_binding.default "{{project_id}} roles/viewer
 
 #### Import via resource identity
 
-`google_project_iam_binding` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/resources/identities) (Terraform 1.12+):
+`google_project_iam_binding` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity) (Terraform 1.12+):
 
 ```tf
 import {
@@ -325,7 +325,7 @@ $ terraform import google_project_iam_policy.default {{project_id}}
 
 #### Import via resource identity
 
-`google_project_iam_policy` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/resources/identities) (Terraform 1.12+):
+`google_project_iam_policy` also supports plannable import via [resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity) (Terraform 1.12+):
 
 ```tf
 import {

--- a/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -99,7 +99,7 @@ import {
 }
 ```
 
-In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/resources/identities) to import service accounts using identity values. For example:
+In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/block/import#identity) to import service accounts using identity values. For example:
 
 ```tf
 import {


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27633

The identity link must've been updated since the introduction of resource identity.

identity block now sends to https://developer.hashicorp.com/terraform/language/block/import#identity and not a 404 page

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
