### PR TITLE
Add Terraform support for GMK public clusters

### DIFF
--- a/mmv1/products/managedkafka/Cluster.yaml
+++ b/mmv1/products/managedkafka/Cluster.yaml
@@ -63,6 +63,10 @@ examples:
     test_vars_overrides:
       key_name: 'kms.BootstrapKMSKeyInLocation(t, "us-central1").CryptoKey.Name'
     external_providers: ["time"]
+  - name: 'managedkafka_cluster_public'
+    primary_resource_id: 'example'
+    vars:
+      cluster_id: 'my-cluster'
 parameters:
   - name: 'location'
     type: String
@@ -111,6 +115,16 @@ properties:
                     The name of the subnet must be in the format `projects/PROJECT_ID/regions/REGION/subnetworks/SUBNET`."
                   required: true
                   diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
+          - name: 'publicClusterConfig'
+            type: NestedObject
+            description: "Public connection configuration for the Kafka cluster."
+            properties:
+              - name: 'allowedSourceIpRanges'
+                type: Array
+                description: "A list of IPv4 addresses or CIDR ranges that are allowed to connect to the cluster."
+                required: true
+                item_type:
+                  type: String
       - name: 'kmsKey'
         type: String
         description: "The Cloud KMS Key name to use for encryption.

--- a/mmv1/templates/terraform/examples/managedkafka_cluster_public.tf.tmpl
+++ b/mmv1/templates/terraform/examples/managedkafka_cluster_public.tf.tmpl
@@ -1,0 +1,23 @@
+resource "google_managed_kafka_cluster" "{{$.PrimaryResourceId}}" {
+  cluster_id = "{{index $.Vars "cluster_id"}}"
+  location = "us-central1"
+  capacity_config {
+    vcpu_count = 3
+    memory_bytes = 3221225472
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = "projects/${data.google_project.project.number}/regions/us-central1/subnetworks/default"
+      }
+      public_cluster_config {
+        allowed_source_ip_ranges = ["192.168.1.0/24"]
+      }
+    }
+  }
+  rebalance_config {
+    mode = "AUTO_REBALANCE_ON_SCALE_UP"
+  }
+}
+data "google_project" "project" {
+}


### PR DESCRIPTION
Porting changes from cl/917852714 to add public_cluster_config to the google_managed_kafka_cluster resource in Magic Modules.

```release-note:enhancement
managedkafka: added `public_cluster_config` field to `google_managed_kafka_cluster` resource
```
