### PR TITLE
apigee: fix google_apigee_endpoint_attachment import panic

### DIFF
--- a/mmv1/templates/terraform/custom_import/apigee_endpoint_attachment.go.tmpl
+++ b/mmv1/templates/terraform/custom_import/apigee_endpoint_attachment.go.tmpl
@@ -1,8 +1,12 @@
 config := meta.(*transport_tpg.Config)
 
-// current import_formats cannot import fields with forward slashes in their value
-if err := tpgresource.ParseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
-	return nil, err
+// The import id is the fully-qualified resource name. Set it directly on the
+// `name` attribute instead of using tpgresource.ParseImportId with a
+// "(?P<name>.+)" regex: `name` is an output-only field and is not part of the
+// resource identity schema, so routing it through ParseImportId (which now also
+// populates the resource identity) panics with "Invalid address to set: name".
+if err := d.Set("name", d.Id()); err != nil {
+	return nil, fmt.Errorf("Error setting name: %s", err)
 }
 
 nameParts := strings.Split(d.Get("name").(string), "/")


### PR DESCRIPTION
## Summary

`TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample` fails **100%** in nightly (ga and beta) with a provider panic during import:

```
panic: Invalid address to set: []string{"name"}
  .../helper/schema/identity_data.go:74
  .../tpgresource/import.go:72
  apigee.resourceApigeeEndpointAttachmentImport (resource_apigee_endpoint_attachment.go:420)
```

## Root cause

The custom import called `tpgresource.ParseImportId([]string{"(?P<name>.+)"}, ...)` purely to load the full import id into the output-only `name` attribute for parsing. `ParseImportId` now also populates the **resource identity** for each captured group, so it called `identity.Set("name", ...)`. `name` is not part of this resource's identity schema, so the SDK panics.

## Fix

Replace the `ParseImportId` call with `d.Set("name", d.Id())`. This keeps the exact same downstream parsing of `org_id` / `endpoint_attachment_id` from `name`, but avoids routing a non-identity field through the identity-setting path.

(Note: `ParseImportId` will panic for any resource whose custom import regex captures a field that isn't in the identity schema — a more general guard there may be worth a follow-up, but this change is scoped to the failing Apigee resource.)

## Test evidence

```
--- PASS: TestAccApigeeEndpointAttachment_apigeeEndpointAttachmentBasicTestExample (1183.83s)
```
(Previously: panic on the import step.)

Fixes hashicorp/terraform-provider-google#27404

```release-note:bug
apigee: fixed a panic when importing `google_apigee_endpoint_attachment`
```
