### PR TITLE
Add external identity set example for IAM roles

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/storage_managed_folder_iam.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/storage_managed_folder_iam.html.markdown
@@ -142,6 +142,7 @@ The following arguments are supported:
   * **projectOwner:projectid**: Owners of the given project. For example, "projectOwner:my-example-project"
   * **projectEditor:projectid**: Editors of the given project. For example, "projectEditor:my-example-project"
   * **projectViewer:projectid**: Viewers of the given project. For example, "projectViewer:my-example-project"
+  * **principalSet://iam.googleapis.com/{poolResourceName}/attribute.{key}/{value}**: An external identity set from a Workload Identity Pool, optionally constrained by an attribute (e.g. GitHub Actions branch via attribute.repository). Example: "principalSet://iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/github-pool/attribute.repository/your-org/your-repo"
 
 * `role` - (Required) The role that should be applied. Only one
     `google_storage_managed_folder_iam_binding` can be used per role. Note that custom roles must be of the format


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Added documentation for `principalSet://` members representing external identity sets from IAM Workload Identity Pools, including an example using attribute-based selection (e.g. GitHub Actions attribute.ref). 
Verified this format is accepted by the underlying IAM API and works via gcloud and the Cloud Console UI.

For Ex
```
# Create the managed folder (run once)
gcloud storage managed-folders create gs://YOUR_BUCKET/nx-cache/

# Add IAM binding on the managed folder
gcloud storage managed-folders add-iam-policy-binding \
  gs://YOUR_BUCKET/nx-cache/ \
  --role="roles/storage.objectCreator" \
  --member="principalSet://iam.googleapis.com/YOUR_POOL_FULL_NAME/attribute.ref/refs/heads/main"

# Verify the IAM policy on the managed folder
gcloud storage managed-folders get-iam-policy gs://YOUR_BUCKET/nx-cache/
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
google_storage_managed_folder_iam: Added documentation for `principalSet://` members
```
