### PR TITLE
test(magician): refactor test-terraform-vcr to use testing sandbox

### DIFF
--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -657,8 +657,13 @@ func getMentions(prNumber string, gh GithubClient) string {
 func appendVCRResultToDiffComment(prNumber string, content string, gh GithubClient, rnr ExecRunner) error {
 	var diffComment *github.PullRequestComment
 
+	workspace := os.Getenv("WORKSPACE")
+	if workspace == "" {
+		workspace = "/workspace"
+	}
+
 	// Try to find by ID from file
-	if idStr, err := rnr.ReadFile("/workspace/diff_comment_id.txt"); err == nil {
+	if idStr, err := rnr.ReadFile(filepath.Join(workspace, "diff_comment_id.txt")); err == nil {
 		if id, err := strconv.Atoi(strings.TrimSpace(idStr)); err == nil {
 			if comment, err := gh.GetPullRequestComment(id); err == nil {
 				diffComment = &comment

--- a/.ci/magician/cmd/test_terraform_vcr.go
+++ b/.ci/magician/cmd/test_terraform_vcr.go
@@ -168,7 +168,7 @@ The following environment variables are required:
 			return fmt.Errorf("error creating VCR tester: %w", err)
 		}
 
-		return execTestTerraformVCR(args[0], args[1], args[2], args[3], args[4], baseBranch, gh, rnr, ctlr, vt)
+		return execTestTerraformVCR(args[0], args[1], args[2], args[3], args[4], baseBranch, "/workspace", gh, rnr, ctlr, vt)
 	},
 }
 
@@ -180,7 +180,7 @@ func listTTVRequiredEnvironmentVariables() string {
 	return result
 }
 
-func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
+func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, baseBranch, workspace string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller, vt *vcr.Tester) error {
 	newBranch := "auto-pr-" + prNumber
 	oldBranch := newBranch + "-old"
 
@@ -251,13 +251,13 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		return fmt.Errorf("error uploading replaying logs: %w", err)
 	}
 
-	if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
+	if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, workspace, replayingResult, vcr.Replaying, gh, rnr); err != nil {
 		return fmt.Errorf("error handling panics: %w", err)
 	} else if hasPanics {
 		return nil
 	}
 
-	if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, replayingResult, vcr.Replaying, gh, rnr); err != nil {
+	if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, workspace, replayingResult, vcr.Replaying, gh, rnr); err != nil {
 		return fmt.Errorf("error handling build failures: %w", err)
 	} else if hasBuildFailures {
 		return nil
@@ -293,7 +293,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			comment = fmt.Sprintf("%s\n\n%s VCR tests complete for %s!", comment, mentionStr, mmCommitSha)
 		}
 	}
-	if err := appendVCRResultToDiffComment(prNumber, comment, gh, rnr); err != nil {
+	if err := appendVCRResultToDiffComment(prNumber, comment, workspace, gh, rnr); err != nil {
 		return fmt.Errorf("error appending comment: %w", err)
 	}
 	if len(replayingResult.FailedTests) > 0 {
@@ -324,13 +324,13 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 			return fmt.Errorf("error uploading recording logs: %w", err)
 		}
 
-		if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
+		if hasPanics, err := handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, workspace, recordingResult, vcr.Recording, gh, rnr); err != nil {
 			return fmt.Errorf("error handling panics: %w", err)
 		} else if hasPanics {
 			return nil
 		}
 
-		if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, recordingResult, vcr.Recording, gh, rnr); err != nil {
+		if hasBuildFailures, err := handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, workspace, recordingResult, vcr.Recording, gh, rnr); err != nil {
 			return fmt.Errorf("error handling build failures: %w", err)
 		} else if hasBuildFailures {
 			return nil
@@ -400,7 +400,7 @@ func execTestTerraformVCR(prNumber, mmCommitSha, buildID, projectID, buildStep, 
 		if mentionStr != "" {
 			recordReplayComment = fmt.Sprintf("%s\n\n%s VCR tests complete for %s!", recordReplayComment, mentionStr, mmCommitSha)
 		}
-		if err := appendVCRResultToDiffComment(prNumber, recordReplayComment, gh, rnr); err != nil {
+		if err := appendVCRResultToDiffComment(prNumber, recordReplayComment, workspace, gh, rnr); err != nil {
 			return fmt.Errorf("error appending comment: %w", err)
 		}
 	}
@@ -553,7 +553,7 @@ func runReplaying(runFullVCR bool, version provider.Version, services map[string
 	return result, testDirs, replayingErr
 }
 
-func handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
+func handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha, workspace string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
 	if len(result.Panics) > 0 {
 		comment := "> [!CAUTION]\n"
 		comment += "> **Panic occurred during VCR tests**\n>\n"
@@ -575,7 +575,7 @@ func handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha string, result vc
 		}
 		comment = header + comment
 
-		if err := appendVCRResultToDiffComment(prNumber, comment, gh, rnr); err != nil {
+		if err := appendVCRResultToDiffComment(prNumber, comment, workspace, gh, rnr); err != nil {
 			return true, fmt.Errorf("error appending comment: %v", err)
 		}
 		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStepUrl, mmCommitSha); err != nil {
@@ -586,7 +586,7 @@ func handlePanics(prNumber, buildID, buildStepUrl, mmCommitSha string, result vc
 	return false, nil
 }
 
-func handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
+func handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha, workspace string, result vcr.Result, mode vcr.Mode, gh GithubClient, rnr ExecRunner) (bool, error) {
 	if len(result.BuildFailures) > 0 {
 		comment := "> [!CAUTION]\n"
 		comment += "> **Build Failure during VCR tests**\n>\n"
@@ -611,7 +611,7 @@ func handleBuildFailures(prNumber, buildID, buildStepUrl, mmCommitSha string, re
 		}
 		comment = header + comment
 
-		if err := appendVCRResultToDiffComment(prNumber, comment, gh, rnr); err != nil {
+		if err := appendVCRResultToDiffComment(prNumber, comment, workspace, gh, rnr); err != nil {
 			return true, fmt.Errorf("error appending comment: %v", err)
 		}
 		if err := gh.PostBuildStatus(prNumber, "VCR-test", "failure", buildStepUrl, mmCommitSha); err != nil {
@@ -654,10 +654,9 @@ func getMentions(prNumber string, gh GithubClient) string {
 // appendVCRResultToDiffComment appends content to the existing diff report comment
 // identified by the ID in /workspace/diff_comment_id.txt.
 // If the file is missing or the comment cannot be fetched, it falls back to posting a new comment.
-func appendVCRResultToDiffComment(prNumber string, content string, gh GithubClient, rnr ExecRunner) error {
+func appendVCRResultToDiffComment(prNumber string, content string, workspace string, gh GithubClient, rnr ExecRunner) error {
 	var diffComment *github.PullRequestComment
 
-	workspace := os.Getenv("WORKSPACE")
 	if workspace == "" {
 		workspace = "/workspace"
 	}

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -663,8 +664,8 @@ func TestHandleBuildFailures(t *testing.T) {
 		BuildFailures: []string{"package1", "package2"},
 	}
 
-	rnr := &mockRunner{}
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, rnr)
+	sb := newSandbox(t)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.True(t, handled)
@@ -690,8 +691,8 @@ func TestHandleBuildFailures_Recording(t *testing.T) {
 		BuildFailures: []string{"package1", "package2"},
 	}
 
-	rnr := &mockRunner{}
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Recording, gh, rnr)
+	sb := newSandbox(t)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Recording, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.True(t, handled)
@@ -709,8 +710,8 @@ func TestHandleBuildFailures_NoFailures(t *testing.T) {
 	}
 	result := vcr.Result{}
 
-	rnr := &mockRunner{}
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, rnr)
+	sb := newSandbox(t)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.False(t, handled)
@@ -736,8 +737,8 @@ func TestAppendVCRResultToDiffComment_NotExists(t *testing.T) {
 		},
 	}
 
-	rnr := &mockRunner{}
-	err := appendVCRResultToDiffComment("123", "VCR Results", gh, rnr)
+	sb := newSandbox(t)
+	err := appendVCRResultToDiffComment("123", "VCR Results", gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.Len(t, gh.calledMethods["PostComment"], 1)
@@ -761,13 +762,13 @@ func TestAppendVCRResultToDiffComment_UseFileID(t *testing.T) {
 			},
 		},
 	}
-	rnr := &mockRunner{
-		fileContents: map[string]string{
-			"/workspace/diff_comment_id.txt": "456",
-		},
-	}
+	sb := newSandbox(t)
+	os.Setenv("WORKSPACE", sb.Dir)
+	defer os.Unsetenv("WORKSPACE")
 
-	err := appendVCRResultToDiffComment("123", "VCR Results", gh, rnr)
+	sb.Runner.WriteFile("diff_comment_id.txt", "456")
+
+	err := appendVCRResultToDiffComment("123", "VCR Results", gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.Len(t, gh.calledMethods["UpdateComment"], 1)

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -665,7 +664,7 @@ func TestHandleBuildFailures(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, sb.Runner)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.True(t, handled)
@@ -692,7 +691,7 @@ func TestHandleBuildFailures_Recording(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Recording, gh, sb.Runner)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Recording, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.True(t, handled)
@@ -711,7 +710,7 @@ func TestHandleBuildFailures_NoFailures(t *testing.T) {
 	result := vcr.Result{}
 
 	sb := newSandbox(t)
-	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", result, vcr.Replaying, gh, sb.Runner)
+	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.False(t, handled)
@@ -738,7 +737,7 @@ func TestAppendVCRResultToDiffComment_NotExists(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
-	err := appendVCRResultToDiffComment("123", "VCR Results", gh, sb.Runner)
+	err := appendVCRResultToDiffComment("123", "VCR Results", sb.Dir, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.Len(t, gh.calledMethods["PostComment"], 1)
@@ -763,12 +762,10 @@ func TestAppendVCRResultToDiffComment_UseFileID(t *testing.T) {
 		},
 	}
 	sb := newSandbox(t)
-	os.Setenv("WORKSPACE", sb.Dir)
-	defer os.Unsetenv("WORKSPACE")
 
 	sb.Runner.WriteFile("diff_comment_id.txt", "456")
 
-	err := appendVCRResultToDiffComment("123", "VCR Results", gh, sb.Runner)
+	err := appendVCRResultToDiffComment("123", "VCR Results", sb.Dir, gh, sb.Runner)
 
 	assert.NoError(t, err)
 	assert.Len(t, gh.calledMethods["UpdateComment"], 1)

--- a/.ci/magician/cmd/test_terraform_vcr_test.go
+++ b/.ci/magician/cmd/test_terraform_vcr_test.go
@@ -664,6 +664,7 @@ func TestHandleBuildFailures(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
@@ -691,6 +692,7 @@ func TestHandleBuildFailures_Recording(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Recording, gh, sb.Runner)
 
 	assert.NoError(t, err)
@@ -710,6 +712,7 @@ func TestHandleBuildFailures_NoFailures(t *testing.T) {
 	result := vcr.Result{}
 
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 	handled, err := handleBuildFailures("123", "build-456", "http://target", "sha789", sb.Dir, result, vcr.Replaying, gh, sb.Runner)
 
 	assert.NoError(t, err)
@@ -737,6 +740,7 @@ func TestAppendVCRResultToDiffComment_NotExists(t *testing.T) {
 	}
 
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 	err := appendVCRResultToDiffComment("123", "VCR Results", sb.Dir, gh, sb.Runner)
 
 	assert.NoError(t, err)
@@ -762,6 +766,7 @@ func TestAppendVCRResultToDiffComment_UseFileID(t *testing.T) {
 		},
 	}
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
 
 	sb.Runner.WriteFile("diff_comment_id.txt", "456")
 


### PR DESCRIPTION
Migrates `test_terraform_vcr_test.go` to replace `mockRunner` with the sandbox testing framework. To support the use of the physical filesys, `test_terraform_vcr.go` was updated to dynamically resolve `diff_comment_id.txt`'s path using the new `WORKSPACE` env variable (defaulting to `/workspace`). This preserves behaviour in production, while allowing local testing in a temporary directory.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none

```
