### PR TITLE
apigee: normalize org_id in google_apigee_sharedflow_deployment

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -46,14 +46,13 @@ func ResourceApigeeSharedFlowDeployment() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization associated with the Apigee instance`,
-				// Normalize org_id by stripping the "organizations/" prefix. Users may
-				// pass google_apigee_organization.id ("organizations/<project-id>");
-				// after import the captured org_id has no prefix, so without
-				// normalization the config/state mismatch triggers a spurious
-				// ForceNew (destroy/recreate). StateFunc stores the normalized value
-				// so both forms match with no diff.
-				StateFunc: func(v interface{}) string {
-					return strings.TrimPrefix(v.(string), "organizations/")
+				// Users may pass google_apigee_organization.id
+				// ("organizations/<project-id>"); after import the captured org_id has
+				// no prefix. Suppress the diff when the two values are equal once the
+				// "organizations/" prefix is stripped, so the prefixed and bare forms
+				// don't trigger a spurious ForceNew (destroy/recreate).
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.TrimPrefix(old, "organizations/") == strings.TrimPrefix(new, "organizations/")
 				},
 			},
 			"revision": {

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -46,6 +46,15 @@ func ResourceApigeeSharedFlowDeployment() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 				Description: `The Apigee Organization associated with the Apigee instance`,
+				// Normalize org_id by stripping the "organizations/" prefix. Users may
+				// pass google_apigee_organization.id ("organizations/<project-id>");
+				// after import the captured org_id has no prefix, so without
+				// normalization the config/state mismatch triggers a spurious
+				// ForceNew (destroy/recreate). StateFunc stores the normalized value
+				// so both forms match with no diff.
+				StateFunc: func(v interface{}) string {
+					return strings.TrimPrefix(v.(string), "organizations/")
+				},
 			},
 			"revision": {
 				Type:        schema.TypeString,

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment.go
@@ -13,6 +13,18 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+// apigeeSharedflowDeploymentCollapseOrgPrefix collapses a doubled
+// "organizations/" segment in a constructed URL/ID. org_id may be supplied
+// either bare or fully-qualified ("organizations/<id>", e.g. from
+// google_apigee_organization.id); the URL templates already prepend
+// "organizations/", so the fully-qualified form would otherwise yield
+// "organizations/organizations/<id>". The stored org_id value is left untouched
+// (the diff is handled by DiffSuppressFunc), so existing resources are never
+// re-created.
+func apigeeSharedflowDeploymentCollapseOrgPrefix(s string) string {
+	return strings.Replace(s, "organizations/organizations/", "organizations/", 1)
+}
+
 func ResourceApigeeSharedFlowDeployment() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceApigeeSharedflowDeploymentCreate,
@@ -88,6 +100,9 @@ func resourceApigeeSharedflowDeploymentCreate(d *schema.ResourceData, meta inter
 	}
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
+	if err == nil {
+		url = apigeeSharedflowDeploymentCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -114,6 +129,9 @@ func resourceApigeeSharedflowDeploymentCreate(d *schema.ResourceData, meta inter
 
 	// Store the ID now
 	id, err := tpgresource.ReplaceVars(d, config, "organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	if err == nil {
+		id = apigeeSharedflowDeploymentCollapseOrgPrefix(id)
+	}
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
@@ -132,6 +150,9 @@ func resourceApigeeSharedflowDeploymentRead(d *schema.ResourceData, meta interfa
 	}
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	if err == nil {
+		url = apigeeSharedflowDeploymentCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -193,6 +214,9 @@ func resourceApigeeSharedflowDeploymentUpdate(d *schema.ResourceData, meta inter
 	}
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments?override=true&serviceAccount={{service_account}}")
+	if err == nil {
+		url = apigeeSharedflowDeploymentCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -219,6 +243,9 @@ func resourceApigeeSharedflowDeploymentUpdate(d *schema.ResourceData, meta inter
 
 	// Store the ID now
 	id, err := tpgresource.ReplaceVars(d, config, "organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	if err == nil {
+		id = apigeeSharedflowDeploymentCollapseOrgPrefix(id)
+	}
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
@@ -246,6 +273,9 @@ func resourceApigeeSharedflowDeploymentDelete(d *schema.ResourceData, meta inter
 	billingProject := ""
 
 	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	if err == nil {
+		url = apigeeSharedflowDeploymentCollapseOrgPrefix(url)
+	}
 	if err != nil {
 		return err
 	}
@@ -287,6 +317,9 @@ func resourceApigeeSharedflowDeploymentImport(d *schema.ResourceData, meta inter
 
 	// Replace import id for the resource id
 	id, err := tpgresource.ReplaceVars(d, config, "organizations/{{org_id}}/environments/{{environment}}/sharedflows/{{sharedflow_id}}/revisions/{{revision}}/deployments")
+	if err == nil {
+		id = apigeeSharedflowDeploymentCollapseOrgPrefix(id)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_sharedflow_deployment_test.go
@@ -43,7 +43,7 @@ func TestAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample(t *
 				ResourceName:            "google_apigee_sharedflow_deployment.sharedflow_deployment_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"org_id"},
 			},
 			{
 				Config: testAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample(context, "./test-fixtures/apigee_sharedflow_bundle2.zip"),
@@ -52,7 +52,7 @@ func TestAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample(t *
 				ResourceName:            "google_apigee_sharedflow_deployment.sharedflow_deployment_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				ImportStateVerifyIgnore: []string{"org_id"},
 			},
 		},
 	})
@@ -146,7 +146,10 @@ resource "google_service_account" "sharedflow_sa" {
 
 resource "google_apigee_sharedflow_deployment" "sharedflow_deployment_test" {
   environment     = google_apigee_environment.apigee_environment.name
-  org_id          = google_apigee_sharedflow.test_apigee_sharedflow.org_id
+  # Use the fully-qualified org id ("organizations/<id>") to exercise org_id
+  # prefix normalization on the deployment resource
+  # (hashicorp/terraform-provider-google#25852).
+  org_id          = google_apigee_organization.apigee_org.id
   revision        = google_apigee_sharedflow.test_apigee_sharedflow.revision[length(google_apigee_sharedflow.test_apigee_sharedflow.revision)-1]
   sharedflow_id   = google_apigee_sharedflow.test_apigee_sharedflow.name
   service_account = google_service_account.sharedflow_sa.email


### PR DESCRIPTION
## Summary

Normalizes `org_id` on `google_apigee_sharedflow_deployment` so it accepts either the bare project id or the fully-qualified `organizations/<id>` form (e.g. from `google_apigee_organization.id`).

Previously, passing the `organizations/<id>` form produced `organizations/organizations/<id>/...` in the API URL (a 404), and after import the prefixed vs. bare forms could disagree.

> **Note:** This PR does **not** fix hashicorp/terraform-provider-google#25852. As @zli82016 identified, that issue is a separate problem — `undeployment validations failed` (`WOULD_BREAK_DEPENDENT`) caused by an in-place `revision` update during import, unrelated to `org_id` formatting. I'll open a separate PR for #25852.

## Changes

- Add a `DiffSuppressFunc` on `org_id` that treats the bare and `organizations/`-prefixed forms as equal (no spurious ForceNew). It does **not** rewrite the stored value, so existing resources are never re-created.
- Collapse any doubled `organizations/` prefix at URL/ID construction time, so the prefixed form reaches the correct API endpoint (Create reads `d.Get("org_id")`, the raw config value, so URL-time normalization is required).

## No user-facing change

Existing configs use the bare `org_id` today (the prefixed form currently 404s), so for them the diff is suppressed, the stored value is untouched, and nothing is re-created. The prefixed form now also works.

## Test evidence

The acceptance test now sets the deployment's `org_id` to `google_apigee_organization.id` (prefixed) and passes:
```
--- PASS: TestAccApigeeSharedflowDeployment_apigeeSharedflowDeploymentTestExample (1317.81s)
```
`org_id` is in `ImportStateVerifyIgnore` because the bare and prefixed forms are equivalent (import returns the bare form).

```release-note:bug
apigee: fixed `google_apigee_sharedflow_deployment` to accept the `organizations/` prefix in `org_id` without producing a doubled prefix in the API URL
```