### PR TITLE
Disable TestAccContainerNodePool_withHostMaintenancePolicy VCR failure (Stockout)

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -5691,11 +5691,12 @@ resource "google_container_node_pool" "with_tpu_topology" {
 {{ if ne $.TargetVersionName `ga` -}}
 func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 	t.Parallel()
+	t.Skip("CI test project ci-test-project-188019 lacks GCE scheduling quota/allowlist for GKE PERIODIC host maintenance pools")
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
 	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(t, 10))
-	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+	networkName := fmt.Sprintf("tf-test-net-%s", acctest.RandString(t, 10))
+	subnetworkName := fmt.Sprintf("tf-test-sub-%s", acctest.RandString(t, 10))
 
 	acctest.VcrTest(t, resource.TestCase{
 			PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -5716,9 +5717,29 @@ func TestAccContainerNodePool_withHostMaintenancePolicy(t *testing.T) {
 
 func testAccContainerNodePool_withHostMaintenancePolicy(cluster, networkName, subnetworkName, np string) string {
 	return fmt.Sprintf(`
+resource "google_compute_network" "net" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "sub" {
+  name          = "%s"
+  network       = google_compute_network.net.id
+  ip_cidr_range = "10.0.0.0/20"
+  region        = "asia-east1"
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.16.0.0/14"
+  }
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.20.0.0/20"
+  }
+}
+
 resource "google_container_cluster" "cluster" {
   name               = "%s"
-  location           = "us-central1-a"
+  location           = "asia-east1-c"
   initial_node_count = 1
   node_config {
     host_maintenance_policy {
@@ -5726,14 +5747,18 @@ resource "google_container_cluster" "cluster" {
     }
     machine_type = "n2-standard-2"
   }
-  network    = "%s"
-  subnetwork = "%s"
+  network    = google_compute_network.net.id
+  subnetwork = google_compute_subnetwork.sub.id
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
   deletion_protection = false
 }
 
 resource "google_container_node_pool" "np" {
   name               = "%s"
-  location           = "us-central1-a"
+  location           = "asia-east1-c"
   cluster            = google_container_cluster.cluster.name
   initial_node_count = 1
   node_config {
@@ -5743,7 +5768,7 @@ resource "google_container_node_pool" "np" {
     machine_type = "n2-standard-2"
   }
 }
-`, cluster, networkName, subnetworkName, np)
+`, networkName, subnetworkName, cluster, np)
 }
 {{- end }}
 


### PR DESCRIPTION
Mitigates https://github.com/hashicorp/terraform-provider-google/issues/25476

Skips `TestAccContainerNodePool_withHostMaintenancePolicy` in CI. 

When requesting `maintenance_interval = "PERIODIC"`, Compute Engine returns persistent `[GCE_STOCKOUT]` scheduling denials across all available testing data centers (`us-central1`, `us-east1`, `us-west1`, and `asia-east1`). Investigation details and quota increase suggestions have been logged on the upstream issue.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
