### PR TITLE
compute: add list resources (batch 2 — firewall policies, backend signed keys)

### DIFF
--- a/mmv1/products/compute/BackendBucketSignedUrlKey.yaml
+++ b/mmv1/products/compute/BackendBucketSignedUrlKey.yaml
@@ -30,6 +30,7 @@ delete_verb: 'POST'
 immutable: true
 mutex: 'signedUrlKey/{{project}}/backendBuckets/{{backend_bucket}}/'
 exclude_import: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/BackendServiceSignedUrlKey.yaml
+++ b/mmv1/products/compute/BackendServiceSignedUrlKey.yaml
@@ -22,6 +22,7 @@ references:
   api: https://cloud.google.com/compute/docs/reference/rest/v1/backendServices
 base_url: projects/{{project}}/global/backendServices/{{backend_service}}
 immutable: true
+generate_list_resource: true
 self_link: projects/{{project}}/global/backendServices/{{backend_service}}
 create_url: projects/{{project}}/global/backendServices/{{backend_service}}/addSignedUrlKey
 delete_url: projects/{{project}}/global/backendServices/{{backend_service}}/deleteSignedUrlKey?keyName={{name}}

--- a/mmv1/products/compute/NetworkEdgeSecurityService.yaml
+++ b/mmv1/products/compute/NetworkEdgeSecurityService.yaml
@@ -29,7 +29,10 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - 'projects/{{project}}/regions/{{region}}/networkEdgeSecurityServices/{{name}}'
-generate_list_resource: true
+# This API only supports aggregatedList (projects/{project}/aggregated/networkEdgeSecurityServices),
+# not a per-region list endpoint. The list resource generation is disabled until the template
+# supports the aggregated response format (items nested under region keys).
+# generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkEdgeSecurityService.yaml
+++ b/mmv1/products/compute/NetworkEdgeSecurityService.yaml
@@ -29,6 +29,7 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - 'projects/{{project}}/regions/{{region}}/networkEdgeSecurityServices/{{name}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkEdgeSecurityService.yaml
+++ b/mmv1/products/compute/NetworkEdgeSecurityService.yaml
@@ -49,6 +49,8 @@ samples:
     primary_resource_id: 'default'
     steps:
       - name: 'compute_network_edge_security_service_basic'
+        vars:
+          region: 'us-east1'
         resource_id_vars:
           resource_name: 'my-edge-security-service'
         test_env_vars:

--- a/mmv1/products/compute/NetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicy.yaml
@@ -20,6 +20,7 @@ base_url: 'projects/{{project}}/global/firewallPolicies'
 self_link: 'projects/{{project}}/global/firewallPolicies/{{name}}'
 create_url: 'projects/{{project}}/global/firewallPolicies'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
@@ -34,6 +34,7 @@ import_format:
   - 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}'
   - '{{project}}/{{firewall_policy}}/{{name}}'
 generate_list_resource: true
+collection_url_key: 'associations'
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyAssociation.yaml
@@ -33,6 +33,7 @@ legacy_long_form_project: true
 import_format:
   - 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/associations/{{name}}'
   - '{{project}}/{{firewall_policy}}/{{name}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
@@ -34,6 +34,7 @@ delete_verb: 'POST'
 legacy_long_form_project: true
 import_format:
   - 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/packetMirroringRules/{{priority}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicyPacketMirroringRule.yaml
@@ -35,6 +35,7 @@ legacy_long_form_project: true
 import_format:
   - 'projects/{{project}}/global/firewallPolicies/{{firewall_policy}}/packetMirroringRules/{{priority}}'
 generate_list_resource: true
+collection_url_key: 'packetMirroringRules'
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/PreviewFeature.yaml
+++ b/mmv1/products/compute/PreviewFeature.yaml
@@ -30,6 +30,7 @@ update_url: 'projects/{{project}}/global/previewFeatures/{{name}}'
 update_verb: 'PATCH'
 update_mask: true
 exclude_delete: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/PublicAdvertisedPrefix.yaml
+++ b/mmv1/products/compute/PublicAdvertisedPrefix.yaml
@@ -23,6 +23,7 @@ docs:
 base_url: 'projects/{{project}}/global/publicAdvertisedPrefixes'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionBackendBucket.yaml
+++ b/mmv1/products/compute/RegionBackendBucket.yaml
@@ -72,26 +72,29 @@ samples:
     primary_resource_id: 'image_backend'
     steps:
       - name: 'region_backend_bucket_basic'
+        vars:
+          region: 'us-central1'
         resource_id_vars:
           backend_bucket_name: 'region-image-backend-bucket'
           bucket_name: 'region-image-store-bucket'
-          region: 'us-central1'
   - name: 'region_backend_bucket_internal_lb'
     primary_resource_id: 'internal_backend'
     steps:
       - name: 'region_backend_bucket_internal_lb'
+        vars:
+          region: 'us-central1'
         resource_id_vars:
           backend_bucket_name: 'regional-internal-backend'
           bucket_name: 'regional-internal-bucket'
-          region: 'us-central1'
   - name: 'region_backend_bucket_external_lb'
     primary_resource_id: 'external_backend'
     steps:
       - name: 'region_backend_bucket_external_lb'
+        vars:
+          region: 'us-east1'
         resource_id_vars:
           backend_bucket_name: 'regional-external-backend'
           bucket_name: 'regional-external-bucket'
-          region: 'us-east1'
 parameters:
   - name: 'region'
     type: ResourceRef

--- a/mmv1/products/compute/RegionBackendBucket.yaml
+++ b/mmv1/products/compute/RegionBackendBucket.yaml
@@ -41,6 +41,7 @@ references:
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/backendBuckets'
 has_self_link: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
@@ -20,6 +20,7 @@ base_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies'
 self_link: 'projects/{{project}}/regions/{{region}}/firewallPolicies/{{name}}'
 create_url: 'projects/{{project}}/regions/{{region}}/firewallPolicies'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/templates/terraform/list_resource.go.tmpl
+++ b/mmv1/templates/terraform/list_resource.go.tmpl
@@ -19,7 +19,7 @@
 
 package {{ lower $.ProductMetadata.Name }}
 
-{{- $hasIntegerIdentity := false -}}
+{{ $hasIntegerIdentity := false -}}
 {{- range $id := $.IdentityProperties -}}
   {{- if eq $id.Type "Integer" -}}
     {{- $hasIntegerIdentity = true -}}

--- a/mmv1/templates/terraform/list_resource.go.tmpl
+++ b/mmv1/templates/terraform/list_resource.go.tmpl
@@ -19,11 +19,21 @@
 
 package {{ lower $.ProductMetadata.Name }}
 
+{{- $hasIntegerIdentity := false -}}
+{{- range $id := $.IdentityProperties -}}
+  {{- if eq $id.Type "Integer" -}}
+    {{- $hasIntegerIdentity = true -}}
+  {{- end -}}
+{{- end -}}
+
 import (
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	{{- if $hasIntegerIdentity }}
+	"strconv"
+	{{- end }}
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -63,6 +63,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 	{{- end }}
 	{{- range $scope := $.ListScopeProperties }}
 		{{- $n := underscore $scope.Name }}
+		{{- if not (index $step.TestContextVars $n) }}
 		{{- if or (eq $n "region") (eq $n "location") }}
 		"{{$n}}": envvar.GetTestRegionFromEnv(),
 		{{- else if eq $n "zone" }}
@@ -70,6 +71,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 		{{- else if eq $n "project" }}
 		{{- if not (index $step.TestEnvVars "project") }}
 		"project": envvar.GetTestProjectFromEnv(),
+		{{- end }}
 		{{- end }}
 		{{- end }}
 	{{- end }}

--- a/mmv1/templates/terraform/samples/services/compute/compute_network_edge_security_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_network_edge_security_service_basic.tf.tmpl
@@ -2,6 +2,6 @@ resource "google_compute_network_edge_security_service" "{{$.PrimaryResourceId}}
   provider     = google-beta  
 
   name         = "{{index $.ResourceIdVars "resource_name"}}"
-  region       = "us-east1"
+  region       = "{{index $.Vars "region"}}"
   description  = "My basic resource"
 }

--- a/mmv1/templates/terraform/samples/services/compute/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_network_firewall_policy_packet_mirroring_rule.tf.tmpl
@@ -21,7 +21,7 @@ resource "google_compute_network_firewall_policy_packet_mirroring_rule" "{{$.Pri
   description             = "This is a simple packet mirroring rule description"
   direction               = "INGRESS"
   disabled                = false
-  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.name
+  firewall_policy         = google_compute_network_firewall_policy.basic_network_firewall_policy.id
   priority                = 1000
   rule_name               = "test-rule"
 


### PR DESCRIPTION
Adds `generate_list_resource: true` for 10 compute resources.

## GA Resources (7)

- `google_compute_backend_bucket_signed_url_key`
- `google_compute_backend_service_signed_url_key`
- `google_compute_network_firewall_policy`
- `google_compute_network_firewall_policy_association`
- `google_compute_preview_feature`
- `google_compute_public_advertised_prefix`
- `google_compute_region_network_firewall_policy`

## Beta-only Resources (3)

These YAML changes are valid and will generate list files in the beta provider:
- `google_compute_network_firewall_policy_packet_mirroring_rule`
- `google_compute_region_backend_bucket`

```release-note:new-list-resource
`google_compute_backend_bucket_signed_url_key`
```
```release-note:new-list-resource
`google_compute_backend_service_signed_url_key`
```
```release-note:new-list-resource
`google_compute_network_firewall_policy`
```
```release-note:new-list-resource
`google_compute_network_firewall_policy_association`
```
```release-note:new-list-resource
`google_compute_network_firewall_policy_packet_mirroring_rule`
```
```release-note:new-list-resource
`google_compute_preview_feature`
```
```release-note:new-list-resource
`google_compute_public_advertised_prefix`
```
```release-note:new-list-resource
`google_compute_region_backend_bucket`
```
```release-note:new-list-resource
`google_compute_region_network_firewall_policy`
```