### PR TITLE
test(magician): add behaviour-driven sandbox framework for testing 

### DIFF
--- a/.ci/magician/cmd/sandbox_sanity_test.go
+++ b/.ci/magician/cmd/sandbox_sanity_test.go
@@ -1,0 +1,39 @@
+/*
+* Copyright 2026 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSandboxInitialization(t *testing.T) {
+	sb := newSandbox(t)
+
+	if _, err := os.Stat(sb.Dir); os.IsNotExist(err) {
+		t.Fatalf("Sandbox directory %s does not exist", sb.Dir)
+	}
+
+	output, err := sb.Runner.Run("git", []string{"status"}, nil)
+	if err != nil {
+		t.Fatalf("Sandbox is not a valid git repository: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "On branch main") {
+		t.Errorf("Expected 'On branch main' in git status output, got: %s", output)
+	}
+}

--- a/.ci/magician/cmd/sandbox_test.go
+++ b/.ci/magician/cmd/sandbox_test.go
@@ -1,0 +1,54 @@
+/*
+* Copyright 2026 Google LLC. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package cmd
+
+import (
+	"testing"
+
+	"magician/exec"
+)
+
+type sandbox struct {
+	Dir    string
+	Runner ExecRunner
+}
+
+func newSandbox(t *testing.T) *sandbox {
+	dir := t.TempDir()
+
+	runner, err := exec.NewRunner()
+	if err != nil {
+		t.Fatalf("Failed to create runner: %v", err)
+	}
+
+	if err := runner.PushDir(dir); err != nil {
+		t.Fatalf("Failed to push dir: %v", err)
+	}
+
+	runner.MustRun("git", []string{"init", "-b", "main"}, nil)
+
+	runner.MustRun("touch", []string{"README.md"}, nil)
+	runner.MustRun("git", []string{"add", "."}, nil)
+	runner.MustRun("git", []string{"config", "user.email", "test@example.com"}, nil)
+	runner.MustRun("git", []string{"config", "user.name", "Test Sandbox"}, nil)
+	runner.MustRun("git", []string{"config", "commit.gpgsign", "false"}, nil)
+	runner.MustRun("git", []string{"commit", "-m", "Initial sandbox commit"}, nil)
+
+	return &sandbox{
+		Dir:    dir,
+		Runner: runner,
+	}
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Adds a temporary Sandbox testing environment in `.ci/magician/cmd` for testing CLI commands.

This framework sets up a real, temporary Git repository for our tests to run in. This will allow us to migrate our existing tests away from hardcoded command mocks, so they can verify actual repository state instead.

```release-note:none

```
