### PR TITLE
fix(tags): restore location-specific base URL for tag binding operation polling

### DIFF
--- a/mmv1/third_party/terraform/services/tags/tags_location_operation.go
+++ b/mmv1/third_party/terraform/services/tags/tags_location_operation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-google/google/services/tagslocation"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
@@ -24,7 +25,7 @@ func (w *TagsLocationOperationWaiter) QueryOp() (interface{}, error) {
 	location := GetLocationFromOpName(w.CommonOperationWaiter.Op.Name)
 	if location != w.CommonOperationWaiter.Op.Name {
 		// Found location in Op.Name, fill it in TagsLocationBasePath and rewrite URL
-		url := fmt.Sprintf("%s%s", strings.Replace(transport_tpg.BaseUrl(Product, w.Config), "{{location}}", location, 1), w.CommonOperationWaiter.Op.Name)
+		url := fmt.Sprintf("%s%s", strings.Replace(transport_tpg.BaseUrl(tagslocation.Product, w.Config), "{{location}}", location, 1), w.CommonOperationWaiter.Op.Name)
 		return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 			Config:    w.Config,
 			Method:    "GET",


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27345
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27511

## Problem

Commit 3d877750b ("Converted most direct references to BasePath fields in the services folders #17394") replaced `w.Config.TagsLocationBasePath` with `transport_tpg.BaseUrl(Product, w.Config)` in `tags_location_operation.go`.

`Product` in the `tags` package resolves to `https://cloudresourcemanager.googleapis.com/v3/` — the global endpoint. This URL does not contain `{{location}}`, so `strings.Replace(..., "{{location}}", location, 1)` is a no-op. The operation polling request hits the global endpoint instead of the location-specific one.

The API rejects it with:

```
Error 400: Operation location 'europe-west2-a' does not match service location 'global'
```

The tag binding itself is created successfully — only the operation wait fails.

## Fix

Use `tagslocation.Product` instead of `Product` for the location-specific branch of `QueryOp()`. `tagslocation.Product` has `BaseUrl: "https://{{location}}-cloudresourcemanager.googleapis.com/v3/"`, so `strings.Replace` correctly substitutes the location.

The global branch (`else`) correctly uses `Product` (tags, global endpoint) and is unchanged.

## Scope

One file changed: `tags_location_operation.go`. Added import for `tagslocation` package and changed `Product` to `tagslocation.Product` on the location-specific code path.

```release-note:bug
tags: fixed `google_tags_location_tag_binding` failing with `Operation location does not match service location 'global'` during creation
```
