### PR TITLE
Remove launchStage from readiness_probe examples

### DIFF
--- a/mmv1/templates/terraform/examples/cloudrunv2_service_readiness_probes.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudrunv2_service_readiness_probes.tf.tmpl
@@ -2,7 +2,6 @@ resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "cloud_run_service_name"}}"
   location = "us-central1"
   deletion_protection = false
-  launch_stage = "BETA"
 
   template {
     containers {

--- a/mmv1/templates/terraform/samples/services/cloudrun/cloud_run_service_readiness_probe.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrun/cloud_run_service_readiness_probe.tf.tmpl
@@ -2,12 +2,6 @@ resource "google_cloud_run_service" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
   location = "us-central1"
 
-  metadata {
-    annotations = {
-      "run.googleapis.com/launch-stage" = "BETA"
-    }
-  }
-
   template {
     spec {
       containers {


### PR DESCRIPTION
`readiness_probe` was accidentally created in both `google` and `google-beta`. The feature is now GA, so we're just updating the examples to remove the launchStage.

```release-note:none
```
