### PR TITLE
Adds IAM resource support to `google_discovery_engine_search_engine`

### DIFF
--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -54,6 +54,15 @@ examples:
     vars:
       engine_id: 'example-engine-id'
       data_store_id: 'example-datastore-id'
+iam_policy:
+  parent_resource_attribute: 'engine_id'
+  method_name_separator: ':'
+  fetch_iam_policy_verb: 'GET'
+  allowed_iam_role: 'roles/discoveryengine.agentspaceUser'
+  import_format:
+    - 'projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/engines/{{engine_id}}'
+    - '{{engine_id}}'
+  sample_config_body: templates/terraform/iam/example_config_body/discovery_engine_search_engine.tf.tmpl
 parameters:
   - name: 'engineId'
     type: String

--- a/mmv1/templates/terraform/iam/example_config_body/discovery_engine_search_engine.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/discovery_engine_search_engine.tf.tmpl
@@ -1,0 +1,4 @@
+  project = google_discovery_engine_search_engine.basic.project
+  location = google_discovery_engine_search_engine.basic.location
+  collection_id = google_discovery_engine_search_engine.basic.collection_id
+  engine_id = google_discovery_engine_search_engine.basic.engine_id

--- a/mmv1/third_party/terraform/services/discoveryengine/iam_discovery_engine_search_engine.go.tmpl
+++ b/mmv1/third_party/terraform/services/discoveryengine/iam_discovery_engine_search_engine.go.tmpl
@@ -1,0 +1,303 @@
+package discoveryengine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	{{- if ne $.Compiler "terraformgoogleconversion-codegen"}}
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	{{- end}}
+	"github.com/hashicorp/terraform-provider-google/google/tpgiamresource"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+var (
+	_ = regexp.Match
+	_ = strings.Trim
+	_ = errwrap.Wrap
+	_ = schema.Noop
+)
+
+{{- if ne $.Compiler "terraformgoogleconversion-codegen"}}
+
+func init() {
+	registry.Schema{
+		Name:        "google_discovery_engine_search_engine_iam_binding",
+		ProductName: "DiscoveryEngine",
+		Type:        registry.SchemaTypeIAMResource,
+		Schema:      tpgiamresource.ResourceIamBinding(DiscoveryEngineSearchEngineIamSchema, DiscoveryEngineSearchEngineIamUpdaterProducer, DiscoveryEngineSearchEngineIdParseFunc),
+	}.Register()
+	registry.Schema{
+		Name:        "google_discovery_engine_search_engine_iam_member",
+		ProductName: "DiscoveryEngine",
+		Type:        registry.SchemaTypeIAMResource,
+		Schema:      tpgiamresource.ResourceIamMember(DiscoveryEngineSearchEngineIamSchema, DiscoveryEngineSearchEngineIamUpdaterProducer, DiscoveryEngineSearchEngineIdParseFunc, tpgiamresource.IamWithParentResourceIdentity(DiscoveryEngineSearchEngineIamParentParentResourceIdentityParser)),
+	}.Register()
+	registry.Schema{
+		Name:        "google_discovery_engine_search_engine_iam_policy",
+		ProductName: "DiscoveryEngine",
+		Type:        registry.SchemaTypeIAMResource,
+		Schema:      tpgiamresource.ResourceIamPolicy(DiscoveryEngineSearchEngineIamSchema, DiscoveryEngineSearchEngineIamUpdaterProducer, DiscoveryEngineSearchEngineIdParseFunc),
+	}.Register()
+	registry.Schema{
+		Name:        "google_discovery_engine_search_engine_iam_policy",
+		ProductName: "DiscoveryEngine",
+		Type:        registry.SchemaTypeIAMDataSource,
+		Schema:      tpgiamresource.DataSourceIamPolicy(DiscoveryEngineSearchEngineIamSchema, DiscoveryEngineSearchEngineIamUpdaterProducer),
+	}.Register()
+}
+{{- end}}
+
+var DiscoveryEngineSearchEngineIamSchema = map[string]*schema.Schema{
+	"project": {
+		Type:     schema.TypeString,
+		Computed: true,
+		Optional: true,
+		ForceNew: true,
+	},
+	"location": {
+		Type:     schema.TypeString,
+		Computed: true,
+		Optional: true,
+		ForceNew: true,
+	},
+	"collection_id": {
+		Type:     schema.TypeString,
+		Required: true,
+		ForceNew: true,
+	},
+	"engine_id": {
+		Type:             schema.TypeString,
+		Required:         true,
+		ForceNew:         true,
+		DiffSuppressFunc: tpgresource.CompareSelfLinkOrResourceName,
+	},
+}
+
+type DiscoveryEngineSearchEngineIamUpdater struct {
+	project      string
+	location     string
+	collectionId string
+	engineId     string
+	d            tpgresource.TerraformResourceData
+	Config       *transport_tpg.Config
+}
+
+func DiscoveryEngineSearchEngineIamUpdaterProducer(d tpgresource.TerraformResourceData, config *transport_tpg.Config) (tpgiamresource.ResourceIamUpdater, error) {
+	values := make(map[string]string)
+
+	project, _ := tpgresource.GetProject(d, config)
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return nil, fmt.Errorf("Error setting project: %s", err)
+		}
+	}
+	values["project"] = project
+	location, _ := tpgresource.GetLocation(d, config)
+	if location != "" {
+		if err := d.Set("location", location); err != nil {
+			return nil, fmt.Errorf("Error setting location: %s", err)
+		}
+	}
+	values["location"] = location
+	if v, ok := d.GetOk("collection_id"); ok {
+		values["collection_id"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("engine_id"); ok {
+		values["engine_id"] = v.(string)
+	}
+
+	// We may have gotten either a long or short name, so attempt to parse long name if possible
+	m, err := tpgresource.GetImportIdQualifiers([]string{"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/collections/(?P<collection_id>[^/]+)/engines/(?P<engine_id>[^/]+)", "(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<collection_id>[^/]+)/(?P<engine_id>[^/]+)", "(?P<location>[^/]+)/(?P<collection_id>[^/]+)/(?P<engine_id>[^/]+)", "(?P<engine_id>[^/]+)"}, d, config, d.Get("engine_id").(string))
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range m {
+		values[k] = v
+	}
+
+	u := &DiscoveryEngineSearchEngineIamUpdater{
+		project:      values["project"],
+		location:     values["location"],
+		collectionId: values["collection_id"],
+		engineId:     values["engine_id"],
+		d:            d,
+		Config:       config,
+	}
+
+	if err := d.Set("project", u.project); err != nil {
+		return nil, fmt.Errorf("Error setting project: %s", err)
+	}
+	if err := d.Set("location", u.location); err != nil {
+		return nil, fmt.Errorf("Error setting location: %s", err)
+	}
+	if err := d.Set("collection_id", u.collectionId); err != nil {
+		return nil, fmt.Errorf("Error setting collection_id: %s", err)
+	}
+	if err := d.Set("engine_id", u.GetResourceId()); err != nil {
+		return nil, fmt.Errorf("Error setting engine_id: %s", err)
+	}
+
+	return u, nil
+}
+
+func DiscoveryEngineSearchEngineIdParseFunc(d *schema.ResourceData, config *transport_tpg.Config) error {
+	values := make(map[string]string)
+
+	project, _ := tpgresource.GetProject(d, config)
+	if project != "" {
+		values["project"] = project
+	}
+
+	location, _ := tpgresource.GetLocation(d, config)
+	if location != "" {
+		values["location"] = location
+	}
+
+	m, err := tpgresource.GetImportIdQualifiers([]string{"projects/(?P<project>[^/]+)/locations/(?P<location>[^/]+)/collections/(?P<collection_id>[^/]+)/engines/(?P<engine_id>[^/]+)", "(?P<project>[^/]+)/(?P<location>[^/]+)/(?P<collection_id>[^/]+)/(?P<engine_id>[^/]+)", "(?P<location>[^/]+)/(?P<collection_id>[^/]+)/(?P<engine_id>[^/]+)", "(?P<engine_id>[^/]+)"}, d, config, d.Id())
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m {
+		values[k] = v
+	}
+
+	u := &DiscoveryEngineSearchEngineIamUpdater{
+		project:      values["project"],
+		location:     values["location"],
+		collectionId: values["collection_id"],
+		engineId:     values["engine_id"],
+		d:            d,
+		Config:       config,
+	}
+	if err := d.Set("engine_id", u.GetResourceId()); err != nil {
+		return fmt.Errorf("Error setting engine_id: %s", err)
+	}
+	d.SetId(u.GetResourceId())
+	return nil
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
+	url, err := u.qualifySearchEngineUrl("getIamPolicy")
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := tpgresource.GetProject(u.d, u.Config)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]interface{}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(u.d, u.Config.UserAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	policy, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    u.Config,
+		Method:    "GET",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving IAM policy for %s: %w", u.DescribeResource(), err)
+	}
+
+	out := &cloudresourcemanager.Policy{}
+	err = tpgresource.Convert(policy, out)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot convert a policy to a resource manager policy: %w", err)
+	}
+
+	return out, nil
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Policy) error {
+	if policy.Etag == "" {
+		currentPolicy, err := u.GetResourceIamPolicy()
+		if err == nil && currentPolicy != nil {
+			policy.Etag = currentPolicy.Etag
+		}
+	}
+
+	json, err := tpgresource.ConvertToMap(policy)
+	if err != nil {
+		return err
+	}
+
+	obj := make(map[string]interface{})
+	obj["policy"] = json
+
+	url, err := u.qualifySearchEngineUrl("setIamPolicy")
+	if err != nil {
+		return err
+	}
+	project, err := tpgresource.GetProject(u.d, u.Config)
+	if err != nil {
+		return err
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(u.d, u.Config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    u.Config,
+		Method:    "POST",
+		Project:   project,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   u.d.Timeout(schema.TimeoutCreate),
+	})
+	if err != nil {
+		return fmt.Errorf("Error setting IAM policy for %s: %w", u.DescribeResource(), err)
+	}
+
+	return nil
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) qualifySearchEngineUrl(methodIdentifier string) (string, error) {
+	urlTemplate := fmt.Sprintf("{{"{{"}}DiscoveryEngineBasePath{{"}}"}}%s:%s", fmt.Sprintf("projects/%s/locations/%s/collections/%s/engines/%s", u.project, u.location, u.collectionId, u.engineId), methodIdentifier)
+	url, err := tpgresource.ReplaceVars(u.d, u.Config, urlTemplate)
+	if err != nil {
+		return "", err
+	}
+	return url, nil
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) GetResourceId() string {
+	return fmt.Sprintf("projects/%s/locations/%s/collections/%s/engines/%s", u.project, u.location, u.collectionId, u.engineId)
+}
+
+func DiscoveryEngineSearchEngineIamParentParentResourceIdentityParser(d *schema.ResourceData, identity *schema.IdentityData, transportConfig *transport_tpg.Config) (string, error) {
+	return tpgiamresource.ParseIamResourceIdentity(d, identity, transportConfig, tpgiamresource.IamResourceIdentityConfig{
+		Params: []tpgiamresource.IamIdentityParam{
+			{Key: "project", IdentityKey: "project"},
+			{Key: "location", IdentityKey: "location"},
+			{Key: "collectionId", IdentityKey: "collection_id"},
+			{Key: "engineId", IdentityKey: "engine_id"},
+		},
+		UriFormat: "projects/%s/locations/%s/collections/%s/engines/%s",
+	})
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) GetMutexKey() string {
+	return fmt.Sprintf("iam-discoveryengine-searchengine-%s", u.GetResourceId())
+}
+
+func (u *DiscoveryEngineSearchEngineIamUpdater) DescribeResource() string {
+	return fmt.Sprintf("discoveryengine searchengine %q", u.GetResourceId())
+}


### PR DESCRIPTION
Reference: [Configure access controls for apps (Gemini Enterprise)](https://docs.cloud.google.com/gemini/enterprise/docs/iam-policy-for-apps)

### Why a custom IAM implementation is required:
The Discovery Engine API strictly requires a valid `etag` to be present in `setIamPolicy` requests, even when performing a full overwrite (i.e., the `_policy` resource). 

As highlighted in the [documentation](https://docs.cloud.google.com/gemini/enterprise/docs/iam-policy-for-apps#get-the-app-iam-policy), the `etag` value returned during a GET is required for any subsequent updates.

The generic MMv1 IAM template (`iam_policy.go.tmpl`) does not copy the `etag` from the Terraform state when updating a `_policy` resource (which is built purely from the HCL `policy_data` map). This results in an empty `etag` payload, causing the Discovery Engine API to reject the request with `Error 400: Policy etag is required`.

To resolve this, we bypassed the default generator with a handwritten template (`iam_discovery_engine_search_engine.go.tmpl`) that:
1. Intercepts `SetResourceIamPolicy`.
2. Detects if the incoming policy is missing the `etag` (always true for `_policy` creations/updates).
3. Pre-fetches the current policy to retrieve and inject the active `etag` before making the write API call.
Additionally, a custom `sample_config_body` is mapped to avoid duplicate generation of the `location` field in tests.

**Release Note Template for Downstream PRs (will be copied)**


```release-note:new-resource
`google_discovery_engine_search_engine_iam_binding`
```
