### PR TITLE
tgc-revival: Support slurm_operator_config in google_container_cluster

### DIFF
--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -633,12 +633,12 @@ func ResourceContainerCluster() *schema.Resource {
 							},
 						},
 						"slurm_operator_config": {
-							Type:          schema.TypeList,
-							Optional:      true,
-							Computed:      true,
-							AtLeastOneOf:  addonsConfigKeys,
-							MaxItems:      1,
-							Description:   `The status of the Slurm Operator addon, which creates slurm related CRDs and KCP pods to manage them. Defaults to disabled for Standard clusters; set enabled = true to enable. It can not be enabled for Autopilot clusters.`,
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `The status of the Slurm Operator addon, which creates slurm related CRDs and KCP pods to manage them. Defaults to disabled for Standard clusters; set enabled = true to enable. It can not be enabled for Autopilot clusters.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -107,6 +107,7 @@ var (
 		"addons_config.0.kalm_config",
 		"addons_config.0.slice_controller_config",
 		"addons_config.0.pod_snapshot_config",
+		"addons_config.0.slurm_operator_config",
 	}
 
 	privateClusterConfigKeys = []string{
@@ -627,6 +628,22 @@ func ResourceContainerCluster() *schema.Resource {
 												},
 											},
 										},
+									},
+								},
+							},
+						},
+						"slurm_operator_config": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							AtLeastOneOf:  addonsConfigKeys,
+							MaxItems:      1,
+							Description:   `The status of the Slurm Operator addon, which creates slurm related CRDs and KCP pods to manage them. Defaults to disabled for Standard clusters; set enabled = true to enable. It can not be enabled for Autopilot clusters.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
 									},
 								},
 							},

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
@@ -646,6 +646,19 @@ func flattenClusterAddonsConfig(v interface{}, enableAutopilot bool) []map[strin
 		}
 	}
 
+	if val, ok := c["slurmOperatorConfig"].(map[string]interface{}); ok {
+		enabled := false
+		if v, ok := val["enabled"]; ok && v != nil {
+			enabled = v.(bool)
+		}
+
+		result["slurm_operator_config"] = []map[string]interface{}{
+			{
+				"enabled": enabled,
+			},
+		}
+	}
+
 	return []map[string]interface{}{result}
 }
 

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
@@ -495,6 +495,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
+	if v, ok := config["slurm_operator_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.SlurmOperatorConfig = &container.SlurmOperatorConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 	return ac
 }
 

--- a/mmv1/third_party/tgc_next/test/utils.go
+++ b/mmv1/third_party/tgc_next/test/utils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// Writes the data into a JSON file
+// Writes the data into a JSON file test
 func writeJSONFile(filename string, data interface{}) error {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {


### PR DESCRIPTION
Support GKE addons_config.slurm_operator_config in google_container_cluster to fix the failed tgc integration tests in https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/

```release-note:none
```