### PR TITLE
test(magician): refactor vcr-cassette-update-test to use testing sandbox

### DIFF
--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"container/list"
 	"fmt"
 	"magician/source"
 	"magician/vcr"
+	"os"
 	"strings"
 	"testing"
 
@@ -304,130 +304,108 @@ func TestFormatVCRCassettesUpdateRecording(t *testing.T) {
 
 func TestExecVCRCassetteUpdate(t *testing.T) {
 	tests := []struct {
-		name          string
-		cmdResults    map[string]string
-		expectedCalls map[string][]ParameterList
+		name                  string
+		simulateReplayFailure bool
 	}{
 		{
-			name:       "replay passed",
-			cmdResults: make(map[string]string),
-			expectedCalls: map[string][]ParameterList{
-				"Run": {
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "gs://ci-vcr-cassettes/beta/fixtures/*", "/mock/dir/magic-modules/.ci/magician/cassettes/beta"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "/mock/dir/magic-modules/.ci/magician/cassettes/beta/*", "gs://vcr-nightly/beta/2024-07-08/buildID/main_cassettes_backup/fixtures/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "https://hashicorp:token@github.com/hashicorp/terraform-provider-google-beta", "gopath/src/github.com/hashicorp/terraform-provider-google-beta"}, map[string]string(nil)},
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"list", "./..."}, map[string]string(nil)},
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"test", "", "-p", "16", "-parallel", "32", "-v", "-run=TestAcc", "-timeout", "360m", "-ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc", "-vet=off"}, map[string]string{
-						"ACCTEST_PARALLELISM":            "32",
-						"GOOGLE_APPLICATION_CREDENTIALS": "/mock/dir/magic-modules/.ci/magician/sa_key.json",
-						"GOOGLE_CREDENTIALS":             "sa_key",
-						"GOOGLE_TEST_DIRECTORY":          "",
-						"SA_KEY":                         "sa_key",
-						"TF_ACC":                         "1",
-						"TF_ACC_REFRESH_AFTER_APPLY":     "1",
-						"TF_LOG":                         "DEBUG",
-						"TF_LOG_CORE":                    "WARN",
-						"TF_LOG_PATH_MASK":               "/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/%s.log",
-						"TF_LOG_SDK_FRAMEWORK":           "INFO",
-						"TF_SCHEMA_PANIC_ON_ERROR":       "1",
-						"VCR_MODE":                       "REPLAYING",
-						"VCR_PATH":                       "/mock/dir/magic-modules/.ci/magician/cassettes/beta",
-					}},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/replaying_test.log", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/replaying/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/*", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/build-log/"}, map[string]string(nil)},
-				},
-			},
+			name:                  "replay passed",
+			simulateReplayFailure: false,
 		},
 		{
-			name: "replay failed then record",
-			cmdResults: map[string]string{
-				"gopath/src/github.com/hashicorp/terraform-provider-google-beta go [test  -p 16 -parallel 32 -v -run=TestAcc -timeout 360m -ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc -vet=off] map[ACCTEST_PARALLELISM:32 GOOGLE_APPLICATION_CREDENTIALS:/mock/dir/magic-modules/.ci/magician/sa_key.json GOOGLE_CREDENTIALS:sa_key GOOGLE_TEST_DIRECTORY: SA_KEY:sa_key TF_ACC:1 TF_ACC_REFRESH_AFTER_APPLY:1 TF_LOG:DEBUG TF_LOG_CORE:WARN TF_LOG_PATH_MASK:/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/%s.log TF_LOG_SDK_FRAMEWORK:INFO TF_SCHEMA_PANIC_ON_ERROR:1 VCR_MODE:REPLAYING VCR_PATH:/mock/dir/magic-modules/.ci/magician/cassettes/beta]":                                     "--- FAIL: TestAccContainerNodePool_defaultDriverInstallation (590.29s)",
-				"gopath/src/github.com/hashicorp/terraform-provider-google-beta go [test  -parallel 1 -v -run=TestAccContainerNodePool_defaultDriverInstallation$ -timeout 360m -ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc -vet=off] map[ACCTEST_PARALLELISM:1 GOOGLE_APPLICATION_CREDENTIALS:/mock/dir/magic-modules/.ci/magician/sa_key.json GOOGLE_CREDENTIALS:sa_key GOOGLE_TEST_DIRECTORY: SA_KEY:sa_key TF_ACC:1 TF_ACC_REFRESH_AFTER_APPLY:1 TF_LOG:DEBUG TF_LOG_CORE:WARN TF_LOG_PATH_MASK:/mock/dir/magic-modules/.ci/magician/testlogs/recording/beta/%s.log TF_LOG_SDK_FRAMEWORK:INFO TF_SCHEMA_PANIC_ON_ERROR:1 VCR_MODE:RECORDING VCR_PATH:/mock/dir/magic-modules/.ci/magician/cassettes/beta]": "--- PASS: TestAccContainerNodePool_defaultDriverInstallation (590.29s)",
-			},
-			expectedCalls: map[string][]ParameterList{
-				"Run": {
-					// replay
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "gs://ci-vcr-cassettes/beta/fixtures/*", "/mock/dir/magic-modules/.ci/magician/cassettes/beta"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "/mock/dir/magic-modules/.ci/magician/cassettes/beta/*", "gs://vcr-nightly/beta/2024-07-08/buildID/main_cassettes_backup/fixtures/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "https://hashicorp:token@github.com/hashicorp/terraform-provider-google-beta", "gopath/src/github.com/hashicorp/terraform-provider-google-beta"}, map[string]string(nil)},
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"list", "./..."}, map[string]string(nil)},
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"test", "", "-p", "16", "-parallel", "32", "-v", "-run=TestAcc", "-timeout", "360m", "-ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc", "-vet=off"}, map[string]string{
-						"ACCTEST_PARALLELISM":            "32",
-						"GOOGLE_APPLICATION_CREDENTIALS": "/mock/dir/magic-modules/.ci/magician/sa_key.json",
-						"GOOGLE_CREDENTIALS":             "sa_key",
-						"GOOGLE_TEST_DIRECTORY":          "",
-						"SA_KEY":                         "sa_key",
-						"TF_ACC":                         "1",
-						"TF_ACC_REFRESH_AFTER_APPLY":     "1",
-						"TF_LOG":                         "DEBUG",
-						"TF_LOG_CORE":                    "WARN",
-						"TF_LOG_PATH_MASK":               "/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/%s.log",
-						"TF_LOG_SDK_FRAMEWORK":           "INFO",
-						"TF_SCHEMA_PANIC_ON_ERROR":       "1",
-						"VCR_MODE":                       "REPLAYING",
-						"VCR_PATH":                       "/mock/dir/magic-modules/.ci/magician/cassettes/beta",
-					}},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/replaying_test.log", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/replaying/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/*", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/build-log/"}, map[string]string(nil)},
-					// record
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"list", "./..."}, map[string]string(nil)},
-					{"gopath/src/github.com/hashicorp/terraform-provider-google-beta", "go", []string{"test", "", "-parallel", "1", "-v", "-run=TestAccContainerNodePool_defaultDriverInstallation$", "-timeout", "360m", "-ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc", "-vet=off"}, map[string]string{
-						"ACCTEST_PARALLELISM":            "1",
-						"GOOGLE_APPLICATION_CREDENTIALS": "/mock/dir/magic-modules/.ci/magician/sa_key.json",
-						"GOOGLE_CREDENTIALS":             "sa_key",
-						"GOOGLE_TEST_DIRECTORY":          "",
-						"SA_KEY":                         "sa_key",
-						"TF_ACC":                         "1",
-						"TF_ACC_REFRESH_AFTER_APPLY":     "1",
-						"TF_LOG":                         "DEBUG",
-						"TF_LOG_CORE":                    "WARN",
-						"TF_LOG_PATH_MASK":               "/mock/dir/magic-modules/.ci/magician/testlogs/recording/beta/%s.log",
-						"TF_LOG_SDK_FRAMEWORK":           "INFO",
-						"TF_SCHEMA_PANIC_ON_ERROR":       "1",
-						"VCR_MODE":                       "RECORDING",
-						"VCR_PATH":                       "/mock/dir/magic-modules/.ci/magician/cassettes/beta",
-					}},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/recording_test.log", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/recording/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "--recursive", "--content-type=text/plain", "/mock/dir/magic-modules/.ci/magician/testlogs/recording/beta/*", "gs://vcr-nightly/beta/2024-07-08/buildID/logs/build-log/"}, map[string]string(nil)},
-					{"/mock/dir/magic-modules/.ci/magician", "gcloud", []string{"storage", "cp", "/mock/dir/magic-modules/.ci/magician/cassettes/beta/*", "gs://ci-vcr-cassettes/beta/fixtures/"}, map[string]string(nil)},
-				},
-			},
+			name:                  "replay failed then record",
+			simulateReplayFailure: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rnr := &mockRunner{
-				calledMethods: make(map[string][]ParameterList),
-				cwd:           "/mock/dir/magic-modules/.ci/magician",
-				dirStack:      list.New(),
-				cmdResults:    tc.cmdResults,
+			sb := newSandbox(t)
+
+			// Intercepts gs:// URLs and translates to local copy operations.
+			fakeGcloud := `#!/bin/bash
+				if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+					ARGS=()
+					for arg in "$@"; do
+						if [[ ! "$arg" == -* ]] && [[ ! "$arg" == "storage" ]] && [[ ! "$arg" == "cp" ]]; then
+							ARGS+=("$arg")
+						fi
+					done
+					length=${#ARGS[@]}
+					DEST=${ARGS[$length-1]}
+					DEST=$(echo "$DEST" | sed 's|gs://|gs/|')
+					mkdir -p "$DEST"
+					for (( i=0; i<length-1; i++ )); do
+						SRC=${ARGS[$i]}
+						SRC=$(echo "$SRC" | sed 's|gs://|gs/|' | sed 's|/\*$||')
+						cp -r "$SRC"/* "$DEST" 2>/dev/null || cp -r "$SRC" "$DEST" 2>/dev/null
+					done
+				fi`
+			sb.Runner.WriteFile("gcloud", fakeGcloud)
+			sb.Runner.MustRun("chmod", []string{"+x", "gcloud"}, nil)
+
+			// Safely mocks git clone by making the destination directory.
+			fakeGit := `#!/bin/bash
+if [ "$1" = "clone" ]; then
+  mkdir -p "$3"
+fi`
+			sb.Runner.WriteFile("git", fakeGit)
+			sb.Runner.MustRun("chmod", []string{"+x", "git"}, nil)
+
+			// Simulates go list and integration tests natively via environment variables.
+			fakeGo := `#!/bin/bash
+				if [ "$1" = "list" ]; then
+					echo "github.com/hashicorp/terraform-provider-google-beta/google-beta"
+					exit 0
+				elif [ "$1" = "test" ]; then
+					if [ "$VCR_MODE" = "REPLAYING" ] && [ "$SIMULATE_REPLAY_FAILURE" = "true" ]; then
+						echo "--- FAIL: TestAccContainerNodePool_defaultDriverInstallation (590.29s)"
+						exit 1
+					elif [ "$VCR_MODE" = "RECORDING" ]; then
+						echo "--- PASS: TestAccContainerNodePool_defaultDriverInstallation (590.29s)"
+						# Write a dummy cassette so we can verify it gets uploaded!
+						echo "data" > "$VCR_PATH/new-cassette.txt"
+						exit 0
+					fi
+					exit 0
+				fi`
+			sb.Runner.WriteFile("go", fakeGo)
+			sb.Runner.MustRun("chmod", []string{"+x", "go"}, nil)
+
+			origPath := os.Getenv("PATH")
+			os.Setenv("PATH", sb.Dir+":"+origPath)
+			defer os.Setenv("PATH", origPath)
+
+			testEnv := map[string]string{
+				"SA_KEY": "sa_key",
+			}
+			if tc.simulateReplayFailure {
+				testEnv["SIMULATE_REPLAY_FAILURE"] = "true"
+			} else {
+				testEnv["SIMULATE_REPLAY_FAILURE"] = "false"
 			}
 
-			ctlr := source.NewController("gopath", "hashicorp", "token", rnr)
-			vt, err := vcr.NewTester(map[string]string{
-				"SA_KEY": "sa_key",
-			}, "ci-vcr-cassettes", "", rnr, false)
+			// Setup dummy cassettes for the test to copy
+			sb.Runner.MustRun("mkdir", []string{"-p", "gs/ci-vcr-cassettes/beta/fixtures"}, nil)
+			sb.Runner.WriteFile("gs/ci-vcr-cassettes/beta/fixtures/dummy-cassette.txt", "data")
+
+			ctlr := source.NewController("gopath", "hashicorp", "token", sb.Runner)
+			vt, err := vcr.NewTester(testEnv, "ci-vcr-cassettes", "", sb.Runner.(vcr.ExecRunner), false)
 			if err != nil {
 				t.Fatalf("Failed to create new tester: %v", err)
 			}
 
-			err = execVCRCassetteUpdate("buildID", "2024-07-08", rnr, ctlr, vt)
+			err = execVCRCassetteUpdate("buildID", "2024-07-08", sb.Runner, ctlr, vt)
 			if err != nil {
 				t.Fatalf("execVCRCassetteUpdate returned error: %v", err)
 			}
 
-			for method, expectedCalls := range tc.expectedCalls {
-				if actualCalls, ok := rnr.Calls(method); !ok {
-					t.Fatalf("Found no calls for %s", method)
-				} else if len(actualCalls) != len(expectedCalls) {
-					t.Fatalf("Unexpected number of calls for %s, got %d, expected %d", method, len(actualCalls), len(expectedCalls))
-				} else {
-					for i, actualParams := range actualCalls {
-						if expectedParams := expectedCalls[i]; cmp.Diff(expectedParams, actualParams) != "" {
-							t.Errorf("Wrong params for call %d to %s, got %v, expected %v, diff = %s", i, method, actualParams, expectedParams, cmp.Diff(expectedParams, actualParams))
-						}
-					}
+			if tc.simulateReplayFailure {
+				if _, err := os.Stat(sb.Dir + "/gs/ci-vcr-cassettes/beta/fixtures/new-cassette.txt"); os.IsNotExist(err) {
+					t.Fatalf("Expected newly recorded cassettes to be copied back to gs/ci-vcr-cassettes/beta/fixtures/")
+				}
+			} else {
+				if _, err := os.Stat(sb.Dir + "/gs/vcr-nightly/beta/2024-07-08/buildID/logs/replaying/replaying_test.log"); os.IsNotExist(err) {
+					t.Fatalf("Expected replaying test log to be uploaded to GCS")
 				}
 			}
 		})
@@ -435,24 +413,47 @@ func TestExecVCRCassetteUpdate(t *testing.T) {
 }
 
 func TestExecVCRCassetteUpdate_BuildFailure(t *testing.T) {
-	rnr := &mockRunner{
-		calledMethods: make(map[string][]ParameterList),
-		cwd:           "/mock/dir/magic-modules/.ci/magician",
-		dirStack:      list.New(),
-		cmdResults: map[string]string{
-			"gopath/src/github.com/hashicorp/terraform-provider-google-beta go [test  -p 16 -parallel 32 -v -run=TestAcc -timeout 360m -ldflags=-X=github.com/hashicorp/terraform-provider-google-beta/version.ProviderVersion=acc -vet=off] map[ACCTEST_PARALLELISM:32 GOOGLE_APPLICATION_CREDENTIALS:/mock/dir/magic-modules/.ci/magician/sa_key.json GOOGLE_CREDENTIALS:sa_key GOOGLE_TEST_DIRECTORY: SA_KEY:sa_key TF_ACC:1 TF_ACC_REFRESH_AFTER_APPLY:1 TF_LOG:DEBUG TF_LOG_CORE:WARN TF_LOG_PATH_MASK:/mock/dir/magic-modules/.ci/magician/testlogs/replaying/beta/%s.log TF_LOG_SDK_FRAMEWORK:INFO TF_SCHEMA_PANIC_ON_ERROR:1 VCR_MODE:REPLAYING VCR_PATH:/mock/dir/magic-modules/.ci/magician/cassettes/beta]": "FAIL\tgithub.com/hashicorp/terraform-provider-google-beta/google-beta/services/corebilling [build failed]",
-		},
-	}
+	sb := newSandbox(t)
 
-	ctlr := source.NewController("gopath", "hashicorp", "token", rnr)
+	// Simulates a build failure during integration testing.
+	fakeGo := `#!/bin/bash
+		if [ "$1" = "list" ]; then
+			echo "github.com/hashicorp/terraform-provider-google-beta/google-beta/services/corebilling"
+			exit 0
+		elif [ "$1" = "test" ]; then
+			echo "FAIL	github.com/hashicorp/terraform-provider-google-beta/google-beta/services/corebilling [build failed]"
+			exit 1
+		fi`
+	sb.Runner.WriteFile("go", fakeGo)
+	sb.Runner.MustRun("chmod", []string{"+x", "go"}, nil)
+
+	fakeGit := `#!/bin/bash
+		if [ "$1" = "clone" ]; then
+			mkdir -p "$3"
+		fi`
+	sb.Runner.WriteFile("git", fakeGit)
+	sb.Runner.MustRun("chmod", []string{"+x", "git"}, nil)
+
+	fakeGcloud := `#!/bin/bash
+		if [ "$1" = "storage" ] && [ "$2" = "cp" ]; then
+			exit 0
+		fi`
+	sb.Runner.WriteFile("gcloud", fakeGcloud)
+	sb.Runner.MustRun("chmod", []string{"+x", "gcloud"}, nil)
+
+	origPath := os.Getenv("PATH")
+	os.Setenv("PATH", sb.Dir+":"+origPath)
+	defer os.Setenv("PATH", origPath)
+
+	ctlr := source.NewController("gopath", "hashicorp", "token", sb.Runner)
 	vt, err := vcr.NewTester(map[string]string{
 		"SA_KEY": "sa_key",
-	}, "ci-vcr-cassettes", "", rnr, false)
+	}, "ci-vcr-cassettes", "", sb.Runner.(vcr.ExecRunner), false)
 	if err != nil {
 		t.Fatalf("Failed to create new tester: %v", err)
 	}
 
-	err = execVCRCassetteUpdate("buildID", "2024-07-08", rnr, ctlr, vt)
+	err = execVCRCassetteUpdate("buildID", "2024-07-08", sb.Runner, ctlr, vt)
 	if err == nil {
 		t.Fatalf("execVCRCassetteUpdate expected to return error on build failure, got nil")
 	}

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -347,7 +347,9 @@ func TestExecVCRCassetteUpdate(t *testing.T) {
 			fakeGit := `#!/bin/bash
 if [ "$1" = "clone" ]; then
   mkdir -p "$3"
-fi`
+  exit 0
+fi
+exec /usr/bin/git "$@"`
 			sb.Runner.WriteFile("git", fakeGit)
 			sb.Runner.MustRun("chmod", []string{"+x", "git"}, nil)
 
@@ -426,7 +428,9 @@ func TestExecVCRCassetteUpdate_BuildFailure(t *testing.T) {
 	fakeGit := `#!/bin/bash
 		if [ "$1" = "clone" ]; then
 			mkdir -p "$3"
-		fi`
+			exit 0
+		fi
+		exec /usr/bin/git "$@"`
 	sb.Runner.WriteFile("git", fakeGit)
 	sb.Runner.MustRun("chmod", []string{"+x", "git"}, nil)
 

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -320,6 +320,7 @@ func TestExecVCRCassetteUpdate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			sb := newSandbox(t)
+			sb.RequireAllowlist()
 
 			// Intercepts gs:// URLs and translates to local copy operations.
 			fakeGcloud := `#!/bin/bash
@@ -412,6 +413,7 @@ exec /usr/bin/git "$@"`
 
 func TestExecVCRCassetteUpdate_BuildFailure(t *testing.T) {
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 
 	// Simulates a build failure during integration testing.
 	fakeGo := `#!/bin/bash

--- a/.ci/magician/cmd/vcr_cassette_update_test.go
+++ b/.ci/magician/cmd/vcr_cassette_update_test.go
@@ -371,10 +371,6 @@ fi`
 			sb.Runner.WriteFile("go", fakeGo)
 			sb.Runner.MustRun("chmod", []string{"+x", "go"}, nil)
 
-			origPath := os.Getenv("PATH")
-			os.Setenv("PATH", sb.Dir+":"+origPath)
-			defer os.Setenv("PATH", origPath)
-
 			testEnv := map[string]string{
 				"SA_KEY": "sa_key",
 			}
@@ -440,10 +436,6 @@ func TestExecVCRCassetteUpdate_BuildFailure(t *testing.T) {
 		fi`
 	sb.Runner.WriteFile("gcloud", fakeGcloud)
 	sb.Runner.MustRun("chmod", []string{"+x", "gcloud"}, nil)
-
-	origPath := os.Getenv("PATH")
-	os.Setenv("PATH", sb.Dir+":"+origPath)
-	defer os.Setenv("PATH", origPath)
 
 	ctlr := source.NewController("gopath", "hashicorp", "token", sb.Runner)
 	vt, err := vcr.NewTester(map[string]string{


### PR DESCRIPTION
Update VCR test files to use the new sandbox framework. Instead of verifying that exact command strings were typed into the terminal, the tests now use fake scripts to move files around in a temporary folder. This ensures the tests are verifying actual file behavior rather than rigid text strings.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none

```
