### PR TITLE
apigee: update developer_app api_products without minting a new credential

### DIFF
--- a/mmv1/products/apigee/DeveloperApp.yaml
+++ b/mmv1/products/apigee/DeveloperApp.yaml
@@ -30,8 +30,10 @@ update_verb: "PUT"
 import_format:
   - "{{org_id}}/developers/{{developer_email}}/apps/{{name}}"
 custom_code:
+  constants: "templates/terraform/constants/apigee_developer_app.go.tmpl"
   decoder: "templates/terraform/decoders/apigee_developer_app.go.tmpl"
   custom_import: "templates/terraform/custom_import/apigee_developer_app.go.tmpl"
+  custom_update: "templates/terraform/custom_update/apigee_developer_app.go.tmpl"
   post_create: "templates/terraform/post_create/apigee_developer_app_credentials.go.tmpl"
 examples:
   - name: "apigee_developer_app_basic"

--- a/mmv1/templates/terraform/constants/apigee_developer_app.go.tmpl
+++ b/mmv1/templates/terraform/constants/apigee_developer_app.go.tmpl
@@ -1,0 +1,125 @@
+// setToList converts a value that may be a *schema.Set (TypeSet fields like
+// api_products and scopes) or already a []interface{} into a []interface{}.
+func setToList(v interface{}) []interface{} {
+	if set, ok := v.(*schema.Set); ok {
+		return set.List()
+	}
+	if list, ok := v.([]interface{}); ok {
+		return list
+	}
+	return nil
+}
+
+// developerAppKeyProductDiff returns the api products that need to be added and
+// removed to take the key's product list from old to new.
+func developerAppKeyProductDiff(oldProducts, newProducts []interface{}) (added []string, removed []string) {
+	oldSet := make(map[string]bool, len(oldProducts))
+	for _, p := range oldProducts {
+		if s, ok := p.(string); ok {
+			oldSet[s] = true
+		}
+	}
+	newSet := make(map[string]bool, len(newProducts))
+	for _, p := range newProducts {
+		if s, ok := p.(string); ok {
+			newSet[s] = true
+		}
+	}
+	for p := range newSet {
+		if !oldSet[p] {
+			added = append(added, p)
+		}
+	}
+	for p := range oldSet {
+		if !newSet[p] {
+			removed = append(removed, p)
+		}
+	}
+	return added, removed
+}
+
+// updateDeveloperAppKeyProductsAndScopes reconciles api_products and scopes on an
+// EXISTING developer app credential (consumer key) using the keys API, instead
+// of PUTting apiProducts on the app object (which causes Apigee to mint a brand
+// new credential, orphaning the previous one).
+//
+//   - Added products:   POST   .../keys/{key}            {"apiProducts":[...]}  (additive)
+//   - Removed products: DELETE .../keys/{key}/apiproducts/{product}
+//   - Scopes:           POST   .../keys/{key}            {"scopes":[...]}       (replaces)
+func updateDeveloperAppKeyProductsAndScopes(config *transport_tpg.Config, d *schema.ResourceData, billingProject, userAgent string) error {
+	consumerKey := ""
+	if creds, ok := d.Get("credentials").([]interface{}); ok && len(creds) > 0 {
+		if cred, ok := creds[0].(map[string]interface{}); ok {
+			if ck, ok := cred["consumer_key"].(string); ok {
+				consumerKey = ck
+			}
+		}
+	}
+	if consumerKey == "" {
+		return fmt.Errorf("cannot update api_products/scopes in place: no existing consumer_key found in state for DeveloperApp %q", d.Id())
+	}
+
+	keyURL, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/developers/{{"{{"}}developer_email{{"}}"}}/apps/{{"{{"}}name{{"}}"}}/keys/"+consumerKey)
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("api_products") {
+		oldRaw, newRaw := d.GetChange("api_products")
+		// api_products is a TypeSet, so GetChange returns *schema.Set.
+		added, removed := developerAppKeyProductDiff(setToList(oldRaw), setToList(newRaw))
+
+		if len(added) > 0 {
+			addedIfaces := make([]interface{}, len(added))
+			for i, p := range added {
+				addedIfaces[i] = p
+			}
+			log.Printf("[DEBUG] Adding api products %v to DeveloperApp key %s", added, consumerKey)
+			if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   billingProject,
+				RawURL:    keyURL,
+				UserAgent: userAgent,
+				Body:      map[string]interface{}{"apiProducts": addedIfaces},
+				Timeout:   d.Timeout(schema.TimeoutUpdate),
+			}); err != nil {
+				return fmt.Errorf("Error adding api products to DeveloperApp key: %s", err)
+			}
+		}
+
+		for _, p := range removed {
+			delURL := keyURL + "/apiproducts/" + p
+			log.Printf("[DEBUG] Removing api product %s from DeveloperApp key %s", p, consumerKey)
+			if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "DELETE",
+				Project:   billingProject,
+				RawURL:    delURL,
+				UserAgent: userAgent,
+				Timeout:   d.Timeout(schema.TimeoutUpdate),
+			}); err != nil {
+				return fmt.Errorf("Error removing api product %q from DeveloperApp key: %s", p, err)
+			}
+		}
+	}
+
+	if d.HasChange("scopes") {
+		// scopes is a TypeSet.
+		scopesRaw := setToList(d.Get("scopes"))
+		log.Printf("[DEBUG] Setting scopes %v on DeveloperApp key %s", scopesRaw, consumerKey)
+		if _, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   billingProject,
+			RawURL:    keyURL,
+			UserAgent: userAgent,
+			Body:      map[string]interface{}{"scopes": scopesRaw},
+			Timeout:   d.Timeout(schema.TimeoutUpdate),
+		}); err != nil {
+			return fmt.Errorf("Error updating scopes on DeveloperApp key: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/mmv1/templates/terraform/custom_update/apigee_developer_app.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/apigee_developer_app.go.tmpl
@@ -1,0 +1,89 @@
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+// Build the app PUT body, intentionally EXCLUDING apiProducts and scopes.
+// Sending apiProducts on the app object causes Apigee to create a brand new
+// credential (consumer key) instead of updating the existing one, orphaning the
+// previous key. apiProducts and scopes are reconciled on the existing key via
+// the keys API below.
+obj := make(map[string]interface{})
+nameProp, err := expandApigeeDeveloperAppName(d.Get("name"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("name"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+	obj["name"] = nameProp
+}
+appFamilyProp, err := expandApigeeDeveloperAppAppFamily(d.Get("app_family"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("app_family"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, appFamilyProp)) {
+	obj["appFamily"] = appFamilyProp
+}
+callbackUrlProp, err := expandApigeeDeveloperAppCallbackUrl(d.Get("callback_url"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("callback_url"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, callbackUrlProp)) {
+	obj["callbackUrl"] = callbackUrlProp
+}
+keyExpiresInProp, err := expandApigeeDeveloperAppKeyExpiresIn(d.Get("key_expires_in"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("key_expires_in"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, keyExpiresInProp)) {
+	obj["keyExpiresIn"] = keyExpiresInProp
+}
+statusProp, err := expandApigeeDeveloperAppStatus(d.Get("status"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("status"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, statusProp)) {
+	obj["status"] = statusProp
+}
+attributesProp, err := expandApigeeDeveloperAppAttributes(d.Get("attributes"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("attributes"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, attributesProp)) {
+	obj["attributes"] = attributesProp
+}
+
+// Only issue the app PUT if a non-key field actually changed.
+appFieldChanged := d.HasChange("name") || d.HasChange("app_family") || d.HasChange("callback_url") ||
+	d.HasChange("key_expires_in") || d.HasChange("status") || d.HasChange("attributes")
+
+if appFieldChanged {
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/developers/{{"{{"}}developer_email{{"}}"}}/apps/{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Updating DeveloperApp %q: %#v", d.Id(), obj)
+	headers := make(http.Header)
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "PUT",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+		Body:      obj,
+		Timeout:   d.Timeout(schema.TimeoutUpdate),
+		Headers:   headers,
+	})
+	if err != nil {
+		return fmt.Errorf("Error updating DeveloperApp %q: %s", d.Id(), err)
+	}
+	log.Printf("[DEBUG] Finished updating DeveloperApp %q: %#v", d.Id(), res)
+}
+
+// Reconcile api_products and scopes on the existing credential (keys API),
+// avoiding creation of a new credential.
+if d.HasChange("api_products") || d.HasChange("scopes") {
+	if err := updateDeveloperAppKeyProductsAndScopes(config, d, billingProject, userAgent); err != nil {
+		return err
+	}
+}
+
+return resourceApigeeDeveloperAppRead(d, meta)

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
@@ -23,6 +24,11 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 		"random_suffix":   acctest.RandString(t, 10),
 	}
 
+	// Capture the consumer key created on first apply so we can assert that
+	// updating api_products/scopes reuses the SAME credential instead of minting
+	// a new one (the bug in hashicorp/terraform-provider-google#26524).
+	var originalConsumerKey string
+
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
@@ -36,6 +42,8 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "credentials.0.consumer_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "credentials.0.consumer_secret"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.#", "1"),
+					testAccApigeeDeveloperAppCaptureConsumerKey(resourceName, &originalConsumerKey),
 				),
 			},
 			{
@@ -49,6 +57,12 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "credentials.0.consumer_key"),
 					resource.TestCheckResourceAttrSet(resourceName, "credentials.0.consumer_secret"),
+					// Updating api_products must NOT create a second credential...
+					resource.TestCheckResourceAttr(resourceName, "credentials.#", "1"),
+					// ...and must keep the SAME consumer key.
+					testAccApigeeDeveloperAppCheckConsumerKeyUnchanged(resourceName, &originalConsumerKey),
+					// Both products should now be associated with that single key.
+					resource.TestCheckResourceAttr(resourceName, "api_products.#", "2"),
 				),
 			},
 			{
@@ -59,6 +73,38 @@ func TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest(t *testing.T) {
 			},
 		},
 	})
+}
+
+// testAccApigeeDeveloperAppCaptureConsumerKey records the current consumer key.
+func testAccApigeeDeveloperAppCaptureConsumerKey(resourceName string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		key := rs.Primary.Attributes["credentials.0.consumer_key"]
+		if key == "" {
+			return fmt.Errorf("credentials.0.consumer_key is empty")
+		}
+		*dst = key
+		return nil
+	}
+}
+
+// testAccApigeeDeveloperAppCheckConsumerKeyUnchanged asserts the consumer key
+// equals the previously captured value, proving the credential was reused.
+func testAccApigeeDeveloperAppCheckConsumerKeyUnchanged(resourceName string, want *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		got := rs.Primary.Attributes["credentials.0.consumer_key"]
+		if got != *want {
+			return fmt.Errorf("consumer_key changed after updating api_products: a new credential was minted (was %q, now %q)", *want, got)
+		}
+		return nil
+	}
 }
 
 func testAccApigeeDeveloperApp_apigeeDeveloperAppBasicTest(context map[string]interface{}) string {


### PR DESCRIPTION
## Summary

When `api_products` (or `scopes`) changed on `google_apigee_developer_app`, the update PUT the app object **with** `apiProducts`. The Apigee API responds to that by minting a **brand new credential** (new consumer key/secret) and orphaning the previous one — leaving an active, unmanaged key outside Terraform state (hashicorp/terraform-provider-google#26524). `terraform apply` succeeds silently, so the operator never sees it.

## Fix

Add a `custom_update` that separates app-level fields from credential-level fields:

- **App PUT** now sends only `name`, `app_family`, `callback_url`, `key_expires_in`, `status`, `attributes` — **never** `apiProducts`/`scopes` — so it can't trigger a new credential.
- **api_products / scopes** are reconciled on the **existing** credential via the keys API:
  - add: `POST .../keys/{key}` with `{"apiProducts":[added]}` (additive)
  - remove: `DELETE .../keys/{key}/apiproducts/{product}`
  - scopes: `POST .../keys/{key}` with `{"scopes":[...]}`

`api_products`/`scopes` are `TypeSet`, handled via a `setToList` helper.

## Test evidence

`TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest` was strengthened to capture the consumer key after create and assert, after an `api_products` update, that:
- `credentials.# == 1` (no second credential minted), and
- the `consumer_key` is **unchanged** (same credential reused), and
- both products are associated.

```
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest (2312.88s)
```

Fixes hashicorp/terraform-provider-google#26524

```release-note:bug
apigee: `google_apigee_developer_app` now updates `api_products` and `scopes` on the existing credential instead of creating a new credential (consumer key) on update
```
