### PR TITLE
tgc-revival: Restrict auto-generated resource labels conversion to AreNewResources only

### DIFF
--- a/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
+++ b/mmv1/templates/tgc_next/cai2hcl/resource_converter.go.tmpl
@@ -165,7 +165,13 @@ func (c *{{ $.ResourceName -}}Cai2hclConverter) convertResourceData(asset caiass
 		}
 	}
 	{{- else -}}
+		{{- if eq $prop.Name "labels" }}
+	if options != nil && options.AreNewResources {
+		hclData["{{ underscore $prop.Name -}}"] = flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}(res["{{ $prop.ApiName -}}"], d, config)
+	}
+		{{- else }}
 	hclData["{{ underscore $prop.Name -}}"] = flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName -}}{{ camelize $prop.Name "upper" -}}(res["{{ $prop.ApiName -}}"], d, config)
+		{{- end }}
 	{{- end}}
 {{- end}}
 


### PR DESCRIPTION
Restrict auto-generated resource labels conversion to AreNewResources only to avoid redundant HCL output.

```release-note:none
```