### PR TITLE
Mark security_token as ignore_read and sensitive in terraform provide…

### DIFF
--- a/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimToken.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimToken.yaml
@@ -61,6 +61,8 @@ properties:
     description:
       The token string provided to the IdP for authentication and will be set only during creation.
     output: true
+    sensitive: true
+    ignore_read: true
   - name: 'state'
     type: Enum
     description: |

--- a/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimToken.yaml
+++ b/mmv1/products/iamworkforcepool/WorkforcePoolProviderScimToken.yaml
@@ -33,7 +33,7 @@ timeouts:
   delete_minutes: 20
 custom_code:
   decoder: 'templates/terraform/decoders/treat_deleted_state_as_gone.go.tmpl'
-  post_create: 'templates/terraform/post_create/sleep.go.tmpl'
+  post_create: 'templates/terraform/post_create/iam_workforce_pool_provider_scim_token.go.tmpl'
   post_update: 'templates/terraform/post_create/sleep.go.tmpl'
 examples:
   - name: 'iam_workforce_pool_provider_scim_token_basic'

--- a/mmv1/templates/terraform/post_create/iam_workforce_pool_provider_scim_token.go.tmpl
+++ b/mmv1/templates/terraform/post_create/iam_workforce_pool_provider_scim_token.go.tmpl
@@ -1,0 +1,9 @@
+// Sleep to wait for the token to be replicated.
+time.Sleep(5 * time.Second)
+
+// Save the security_token to state
+if val, ok := res["securityToken"]; ok {
+    if err := d.Set("security_token", val); err != nil {
+        return fmt.Errorf("Error setting security_token: %v", err)
+    }
+}

--- a/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
+++ b/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
@@ -45,7 +45,6 @@ func TestAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(t *testing.T) 
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
-					// Verify the token is STILL preserved in the state after the update call
 					resource.TestCheckResourceAttrSet("google_iam_workforce_pool_provider_scim_token.scim_token", "security_token"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
+++ b/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
@@ -35,7 +35,7 @@ func TestAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(t *testing.T) 
 				ResourceName:            "google_iam_workforce_pool_provider_scim_token.scim_token",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"state"},
+				ImportStateVerifyIgnore: []string{"state", "security_token"},
 			},
 			{
 				Config: testAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(context),
@@ -52,7 +52,7 @@ func TestAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(t *testing.T) 
 				ResourceName:            "google_iam_workforce_pool_provider_scim_token.scim_token",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"state"},
+				ImportStateVerifyIgnore: []string{"state", "security_token"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
+++ b/mmv1/third_party/terraform/services/iamworkforcepool/resource_iam_workforce_pool_provider_scim_token_test.go
@@ -27,6 +27,9 @@ func TestAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(t *testing.T) 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIAMWorkforcePoolWorkforcePoolProviderScimToken_full(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_iam_workforce_pool_provider_scim_token.scim_token", "security_token"),
+				),
 			},
 			{
 				ResourceName:            "google_iam_workforce_pool_provider_scim_token.scim_token",
@@ -41,6 +44,10 @@ func TestAccIAMWorkforcePoolWorkforcePoolProviderScimToken_update(t *testing.T) 
 						plancheck.ExpectResourceAction("google_iam_workforce_pool_provider_scim_token.scim_token", plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: resource.ComposeTestCheckFunc(
+					// Verify the token is STILL preserved in the state after the update call
+					resource.TestCheckResourceAttrSet("google_iam_workforce_pool_provider_scim_token.scim_token", "security_token"),
+				),
 			},
 			{
 				ResourceName:            "google_iam_workforce_pool_provider_scim_token.scim_token",


### PR DESCRIPTION
<!--
Mark security_token as ignore_read and sensitive in terraform. This is because the security_token is only returned in create but not in get and update api. This was leading to an empty string being returned in Read and Update providers which was breaking customer usages: b/522302778.
-->

Mark security_token as ignore_read and sensitive in terraform. This is because the security_token is only returned in create but not in get and update api. This was leading to an empty string being returned in Read and Update providers which was breaking customer usages: b/522302778.

```release-note: bug
iamworkforcepool: marked sensitive and ignore_read as true for `security_token` in `google_iam_workforce_pool_provider_scim_token` resource
```
