### PR TITLE
apigee: support environment type update via modifyEnvironment

### DIFF
--- a/mmv1/products/apigee/Environment.yaml
+++ b/mmv1/products/apigee/Environment.yaml
@@ -47,6 +47,7 @@ iam_policy:
     - '{{name}}'
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_environment.go.tmpl'
+  custom_update: 'templates/terraform/custom_update/apigee_environment.go.tmpl'
 examples:
   - name: 'apigee_environment_basic'
     vars:

--- a/mmv1/templates/terraform/custom_update/apigee_environment.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/apigee_environment.go.tmpl
@@ -1,0 +1,156 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+baseUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/environments/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+// `type` and `nodeConfig` cannot be changed through the standard
+// updateEnvironment (PUT) call -- the API rejects it with
+// "updating environment type is not supported today". These fields must be
+// modified through modifyEnvironment, which is a PATCH with an updateMask and
+// returns a long-running operation.
+modifyMask := []string{}
+modifyObj := make(map[string]interface{})
+if d.HasChange("type") {
+	typeProp, err := expandApigeeEnvironmentType(d.Get("type"), d, config)
+	if err != nil {
+		return err
+	}
+	modifyObj["type"] = typeProp
+	modifyMask = append(modifyMask, "type")
+}
+if d.HasChange("node_config") {
+	nodeConfigProp, err := expandApigeeEnvironmentNodeConfig(d.Get("node_config"), d, config)
+	if err != nil {
+		return err
+	}
+	modifyObj["nodeConfig"] = nodeConfigProp
+	modifyMask = append(modifyMask, "nodeConfig")
+}
+
+if len(modifyMask) > 0 {
+	modifyUrl, err := transport_tpg.AddQueryParams(baseUrl, map[string]string{"updateMask": strings.Join(modifyMask, ",")})
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Modifying Environment %q via modifyEnvironment: %#v", d.Id(), modifyObj)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PATCH",
+		Project:   billingProject,
+		RawURL:    modifyUrl,
+		UserAgent: userAgent,
+		Body:      modifyObj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+	})
+	if err != nil {
+		return fmt.Errorf("Error modifying Environment %q: %s", d.Id(), err)
+	}
+	if err := ApigeeOperationWaitTime(config, res, "Modifying Environment", userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return fmt.Errorf("Error waiting to modify Environment %q: %s", d.Id(), err)
+	}
+}
+
+// Remaining mutable fields go through the standard updateEnvironment (PUT),
+// which replaces the resource. Skip the PUT when only type/node_config changed.
+otherChanged := false
+for _, f := range []string{"display_name", "description", "deployment_type", "api_proxy_type", "forward_proxy_uri", "properties", "client_ip_resolution_config"} {
+	if d.HasChange(f) {
+		otherChanged = true
+		break
+	}
+}
+
+if otherChanged {
+	obj := make(map[string]interface{})
+	nameProp, err := expandApigeeEnvironmentName(d.Get("name"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(nameProp)) {
+		obj["name"] = nameProp
+	}
+	displayNameProp, err := expandApigeeEnvironmentDisplayName(d.Get("display_name"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(displayNameProp)) {
+		obj["displayName"] = displayNameProp
+	}
+	descriptionProp, err := expandApigeeEnvironmentDescription(d.Get("description"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(descriptionProp)) {
+		obj["description"] = descriptionProp
+	}
+	deploymentTypeProp, err := expandApigeeEnvironmentDeploymentType(d.Get("deployment_type"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(deploymentTypeProp)) {
+		obj["deploymentType"] = deploymentTypeProp
+	}
+	apiProxyTypeProp, err := expandApigeeEnvironmentApiProxyType(d.Get("api_proxy_type"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(apiProxyTypeProp)) {
+		obj["apiProxyType"] = apiProxyTypeProp
+	}
+	// Preserve type and node_config in the full-object PUT so they are not
+	// cleared by the replace semantics.
+	typeProp, err := expandApigeeEnvironmentType(d.Get("type"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(typeProp)) {
+		obj["type"] = typeProp
+	}
+	nodeConfigProp, err := expandApigeeEnvironmentNodeConfig(d.Get("node_config"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(nodeConfigProp)) {
+		obj["nodeConfig"] = nodeConfigProp
+	}
+	forwardProxyUriProp, err := expandApigeeEnvironmentForwardProxyUri(d.Get("forward_proxy_uri"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(forwardProxyUriProp)) {
+		obj["forwardProxyUri"] = forwardProxyUriProp
+	}
+	propertiesProp, err := expandApigeeEnvironmentProperties(d.Get("properties"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(propertiesProp)) {
+		obj["properties"] = propertiesProp
+	}
+	clientIpResolutionConfigProp, err := expandApigeeEnvironmentClientIpResolutionConfig(d.Get("client_ip_resolution_config"), d, config)
+	if err != nil {
+		return err
+	} else if !tpgresource.IsEmptyValue(reflect.ValueOf(clientIpResolutionConfigProp)) {
+		obj["clientIpResolutionConfig"] = clientIpResolutionConfigProp
+	}
+
+	log.Printf("[DEBUG] Updating Environment %q: %#v", d.Id(), obj)
+	headers := make(http.Header)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PUT",
+		Project:   billingProject,
+		RawURL:    baseUrl,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating Environment %q: %s", d.Id(), err)
+	}
+	log.Printf("[DEBUG] Finished updating Environment %q: %#v", d.Id(), res)
+}
+
+return resourceApigeeEnvironmentRead(d, meta)

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -7,11 +7,17 @@ resource "google_project" "project" {
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on      = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -38,12 +44,17 @@ resource "google_project_service" "kms" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "time_sleep" "wait_for_services" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.kms]
+}
+
 resource "google_compute_network" "apigee_network" {
   provider = google-beta
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -72,7 +83,7 @@ resource "google_kms_key_ring" "apigee_keyring" {
   name       = "apigee-keyring"
   location   = "us-central1"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key" "apigee_key" {
@@ -87,7 +98,7 @@ resource "google_project_service_identity" "apigee_sa" {
 
   project    = google_project.project.project_id
   service    = google_project_service.apigee.service
-  depends_on = [google_project_service.apigee, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -97,6 +108,11 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+}
+
+resource "time_sleep" "wait_for_iam" {
+  create_duration = "120s"
+  depends_on      = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -110,8 +126,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+    time_sleep.wait_for_iam,
   ]
 }
 

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -5,12 +5,6 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
-  deletion_policy = "DELETE"
-}
-
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-  depends_on = [google_project.project]
 }
 
 resource "google_project_service" "apigee" {
@@ -18,36 +12,30 @@ resource "google_project_service" "apigee" {
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
-  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "compute.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
   depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "servicenetworking.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
   depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "cloudkms.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "cloudkms.googleapis.com"
   depends_on = [google_project_service.servicenetworking]
-}
-
-resource "time_sleep" "wait_300_seconds" {
-  create_duration = "300s"
-  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -55,7 +43,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_300_seconds]
+  depends_on = [google_project_service.compute, google_project_service.kms]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -90,15 +78,16 @@ resource "google_kms_key_ring" "apigee_keyring" {
 resource "google_kms_crypto_key" "apigee_key" {
   provider = google-beta
 
-  name            = "apigee-key"
-  key_ring        = google_kms_key_ring.apigee_keyring.id
+  name     = "apigee-key"
+  key_ring = google_kms_key_ring.apigee_keyring.id
 }
 
 resource "google_project_service_identity" "apigee_sa" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = google_project_service.apigee.service
+  project    = google_project.project.project_id
+  service    = google_project_service.apigee.service
+  depends_on = [google_project_service.apigee, google_project_service.kms]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -107,7 +96,7 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  member = google_project_service_identity.apigee_sa.member
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -5,6 +5,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "{{index $.TestEnvVars "org_id"}}"
   billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {

--- a/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_environment_patch_update_test.tf.tmpl
@@ -102,6 +102,14 @@ resource "google_project_service_identity" "apigee_sa" {
   depends_on = [time_sleep.wait_for_services]
 }
 
+# The Apigee service identity email is returned before the service account has
+# fully propagated. Wait before granting it IAM so the KMS binding does not fail
+# with "Service account ... does not exist".
+resource "time_sleep" "wait_for_sa" {
+  create_duration = "60s"
+  depends_on      = [google_project_service_identity.apigee_sa]
+}
+
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
@@ -109,6 +117,8 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+
+  depends_on = [time_sleep.wait_for_sa]
 }
 
 resource "time_sleep" "wait_for_iam" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -13,21 +13,16 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 	acctest.SkipIfVcr(t)
 	t.Parallel()
 
-	randomSuffix := acctest.RandString(t, 10)
-
-  context := map[string]interface{}{
-    "billing_account": envvar.GetTestBillingAccountFromEnv(t),
-    "org_id":          envvar.GetTestOrgFromEnv(t),
-    "random_suffix":   randomSuffix,
-  }
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		ExternalProviders: map[string]resource.ExternalProvider{
-			"time": {},
-		},
-		CheckDestroy: testAccCheckApigeeEnvironmentDestroyProducer(t),
+		CheckDestroy:             testAccCheckApigeeEnvironmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExample(context),
@@ -62,17 +57,11 @@ resource "google_project" "project" {
   billing_account = "%{billing_account}"
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  create_duration = "60s"
-  depends_on = [google_project.project]
-}
-
 resource "google_project_service" "apigee" {
   provider = google-beta
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
-  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -80,7 +69,6 @@ resource "google_project_service" "compute" {
 
   project = google_project.project.project_id
   service = "compute.googleapis.com"
-  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
@@ -88,7 +76,6 @@ resource "google_project_service" "servicenetworking" {
 
   project = google_project.project.project_id
   service = "servicenetworking.googleapis.com"
-  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
@@ -96,12 +83,6 @@ resource "google_project_service" "kms" {
 
   project = google_project.project.project_id
   service = "cloudkms.googleapis.com"
-  depends_on = [google_project_service.servicenetworking]
-}
-
-resource "time_sleep" "wait_300_seconds" {
-  create_duration = "300s"
-  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -109,7 +90,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [time_sleep.wait_300_seconds]
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_compute_global_address" "apigee_range" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -52,7 +52,7 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 }
 
 func testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(context map[string]interface{}) string {
-        return acctest.Nprintf(`
+	return acctest.Nprintf(`
 resource "google_project" "project" {
   provider = google-beta
 
@@ -63,11 +63,17 @@ resource "google_project" "project" {
   deletion_policy = "DELETE"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
   project = google_project.project.project_id
   service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -75,6 +81,7 @@ resource "google_project_service" "compute" {
 
   project = google_project.project.project_id
   service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
@@ -82,6 +89,7 @@ resource "google_project_service" "servicenetworking" {
 
   project = google_project.project.project_id
   service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
@@ -89,11 +97,12 @@ resource "google_project_service" "kms" {
 
   project = google_project.project.project_id
   service = "cloudkms.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
 }
 
 resource "time_sleep" "wait_300_seconds" {
   create_duration = "300s"
-  depends_on = [google_project_service.compute]
+  depends_on = [google_project_service.kms]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -107,7 +116,7 @@ resource "google_compute_network" "apigee_network" {
 resource "google_compute_global_address" "apigee_range" {
   provider = google-beta
 
-  name          = "tf-test-apigee-range%{random_suffix}"
+  name          = "apigee-range"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
@@ -175,11 +184,11 @@ resource "google_apigee_organization" "apigee_org" {
 resource "google_apigee_environment" "apigee_environment" {
   provider = google-beta
 
-  org_id       = google_apigee_organization.apigee_org.id
-  name         = "tf-test%{random_suffix}"
-  description  = "Apigee Environment"
-  display_name = "tf-test%{random_suffix}"
-  type         = "INTERMEDIATE"
+  org_id            = google_apigee_organization.apigee_org.id
+  name              = "tf-test%{random_suffix}"
+  description       = "Apigee Environment"
+  display_name      = "tf-test%{random_suffix}"
+  type              = "INTERMEDIATE"
   forward_proxy_uri = "http://test:456"
 }
 `, context)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -22,7 +22,10 @@ func TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate(t *t
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
-		CheckDestroy:             testAccCheckApigeeEnvironmentDestroyProducer(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeEnvironmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExample(context),
@@ -57,11 +60,17 @@ resource "google_project" "project" {
   billing_account = "%{billing_account}"
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on      = [google_project.project]
+}
+
 resource "google_project_service" "apigee" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "apigee.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
 }
 
 resource "google_project_service" "compute" {
@@ -88,12 +97,17 @@ resource "google_project_service" "kms" {
   depends_on = [google_project_service.servicenetworking]
 }
 
+resource "time_sleep" "wait_for_services" {
+  create_duration = "300s"
+  depends_on      = [google_project_service.kms]
+}
+
 resource "google_compute_network" "apigee_network" {
   provider = google-beta
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -122,7 +136,7 @@ resource "google_kms_key_ring" "apigee_keyring" {
   name       = "apigee-keyring"
   location   = "us-central1"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key" "apigee_key" {
@@ -137,7 +151,7 @@ resource "google_project_service_identity" "apigee_sa" {
 
   project    = google_project.project.project_id
   service    = google_project_service.apigee.service
-  depends_on = [google_project_service.apigee, google_project_service.kms]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
@@ -147,6 +161,11 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+}
+
+resource "time_sleep" "wait_for_iam" {
+  create_duration = "120s"
+  depends_on      = [google_kms_crypto_key_iam_member.apigee_sa_keyuser]
 }
 
 resource "google_apigee_organization" "apigee_org" {
@@ -160,8 +179,7 @@ resource "google_apigee_organization" "apigee_org" {
 
   depends_on = [
     google_service_networking_connection.apigee_vpc_connection,
-    google_project_service.apigee,
-    google_kms_crypto_key_iam_member.apigee_sa_keyuser,
+    time_sleep.wait_for_iam,
   ]
 }
 

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -67,22 +67,25 @@ resource "google_project_service" "apigee" {
 resource "google_project_service" "compute" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "compute.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
 }
 
 resource "google_project_service" "servicenetworking" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "servicenetworking.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
 }
 
 resource "google_project_service" "kms" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = "cloudkms.googleapis.com"
+  project    = google_project.project.project_id
+  service    = "cloudkms.googleapis.com"
+  depends_on = [google_project_service.servicenetworking]
 }
 
 resource "google_compute_network" "apigee_network" {
@@ -90,7 +93,7 @@ resource "google_compute_network" "apigee_network" {
 
   name       = "apigee-network"
   project    = google_project.project.project_id
-  depends_on = [google_project_service.compute]
+  depends_on = [google_project_service.compute, google_project_service.kms]
 }
 
 resource "google_compute_global_address" "apigee_range" {
@@ -125,15 +128,16 @@ resource "google_kms_key_ring" "apigee_keyring" {
 resource "google_kms_crypto_key" "apigee_key" {
   provider = google-beta
 
-  name            = "apigee-key"
-  key_ring        = google_kms_key_ring.apigee_keyring.id
+  name     = "apigee-key"
+  key_ring = google_kms_key_ring.apigee_keyring.id
 }
 
 resource "google_project_service_identity" "apigee_sa" {
   provider = google-beta
 
-  project = google_project.project.project_id
-  service = google_project_service.apigee.service
+  project    = google_project.project.project_id
+  service    = google_project_service.apigee.service
+  depends_on = [google_project_service.apigee, google_project_service.kms]
 }
 
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -60,7 +60,6 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
-  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -161,7 +161,7 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   crypto_key_id = google_kms_crypto_key.apigee_key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
-  member = google_project_service_identity.apigee_sa.member
+  member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
 }
 
 resource "google_apigee_organization" "apigee_org" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -58,6 +58,7 @@ resource "google_project" "project" {
   name            = "tf-test%{random_suffix}"
   org_id          = "%{org_id}"
   billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
 }
 
 resource "time_sleep" "wait_60_seconds" {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_environment_type_test.go.tmpl
@@ -160,6 +160,12 @@ resource "google_project_service_identity" "apigee_sa" {
   depends_on = [time_sleep.wait_for_services]
 }
 
+# Wait for the Apigee service identity to propagate before granting it IAM.
+resource "time_sleep" "wait_for_sa" {
+  create_duration = "60s"
+  depends_on      = [google_project_service_identity.apigee_sa]
+}
+
 resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   provider = google-beta
 
@@ -167,6 +173,8 @@ resource "google_kms_crypto_key_iam_member" "apigee_sa_keyuser" {
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
   member = "serviceAccount:${google_project_service_identity.apigee_sa.email}"
+
+  depends_on = [time_sleep.wait_for_sa]
 }
 
 resource "time_sleep" "wait_for_iam" {


### PR DESCRIPTION
## Summary

Re-opens #16945 (auto-closed for inactivity; GitHub blocks reopening after the branch was updated post-closure). Rebased onto current `main`.

Fixes `TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate` (hashicorp/terraform-provider-google#21510, still OPEN). Two root causes:

1. **Environment `type` is not updatable via the standard `updateEnvironment` (PUT)** — the API now returns `400: updating environment type is not supported today`. Added a `custom_update` that routes `type`/`node_config` changes through **`modifyEnvironment`** (PATCH + `updateMask`, long-running operation) and other fields through the existing PUT.
2. **Service-account propagation race**: `google_project_service_identity` returns the SA email before the SA exists, so the KMS IAM binding failed with "Service account does not exist". Added a `wait_for_sa` `time_sleep` between the identity and the IAM binding (plus existing wait gates), kept `deletion_policy = DELETE` (review feedback from @BBBmau), and removed duplicate resource blocks.

## Test evidence

Real Apigee org (beta):
```
--- PASS: TestAccApigeeEnvironment_apigeeEnvironmentPatchUpdateTestExampleUpdate (1499.06s)
```
The update step changes `type` COMPREHENSIVE→INTERMEDIATE in place via `modifyEnvironment`.

Fixes hashicorp/terraform-provider-google#21510

```release-note:bug
apigee: fixed `google_apigee_environment` `type` updates by routing them through the modifyEnvironment API instead of the full-replace update
```
