### PR TITLE
Add additional allow project to google_secure_source_manager_instance

### DIFF
--- a/mmv1/products/securesourcemanager/Instance.yaml
+++ b/mmv1/products/securesourcemanager/Instance.yaml
@@ -89,6 +89,8 @@ examples:
       - 'update_time'
       - 'deletion_policy'
     exclude_docs: true
+    test_env_vars:
+      org_id: 'ORG_ID'
   - name: 'secure_source_manager_instance_private'
     primary_resource_id: 'default'
     vars:
@@ -305,6 +307,13 @@ properties:
         description: |
           Service Attachment for SSH, resource is in the format of `projects/{project}/regions/{region}/serviceAttachments/{service_attachment}`.
         output: true
+      - name: 'pscAllowedProjects'
+        type: Array
+        description: |
+          Optional. Additional allowed projects for setting up PSC connections.
+          Instance host project is automatically allowed and does not need to be included in this list.
+        item_type:
+          type: String
   - name: 'workforceIdentityFederationConfig'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
@@ -1,9 +1,21 @@
+resource "google_project" "psc_other_project" {
+  project_id      = "tf-test-psc-%{random_suffix}"
+  name            = "tf-test-psc-%{random_suffix}"
+  # These vars are typically available in the test environment
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  deletion_policy = "DELETE"
+}
+
 resource "google_secure_source_manager_instance" "{{$.PrimaryResourceId}}" {
   instance_id = "{{index $.Vars "instance_id"}}"
   location    = "us-central1"
 
   private_config {
     is_private = true
+    psc_allowed_projects = [
+      google_project.psc_other_project.project_id
+    ]
   }
   deletion_policy = "DELETE"
 }
+

--- a/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
+++ b/mmv1/templates/terraform/examples/secure_source_manager_instance_private_trusted_cert.tf.tmpl
@@ -1,7 +1,6 @@
 resource "google_project" "psc_other_project" {
   project_id      = "tf-test-psc-%{random_suffix}"
   name            = "tf-test-psc-%{random_suffix}"
-  # These vars are typically available in the test environment
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   deletion_policy = "DELETE"
 }


### PR DESCRIPTION
Add support for the `psc_allowed_projects` field to the `google_secure_source_manager_instance` resource. 

* Updated `mmv1/products/securesourcemanager/Instance.yaml` to include the `psc_allowed_projects` field.
* Added a new example template `secure_source_manager_instance_private_trusted_cert.tf.tmpl` demonstrating the use of this field alongside private configurations.
* Verified the changes by running the generated acceptance test: `TestAccSecureSourceManagerInstance_secureSourceManagerInstancePrivateTrustedCertExample`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
securesourcemanager: added `psc_allowed_projects` field to `google_secure_source_manager_instance` resource
```
