### PR TITLE
`MMv1`: move identity value set before flattener in list-resources

### DIFF
--- a/mmv1/templates/terraform/list_resource_method.go.tmpl
+++ b/mmv1/templates/terraform/list_resource_method.go.tmpl
@@ -79,9 +79,6 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 				return fmt.Errorf("error decoding {{ $.ResourceName }} from list response")
 			}
 {{- end }}
-			if err = Resource{{ $.ResourceName }}Flatten(d, config, res, config, {{ if $.HasProject }}project, {{ end }}userAgent, billingProject, url, headers); err != nil {
-				return err
-			}
 {{- /* url_param_only identity fields (e.g. name) are not GettableProperties, so the flattener does not Set them. Copy from res → d here so SetId/ListResultDisplayName can find them. Integer ids sometimes arrive as strings and need coercion. */ -}}
 {{- range $id := $.IdentityProperties }}
 {{- if $id.ApiName }}
@@ -101,6 +98,9 @@ func List{{ $.ResourceName }}s(config *transport_tpg.Config,
 			}
 {{- end }}
 {{- end }}
+			if err = Resource{{ $.ResourceName }}Flatten(d, config, res, config, {{ if $.HasProject }}project, {{ end }}userAgent, billingProject, url, headers); err != nil {
+				return err
+			}
 			id, err := tpgresource.ReplaceVars{{if $.LegacyLongFormProject -}}ForId{{ end -}}(d, config, "{{ $.IdFormat -}}")
 			if err != nil {
 				return fmt.Errorf("error constructing id: %w", err)


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

we run into a case where a res[""] value could overwritten a value that is supplied on flattener. This moves the value set prior to flattener instead of after.

`main`
```hcl
󰀵 mau  …/terraform-provider-google   main $   v1.26.1   17:57   envchain GCLOUD make testacc TEST=./google/services/pubsub TESTARGS='-run=TestAccPubsubSubscriptionListQuery_generated'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/pubsub -v -run=TestAccPubsubSubscriptionListQuery_generated -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccPubsubSubscriptionListQuery_generated
=== PAUSE TestAccPubsubSubscriptionListQuery_generated
=== CONT  TestAccPubsubSubscriptionListQuery_generated
    list_pubsub_subscription_generated_test.go:51: Step 2/2 error running query checks: google_pubsub_subscription.list_query - no query results found after filtering
--- FAIL: TestAccPubsubSubscriptionListQuery_generated (19.42s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-google/google/services/pubsub   20.763s
FAIL
make: *** [testacc] Error 1
```

`after moving to before the flattener`
```hcl
󰀵 mau  …/terraform-provider-google   main $?⇣   v1.26.1   17:58   envchain GCLOUD make testacc TEST=./google/services/pubsub TESTARGS='-run=TestAccPubsubSubscriptionListQuery_generated'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/pubsub -v -run=TestAccPubsubSubscriptionListQuery_generated -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccPubsubSubscriptionListQuery_generated
=== PAUSE TestAccPubsubSubscriptionListQuery_generated
=== CONT  TestAccPubsubSubscriptionListQuery_generated
--- PASS: TestAccPubsubSubscriptionListQuery_generated (18.17s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/pubsub   19.501s
```

comes from opening:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17823

and noticing failing tests

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
