### PR TITLE
Deprecate protocols field in google_network_services_agent_gateway

### DIFF
--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -111,7 +111,7 @@ properties:
       type: Enum
       enum_values:
         - 'MCP'
-    required: true
+    deprecation_message: '`protocols` is deprecated and will be removed in a future major release.'
   - name: 'googleManaged'
     immutable: true
     exactly_one_of:

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_client_to_agent.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_client_to_agent.tf.tmpl
@@ -2,8 +2,6 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
   name     = "{{index $.Vars "name"}}"
   location = "us-central1"
 
-  protocols = ["MCP"]
-
   google_managed {
     governed_access_path = "CLIENT_TO_AGENT"
   }

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
@@ -7,6 +7,7 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
     tier = "gold"
   }
 
+  protocols = ["MCP"]
   google_managed {
     governed_access_path = "AGENT_TO_ANYWHERE"
   }

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_full.tf.tmpl
@@ -7,7 +7,6 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
     tier = "gold"
   }
 
-  protocols = ["MCP"]
   google_managed {
     governed_access_path = "AGENT_TO_ANYWHERE"
   }

--- a/mmv1/templates/terraform/examples/network_services_agent_gateway_self_managed.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_agent_gateway_self_managed.tf.tmpl
@@ -2,8 +2,6 @@ resource "google_network_services_agent_gateway" "{{$.PrimaryResourceId}}" {
   name = "{{index $.Vars "name"}}"
   location = "us-central1"
 
-  protocols = ["MCP"]
-
   self_managed {
     resource_uri = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1/gateways/my-gateway"
   }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go.tmpl
@@ -88,6 +88,7 @@ resource "google_network_services_agent_gateway" "default" {
     tier = "silver"
   }
 
+  protocols = ["MCP"]
   google_managed {
     governed_access_path = "AGENT_TO_ANYWHERE"
   }

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_agent_gateway_test.go.tmpl
@@ -88,7 +88,6 @@ resource "google_network_services_agent_gateway" "default" {
     tier = "silver"
   }
 
-  protocols = []
   google_managed {
     governed_access_path = "AGENT_TO_ANYWHERE"
   }


### PR DESCRIPTION
This field is being deprecated in the API and will be removed in a future major release. This change marks the field as deprecated in Magic Modules and removes its usage from examples and tests.


```release-note:deprecation
networkservices: deprecated `protocols` on `google_network_services_agent_gateway`
```