### PR TITLE
fix(networkservices): use custom expander for AgentGateway name field to support proto validation

### DIFF
--- a/mmv1/products/networkservices/AgentGateway.yaml
+++ b/mmv1/products/networkservices/AgentGateway.yaml
@@ -68,8 +68,9 @@ parameters:
     type: String
     description: |
       Name of the AgentGateway resource.
-    url_param_only: true
     required: true
+    ignore_read: true
+    custom_expand: 'templates/terraform/custom_expand/network_services_agent_gateway_name.go.tmpl'
   - name: 'location'
     type: String
     description: |

--- a/mmv1/templates/terraform/custom_expand/network_services_agent_gateway_name.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/network_services_agent_gateway_name.go.tmpl
@@ -1,0 +1,20 @@
+func expandNetworkServicesAgentGatewayName(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return nil, err
+	}
+	
+	location := d.Get("location").(string)
+	name := v.(string)
+	
+	// If name is already a full resource name, return it as-is.
+	if strings.HasPrefix(name, "projects/") {
+		return name, nil
+	}
+	
+	return fmt.Sprintf("projects/%s/locations/%s/agentGateways/%s", project, location, name), nil
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This PR fixes a field-level blocker for `networkservices.googleapis.com/AgentGateway` where the `name` field was failing API validation during resource creation and updates.

### Problem
When `url_param_only: true` was removed from the `name` field in `AgentGateway.yaml` to address missing coverage, the provider started sending `name` in the request body. However, because it sent the short name (e.g. `my-gateway`), the API returned a validation error (`AGENT_GATEWAY_MALFORMED_NAME`) because the API backend expects a fully qualified resource name path.

### Solution
1. Modified `mmv1/products/networkservices/AgentGateway.yaml` to remove `url_param_only: true`, set `ignore_read: true` for the `name` field, and assigned a `custom_expand` template.
2. Implemented a new custom expander template at `mmv1/templates/terraform/custom_expand/network_services_agent_gateway_name.go.tmpl`. This template checks if the name provided in configuration already starts with `projects/`. If it does not, it expands the name into a fully qualified resource name (`projects/{{project}}/locations/{{location}}/agentGateways/{{name}}`).
3. Regenerated the provider code using `make provider` and successfully ran acceptance tests (e.g., `TestAccNetworkServicesAgentGateway_networkServicesAgentGatewayClientToAgentExample`), which passed, verifying that creation and deletion work correctly with the new name expansion logic.

Fixes missing coverage on the launch-blocker dashboard for `networkservices.googleapis.com/AgentGateway`.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
networkservices: fixed `name` field expansion for `google_network_services_agent_gateway` resources so that short names are automatically expanded to full resource names, preventing API validation errors on create and update.
```
