### PR TITLE
Fix diff with existing_reservations in google_region_commitment

### DIFF
--- a/mmv1/products/compute/RegionCommitment.yaml
+++ b/mmv1/products/compute/RegionCommitment.yaml
@@ -205,7 +205,8 @@ properties:
     type: String
     description: |
       Specifies the already existing reservations to attach to the Commitment.
-    default_from_api: true
+    # Ignore read as a temporary fix because the API only returns these in the `reservations` list
+    ignore_read: true
   - name: 'params'
     type: NestedObject
     ignore_read: true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27579

(Although, this is not a permanent fix, because if `reservations` is ever added, we will need to resolve the diffing behavior)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fix diff when using `existing_reservations` field in `google_region_commitment`
```
