### PR TITLE
Fixes hashicorp/terraform-provider-google#27300

### DIFF
--- a/mmv1/third_party/terraform/services/chronicle/resource_chronicle_rule_test.go
+++ b/mmv1/third_party/terraform/services/chronicle/resource_chronicle_rule_test.go
@@ -71,6 +71,7 @@ resource "google_chronicle_data_access_scope" "data_access_scope_test" {
 resource "google_chronicle_rule" "example" {
  location = "us"
  instance = "%{chronicle_id}"
+ scope = resource.google_chronicle_data_access_scope.data_access_scope_test.name
  text = <<-EOT
              rule test_rule { meta: events:  $updated_userid = $e.principal.user.userid  match: $updated_userid over 10m condition: $e }
          EOT


### PR DESCRIPTION
Update Chronicle Rule test was missing a dependency between Rule and DataAccessScope.
This was causing errors during deletion phase of the test.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27300

```release-note:none
```
