### PR TITLE
feat(iap): add agent registry MCP server, endpoint, and agent IAM resources

### DIFF
--- a/mmv1/products/iap/AgentRegistryAgent.yaml
+++ b/mmv1/products/iap/AgentRegistryAgent.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: 'AgentRegistryAgent'
+min_version: 'beta'
+description: |
+  Only used to generate IAM resources for agents under an IAP Agent
+  Registry. The agents themselves are provisioned via the Gemini
+  Enterprise Agent Platform; this resource only attaches IAM bindings
+  used for agent-to-agent egress (one agent's principal granted
+  roles/iap.egressor on another agent).
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent}}'
+base_url: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent}}'
+self_link: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent}}'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent}}'
+  - '{{agent}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: 'google_project_service'
+  fetch_iam_policy_verb: 'POST'
+  allowed_iam_role: 'roles/iap.egressor'
+  parent_resource_attribute: 'agent'
+  parent_is_resource_id: true
+  iam_conditions_request_type: 'REQUEST_BODY'
+  example_config_body: 'templates/terraform/iam/example_config_body/iap_agent_registry_agent.tf.tmpl'
+exclude_tgc: true
+examples:
+  - name: 'iap_agent_registry_agent_beta'
+    primary_resource_id: 'project_service'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'agent_id': 'envvar.MultiEnvSearch([]string{"IAP_AGENT_REGISTRY_AGENT_ID"})'
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    description: The location of the agent registry.
+  - name: 'agent'
+    type: String
+    required: true
+    description: The agent ID within the agent registry.
+properties:
+  - name: 'name'
+    type: String
+    description: Dummy property.
+    required: true

--- a/mmv1/products/iap/AgentRegistryEndpoint.yaml
+++ b/mmv1/products/iap/AgentRegistryEndpoint.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: 'AgentRegistryEndpoint'
+min_version: 'beta'
+description: |
+  Only used to generate IAM resources for endpoints under an IAP Agent
+  Registry. The endpoints themselves are provisioned via the Gemini
+  Enterprise Agent Platform; this resource only attaches IAM bindings.
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint}}'
+base_url: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint}}'
+self_link: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint}}'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint}}'
+  - '{{endpoint}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: 'google_project_service'
+  fetch_iam_policy_verb: 'POST'
+  allowed_iam_role: 'roles/iap.egressor'
+  parent_resource_attribute: 'endpoint'
+  parent_is_resource_id: true
+  iam_conditions_request_type: 'REQUEST_BODY'
+  example_config_body: 'templates/terraform/iam/example_config_body/iap_agent_registry_endpoint.tf.tmpl'
+exclude_tgc: true
+examples:
+  - name: 'iap_agent_registry_endpoint_beta'
+    primary_resource_id: 'project_service'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'endpoint_id': 'envvar.MultiEnvSearch([]string{"IAP_AGENT_REGISTRY_ENDPOINT_ID"})'
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    description: The location of the agent registry.
+  - name: 'endpoint'
+    type: String
+    required: true
+    description: The endpoint ID within the agent registry.
+properties:
+  - name: 'name'
+    type: String
+    description: Dummy property.
+    required: true

--- a/mmv1/products/iap/AgentRegistryMcpServer.yaml
+++ b/mmv1/products/iap/AgentRegistryMcpServer.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: 'AgentRegistryMcpServer'
+min_version: 'beta'
+description: |
+  Only used to generate IAM resources for MCP servers under an IAP Agent
+  Registry. The MCP servers themselves are provisioned via the Gemini
+  Enterprise Agent Platform; this resource only attaches IAM bindings.
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+id_format: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server}}'
+base_url: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server}}'
+self_link: 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server}}'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server}}'
+  - '{{mcp_server}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: 'google_project_service'
+  fetch_iam_policy_verb: 'POST'
+  allowed_iam_role: 'roles/iap.egressor'
+  parent_resource_attribute: 'mcp_server'
+  parent_is_resource_id: true
+  iam_conditions_request_type: 'REQUEST_BODY'
+  example_config_body: 'templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl'
+exclude_tgc: true
+examples:
+  - name: 'iap_agent_registry_mcp_server_beta'
+    primary_resource_id: 'project_service'
+    test_env_vars:
+      project_id: 'PROJECT_NAME'
+    test_vars_overrides:
+      'mcp_server_id': 'envvar.MultiEnvSearch([]string{"IAP_AGENT_REGISTRY_MCP_SERVER_ID"})'
+parameters:
+  - name: 'location'
+    type: String
+    required: true
+    description: The location of the agent registry.
+  - name: 'mcpServer'
+    type: String
+    required: true
+    description: The MCP server ID within the agent registry.
+properties:
+  - name: 'name'
+    type: String
+    description: Dummy property.
+    required: true

--- a/mmv1/templates/terraform/examples/iap_agent_registry_agent_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iap_agent_registry_agent_beta.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_project_service" "project_service" {
+  provider = google-beta
+  project  = "%{project_id}"
+  service  = "iap.googleapis.com"
+}

--- a/mmv1/templates/terraform/examples/iap_agent_registry_endpoint_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iap_agent_registry_endpoint_beta.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_project_service" "project_service" {
+  provider = google-beta
+  project  = "%{project_id}"
+  service  = "iap.googleapis.com"
+}

--- a/mmv1/templates/terraform/examples/iap_agent_registry_mcp_server_beta.tf.tmpl
+++ b/mmv1/templates/terraform/examples/iap_agent_registry_mcp_server_beta.tf.tmpl
@@ -1,0 +1,5 @@
+resource "google_project_service" "project_service" {
+  provider = google-beta
+  project  = "%{project_id}"
+  service  = "iap.googleapis.com"
+}

--- a/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_agent.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_agent.tf.tmpl
@@ -1,0 +1,3 @@
+  project = google_project_service.project_service.project
+  location = "us-central1"
+  agent = "%{agent_id}"

--- a/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_endpoint.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_endpoint.tf.tmpl
@@ -1,0 +1,3 @@
+  project = google_project_service.project_service.project
+  location = "us-central1"
+  endpoint = "%{endpoint_id}"

--- a/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl
@@ -1,0 +1,3 @@
+  project = google_project_service.project_service.project
+  location = "us-central1"
+  mcp_server = "%{mcp_server_id}"


### PR DESCRIPTION
Adds three IAM-only resource families to the IAP product that bind `roles/iap.egressor` on individual MCP servers, endpoints, and agents under an Agent Registry:

- `google_iap_agent_registry_mcp_server_iam_{member,binding,policy}`
- `google_iap_agent_registry_endpoint_iam_{member,binding,policy}`
- `google_iap_agent_registry_agent_iam_{member,binding,policy}`

These complement the existing `google_iap_agent_registry_iam_*` family (added in #17022), which only operates at the whole-registry scope, by exposing the per registry entry IAP REST surface at:

```
projects/{project}/locations/{location}/iap_web/agentRegistry/{mcpServers|endpoints|agents}/{id}
```

The agent scope supports the [agent-to-agent egress pattern](https://docs.cloud.google.com/gemini-enterprise-agent-platform/govern/policies/assign-identity-iam#agent-to-agent), where one agent's principal is granted `roles/iap.egressor` on another agent.

All three resources support IAM conditions (`REQUEST_BODY`) and the `roles/iap.egressor` role, matching the parent `AgentRegistry` resource and the IAP API. They follow the same IAM-only pattern as `AgentRegistry.yaml` (`exclude_resource: true`): the underlying CRUD resources are provisioned via the Gemini Enterprise Agent Platform and are not yet exposed by Terraform.

### Note on resource IDs

The registry entry identifier is the **last segment of the resource `name`** (e.g. `agentregistry-00000000-0000-0000-958c-aa0b68767675`), discoverable via `gcloud alpha agent-registry {agents,endpoints,mcp-servers} list` — not the `mcpServerId`/`endpointId` URN. The generated REST path matches the IAP API exactly (`.../iap_web/agentRegistry/{kind}/{id}:getIamPolicy`).

### Testing

Generated into `terraform-provider-google-beta` and built cleanly. Acceptance tests were run **live against a real Agent Registry** (project with pre-provisioned agent/endpoint/MCP-server entries), all passing:

- `TestAccIapAgentRegistryAgentIamMemberGenerated`
- `TestAccIapAgentRegistryMcpServerIamMemberGenerated`
- `TestAccIapAgentRegistryEndpointIamMemberGenerated`
- `TestAccIapAgentRegistryAgentIamBindingGenerated` (+ `_withCondition`, `_withAndWithoutCondition`)
- `TestAccIapAgentRegistryAgentIamPolicyGenerated` (+ `_withCondition`)

Each exercised the full lifecycle: setIamPolicy, getIamPolicy read-back, import verify, update, and destroy. This confirms URL construction, ID parsing, IAM conditions, and import IDs all work end-to-end.

<!-- Self-review checklist: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/ -->

```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_policy`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_policy`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_policy`
```