### PR TITLE
Add terraform support for biglake hive catalogs

### DIFF
--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -21,6 +21,8 @@ references:
 # Marks the resource as beta-only. Ensure a beta version block is present in
 # provider.yaml.
 min_version: beta
+# hive/v1beta is added here instead of into the base url of the product.yaml.
+# This is because the IAM policy does not contain this prefix, so it must be separated.
 base_url: 'hive/v1beta/projects/{{project}}/catalogs'
 self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{name}}'
 create_url: 'hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{name}}&primary_location={{primary_location}}'

--- a/mmv1/products/biglakehive/HiveCatalog.yaml
+++ b/mmv1/products/biglakehive/HiveCatalog.yaml
@@ -1,0 +1,117 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'HiveCatalog'
+description: |
+  Hive Catalogs in Biglake Metastore
+references:
+  guides:
+    'QUICKSTART_TITLE': 'https://docs.cloud.google.com/lakehouse/docs/about-spark-hive-metastore'
+# Marks the resource as beta-only. Ensure a beta version block is present in
+# provider.yaml.
+min_version: beta
+base_url: 'hive/v1beta/projects/{{project}}/catalogs'
+self_link: 'hive/v1beta/projects/{{project}}/catalogs/{{name}}'
+create_url: 'hive/v1beta/projects/{{project}}/catalogs?hiveCatalogId={{name}}&primary_location={{primary_location}}'
+update_verb: 'PATCH'
+update_mask: true
+
+# The IAM policy is shared with Iceberg Catalog (biglakeiceberg).
+iam_policy:
+  base_url: 'v1/projects/{{project}}/catalogs/{{name}}'
+  parent_resource_attribute: 'name'
+  method_name_separator: ":"
+  fetch_iam_policy_verb: 'GET'
+  import_format:
+    - 'projects/{{project}}/catalogs/{{name}}'
+    - '{{name}}'
+  allowed_iam_role: 'roles/biglake.editor'
+examples:
+  - name: 'biglake_hive_catalog'
+    primary_resource_id: 'my_hive_catalog'
+    vars:
+      name: 'my_hive_catalog'
+    test_env_vars:
+      GOOGLE_BILLING_PROJECT: 'PROJECT'
+      USER_PROJECT_OVERRIDE: 'true'
+  - name: 'biglake_hive_catalog_full'
+    primary_resource_id: 'my_hive_catalog'
+    vars:
+      name: 'my_hive_catalog'
+    test_env_vars:
+      GOOGLE_BILLING_PROJECT: 'PROJECT'
+      USER_PROJECT_OVERRIDE: 'true'
+parameters:
+  - name: 'name'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: |
+      Name of the Hive Catalog.
+  - name: 'primary_location'
+    type: String
+    url_param_only: true
+    immutable: true
+    required: true
+    description: |
+      The primary location for mirroring the remote catalog metadata. It must be
+      a BigLake-supported location, and it should be proximate to the remote
+      catalog's location.
+properties:
+  - name: 'location_uri'
+    api_name: 'locationUri'
+    type: String
+    required: true
+    description: |
+      Cloud Storage location path where the catalog data will be stored. Format: gs://bucket/path/to/catalog
+  - name: 'description'
+    type: String
+    description: |
+      Description of the Hive catalog.
+  - name: 'create_time'
+    api_name: 'createTime'
+    type: String
+    description: Output only. The creation time of the catalog.
+    output: true
+  - name: 'update_time'
+    api_name: 'updateTime'
+    type: String
+    description: Output only. The update time of the catalog.
+    output: true
+  - name: 'replicas'
+    type: Array
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'region'
+          type: String
+          description: The region of the replica, e.g., `us-east1`.
+          output: true
+        - name: 'state'
+          type: Enum
+          description: If the catalog is replicated to multiple regions, this enum
+            describes the current state of the replica. STATE_UNSPECIFIED - The replica
+            state is unknown. STATE_PRIMARY - The replica is the writable primary.
+            STATE_PRIMARY_IN_PROGRESS - The replica has been recently assigned as
+            the primary, but not all databases are writeable yet. STATE_SECONDARY -
+            The replica is a read-only secondary replica.
+          output: true
+          enum_values:
+            - 'STATE_UNSPECIFIED'
+            - 'STATE_PRIMARY'
+            - 'STATE_PRIMARY_IN_PROGRESS'
+            - 'STATE_SECONDARY'
+    description: Output only. The replicas for the catalog metadata.
+    output: true

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'BiglakeHive'
+legacy_name: 'biglake'
+display_name: 'Biglake'
+versions:
+  - name: 'ga'
+    base_url: 'https://biglake.googleapis.com/'
+  - name: 'beta'
+    base_url: 'https://biglake.googleapis.com/'
+scopes:
+  - 'https://www.googleapis.com/auth/bigquery'
+  - 'https://www.googleapis.com/auth/cloud-platform'

--- a/mmv1/products/biglakehive/product.yaml
+++ b/mmv1/products/biglakehive/product.yaml
@@ -14,7 +14,7 @@
 ---
 name: 'BiglakeHive'
 legacy_name: 'biglake'
-display_name: 'Biglake'
+display_name: 'BigLake Hive Metastore'
 versions:
   - name: 'ga'
     base_url: 'https://biglake.googleapis.com/'

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
@@ -7,11 +7,11 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
-    name = "{{index $.Vars "name"}}"
-    primary_location="us-central1"
-    location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
-    depends_on = [
-      google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
-    ]
-    provider = google-beta
+  name = "{{index $.Vars "name"}}"
+  primary_location = "us-central1"
+  location_uri = "gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+  depends_on = [
+    google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
+  ]
+  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
+  name          = "{{index $.Vars "name"}}"
+  location      = "us-central1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+  provider = google-beta
+}
+
+resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
+    name = "{{index $.Vars "name"}}"
+    primary_location="us-central1"
+    location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+    depends_on = [
+      google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
+    ]
+    provider = google-beta
+}

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
@@ -7,12 +7,12 @@ resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
 }
 
 resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
-    name = "{{index $.Vars "name"}}"
-    primary_location="us-central1"
-    location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
-    description="terraform test hive catalog"
-    depends_on = [
-      google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
-    ]
-    provider = google-beta
+  name = "{{index $.Vars "name"}}"
+  primary_location = "us-central1"
+  location_uri = "gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+  description = "terraform test hive catalog"
+  depends_on = [
+    google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
+  ]
+  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/biglake_hive_catalog_full.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_storage_bucket" "bucket_for_{{$.PrimaryResourceId}}" {
+  name          = "{{index $.Vars "name"}}"
+  location      = "us-central1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+  provider = google-beta
+}
+
+resource "google_biglake_hive_catalog" "{{$.PrimaryResourceId}}" {
+    name = "{{index $.Vars "name"}}"
+    primary_location="us-central1"
+    location_uri="gs://${google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}.name}"
+    description="terraform test hive catalog"
+    depends_on = [
+      google_storage_bucket.bucket_for_{{$.PrimaryResourceId}}
+    ]
+    provider = google-beta
+}

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -91,6 +91,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Biglake",
         "path" to "./google-beta/services/biglake"
     ),
+    "biglakehive" to mapOf(
+        "name" to "biglakehive",
+        "displayName" to "BiglakeHive",
+        "path" to "./google-beta/services/biglakehive"
+    ),
     "biglakeiceberg" to mapOf(
         "name" to "biglakeiceberg",
         "displayName" to "BiglakeIceberg",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -91,6 +91,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Biglake",
         "path" to "./google/services/biglake"
     ),
+    "biglakehive" to mapOf(
+        "name" to "biglakehive",
+        "displayName" to "BiglakeHive",
+        "path" to "./google/services/biglakehive"
+    ),
     "biglakeiceberg" to mapOf(
         "name" to "biglakeiceberg",
         "displayName" to "BiglakeIceberg",

--- a/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go.tmpl
@@ -1,0 +1,104 @@
+package biglakehive_test
+
+{{- if ne $.TargetVersionName "ga" }}
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+	"google.golang.org/api/googleapi"
+)
+
+var (
+	_ = fmt.Sprintf
+	_ = log.Print
+	_ = strconv.Atoi
+	_ = strings.Trim
+	_ = time.Now
+	_ = resource.TestMain
+	_ = terraform.NewState
+	_ = envvar.TestEnvVar
+	_ = tpgresource.SetLabels
+	_ = transport_tpg.Config{}
+	_ = googleapi.Error{}
+)
+
+func TestAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"name":          "tf_test_my_hive_catalog" + randomSuffix,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+		CheckDestroy:             testAccCheckBiglakeHiveHiveCatalogDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBiglakeHiveHiveCatalog_biglakeHiveCatalogExample(context),
+			},
+			{
+				ResourceName:            "google_biglake_hive_catalog.my_hive_catalog",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "primary_location"},
+			},
+			{
+				Config: testAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_biglake_hive_catalog.my_hive_catalog", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:       "google_biglake_hive_catalog.my_hive_catalog",
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				ImportStateKind:    resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
+func testAccBiglakeHiveHiveCatalog_biglakeHiveCatalog_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+provider "google-beta" {
+}
+resource "google_storage_bucket" "bucket_for_my_hive_catalog" {
+  name          = "%{name}"
+  location      = "us-central1"
+  force_destroy = true
+  uniform_bucket_level_access = true
+  provider      = google-beta
+}
+
+resource "google_biglake_hive_catalog" "my_hive_catalog" {
+    name = google_storage_bucket.bucket_for_my_hive_catalog.name
+	primary_location="us-central1"
+    location_uri="gs://%{name}"
+    description="terraform test hive catalog updated"
+    depends_on = [
+      google_storage_bucket.bucket_for_my_hive_catalog
+    ]
+	provider      = google-beta
+}
+`, context)
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/biglakehive/resource_biglake_hive_catalog_test.go.tmpl
@@ -90,14 +90,14 @@ resource "google_storage_bucket" "bucket_for_my_hive_catalog" {
 }
 
 resource "google_biglake_hive_catalog" "my_hive_catalog" {
-    name = google_storage_bucket.bucket_for_my_hive_catalog.name
-	primary_location="us-central1"
-    location_uri="gs://%{name}"
-    description="terraform test hive catalog updated"
-    depends_on = [
-      google_storage_bucket.bucket_for_my_hive_catalog
-    ]
-	provider      = google-beta
+  name = google_storage_bucket.bucket_for_my_hive_catalog.name
+  primary_location = "us-central1"
+  location_uri = "gs://%{name}"
+  description = "terraform test hive catalog updated"
+  depends_on = [
+	google_storage_bucket.bucket_for_my_hive_catalog
+  ]
+  provider = google-beta
 }
 `, context)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27576

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_biglake_hive_catalog`
```