### PR TITLE
artifactregistry: Remove Immutable from upstream_credentials

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -761,27 +761,23 @@ properties:
         type: NestedObject
         description: |-
           The credentials used to access the remote repository.
-        immutable: true
         is_missing_in_cai: true
         properties:
           - name: 'usernamePasswordCredentials'
             type: NestedObject
             description: |-
               Use username and password to access the remote repository.
-            immutable: true
             properties:
               - name: 'username'
                 type: String
                 description: |-
                   The username to access the remote repository.
-                immutable: true
               - name: 'passwordSecretVersion'
                 type: String
                 description: |-
                   The Secret Manager key version that holds the password to access the
                   remote repository. Must be in the format of
                   `projects/{project}/secrets/{secret}/versions/{version}`.
-                immutable: true
       - name: 'disableUpstreamValidation'
         type: Boolean
         description: |-

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -761,7 +761,6 @@ properties:
         type: NestedObject
         description: |-
           The credentials used to access the remote repository.
-        is_missing_in_cai: true
         properties:
           - name: 'usernamePasswordCredentials'
             type: NestedObject

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -506,7 +506,6 @@ properties:
     type: NestedObject
     description: |-
       Configuration specific for a Remote Repository.
-    immutable: true
     conflicts:
       - virtual_repository_config
     properties:

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -53,6 +53,7 @@ iam_policy:
 custom_code:
   constants: 'templates/terraform/constants/artifact_registry_repository.go.tmpl'
   encoder: 'templates/terraform/encoders/location_from_region.go.tmpl'
+  pre_update: 'templates/terraform/update_encoder/artifact_registry_repository_update.go.tmpl'
 sweeper:
   url_substitutions:
     - region: "us-central1"
@@ -506,6 +507,7 @@ properties:
     type: NestedObject
     description: |-
       Configuration specific for a Remote Repository.
+    immutable: true
     conflicts:
       - virtual_repository_config
     properties:

--- a/mmv1/templates/terraform/update_encoder/artifact_registry_repository_update.go.tmpl
+++ b/mmv1/templates/terraform/update_encoder/artifact_registry_repository_update.go.tmpl
@@ -1,0 +1,20 @@
+
+remoteRepositoryConfigProp, err := expandArtifactRegistryRepositoryRemoteRepositoryConfig(d.Get("remote_repository_config"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("remote_repository_config"); !tpgresource.IsEmptyValue(reflect.ValueOf(remoteRepositoryConfigProp)) && (ok || !reflect.DeepEqual(v, remoteRepositoryConfigProp)) {
+		obj["remoteRepositoryConfig"] = remoteRepositoryConfigProp
+	}
+
+if d.HasChange("remote_repository_config.0.upstream_credentials.0.username_password_credentials.0.username") {
+  updateMask = append(updateMask, "remoteRepositoryConfig.upstreamCredentials.usernamePasswordCredentials.username")
+}
+
+if d.HasChange("remote_repository_config.0.upstream_credentials.0.username_password_credentials.0.password_secret_version") {
+  updateMask = append(updateMask, "remoteRepositoryConfig.upstreamCredentials.usernamePasswordCredentials.passwordSecretVersion")
+}
+
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+  return err
+}

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -381,7 +381,7 @@ func testAccArtifactRegistryRepository_remoteWithAuthUpdate(context map[string]i
 data "google_project" "project" {}
 
 resource "google_secret_manager_secret" "secret" {
-  secret_id = "tf-test-example-secret"
+  secret_id = "tf-test-example-secret-%{random_suffix}"
   replication {
     auto {}
   }
@@ -425,7 +425,7 @@ func testAccArtifactRegistryRepository_remoteWithAuthUpdate2(context map[string]
 data "google_project" "project" {}
 
 resource "google_secret_manager_secret" "secret" {
-  secret_id = "tf-test-example-secret"
+  secret_id = "tf-test-example-secret-%{random_suffix}"
   replication {
     auto {}
   }

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -361,6 +361,7 @@ func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
 				ResourceName:            "google_artifact_registry_repository.my-repo",
 				ImportState:             true,
 				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
 			},
 			{
 				Config: testAccArtifactRegistryRepository_remoteWithAuthUpdate2(context),
@@ -369,6 +370,7 @@ func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
 				ResourceName:            "google_artifact_registry_repository.my-repo",
 				ImportState:             true,
 				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -343,9 +343,9 @@ func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
 	t.Parallel()
 
 
-	context_1 := map[string]interface{}{
-		"username_1":           "tf-test-username" + randomSuffix,
-		"username_2":           "tf-test-username-new" + randomSuffix,
+	context := map[string]interface{}{
+		"username_1":           "tf-test-username",
+		"username_2":           "tf-test-username-new",
 		"random_suffix":         acctest.RandString(t, 10),
 	}
 

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -339,6 +339,136 @@ resource "google_artifact_registry_repository" "test" {
 `, repositoryID)
 }
 
+func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
+	t.Parallel()
+
+
+	context_1 := map[string]interface{}{
+		"username_1":           "tf-test-username" + randomSuffix,
+		"username_2":           "tf-test-username-new" + randomSuffix,
+		"random_suffix":         acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArtifactRegistryRepository_remoteWithAuthUpdate(context),
+			},
+			{
+				ResourceName:            "google_artifact_registry_repository.my-repo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
+			},
+			{
+				Config: testAccArtifactRegistryRepository_remoteWithAuthUpdate2(context),
+			},
+			{
+				ResourceName:            "google_artifact_registry_repository.my-repo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccArtifactRegistryRepository_remoteWithAuthUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "tf-test-example-secret"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  secret = google_secret_manager_secret.secret.id
+  secret_data = "tf-test-password"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret-access" {
+  secret_id = google_secret_manager_secret.secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+}
+
+resource "google_artifact_registry_repository" "my-repo" {
+  location      = "us-central1"
+  repository_id = "tf-test-my-repository-%{random_suffix}"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    description = "docker hub with custom credentials"
+    disable_upstream_validation = true
+    docker_repository {
+      public_repository = "DOCKER_HUB"
+    }
+    upstream_credentials {
+      username_password_credentials {
+        username = "%{username_1}"
+        password_secret_version = google_secret_manager_secret_version.secret_version.name
+      }
+    }
+  }
+}
+`, context)
+}
+
+func testAccArtifactRegistryRepository_remoteWithAuthUpdate2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_project" "project" {}
+
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "tf-test-example-secret"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret_version" {
+  secret = google_secret_manager_secret.secret.id
+  secret_data = "tf-test-password"
+}
+
+resource "google_secret_manager_secret_version" "secret_version_updated" {
+  secret = google_secret_manager_secret.secret.id
+  secret_data = "tf-test-password-updated"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret-access" {
+  secret_id = google_secret_manager_secret.%{secret_resource_id}.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+}
+
+resource "google_artifact_registry_repository" "my-repo" {
+  location      = "us-central1"
+  repository_id = "tf-test-my-repository-%{random_suffix}"
+  format        = "DOCKER"
+  mode          = "REMOTE_REPOSITORY"
+  remote_repository_config {
+    description = "docker hub with custom credentials"
+    disable_upstream_validation = true
+    docker_repository {
+      public_repository = "DOCKER_HUB"
+    }
+    upstream_credentials {
+      username_password_credentials {
+        username = "%{username_2}"
+        password_secret_version = google_secret_manager_secret_version.secret_version_updated.name
+      }
+    }
+  }
+}
+`, context)
+}
+
 {{ if ne $.TargetVersionName `ga` -}}
 
 func TestAccArtifactRegistryRepository_virtual(t *testing.T) {

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -442,7 +442,7 @@ resource "google_secret_manager_secret_version" "secret_version_updated" {
 }
 
 resource "google_secret_manager_secret_iam_member" "secret-access" {
-  secret_id = google_secret_manager_secret.%{secret_resource_id}.id
+  secret_id = google_secret_manager_secret.secret.id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
 }

--- a/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/artifactregistry/resource_artifact_registry_repository_test.go.tmpl
@@ -361,7 +361,6 @@ func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
 				ResourceName:            "google_artifact_registry_repository.my-repo",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
 			},
 			{
 				Config: testAccArtifactRegistryRepository_remoteWithAuthUpdate2(context),
@@ -370,7 +369,6 @@ func TestAccArtifactRegistryRepository_remoteWithAuthUpdate(t *testing.T) {
 				ResourceName:            "google_artifact_registry_repository.my-repo",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"labels", "location", "remote_repository_config.0.disable_upstream_validation", "repository_id", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes for https://github.com/hashicorp/terraform-provider-google/issues/20520 and  https://github.com/hashicorp/terraform-provider-google/issues/20520

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.


```release-note:enhancement
artifactregistry: Allows `upstream_credentials` to be updated in place
```
