### PR TITLE
fix(securityscanner): resolve IP propagation delay in ScanConfig test

### DIFF
--- a/mmv1/products/securityscanner/ScanConfig.yaml
+++ b/mmv1/products/securityscanner/ScanConfig.yaml
@@ -39,6 +39,7 @@ examples:
   - name: scan_config_ignore_http_status_errors
     primary_resource_id: scan-config
     min_version: beta
+    external_providers: ["time"]
     vars:
       address_name: scan-ignore-http-ip
       scan_config_name: terraform-scan-config

--- a/mmv1/templates/terraform/examples/scan_config_ignore_http_status_errors.tf.tmpl
+++ b/mmv1/templates/terraform/examples/scan_config_ignore_http_status_errors.tf.tmpl
@@ -3,10 +3,16 @@ resource "google_compute_address" "scanner_static_ip" {
   name     = "{{index $.Vars "address_name"}}"
 }
 
+resource "time_sleep" "wait_15_seconds" {
+  create_duration = "15s"
+  depends_on      = [google_compute_address.scanner_static_ip]
+}
+
 resource "google_security_scanner_scan_config" "{{$.PrimaryResourceId}}" {
   provider                  = google-beta
   display_name              = "{{index $.Vars "scan_config_name"}}"
   starting_urls             = ["http://${google_compute_address.scanner_static_ip.address}"]
   target_platforms          = ["COMPUTE"]
   ignore_http_status_errors = true
+  depends_on                = [time_sleep.wait_15_seconds]
 }


### PR DESCRIPTION
Add a 15-second `time_sleep` delay resource between the static IP address reservation and the ScanConfig creation in the `scan_config_ignore_http_status_errors` example.

This allows the newly reserved IP address to propagate through before the Web Security Scanner checks it, resolving the `SEED_URL_HAS_UNRESERVED_IP_ADDRESS` errors observed in the nightly CI test runs.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27749

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
