### PR TITLE
[Workbench Instance] Add NVIDIA_RTX6000 to google_workbench_instance accelerator types

### DIFF
--- a/mmv1/products/workbench/Instance.yaml
+++ b/mmv1/products/workbench/Instance.yaml
@@ -196,6 +196,7 @@ properties:
                 - 'NVIDIA_H100_MEGA_80GB'
                 - 'NVIDIA_H200_141GB'
                 - 'NVIDIA_B200'
+                - 'NVIDIA_RTX6000'
                 - 'NVIDIA_TESLA_T4_VWS'
                 - 'NVIDIA_TESLA_P100_VWS'
                 - 'NVIDIA_TESLA_P4_VWS'


### PR DESCRIPTION
## Tests
Verified end-to-end with dev overrides against the
`deeplearning-platform` project in `us-east4-c`:
- `terraform plan` accepts `type = "NVIDIA_RTX6000"` (would fail
  pre-change with `expected ... got NVIDIA_RTX6000`).
- `terraform apply` successfully provisioned a live workbench
  instance with `NVIDIA_RTX6000 × 1` on `g4-standard-48` + hyperdisk
  in 1m47s.

BUG=481421045

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
workbench: added `NVIDIA_RTX6000` to the supported `gce_setup.accelerator_configs.type` values on `google_workbench_instance`
```
