### PR TITLE
Preventing License Manager users from creating inactive configurations.

### DIFF
--- a/mmv1/templates/terraform/encoders/licensemanager_configuration.go.tmpl
+++ b/mmv1/templates/terraform/encoders/licensemanager_configuration.go.tmpl
@@ -1,4 +1,11 @@
 // Reference design doc: go/lima-terraform
+// Check if we are trying to create an inactive configuration
+if d.IsNewResource() {
+	if val, ok := d.GetOkExists("active"); ok && !val.(bool) {
+		return nil, fmt.Errorf("creating an inactive configuration is not supported; you must create it as active (active = true) first, and then deactivate it")
+	}
+}
+
 var product string
 if val, ok := obj["product"]; ok && val != nil {
 	product = val.(string)

--- a/mmv1/third_party/terraform/services/licensemanager/resource_license_manager_configuration_custom_test.go
+++ b/mmv1/third_party/terraform/services/licensemanager/resource_license_manager_configuration_custom_test.go
@@ -2,9 +2,9 @@ package licensemanager_test
 
 import (
 	"fmt"
-	"regexp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"regexp"
 	"testing"
 )
 

--- a/mmv1/third_party/terraform/services/licensemanager/resource_license_manager_configuration_custom_test.go
+++ b/mmv1/third_party/terraform/services/licensemanager/resource_license_manager_configuration_custom_test.go
@@ -2,6 +2,7 @@ package licensemanager_test
 
 import (
 	"fmt"
+	"regexp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"testing"
@@ -52,4 +53,26 @@ resource "google_license_manager_configuration" "example" {
   active           = `+fmt.Sprintf("%t", active)+`
 }
 `, context)
+}
+
+func TestAccLicenseManagerConfiguration_createInactive(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"configuration_id": "tf-test-example-config-" + randomSuffix,
+		"product":          "Office2021ProfessionalPlus",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccLicenseManagerConfiguration_active(context, false, 10),
+				ExpectError: regexp.MustCompile("creating an inactive configuration is not supported"),
+			},
+		},
+	})
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This is necessary because if we allow them to create active, then deactivate with a post_create hook,
the customer will still be billed for that full month - likely subverting their expectation.
Instead we tell them that they must create an active configuration and issue a deactivate update afterwards.


```release-note:new-resource
`google_license_manager_configuration`
```
