### PR TITLE
Add additional_options in mongodb_profile in google_datastream_connection_profile

### DIFF
--- a/mmv1/products/datastream/ConnectionProfile.yaml
+++ b/mmv1/products/datastream/ConnectionProfile.yaml
@@ -744,6 +744,12 @@ properties:
             immutable: true
             sensitive: true
             ignore_read: true
+      - name: additionalOptions
+        type: KeyValuePairs
+        description: |
+          A map of additional options for the MongoDB connection.
+          Keys are case-sensitive and should match the official
+          MongoDB connection string options: https://www.mongodb.com/docs/manual/reference/connection-string-options/
       - name: srvConnectionFormat
         type: NestedObject
         description: |

--- a/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
@@ -14,7 +14,6 @@ resource "google_datastream_connection_profile" "default" {
         replica_set = "myReplicaSet"
         username    = "mongoUser"
         password    = "mongoPassword"
-        database    = "myDatabase"
 
         standard_connection_format = {}
     }

--- a/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
@@ -16,5 +16,10 @@ resource "google_datastream_connection_profile" "default" {
         password    = "mongoPassword"
 
         standard_connection_format {}
+
+        additional_options = {
+          readPreference     = "secondary"
+          readPreferenceTags = "nodeType:ANALYTICS"
+        }
     }
 }

--- a/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/datastream/datastream_connection_profile_mongodb.tf.tmpl
@@ -15,6 +15,6 @@ resource "google_datastream_connection_profile" "default" {
         username    = "mongoUser"
         password    = "mongoPassword"
 
-        standard_connection_format = {}
+        standard_connection_format {}
     }
 }

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -633,6 +633,9 @@ resource "google_datastream_connection_profile" "default" {
       client_certificate           = file("text-fixtures/cert.pem")
       secret_manager_stored_client_key = google_secret_manager_secret_version.client_key_secret_version.id
     }
+	additional_options = {
+		readPreference = "secondary"
+	}
     standard_connection_format {
       direct_connection = true
     }
@@ -725,6 +728,9 @@ resource "google_datastream_connection_profile" "default" {
       client_certificate           = file("text-fixtures/cert.pem")
       secret_manager_stored_client_key = google_secret_manager_secret_version.client_key_secret_version.id
     }
+	additional_options = {
+		readPreference = "secondary"
+	}
     standard_connection_format {
       direct_connection = true
     }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR adds `additional_options` field to `google_datastream_connection_profile` resource.

This field is a map that specifies additional options for the MongoDB connection, like `readPreference`, `readPreferenceTags`, etc. Keys are case-sensitive and should match the official MongoDB connection string options: https://www.mongodb.com/docs/manual/reference/connection-string-options/



This field (`additionalOptions`) already exists in `MongodbProfile` in  Datastream API, documentation can be found here: https://docs.cloud.google.com/datastream/docs/reference/rest/v1/projects.locations.connectionProfiles#mongodbprofile

Additionally, this pull request removes a non-existent field `database` and fixes the `standard_connection_format {}` block in the `mongodb_profile` example template.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: enhancement
datastream: added `additional_options` field to `google_datastream_connection_profile` resource
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27750