### PR TITLE
test: Fix hardcoded project number in Dataform Repository VCR test

### DIFF
--- a/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo_and_ssh.tf.tmpl
+++ b/mmv1/templates/terraform/examples/dataform_repository_with_cloudsource_repo_and_ssh.tf.tmpl
@@ -38,5 +38,9 @@ resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
     table_prefix = "prefix_"
   }
 
-  service_account = "1234567890-compute@developer.gserviceaccount.com"
+  service_account = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}
+
+data "google_project" "project" {
+  provider = google-beta
 }

--- a/mmv1/third_party/terraform/services/dataform/resource_dataform_config_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/dataform/resource_dataform_config_test.go.tmpl
@@ -37,6 +37,7 @@ var (
 	_ = googleapi.Error{}
 )
 
+// Force VCR re-record to fix ambient flake
 func TestAccDataformConfig_update(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes VCR test failures in `TestAccDataformRepository_dataformRepositoryWithCloudsourceRepoAndSshExample` and ambient flakes in `TestAccDataformConfig_update`.

The `dataform_repository_with_cloudsource_repo_and_ssh` test previously used a hardcoded project number for the service account, which caused failures when running in dynamic CI testing projects. This PR replaces the hardcoded number with dynamic lookup via the `google_project` data source.

Additionally, a harmless comment was introduced to `TestAccDataformConfig_update` to preserve a Git diff on the test file. This diff forces the CI pipeline to run the suite in "Recording Mode", refreshing its stale VCR cassette and eliminating an ambient `Requested interaction not found` replay flake.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
