### PR TITLE
Add support for dataplane_optimization_mode in google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2484,6 +2484,12 @@ func ResourceContainerCluster() *schema.Resource {
 				ValidateFunc:     validation.StringInSlice([]string{"DATAPATH_PROVIDER_UNSPECIFIED", "LEGACY_DATAPATH", "ADVANCED_DATAPATH"}, false),
 				DiffSuppressFunc: tpgresource.EmptyOrDefaultStringSuppress("DATAPATH_PROVIDER_UNSPECIFIED"),
 			},
+			"dataplane_optimization_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The desired dataplane optimization mode.`,
+			},
 			"enable_cilium_clusterwide_network_policy": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -3067,6 +3073,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			EnableIntraNodeVisibility:            d.Get("enable_intranode_visibility").(bool),
 			DefaultSnatStatus:                    expandDefaultSnatStatus(d.Get("default_snat_status")),
 			DatapathProvider:                     d.Get("datapath_provider").(string),
+			DataplaneV2Config:                    expandDataplaneV2Config(d.Get("dataplane_optimization_mode")),
 			EnableCiliumClusterwideNetworkPolicy: d.Get("enable_cilium_clusterwide_network_policy").(bool),
 			PrivateIpv6GoogleAccess:              d.Get("private_ipv6_google_access").(string),
 			InTransitEncryptionConfig:            d.Get("in_transit_encryption_config").(string),
@@ -3678,6 +3685,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if err := d.Set("datapath_provider", cluster.NetworkConfig.DatapathProvider); err != nil {
 		return fmt.Errorf("Error setting datapath_provider: %s", err)
+	}
+	if cluster.NetworkConfig.DataplaneV2Config != nil {
+		if err := d.Set("dataplane_optimization_mode", cluster.NetworkConfig.DataplaneV2Config.ScalabilityMode); err != nil {
+			return fmt.Errorf("Error setting dataplane_optimization_mode: %s", err)
+		}
 	}
 	if err := d.Set("enable_cilium_clusterwide_network_policy", cluster.NetworkConfig.EnableCiliumClusterwideNetworkPolicy); err != nil {
 		return fmt.Errorf("Error setting enable_cilium_clusterwide_network_policy: %s", err)
@@ -6970,6 +6982,19 @@ func expandDefaultSnatStatus(configured interface{}) *container.DefaultSnatStatu
 		ForceSendFields: []string{"Disabled"},
 	}
 
+}
+
+func expandDataplaneV2Config(v interface{}) *container.DataplaneV2Config {
+	if v == nil {
+		return nil
+	}
+	s := v.(string)
+	if s == "" {
+		return nil
+	}
+	return &container.DataplaneV2Config{
+		ScalabilityMode: s,
+	}
 }
 
 func expandWorkloadIdentityConfig(configured interface{}) *container.WorkloadIdentityConfig {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -132,6 +132,8 @@ fields:
   - api_field: 'costManagementConfig.enabled'
   - api_field: 'databaseEncryption.keyName'
   - api_field: 'databaseEncryption.state'
+  - field: 'dataplane_optimization_mode'
+    api_field: 'networkConfig.dataplaneV2Config.scalabilityMode'
   - field: 'datapath_provider'
     api_field: 'networkConfig.datapathProvider'
   - field: 'default_max_pods_per_node'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -6315,6 +6315,62 @@ func TestAccContainerCluster_withAdvancedDatapath(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_dataplaneOptimizationMode(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_dataplaneOptimizationMode(clusterName, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "datapath_provider", "ADVANCED_DATAPATH"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "dataplane_optimization_mode", "SCALE_OPTIMIZED"),
+				),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "remove_default_node_pool"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_dataplaneOptimizationMode(clusterName, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = "%s"
+  subnetwork = "%s"
+
+  networking_mode = "VPC_NATIVE"
+  datapath_provider = "ADVANCED_DATAPATH"
+  dataplane_optimization_mode = "SCALE_OPTIMIZED"
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "/14"
+    services_ipv4_cidr_block = "/20"
+  }
+
+  remove_default_node_pool = false
+  
+  deletion_protection = false
+}
+`, clusterName, networkName, subnetworkName)
+}
+
+
 func TestAccContainerCluster_enableCiliumPolicies(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -411,6 +411,8 @@ subnetwork in which the cluster's instances are launched.
 * `datapath_provider` - (Optional)
     The desired datapath provider for this cluster. This is set to `LEGACY_DATAPATH` by default, which uses the IPTables-based kube-proxy implementation. Set to `ADVANCED_DATAPATH` to enable Dataplane v2.
 
+* `dataplane_optimization_mode` - (Optional) The dataplane optimization mode for the cluster. Possible values: `SCALE_OPTIMIZED`.
+
 * `in_transit_encryption_config` - (Optional)
     Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
 


### PR DESCRIPTION
Add the `dataplane_optimization_mode` attribute within the `google_container_cluster` resource.

reference: b/466291171

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `dataplane_optimization_mode` in `google_container_cluster`
```

