### PR TITLE
Update google_network_services_authz_extension IAP example documentation

### DIFF
--- a/mmv1/products/networkservices/AuthzExtension.yaml
+++ b/mmv1/products/networkservices/AuthzExtension.yaml
@@ -65,8 +65,6 @@ examples:
     test_env_vars:
       project: 'PROJECT_NAME'
   - name: 'network_services_authz_extension_iap'
-    skip_docs: true  # temporary b/484137930
-    skip_test: true  # temporary b/484137930
     primary_resource_id: 'default'
     vars:
       resource_name: 'my-authz-ext'

--- a/mmv1/templates/terraform/examples/network_services_authz_extension_iap.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_authz_extension_iap.tf.tmpl
@@ -4,4 +4,7 @@ resource "google_network_services_authz_extension" "{{$.PrimaryResourceId}}" {
 
   service               = "iap.googleapis.com"
   timeout               = "0.1s"
+  metadata = {
+    "iapPolicyVersion" = "V1"
+  }
 }


### PR DESCRIPTION
- Added metadata block to IAP example template
- Enabled docs and tests for IAP example in AuthzExtension.yaml

```release-note:enhancement
networkservices: Update google_network_services_authz_extension IAP example documentation
```