### PR TITLE
[Cloudbuildv2] Update GleConnection test to use new GLE server

### DIFF
--- a/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
+++ b/mmv1/third_party/terraform/services/cloudbuildv2/resource_cloudbuildv2_connection_test.go
@@ -660,15 +660,15 @@ resource "google_cloudbuildv2_connection" "primary" {
 
   gitlab_config {
     authorizer_credential {
-      user_token_secret_version = "projects/407304063574/secrets/gle-old-api-token/versions/2"
+      user_token_secret_version = "projects/407304063574/secrets/gle-asia-api-token/versions/latest"
     }
 
     read_authorizer_credential {
-      user_token_secret_version = "projects/407304063574/secrets/gle-old-read-token/versions/3"
+      user_token_secret_version = "projects/407304063574/secrets/gle-asia-read-token/versions/latest"
     }
 
     webhook_secret_secret_version = "projects/407304063574/secrets/gle-webhook-secret/versions/latest"
-    host_uri                      = "https://gle-old.gcb-test.com"
+    host_uri                      = "https://gle-asia.gcb-test.com"
   }
 
   project     = "%{project_name}"


### PR DESCRIPTION
The old GLE server (gle-old.gcb-test.com) has been retired. This updates TestAccCloudbuildv2Connection_GleConnection to use the new server (gle-asia.gcb-test.com) and its corresponding secrets:
- gle-asia-api-token (v1/latest)
- gle-asia-read-token (v1/latest)

This resolves the test failures caused by the retired server.

Fixes
https://github.com/hashicorp/terraform-provider-google/issues/27518

```release-note:none
```
