### PR TITLE
Update BackupDR Beta endpoint to v1beta

### DIFF
--- a/mmv1/products/backupdr/product.yaml
+++ b/mmv1/products/backupdr/product.yaml
@@ -18,7 +18,7 @@ versions:
   - name: 'ga'
     base_url: 'https://backupdr.googleapis.com/v1/'
   - name: 'beta'
-    base_url: 'https://backupdr.googleapis.com/v1/'
+    base_url: 'https://backupdr.googleapis.com/v1beta/'
 scopes:
   - 'https://www.googleapis.com/auth/cloud-platform'
 async:


### PR DESCRIPTION
### Description

Currently, both the GA and Beta versions of the BackupDR product in Magic Modules are pointing to the `v1` API endpoint. This PR updates the `beta` version's `base_url` to point to the correct `v1beta` endpoint (`https://backupdr.googleapis.com/v1beta/`). 

The `ga` version remains unchanged, pointing to `v1`.

### Affected Resources
*   All `backupdr` resources when using the Beta provider (e.g., `google_backup_dr_backup_plan`, `google_backup_dr_backup_vault`, etc.).

### Tests Performed

I have verified this change by generating and building both the GA and Beta providers, and running integration tests.

1. **GA Provider Build**: Verified that the GA provider still generates and compiles successfully with no regressions.
2. **Beta Provider Build**: Verified that the Beta provider generates and compiles successfully with the new `v1beta` endpoint.
3. **Acceptance Tests**: Ran the `BackupVault` acceptance tests in the generated **Beta** provider against a live GCP project (`nkuravi-consumer-100`). All tests passed successfully:

```text
=== RUN   TestAccBackupDRBackupVault_backupDrBackupVaultSimpleExample
--- PASS: TestAccBackupDRBackupVault_backupDrBackupVaultSimpleExample (106.05s)
=== RUN   TestAccBackupDRBackupVault_backupDrBackupVaultCmekExample
--- PASS: TestAccBackupDRBackupVault_backupDrBackupVaultCmekExample (125.77s)
=== RUN   TestAccBackupDRBackupVault_fullUpdate
--- PASS: TestAccBackupDRBackupVault_fullUpdate (133.28s)
PASS
ok      github.com/hashicorp/terraform-provider-google-beta/google-beta/services/backupdr       133.448s
```
```release-note:bug
backupdr: updated the Beta provider to point to the `v1beta` API endpoint (beta)
```
