### PR TITLE
Address test failures due to stockout. 

### DIFF
--- a/mmv1/templates/terraform/examples/node_group_maintenance_interval.tf.tmpl
+++ b/mmv1/templates/terraform/examples/node_group_maintenance_interval.tf.tmpl
@@ -8,7 +8,7 @@ resource "google_compute_node_template" "soletenant-tmpl" {
 resource "google_compute_node_group" "{{$.PrimaryResourceId}}" {
   provider    = google-beta
   name        = "{{index $.Vars "group_name"}}"
-  zone        = "us-central1-f"
+  zone        = "us-central1-c"
   description = "example google_compute_node_group for Terraform Google Provider"
 
   initial_size          = 1


### PR DESCRIPTION
Capacity for c2-node-60-240 is limited in us-central1-f, moving the test to us-central1-c, which has less capacity pressure (currently)
https://github.com/hashicorp/terraform-provider-google/issues/27617

**Release Note Template for Downstream PRs (will be copied)**


```release-note:none
Fix test failure due to stockout by moving test from us-central1-f to us-central1-c
```
