### PR TITLE
test(magician): refactor delete-branches to use testing sandbox

### DIFF
--- a/.ci/magician/cmd/delete_branches_test.go
+++ b/.ci/magician/cmd/delete_branches_test.go
@@ -6,6 +6,7 @@ import (
 
 func TestFetchPRNumber(t *testing.T) {
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 	gh := &mockGithub{
 		calledMethods: make(map[string][][]any),
 		commitMessage: "Add `additional_group_keys` attribute to `google_cloud_identity_group` resource (#9217) (#6504)\n\n* Add `additional_group_keys` attribute to `google_cloud_identity_group` resource\n\n* Update acceptance test to check for attribute\n\n* Fix test check\n\n* Add `output: true` to nested properties in output field\n[upstream:49d3741f9d4d810a0a4768363bb8498afa21c688]\n\nSigned-off-by: Modular Magician <magic-modules@google.com>",

--- a/.ci/magician/cmd/delete_branches_test.go
+++ b/.ci/magician/cmd/delete_branches_test.go
@@ -5,14 +5,13 @@ import (
 )
 
 func TestFetchPRNumber(t *testing.T) {
-	mr := NewMockRunner()
+	sb := newSandbox(t)
 	gh := &mockGithub{
 		calledMethods: make(map[string][][]any),
 		commitMessage: "Add `additional_group_keys` attribute to `google_cloud_identity_group` resource (#9217) (#6504)\n\n* Add `additional_group_keys` attribute to `google_cloud_identity_group` resource\n\n* Update acceptance test to check for attribute\n\n* Fix test check\n\n* Add `output: true` to nested properties in output field\n[upstream:49d3741f9d4d810a0a4768363bb8498afa21c688]\n\nSigned-off-by: Modular Magician <magic-modules@google.com>",
 	}
 
-	// Call function with mocks
-	prNumber, err := fetchPRNumber("8c6e61bb62d52c950008340deafc1e2a2041898a", "main", mr, gh)
+	prNumber, err := fetchPRNumber("8c6e61bb62d52c950008340deafc1e2a2041898a", "main", sb.Runner, gh)
 	if err != nil {
 		t.Errorf("error fetching PR number: %s", err)
 	}


### PR DESCRIPTION
Replace all instances of `mockRunner` with the sandbox and `sb.Runner`.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none

```
