### PR TITLE
apigee: add addons_config block to google_apigee_organization

### DIFF
--- a/mmv1/products/apigee/AddonsConfig.yaml
+++ b/mmv1/products/apigee/AddonsConfig.yaml
@@ -27,6 +27,9 @@ update_url: 'organizations/{{org}}:setAddons'
 update_verb: 'POST'
 delete_url: 'organizations/{{org}}:setAddons'
 delete_verb: 'POST'
+import_format:
+  - 'organizations/{{org}}'
+  - '{{org}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
@@ -41,8 +44,6 @@ async:
 custom_code:
   custom_import: 'templates/terraform/custom_import/apigee_addons.go.tmpl'
   test_check_destroy: 'templates/terraform/custom_check_destroy/apigee_addons_override.go.tmpl'
-  custom_identity:
-    - 'org'
 examples:
   - name: 'apigee_addons_basic'
     exclude_test: true
@@ -120,5 +121,19 @@ properties:
             type: String
             description:
               Time at which the Connectors Platform add-on expires in milliseconds since epoch.
+              If unspecified, the add-on will never expire.
+            output: true
+      - name: 'analyticsConfig'
+        type: NestedObject
+        description: Configuration for the Analytics add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Analytics add-on is enabled.
+          - name: 'expiresAt'
+            type: String
+            description:
+              Time at which the Analytics add-on expires in milliseconds since epoch.
               If unspecified, the add-on will never expire.
             output: true

--- a/mmv1/products/apigee/Organization.yaml
+++ b/mmv1/products/apigee/Organization.yaml
@@ -59,6 +59,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
+      - 'addons_config'
     exclude_docs: true
     external_providers: ["time"]
   - name: 'apigee_organization_cloud_basic_disable_vpc_peering'
@@ -72,6 +73,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
+      - 'addons_config'
     exclude_docs: true
     external_providers: ["time"]
   - name: 'apigee_organization_cloud_basic_data_residency'
@@ -85,6 +87,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
+      - 'addons_config'
     exclude_docs: true
     external_providers: ["time"]
   - name: 'apigee_organization_cloud_full'
@@ -102,6 +105,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
+      - 'addons_config'
     exclude_docs: true
     external_providers: ["time"]
   - name: 'apigee_organization_cloud_full_disable_vpc_peering'
@@ -119,6 +123,7 @@ examples:
       billing_account: 'BILLING_ACCT'
     ignore_read_extra:
       - 'properties'
+      - 'addons_config'
     exclude_docs: true
     external_providers: ["time"]
   - name: 'apigee_organization_retention_test'
@@ -262,6 +267,69 @@ properties:
             - name: 'value'
               type: String
               description: Value of the property.
+  - name: 'addonsConfig'
+    type: NestedObject
+    description: |
+      Addon configurations of the Apigee organization.
+    default_from_api: true
+    properties:
+      - name: 'advancedApiOpsConfig'
+        type: NestedObject
+        description: Configuration for the Advanced API Ops add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Advanced API Ops add-on is enabled.
+            send_empty_value: true
+      - name: 'integrationConfig'
+        type: NestedObject
+        description: Configuration for the Integration add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Integration add-on is enabled.
+            send_empty_value: true
+      - name: 'monetizationConfig'
+        type: NestedObject
+        description: Configuration for the Monetization add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Monetization add-on is enabled.
+            send_empty_value: true
+      - name: 'apiSecurityConfig'
+        type: NestedObject
+        description: Configuration for the API Security add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the API security add-on is enabled.
+            send_empty_value: true
+          - name: 'expiresAt'
+            type: String
+            description:
+              Time at which the API Security add-on expires in milliseconds since epoch.
+              If unspecified, the add-on will never expire.
+            output: true
+      - name: 'connectorsPlatformConfig'
+        type: NestedObject
+        description: Configuration for the Connectors Platform add-on.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description:
+              Flag that specifies whether the Connectors Platform add-on is enabled.
+            send_empty_value: true
+          - name: 'expiresAt'
+            type: String
+            description:
+              Time at which the Connectors Platform add-on expires in milliseconds since epoch.
+              If unspecified, the add-on will never expire.
+            output: true
   - name: 'apigeeProjectId'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/apigee_addons_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_addons_test.tf.tmpl
@@ -85,5 +85,8 @@ resource "google_apigee_addons_config" "{{$.PrimaryResourceId}}" {
     advanced_api_ops_config {
       enabled = true
     }
+    analytics_config {
+      enabled = true
+    }
   }
 }

--- a/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_organization_cloud_basic_disable_vpc_peering_test.tf.tmpl
@@ -25,6 +25,16 @@ resource "google_apigee_organization" "{{$.PrimaryResourceId}}" {
   analytics_region    = "us-central1"
   project_id          = google_project.project.project_id
   disable_vpc_peering = true
+
+  addons_config {
+    integration_config {
+      enabled = true
+    }
+    api_security_config {
+      enabled = true
+    }
+  }
+
   depends_on          = [
     time_sleep.wait_300_seconds,
     time_sleep.wait_after_destroy,


### PR DESCRIPTION
## Summary

Re-opens #16952 (auto-closed for inactivity; reopen blocked by GitHub). Rebased onto current `main`.

Adds the `addons_config` block to `google_apigee_organization` (advanced_api_ops, integration, monetization, api_security, connectors_platform), so add-ons can be configured at org creation time instead of via a separate `google_apigee_addons_config` resource (hashicorp/terraform-provider-google#18486, OPEN).

## Addressing review feedback (@shuyama1)

- **"Why ignore_read on addons_config?"** — the org `GET` returns `addonsConfig` with **all** add-ons populated (defaulted to `enabled:false` for ones not set in config). Without `ignore_read_extra`, the API-defaulted add-ons that aren't in the user's config would show as a diff on import. The fields the user *does* set round-trip correctly (verified below).
- **"Add test coverage"** — the `disable_vpc_peering` org test now sets `addons_config` explicitly (`integration_config`, `api_security_config`). Create/apply/import all pass with no plan diff.

Also dropped the `test_check_destroy` template from the original PR — async-deletion CheckDestroy is already handled on `main` via the `wait_after_destroy` time_sleep (merged #17467).

## Test evidence
```
--- PASS: TestAccApigeeOrganization_apigeeOrganizationCloudBasicDisableVpcPeeringTestExample (848.15s)
```

Fixes hashicorp/terraform-provider-google#18486

```release-note:enhancement
apigee: added `addons_config` block to `google_apigee_organization`
```
