### PR TITLE
Use proto JSON names for BackupDR RestoreWorkload networking/reservation fields

### DIFF
--- a/mmv1/products/backupdr/RestoreWorkload.yaml
+++ b/mmv1/products/backupdr/RestoreWorkload.yaml
@@ -403,6 +403,7 @@ properties:
               description: 'Optional. The URL of the Subnetwork resource for this instance.'
             - name: 'ipAddress'
               type: String
+              api_name: 'networkIP'
               description: 'Optional. An IPv4 internal IP address to assign to the instance.'
             - name: 'ipv6Address'
               type: String
@@ -427,6 +428,7 @@ properties:
                     description: 'Optional. The name of this access configuration.'
                   - name: 'externalIp'
                     type: String
+                    api_name: 'natIP'
                   - name: 'externalIpv6'
                     type: String
                   - name: 'externalIpv6PrefixLength'
@@ -458,6 +460,7 @@ properties:
                     description: 'Optional. The name of this access configuration.'
                   - name: 'externalIp'
                     type: String
+                    api_name: 'natIP'
                   - name: 'externalIpv6'
                     type: String
                   - name: 'externalIpv6PrefixLength'
@@ -535,10 +538,12 @@ properties:
           - 'ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE'
       - name: 'allocationAffinity'
         type: NestedObject
+        api_name: 'reservationAffinity'
         description: 'Optional. Specifies the reservations that this instance can consume from.'
         properties:
           - name: 'consumeAllocationType'
             type: Enum
+            api_name: 'consumeReservationType'
             enum_values:
               - 'TYPE_UNSPECIFIED'
               - 'NO_RESERVATION'

--- a/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
@@ -422,7 +422,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
                     niObj["subnetwork"] = v.(string)
                 }
                 if v, ok := niMap["ip_address"]; ok && v != "" {
-                    niObj["ipAddress"] = v.(string)
+                    niObj["networkIP"] = v.(string)
                 }
                 if v, ok := niMap["ipv6_address"]; ok && v != "" {
                     niObj["ipv6Address"] = v.(string)
@@ -463,7 +463,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
                             acObj["name"] = n.(string)
                         }
                         if ei, ok := acMap["external_ip"]; ok && ei != "" {
-                            acObj["externalIp"] = ei.(string)
+                            acObj["natIP"] = ei.(string)
                         }
                         if eiv6, ok := acMap["external_ipv6"]; ok && eiv6 != "" {
                             acObj["externalIpv6"] = eiv6.(string)
@@ -506,7 +506,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
                             iacObj["name"] = n.(string)
                         }
                         if ei, ok := iacMap["external_ip"]; ok && ei != "" {
-                            iacObj["externalIp"] = ei.(string)
+                            iacObj["natIP"] = ei.(string)
                         }
                         if eiv6, ok := iacMap["external_ipv6"]; ok && eiv6 != "" {
                             iacObj["externalIpv6"] = eiv6.(string)
@@ -614,7 +614,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
                 aa := aaList[0].(map[string]interface{})
                 aaObj := make(map[string]interface{})
                 if cat, ok := aa["consume_allocation_type"]; ok && cat != "" {
-                    aaObj["consumeAllocationType"] = cat.(string)
+                    aaObj["consumeReservationType"] = cat.(string)
                 }
                 if k, ok := aa["key"]; ok && k != "" {
                     aaObj["key"] = k.(string)
@@ -623,7 +623,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
                     aaObj["values"] = v.([]interface{})
                 }
                 if len(aaObj) > 0 {
-                    props["allocationAffinity"] = aaObj
+                    props["reservationAffinity"] = aaObj
                 }
             }
         }


### PR DESCRIPTION
This PR corrects the internal mapping between the Terraform provider and the GCE API for Backup DR network parameters. This is strictly a bug fix, not a breaking change.

- The user-facing Terraform schema remains exactly the same.
- The Backup DR proto uses `json_name` overrides (e.g., mapping `ip_address` to `networkIP`) for GCE compatibility, which the provider was previously not considering.
- Crucially, setting these fields previously resulted in a 400 error. Because these fields were non-functional, no existing working configurations are impacted. We are strictly moving from 400 errors to valid, functioning API values.
- This mapping issue was missed in our standard provider tests because we do not set explicit network parameters. Hardcoding specific IPs is too brittle since we cannot guarantee their availability in the test network, so we rely on auto-assignment.


manual runs

```release-note:bug
backupdr: fixed an issue where `google_backup_dr_restore_workload` did not use the correct API JSON names for networking/reservation fields
```