### PR TITLE
feat: add HA policy example for RegionBackendService and update Netwo…

### DIFF
--- a/mmv1/products/compute/NetworkEndpoints.yaml
+++ b/mmv1/products/compute/NetworkEndpoints.yaml
@@ -134,4 +134,4 @@ properties:
             IPv4 address of network endpoint. The IP address must belong
             to a VM in GCE (either the primary IP or as part of an aliased IP
             range).
-          required: true
+            **Note** `ip_address` is required unless the Network Endpoint Group is created with the type of `GCE_VM_IP_DEDICATED_BACKEND`

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -167,6 +167,15 @@ examples:
       subnetwork_name: 'rbs-subnet'
       instance_name: 'rbs-instance'
       neg_name: 'rbs-neg'
+  - name: 'region_backend_service_ha_policy_internal_lb'
+    primary_resource_id: 'default'
+    vars:
+      region_backend_service_name: 'region-service'
+      network_name: 'rbs-net'
+      subnetwork_name: 'rbs-subnet'
+      instance_name: 'rbs-instance'
+      neg_name: 'rbs-neg'
+    exclude_test: true
   - name: 'region_backend_service_tls_settings'
     primary_resource_id: 'default'
     vars:

--- a/mmv1/templates/terraform/examples/region_backend_service_ha_policy_internal_lb.tf.tmpl
+++ b/mmv1/templates/terraform/examples/region_backend_service_ha_policy_internal_lb.tf.tmpl
@@ -1,0 +1,80 @@
+resource "google_compute_network" "default" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "default" {
+  name          = "{{index $.Vars "subnetwork_name"}}"
+  ip_cidr_range = "10.1.2.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.default.id
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "endpoint-instance" {
+  name         = "{{index $.Vars "instance_name"}}"
+  machine_type = "e2-medium"
+
+  boot_disk {
+    auto_delete = true
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.default.id
+    access_config {
+    }
+  }
+}
+
+resource "google_compute_network_endpoint_group" "neg" {
+  name                  = "{{index $.Vars "neg_name"}}"
+  network_endpoint_type = "GCE_VM_IP_DEDICATED_BACKEND"
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  zone                  = "us-central1-a"
+}
+
+resource "google_compute_network_endpoints" "endpoint" {
+  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  network_endpoints {
+    instance   = google_compute_instance.endpoint-instance.name
+  }
+}
+
+resource "google_compute_region_backend_service" "{{$.PrimaryResourceId}}" {
+  region                          = "us-central1"
+  name                            = "{{index $.Vars "region_backend_service_name"}}"
+  protocol                        = "UNSPECIFIED"
+  load_balancing_scheme           = "INTERNAL"
+  network                         = google_compute_network.default.id
+  backend {
+    group                         = google_compute_network_endpoint_group.neg.self_link
+    balancing_mode                = "CONNECTION"
+  }
+  ha_policy  {
+    fast_ip_move                  = "GARP_RA"
+    leader {
+      backend_group               = google_compute_network_endpoint_group.neg.self_link
+      network_endpoint {
+        instance                  = google_compute_instance.endpoint-instance.name
+      }
+    }
+  }
+  // Must explicitly disable connection draining to override default value.
+  connection_draining_timeout_sec = 0
+
+  // This block prevents Terraform from reverting external updates to leadership.
+  lifecycle {
+    ignore_changes = [
+      ha_policy[0].leader
+    ]
+  }
+}
+


### PR DESCRIPTION
…rkEndpoints documentation for GCE_VM_IP_DEDICATED_BACKEND

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
compute: made `network_endpoints.ip_address` optional in `google_compute_network_endpoints` resource to support attaching endpoints to a network endpoint group of type `GCE_VM_IP_DEDICATED_BACKEND`
```