### PR TITLE
Fix TestAccContainerCluster_withLoggingConfig VCR failure (Error 400)

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -13495,8 +13495,11 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+  // TODO(b/479239870): Re-add "KCP_VPA" 
+  // to enable_components once the GKE API feature is fully rolled out to production and
+  // no longer behind an internal visibility label.
   logging_config {
-    enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER", "KCP_CONNECTION", "KCP_SSHD", "KCP_HPA", "KCP_VPA" ]
+    enable_components = [ "SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "SCHEDULER", "KCP_CONNECTION", "KCP_SSHD", "KCP_HPA" ]
   }
   monitoring_config {
     enable_components = [ "SYSTEM_COMPONENTS" ]


### PR DESCRIPTION
Fixes `TestAccContainerCluster_withLoggingConfig` failing in CI with a `400 Invalid Argument` error. 

The test previously attempted to enable the `KCP_VPA` logging component. While this field was added to the Terraform schema in PR #17724, the backend GKE API for it is still behind an internal visibility label and hasn't fully rolled out to production, making it invalid for external testing projects. 

This commit removes `KCP_VPA` from the test to restore CI stability. A `TODO` comment tracking the internal rollout bug (b/479239870) was added so it can be re-added once the API is public.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```