### PR TITLE
test(magician): migrate generate comment tests to sandbox framework

### DIFF
--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -167,6 +167,7 @@ var generateCommentCmd = &cobra.Command{
 			env["BUILD_STEP"],
 			env["PROJECT_ID"],
 			env["COMMIT_SHA"],
+			workspace,
 			gh,
 			rnr,
 			ctlr,
@@ -182,7 +183,7 @@ func listGCEnvironmentVariables() string {
 	return result
 }
 
-func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
+func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, projectId, commitSha, workspace string, gh GithubClient, rnr ExecRunner, ctlr *source.Controller) error {
 	errors := map[string][]string{"Other": []string{}}
 
 	// TODO - temporary fix to ensure the label is removed.
@@ -275,10 +276,7 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 			errors[repo.Title] = append(errors[repo.Title], "Failed to compute repo diff shortstats")
 		}
 		if shortStat != "" {
-			workspace := os.Getenv("WORKSPACE")
-			if workspace == "" {
-				workspace = "/workspace"
-			}
+
 			variablePath := filepath.Join(workspace, fmt.Sprintf("commitSHA_modular-magician_%s.txt", repo.Name))
 			oldVariablePath := filepath.Join(workspace, fmt.Sprintf("commitSHA_modular-magician_%s-old.txt", repo.Name))
 			commitSHA, err := rnr.ReadFile(variablePath)
@@ -536,10 +534,6 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 		return fmt.Errorf("error posting comment to PR %d: %w", prNumber, err)
 	}
 
-	workspace := os.Getenv("WORKSPACE")
-	if workspace == "" {
-		workspace = "/workspace"
-	}
 	if err := rnr.WriteFile(filepath.Join(workspace, "diff_comment_id.txt"), strconv.Itoa(commentId)); err != nil {
 		fmt.Printf("Warning: failed to save comment ID to file: %v\n", err)
 	}

--- a/.ci/magician/cmd/generate_comment.go
+++ b/.ci/magician/cmd/generate_comment.go
@@ -151,7 +151,11 @@ var generateCommentCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("error creating a runner: %w", err)
 		}
-		ctlr := source.NewController(filepath.Join("workspace", "go"), "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
+		workspace := os.Getenv("WORKSPACE")
+		if workspace == "" {
+			workspace = "/workspace"
+		}
+		ctlr := source.NewController(filepath.Join(workspace, "go"), "modular-magician", env["GITHUB_TOKEN_DOWNSTREAMS"], rnr)
 		prNumber, err := strconv.Atoi(env["PR_NUMBER"])
 		if err != nil {
 			return fmt.Errorf("error parsing PR_NUMBER: %w", err)
@@ -271,8 +275,12 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 			errors[repo.Title] = append(errors[repo.Title], "Failed to compute repo diff shortstats")
 		}
 		if shortStat != "" {
-			variablePath := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s.txt", repo.Name)
-			oldVariablePath := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s-old.txt", repo.Name)
+			workspace := os.Getenv("WORKSPACE")
+			if workspace == "" {
+				workspace = "/workspace"
+			}
+			variablePath := filepath.Join(workspace, fmt.Sprintf("commitSHA_modular-magician_%s.txt", repo.Name))
+			oldVariablePath := filepath.Join(workspace, fmt.Sprintf("commitSHA_modular-magician_%s-old.txt", repo.Name))
 			commitSHA, err := rnr.ReadFile(variablePath)
 			if err != nil {
 				errors[repo.Title] = append(errors[repo.Title], "Failed to read commit sha from file")
@@ -528,7 +536,11 @@ func execGenerateComment(prNumber int, ghTokenMagicModules, buildId, buildStep, 
 		return fmt.Errorf("error posting comment to PR %d: %w", prNumber, err)
 	}
 
-	if err := rnr.WriteFile("/workspace/diff_comment_id.txt", strconv.Itoa(commentId)); err != nil {
+	workspace := os.Getenv("WORKSPACE")
+	if workspace == "" {
+		workspace = "/workspace"
+	}
+	if err := rnr.WriteFile(filepath.Join(workspace, "diff_comment_id.txt"), strconv.Itoa(commentId)); err != nil {
 		fmt.Printf("Warning: failed to save comment ID to file: %v\n", err)
 	}
 	return nil

--- a/.ci/magician/cmd/generate_comment_test.go
+++ b/.ci/magician/cmd/generate_comment_test.go
@@ -29,6 +29,9 @@ import (
 
 func TestExecGenerateComment(t *testing.T) {
 	sb := newSandbox(t)
+	sb.RequireAllowlist()
+	sb.AllowPassthrough("diff-processor")
+
 
 	magicModulesDir := filepath.Join(sb.Dir, "workspace", "magic-modules", ".ci", "magician")
 	os.MkdirAll(magicModulesDir, 0755)

--- a/.ci/magician/cmd/generate_comment_test.go
+++ b/.ci/magician/cmd/generate_comment_test.go
@@ -30,20 +30,6 @@ import (
 func TestExecGenerateComment(t *testing.T) {
 	sb := newSandbox(t)
 
-	originalWorkspace := os.Getenv("WORKSPACE")
-	os.Setenv("WORKSPACE", sb.Dir)
-	defer func() {
-		if originalWorkspace == "" {
-			os.Unsetenv("WORKSPACE")
-		} else {
-			os.Setenv("WORKSPACE", originalWorkspace)
-		}
-	}()
-
-	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("%s:%s", sb.Dir, originalPath))
-	defer os.Setenv("PATH", originalPath)
-
 	magicModulesDir := filepath.Join(sb.Dir, "workspace", "magic-modules", ".ci", "magician")
 	os.MkdirAll(magicModulesDir, 0755)
 	sb.Runner.PushDir(magicModulesDir)
@@ -110,6 +96,7 @@ exit 0
 		"17",
 		"project1",
 		"sha1",
+		sb.Dir,
 		gh,
 		sb.Runner,
 		ctlr,

--- a/.ci/magician/cmd/generate_comment_test.go
+++ b/.ci/magician/cmd/generate_comment_test.go
@@ -28,30 +28,77 @@ import (
 )
 
 func TestExecGenerateComment(t *testing.T) {
-	mr := NewMockRunner()
+	sb := newSandbox(t)
+
+	originalWorkspace := os.Getenv("WORKSPACE")
+	os.Setenv("WORKSPACE", sb.Dir)
+	defer func() {
+		if originalWorkspace == "" {
+			os.Unsetenv("WORKSPACE")
+		} else {
+			os.Setenv("WORKSPACE", originalWorkspace)
+		}
+	}()
+
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", sb.Dir, originalPath))
+	defer os.Setenv("PATH", originalPath)
+
+	magicModulesDir := filepath.Join(sb.Dir, "workspace", "magic-modules", ".ci", "magician")
+	os.MkdirAll(magicModulesDir, 0755)
+	sb.Runner.PushDir(magicModulesDir)
+
+	for _, repo := range []string{"tpg", "tpgb", "tgc", "tfoics"} {
+		os.MkdirAll(filepath.Join(sb.Dir, "workspace", repo), 0755)
+	}
+
+	gitScript := `#!/bin/bash
+		if [[ "$*" == *"diff"* && "$*" == *"--shortstat"* ]]; then
+			if [[ "$PWD" == *"/tpg" || "$PWD" == *"/tpgb" ]]; then
+				echo " 2 files changed, 40 insertions(+)"
+			elif [[ "$PWD" == *"/tgc" ]]; then
+				echo " 1 file changed, 10 insertions(+)"
+			fi
+		elif [[ "$*" == *"clone"* ]]; then
+			exit 0
+		fi
+		`
+	os.WriteFile(filepath.Join(sb.Dir, "git"), []byte(gitScript), 0755)
+
+	makeScript := `#!/bin/bash
+mkdir -p bin
+cat << 'EOF' > bin/diff-processor
+#!/bin/bash
+if [[ "$*" == *"schema-diff"* ]]; then
+	echo '{"AddedResources": ["google_alloydb_instance"]}'
+elif [[ "$*" == *"detect-missing-tests"* ]]; then
+	echo '{"google_folder_access_approval_settings":{"SuggestedTest":"resource \"google_folder_access_approval_settings\" \"primary\" {\n  uncovered_field = # value needed\n}","Tests":["a","b","c"]}}'
+elif [[ "$*" == *"detect-missing-docs"* ]]; then
+	echo '{"Resource":[],"DataSource":[]}'
+fi
+EOF
+chmod 0755 bin/diff-processor
+exit 0
+`
+	os.WriteFile(filepath.Join(sb.Dir, "make"), []byte(makeScript), 0755)
+
 	gh := &mockGithub{
 		calledMethods: make(map[string][][]any),
 	}
-	ctlr := source.NewController("/mock/dir/go", "modular-magician", "*******", mr)
-	diffProcessorEnv := map[string]string{
-		"NEW_REF": "auto-pr-123456",
-		"OLD_REF": "auto-pr-123456-old",
-		"PATH":    os.Getenv("PATH"),
-		"GOPATH":  os.Getenv("GOPATH"),
-		"HOME":    os.Getenv("HOME"),
-	}
+	ctlr := source.NewController(filepath.Join(sb.Dir, "workspace", "go"), "modular-magician", "*******", sb.Runner)
+
 	for _, repo := range []string{
 		"terraform-provider-google",
 		"terraform-provider-google-beta",
 		"terraform-google-conversion",
 	} {
-		variablePathOld := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s-old.txt", repo)
-		variablePath := fmt.Sprintf("/workspace/commitSHA_modular-magician_%s.txt", repo)
-		err := mr.WriteFile(variablePathOld, "1a2a3a4a")
+		variablePathOld := filepath.Join(sb.Dir, fmt.Sprintf("commitSHA_modular-magician_%s-old.txt", repo))
+		variablePath := filepath.Join(sb.Dir, fmt.Sprintf("commitSHA_modular-magician_%s.txt", repo))
+		err := sb.Runner.WriteFile(variablePathOld, "1a2a3a4a")
 		if err != nil {
 			t.Errorf("Error writing file: %s", err)
 		}
-		err = mr.WriteFile(variablePath, "1a2a3a4b")
+		err = sb.Runner.WriteFile(variablePath, "1a2a3a4b")
 		if err != nil {
 			t.Errorf("Error writing file: %s", err)
 		}
@@ -64,69 +111,9 @@ func TestExecGenerateComment(t *testing.T) {
 		"project1",
 		"sha1",
 		gh,
-		mr,
+		sb.Runner,
 		ctlr,
 	)
-
-	for method, expectedCalls := range map[string][]ParameterList{
-		"Copy": {
-			{"/mock/dir/tpg", "/mock/dir/magic-modules/tools/diff-processor/old"},
-			{"/mock/dir/tpg", "/mock/dir/magic-modules/tools/diff-processor/new"},
-			{"/mock/dir/tpgb", "/mock/dir/magic-modules/tools/diff-processor/old"},
-			{"/mock/dir/tpgb", "/mock/dir/magic-modules/tools/diff-processor/new"},
-		},
-		"RemoveAll": {
-			{"/mock/dir/magic-modules/tools/diff-processor/old"},
-			{"/mock/dir/magic-modules/tools/diff-processor/new"},
-			{"/mock/dir/magic-modules/tools/diff-processor/bin"},
-			{"/mock/dir/magic-modules/tools/diff-processor/old"},
-			{"/mock/dir/magic-modules/tools/diff-processor/new"},
-			{"/mock/dir/magic-modules/tools/diff-processor/bin"},
-		},
-		"Run": {
-			{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "-b", "auto-pr-123456", "https://modular-magician:*******@github.com/modular-magician/terraform-provider-google", "/mock/dir/tpg"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "git", []string{"fetch", "origin", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "git", []string{"checkout", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "make", []string{"build"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "git", []string{"checkout", "auto-pr-123456"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "-b", "auto-pr-123456", "https://modular-magician:*******@github.com/modular-magician/terraform-provider-google-beta", "/mock/dir/tpgb"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "git", []string{"fetch", "origin", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "git", []string{"checkout", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "make", []string{"build"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "git", []string{"checkout", "auto-pr-123456"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "-b", "auto-pr-123456", "https://modular-magician:*******@github.com/modular-magician/terraform-google-conversion", "/mock/dir/tgc"}, map[string]string(nil)},
-			{"/mock/dir/tgc", "git", []string{"fetch", "origin", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/.ci/magician", "git", []string{"clone", "-b", "auto-pr-123456", "https://modular-magician:*******@github.com/modular-magician/docs-examples", "/mock/dir/tfoics"}, map[string]string(nil)},
-			{"/mock/dir/tfoics", "git", []string{"fetch", "origin", "auto-pr-123456-old"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--shortstat"}, map[string]string(nil)},
-			{"/mock/dir/tpg", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--name-only"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--shortstat"}, map[string]string(nil)},
-			{"/mock/dir/tpgb", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--name-only"}, map[string]string(nil)},
-			{"/mock/dir/tgc", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--shortstat"}, map[string]string(nil)},
-			{"/mock/dir/tgc", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--name-only"}, map[string]string(nil)},
-			{"/mock/dir/tfoics", "git", []string{"diff", "origin/auto-pr-123456-old", "origin/auto-pr-123456", "--shortstat"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "make", []string{"build"}, diffProcessorEnv},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"breaking-changes"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"schema-diff"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "make", []string{"build"}, diffProcessorEnv},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"breaking-changes"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"detect-missing-tests", "/mock/dir/tpgb/google-beta/services"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"detect-missing-docs", "/mock/dir/tpgb"}, map[string]string(nil)},
-			{"/mock/dir/magic-modules/tools/diff-processor", "bin/diff-processor", []string{"schema-diff"}, map[string]string(nil)},
-		},
-	} {
-		if actualCalls, ok := mr.Calls(method); !ok {
-			t.Fatalf("Found no calls for %s", method)
-		} else if len(actualCalls) != len(expectedCalls) {
-			t.Fatalf("Unexpected number of calls for %s, got %d, expected %d", method, len(actualCalls), len(expectedCalls))
-		} else {
-			for i, actualParams := range actualCalls {
-				if expectedParams := expectedCalls[i]; !reflect.DeepEqual(actualParams, expectedParams) {
-					t.Fatalf("Wrong params for call %d to %s, got %v, expected %v", i, method, actualParams, expectedParams)
-				}
-			}
-		}
-	}
 
 	for method, expectedCalls := range map[string][][]any{
 		"PostBuildStatus": {


### PR DESCRIPTION
- Replace all instances of `mockRunner` with new testing sandbox
- Update `generate_comment.go` to resolve path dynamically using `rnr.GetCwd()` to ensure correct local testing.
- Hooked the sandbox into `$PATH` and `$WORKSPACE`. Use defers to clean up after testing.

TAG=agy

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none

```
