### PR TITLE
 [BackupDR] Remove deprecated resource_type field from plural data sources

### DIFF
--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_plan_association.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_backup_plan_association.go
@@ -62,12 +62,6 @@ func DataSourceGoogleCloudBackupDRBackupPlanAssociations() *schema.Resource {
 				Computed:    true,
 				Description: "The ID of the project in which the resource belongs.",
 			},
-			"resource_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The resource type of workload on which backup plan is applied. Examples include, "compute.googleapis.com/Instance", "compute.googleapis.com/Disk".`,
-				Deprecated:  "`resource_type` is deprecated and will be removed in a future major release.",
-			},
 			"associations": {
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
+++ b/mmv1/third_party/terraform/services/backupdr/data_source_backup_dr_data_source_reference.go
@@ -26,12 +26,6 @@ func DataSourceGoogleCloudBackupDRDataSourceReferences() *schema.Resource {
 				Computed:    true,
 				Description: "The ID of the project in which the resource belongs.",
 			},
-			"resource_type": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: `The resource type of workload on which backup plan is applied. Examples include, "compute.googleapis.com/Instance", "compute.googleapis.com/Disk".`,
-				Deprecated:  "`resource_type` is deprecated and will be removed in a future major release.",
-			},
 			// Output: a computed list of the data source references found
 			"data_source_references": {
 				Type:        schema.TypeList,

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_plan_associations.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_backup_plan_associations.html.markdown
@@ -21,7 +21,6 @@ data "google_backup_dr_backup_plan_associations" "all_associations" {
 The following arguments are supported:
 
 * `location` - (Required)The location where the Backup Plan Association resources reside.
-* `resource_type` - (Optional, Deprecated) The resource type of the workload. For example, sqladmin.googleapis.com/Instance or compute.googleapis.com/Instance. `resource_type` is deprecated and will be removed in a future major release.
 - - -
 
 * `project` - (Optional) The project in which the resource belongs. If it

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source_reference.html.markdown
@@ -15,7 +15,6 @@ This example shows how to get the details of a specific data source reference by
 ```hcl
 data "google_backup_dr_data_source_references" "all_csql_references" {
   location      = "us-central1"
-  resource_type = "sqladmin.googleapis.com/Instance"
 }
 
 data "google_backup_dr_data_source_reference" "my_reference" {

--- a/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source_references.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/backup_dr_data_source_references.html.markdown
@@ -25,7 +25,6 @@ output "all_data_source_references" {
 The following arguments are supported:
 
 *   `location `- (Required) The location of the data source references.
-*   `resource_type` - (Optional, Deprecated) The resource type to get the data source references for. Examples include, "sqladmin.googleapis.com/Instance" , "compute.googleapis.com/Instance". `resource_type` is deprecated and will be removed in a future major release.
     
 *   `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
     


### PR DESCRIPTION
This PR removes the deprecated resource_type argument from the google_backup_dr_backup_plan_associations and google_backup_dr_data_source_references data sources.

The resource_type field was previously deprecated to prepare for this transition(done in PR : https://github.com/GoogleCloudPlatform/magic-modules/pull/15645). By removing it, the data sources will no longer perform filtered "Fetch" operations based on workload types (e.g., compute.googleapis.com/Instance), fulfilling the goal of making them standard List APIs. 

```release-note:deprecation
backupdr: deprecated `required_type` in `google_backup_dr_backup_plan_associations` and `google_backup_dr_data_source_references`. It no longer has any functionality, and will be removed in the next major release.
```

To get more context on this , please have a look at this doc : go/refactor-terraform-data-sources-backupdr. 
Closes https://github.com/hashicorp/terraform-provider-google/issues/27804