### PR TITLE
feat: Add sort_order support to BigLake Iceberg Table

### DIFF
--- a/mmv1/products/biglakeiceberg/IcebergTable.yaml
+++ b/mmv1/products/biglakeiceberg/IcebergTable.yaml
@@ -39,6 +39,7 @@ import_format:
   - '{{catalog}}/{{namespace}}/{{name}}'
 supports_indirect_user_project_override: true
 custom_code:
+  encoder: templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
   update_encoder: templates/terraform/encoders/biglake_iceberg_table.go.tmpl
   constants: templates/terraform/constants/biglake_iceberg_table.go.tmpl
   post_read: templates/terraform/post_read/biglake_iceberg_table.go.tmpl
@@ -185,6 +186,47 @@ properties:
               required: true
               description: |
                 The transform to apply to the source field.
+  - name: sort_order
+    api_name: write-order
+    type: NestedObject
+    default_from_api: true
+    description: |
+      The sort order of the table.
+    properties:
+      - name: order_id
+        api_name: order-id
+        type: Integer
+        output: true
+        description: |
+          The unique identifier of the sort order.
+      - name: fields
+        type: Array
+        required: true
+        item_type:
+          type: NestedObject
+          properties:
+            - name: source_id
+              api_name: source-id
+              type: Integer
+              required: true
+              description: |
+                The source field ID for the sort field.
+            - name: transform
+              type: String
+              required: true
+              description: |
+                The transform to apply to the source field.
+            - name: direction
+              type: String
+              required: true
+              description: |
+                The sort direction for the sort field. Possible values: "asc", "desc".
+            - name: null_order
+              api_name: null-order
+              type: String
+              required: true
+              description: |
+                The null ordering for the sort field. Possible values: "nulls-first", "nulls-last".
   - name: properties
     type: KeyValuePairs
     description: |

--- a/mmv1/products/biglakeiceberg/IcebergTable.yaml
+++ b/mmv1/products/biglakeiceberg/IcebergTable.yaml
@@ -52,6 +52,14 @@ samples:
           bucket_name: my-bucket
           namespace_id: my_namespace
           table_name: my_table
+  - name: biglake_iceberg_table_sort_order
+    primary_resource_id: my_iceberg_table
+    steps:
+      - name: biglake_iceberg_table_sort_order
+        resource_id_vars:
+          bucket_name: my-bucket
+          namespace_id: my_namespace
+          table_name: my_table
   - name: biglake_iceberg_table_update
     primary_resource_id: my_iceberg_table
     skip_test: true
@@ -186,14 +194,23 @@ properties:
               required: true
               description: |
                 The transform to apply to the source field.
-  - name: sort_order
+  # The Iceberg REST Catalog API uses three different names for one concept:
+  # the create request body field is "write-order" (hence api_name), the read
+  # response returns "sort-orders" + "default-sort-order-id" (bridged in
+  # post_read), and updates use "add-sort-order"/"set-default-sort-order" commit
+  # actions. The user-facing field stays "sort_order" to match the read shape and
+  # to mirror the existing "partition_spec" field. default_from_api is set
+  # because the API always returns a sort order (order-id 0, the unsorted order)
+  # even when none is configured, which would otherwise diff against an empty
+  # config.
+  - name: sortOrder
     api_name: write-order
     type: NestedObject
     default_from_api: true
     description: |
       The sort order of the table.
     properties:
-      - name: order_id
+      - name: orderId
         api_name: order-id
         type: Integer
         output: true
@@ -205,7 +222,7 @@ properties:
         item_type:
           type: NestedObject
           properties:
-            - name: source_id
+            - name: sourceId
               api_name: source-id
               type: Integer
               required: true
@@ -221,7 +238,7 @@ properties:
               required: true
               description: |
                 The sort direction for the sort field. Possible values: "asc", "desc".
-            - name: null_order
+            - name: nullOrder
               api_name: null-order
               type: String
               required: true

--- a/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
+++ b/mmv1/templates/terraform/constants/biglake_iceberg_table.go.tmpl
@@ -13,3 +13,41 @@ func icebergTablePropertiesDiffSuppress(k, old, new string, d *schema.ResourceDa
 	}
 	return false
 }
+
+// expandIcebergTableSortOrderForCommit converts the Terraform "sort_order" block
+// into the SortOrder body of an "add-sort-order" commit update. The "order-id" is
+// assigned by the server, so only the fields are sent. Returns nil when no sort
+// order is configured.
+func expandIcebergTableSortOrderForCommit(v interface{}) map[string]interface{} {
+	l, ok := v.([]interface{})
+	if !ok || len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	raw, ok := l[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	rawFields, ok := raw["fields"].([]interface{})
+	if !ok || len(rawFields) == 0 {
+		return nil
+	}
+	fields := make([]interface{}, 0, len(rawFields))
+	for _, f := range rawFields {
+		fm, ok := f.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fields = append(fields, map[string]interface{}{
+			"source-id":  fm["source_id"],
+			"transform":  fm["transform"],
+			"direction":  fm["direction"],
+			"null-order": fm["null_order"],
+		})
+	}
+	return map[string]interface{}{
+		// order-id is required on the SortOrder body; the server reassigns it,
+		// and "set-default-sort-order: -1" then selects this last-added order.
+		"order-id": 1,
+		"fields":   fields,
+	}
+}

--- a/mmv1/templates/terraform/encoders/biglake_iceberg_table.go.tmpl
+++ b/mmv1/templates/terraform/encoders/biglake_iceberg_table.go.tmpl
@@ -1,3 +1,6 @@
+	// Accumulate the metadata update actions of a CommitTableRequest.
+	updateActions := []interface{}{}
+
 	if d.HasChange("properties") {
 		oldProp, newProp := d.GetChange("properties")
 		oldMap := oldProp.(map[string]interface{})
@@ -21,19 +24,40 @@
 			updates[k] = v.(string)
 		}
 
+		updateActions = append(updateActions,
+			map[string]interface{}{
+				"action":  "set-properties",
+				"updates": updates,
+			},
+			map[string]interface{}{
+				"action":   "remove-properties",
+				"removals": removals,
+			},
+		)
+	}
+
+	if d.HasChange("sort_order") {
+		if sortOrder := expandIcebergTableSortOrderForCommit(d.Get("sort_order")); sortOrder != nil {
+			// Add the new sort order, then make it the table's default. The
+			// server assigns the new order id, so "-1" selects the last added.
+			updateActions = append(updateActions,
+				map[string]interface{}{
+					"action":     "add-sort-order",
+					"sort-order": sortOrder,
+				},
+				map[string]interface{}{
+					"action":        "set-default-sort-order",
+					"sort-order-id": -1,
+				},
+			)
+		}
+	}
+
+	if len(updateActions) > 0 {
 		// Wrap in 'updates' and 'requirements' as per CommitTableRequest
 		return map[string]interface{}{
 			"requirements": []interface{}{},
-			"updates": []interface{}{
-				map[string]interface{}{
-					"action":  "set-properties",
-					"updates": updates,
-				},
-				map[string]interface{}{
-					"action":   "remove-properties",
-					"removals": removals,
-				},
-			},
+			"updates":      updateActions,
 		}, nil
 	}
 	return nil, nil

--- a/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
+++ b/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
@@ -1,7 +1,8 @@
-	// The Iceberg SortOrder sent as "write-order" requires an "order-id". It is
-	// server-assigned on read (and reassigned if needed), but the create request
-	// is rejected without it. Inject the initial sort order id (1; 0 is reserved
-	// for the unsorted order) when the user configured a sort order.
+	// The Iceberg SortOrder sent as "write-order" requires an "order-id", and the
+	// create request is rejected without it. order_id is not user-settable (it is
+	// output-only in the schema): a table created with a sort order always gets
+	// id 1, since id 0 is reserved for the unsorted order. So we inject 1 here
+	// rather than asking the user for it.
 	if wo, ok := obj["write-order"].(map[string]interface{}); ok {
 		if _, hasId := wo["order-id"]; !hasId {
 			wo["order-id"] = 1

--- a/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
+++ b/mmv1/templates/terraform/encoders/biglake_iceberg_table_create.go.tmpl
@@ -1,0 +1,10 @@
+	// The Iceberg SortOrder sent as "write-order" requires an "order-id". It is
+	// server-assigned on read (and reassigned if needed), but the create request
+	// is rejected without it. Inject the initial sort order id (1; 0 is reserved
+	// for the unsorted order) when the user configured a sort order.
+	if wo, ok := obj["write-order"].(map[string]interface{}); ok {
+		if _, hasId := wo["order-id"]; !hasId {
+			wo["order-id"] = 1
+		}
+	}
+	return obj, nil

--- a/mmv1/templates/terraform/post_read/biglake_iceberg_table.go.tmpl
+++ b/mmv1/templates/terraform/post_read/biglake_iceberg_table.go.tmpl
@@ -78,6 +78,48 @@ if metadata, ok := res["metadata"].(map[string]interface{}); ok {
 		}
 	}
 
+	// Same for sort order. The create request sends "write-order", but the
+	// table metadata returns the list of "sort-orders" plus the id of the
+	// current one in "default-sort-order-id".
+	if sortOrders, ok := metadata["sort-orders"].([]interface{}); ok {
+		defaultSortOrderId := -1
+		if id, ok := metadata["default-sort-order-id"]; ok {
+			switch v := id.(type) {
+			case json.Number:
+				id64, _ := v.Int64()
+				defaultSortOrderId = int(id64)
+			case float64:
+				defaultSortOrderId = int(v)
+			case int:
+				defaultSortOrderId = v
+			}
+		}
+
+		for _, s := range sortOrders {
+			if sm, ok := s.(map[string]interface{}); ok {
+				sid := -1
+				if id, ok := sm["order-id"]; ok {
+					switch v := id.(type) {
+					case json.Number:
+						id64, _ := v.Int64()
+						sid = int(id64)
+					case float64:
+						sid = int(v)
+					case int:
+						sid = v
+					}
+				}
+				if sid == defaultSortOrderId {
+					res["write-order"] = sm
+					break
+				}
+			}
+		}
+		if _, ok := res["write-order"]; !ok && len(sortOrders) > 0 {
+			res["write-order"] = sortOrders[0]
+		}
+	}
+
 	res["location"] = metadata["location"]
 	res["properties"] = metadata["properties"]
 }

--- a/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_table_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_table_basic.tf.tmpl
@@ -44,4 +44,12 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       transform = "identity"
     }
   }
+  sort_order {
+    fields {
+      source_id  = 1
+      transform  = "identity"
+      direction  = "asc"
+      null_order = "nulls-first"
+    }
+  }
 }

--- a/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_table_sort_order.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_table_sort_order.tf.tmpl
@@ -19,7 +19,6 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
   catalog   = google_biglake_iceberg_catalog.catalog.name
   namespace = google_biglake_iceberg_namespace.namespace.namespace_id
   name      = "{{index $.ResourceIdVars "table_name"}}"
-  location  = "gs://${google_storage_bucket.bucket.name}/${google_biglake_iceberg_namespace.namespace.namespace_id}/{{index $.ResourceIdVars "table_name"}}"
   schema {
     type = "struct"
     fields {
@@ -27,21 +26,14 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       name     = "id"
       type     = "long"
       required = true
-      doc      = "The ID of the record"
     }
-    fields {
-      id       = 2
-      name     = "name"
-      type     = "string"
-      required = false
-    }
-    identifier_field_ids = [1]
   }
-  partition_spec {
+  sort_order {
     fields {
-      name      = "id_partition"
-      source_id = 1
-      transform = "identity"
+      source_id  = 1
+      transform  = "identity"
+      direction  = "asc"
+      null_order = "nulls-first"
     }
   }
 }

--- a/mmv1/third_party/terraform/services/biglakeiceberg/resource_biglake_iceberg_table_test.go
+++ b/mmv1/third_party/terraform/services/biglakeiceberg/resource_biglake_iceberg_table_test.go
@@ -81,6 +81,12 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       type     = "long"
       required = true
     }
+    fields {
+      id       = 2
+      name     = "data"
+      type     = "long"
+      required = true
+    }
   }
   sort_order {
     fields {
@@ -129,11 +135,17 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       type     = "long"
       required = true
     }
+    fields {
+      id       = 2
+      name     = "data"
+      type     = "long"
+      required = true
+    }
   }
   sort_order {
     fields {
-      source_id  = 1
-      transform  = "identity"
+      source_id  = 2
+      transform  = "bucket[4]"
       direction  = "desc"
       null_order = "nulls-last"
     }

--- a/mmv1/third_party/terraform/services/biglakeiceberg/resource_biglake_iceberg_table_test.go
+++ b/mmv1/third_party/terraform/services/biglakeiceberg/resource_biglake_iceberg_table_test.go
@@ -82,6 +82,14 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       required = true
     }
   }
+  sort_order {
+    fields {
+      source_id  = 1
+      transform  = "identity"
+      direction  = "asc"
+      null_order = "nulls-first"
+    }
+  }
 
   properties = {
     key = "initial"
@@ -120,6 +128,14 @@ resource "google_biglake_iceberg_table" "my_iceberg_table" {
       name     = "id"
       type     = "long"
       required = true
+    }
+  }
+  sort_order {
+    fields {
+      source_id  = 1
+      transform  = "identity"
+      direction  = "desc"
+      null_order = "nulls-last"
     }
   }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Another weird Iceberg PR! We don't control the shape of the Table API, so we have to do weird things to make it work with Magic Modules. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
biglakeiceberg: added `sort_order` field to `google_biglake_iceberg_table` resource
```
