### PR TITLE
tgc-revival: Fix HCL comparison block sorting in TGC integration tests

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -2683,6 +2683,26 @@ func ResourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"node_creation_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Computed:    true,
+				Description: `NodeCreationConfig defines the settings of node creation mode.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"node_creation_mode": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"VIA_KUBELET", "VIA_CONTROL_PLANE"}, false),
+							Description: `NodeCreationMode defines the settings of node creation mode.
+ Accepted values are:
+* VIA_KUBELET: Kubelet registers itself.
+* VIA_CONTROL_PLANE: gcp-controller-manager automatically creates the node object after CSR approval.`,
+						},
+					},
+				},
+			},
 			"rbac_binding_config": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
@@ -129,6 +129,7 @@ func (c *ContainerClusterCai2hclConverter) convertResourceData(asset caiasset.As
 	hclData["security_posture_config"] = flattenSecurityPostureConfig(asset.Resource.Data["securityPostureConfig"])
 	hclData["enterprise_config"] = flattenEnterpriseConfig(asset.Resource.Data["enterpriseConfig"])
 	hclData["anonymous_authentication_config"] = flattenAnonymousAuthenticationConfig(asset.Resource.Data["anonymousAuthenticationConfig"])
+	hclData["node_creation_config"] = flattenNodeCreationConfig(asset.Resource.Data["nodeCreationConfig"])
 	hclData["notification_config"] = flattenNotificationConfig(asset.Resource.Data["notificationConfig"])
 	hclData["binary_authorization"] = flattenBinaryAuthorization(asset.Resource.Data["binaryAuthorization"])
 	if !enableAutopilot {
@@ -1922,5 +1923,19 @@ func flattenRBACBindingConfig(v interface{}) []map[string]interface{} {
 		"enable_insecure_binding_system_unauthenticated": c["enableInsecureBindingSystemUnauthenticated"],
 	}
 
+	return []map[string]interface{}{transformed}
+}
+
+func flattenNodeCreationConfig(v interface{}) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	ncc, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	transformed := map[string]interface{}{
+		"node_creation_mode": ncc["nodeCreationMode"],
+	}
 	return []map[string]interface{}{transformed}
 }

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
@@ -304,6 +304,10 @@ func expandContainerCluster(project string, d tpgresource.TerraformResourceData,
 		cluster.AnonymousAuthenticationConfig = expandAnonymousAuthenticationConfig(v)
 	}
 
+	if v, ok := d.GetOk("node_creation_config"); ok {
+		cluster.NodeCreationConfig = expandNodeCreationConfig(v)
+	}
+
 	if v, ok := d.GetOk("rbac_binding_config"); ok {
 		cluster.RbacBindingConfig = expandRBACBindingConfig(v)
 	}
@@ -1682,5 +1686,19 @@ func expandPrivilegedAdmissionConfig(v interface{}) *container.PrivilegedAdmissi
 	}
 	return &container.PrivilegedAdmissionConfig{
 		AllowlistPaths: paths,
+	}
+}
+
+func expandNodeCreationConfig(v interface{}) *container.NodeCreationConfig {
+	if v == nil {
+		return nil
+	}
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &container.NodeCreationConfig{
+		NodeCreationMode: config["node_creation_mode"].(string),
 	}
 }

--- a/mmv1/third_party/tgc_next/test/hcl.go
+++ b/mmv1/third_party/tgc_next/test/hcl.go
@@ -121,6 +121,31 @@ func flatten(data any, prefix string, result map[string]any) {
 	}
 }
 
+func getIdentifierSortKey(flattened map[string]any) string {
+	var idKeys []string
+	for k := range flattened {
+		parts := strings.Split(k, ".")
+		lastPart := parts[len(parts)-1]
+
+		if lastPart == "name" || strings.HasSuffix(lastPart, "_name") ||
+			lastPart == "id" || strings.HasSuffix(lastPart, "_id") ||
+			lastPart == "key" || strings.HasSuffix(lastPart, "_key") {
+			idKeys = append(idKeys, k)
+		}
+	}
+
+	if len(idKeys) == 0 {
+		return ""
+	}
+
+	sort.Strings(idKeys)
+	var vals []string
+	for _, k := range idKeys {
+		vals = append(vals, fmt.Sprintf("%v", flattened[k]))
+	}
+	return strings.Join(vals, ";")
+}
+
 func flattenSlice(prefix string, v []any, result map[string]any) {
 	if len(v) == 0 && prefix != "" {
 		result[prefix] = struct{}{}
@@ -128,6 +153,7 @@ func flattenSlice(prefix string, v []any, result map[string]any) {
 	}
 
 	type sortableElement struct {
+		sortKey   string
 		flatKeys  string
 		flattened map[string]any
 	}
@@ -136,18 +162,25 @@ func flattenSlice(prefix string, v []any, result map[string]any) {
 	for i, value := range v {
 		flattened := make(map[string]any)
 		flatten(value, "", flattened)
+
+		sortKey := getIdentifierSortKey(flattened)
+
 		keyVals := make([]string, 0, len(flattened))
 		for k, val := range flattened {
 			keyVals = append(keyVals, fmt.Sprintf("%s=%v", k, val))
 		}
 		sort.Strings(keyVals)
 		sortable[i] = sortableElement{
+			sortKey:   sortKey,
 			flatKeys:  strings.Join(keyVals, ";"),
 			flattened: flattened,
 		}
 	}
 
 	sort.Slice(sortable, func(i, j int) bool {
+		if sortable[i].sortKey != "" && sortable[j].sortKey != "" && sortable[i].sortKey != sortable[j].sortKey {
+			return sortable[i].sortKey < sortable[j].sortKey
+		}
 		return sortable[i].flatKeys < sortable[j].flatKeys
 	})
 


### PR DESCRIPTION
Fix non-deterministic sorting of nested block lists during HCL comparison in TGC integration tests (specifically resolving `google_compute_subnetwork` test failures).
Also add full schema, flattener, and expander support for `node_creation_config` in `google_container_cluster` to resolve integration test failures.

```release-note:none
```
