### PR TITLE
compute: add list resources (batch 3 — VPN, interconnect, network endpoint groups)

### DIFF
--- a/mmv1/products/compute/CrossSiteNetwork.yaml
+++ b/mmv1/products/compute/CrossSiteNetwork.yaml
@@ -23,6 +23,7 @@ docs:
 base_url: 'projects/{{project}}/global/crossSiteNetworks'
 self_link: 'projects/{{project}}/global/crossSiteNetworks/{{name}}'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/ExternalVpnGateway.yaml
+++ b/mmv1/products/compute/ExternalVpnGateway.yaml
@@ -23,6 +23,7 @@ docs:
 base_url: 'projects/{{project}}/global/externalVpnGateways'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/GlobalNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/GlobalNetworkEndpointGroup.yaml
@@ -30,6 +30,7 @@ docs:
 base_url: 'projects/{{project}}/global/networkEndpointGroups'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/HaVpnGateway.yaml
+++ b/mmv1/products/compute/HaVpnGateway.yaml
@@ -28,6 +28,7 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/vpnGateways'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/InterconnectAttachmentGroup.yaml
+++ b/mmv1/products/compute/InterconnectAttachmentGroup.yaml
@@ -25,6 +25,7 @@ docs:
 base_url: 'projects/{{project}}/global/interconnectAttachmentGroups'
 self_link: 'projects/{{project}}/global/interconnectAttachmentGroups/{{name}}'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/InterconnectGroup.yaml
+++ b/mmv1/products/compute/InterconnectGroup.yaml
@@ -25,6 +25,7 @@ docs:
 base_url: 'projects/{{project}}/global/interconnectGroups'
 self_link: 'projects/{{project}}/global/interconnectGroups/{{name}}'
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/PublicDelegatedPrefix.yaml
+++ b/mmv1/products/compute/PublicDelegatedPrefix.yaml
@@ -23,6 +23,7 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/publicDelegatedPrefixes'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionCommitment.yaml
+++ b/mmv1/products/compute/RegionCommitment.yaml
@@ -32,6 +32,7 @@ has_self_link: true
 exclude_delete: true
 # Cannot be updated (as of implementation date)
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
+++ b/mmv1/products/compute/RegionNetworkEndpointGroup.yaml
@@ -35,6 +35,7 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/networkEndpointGroups'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/VpnGateway.yaml
+++ b/mmv1/products/compute/VpnGateway.yaml
@@ -27,6 +27,7 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/targetVpnGateways'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/WireGroup.yaml
+++ b/mmv1/products/compute/WireGroup.yaml
@@ -29,6 +29,7 @@ update_verb: 'PATCH'
 update_mask: true
 import_format:
   - 'projects/{{project}}/global/crossSiteNetworks/{{cross_site_network}}/wireGroups/{{name}}'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20


### PR DESCRIPTION
Adds `generate_list_resource: true` for 11 compute resources.

## Resources

- `google_compute_cross_site_network`
- `google_compute_external_vpn_gateway`
- `google_compute_global_network_endpoint_group`
- `google_compute_ha_vpn_gateway`
- `google_compute_interconnect_attachment_group`
- `google_compute_interconnect_group`
- `google_compute_public_delegated_prefix`
- `google_compute_region_commitment`
- `google_compute_region_network_endpoint_group`
- `google_compute_vpn_gateway`
- `google_compute_wire_group`

```release-note:new-list-resource
`google_compute_cross_site_network`
```
```release-note:new-list-resource
`google_compute_external_vpn_gateway`
```
```release-note:new-list-resource
`google_compute_global_network_endpoint_group`
```
```release-note:new-list-resource
`google_compute_ha_vpn_gateway`
```
```release-note:new-list-resource
`google_compute_interconnect_attachment_group`
```
```release-note:new-list-resource
`google_compute_interconnect_group`
```
```release-note:new-list-resource
`google_compute_public_delegated_prefix`
```
```release-note:new-list-resource
`google_compute_region_commitment`
```
```release-note:new-list-resource
`google_compute_region_network_endpoint_group`
```
```release-note:new-list-resource
`google_compute_vpn_gateway`
```
```release-note:new-list-resource
`google_compute_wire_group`
```