### PR TITLE
Enable write-only support for pem_private_key from google_certificate_manager_certificate

### DIFF
--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -99,6 +99,15 @@ samples:
       - name: certificate_manager_self_managed_certificate_write_only
         resource_id_vars:
           cert_name: self-managed-cert
+  - name: certificate_manager_self_managed_certificate_deprecated_fields
+    primary_resource_id: default
+    # Uses the deprecated certificate_pem/private_key_pem fields for test
+    # coverage only; not surfaced in docs to avoid promoting deprecated usage.
+    exclude_basic_doc: true
+    steps:
+      - name: certificate_manager_self_managed_certificate_deprecated_fields
+        resource_id_vars:
+          cert_name: self-managed-cert
   - name: certificate_manager_self_managed_certificate_regional
     primary_resource_id: default
     steps:

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -92,6 +92,13 @@ samples:
       - name: certificate_manager_self_managed_certificate
         resource_id_vars:
           cert_name: self-managed-cert
+  - name: certificate_manager_self_managed_certificate_write_only
+    primary_resource_id: default
+    skip_vcr: true
+    steps:
+      - name: certificate_manager_self_managed_certificate_write_only
+        resource_id_vars:
+          cert_name: self-managed-cert
   - name: certificate_manager_self_managed_certificate_regional
     primary_resource_id: default
     steps:
@@ -242,6 +249,7 @@ properties:
           The private key of the leaf certificate in PEM-encoded form.
         immutable: true
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
         exactly_one_of:
           - self_managed.0.private_key_pem

--- a/mmv1/products/certificatemanager/Certificate.yaml
+++ b/mmv1/products/certificatemanager/Certificate.yaml
@@ -98,6 +98,13 @@ samples:
       - name: certificate_manager_self_managed_certificate_update
         resource_id_vars:
           cert_name: self-managed-cert
+  - name: certificate_manager_self_managed_certificate_write_only
+    primary_resource_id: default
+    skip_vcr: true
+    steps:
+      - name: certificate_manager_self_managed_certificate_write_only
+        resource_id_vars:
+          cert_name: self-managed-cert
   - name: certificate_manager_self_managed_certificate_regional
     primary_resource_id: default
     steps:
@@ -247,6 +254,7 @@ properties:
         description: |
           The private key of the leaf certificate in PEM-encoded form.
         sensitive: true
+        write_only: true
         is_missing_in_cai: true
         exactly_one_of:
           - self_managed.0.private_key_pem

--- a/mmv1/templates/terraform/samples/services/certificatemanager/certificate_manager_self_managed_certificate_deprecated_fields.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/certificatemanager/certificate_manager_self_managed_certificate_deprecated_fields.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_certificate_manager_certificate" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.ResourceIdVars "cert_name"}}"
+  description = "Global cert"
+  scope       = "ALL_REGIONS"
+  self_managed {
+    certificate_pem = file("test-fixtures/cert.pem")
+    private_key_pem = file("test-fixtures/private-key.pem")
+  }
+}

--- a/mmv1/templates/terraform/samples/services/certificatemanager/certificate_manager_self_managed_certificate_write_only.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/certificatemanager/certificate_manager_self_managed_certificate_write_only.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_certificate_manager_certificate" "{{$.PrimaryResourceId}}" {
+  name        = "{{index $.ResourceIdVars "cert_name"}}"
+  description = "Global cert"
+  scope       = "ALL_REGIONS"
+  self_managed {
+    pem_certificate            = file("test-fixtures/cert.pem")
+    pem_private_key_wo         = file("test-fixtures/private-key.pem")
+    pem_private_key_wo_version = parseint(filesha256("test-fixtures/private-key.pem"), 16) % pow(2, 32)
+  }
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Applies the same write-only pattern from https://github.com/GoogleCloudPlatform/magic-modules/pull/16183 (which enabled write-only support for `private_key` on `google_compute_(region_)ssl_certificate`) to the `self_managed.pem_private_key` field of `google_certificate_manager_certificate`. This matches the previous implementation in that PR.

```release-note:enhancement
certificatemanager: Enable write-only support for `pem_private_key` to `google_certificate_manager_certificate` resource
```