### PR TITLE
feat(networkservices): promote agent gateway to ga

### DIFF
--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -41,7 +41,6 @@ async:
 examples:
   - name: 'network_services_agent_gateway_full'
     skip_docs: true  # temporary b/484137930
-    skip_test: true  # temporary b/484137930
     primary_resource_id: 'default'
     vars:
       name: 'my-full-agent-gateway'
@@ -49,7 +48,6 @@ examples:
       project: 'PROJECT_NAME'
   - name: 'network_services_agent_gateway_client_to_agent'
     skip_docs: true  # temporary b/484137930
-    skip_test: true  # temporary b/484137930
     primary_resource_id: 'default'
     vars:
       name: 'my-client-to-agent-gateway'
@@ -171,6 +169,7 @@ properties:
           - name: 'networkAttachment'
             type: String
             required: true
+            immutable: true
             diff_suppress_func: 'tpgresource.ProjectNumberDiffSuppress'
             description: |
               The URI of the Network Attachment resource.

--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -13,12 +13,11 @@
 
 ---
 name: 'AgentGateway'
-min_version: beta
 description: |
   AgentGateway represents the agent gateway resource.
 references:
   guides:
-  api: 'https://cloud.google.com/network-services/docs/reference/network-services/rest/v1beta1/projects.locations.agentGateways'
+  api: 'https://cloud.google.com/network-services/docs/reference/network-services/rest/v1/projects.locations.agentGateways'
 docs:
 base_url: 'projects/{{project}}/locations/{{location}}/agentGateways'
 self_link: 'projects/{{project}}/locations/{{location}}/agentGateways/{{name}}'

--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -40,14 +40,12 @@ async:
     resource_inside_response: true
 examples:
   - name: 'network_services_agent_gateway_full'
-    skip_docs: true  # temporary b/484137930
     primary_resource_id: 'default'
     vars:
       name: 'my-full-agent-gateway'
     test_env_vars:
       project: 'PROJECT_NAME'
   - name: 'network_services_agent_gateway_client_to_agent'
-    skip_docs: true  # temporary b/484137930
     primary_resource_id: 'default'
     vars:
       name: 'my-client-to-agent-gateway'

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_client_to_agent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_client_to_agent.tf.tmpl
@@ -9,4 +9,11 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
   registries = [
     "//agentregistry.googleapis.com/projects/{{index $.TestEnvVars "project"}}/locations/us-central1"
   ]
+
+  depends_on = [google_project_service.agent_registry]
+}
+
+resource "google_project_service" "agent_registry" {
+  service            = "agentregistry.googleapis.com"
+  disable_on_destroy = false
 }

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
@@ -18,7 +18,26 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
 
   network_config {
     egress {
-      network_attachment = "projects/{{index $.TestEnvVars "project"}}/regions/us-central1/networkAttachments/my-network-attachment"
+      network_attachment = google_compute_network_attachment.default.id
     }
   }
+}
+
+resource "google_compute_network" "default" {
+  name                    = "net-{{index $.Vars "name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "subnet-{{index $.Vars "name"}}"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network_attachment" "default" {
+  name                  = "na-{{index $.Vars "name"}}"
+  region                = "us-central1"
+  connection_preference = "ACCEPT_AUTOMATIC"
+  subnetworks           = [google_compute_subnetwork.default.self_link]
 }

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
@@ -21,6 +21,13 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
       network_attachment = google_compute_network_attachment.default.id
     }
   }
+
+  depends_on = [google_project_service.agent_registry]
+}
+
+resource "google_project_service" "agent_registry" {
+  service            = "agentregistry.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_compute_network" "default" {

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
@@ -99,12 +99,19 @@ resource "google_network_services_agent_gateway" "default" {
       network_attachment = google_compute_network_attachment.default.id
     }
   }
+
+  depends_on = [google_project_service.agent_registry]
 }
 `, context) + testAccNetworkServicesAgentGateway_sharedNetworkResources(context)
 }
 
 func testAccNetworkServicesAgentGateway_sharedNetworkResources(context map[string]interface{}) string {
 	return acctest.Nprintf(`
+resource "google_project_service" "agent_registry" {
+  service            = "agentregistry.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_compute_network" "default" {
   name                    = "net-%{name}"
   auto_create_subnetworks = false
@@ -151,6 +158,8 @@ resource "google_network_services_agent_gateway" "default" {
       network_attachment = google_compute_network_attachment.default.id
     }
   }
+
+  depends_on = [google_project_service.agent_registry]
 }
 `, context) + testAccNetworkServicesAgentGateway_sharedNetworkResources(context)
 }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
@@ -1,7 +1,5 @@
 package networkservices_test
 
-{{- if ne $.TargetVersionName "ga" }}
-
 import (
 	"testing"
 
@@ -9,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/networkservices"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/networkservices"
 )
 
 func TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayUpdate(t *testing.T) {
@@ -105,5 +103,3 @@ resource "google_network_services_agent_gateway" "default" {
 }
 `, context)
 }
-
-{{ end }}

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayUpdate(t *testing.T) {
-	t.Skip("b/484137930")
 	t.Parallel()
 
 	randomSuffix := acctest.RandString(t, 10)
@@ -38,7 +37,7 @@ func TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayUpdate(t *tes
 				ImportStateVerifyIgnore: []string{"labels", "location", "name", "terraform_labels"},
 			},
 			{
-				Config: testAccNetworkServicesAgentGateway_networkServicesAgentGatewayFullExample(context),
+				Config: testAccNetworkServicesAgentGateway_networkServicesAgentGatewayUpdateStep3(context),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(
@@ -97,9 +96,61 @@ resource "google_network_services_agent_gateway" "default" {
 
   network_config {
     egress {
-      network_attachment = "projects/%{project}/regions/us-central1/networkAttachments/oh-my-network-attachment"
+      network_attachment = google_compute_network_attachment.default.id
     }
   }
 }
+`, context) + testAccNetworkServicesAgentGateway_sharedNetworkResources(context)
+}
+
+func testAccNetworkServicesAgentGateway_sharedNetworkResources(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_compute_network" "default" {
+  name                    = "net-%{name}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "subnet-%{name}"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_network_attachment" "default" {
+  name                  = "na-%{name}"
+  region                = "us-central1"
+  connection_preference = "ACCEPT_AUTOMATIC"
+  subnetworks           = [google_compute_subnetwork.default.self_link]
+}
 `, context)
+}
+
+func testAccNetworkServicesAgentGateway_networkServicesAgentGatewayUpdateStep3(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_network_services_agent_gateway" "default" {
+  name     = "%{name}"
+  location = "us-central1"
+  description = "A full configuration for Agent Gateway"
+  labels = {
+    env = "prod"
+    tier = "silver"
+  }
+
+  protocols = ["MCP"]
+  google_managed {
+    governed_access_path = "AGENT_TO_ANYWHERE"
+  }
+
+  registries = [
+    "//agentregistry.googleapis.com/projects/%{project}/locations/us-central1"
+  ]
+
+  network_config {
+    egress {
+      network_attachment = google_compute_network_attachment.default.id
+    }
+  }
+}
+`, context) + testAccNetworkServicesAgentGateway_sharedNetworkResources(context)
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

### Description

Promote **Agent Gateway** (`google_network_services_agent_gateway`) resource to GA. 

#### Changes Made:
1. **Removed Beta Version Restriction**: Removed `min_version: beta` from `AgentGateway.yaml` to ensure code generation occurs in both GA (`google`) and Beta (`google-beta`) providers.
2. **Updated API Documentation Link**: Changed the REST API guide URL reference from `v1beta1` to `v1`.
3. **Enabled Acceptance Tests**: Removed target version conditional constraints from the acceptance test file to generate and run them in both GA and Beta environments.
4. **Renamed Test Template**: Renamed `resource_network_services_agent_gateway_test.go.tmpl` to `resource_network_services_agent_gateway_test.go` as it no longer contains compile-time Go template syntax, resolving validator check failures.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_network_services_agent_gateway` (GA)
```