### PR TITLE
compute: add list resources (batch 4 — proxies, URL maps, snapshots)

### DIFF
--- a/mmv1/products/compute/InstantSnapshot.yaml
+++ b/mmv1/products/compute/InstantSnapshot.yaml
@@ -32,6 +32,7 @@ docs:
 base_url: 'projects/{{project}}/zones/{{zone}}/instantSnapshots'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionInstantSnapshot.yaml
+++ b/mmv1/products/compute/RegionInstantSnapshot.yaml
@@ -32,6 +32,7 @@ docs:
 base_url: 'projects/{{project}}/regions/{{region}}/instantSnapshots'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionTargetHttpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetHttpProxy.yaml
@@ -27,6 +27,7 @@ has_self_link: true
 immutable: true
 datasource_experimental:
   generate: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RegionTargetTcpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetTcpProxy.yaml
@@ -25,6 +25,7 @@ references:
 base_url: projects/{{project}}/regions/{{region}}/targetTcpProxies
 immutable: true
 has_self_link: true
+generate_list_resource: true
 id_format: projects/{{project}}/regions/{{region}}/targetTcpProxies/{{name}}
 sweeper:
   url_substitutions:

--- a/mmv1/products/compute/RegionTargetTcpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetTcpProxy.yaml
@@ -40,6 +40,8 @@ samples:
     primary_resource_id: default
     steps:
       - name: region_target_tcp_proxy_basic
+        test_context_vars:
+          region: envvar.GetTestRegionFromEnv()
         resource_id_vars:
           health_check_name: health-check
           region_backend_service_name: backend-service

--- a/mmv1/products/compute/RegionTargetTcpProxy.yaml
+++ b/mmv1/products/compute/RegionTargetTcpProxy.yaml
@@ -40,8 +40,8 @@ samples:
     primary_resource_id: default
     steps:
       - name: region_target_tcp_proxy_basic
-        test_context_vars:
-          region: envvar.GetTestRegionFromEnv()
+        vars:
+          region: us-central1
         resource_id_vars:
           health_check_name: health-check
           region_backend_service_name: backend-service

--- a/mmv1/products/compute/RegionUrlMap.yaml
+++ b/mmv1/products/compute/RegionUrlMap.yaml
@@ -21,6 +21,7 @@ description: |
 docs:
 base_url: 'projects/{{project}}/regions/{{region}}/urlMaps'
 has_self_link: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/RolloutPlan.yaml
+++ b/mmv1/products/compute/RolloutPlan.yaml
@@ -24,6 +24,7 @@ references:
   api: 'https://cloud.google.com/compute/docs/reference/rest/beta/rolloutPlans'
 base_url: 'projects/{{project}}/global/rolloutPlans'
 has_self_link: true
+generate_list_resource: true
 immutable: true
 create_url: 'projects/{{project}}/global/rolloutPlans'
 create_verb: 'POST'

--- a/mmv1/products/compute/TargetGrpcProxy.yaml
+++ b/mmv1/products/compute/TargetGrpcProxy.yaml
@@ -27,6 +27,7 @@ docs:
 base_url: 'projects/{{project}}/global/targetGrpcProxies'
 has_self_link: true
 update_verb: 'PATCH'
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/TargetHttpProxy.yaml
+++ b/mmv1/products/compute/TargetHttpProxy.yaml
@@ -27,6 +27,7 @@ has_self_link: true
 immutable: true
 datasource_experimental:
   generate: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/TargetSslProxy.yaml
+++ b/mmv1/products/compute/TargetSslProxy.yaml
@@ -26,6 +26,7 @@ docs:
 base_url: 'projects/{{project}}/global/targetSslProxies'
 has_self_link: true
 immutable: true
+generate_list_resource: true
 timeouts:
   insert_minutes: 20
   update_minutes: 20

--- a/mmv1/products/compute/TargetTcpProxy.yaml
+++ b/mmv1/products/compute/TargetTcpProxy.yaml
@@ -24,6 +24,7 @@ references:
 base_url: projects/{{project}}/global/targetTcpProxies
 immutable: true
 has_self_link: true
+generate_list_resource: true
 collection_url_key: items
 kind: compute#targetTcpProxy
 id_format: projects/{{project}}/global/targetTcpProxies/{{name}}

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -63,6 +63,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 	{{- end }}
 	{{- range $scope := $.ListScopeProperties }}
 		{{- $n := underscore $scope.Name }}
+		{{- if not (index $step.TestContextVars $n) }}
 		{{- if or (eq $n "region") (eq $n "location") }}
 		"{{$n}}": envvar.GetTestRegionFromEnv(),
 		{{- else if eq $n "zone" }}
@@ -70,6 +71,7 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 		{{- else if eq $n "project" }}
 		{{- if not (index $step.TestEnvVars "project") }}
 		"project": envvar.GetTestProjectFromEnv(),
+		{{- end }}
 		{{- end }}
 		{{- end }}
 	{{- end }}

--- a/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/query_test_file.go.tmpl
@@ -63,7 +63,6 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 	{{- end }}
 	{{- range $scope := $.ListScopeProperties }}
 		{{- $n := underscore $scope.Name }}
-		{{- if not (index $step.TestContextVars $n) }}
 		{{- if or (eq $n "region") (eq $n "location") }}
 		"{{$n}}": envvar.GetTestRegionFromEnv(),
 		{{- else if eq $n "zone" }}
@@ -71,7 +70,6 @@ func TestAcc{{ $.ResourceName }}ListQuery_generated(t *testing.T) {
 		{{- else if eq $n "project" }}
 		{{- if not (index $step.TestEnvVars "project") }}
 		"project": envvar.GetTestProjectFromEnv(),
-		{{- end }}
 		{{- end }}
 		{{- end }}
 	{{- end }}

--- a/mmv1/templates/terraform/samples/services/compute/region_target_tcp_proxy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_target_tcp_proxy_basic.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_region_target_tcp_proxy" "{{$.PrimaryResourceId}}" {
   name            = "{{index $.ResourceIdVars "region_target_tcp_proxy_name"}}"
-  region          = "%{region}"
+  region          = "{{index $.Vars "region"}}"
   backend_service = google_compute_region_backend_service.default.id
 }
 
@@ -8,7 +8,7 @@ resource "google_compute_region_backend_service" "default" {
   name        = "{{index $.ResourceIdVars "region_backend_service_name"}}"
   protocol    = "TCP"
   timeout_sec = 10
-  region      = "%{region}"
+  region      = "{{index $.Vars "region"}}"
 
   health_checks         = [google_compute_region_health_check.default.id]
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -16,7 +16,7 @@ resource "google_compute_region_backend_service" "default" {
 
 resource "google_compute_region_health_check" "default" {
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
-  region             = "%{region}"
+  region             = "{{index $.Vars "region"}}"
   timeout_sec        = 1
   check_interval_sec = 1
   tcp_health_check {

--- a/mmv1/templates/terraform/samples/services/compute/region_target_tcp_proxy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/region_target_tcp_proxy_basic.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_region_target_tcp_proxy" "{{$.PrimaryResourceId}}" {
   name            = "{{index $.ResourceIdVars "region_target_tcp_proxy_name"}}"
-  region          = "europe-west4"
+  region          = "%{region}"
   backend_service = google_compute_region_backend_service.default.id
 }
 
@@ -8,7 +8,7 @@ resource "google_compute_region_backend_service" "default" {
   name        = "{{index $.ResourceIdVars "region_backend_service_name"}}"
   protocol    = "TCP"
   timeout_sec = 10
-  region      = "europe-west4"
+  region      = "%{region}"
 
   health_checks         = [google_compute_region_health_check.default.id]
   load_balancing_scheme = "INTERNAL_MANAGED"
@@ -16,7 +16,7 @@ resource "google_compute_region_backend_service" "default" {
 
 resource "google_compute_region_health_check" "default" {
   name               = "{{index $.ResourceIdVars "health_check_name"}}"
-  region             = "europe-west4"
+  region             = "%{region}"
   timeout_sec        = 1
   check_interval_sec = 1
   tcp_health_check {


### PR DESCRIPTION
Adds `generate_list_resource: true` for 10 compute resources.

## GA Resources (9)

- `google_compute_instant_snapshot`
- `google_compute_region_instant_snapshot`
- `google_compute_region_target_http_proxy`
- `google_compute_region_target_tcp_proxy`
- `google_compute_region_url_map`
- `google_compute_target_grpc_proxy`
- `google_compute_target_http_proxy`
- `google_compute_target_ssl_proxy`
- `google_compute_target_tcp_proxy`

## Beta-only Resources (1)

- `google_compute_rollout_plan`

```release-note:new-list-resource
`google_compute_instant_snapshot`
```
```release-note:new-list-resource
`google_compute_region_instant_snapshot`
```
```release-note:new-list-resource
`google_compute_region_target_http_proxy`
```
```release-note:new-list-resource
`google_compute_region_target_tcp_proxy`
```
```release-note:new-list-resource
`google_compute_region_url_map`
```
```release-note:new-list-resource
`google_compute_rollout_plan`
```
```release-note:new-list-resource
`google_compute_target_grpc_proxy`
```
```release-note:new-list-resource
`google_compute_target_http_proxy`
```
```release-note:new-list-resource
`google_compute_target_ssl_proxy`
```
```release-note:new-list-resource
`google_compute_target_tcp_proxy`
```