### PR TITLE
fix(iam): fix duplicate /keys in ephemeral service account key URL

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/ephemeral_google_service_account_key.go
@@ -222,6 +222,8 @@ func (p *googleEphemeralServiceAccountKey) Open(ctx context.Context, req ephemer
 	nameToWait := saName
 	if serviceAccountKey != nil {
 		nameToWait = serviceAccountKey.Name
+	} else if data.Name.ValueString() != "" {
+		nameToWait = data.Name.ValueString()
 	}
 	log.Printf("[DEBUG] Retrieving Service Account Key %q\n", nameToWait)
 	if err := ServiceAccountKeyWaitTime(keys, nameToWait, publicKeyType, "Retrieving Service account key", 4*time.Minute); err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27387

## Problem

When the ephemeral `google_service_account_key` resource is used with `fetch_key = true` and a `name` field containing the full key path (`projects/.../serviceAccounts/.../keys/KEYID`), the provider constructs a URL with `/keys` duplicated:

```
/v1/projects/x/serviceAccounts/.../keys/KEYID/keys
```

This happens because:
1. `name` (a full key path) is passed to `ServiceAccountFQN()` which returns it unchanged (it starts with `projects/`)
2. The result is used as `nameToWait` for `ServiceAccountKeyWaitTime`
3. The waiter calls `keys.Get(nameToWait)` which appends `/keys` to the path again

Worked in v7.31.0, broke in v7.32.0 when the ephemeral resource was expanded to support key creation alongside fetching.

## Fix

When `fetch_key = true` and `name` is provided, use `data.Name.ValueString()` directly as the key name for the waiter, instead of the `saName` that was mangled by `ServiceAccountFQN`. The full key path is already in the correct format for `keys.Get()`.

Similar in nature to #17485 (BigQuery reservation assignment 404 from malformed URL) and #17801 (tags location binding polling wrong endpoint).

```release-note:bug
iam: Fixed ephemeral `google_service_account_key` producing a 404 due to duplicate `/keys` in the URL when `fetch_key = true` and `name` is provided
```