### PR TITLE
Bump Node.js version to the latest LTS (24)

### DIFF
--- a/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/examples/app_engine_flexible_app_version.tf.tmpl
@@ -48,8 +48,8 @@ resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
   service    = "default"
   runtime    = "nodejs"
   flexible_runtime_settings {
-    operating_system = "ubuntu22"
-    runtime_version = "20"
+    operating_system = "ubuntu24"
+    runtime_version = "24"
   }
 
   entrypoint {

--- a/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_network_endpoint_group_appengine.tf.tmpl
@@ -14,8 +14,8 @@ resource "google_app_engine_flexible_app_version" "{{$.PrimaryResourceId}}" {
   service    = "{{index $.Vars "neg_name"}}"
   runtime    = "nodejs"
   flexible_runtime_settings {
-    operating_system = "ubuntu22"
-    runtime_version = "20"
+    operating_system = "ubuntu24"
+    runtime_version = "24"
   }
 
   entrypoint {


### PR DESCRIPTION
Bumping the Node.js version to `24` (latest LTS) in App Engine Flexible environment requires updating the underlying operating system stack. According to [Google Cloud App Engine Flexible Node.js runtime documentation](https://cloud.google.com/appengine/docs/flexible/nodejs/runtime), Node.js `24` is only supported on the `ubuntu24` stack and attempts to deploy it on ubuntu22 result in a validation error (`unsupported stack ubuntu22 for runtime nodejs version 24`).

Updated both templates to use `ubuntu24` for the OS stack to align with Node.js 24 requirements.

```release-note:none
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27453