### PR TITLE
apigee: add acceptance test for google_apigee_dns_zone (no-VPC-peering)

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_dns_zone_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_dns_zone_test.go
@@ -1,0 +1,121 @@
+package apigee_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccApigeeDnsZone_apigeeDnsZoneBasicTest(t *testing.T) {
+	// This test provisions a brand-new project and an Apigee organization (a
+	// long-running, billed operation), matching the other project-creating
+	// Apigee acceptance tests (e.g. TestAccApigeeOrganization_*,
+	// TestAccApigeeInstance_*) which all skip VCR for the same reason.
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeDnsZoneDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeDnsZone_basicTest(context),
+			},
+			{
+				ResourceName:            "google_apigee_dns_zone.apigee_dns_zone",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"org_id", "dns_zone_id"},
+			},
+		},
+	})
+}
+
+func testAccApigeeDnsZone_basicTest(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+}
+
+resource "google_project_service" "compute" {
+  project    = google_project.project.project_id
+  service    = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "dns" {
+  project    = google_project.project.project_id
+  service    = "dns.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_120_seconds" {
+  create_duration = "120s"
+  depends_on      = [google_project_service.dns]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_120_seconds]
+}
+
+# Create the Apigee org first. This provisions the Apigee service agent SA
+# (service-{project_number}@gcp-sa-apigee.iam.gserviceaccount.com).
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region    = "us-central1"
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+  depends_on = [
+    google_project_service.apigee,
+    google_project_service.compute,
+    google_project_service.dns,
+  ]
+}
+
+# Grant dns.peer to the Apigee service agent AFTER the org is created (the SA
+# only exists once the org has been provisioned).
+resource "google_project_iam_member" "apigee_dns_peer" {
+  project    = google_project.project.project_id
+  role       = "roles/dns.peer"
+  member     = "serviceAccount:service-${google_project.project.number}@gcp-sa-apigee.iam.gserviceaccount.com"
+  depends_on = [google_apigee_organization.apigee_org]
+}
+
+resource "google_apigee_dns_zone" "apigee_dns_zone" {
+  dns_zone_id = "tf-test%{random_suffix}"
+  org_id      = google_apigee_organization.apigee_org.id
+  domain      = "foo.example.com"
+  description = "Test DNS zone"
+  peering_config {
+    target_project_id = google_project.project.project_id
+    target_network_id = google_compute_network.apigee_network.name
+  }
+  depends_on = [google_project_iam_member.apigee_dns_peer]
+}
+`, context)
+}


### PR DESCRIPTION
## Summary

Re-opens #16968 (auto-closed; reopen blocked by GitHub). Rebased onto current `main`.

Adds a handwritten acceptance test for `google_apigee_dns_zone` covering the no-VPC-peering path (`disable_vpc_peering=true`): creates a project, creates the Apigee org **first** (which provisions the Apigee service agent SA), grants `roles/dns.peer` to that SA, then creates the `dns_zone` with a peering config and verifies import (b/397447683 — there was no acceptance coverage for this resource before).

## Re: SkipIfVcr (@rileykarson)

I kept `SkipIfVcr` and added a comment explaining why. This test provisions a brand-new project and a full Apigee organization, which is the same situation as every other project-creating Apigee acceptance test (`TestAccApigeeOrganization_*`, `TestAccApigeeInstance_*`, etc.) — they all `SkipIfVcr` because the per-run project/org creation can't be meaningfully covered by a recorded cassette in replay mode. Happy to drop the skip if you'd prefer this test to be VCR-recorded like the generated examples, but this keeps it consistent with the existing handwritten project-creating tests.

## Test evidence
```
--- PASS: TestAccApigeeDnsZone_apigeeDnsZoneBasicTest (619.01s)
```

Fixes b/397447683

```release-note:none
```
