### PR TITLE
Add allow_limited_availability_info_types field to data_loss_prevention_inspect_template

### DIFF
--- a/mmv1/products/dlp/InspectTemplate.yaml
+++ b/mmv1/products/dlp/InspectTemplate.yaml
@@ -629,3 +629,8 @@ properties:
                     Resource name of the requested StoredInfoType, for example `organizations/433245324/storedInfoTypes/432452342`
                     or `projects/project-id/storedInfoTypes/432452342`.
                   required: true
+  - name: 'allowLimitedAvailabilityInfoTypes'
+    type: Boolean
+    description: |
+      Enables the use of [limited-availability built-in infoTypes](https://docs.cloud.google.com/sensitive-data-protection/docs/infotypes-reference#limited-availability-infotypes)
+      in inspect_config. These infoTypes are supported only in specific regions and can cause scanning errors if used elsewhere.

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_inspect_template_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_inspect_template_test.go
@@ -239,6 +239,7 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 			}
 		}
 	}
+	allow_limited_availability_info_types = true
 }
 `, context)
 }
@@ -1235,6 +1236,101 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 			}
 		}
 	}
+}
+`, context)
+}
+
+func TestAccDataLossPreventionInspectTemplate_dlpInspectTemplate_allowLimitedAvailabilityInfoTypes(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project": envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionInspectTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withAllowLimitedAvailabilityInfoTypes(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_inspect_template.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withAllowLimitedAvailabilityInfoTypesUpdate(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_inspect_template.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withAllowLimitedAvailabilityInfoTypes(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+	parent = "projects/%{project}"
+	description = "Description"
+	display_name = "Display"
+
+	inspect_config {
+		info_types {
+			name = "EMAIL_ADDRESS"
+		}
+		info_types {
+			name    = "PERSON_NAME"
+			version = "latest"
+		}
+		info_types {
+			name = "LAST_NAME"
+		}
+		info_types {
+			name = "DOMAIN_NAME"
+		}
+		info_types {
+			name = "PHONE_NUMBER"
+		}
+		info_types {
+			name = "FIRST_NAME"
+		}
+	}
+	allow_limited_availability_info_types = true
+}
+`, context)
+}
+
+func testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withAllowLimitedAvailabilityInfoTypesUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+	parent = "projects/%{project}"
+	description = "Updated"
+	display_name = "Different"
+
+	inspect_config {
+		info_types {
+			name    = "PERSON_NAME"
+			version = "latest"
+		}
+		info_types {
+			name = "LAST_NAME"
+		}
+		info_types {
+			name = "DOMAIN_NAME"
+		}
+		info_types {
+			name = "PHONE_NUMBER"
+		}
+		info_types {
+			name = "FIRST_NAME"
+		}
+	}
+	allow_limited_availability_info_types = false
 }
 `, context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dlp: added `allow_limited_availability_info_types` to `google_data_loss_prevention_inspect_template`
```

