### PR TITLE
feat(discoveryengine): add EUA and federated config support to DataConnector

### DIFF
--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -62,6 +62,10 @@ examples:
     primary_resource_id: 'jira-eua'
     vars:
       collection_id: 'collection-id'
+  - name: 'discoveryengine_dataconnector_jira_eua_json_auth'
+    primary_resource_id: 'jira-eua-json-auth'
+    vars:
+      collection_id: 'collection-id'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -58,6 +58,10 @@ examples:
     primary_resource_id: 'jira-with-actions'
     vars:
       collection_id: 'collection-id'
+  - name: 'discoveryengine_dataconnector_jira_eua'
+    primary_resource_id: 'jira-eua'
+    vars:
+      collection_id: 'collection-id'
 parameters:
   - name: 'location'
     type: String
@@ -438,6 +442,81 @@ properties:
       'EUA', 'FEDERATED_AND_EUA'.
     item_type:
       type: String
+  - name: 'endUserConfig'
+    type: NestedObject
+    description: |
+      Optional. Any params and credentials used specifically for EUA connectors.
+    properties:
+      - name: 'authParams'
+        type: String
+        description: |
+          Optional. Any authentication parameters specific to EUA connectors.
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        validation:
+          function: 'validation.StringIsJSON'
+      - name: 'jsonAuthParams'
+        type: String
+        description: |
+          Optional. Any authentication parameters specific to EUA connectors in json string format.
+      - name: 'additionalParams'
+        type: String
+        description: |
+          Optional. Any additional parameters needed for EUA.
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        validation:
+          function: 'validation.StringIsJSON'
+      - name: 'tenant'
+        type: NestedObject
+        description: |
+          Optional. The tenant project the connector is connected to.
+        properties:
+          - name: 'id'
+            type: String
+            description: |
+              The tenant's instance ID. Examples: Jira ("8594f221-9797-5f78-1fa4-485e198d7cd0"), Slack ("T123456").
+          - name: 'uri'
+            type: String
+            description: |
+              The URI of the tenant, if applicable. For example, the URI of a Jira instance is https://my-jira-instance.atlassian.net, and a Slack tenant does not have a URI.
+          - name: 'displayName'
+            type: String
+            description: |
+              Optional display name for the tenant, e.g. "My Slack Team".
+  - name: 'federatedConfig'
+    type: NestedObject
+    description: |
+      Optional. Any params and credentials used specifically for hybrid connectors supporting FEDERATED mode. This field should only be set if the connector is a hybrid connector and we want to enable FEDERATED mode.
+    properties:
+      - name: 'authParams'
+        type: String
+        description: |
+          Optional. Any authentication parameters specific to FEDERATED connectors.
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        validation:
+          function: 'validation.StringIsJSON'
+      - name: 'jsonAuthParams'
+        type: String
+        description: |
+          Optional. Any authentication parameters specific to FEDERATED connectors in json string format.
+      - name: 'additionalParams'
+        type: String
+        description: |
+          Optional. Any additional parameters needed for FEDERATED.
+        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+        custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+        validation:
+          function: 'validation.StringIsJSON'
+  - name: 'createEuaSaas'
+    type: Boolean
+    description: |
+      Optional. Whether the END USER AUTHENTICATION connector is created in SaaS.
   - name: 'syncMode'
     type: String
     description: |

--- a/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_eua.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_eua.tf.tmpl
@@ -1,0 +1,62 @@
+resource "google_discovery_engine_data_connector" "jira-eua" {
+  location                = "global"
+  collection_id           = "{{index $.Vars "collection_id"}}"
+  collection_display_name = "Jira EUA"
+  data_source             = "jira"
+  data_source_version     = 3
+  params = {
+    instance_uri  = "https://example.atlassian.net"
+    instance_id   = "SECRET_MANAGER_RESOURCE_NAME"
+    client_id     = "SECRET_MANAGER_RESOURCE_NAME"
+    client_secret = "SECRET_MANAGER_RESOURCE_NAME"
+    auth_type     = "OAUTH"
+  }
+  refresh_interval = "86400s"
+  entities {
+    entity_name = "project"
+  }
+  entities {
+    entity_name = "issue"
+  }
+  static_ip_enabled = false
+  destination_configs {
+    key = "url"
+    destinations {
+      host = "https://example.atlassian.net"
+    }
+  }
+  connector_modes = ["FEDERATED_AND_EUA"]
+  sync_mode       = "PERIODIC"
+
+  end_user_config {
+    auth_params = jsonencode({
+      authorization_uri = "https://auth.atlassian.com/authorize"
+      client_id         = "SECRET_MANAGER_RESOURCE_NAME"
+      client_secret     = "SECRET_MANAGER_RESOURCE_NAME"
+      token_uri         = "https://auth.atlassian.com/oauth/token"
+    })
+    additional_params = jsonencode({
+      scopes = [
+        "read:jira-work",
+        "write:jira-work",
+      ]
+    })
+    tenant {
+      id           = "8594f221-9797-5f78-1fa4-485e198d7cd0"
+      uri          = "https://example.atlassian.net"
+      display_name = "Example Jira"
+    }
+  }
+
+  federated_config {
+    auth_params = jsonencode({
+      client_id     = "SECRET_MANAGER_RESOURCE_NAME"
+      client_secret = "SECRET_MANAGER_RESOURCE_NAME"
+    })
+    additional_params = jsonencode({
+      instance_uri = "https://example.atlassian.net"
+    })
+  }
+
+  create_eua_saas = true
+}

--- a/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_eua_json_auth.tf.tmpl
+++ b/mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_eua_json_auth.tf.tmpl
@@ -1,0 +1,62 @@
+resource "google_discovery_engine_data_connector" "jira-eua-json-auth" {
+  location                = "global"
+  collection_id           = "{{index $.Vars "collection_id"}}"
+  collection_display_name = "Jira EUA JSON Auth"
+  data_source             = "jira"
+  data_source_version     = 3
+  params = {
+    instance_uri  = "https://example.atlassian.net"
+    instance_id   = "SECRET_MANAGER_RESOURCE_NAME"
+    client_id     = "SECRET_MANAGER_RESOURCE_NAME"
+    client_secret = "SECRET_MANAGER_RESOURCE_NAME"
+    auth_type     = "OAUTH"
+  }
+  refresh_interval = "86400s"
+  entities {
+    entity_name = "project"
+  }
+  entities {
+    entity_name = "issue"
+  }
+  static_ip_enabled = false
+  destination_configs {
+    key = "url"
+    destinations {
+      host = "https://example.atlassian.net"
+    }
+  }
+  connector_modes = ["FEDERATED_AND_EUA"]
+  sync_mode       = "PERIODIC"
+
+  end_user_config {
+    json_auth_params = jsonencode({
+      authorization_uri = "https://auth.atlassian.com/authorize"
+      client_id         = "SECRET_MANAGER_RESOURCE_NAME"
+      client_secret     = "SECRET_MANAGER_RESOURCE_NAME"
+      token_uri         = "https://auth.atlassian.com/oauth/token"
+    })
+    additional_params = jsonencode({
+      scopes = [
+        "read:jira-work",
+        "write:jira-work",
+      ]
+    })
+    tenant {
+      id           = "8594f221-9797-5f78-1fa4-485e198d7cd0"
+      uri          = "https://example.atlassian.net"
+      display_name = "Example Jira"
+    }
+  }
+
+  federated_config {
+    json_auth_params = jsonencode({
+      client_id     = "SECRET_MANAGER_RESOURCE_NAME"
+      client_secret = "SECRET_MANAGER_RESOURCE_NAME"
+    })
+    additional_params = jsonencode({
+      instance_uri = "https://example.atlassian.net"
+    })
+  }
+
+  create_eua_saas = true
+}

--- a/mmv1/templates/terraform/state_migrations/discovery_engine_data_connector.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/discovery_engine_data_connector.go.tmpl
@@ -88,6 +88,81 @@ sync will be disabled.`,
 					Type: schema.TypeString,
 				},
 			},
+			"end_user_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_params": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							StateFunc:    func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s },
+						},
+						"json_auth_params": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"additional_params": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							StateFunc:    func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s },
+						},
+						"tenant": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"id": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"uri": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"display_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"federated_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"auth_params": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							StateFunc:    func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s },
+						},
+						"json_auth_params": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"additional_params": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsJSON,
+							StateFunc:    func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s },
+						},
+					},
+				},
+			},
+			"create_eua_saas": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"entities": {
 				Type:        schema.TypeList,
 				Optional:    true,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27746.

Adds the missing API surface for Gemini Enterprise / AgentSpace end-user-auth and hybrid federated data connectors to `google_discovery_engine_data_connector`.

## New fields

### `end_user_config` block
Configures parameters and credentials used specifically for EUA connectors.

- `auth_params` (JSON string) — authentication parameters specific to EUA connectors
- `json_auth_params` (string) — authentication parameters in JSON string format
- `additional_params` (JSON string) — additional parameters needed for EUA
- `tenant` block — tenant ID, URI, and display name

### `federated_config` block
Configures parameters and credentials used specifically for hybrid connectors supporting `FEDERATED` mode.

- `auth_params` (JSON string) — authentication parameters specific to FEDERATED connectors
- `json_auth_params` (string) — authentication parameters in JSON string format
- `additional_params` (JSON string) — additional parameters needed for FEDERATED

### `create_eua_saas`
Whether the END USER AUTHENTICATION connector is created in SaaS.

## Implementation notes

This follows the existing `DataConnector` patterns from:

- GoogleCloudPlatform/magic-modules#16290 / hashicorp/terraform-provider-google#26287 for adding missing AgentSpace DataConnector API surface, examples, and state migration schema entries.
- GoogleCloudPlatform/magic-modules#15296 / hashicorp/terraform-provider-google#24658 for representing protobuf `Struct` fields as JSON strings with `json_schema.tmpl` expand/flatten handling.

## Changes

- **`mmv1/products/discoveryengine/DataConnector.yaml`** — added `endUserConfig`, `federatedConfig`, and `createEuaSaas` property definitions.
- **`mmv1/templates/terraform/examples/discoveryengine_dataconnector_jira_eua.tf.tmpl`** — new Jira EUA example demonstrating the new fields.
- **`mmv1/templates/terraform/state_migrations/discovery_engine_data_connector.go.tmpl`** — added the new fields to the v0 schema for state migration compatibility.

```release-note:enhancement
discoveryengine: added `end_user_config`, `federated_config`, and `create_eua_saas` to `google_discovery_engine_data_connector` resource
```

Generated by GPT-5 in Conductor on behalf of @lilmatt.