### PR TITLE
feat(agentregistry): add Agent Registry Agent, MCP Server, and Endpoint resources

### DIFF
--- a/mmv1/products/agentregistry/Agent.yaml
+++ b/mmv1/products/agentregistry/Agent.yaml
@@ -1,0 +1,117 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Agent
+description: Represents a registered Agent in the Agent Registry.
+base_url: projects/{{project}}/locations/{{location}}/services
+self_link: projects/{{project}}/locations/{{location}}/services/{{agent_id}}
+create_url: projects/{{project}}/locations/{{location}}/services?serviceId={{agent_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/services/{{agent_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/services/{{agent_id}}
+min_version: beta
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+examples:
+  - name: agent_registry_agent_basic
+    primary_resource_id: example
+    min_version: beta
+    vars:
+      agent_id: default-agent
+parameters:
+  - name: location
+    type: String
+    description: The location of the Agent Registry service.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: agentId
+    type: String
+    description: The ID to use for the agent service.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Output only. The resource name of the Agent.
+    output: true
+  - name: displayName
+    type: String
+    description: User-defined display name for the Agent.
+  - name: description
+    type: String
+    description: User-defined description of the Agent.
+  - name: registryResource
+    type: String
+    description: Output only. The resource name of the resulting Agent.
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. The creation timestamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. The update timestamp.
+    output: true
+  - name: interfaces
+    type: Array
+    description: The connection details for the Agent.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: url
+          type: String
+          required: true
+          description: The destination URL.
+        - name: protocolBinding
+          type: Enum
+          required: true
+          description: The transport protocol binding.
+          enum_values:
+            - PROTOCOL_BINDING_UNSPECIFIED
+            - JSONRPC
+            - GRPC
+            - HTTP_JSON
+  - name: agentSpec
+    type: NestedObject
+    required: true
+    description: The specification of the Agent.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        description: The type of the agent spec content.
+        enum_values:
+          - TYPE_UNSPECIFIED
+          - NO_SPEC
+          - A2A_AGENT_CARD
+      - name: content
+        type: KeyValuePairs
+        description: Optional. The content of the Agent spec in JSON format.

--- a/mmv1/products/agentregistry/Agent.yaml
+++ b/mmv1/products/agentregistry/Agent.yaml
@@ -113,5 +113,10 @@ properties:
           - NO_SPEC
           - A2A_AGENT_CARD
       - name: content
-        type: KeyValuePairs
+        type: String
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        validation:
+          function: 'validation.StringIsJSON'
         description: Optional. The content of the Agent spec in JSON format.

--- a/mmv1/products/agentregistry/Endpoint.yaml
+++ b/mmv1/products/agentregistry/Endpoint.yaml
@@ -1,0 +1,116 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Endpoint
+description: Represents a registered Endpoint in the Agent Registry.
+base_url: projects/{{project}}/locations/{{location}}/services
+self_link: projects/{{project}}/locations/{{location}}/services/{{endpoint_id}}
+create_url: projects/{{project}}/locations/{{location}}/services?serviceId={{endpoint_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/services/{{endpoint_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/services/{{endpoint_id}}
+min_version: beta
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+examples:
+  - name: agent_registry_endpoint_basic
+    primary_resource_id: example
+    min_version: beta
+    vars:
+      endpoint_id: default-endpoint
+parameters:
+  - name: location
+    type: String
+    description: The location of the Agent Registry service.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: endpointId
+    type: String
+    description: The ID to use for the endpoint service.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Output only. The resource name of the Endpoint.
+    output: true
+  - name: displayName
+    type: String
+    description: User-defined display name for the Endpoint.
+  - name: description
+    type: String
+    description: User-defined description of the Endpoint.
+  - name: registryResource
+    type: String
+    description: Output only. The resource name of the resulting Endpoint.
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. The creation timestamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. The update timestamp.
+    output: true
+  - name: interfaces
+    type: Array
+    description: The connection details for the Endpoint.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: url
+          type: String
+          required: true
+          description: The destination URL.
+        - name: protocolBinding
+          type: Enum
+          required: true
+          description: The transport protocol binding.
+          enum_values:
+            - PROTOCOL_BINDING_UNSPECIFIED
+            - JSONRPC
+            - GRPC
+            - HTTP_JSON
+  - name: endpointSpec
+    type: NestedObject
+    required: true
+    description: The specification of the Endpoint.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        description: The type of the Endpoint spec content.
+        enum_values:
+          - TYPE_UNSPECIFIED
+          - NO_SPEC
+      - name: content
+        type: KeyValuePairs
+        description: Optional. The content of the Endpoint spec.

--- a/mmv1/products/agentregistry/Endpoint.yaml
+++ b/mmv1/products/agentregistry/Endpoint.yaml
@@ -112,5 +112,10 @@ properties:
           - TYPE_UNSPECIFIED
           - NO_SPEC
       - name: content
-        type: KeyValuePairs
+        type: String
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        validation:
+          function: 'validation.StringIsJSON'
         description: Optional. The content of the Endpoint spec.

--- a/mmv1/products/agentregistry/McpServer.yaml
+++ b/mmv1/products/agentregistry/McpServer.yaml
@@ -1,0 +1,117 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: McpServer
+description: Represents a registered MCP (Model Context Protocol) Server in the Agent Registry.
+base_url: projects/{{project}}/locations/{{location}}/services
+self_link: projects/{{project}}/locations/{{location}}/services/{{mcp_server_id}}
+create_url: projects/{{project}}/locations/{{location}}/services?serviceId={{mcp_server_id}}
+update_mask: true
+update_verb: PATCH
+id_format: projects/{{project}}/locations/{{location}}/services/{{mcp_server_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/services/{{mcp_server_id}}
+min_version: beta
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  type: OpAsync
+  operation:
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - delete
+    - update
+  result:
+    resource_inside_response: true
+  include_project: false
+examples:
+  - name: agent_registry_mcp_server_basic
+    primary_resource_id: example
+    min_version: beta
+    vars:
+      mcp_server_id: default-mcp-server
+parameters:
+  - name: location
+    type: String
+    description: The location of the Agent Registry service.
+    immutable: true
+    url_param_only: true
+    required: true
+  - name: mcpServerId
+    type: String
+    description: The ID to use for the MCP Server service.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Output only. The resource name of the MCP Server.
+    output: true
+  - name: displayName
+    type: String
+    description: User-defined display name for the MCP Server.
+  - name: description
+    type: String
+    description: User-defined description of the MCP Server.
+  - name: registryResource
+    type: String
+    description: Output only. The resource name of the resulting MCP Server.
+    output: true
+  - name: createTime
+    type: String
+    description: Output only. The creation timestamp.
+    output: true
+  - name: updateTime
+    type: String
+    description: Output only. The update timestamp.
+    output: true
+  - name: interfaces
+    type: Array
+    description: The connection details for the MCP Server.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: url
+          type: String
+          required: true
+          description: The destination URL.
+        - name: protocolBinding
+          type: Enum
+          required: true
+          description: The transport protocol binding.
+          enum_values:
+            - PROTOCOL_BINDING_UNSPECIFIED
+            - JSONRPC
+            - GRPC
+            - HTTP_JSON
+  - name: mcpServerSpec
+    type: NestedObject
+    required: true
+    description: The specification of the MCP Server.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        description: The type of the MCP Server spec content.
+        enum_values:
+          - TYPE_UNSPECIFIED
+          - NO_SPEC
+          - TOOL_SPEC
+      - name: content
+        type: KeyValuePairs
+        description: Optional. The content of the MCP Server spec.

--- a/mmv1/products/agentregistry/McpServer.yaml
+++ b/mmv1/products/agentregistry/McpServer.yaml
@@ -113,5 +113,10 @@ properties:
           - NO_SPEC
           - TOOL_SPEC
       - name: content
-        type: KeyValuePairs
+        type: String
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        validation:
+          function: 'validation.StringIsJSON'
         description: Optional. The content of the MCP Server spec.

--- a/mmv1/products/agentregistry/product.yaml
+++ b/mmv1/products/agentregistry/product.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AgentRegistry
+display_name: Agent Registry
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - base_url: https://agentregistry.googleapis.com/v1alpha/
+    name: beta

--- a/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_agent_registry_agent" "{{$.PrimaryResourceId}}" {
+  provider     = google-beta
+  agent_id     = "{{index $.Vars "agent_id"}}"
+  location     = "global"
+  display_name = "My Agent"
+  description  = "An agent registered in Agent Registry"
+
+  interfaces {
+    url              = "https://myagent.com"
+    protocol_binding = "HTTP_JSON"
+  }
+
+  agent_spec {
+    type = "NO_SPEC"
+    content = {
+      description = "Spec content"
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
@@ -11,9 +11,9 @@ resource "google_agent_registry_agent" "{{$.PrimaryResourceId}}" {
   }
 
   agent_spec {
-    type = "NO_SPEC"
-    content = {
+    type    = "NO_SPEC"
+    content = jsonencode({
       description = "Spec content"
-    }
+    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
@@ -12,8 +12,5 @@ resource "google_agent_registry_agent" "{{$.PrimaryResourceId}}" {
 
   agent_spec {
     type    = "NO_SPEC"
-    content = jsonencode({
-      description = "Spec content"
-    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
@@ -12,8 +12,5 @@ resource "google_agent_registry_endpoint" "{{$.PrimaryResourceId}}" {
 
   endpoint_spec {
     type    = "NO_SPEC"
-    content = jsonencode({
-      description = "Spec content"
-    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
@@ -11,9 +11,9 @@ resource "google_agent_registry_endpoint" "{{$.PrimaryResourceId}}" {
   }
 
   endpoint_spec {
-    type = "NO_SPEC"
-    content = {
+    type    = "NO_SPEC"
+    content = jsonencode({
       description = "Spec content"
-    }
+    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_agent_registry_endpoint" "{{$.PrimaryResourceId}}" {
+  provider     = google-beta
+  endpoint_id  = "{{index $.Vars "endpoint_id"}}"
+  location     = "global"
+  display_name = "My Endpoint"
+  description  = "An Endpoint registered in Agent Registry"
+
+  interfaces {
+    url              = "https://myendpoint.com"
+    protocol_binding = "HTTP_JSON"
+  }
+
+  endpoint_spec {
+    type = "NO_SPEC"
+    content = {
+      description = "Spec content"
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
@@ -12,8 +12,5 @@ resource "google_agent_registry_mcp_server" "{{$.PrimaryResourceId}}" {
 
   mcp_server_spec {
     type    = "NO_SPEC"
-    content = jsonencode({
-      description = "Spec content"
-    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
@@ -11,9 +11,9 @@ resource "google_agent_registry_mcp_server" "{{$.PrimaryResourceId}}" {
   }
 
   mcp_server_spec {
-    type = "NO_SPEC"
-    content = {
+    type    = "NO_SPEC"
+    content = jsonencode({
       description = "Spec content"
-    }
+    })
   }
 }

--- a/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_agent_registry_mcp_server" "{{$.PrimaryResourceId}}" {
+  provider      = google-beta
+  mcp_server_id = "{{index $.Vars "mcp_server_id"}}"
+  location      = "global"
+  display_name  = "My MCP Server"
+  description   = "An MCP Server registered in Agent Registry"
+
+  interfaces {
+    url              = "https://mymcp.com"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type = "NO_SPEC"
+    content = {
+      description = "Spec content"
+    }
+  }
+}

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -31,6 +31,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google-beta/services/activedirectory"
     ),
+    "agentregistry" to mapOf(
+        "name" to "agentregistry",
+        "displayName" to "Agentregistry",
+        "path" to "./google-beta/services/agentregistry"
+    ),
     "alloydb" to mapOf(
         "name" to "alloydb",
         "displayName" to "Alloydb",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -31,6 +31,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google/services/activedirectory"
     ),
+    "agentregistry" to mapOf(
+        "name" to "agentregistry",
+        "displayName" to "Agentregistry",
+        "path" to "./google/services/agentregistry"
+    ),
     "alloydb" to mapOf(
         "name" to "alloydb",
         "displayName" to "Alloydb",

--- a/mmv1/third_party/terraform/services/agentregistry/agent_registry_operation.go
+++ b/mmv1/third_party/terraform/services/agentregistry/agent_registry_operation.go
@@ -1,0 +1,55 @@
+package agentregistry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+type AgentRegistryOperationWaiter struct {
+	Config    *transport_tpg.Config
+	UserAgent string
+	Project   string
+	tpgresource.CommonOperationWaiter
+}
+
+func (w *AgentRegistryOperationWaiter) QueryOp() (interface{}, error) {
+	if w == nil {
+		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
+	}
+	url := fmt.Sprintf("%s%s", transport_tpg.BaseUrl(Product, w.Config), w.OpName())
+
+	return transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    w.Config,
+		Method:    "GET",
+		Project:   w.Project,
+		RawURL:    url,
+		UserAgent: w.UserAgent,
+	})
+}
+
+func createAgentRegistryWaiter(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string) (*AgentRegistryOperationWaiter, error) {
+	w := &AgentRegistryOperationWaiter{
+		Config:    config,
+		UserAgent: userAgent,
+		Project:   project,
+	}
+	if err := w.SetOp(op); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func AgentRegistryOperationWaitTime(config *transport_tpg.Config, op map[string]interface{}, project, activity, userAgent string, timeout time.Duration) error {
+	if val, ok := op["name"]; !ok || val == "" {
+		// This was a synchronous call - there is no operation to wait for.
+		return nil
+	}
+	w, err := createAgentRegistryWaiter(config, op, project, activity, userAgent)
+	if err != nil {
+		return err
+	}
+	return tpgresource.OperationWait(w, activity, timeout, config.PollInterval)
+}

--- a/tools/issue-labeler/labeler/enrolled_teams.yml
+++ b/tools/issue-labeler/labeler/enrolled_teams.yml
@@ -7,6 +7,9 @@ service/accessapproval:
 service/accesscontextmanager:
   resources:
   - google_access_context_manager_.*
+service/agentregistry:
+  resources:
+  - google_agent_registry_.*
 service/aiplatform-agent-engine:
   resources:
   - google_vertex_ai_reasoning_engine.*

--- a/tools/template-check/cmd/unusedtmpl_test.go
+++ b/tools/template-check/cmd/unusedtmpl_test.go
@@ -124,7 +124,7 @@ func TestFindCodeReferencedTmpls(t *testing.T) {
 	if !got["templates/terraform/resource.go.tmpl"] {
 		t.Errorf("findCodeReferencedTmpls() expected to find templates/terraform/resource.go.tmpl")
 	}
-	if !got["templates/terraform/examples/base_configs/test_file.go.tmpl"] {
-		t.Errorf("findCodeReferencedTmpls() expected to find templates/terraform/examples/base_configs/test_file.go.tmpl")
+	if !got["templates/terraform/samples/base_configs/test_file.go.tmpl"] {
+		t.Errorf("findCodeReferencedTmpls() expected to find templates/terraform/samples/base_configs/test_file.go.tmpl")
 	}
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.
-->

### Description
This PR introduces support for Google Cloud's **Agent Registry** (`v1alpha`) in the `google-beta` provider. 

It implements the schemas, code generators, and automated test templates for registering, deleting, and modifying entries of three primary Agent Registry resources:
1. **Agents (`google_agent_registry_agent`)**: Registered agents with specification types.
2. **MCP Servers (`google_agent_registry_mcp_server`)**: Model Context Protocol servers communicating over standard `JSONRPC` protocol bindings.
3. **Endpoints (`google_agent_registry_endpoint`)**: Unified API and service endpoints.

Additionally, this PR adds a custom long-running operation (LRO) helper under `third_party/terraform/services/agentregistry/agent_registry_operation.go` to handle asynchronous backend creation, update, and deletion lifecycles.
<!--
### References
* Resolves #REPLACEME_WITH_ISSUE_ID (if any, e.g. Fixes https://github.com/hashicorp/terraform-provider-google/issues/12345)
-->
### Verification
Local downstream code generation and compilation have been verified cleanly. Live-project acceptance tests were executed successfully:

```
=== RUN   TestAccAgentRegistryAgent_agentRegistryAgentBasicExample
=== RUN   TestAccAgentRegistryEndpoint_agentRegistryEndpointBasicExample
=== RUN   TestAccAgentRegistryMcpServer_agentRegistryMcpServerBasicExample
--- PASS: TestAccAgentRegistryAgent_agentRegistryAgentBasicExample (31.32s)
--- PASS: TestAccAgentRegistryEndpoint_agentRegistryEndpointBasicExample (31.33s)
--- PASS: TestAccAgentRegistryMcpServer_agentRegistryMcpServerBasicExample (31.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-google-beta/google-beta/services/agentregistry	32.531s
```

***

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_agent_registry_agent`
```
```release-note:new-resource
`google_agent_registry_mcp_server`
```
```release-note:new-resource
`google_agent_registry_endpoint`
```