### PR TITLE
fix(compute): increase delay project metadata basic and modify

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_project_metadata_test.go
@@ -154,8 +154,8 @@ resource "google_project_service" "compute" {
   depends_on = [time_sleep.wait_60_seconds]
 }
 
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
+resource "time_sleep" "wait_240_seconds" {
+  create_duration = "240s"
   depends_on = [google_project_service.compute]
 }
 
@@ -165,7 +165,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     banana = "orange"
     sofa   = "darwinism"
   }
-  depends_on = [time_sleep.wait_120_seconds]
+  depends_on = [time_sleep.wait_240_seconds]
 }
 `, projectID, projectID, org, billing)
 }
@@ -191,8 +191,8 @@ resource "google_project_service" "compute" {
   depends_on = [time_sleep.wait_60_seconds]
 }
 
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
+resource "time_sleep" "wait_240_seconds" {
+  create_duration = "240s"
   depends_on = [google_project_service.compute]
 }
 
@@ -202,7 +202,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     kiwi    = "papaya"
     finches = "darwinism"
   }
-  depends_on = [time_sleep.wait_120_seconds]
+  depends_on = [time_sleep.wait_240_seconds]
 }
 `, projectID, projectID, org, billing)
 }
@@ -228,8 +228,8 @@ resource "google_project_service" "compute" {
   depends_on = [time_sleep.wait_60_seconds]
 }
 
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
+resource "time_sleep" "wait_240_seconds" {
+  create_duration = "240s"
   depends_on = [google_project_service.compute]
 }
 
@@ -240,7 +240,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     genghis_khan = "french bread"
     happy        = "smiling"
   }
-  depends_on = [time_sleep.wait_120_seconds]
+  depends_on = [time_sleep.wait_240_seconds]
 }
 `, projectID, projectID, org, billing)
 }
@@ -266,8 +266,8 @@ resource "google_project_service" "compute" {
   depends_on = [time_sleep.wait_60_seconds]
 }
 
-resource "time_sleep" "wait_120_seconds" {
-  create_duration = "120s"
+resource "time_sleep" "wait_240_seconds" {
+  create_duration = "240s"
   depends_on = [google_project_service.compute]
 }
 
@@ -278,7 +278,7 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     paris = "french bread"
     happy = "laughing"
   }
-  depends_on = [time_sleep.wait_120_seconds]
+  depends_on = [time_sleep.wait_240_seconds]
 }
 `, projectID, projectID, org, billing)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none
compute: Fixed potential flakiness in `google_compute_project_metadata` tests by increasing internal delay from 120s to 240s to allow for API propagation.```

The following change has been made:
* `time_sleep` resource duration has been increased from 120s to 240s

Fixes:
[b/518616211](https://buganizer.corp.google.com/issues/518616211)
[Issue: #27631](https://github.com/hashicorp/terraform-provider-google/issues/27631)



