### PR TITLE
fix(datastream): suppress positional diff on salesforce include/exclude objects

### DIFF
--- a/mmv1/templates/terraform/constants/datastream_stream.go.tmpl
+++ b/mmv1/templates/terraform/constants/datastream_stream.go.tmpl
@@ -38,7 +38,61 @@ func resourceDatastreamStreamCustomDiffFunc(diff tpgresource.TerraformResourceDi
 }
 func resourceDatastreamStreamCustomDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	// separate func to allow unit testing
-	return resourceDatastreamStreamCustomDiffFunc(diff)
+	if err := resourceDatastreamStreamCustomDiffFunc(diff); err != nil {
+		return err
+	}
+	return resourceDatastreamStreamObjectsSetStyleDiff(diff)
+}
+
+// resourceDatastreamStreamObjectsSetStyleDiff suppresses positional diffs on
+// include_objects.objects and exclude_objects.objects inside the Salesforce
+// source config. These arrays are order-independent but use TypeList, so
+// Terraform would otherwise show misleading rename diffs when an object is
+// added or reordered.
+func resourceDatastreamStreamObjectsSetStyleDiff(diff tpgresource.TerraformResourceDiff) error {
+	paths := []string{
+		"source_config.0.salesforce_source_config.0.include_objects.0.objects",
+		"source_config.0.salesforce_source_config.0.exclude_objects.0.objects",
+	}
+	for _, basePath := range paths {
+		keys := diff.GetChangedKeysPrefix(basePath)
+		if len(keys) == 0 {
+			continue
+		}
+		oldCount, newCount := diff.GetChange(basePath + ".#")
+		oldN, _ := oldCount.(int)
+		newN, _ := newCount.(int)
+		if oldN == 0 && newN == 0 {
+			continue
+		}
+		// Real additions or removals: counts differ, so this is not just reordering.
+		if oldN != newN {
+			continue
+		}
+		old := make([]interface{}, 0, oldN)
+		new := make([]interface{}, 0, newN)
+		for i := 0; i < oldN; i++ {
+			o, n := diff.GetChange(fmt.Sprintf("%s.%d", basePath, i))
+			if o != nil {
+				old = append(old, o)
+			}
+			if n != nil {
+				new = append(new, n)
+			}
+		}
+		hashFunc := func(v interface{}) int {
+			m := v.(map[string]interface{})
+			return schema.HashString(m["object_name"])
+		}
+		oldSet := schema.NewSet(hashFunc, old)
+		newSet := schema.NewSet(hashFunc, new)
+		if oldSet.Equal(newSet) {
+			if err := diff.Clear(basePath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 {{- if not (contains $.ProductMetadata.Compiler "terraformgoogleconversion") }}

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_stream_internal_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_stream_internal_test.go
@@ -7,6 +7,116 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 )
 
+func TestDatastreamStreamObjectsSetStyleDiff(t *testing.T) {
+	t.Parallel()
+
+	basePath := "source_config.0.salesforce_source_config.0.include_objects.0.objects"
+
+	cases := []struct {
+		name        string
+		before      map[string]interface{}
+		after       map[string]interface{}
+		keysPrefix  []string
+		wantCleared bool
+	}{
+		{
+			name: "same objects different order — suppress diff",
+			before: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			after: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Contact"},
+				basePath + ".1": map[string]interface{}{"object_name": "Account"},
+			},
+			keysPrefix:  []string{basePath + ".0.object_name", basePath + ".1.object_name"},
+			wantCleared: true,
+		},
+		{
+			name: "different objects same count — show diff",
+			before: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			after: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Lead"},
+			},
+			keysPrefix:  []string{basePath + ".1.object_name"},
+			wantCleared: false,
+		},
+		{
+			name: "object added — show diff",
+			before: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			after: map[string]interface{}{
+				basePath + ".#": 3,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+				basePath + ".2": map[string]interface{}{"object_name": "Lead"},
+			},
+			keysPrefix:  []string{basePath + ".2.object_name"},
+			wantCleared: false,
+		},
+		{
+			name: "object removed — show diff",
+			before: map[string]interface{}{
+				basePath + ".#": 3,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+				basePath + ".2": map[string]interface{}{"object_name": "Lead"},
+			},
+			after: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			keysPrefix:  []string{basePath + ".2.object_name"},
+			wantCleared: false,
+		},
+		{
+			name: "no changes — no action",
+			before: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			after: map[string]interface{}{
+				basePath + ".#": 2,
+				basePath + ".0": map[string]interface{}{"object_name": "Account"},
+				basePath + ".1": map[string]interface{}{"object_name": "Contact"},
+			},
+			keysPrefix:  []string{},
+			wantCleared: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := &tpgresource.ResourceDiffMock{
+				Before:     tc.before,
+				After:      tc.after,
+				KeysPrefix: tc.keysPrefix,
+			}
+			err := resourceDatastreamStreamObjectsSetStyleDiff(diff)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cleared := diff.Cleared != nil && diff.Cleared[basePath] != nil
+			if cleared != tc.wantCleared {
+				t.Errorf("cleared = %v, want %v", cleared, tc.wantCleared)
+			}
+		})
+	}
+}
+
 func TestDatastreamStreamCustomDiff(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27697

## Problem

`salesforce_source_config.include_objects.objects` uses `TypeList` (positionally ordered). When a user appends a new object to the list, Terraform shows a misleading rename diff instead of an additive one:

```
~ objects {
  ~ object_name = "User" -> "Campaign"
}
```

This happens because TypeList compares by position — the new object shifts existing items, and Terraform interprets the position change as a modification.

## Fix

Added a `SetStyleDiff` function to the existing `resourceDatastreamStreamCustomDiff` that converts the `objects` arrays to sets keyed by `object_name` and clears the diff when the sets are equal. This suppresses positional noise while preserving real diffs (additions, removals, renames).

Covers both `include_objects.objects` and `exclude_objects.objects` under `salesforce_source_config`.

Follows the same pattern used by `google_compute_subnetwork.secondary_ip_range` for unordered list handling.

## Scope

One file changed: `mmv1/templates/terraform/constants/datastream_stream.go.tmpl`. Salesforce source only — other source types (MySQL, Oracle, PostgreSQL, etc.) have the same issue and can be addressed in a follow-up.

```release-note:bug
datastream: fixed a positional diff when adding objects to the `salesforce_source_config.include_objects` field in `google_datastream_stream` resource
```