### PR TITLE
apigee: document & test /28 support range for google_apigee_instance ip_range

### DIFF
--- a/mmv1/products/apigee/Instance.yaml
+++ b/mmv1/products/apigee/Instance.yaml
@@ -94,6 +94,15 @@ examples:
     # Resource creation race
     skip_vcr: true
     external_providers: ["time"]
+  - name: 'apigee_instance_ip_range_with_support_range_test'
+    primary_resource_id: 'apigee_instance'
+    test_env_vars:
+      org_id: 'ORG_ID'
+      billing_account: 'BILLING_ACCT'
+    exclude_docs: true
+    # Resource creation race
+    skip_vcr: true
+    external_providers: ["time"]
   - name: 'apigee_instance_full'
     vars:
       instance_name: 'my-instance-name'
@@ -151,13 +160,15 @@ properties:
   - name: 'ipRange'
     type: String
     description: |
-      IP range represents the customer-provided CIDR block of length 22 that will be used for
-      the Apigee instance creation. This optional range, if provided, should be freely
-      available as part of larger named range the customer has allocated to the Service
-      Networking peering. If this is not provided, Apigee will automatically request for any
-      available /22 CIDR block from Service Networking. The customer should use this CIDR block
-      for configuring their firewall needs to allow traffic from Apigee.
-      Input format: "a.b.c.d/22"
+      IP range represents the customer-provided CIDR block(s) that will be used for the Apigee
+      instance creation. This optional range, if provided, should be freely available as part of
+      a larger named range the customer has allocated to the Service Networking peering. You may
+      provide a /22 (runtime) block, a /28 (support/troubleshooting) block, or both. To specify
+      both, provide them as a comma-separated list. If this is not provided, Apigee will
+      automatically request for any available /22 and /28 CIDR blocks from Service Networking.
+      The customer should use the /22 CIDR block for configuring their firewall needs to allow
+      traffic from Apigee.
+      Input formats: "a.b.c.d/22", "e.f.g.h/28", or "a.b.c.d/22,e.f.g.h/28"
     immutable: true
     ignore_read: true
   - name: 'description'

--- a/mmv1/templates/terraform/examples/apigee_instance_ip_range_with_support_range_test.tf.tmpl
+++ b/mmv1/templates/terraform/examples/apigee_instance_ip_range_with_support_range_test.tf.tmpl
@@ -1,0 +1,87 @@
+resource "google_project" "project" {
+  project_id      = "tf-test%{random_suffix}"
+  name            = "tf-test%{random_suffix}"
+  org_id          = "{{index $.TestEnvVars "org_id"}}"
+  billing_account = "{{index $.TestEnvVars "billing_account"}}"
+  deletion_policy = "DELETE"
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "google_project_service" "compute" {
+  project = google_project.project.project_id
+  service = "compute.googleapis.com"
+  depends_on = [google_project_service.apigee]
+}
+
+resource "google_project_service" "servicenetworking" {
+  project = google_project.project.project_id
+  service = "servicenetworking.googleapis.com"
+  depends_on = [google_project_service.compute]
+}
+
+resource "time_sleep" "wait_300_seconds" {
+  create_duration = "300s"
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_compute_network" "apigee_network" {
+  name       = "apigee-network"
+  project    = google_project.project.project_id
+  depends_on = [time_sleep.wait_300_seconds]
+}
+
+# Reserve a /20 so we can carve out both an explicit /22 (runtime) and an
+# explicit /28 (support) range to hand to the Apigee instance.
+resource "google_compute_global_address" "apigee_range" {
+  name          = "apigee-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 20
+  network       = google_compute_network.apigee_network.id
+  project       = google_project.project.project_id
+}
+
+resource "google_service_networking_connection" "apigee_vpc_connection" {
+  network                 = google_compute_network.apigee_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.apigee_range.name]
+  depends_on              = [google_project_service.servicenetworking]
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region   = "us-central1"
+  project_id         = google_project.project.project_id
+  authorized_network = google_compute_network.apigee_network.id
+  depends_on         = [
+    google_service_networking_connection.apigee_vpc_connection,
+    google_project_service.apigee,
+  ]
+}
+
+locals {
+  # The reserved block as a CIDR string (e.g. "10.73.144.0/20").
+  apigee_reserved_cidr = "${google_compute_global_address.apigee_range.address}/${google_compute_global_address.apigee_range.prefix_length}"
+  # Carve an explicit /22 (runtime) and a non-overlapping /28 (support) range.
+  apigee_runtime_22 = cidrsubnet(local.apigee_reserved_cidr, 2, 0)   # first /22 of the /20
+  apigee_support_28 = cidrsubnet(local.apigee_reserved_cidr, 8, 192) # a /28 outside the first /22
+}
+
+resource "google_apigee_instance" "{{$.PrimaryResourceId}}" {
+  name     = "tf-test%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+
+  # Explicitly choose both the /22 runtime range and the /28 support range,
+  # supplied as a comma-separated list.
+  ip_range = "${local.apigee_runtime_22},${local.apigee_support_28}"
+}


### PR DESCRIPTION
## Summary

`google_apigee_organization` / `google_apigee_instance` users with multiple /28s couldn't choose which **/28 support range** to use — the `ip_range` field only documented the /22 runtime block, and the UI exposed an option the provider seemingly didn't (hashicorp/terraform-provider-google#19501).

In fact the Apigee Instance API's `ipRange` already accepts a **comma-separated list of /22 and/or /28** blocks (`"a.b.c.d/22,e.f.g.h/28"`), and the provider's `ip_range` is a plain string that passes the value straight through. So the value worked — the gap was **documentation** and the lack of an example showing it.

## Changes

- Update the `ip_range` field description to document the /28 support range and the comma-separated `"/22,/28"` input format (matching the API docs).
- Add `apigee_instance_ip_range_with_support_range_test`: reserves a /20 and creates an instance with **both** an explicit /22 runtime range and an explicit /28 support range, proving the combined format works end to end.

No schema/behavior change — `ip_range` already forwarded the value; this makes the capability discoverable and regression-tested.

## Test evidence
```
--- PASS: TestAccApigeeInstance_apigeeInstanceIpRangeWithSupportRangeTestExample (2987.90s)
```

Fixes hashicorp/terraform-provider-google#19501

```release-note:none
```
