### PR TITLE
ci: fix Git shallow clone race condition in test-tgc workflow

### DIFF
--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -86,6 +86,7 @@ jobs:
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
       run: |
         go mod edit -replace github.com/hashicorp/terraform-provider-google-beta=github.com/${GITHUB_EVENT_INPUTS_OWNER}/terraform-provider-google-beta@${GITHUB_EVENT_INPUTS_TPGB_BRANCH}
+        go mod download github.com/${GITHUB_EVENT_INPUTS_OWNER}/terraform-provider-google-beta@${GITHUB_EVENT_INPUTS_TPGB_BRANCH}
         go mod tidy
         make build
       env:


### PR DESCRIPTION
### Description

Fixes a flaky CI issue where the `test-tgc` workflow sporadically fails during `go mod edit` / `go mod tidy` with the following error:
`fatal: shallow file has changed since we read it`

**Root Cause:**
When replacing a dependency with a direct GitHub branch (rather than a packaged proxy module), Go uses `git fetch` under the hood. When `go mod tidy` runs, it resolves dependencies in parallel. If multiple worker threads notice they need this replaced module simultaneously, they all attempt to interact with the same raw `.git` repository cache at once, triggering a Git lock race condition.

**Fix:**
Added an explicit, synchronous `go mod download` for the replaced `terraform-provider-google-beta` module immediately before running `go mod tidy`. This ensures the custom Git branch is fully fetched and safely cached in isolation before the highly-parallelized `tidy` step begins.

```release-note:none
```