### PR TITLE
Remove GKE writable cgroups update tests

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -15578,28 +15578,7 @@ func TestAccContainerCluster_writableCgroups(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
 			},
-			// Test configuring writable_cgroups on the cluster's default node pool directly via node_config.
-			{
-				Config: testAccContainerCluster_withNodeConfigWritableCgroups(clusterName, networkName, subnetworkName),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acctest.ExpectNoDelete(),
-					},
-				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_container_cluster.primary",
-						"node_config.0.containerd_config.0.writable_cgroups.0.enabled",
-						"true",
-					),
-				),
-			},
-			{
-				ResourceName:            "google_container_cluster.primary",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"min_master_version", "deletion_protection"},
-			},
+
 			// Test configuring writable_cgroups on a named node pool defined within the cluster.
 			// This change from a default to a named node pool is expected to force recreation.
 			{
@@ -15701,32 +15680,6 @@ resource "google_container_cluster" "primary" {
 `, clusterName, networkName, subnetworkName, nodePoolName)
 }
 
-func testAccContainerCluster_withNodeConfigWritableCgroups(clusterName, networkName, subnetworkName string) string {
-	return fmt.Sprintf(`
-data "google_container_engine_versions" "central1a" {
-  location = "us-central1-a"
-}
-
-resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
-  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["RAPID"]
-  network             = "%s"
-  subnetwork          = "%s"
-  deletion_protection = false
-
-  node_config {
-    containerd_config {
-      writable_cgroups {
-        enabled = true
-      }
-    }
-  }
-
-}
-`, clusterName, networkName, subnetworkName)
-}
 
 func TestAccContainerCluster_withProviderDefaultLabels(t *testing.T) {
 	// The test failed if VCR testing is enabled, because the cached provider config is used.

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -6114,9 +6114,6 @@ resource "google_container_node_pool" "np" {
 
 func TestAccContainerNodePool_writableCgroups(t *testing.T) {
 	t.Parallel()
-	// TODO(chrishenzie): Convert this to a negative test (expecting failure)
-	// once the API behavior change is fully rolled out.
-	t.Skip("Skipping due to API behavior change blocking writable cgroups modifications on node pools")
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	nodepool := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
@@ -6139,22 +6136,7 @@ func TestAccContainerNodePool_writableCgroups(t *testing.T) {
 					),
 				),
 			},
-			// Test disabling writable_cgroups on a node pool.
-			{
-				Config: testAccContainerNodePool_writableCgroupsDisabled(cluster, nodepool, networkName, subnetworkName),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						acctest.ExpectNoDelete(),
-					},
-				},
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np",
-						"node_config.0.containerd_config.0.writable_cgroups.0.enabled",
-						"false",
-					),
-				),
-			},
+
 		},
 	})
 }
@@ -6193,39 +6175,6 @@ resource "google_container_node_pool" "np" {
 `, cluster, network, subnetwork, nodepool)
 }
 
-func testAccContainerNodePool_writableCgroupsDisabled(cluster, nodepool, network, subnetwork string) string {
-	return fmt.Sprintf(`
-data "google_container_engine_versions" "central1a" {
-  location = "us-central1-a"
-}
-
-resource "google_container_cluster" "primary" {
-  name                = "%s"
-  location            = "us-central1-a"
-  initial_node_count  = 1
-  min_master_version  = data.google_container_engine_versions.central1a.release_channel_latest_version["RAPID"]
-  network             = "%s"
-  subnetwork          = "%s"
-  deletion_protection = false
-}
-
-resource "google_container_node_pool" "np" {
-  name               = "%s"
-  location           = "us-central1-a"
-  cluster            = google_container_cluster.primary.name
-  initial_node_count = 1
-
-  node_config {
-    image_type   = "COS_CONTAINERD"
-    containerd_config {
-      writable_cgroups {
-        enabled = false
-      }
-    }
-  }
-}
-`, cluster, network, subnetwork, nodepool)
-}
 
 func TestAccContainerNodePool_registryHosts(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes GKE `writable_cgroups` acceptance tests which were affected by a server-side API validation change blocking updates on existing node pools.

Instead of asserting that these updates fail, this change removes the update steps entirely from both `TestAccContainerCluster_writableCgroups` and `TestAccContainerNodePool_writableCgroups`. This aligns with the recommendation to not include negative tests for immutable fields, making the tests less fragile to API error message changes.

The node pool test `TestAccContainerNodePool_writableCgroups` has also been un-skipped.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
