### PR TITLE
Document VMware Engine datastore mounting in cluster examples and templates

### DIFF
--- a/mmv1/products/vmwareengine/Datastore.yaml
+++ b/mmv1/products/vmwareengine/Datastore.yaml
@@ -13,7 +13,24 @@
 
 ---
 name: Datastore
-description: A datastore resource that can be mounted on a privatecloud cluster
+description: |
+  A datastore resource that can be mounted on a VMware Engine cluster.
+
+  ~> **Note:** To mount a datastore on a VMware Engine cluster, configure the
+  `datastore_mount_config` block within the `google_vmwareengine_cluster` resource.
+  A datastore cannot be mounted directly using the `google_vmwareengine_datastore` resource.
+
+  If you are mounting a datastore that was already created outside of Terraform (or in a
+  separate Terraform configuration), reference it directly by its full resource URI in the
+  `datastore_mount_config.datastore` field inside the cluster resource:
+  ```terraform
+  datastore_mount_config {
+    datastore = "projects/PROJECT_ID/locations/LOCATION/datastores/DATASTORE_ID"
+    datastore_network {
+      # ...
+    }
+  }
+  ```
 base_url: projects/{{project}}/locations/{{location}}/datastores
 update_mask: true
 self_link: projects/{{project}}/locations/{{location}}/datastores/{{name}}

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_nfs_datastore_filestore.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_nfs_datastore_filestore.tf.tmpl
@@ -90,6 +90,8 @@ resource "google_vmwareengine_datastore" "test_fs_datastore" {
   }
 }
 
+# Mount NFS datastore on vSphere cluster
+# This code block is required to mount the datastore on ESXi hosts
 resource "google_vmwareengine_cluster" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "name"}}"
   parent   = google_vmwareengine_private_cloud.cluster-pc.id

--- a/mmv1/templates/terraform/examples/vmware_engine_cluster_nfs_datastore_netapp.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_cluster_nfs_datastore_netapp.tf.tmpl
@@ -102,6 +102,8 @@ resource "google_vmwareengine_datastore" "test_fs_datastore" {
   }
 }
 
+# Mount NFS datastore on vSphere cluster
+# This code block is required to mount the datastore on ESXi hosts
 resource "google_vmwareengine_cluster" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "name"}}"
   parent   = google_vmwareengine_private_cloud.cluster-pc.id

--- a/mmv1/templates/terraform/examples/vmware_engine_datastore_filestore.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_datastore_filestore.tf.tmpl
@@ -4,7 +4,18 @@ data "google_filestore_instance" "test_instance" {
   location = "{{index $.TestEnvVars "zone"}}"
 }
 
-# Create a VmwareEngine Datastore, referencing the filestore instance
+# Create a VmwareEngine Datastore, referencing the filestore instance.
+# Note: To mount this datastore on a vSphere cluster, configure the `datastore_mount_config`
+# block within the `google_vmwareengine_cluster` resource. For example:
+#
+#  datastore_mount_config {
+#    datastore        = google_vmwareengine_datastore.example_filestore.id
+#    datastore_network {
+#      subnet           = google_vmwareengine_subnet.example_subnet.id
+#      connection_count = 4
+#      mtu              = 1500
+#    }
+#  }
 resource "google_vmwareengine_datastore" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "resource_name"}}"
   location    = "{{index $.TestEnvVars "zone"}}"

--- a/mmv1/templates/terraform/examples/vmware_engine_datastore_netapp.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_datastore_netapp.tf.tmpl
@@ -4,7 +4,18 @@ resource "google_netapp_volume" "test_volume" {
   location = "{{index $.TestEnvVars "region"}}"
 }
 
-# Create a VmwareEngine Datastore, referencing the netapp volume
+# Create a VmwareEngine Datastore, referencing the netapp volume.
+# Note: To mount this datastore on a vSphere cluster, configure the `datastore_mount_config`
+# block within the `google_vmwareengine_cluster` resource. For example:
+#
+#  datastore_mount_config {
+#    datastore        = google_vmwareengine_datastore.example_netapp.id
+#    datastore_network {
+#      subnet           = google_vmwareengine_subnet.example_subnet.id
+#      connection_count = 4
+#      mtu              = 1500
+#    }
+#  }
 resource "google_vmwareengine_datastore" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "resource_name"}}"
   location    = "{{index $.TestEnvVars "region"}}"

--- a/mmv1/templates/terraform/examples/vmware_engine_datastore_thirdparty.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vmware_engine_datastore_thirdparty.tf.tmpl
@@ -3,7 +3,18 @@ data "google_compute_network" "default" {
   name      = "default"
 }
 
-# create a thirdparty datastore
+# Create a thirdparty datastore.
+# Note: To mount this datastore on a vSphere cluster, configure the `datastore_mount_config`
+# block within the `google_vmwareengine_cluster` resource. For example:
+#
+#  datastore_mount_config {
+#    datastore        = google_vmwareengine_datastore.example_thirdparty.id
+#    datastore_network {
+#      subnet           = google_vmwareengine_subnet.example_subnet.id
+#      connection_count = 4
+#      mtu              = 1500
+#    }
+#  }
 resource "google_vmwareengine_datastore" "{{$.PrimaryResourceId}}" {
   name        = "{{index $.Vars "resource_name"}}"
   location    = "{{index $.TestEnvVars "region"}}-a"


### PR DESCRIPTION
### Description
  This PR updates the VMware Engine Datastore resources, schemas, and templates to provide clear instructions and concrete Terraform configurations on how to mount datastores on a cluster.
  
  1. **Datastore.yaml Schema**: Clarifies in the description that mounting must be configured via the `datastore_mount_config` block within the `google_vmwareengine_cluster` resource, rather than on the datastore itself. Added a config block showcasing how to mount a pre-existing, out-of-band datastore.
  2. **Interpolated Example Comments**: Embedded concrete code block examples of `datastore_mount_config` directly into the inline comments of `vmware_engine_datastore_filestore.tf.tmpl`, `vmware_engine_datastore_netapp.tf.tmpl`, and `vmware_engine_datastore_thirdparty.tf.tmpl` so that users can easily configure cluster mounting in their configurations.

```release-note:enhancement
vmwareengine: update documentation and cluster examples to show how to mount datastores
```