### PR TITLE
Fix GPU diff in Cloud Run Service

### DIFF
--- a/mmv1/templates/terraform/constants/cloud_run_service.go.tmpl
+++ b/mmv1/templates/terraform/constants/cloud_run_service.go.tmpl
@@ -9,6 +9,7 @@ func revisionNameCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v i
 
 var cloudRunGoogleProvidedTemplateAnnotations = regexp.MustCompile(`template\.0\.metadata\.0\.annotations\.run\.googleapis\.com/sandbox`)
 var cloudRunGoogleProvidedTemplateAnnotations_autoscaling_maxscale = regexp.MustCompile(`template\.0\.metadata\.0\.annotations\.autoscaling\.knative\.dev/maxScale`)
+var cloudRunGoogleProvidedTemplateAnnotations_gpu_zonal_redundancy_disabled = regexp.MustCompile(`template\.0\.metadata\.0\.annotations\.run\.googleapis\.com/gpu-zonal-redundancy-disabled`)
 
 func cloudrunTemplateAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Suppress diffs for the annotations provided by API
@@ -19,6 +20,16 @@ func cloudrunTemplateAnnotationDiffSuppress(k, old, new string, d *schema.Resour
 
 	if cloudRunGoogleProvidedTemplateAnnotations_autoscaling_maxscale.MatchString(k) && new == "" {
 		return true
+	}
+
+	if cloudRunGoogleProvidedTemplateAnnotations_gpu_zonal_redundancy_disabled.MatchString(k) && new == "" {
+		if limitsRaw, ok := d.GetOk("template.0.spec.0.containers.0.resources.0.limits"); ok {
+			if limits, ok := limitsRaw.(map[string]interface{}); ok {
+				if _, hasGpu := limits["nvidia.com/gpu"]; hasGpu {
+					return true
+				}
+			}
+		}
 	}
 
 	// For other keys, don't suppress diff.

--- a/mmv1/templates/terraform/samples/services/cloudrun/cloud_run_service_gpu.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrun/cloud_run_service_gpu.tf.tmpl
@@ -2,17 +2,16 @@ resource "google_cloud_run_service" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
   location = "us-central1"
 
-  metadata {
-    annotations = {
-      "run.googleapis.com/launch-stage" = "BETA"
-    }
-  }
 
   template {
     metadata {
       annotations = {
         "autoscaling.knative.dev/maxScale": "1"
         "run.googleapis.com/cpu-throttling": "false"
+        # Explicitly disable zonal redundancy to bypass quota limits in the HashiCorp test project.
+        # Alternatively, if quota is granted to the test project, this annotation can be removed 
+        # to properly test the DiffSuppressFunc.
+        "run.googleapis.com/gpu-zonal-redundancy-disabled": "true"
       }
     }
     spec {


### PR DESCRIPTION
This PR resolves the `TestAccCloudRunService_cloudRunServiceGpuExample` VCR test failure by adding a custom diff suppress function for the `run.googleapis.com/gpu-zonal-redundancy-disabled` annotation. 

The Cloud Run API silently injects this annotation when an accelerator is configured, which was causing `ImportStateVerify` mismatches. Using a diff suppress function instead of making the entire annotations map `computed: true` ensures users can still explicitly manage and clear other annotations.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/21999

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudrun: fixed a permadiff for the `run.googleapis.com/gpu-zonal-redundancy-disabled` annotation in `google_cloud_run_service`
```