### PR TITLE
tgc-revival: Support ResourceName override in HCL block name generation

### DIFF
--- a/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
@@ -93,7 +93,7 @@ func (c *{{ $.ResourceName -}}Cai2hclConverter) Convert(assets []caiasset.Asset,
 	}
 
 	var blocks []*models.TerraformResourceBlock
-	block, err := c.convertResourceData(assets[0])
+	block, err := c.convertResourceData(assets[0], options)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *{{ $.ResourceName -}}Cai2hclConverter) Convert(assets []caiasset.Asset,
 	return blocks, nil
 }
 
-func (c *{{ $.ResourceName -}}Cai2hclConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+func (c *{{ $.ResourceName -}}Cai2hclConverter) convertResourceData(asset caiasset.Asset, options *models.ResourceConverterOptions) (*models.TerraformResourceBlock, error) {
 	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
@@ -119,14 +119,19 @@ func (c *{{ $.ResourceName -}}Cai2hclConverter) convertResourceData(asset caiass
 
 	assetNameParts := strings.Split(asset.Name, "/")
 
-	hclBlockName := assetNameParts[len(assetNameParts)-1]
-	digitRegex := regexp.MustCompile(`^\d+$`)
-	nameValidator := regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_-]*$")
-	if digitRegex.MatchString(hclBlockName) || !nameValidator.MatchString(hclBlockName) {
-		hasher := sha256.New()
-		hasher.Write([]byte(hclBlockName))
-		fullHash := hex.EncodeToString(hasher.Sum(nil))
-		hclBlockName = fmt.Sprintf("resource%s", fullHash[:8])
+	var hclBlockName string
+	if options != nil && options.ResourceName != "" {
+		hclBlockName = options.ResourceName
+	} else {
+		hclBlockName = assetNameParts[len(assetNameParts)-1]
+		digitRegex := regexp.MustCompile(`^\d+$`)
+		nameValidator := regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_-]*$")
+		if digitRegex.MatchString(hclBlockName) || !nameValidator.MatchString(hclBlockName) {
+			hasher := sha256.New()
+			hasher.Write([]byte(hclBlockName))
+			fullHash := hex.EncodeToString(hasher.Sum(nil))
+			hclBlockName = fmt.Sprintf("resource%s", fullHash[:8])
+		}
 	}
 	hclData := make(map[string]interface{})
 

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
@@ -11,8 +11,8 @@ import (
 func TestConvertWithResourceName(t *testing.T) {
 	assets := []caiasset.Asset{
 		{
-			Name:      "//cloudresourcemanager.googleapis.com/projects/example-project",
-			Type:      "cloudresourcemanager.googleapis.com/Project",
+			Name: "//cloudresourcemanager.googleapis.com/projects/example-project",
+			Type: "cloudresourcemanager.googleapis.com/Project",
 			Resource: &caiasset.AssetResource{
 				Version:              "v1",
 				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
@@ -1,0 +1,45 @@
+package cai2hcl
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/cai2hcl/converters"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/cai2hcl/models"
+	"github.com/GoogleCloudPlatform/terraform-google-conversion/v7/pkg/caiasset"
+)
+
+func TestConvertWithResourceName(t *testing.T) {
+	assets := []caiasset.Asset{
+		{
+			Name:      "//cloudresourcemanager.googleapis.com/projects/example-project",
+			Type:      "cloudresourcemanager.googleapis.com/Project",
+			Resource: &caiasset.AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+				DiscoveryName:        "Project",
+				Parent:               "//cloudresourcemanager.googleapis.com/folders/456",
+				Data: map[string]interface{}{
+					"name":      "My Project",
+					"projectId": "example-project",
+				},
+			},
+		},
+	}
+
+	got, err := converters.ConvertResource(assets, &models.ResourceConverterOptions{
+		ResourceName: "custom_project_name",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `resource "google_project" "custom_project_name" {
+  folder_id  = "456"
+  name       = "My Project"
+  project_id = "example-project"
+}
+`
+	if string(got) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(got))
+	}
+}

--- a/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
+++ b/mmv1/third_party/tgc_next/pkg/cai2hcl/convert_test.go
@@ -43,3 +43,37 @@ func TestConvertWithResourceName(t *testing.T) {
 		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(got))
 	}
 }
+
+func TestConvertWithoutResourceName(t *testing.T) {
+	assets := []caiasset.Asset{
+		{
+			Name: "//cloudresourcemanager.googleapis.com/projects/example-project",
+			Type: "cloudresourcemanager.googleapis.com/Project",
+			Resource: &caiasset.AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+				DiscoveryName:        "Project",
+				Parent:               "//cloudresourcemanager.googleapis.com/folders/456",
+				Data: map[string]interface{}{
+					"name":      "My Project",
+					"projectId": "example-project",
+				},
+			},
+		},
+	}
+
+	got, err := converters.ConvertResource(assets, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `resource "google_project" "example-project" {
+  folder_id  = "456"
+  name       = "My Project"
+  project_id = "example-project"
+}
+`
+	if string(got) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(got))
+	}
+}

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_cai2hcl.go
@@ -40,7 +40,7 @@ func (c *ComputeInstanceCai2hclConverter) Convert(assets []caiasset.Asset, optio
 	}
 
 	var blocks []*models.TerraformResourceBlock
-	block, err := c.convertResourceData(assets[0])
+	block, err := c.convertResourceData(assets[0], options)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (c *ComputeInstanceCai2hclConverter) Convert(assets []caiasset.Asset, optio
 	return blocks, nil
 }
 
-func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Asset, options *models.ResourceConverterOptions) (*models.TerraformResourceBlock, error) {
 	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
@@ -126,8 +126,14 @@ func (c *ComputeInstanceCai2hclConverter) convertResourceData(asset caiasset.Ass
 	if err != nil {
 		return nil, err
 	}
+	var hclBlockName string
+	if options != nil && options.ResourceName != "" {
+		hclBlockName = options.ResourceName
+	} else {
+		hclBlockName = instanceName
+	}
 	return &models.TerraformResourceBlock{
-		Labels: []string{c.name, instanceName},
+		Labels: []string{c.name, hclBlockName},
 		Value:  ctyVal,
 	}, nil
 }

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
@@ -32,7 +32,7 @@ func (c *ContainerClusterCai2hclConverter) Convert(assets []caiasset.Asset, opti
 	}
 
 	var blocks []*models.TerraformResourceBlock
-	block, err := c.convertResourceData(assets[0])
+	block, err := c.convertResourceData(assets[0], options)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (c *ContainerClusterCai2hclConverter) Convert(assets []caiasset.Asset, opti
 	return blocks, nil
 }
 
-func (c *ContainerClusterCai2hclConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+func (c *ContainerClusterCai2hclConverter) convertResourceData(asset caiasset.Asset, options *models.ResourceConverterOptions) (*models.TerraformResourceBlock, error) {
 	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
@@ -233,8 +233,14 @@ func (c *ContainerClusterCai2hclConverter) convertResourceData(asset caiasset.As
 	}
 	// name is likely string, safe cast or fallback
 	name, _ := asset.Resource.Data["name"].(string)
+	var hclBlockName string
+	if options != nil && options.ResourceName != "" {
+		hclBlockName = options.ResourceName
+	} else {
+		hclBlockName = name
+	}
 	return &models.TerraformResourceBlock{
-		Labels: []string{c.name, name},
+		Labels: []string{c.name, hclBlockName},
 		Value:  ctyVal,
 	}, nil
 }

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_node_pool_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_node_pool_cai2hcl.go
@@ -34,7 +34,7 @@ func (c *ContainerNodePoolCai2hclConverter) Convert(assets []caiasset.Asset, opt
 	}
 
 	var blocks []*models.TerraformResourceBlock
-	block, err := c.convertResourceData(assets[0])
+	block, err := c.convertResourceData(assets[0], options)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (c *ContainerNodePoolCai2hclConverter) Convert(assets []caiasset.Asset, opt
 	return blocks, nil
 }
 
-func (c *ContainerNodePoolCai2hclConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+func (c *ContainerNodePoolCai2hclConverter) convertResourceData(asset caiasset.Asset, options *models.ResourceConverterOptions) (*models.TerraformResourceBlock, error) {
 	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
@@ -75,8 +75,14 @@ func (c *ContainerNodePoolCai2hclConverter) convertResourceData(asset caiasset.A
 	if err != nil {
 		return nil, err
 	}
+	var hclBlockName string
+	if options != nil && options.ResourceName != "" {
+		hclBlockName = options.ResourceName
+	} else {
+		hclBlockName = asset.Resource.Data["name"].(string)
+	}
 	return &models.TerraformResourceBlock{
-		Labels: []string{c.name, asset.Resource.Data["name"].(string)},
+		Labels: []string{c.name, hclBlockName},
 		Value:  ctyVal,
 	}, nil
 }

--- a/mmv1/third_party/tgc_next/pkg/services/resourcemanager/project_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/resourcemanager/project_cai2hcl.go
@@ -35,7 +35,7 @@ func (c *ProjectCai2hclConverter) Convert(assets []caiasset.Asset, options *mode
 	}
 
 	var blocks []*models.TerraformResourceBlock
-	block, err := c.convertResourceData(assets[0])
+	block, err := c.convertResourceData(assets[0], options)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (c *ProjectCai2hclConverter) Convert(assets []caiasset.Asset, options *mode
 	return blocks, nil
 }
 
-func (c *ProjectCai2hclConverter) convertResourceData(asset caiasset.Asset) (*models.TerraformResourceBlock, error) {
+func (c *ProjectCai2hclConverter) convertResourceData(asset caiasset.Asset, options *models.ResourceConverterOptions) (*models.TerraformResourceBlock, error) {
 	if asset.Resource == nil || asset.Resource.Data == nil {
 		return nil, fmt.Errorf("asset resource data is nil")
 	}
@@ -64,8 +64,14 @@ func (c *ProjectCai2hclConverter) convertResourceData(asset caiasset.Asset) (*mo
 	if err != nil {
 		return nil, err
 	}
+	var hclBlockName string
+	if options != nil && options.ResourceName != "" {
+		hclBlockName = options.ResourceName
+	} else {
+		hclBlockName = assetResourceData["projectId"].(string)
+	}
 	return &models.TerraformResourceBlock{
-		Labels: []string{c.name, assetResourceData["projectId"].(string)},
+		Labels: []string{c.name, hclBlockName},
 		Value:  ctyVal,
 	}, nil
 }


### PR DESCRIPTION
Support custom ResourceName override in HCL block name generation for tgc_next conversion pipeline.

```release-note:none
```