### PR TITLE
fix(apigee): prevent permadiff on key_expires_in for developer app

### DIFF
--- a/mmv1/products/apigee/DeveloperApp.yaml
+++ b/mmv1/products/apigee/DeveloperApp.yaml
@@ -110,6 +110,7 @@ properties:
       the API key never expires. The expiration time can't be updated after it is set.
     default_value: "-1"
     immutable: true
+    ignore_read: true
   - name: "apiProducts"
     type: Array
     description: |

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
@@ -41,7 +41,7 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"org_id"},
+				ImportStateVerifyIgnore: []string{"key_expires_in", "org_id"},
 			},
 			{
 				Config: testAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(context),
@@ -54,7 +54,7 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"org_id"},
+				ImportStateVerifyIgnore: []string{"key_expires_in", "org_id"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27071

## Problem

google_apigee_developer_app is replaced on every apply when key_expires_in is set. The field is a duration in milliseconds, but the API returns it as an absolute timestamp. Since the field has immutable: true (ForceNew), any diff triggers a destroy and recreate on every apply.

## Fix

Added ignore_read: true to keyExpiresIn in DeveloperApp.yaml. This prevents the provider from reading the API-returned timestamp back into state, so the original config value is preserved and no diff is produced.

```release-note:bug
apigee: fixed an issue where the resource would attempt recreation if the `key_expires_in` field was set in `google_apigee_developer_app` resource
```