### PR TITLE
iamworkforcepool: write-only support for `oidc.client_secret` in `google_iam_workforce_pool_provider`

### DIFF
--- a/mmv1/products/iamworkforcepool/WorkforcePoolProvider.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePoolProvider.yaml
@@ -351,7 +351,7 @@ properties:
                 required: true
                 description: |
                   The plain text of the client secret value.
-                sensitive: true
+                write_only: true
                 validation:
                   function: validation.StringIsNotEmpty
               - name: thumbprint
@@ -457,6 +457,7 @@ properties:
                 required: true
                 description: |
                   The plain text of the client secret value.
+                write_only: true
                 validation:
                   function: validation.StringIsNotEmpty
               - name: thumbprint
@@ -549,6 +550,7 @@ properties:
                 required: true
                 description: |
                   The plain text of the client secret value.
+                write_only: true
                 validation:
                   function: validation.StringIsNotEmpty
               - name: thumbprint

--- a/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_extended_attributes_oauth2_config_client_secret_value.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_extended_attributes_oauth2_config_client_secret_value.go.tmpl
@@ -20,6 +20,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	}
 	transformed := make(map[string]interface{})
 	transformed["thumbprint"] = original["thumbprint"]
+	transformed["plain_text_wo_version"] = d.Get("extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version")
 	// Trigger a diff based on the plain_text if there is no change in the thumbprint,
 	// otherwise leave plain_text empty to always trigger a diff.
 	if original["thumbprint"].(string) == d.Get("extended_attributes_oauth2_client.0.client_secret.0.value.0.thumbprint").(string) {

--- a/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_extra_attributes_oauth2_config_client_secret_value.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_extra_attributes_oauth2_config_client_secret_value.go.tmpl
@@ -20,6 +20,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	}
 	transformed := make(map[string]interface{})
 	transformed["thumbprint"] = original["thumbprint"]
+	transformed["plain_text_wo_version"] = d.Get("extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version")
 	// Trigger a diff based on the plain_text if there is no change in the thumbprint,
 	// otherwise leave plain_text empty to always trigger a diff.
 	if original["thumbprint"].(string) == d.Get("extra_attributes_oauth2_client.0.client_secret.0.value.0.thumbprint").(string) {

--- a/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_oidc_client_secret_value.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/iam_workforce_pool_provider_oidc_client_secret_value.go.tmpl
@@ -20,6 +20,7 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
 	}
 	transformed := make(map[string]interface{})
 	transformed["thumbprint"] = original["thumbprint"]
+	transformed["plain_text_wo_version"] = d.Get("oidc.0.client_secret.0.value.0.plain_text_wo_version")
 	// Trigger a diff based on the plain_text if there is no change in the thumbprint,
 	// otherwise leave plain_text empty to always trigger a diff.
 	if original["thumbprint"].(string) == d.Get("oidc.0.client_secret.0.value.0.thumbprint").(string) {

--- a/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_test.go.tmpl
@@ -664,6 +664,7 @@ resource "google_iam_workforce_pool_provider" "my_provider" {
     web_sso_config {
       response_type             = "CODE"
       assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = []
     }
   }
 }
@@ -697,6 +698,7 @@ resource "google_iam_workforce_pool_provider" "my_provider" {
     web_sso_config {
       response_type             = "CODE"
       assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = []
     }
   }
 }

--- a/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_test.go.tmpl
@@ -121,6 +121,51 @@ func TestAccIAMWorkforcePoolWorkforcePoolProvider_saml(t *testing.T) {
 	})
 }
 
+func TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"random_password_1": acctest.RandString(t, 16),
+		"random_password_2": acctest.RandString(t, 16),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckIAMWorkforcePoolWorkforcePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolProvider_oidc_wo(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "oidc.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "oidc.0.client_secret.0.value.0.plain_text_wo_version", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text"},
+			},
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolProvider_oidc_wo_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "oidc.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "oidc.0.client_secret.0.value.0.plain_text_wo_version", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text"},
+			},
+		},
+	})
+}
+
 func TestAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Client(t *testing.T) {
 	t.Parallel()
 
@@ -176,6 +221,51 @@ func TestAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Clien
 			    Check: resource.ComposeTestCheckFunc(
 			            testAccCheckIAMWorkforcePoolWorkforcePoolProviderAccess(t, random_suffix),
 			    ),
+			},
+		},
+	})
+}
+
+func TestAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2ClientWo(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"random_password_1": acctest.RandString(t, 16),
+		"random_password_2": acctest.RandString(t, 16),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckIAMWorkforcePoolWorkforcePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Client_wo(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text"},
+			},
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Client_wo_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text", "extra_attributes_oauth2_client.0.client_secret.0.value.0.plain_text"},
 			},
 		},
 	})
@@ -297,6 +387,51 @@ func TestAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2Cl
 			    Check: resource.ComposeTestCheckFunc(
 			            testAccCheckIAMWorkforcePoolWorkforcePoolProviderAccess(t, random_suffix),
 			    ),
+			},
+		},
+	})
+}
+
+func TestAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2ClientWo(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"random_password_1": acctest.RandString(t, 16),
+		"random_password_2": acctest.RandString(t, 16),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckIAMWorkforcePoolWorkforcePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2Client_wo(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version", "1"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text"},
+			},
+			{
+				Config: testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2Client_wo_update(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr("google_iam_workforce_pool_provider.my_provider", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo"),
+					resource.TestCheckResourceAttr("google_iam_workforce_pool_provider.my_provider", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text_wo_version", "2"),
+				),
+			},
+			{
+				ResourceName:            "google_iam_workforce_pool_provider.my_provider",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.0.client_secret.0.value.0.plain_text", "extended_attributes_oauth2_client.0.client_secret.0.value.0.plain_text"},
 			},
 		},
 	})
@@ -524,6 +659,72 @@ resource "google_iam_workforce_pool_provider" "my_provider" {
     client_secret {
       value {
         plain_text = "client-secret"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+    }
+  }
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolProvider_oidc_wo(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id  = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location           = google_iam_workforce_pool.my_pool.location
+  provider_id        = "my-provider-%{random_suffix}"
+  attribute_mapping  = {
+    "google.subject" = "assertion.sub"
+  }
+  oidc {
+    issuer_uri       = "https://accounts.thirdparty.com"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_1}"
+        plain_text_wo_version = "1"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+    }
+  }
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolProvider_oidc_wo_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id  = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location           = google_iam_workforce_pool.my_pool.location
+  provider_id        = "my-provider-%{random_suffix}"
+  attribute_mapping  = {
+    "google.subject" = "assertion.sub"
+  }
+  oidc {
+    issuer_uri       = "https://accounts.thirdparty.com"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_2}"
+        plain_text_wo_version = "2"
       }
     }
     web_sso_config {
@@ -835,6 +1036,102 @@ resource "google_iam_workforce_pool_provider" "my_provider" {
           plain_text = "client-secret"
         }
       }
+    attributes_type = "AZURE_AD_GROUPS_MAIL"
+  }
+  display_name        = "New Display name"
+  description         = "A sample OIDC workforce pool provider with updated description."
+  disabled            = true
+  attribute_condition = "false"
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Client_wo(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id   = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location            = google_iam_workforce_pool.my_pool.location
+  provider_id         = "my-provider-%{random_suffix}"
+  attribute_mapping   = {
+    "google.subject"  = "false"
+  }
+  oidc {
+    issuer_uri        = "https://sts.windows.net/826602fe-2101-470c-9d71-ee1343668989/"
+    client_id         = "https://analysis.windows.net/powerbi/connector/GoogleBigQuery"
+    client_secret {
+      value {
+        plain_text = "client-secret"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = ["groups", "roles"]
+    }
+  }
+  extra_attributes_oauth2_client {
+    issuer_uri       = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_1}"
+        plain_text_wo_version = "1"
+      }
+    }
+    attributes_type = "AZURE_AD_GROUPS_MAIL"
+  }
+  display_name        = "New Display name"
+  description         = "A sample OIDC workforce pool provider with updated description."
+  disabled            = true
+  attribute_condition = "false"
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extraAttributesOauth2Client_wo_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id   = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location            = google_iam_workforce_pool.my_pool.location
+  provider_id         = "my-provider-%{random_suffix}"
+  attribute_mapping   = {
+    "google.subject"  = "false"
+  }
+  oidc {
+    issuer_uri        = "https://sts.windows.net/826602fe-2101-470c-9d71-ee1343668989/"
+    client_id         = "https://analysis.windows.net/powerbi/connector/GoogleBigQuery"
+    client_secret {
+      value {
+        plain_text = "client-secret"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = ["groups", "roles"]
+    }
+  }
+  extra_attributes_oauth2_client {
+    issuer_uri       = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_2}"
+        plain_text_wo_version = "2"
+      }
+    }
     attributes_type = "AZURE_AD_GROUPS_MAIL"
   }
   display_name        = "New Display name"
@@ -1321,6 +1618,102 @@ resource "google_iam_workforce_pool_provider" "my_provider" {
           plain_text = "client-secret"
         }
       }
+    attributes_type = "AZURE_AD_GROUPS_ID"
+  }
+  display_name        = "New Display name"
+  description         = "A sample OIDC workforce pool provider with updated description."
+  disabled            = true
+  attribute_condition = "false"
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2Client_wo(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id   = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location            = google_iam_workforce_pool.my_pool.location
+  provider_id         = "my-provider-%{random_suffix}"
+  attribute_mapping   = {
+    "google.subject"  = "false"
+  }
+  oidc {
+    issuer_uri        = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id         = "https://analysis.windows.net/powerbi/connector/GoogleBigQuery"
+    client_secret {
+      value {
+        plain_text = "client-secret"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = ["groups", "roles"]
+    }
+  }
+  extended_attributes_oauth2_client {
+    issuer_uri       = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_1}"
+        plain_text_wo_version = "1"
+      }
+    }
+    attributes_type = "AZURE_AD_GROUPS_ID"
+  }
+  display_name        = "New Display name"
+  description         = "A sample OIDC workforce pool provider with updated description."
+  disabled            = true
+  attribute_condition = "false"
+}
+`, context)
+}
+
+func testAccIAMWorkforcePoolWorkforcePoolOidcProvider_extendedAttributesOauth2Client_wo_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_iam_workforce_pool" "my_pool" {
+  workforce_pool_id = "my-pool-%{random_suffix}"
+  parent            = "organizations/%{org_id}"
+  location          = "global"
+}
+
+resource "google_iam_workforce_pool_provider" "my_provider" {
+  workforce_pool_id   = google_iam_workforce_pool.my_pool.workforce_pool_id
+  location            = google_iam_workforce_pool.my_pool.location
+  provider_id         = "my-provider-%{random_suffix}"
+  attribute_mapping   = {
+    "google.subject"  = "false"
+  }
+  oidc {
+    issuer_uri        = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id         = "https://analysis.windows.net/powerbi/connector/GoogleBigQuery"
+    client_secret {
+      value {
+        plain_text = "client-secret"
+      }
+    }
+    web_sso_config {
+      response_type             = "CODE"
+      assertion_claims_behavior = "MERGE_USER_INFO_OVER_ID_TOKEN_CLAIMS"
+      additional_scopes         = ["groups", "roles"]
+    }
+  }
+  extended_attributes_oauth2_client {
+    issuer_uri       = "https://login.microsoftonline.com/826602fe-2101-470c-9d71-ee1343668989/v2.0"
+    client_id        = "client-id"
+    client_secret {
+      value {
+        plain_text_wo         = "%{random_password_2}"
+        plain_text_wo_version = "2"
+      }
+    }
     attributes_type = "AZURE_AD_GROUPS_ID"
   }
   display_name        = "New Display name"


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/27642

Implements a write-only variant argument for `oidc.client_secret` in the `google_iam_workforce_pool_provider`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
iamworkforcepool: write-only support for `oidc.client_secret` in `google_iam_workforce_pool_provider`
```

### Local test

```console
╰─❮ make testacc TEST=./google/services/iamworkforcepool TESTARGS='-run=TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo'
sh -c "'/Users/ramon/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/iamworkforcepool -v -run=TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo (142.24s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/iamworkforcepool (cached)
```

```console
╰─❯ make testacc TEST=./google/services/iamworkforcepool TESTARGS='-run=TestAccIAMWorkforcePoolWorkforcePoolProvider_'
sh -c "'/Users/ramon/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/iamworkforcepool -v -run=TestAccIAMWorkforcePoolWorkforcePoolProvider_ -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlBasicExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlBasicExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlFullExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlFullExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcBasicExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcBasicExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcFullExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcFullExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcUploadKeyExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcUploadKeyExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientBasicExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientBasicExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientFullExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientFullExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientBasicExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientBasicExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientFullExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientFullExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientBasicExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientBasicExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientFullExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientFullExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcDetailedAuditLoggingExample
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcDetailedAuditLoggingExample
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_oidc
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_oidc
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_saml
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_saml
=== RUN   TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
=== PAUSE TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlBasicExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientFullExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_oidc
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcDetailedAuditLoggingExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientFullExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientBasicExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientFullExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientBasicExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientBasicExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcUploadKeyExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcFullExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcBasicExample
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlFullExample
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcBasicExample (121.13s)
=== CONT  TestAccIAMWorkforcePoolWorkforcePoolProvider_saml
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlBasicExample (131.43s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcUploadKeyExample (131.86s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientFullExample (132.78s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientBasicExample (132.96s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesOauth2ConfigClientBasicExample (133.02s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtendedAttributesOauth2ConfigClientFullExample (133.57s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderSamlFullExample (133.99s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcDetailedAuditLoggingExample (135.90s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientBasicExample (137.40s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderOidcFullExample (143.96s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_iamWorkforcePoolProviderExtraAttributesDisplayNameOauth2ConfigClientFullExample (144.19s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_oidcWo (147.66s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_oidc (189.63s)
--- PASS: TestAccIAMWorkforcePoolWorkforcePoolProvider_saml (165.37s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/iamworkforcepool 287.279s
```