### PR TITLE
`.ci`: Update release note template for `new-list-resource`

### DIFF
--- a/.ci/release-note2.tmpl
+++ b/.ci/release-note2.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{ end }}{{.Body}} ([#{{- .Issue -}}])
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-list-resource" .Type}}**New List Resource:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{ end }}{{.Body}} ([#{{- .Issue -}}])
 {{- end -}}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

I generated the changelog on friday but found that list resources did not have a header similar to new resource or new datasource. I discovered that `.ci/release-note2.tmpl` needed to have this in order for generations to include a new list resource as part of the changelog notes

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
