### PR TITLE
test(magician): add interceptingRunner to reroute sandbox executions

### DIFF
--- a/.ci/magician/cmd/sandbox_sanity_test.go
+++ b/.ci/magician/cmd/sandbox_sanity_test.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,7 @@ func TestSandboxInitialization(t *testing.T) {
 		t.Fatalf("Sandbox directory %s does not exist", sb.Dir)
 	}
 
+	sb.AllowPassthrough("git")
 	output, err := sb.Runner.Run("git", []string{"status"}, nil)
 	if err != nil {
 		t.Fatalf("Sandbox is not a valid git repository: %v\nOutput: %s", err, output)
@@ -35,5 +37,41 @@ func TestSandboxInitialization(t *testing.T) {
 
 	if !strings.Contains(output, "On branch main") {
 		t.Errorf("Expected 'On branch main' in git status output, got: %s", output)
+	}
+}
+
+func TestSandboxInterceptor_AllowedCommand(t *testing.T) {
+	sb := newSandbox(t)
+	sb.RequireWhitelist()
+	_, err := sb.Runner.Run("touch", []string{"test_file.txt"}, nil)
+	if err != nil {
+		t.Fatalf("Expected whitelisted command to succeed, got: %v", err)
+	}
+}
+
+func TestSandboxInterceptor_MockOverridesAllowed(t *testing.T) {
+	sb := newSandbox(t)
+	sb.RequireWhitelist()
+	sb.Runner.WriteFile("echo", "#!/bin/bash\necho 'intercepted echo'")
+	os.Chmod(filepath.Join(sb.Dir, "echo"), 0755)
+
+	output, err := sb.Runner.Run("echo", []string{"hello"}, nil)
+	if err != nil {
+		t.Fatalf("Expected mocked command to succeed, got: %v", err)
+	}
+	if !strings.Contains(output, "intercepted echo") {
+		t.Errorf("Expected sandbox mock to override whitelist, got: %s", output)
+	}
+}
+
+func TestSandboxInterceptor_UnhandledCommandPanics(t *testing.T) {
+	sb := newSandbox(t)
+	sb.RequireWhitelist()
+	_, err := sb.Runner.Run("curl", []string{"http://example.com"}, nil)
+	if err == nil {
+		t.Fatalf("Expected unhandled command to return error, but it succeeded")
+	}
+	if !strings.Contains(err.Error(), "not in the passthrough list") {
+		t.Errorf("Expected strict interceptor error, got: %v", err)
 	}
 }

--- a/.ci/magician/cmd/sandbox_test.go
+++ b/.ci/magician/cmd/sandbox_test.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,18 +33,34 @@ type sandbox struct {
 // Routes some commands to fake sandbox scripts, bypassing $PATH.
 type interceptingRunner struct {
 	*exec.Runner
-	sbDir string
+	sbDir              string
+	allowedPassthrough map[string]bool
+	strictMode         bool
 }
 
 func (s *interceptingRunner) Run(name string, args []string, env map[string]string) (string, error) {
-	// Only intercept bare commands (git, make, etc.)
-	if !strings.Contains(name, string(filepath.Separator)) {
-		sandboxBin := filepath.Join(s.sbDir, name)
-		if _, err := os.Stat(sandboxBin); err == nil {
-			name = sandboxBin
+	if !s.strictMode {
+		if !strings.Contains(name, string(filepath.Separator)) {
+			sandboxBin := filepath.Join(s.sbDir, name)
+			if _, err := os.Stat(sandboxBin); err == nil {
+				name = sandboxBin
+			}
 		}
+		return s.Runner.Run(name, args, env)
 	}
-	return s.Runner.Run(name, args, env)
+
+	baseName := filepath.Base(name)
+
+	sandboxBin := filepath.Join(s.sbDir, baseName)
+	if _, err := os.Stat(sandboxBin); err == nil {
+		return s.Runner.Run(sandboxBin, args, env)
+	}
+
+	if s.allowedPassthrough[baseName] {
+		return s.Runner.Run(name, args, env)
+	}
+
+	return "", fmt.Errorf("command %q is not in the passthrough list and no sandbox mock was found. Please mock it or add it to the passthrough list", baseName)
 }
 
 func newSandbox(t *testing.T) *sandbox {
@@ -54,26 +71,52 @@ func newSandbox(t *testing.T) *sandbox {
 		t.Fatalf("Failed to create runner: %v", err)
 	}
 
-	runner := &interceptingRunner{
-		Runner: realRunner,
-		sbDir:  dir,
-	}
-
-	if err := runner.PushDir(dir); err != nil {
+	if err := realRunner.PushDir(dir); err != nil {
 		t.Fatalf("Failed to push dir: %v", err)
 	}
 
-	runner.MustRun("git", []string{"init", "-b", "main"}, nil)
+	realRunner.MustRun("git", []string{"init", "-b", "main"}, nil)
 
-	runner.MustRun("touch", []string{"README.md"}, nil)
-	runner.MustRun("git", []string{"add", "."}, nil)
-	runner.MustRun("git", []string{"config", "user.email", "test@example.com"}, nil)
-	runner.MustRun("git", []string{"config", "user.name", "Test Sandbox"}, nil)
-	runner.MustRun("git", []string{"config", "commit.gpgsign", "false"}, nil)
-	runner.MustRun("git", []string{"commit", "-m", "Initial sandbox commit"}, nil)
+	realRunner.MustRun("touch", []string{"README.md"}, nil)
+	realRunner.MustRun("git", []string{"add", "."}, nil)
+	realRunner.MustRun("git", []string{"config", "user.email", "test@example.com"}, nil)
+	realRunner.MustRun("git", []string{"config", "user.name", "Test Sandbox"}, nil)
+	realRunner.MustRun("git", []string{"config", "commit.gpgsign", "false"}, nil)
+	realRunner.MustRun("git", []string{"commit", "-m", "Initial sandbox commit"}, nil)
+
+	runner := &interceptingRunner{
+		Runner: realRunner,
+		sbDir:  dir,
+		allowedPassthrough: map[string]bool{
+			"chmod": true,
+			"rm":    true,
+			"mkdir": true,
+			"touch": true,
+			"cp":    true,
+			"mv":    true,
+			"ls":    true,
+			"echo":  true,
+			"cat":   true,
+			"grep":  true,
+		},
+	}
 
 	return &sandbox{
 		Dir:    dir,
 		Runner: runner,
+	}
+}
+
+func (s *sandbox) AllowPassthrough(commands ...string) {
+	if runner, ok := s.Runner.(*interceptingRunner); ok {
+		for _, cmd := range commands {
+			runner.allowedPassthrough[cmd] = true
+		}
+	}
+}
+
+func (s *sandbox) RequireWhitelist() {
+	if runner, ok := s.Runner.(*interceptingRunner); ok {
+		runner.strictMode = true
 	}
 }

--- a/.ci/magician/cmd/sandbox_test.go
+++ b/.ci/magician/cmd/sandbox_test.go
@@ -16,6 +16,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"magician/exec"
@@ -26,12 +29,34 @@ type sandbox struct {
 	Runner ExecRunner
 }
 
+// Routes some commands to fake sandbox scripts, bypassing $PATH.
+type interceptingRunner struct {
+	*exec.Runner
+	sbDir string
+}
+
+func (s *interceptingRunner) Run(name string, args []string, env map[string]string) (string, error) {
+	// Only intercept bare commands (git, make, etc.)
+	if !strings.Contains(name, string(filepath.Separator)) {
+		sandboxBin := filepath.Join(s.sbDir, name)
+		if _, err := os.Stat(sandboxBin); err == nil {
+			name = sandboxBin
+		}
+	}
+	return s.Runner.Run(name, args, env)
+}
+
 func newSandbox(t *testing.T) *sandbox {
 	dir := t.TempDir()
 
-	runner, err := exec.NewRunner()
+	realRunner, err := exec.NewRunner()
 	if err != nil {
 		t.Fatalf("Failed to create runner: %v", err)
+	}
+
+	runner := &interceptingRunner{
+		Runner: realRunner,
+		sbDir:  dir,
 	}
 
 	if err := runner.PushDir(dir); err != nil {


### PR DESCRIPTION
The `interceptingRunner` wraps around `exec.Runner` and reroutes commands (such as git, make) to fake scripts inside the sandbox, if they exist. This eliminates the need to modify environment variables and allows for safe parallel testing.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

```release-note:none

```
