### PR TITLE
Add timeout and toolFakeConfig to CES Tool and Toolset

### DIFF
--- a/mmv1/products/ces/Tool.yaml
+++ b/mmv1/products/ces/Tool.yaml
@@ -1536,6 +1536,26 @@ properties:
         description: |-
           The name of the system tool.
         output: true
+  - name: timeout
+    type: String
+    description: |-
+      The timeout for the tool execution. If not set, the default timeout is 30
+      seconds for SYNCHRONOUS tools and 60 seconds for ASYNCHRONOUS tools.
+  - name: toolFakeConfig
+    type: NestedObject
+    description: Configuration for tool behavior in fake mode.
+    properties:
+      - name: enableFakeMode
+        type: Boolean
+        description: Whether the tool is using fake mode.
+      - name: codeBlock
+        type: NestedObject
+        description: Code block which will be executed instead of a real tool call.
+        properties:
+          - name: pythonCode
+            type: String
+            required: true
+            description: Python code which will be invoked in tool fake mode.
   - name: widgetTool
     type: NestedObject
     description: Represents a widget tool that the agent can invoke.

--- a/mmv1/products/ces/Toolset.yaml
+++ b/mmv1/products/ces/Toolset.yaml
@@ -572,6 +572,21 @@ properties:
             set in the session variables. See
             https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps/tool/open-api#openapi-injection
             for more details.
+  - name: toolFakeConfig
+    type: NestedObject
+    description: Configuration for tools behavior in fake mode.
+    properties:
+      - name: enableFakeMode
+        type: Boolean
+        description: Whether the tool is using fake mode.
+      - name: codeBlock
+        type: NestedObject
+        description: Code block which will be executed instead of a real tool call.
+        properties:
+          - name: pythonCode
+            type: String
+            required: true
+            description: Python code which will be invoked in tool fake mode.
   - name: updateTime
     type: String
     description: Timestamp when the toolset was last updated.

--- a/mmv1/third_party/terraform/services/ces/ces_tool_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_tool_test.go
@@ -654,6 +654,13 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
+    timeout        = "45s"
+    tool_fake_config {
+        enable_fake_mode = true
+        code_block {
+            python_code = "def fake_tool_call(tool, input, callback_context): return {'result': 'fake'}"
+        }
+    }
     python_function {
         name = "example_function"
         python_code = "def example_function() -> int: return 0"
@@ -678,6 +685,13 @@ resource "google_ces_tool" "ces_tool_python_function_basic" {
     app            = google_ces_app.my-app.name
     tool_id        = "tf_test_ces_tool_basic5%{random_suffix}"
     execution_type = "SYNCHRONOUS"
+    timeout        = "30s"
+    tool_fake_config {
+        enable_fake_mode = false
+        code_block {
+            python_code = "def fake_tool_call(tool, input, callback_context): return {'result': 'fake_updated'}"
+        }
+    }
     python_function {
         name = "example_function_updated"
         python_code = "def example_function_updated() -> int: return 0"

--- a/mmv1/third_party/terraform/services/ces/ces_toolset_test.go
+++ b/mmv1/third_party/terraform/services/ces/ces_toolset_test.go
@@ -698,6 +698,13 @@ resource "google_ces_toolset" "ces_toolset_bearer_token_config" {
   app      = google_ces_app.ces_app_for_toolset.app_id
   display_name = "Basic toolset display name"
 
+  tool_fake_config {
+    enable_fake_mode = true
+    code_block {
+      python_code = "def fake_tool_call(tool, input, callback_context): return {'result': 'fake'}"
+    }
+  }
+
   open_api_toolset {
     open_api_schema = <<-EOT
       openapi: 3.0.0
@@ -753,6 +760,13 @@ resource "google_ces_toolset" "ces_toolset_bearer_token_config" {
   location = "us"
   app      = google_ces_app.ces_app_for_toolset.app_id
   display_name = "Basic toolset display name"
+
+  tool_fake_config {
+    enable_fake_mode = false
+    code_block {
+      python_code = "def fake_tool_call(tool, input, callback_context): return {'result': 'fake_updated'}"
+    }
+  }
 
   open_api_toolset {
     open_api_schema = <<-EOT


### PR DESCRIPTION
This PR adds support for `timeout` and `tool_fake_config` fields in the `google_ces_tool` and `google_ces_toolset` resources.

These fields allow users to:
1. Configure execution timeouts for CES Tools.
2. Configure fake/mock behavior for CES Tools and Toolsets, including executing custom Python code blocks for testing.

We also updated the corresponding integration tests to verify these new fields work correctly during creation and updates.

***

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
ces: added `timeout` and `tool_fake_config` fields to `google_ces_tool` and `google_ces_toolset` resource
```