### PR TITLE
apigee: fix consumer_accept_list perpetual diff for API-managed entries

### DIFF
--- a/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_instance.go.tmpl
@@ -1,8 +1,34 @@
-// Suppress diffs when the lists of project have the same number of entries to handle the case that
-// API does not return what the user originally provided. Instead, API does some transformation.
-// For example, user provides a list of project number, but API returns a list of project Id.
+// Suppress diffs on consumer_accept_list to account for two server-side behaviors:
+//
+//  1. Normalization: the API may return a project ID where the user supplied the
+//     corresponding project number (e.g. user writes "12345", API returns
+//     "my-project"). These are the same project expressed differently.
+//  2. Auto-managed entries: the API may automatically add extra entries
+//     (e.g. the tenant project "<org>-tp" associated with the Apigee
+//     organization) that the user never specified.
+//
+// In both cases the user's configured projects are still honored, so the diff is
+// spurious and should be suppressed. A genuine user change (replacing one
+// project with a different one, or removing a user-specified project) must NOT
+// be suppressed.
 func projectListDiffSuppress(_, _, _ string, d *schema.ResourceData) bool {
     return ProjectListDiffSuppressFunc(d)
+}
+
+// isProjectNumber reports whether s looks like a GCP project number (all digits).
+// The API normalizes project numbers to project IDs, so an old value that is a
+// pure project number changing to a non-numeric new value is treated as
+// normalization rather than a user-initiated change.
+func isProjectNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool {
@@ -20,5 +46,71 @@ func ProjectListDiffSuppressFunc(d tpgresource.TerraformResourceDataChange) bool
 	}
 	log.Printf("[DEBUG] - suppressing diff with oldInt %d, newInt %d", oldInt, newInt)
 
-	return oldInt == newInt
+	// "old" is the value in state (what the API last returned); "new" is the
+	// user's configured value.
+	getValue := func(which string, i int) string {
+		k := fmt.Sprintf("consumer_accept_list.%d", i)
+		oldVal, newVal := d.GetChange(k)
+		var v interface{}
+		if which == "old" {
+			v = oldVal
+		} else {
+			v = newVal
+		}
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return ""
+	}
+
+	// Collect the API-returned (old) values into a set so we can test membership.
+	oldValues := make(map[string]bool, oldInt)
+	for i := 0; i < oldInt; i++ {
+		if v := getValue("old", i); v != "" {
+			oldValues[v] = true
+		}
+	}
+
+	// Equal lengths: this is either pure normalization (number -> ID) or a
+	// genuine one-for-one swap. Suppress only when every configured (new) value
+	// is either already present in the API response, or is the normalized form
+	// of a project number that the API returned at the same position. A real
+	// swap to an unrelated project is not suppressed.
+	if oldInt == newInt {
+		for i := 0; i < newInt; i++ {
+			newVal := getValue("new", i)
+			if newVal == "" {
+				continue
+			}
+			if oldValues[newVal] {
+				continue
+			}
+			// Not a direct match; allow only if the old value at this position
+			// is a project number being normalized to an ID.
+			if isProjectNumber(getValue("old", i)) {
+				continue
+			}
+			return false
+		}
+		return true
+	}
+
+	// API returned more items than the user configured (e.g. auto-added tenant
+	// project). Suppress only if every configured (new) value is present in the
+	// API response; otherwise the user removed/changed a project and the diff is
+	// real.
+	if oldInt > newInt && newInt > 0 {
+		for i := 0; i < newInt; i++ {
+			newVal := getValue("new", i)
+			if newVal == "" {
+				continue
+			}
+			if !oldValues[newVal] {
+				return false
+			}
+		}
+		return true
+	}
+
+	return false
 }

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_test.go
@@ -36,6 +36,48 @@ var apigeeInstanceDiffSuppressTestCases = []ApigeeInstanceDiffSuppressTestCase{
 		},
 	},
 	{
+		Name:           "API adds extra entry (e.g. tenant project), user-specified items are all present in API response",
+		KeysToSuppress: []string{"consumer_accept_list.#", "consumer_accept_list.1"},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "xf6b33cd4be340fd3-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+		},
+	},
+	{
+		Name:           "user-specified item not present in API response (no suppression)",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "project-a",
+			"consumer_accept_list.1": "xf6b33cd4be340fd3-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 1,
+			"consumer_accept_list.0": "project-b",
+		},
+	},
+	{
+		// Equal length, but the user replaced a real project (not a number->ID
+		// normalization) with a different project. This must NOT be suppressed.
+		Name:           "same length but user swaps one project for a different one (no suppression)",
+		KeysToSuppress: []string{},
+		Before: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "xf6b33cd4be340fd3-tp",
+		},
+		After: map[string]interface{}{
+			"consumer_accept_list.#": 2,
+			"consumer_accept_list.0": "tf-test8v1bd04pxa",
+			"consumer_accept_list.1": "tf-testnew",
+		},
+	},
+	{
 		Name:           "projects with the same length and no project conversion",
 		KeysToSuppress: []string{},
 		Before: map[string]interface{}{

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_instance_update_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/apigee"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/compute"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/servicenetworking"
 )
 
 func TestAccApigeeInstance_updateConsumerAcceptList(t *testing.T) {
@@ -38,7 +34,7 @@ func TestAccApigeeInstance_updateConsumerAcceptList(t *testing.T) {
 				ResourceName:            "google_apigee_instance.apigee_instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ip_range", "org_id"},
+				ImportStateVerifyIgnore: []string{"ip_range", "org_id", "consumer_accept_list"},
 			},
 			{
 				Config: testAccApigeeInstance_updateConsumerAcceptList(context),
@@ -47,7 +43,7 @@ func TestAccApigeeInstance_updateConsumerAcceptList(t *testing.T) {
 				ResourceName:            "google_apigee_instance.apigee_instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ip_range", "org_id"},
+				ImportStateVerifyIgnore: []string{"ip_range", "org_id", "consumer_accept_list"},
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Re-opens #16933 (auto-closed for inactivity; the original PR could not be
reopened because its head branch was force-pushed after closure, which GitHub
permanently blocks from reopening).

The Apigee API automatically adds the tenant project (e.g. `<id>-tp`) to
`consumer_accept_list` and normalizes project numbers to project IDs, causing
`TestAccApigeeInstance_updateConsumerAcceptList` to fail with a non-empty plan
(hashicorp/terraform-provider-google#26274, still failing 100% in nightly).

## Changes

`ProjectListDiffSuppressFunc` now:
- **Equal length:** suppress only when each configured value is present in the
  API response, or the old value is a project *number* being normalized to an
  ID. A genuine one-for-one swap to an unrelated project is **not** suppressed.
  This addresses the prior review feedback from @zli82016 that an equal-length
  value change was being incorrectly suppressed.
- **API returned more entries than configured** (auto-added tenant project):
  suppress only when every configured value is still present.

Adds unit cases for the auto-added-entry and equal-length-swap scenarios, and
ignores `consumer_accept_list` during import verification.

## Test evidence

Unit: `TestUnitApigeeInstance_projectListDiffSuppress` PASS (incl. the
equal-length-swap case from review).

Acceptance (real Apigee instance, ~50 min):
```
--- PASS: TestAccApigeeInstance_updateConsumerAcceptList (3023.29s)
```

Fixes hashicorp/terraform-provider-google#26274

```release-note:bug
apigee: fixed `google_apigee_instance` perpetual plan diff when the Apigee API auto-adds the tenant project to `consumer_accept_list` or normalizes project numbers to IDs
```
