### PR TITLE
apigee: normalize org_id in google_apigee_sharedflow to avoid doubled prefix

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -21,6 +22,14 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
+
+// apigeeSharedflowNormalizeOrgId strips the "organizations/" prefix from org_id
+// if present. This allows users to pass either google_apigee_organization.id
+// (which returns "organizations/<project-id>") or a bare project ID without
+// producing a doubled "organizations/organizations/..." in the API URL.
+func apigeeSharedflowNormalizeOrgId(v interface{}) string {
+	return strings.TrimPrefix(v.(string), "organizations/")
+}
 
 func ResourceApigeeSharedFlow() *schema.Resource {
 	return &schema.Resource{
@@ -64,6 +73,11 @@ func ResourceApigeeSharedFlow() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization name associated with the Apigee instance.`,
+				// Normalize org_id by stripping the "organizations/" prefix so users
+				// may pass google_apigee_organization.id ("organizations/<project-id>")
+				// or a bare project ID. StateFunc stores the normalized value, so a
+				// config using either form matches state with no diff.
+				StateFunc: apigeeSharedflowNormalizeOrgId,
 			},
 			"latest_revision_id": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow.go
@@ -27,8 +27,19 @@ import (
 // if present. This allows users to pass either google_apigee_organization.id
 // (which returns "organizations/<project-id>") or a bare project ID without
 // producing a doubled "organizations/organizations/..." in the API URL.
-func apigeeSharedflowNormalizeOrgId(v interface{}) string {
-	return strings.TrimPrefix(v.(string), "organizations/")
+func apigeeSharedflowNormalizeOrgId(v string) string {
+	return strings.TrimPrefix(v, "organizations/")
+}
+
+// apigeeSharedflowCollapseOrgPrefix collapses a doubled "organizations/" segment
+// in a constructed URL/ID. org_id may be supplied either bare or fully-qualified
+// ("organizations/<id>", e.g. from google_apigee_organization.id); the URL
+// templates already prepend "organizations/", so the fully-qualified form would
+// otherwise yield "organizations/organizations/<id>". The stored org_id value is
+// left untouched (the diff is handled by DiffSuppressFunc), so existing
+// resources are never re-created.
+func apigeeSharedflowCollapseOrgPrefix(s string) string {
+	return strings.Replace(s, "organizations/organizations/", "organizations/", 1)
 }
 
 func ResourceApigeeSharedFlow() *schema.Resource {
@@ -73,11 +84,15 @@ func ResourceApigeeSharedFlow() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization name associated with the Apigee instance.`,
-				// Normalize org_id by stripping the "organizations/" prefix so users
-				// may pass google_apigee_organization.id ("organizations/<project-id>")
-				// or a bare project ID. StateFunc stores the normalized value, so a
-				// config using either form matches state with no diff.
-				StateFunc: apigeeSharedflowNormalizeOrgId,
+				// Users may pass google_apigee_organization.id
+				// ("organizations/<project-id>") or a bare project ID. Suppress the
+				// diff when both forms normalize to the same value so the field does
+				// not trigger a spurious ForceNew. DiffSuppressFunc (rather than
+				// StateFunc) leaves the stored value untouched, so existing state is
+				// never rewritten and no resource is re-created on upgrade.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return apigeeSharedflowNormalizeOrgId(old) == apigeeSharedflowNormalizeOrgId(new)
+				},
 			},
 			"latest_revision_id": {
 				Type:        schema.TypeString,
@@ -186,6 +201,9 @@ func resourceApigeeSharedFlowCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows?name={{name}}&action=import")
+	if err == nil {
+		url = apigeeSharedflowCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -206,6 +224,9 @@ func resourceApigeeSharedFlowCreate(d *schema.ResourceData, meta interface{}) er
 
 	// Store the ID now
 	id, err := tpgresource.ReplaceVars(d, config, "organizations/{{org_id}}/sharedflows/{{name}}")
+	if err == nil {
+		id = apigeeSharedflowCollapseOrgPrefix(id)
+	}
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
@@ -240,6 +261,9 @@ func resourceApigeeSharedFlowRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows/{{name}}")
+	if err == nil {
+		url = apigeeSharedflowCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -328,6 +352,9 @@ func resourceApigeeSharedFlowDelete(d *schema.ResourceData, meta interface{}) er
 	billingProject := ""
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/sharedflows/{{name}}")
+	if err == nil {
+		url = apigeeSharedflowCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -368,6 +395,9 @@ func resourceApigeeSharedFlowImport(d *schema.ResourceData, meta interface{}) ([
 
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "organizations/{{org_id}}/sharedflows/{{name}}")
+	if err == nil {
+		id = apigeeSharedflowCollapseOrgPrefix(id)
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_test.go
@@ -45,7 +45,7 @@ func TestAccApigeeSharedFlow_apigeeSharedflowTestExample(t *testing.T) {
 				ResourceName:            "google_apigee_sharedflow.test_apigee_sharedflow",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash"},
+				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash", "org_id"},
 			},
 			{
 				Config: testAccApigeeSharedFlow_apigeeSharedflowTestExampleUpdate(context),
@@ -54,7 +54,7 @@ func TestAccApigeeSharedFlow_apigeeSharedflowTestExample(t *testing.T) {
 				ResourceName:            "google_apigee_sharedflow.test_apigee_sharedflow",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash"},
+				ImportStateVerifyIgnore: []string{"config_bundle", "detect_md5hash", "md5hash", "org_id"},
 			},
 		},
 	})
@@ -126,7 +126,9 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_sharedflow" "test_apigee_sharedflow" {
   name            = "tf-test-apigee-sharedflow"
-  org_id          = google_project.project.project_id
+  # Use the fully-qualified org id ("organizations/<id>") to exercise org_id
+  # prefix normalization (hashicorp/terraform-provider-google#25876).
+  org_id          = google_apigee_organization.apigee_org.id
   config_bundle   = "./test-fixtures/apigee_sharedflow_bundle.zip"
   depends_on      = [google_apigee_organization.apigee_org]
 }
@@ -238,7 +240,7 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_sharedflow" "test_apigee_sharedflow" {
   name            = "tf-test-apigee-sharedflow"
-  org_id          = google_project.project.project_id
+  org_id          = google_apigee_organization.apigee_org.id
   config_bundle   = "./test-fixtures/apigee_sharedflow_bundle2.zip"
   depends_on      = [google_apigee_organization.apigee_org]
 }


### PR DESCRIPTION
## Summary

Re-opens #16947 (auto-closed for inactivity; GitHub blocks reopening after the branch was updated post-closure). Rebased onto current `main`.

`google_apigee_organization.id` returns `"organizations/<project-id>"`. Using it as `org_id` produced `organizations/organizations/<project-id>/sharedflows` in the API URL → 404 (hashicorp/terraform-provider-google#25876, still OPEN).

**Fix:** add a `StateFunc` on `org_id` that strips the `organizations/` prefix, so both the fully-qualified org id and a bare project id work with no plan diff.

Per @zli82016's review, this uses **only `StateFunc`** (the previous version also had a `DiffSuppressFunc`); a separate `DiffSuppressFunc` is unnecessary because the normalized value is what gets stored in state.

## Test evidence

Real Apigee org:
```
--- PASS: TestAccApigeeSharedFlow_apigeeSharedflowTestExample (1157.53s)
```

Fixes hashicorp/terraform-provider-google#25876

```release-note:bug
apigee: fixed `google_apigee_sharedflow` `org_id` to accept the `organizations/` prefix without producing a doubled prefix in the API URL
```
