### PR TITLE
`list/MMv1`: treat `steam closed` error as a `return` and not a `push(diag.result)`

### DIFF
--- a/mmv1/templates/terraform/list_resource.go.tmpl
+++ b/mmv1/templates/terraform/list_resource.go.tmpl
@@ -93,6 +93,7 @@ func (listR *{{ $.ResourceName -}}ListResource) List(ctx context.Context, listRe
 {{- end }}
 {{- end }}
 
+	errStreamClosed := errors.New("stream closed")
 	stream.Results = func(push func(list.ListResult) bool) {
 		err := List{{ $.ResourceName }}s(
 			listR.Client,
@@ -107,17 +108,19 @@ func (listR *{{ $.ResourceName -}}ListResource) List(ctx context.Context, listRe
 				}
 
 				if !push(result) {
-					return errors.New("stream closed")
+					return errStreamClosed
 				}
 				return nil
 			},
 		)
-		if err != nil {
-			diags.AddError("API Error", err.Error())
-			result := listReq.NewListResult(ctx)
-			result.Diagnostics = diags
-			push(result)
+		// A closed stream is not an error: return without pushing again.
+		if err == nil || errors.Is(err, errStreamClosed) {
+			return
 		}
+		diags.AddError("API Error", err.Error())
+		result := listReq.NewListResult(ctx)
+		result.Diagnostics = diags
+		push(result)
 	}
 }
 

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_service_account.go
@@ -64,6 +64,7 @@ func (listR *GoogleServiceAccountListResource) List(ctx context.Context, listReq
 	}
 	project := listR.GetProject(data.Project)
 
+	errServiceAccountListStreamClosed := errors.New("stream closed")
 	stream.Results = func(push func(list.ListResult) bool) {
 		err := ListServiceAccounts(listR.Client, project, func(rd *schema.ResourceData) error {
 			result := listReq.NewListResult(ctx)
@@ -73,16 +74,18 @@ func (listR *GoogleServiceAccountListResource) List(ctx context.Context, listReq
 			}
 
 			if !push(result) {
-				return errors.New("stream closed")
+				return errServiceAccountListStreamClosed
 			}
 			return nil
 		})
-		if err != nil {
-			diags.AddError("API Error", err.Error())
-			result := listReq.NewListResult(ctx)
-			result.Diagnostics = diags
-			push(result)
+		// A closed stream is not an error: return without pushing again.
+		if err == nil || errors.Is(err, errServiceAccountListStreamClosed) {
+			return
 		}
+		diags.AddError("API Error", err.Error())
+		result := listReq.NewListResult(ctx)
+		result.Diagnostics = diags
+		push(result)
 	}
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

wsa investigating the build error in this list resource PR and came to the conclusion of the following:
- https://github.com/GoogleCloudPlatform/magic-modules/pull/17878

The generated List method treated a closed stream ([push](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) returning false) as an error, then called [push](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) again from the error-handling branch — a second push on an already-terminated range-over-func, which panics.

This results in a `panic: with range function continued iteration after function for loop body` due to terraform hitting its default limit of 100 resulting in a close the result stream before the provider finishes paginating.

This was surfaced via the [ComputeHttpHealthCheck list acceptance test](https://ff2961e7dbeb7836c60078c362d3f9d547cbe85938d0992ae065215-apidata.googleusercontent.com/download/storage/v1/b/ci-vcr-logs/o/beta%2Frefs%2Fheads%2Fauto-pr-17878%2Fartifacts%2F15d5822d-4527-4259-8abe-bc0800f8f0d7%2Fbuild-log%2Frecording_test.log?jk=ARss-vYvsXSlWz0kGyNvFN7ddZ352ybRPAtJZhpcZFwVz-YGppMmqce8kqFUvK-s0XaeVfMj_sIISP2Ru46n49IzNyqewohjM0jst2CmHQNBsBknYsoLVacDbyz-OQ-trofkjn4a6wcmF2jInn3S-g7VsJ-cG792arSp2uLn1w9f7K9Hje90soHSt3iaSUhmUOhXOUoU-F-kerx3fokWbgCbi8LKR-u8aupEX7f38GrLKylknwQuPrshbWvEyHvbq30E1Pily0U08Dtag4MzlLUNW9e5FbnqXxYc-P9eh7fc5i_L6H_2mZe4ssJ78YR-Y66lo7N0Wu90nHDk9dgu94C6F28g7oXChVRBtvfesjG-qfMBSwXuehCaCFiwIYZo4eu-IVPa5nChJKJVmDftLfyu6wCoK50HGYhGScUsZ8BFvWQkekiwemV3D1IluOnI2R9bsTMR7UoXJkaYJ4BXBmLm7h2-n4dZSBWeej0tC7xp2UD4rrj4wJyhX-K1Zx4QRyCXOxbH4uQIwkkWY5T89NTltsqUIjGOx-C6-bJ7ytMaqh2eh5kScBNNosqIS3hP29erc1huo6KxinQGKSk-0mFjfst6hvW6pWW8el_bENpDy1APn1QnpsAZP2tdC6pncAyBP_zJMEvQ8ovw9HwGJK3ojdK2Cdt0vXSPlw2jFzlbgkwlThC8CAFOsi-P0sVr4rUsjqxIJC5HruynDBZQEjFbBIh-ubK8vOkpH-NYbbuN3vAO55XTOkqBsJIFrM5VK_rLQqWfJeygwfvr1UklakOi2qKoNcW7XIZfT92HA9UC4ZwMOwC-yxh0KV7RN0OmCstFXDanUxIeGJCiCu84uWIxtPwCqlnqS_0kziOL49wg6WnnGo6r2LGWHljBekTpw-hfko7TMVMxHP17Cv1z6PDuEMPgQiYphB0w2sCQa88wCEg2_7rM4MxvcxACRb5qM6mgpF5isqqKlp_iubkDdakl0X_bahqvt228pZ0YnbqVftFnevFv3Kgys_WJY-ZkWXOJ7i4E0cK0TfpNX3PtR55LdkUPtD3q9-6o6i7pdu15Y0l13rgiEOX_e72k2LdHNsTjCHhdsY_SoPEao9qke3yelvutUK4ih0i2kHvpSR3Ii_-p1cXvxNhKvZFJZKFXYzMpGBZq6nbKeiM3u-nU7Rqvs_JjGWokLldhDsAcEhSozAeFb6RvZFvVdt3ItPaYmWBybsLM-oMlSZFHAM1UaT0saMpPYMNUsH34RFs8xkXcQlo4qvj6gO4ARFxNz9oNEfx4uUWKcOBiSZK4bpMKx3dOMDQe01xpPQGwHy4cRFTl8V3btW4KSw1CEGDH3F38pTOlMm9utoA&isca=1#:~:text=panic%3A%20runtime%20error%3A%20range%20function%20continued%20iteration%20after%20function%20for%20loop%20body%20returned%20false), since it lists project-wide and the shared test project holds >100 instances, but it effectively touches all generated list-resources.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
