### PR TITLE
apigee: add static consumer_key/consumer_secret to google_apigee_developer_app (re-land with fix)

### DIFF
--- a/mmv1/products/apigee/DeveloperApp.yaml
+++ b/mmv1/products/apigee/DeveloperApp.yaml
@@ -32,6 +32,7 @@ import_format:
 custom_code:
   decoder: "templates/terraform/decoders/apigee_developer_app.go.tmpl"
   custom_import: "templates/terraform/custom_import/apigee_developer_app.go.tmpl"
+  post_create: "templates/terraform/post_create/apigee_developer_app_credentials.go.tmpl"
 examples:
   - name: "apigee_developer_app_basic"
     primary_resource_id: "apigee_developer_app"
@@ -84,6 +85,34 @@ parameters:
     url_param_only: true
     required: true
     immutable: true
+  - name: "consumerKey"
+    type: String
+    description: |
+      Optionally specify a static consumer key for the developer app's credential.
+      If not set, the API auto-generates a key. The consumer key must be unique
+      across all developer apps in an organization. Changing this field forces the
+      resource to be recreated.
+
+      This is a write-only input used at create time: the provider creates the
+      credential with this key via the keys API and removes the auto-generated
+      one. The effective key is exposed in the `credentials` output.
+    url_param_only: true
+    immutable: true
+    ignore_read: true
+  - name: "consumerSecret"
+    type: String
+    description: |
+      Optionally specify a static consumer secret for the developer app's
+      credential. Required if `consumer_key` is specified. If not set, the API
+      auto-generates a secret. Changing this field forces the resource to be
+      recreated.
+
+      This is a write-only input used at create time; the effective secret is
+      exposed in the `credentials` output.
+    url_param_only: true
+    sensitive: true
+    immutable: true
+    ignore_read: true
 properties:
   - name: "name"
     type: String

--- a/mmv1/templates/terraform/post_create/apigee_developer_app_credentials.go.tmpl
+++ b/mmv1/templates/terraform/post_create/apigee_developer_app_credentials.go.tmpl
@@ -1,0 +1,102 @@
+// If a static consumer_key was specified, replace the auto-generated credential
+// with the user-supplied key/secret.
+//
+// consumer_key/consumer_secret are url_param_only inputs (they are NOT part of
+// the DeveloperApp create body -- the create API has no such fields), so the
+// app is first created with an auto-generated credential and then, here, we swap
+// in the user-supplied credential via the keys API.
+if consumerKey, ok := d.GetOk("consumer_key"); ok {
+	consumerSecret := d.Get("consumer_secret").(string)
+
+	// First, obtain the auto-generated consumer key(s) to delete them later.
+	readURL, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/developers/{{"{{"}}developer_email{{"}}"}}/apps/{{"{{"}}name{{"}}"}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing URL for DeveloperApp read: %s", err)
+	}
+	appRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    readURL,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return fmt.Errorf("Error reading DeveloperApp for credential replacement: %s", err)
+	}
+
+	// Collect auto-generated consumer keys to delete after creating the static key.
+	var autoKeys []string
+	if creds, ok := appRes["credentials"].([]interface{}); ok {
+		for _, cred := range creds {
+			if cm, ok := cred.(map[string]interface{}); ok {
+				if k, ok := cm["consumerKey"].(string); ok {
+					autoKeys = append(autoKeys, k)
+				}
+			}
+		}
+	}
+
+	// Create the static credential via the keys API.
+	keysURL, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ApigeeBasePath{{"}}"}}{{"{{"}}org_id{{"}}"}}/developers/{{"{{"}}developer_email{{"}}"}}/apps/{{"{{"}}name{{"}}"}}/keys")
+	if err != nil {
+		return fmt.Errorf("Error constructing keys URL for DeveloperApp: %s", err)
+	}
+	keyBody := map[string]interface{}{
+		"consumerKey":    consumerKey.(string),
+		"consumerSecret": consumerSecret,
+	}
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "POST",
+		Project:   billingProject,
+		RawURL:    keysURL,
+		UserAgent: userAgent,
+		Body:      keyBody,
+		Timeout:   d.Timeout(schema.TimeoutCreate),
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating static credential for DeveloperApp: %s", err)
+	}
+
+	// Associate api_products and scopes with the new key if specified.
+	if apiProducts, ok := d.GetOk("api_products"); ok {
+		products := apiProducts.(*schema.Set).List()
+		if len(products) > 0 {
+			keyUpdateURL := keysURL + "/" + consumerKey.(string)
+			keyUpdateBody := map[string]interface{}{
+				"apiProducts": products,
+			}
+			if scopes, ok := d.GetOk("scopes"); ok {
+				keyUpdateBody["scopes"] = scopes.(*schema.Set).List()
+			}
+			_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "POST",
+				Project:   billingProject,
+				RawURL:    keyUpdateURL,
+				UserAgent: userAgent,
+				Body:      keyUpdateBody,
+				Timeout:   d.Timeout(schema.TimeoutCreate),
+			})
+			if err != nil {
+				return fmt.Errorf("Error associating API products with static credential for DeveloperApp: %s", err)
+			}
+		}
+	}
+
+	// Delete the auto-generated key(s).
+	for _, autoKey := range autoKeys {
+		deleteKeyURL := keysURL + "/" + autoKey
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "DELETE",
+			Project:   billingProject,
+			RawURL:    deleteKeyURL,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutCreate),
+		})
+		if err != nil && !transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+			return fmt.Errorf("Error deleting auto-generated credential for DeveloperApp: %s", err)
+		}
+	}
+}

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_developer_app_update_test.go
@@ -1,6 +1,7 @@
 package apigee_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -194,6 +195,140 @@ resource "google_apigee_api_product" "another_api_product" {
   scopes = [
     "write:files",
     "read:weather"
+  ]
+
+  depends_on = [
+    google_apigee_instance.apigee_instance
+  ]
+}
+
+resource "google_apigee_developer" "developer" {
+  email      = "john.doe@acme.com%{random_suffix}"
+  first_name = "John"
+  last_name  = "Doe"
+  user_name  = "john.doe"
+  org_id     = google_apigee_organization.apigee_org.id
+
+  depends_on = [
+    google_apigee_instance.apigee_instance
+  ]
+}
+
+resource "google_apigee_instance" "apigee_instance" {
+  name     = "tf-test-instance%{random_suffix}"
+  location = "us-central1"
+  org_id   = google_apigee_organization.apigee_org.id
+}
+
+resource "google_apigee_organization" "apigee_org" {
+  analytics_region    = "us-central1"
+  project_id          = google_project.project.project_id
+  disable_vpc_peering = true
+
+  depends_on = [
+    google_project_service.apigee
+  ]
+}
+
+resource "google_project_service" "apigee" {
+  project = google_project.project.project_id
+  service = "apigee.googleapis.com"
+
+  depends_on = [time_sleep.wait_60_seconds]
+}
+
+resource "time_sleep" "wait_60_seconds" {
+  create_duration = "60s"
+
+  depends_on = [google_project.project]
+}
+
+resource "google_project" "project" {
+  project_id      = "tf-test-prj%{random_suffix}"
+  name            = "tf-test-prj%{random_suffix}"
+  org_id          = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+`, context)
+}
+
+// TestAccApigeeDeveloperApp_apigeeDeveloperAppStaticCredentialsTest verifies that
+// a user-supplied static consumer_key/consumer_secret is used for the app's
+// credential (the auto-generated one is replaced), per
+// hashicorp/terraform-provider-google#25525.
+func TestAccApigeeDeveloperApp_apigeeDeveloperAppStaticCredentialsTest(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	resourceName := "google_apigee_developer_app.apigee_developer_app"
+
+	context := map[string]interface{}{
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeDeveloperAppDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeDeveloperApp_apigeeDeveloperAppStaticCredentialsTest(context),
+				Check: resource.ComposeTestCheckFunc(
+					// The static key should be the (only) credential on the app:
+					// the auto-generated credential must have been deleted.
+					resource.TestCheckResourceAttr(resourceName, "credentials.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.consumer_key", fmt.Sprintf("static-key-%s", context["random_suffix"])),
+					resource.TestCheckResourceAttr(resourceName, "credentials.0.consumer_secret", fmt.Sprintf("static-secret-%s", context["random_suffix"])),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// consumer_key and consumer_secret are write-only inputs; they are
+				// not returned by the API read so must be ignored on import verify.
+				ImportStateVerifyIgnore: []string{"org_id", "consumer_key", "consumer_secret", "key_expires_in"},
+			},
+		},
+	})
+}
+
+func testAccApigeeDeveloperApp_apigeeDeveloperAppStaticCredentialsTest(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_apigee_developer_app" "apigee_developer_app" {
+  name            = "tf-test-sample-app%{random_suffix}"
+  app_family      = "default"
+  org_id          = google_apigee_organization.apigee_org.id
+  developer_email = google_apigee_developer.developer.email
+  callback_url    = "https://example-call.url"
+  key_expires_in  = "-1"
+  status          = "approved"
+
+  consumer_key    = "static-key-%{random_suffix}"
+  consumer_secret = "static-secret-%{random_suffix}"
+
+  api_products = [
+    google_apigee_api_product.api_product.name
+  ]
+
+  scopes = google_apigee_api_product.api_product.scopes
+}
+
+resource "google_apigee_api_product" "api_product" {
+  name          = "tf-test-sample-api%{random_suffix}"
+  org_id        = google_apigee_organization.apigee_org.id
+  display_name  = "A sample API Product"
+  approval_type = "auto"
+
+  scopes = [
+    "read:weather",
+    "write:reports"
   ]
 
   depends_on = [


### PR DESCRIPTION
## Summary

Re-lands #16953 ("add static `consumer_key`/`consumer_secret` to `google_apigee_developer_app`"), which was reverted in #17089 — with the bug that caused the revert **fixed**.

Fixes hashicorp/terraform-provider-google#25525 (the feature was never actually delivered: #16953 merged but was reverted, so static credentials are still unsupported on `main`).

## What went wrong the first time

In #16953, `consumer_key`/`consumer_secret` were declared as **regular properties**, with only `ignore_read: true`. `ignore_read` suppresses *reading* a field back, but does **not** exclude it from the *create request body*. So the generated `Create` serialized them into the `CreateDeveloperApp` POST:

```go
obj["consumerKey"] = consumerKeyProp
obj["consumerSecret"] = consumerSecretProp
```

That endpoint has no such fields (they belong to the `DeveloperAppKey` sub-resource), so create failed **100%** in nightly:

```
Error 400: Invalid JSON payload received. Unknown name "consumerKey" at 'developer_app': Cannot find field.
```

The post_create hook (which correctly creates the static key via the keys API) never ran because create failed first. The regression slipped through because the `StaticCredentialsTest` is `SkipIfVcr` and was **never executed in the PR's presubmit** — it only ran (and failed) in nightly.

## The fix

Declare `consumer_key`/`consumer_secret` as **`url_param_only: true`** inputs, so they are **not** placed in the app create/update body. They're consumed only by the `post_create` hook, which:
1. records the auto-generated credential,
2. creates the user-supplied credential via `POST .../apps/{app}/keys`,
3. associates `api_products`/`scopes` with it, and
4. deletes the auto-generated key.

## Test evidence (real Apigee org)

The previously-failing test now passes, and I verified the full developer_app suite:

```
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppStaticCredentialsTest (2153.58s)
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppBasicTestExample (2270.81s)
--- PASS: TestAccApigeeDeveloperApp_apigeeDeveloperAppUpdateTest (2280.71s)
```

The StaticCredentials test was also strengthened to assert `credentials.# == 1` (the auto-generated key is removed, leaving only the static one).

> Note: `StaticCredentialsTest` is `SkipIfVcr` (it provisions a real org), so it must be verified manually — done above. This is the verification gap that allowed the original regression.

Fixes hashicorp/terraform-provider-google#25525

```release-note:enhancement
apigee: added `consumer_key` and `consumer_secret` fields to `google_apigee_developer_app` to allow specifying a static credential
```
