### PR TITLE
firestore: Retry user_creds on 409 errors

### DIFF
--- a/mmv1/products/firestore/UserCreds.yaml
+++ b/mmv1/products/firestore/UserCreds.yaml
@@ -27,6 +27,8 @@ create_url: 'projects/{{project}}/databases/{{database}}/userCreds?userCredsId={
 autogen_async: false
 custom_code:
   post_create: templates/terraform/post_create/firestore_user_creds.go.tmpl
+error_retry_predicates:
+  - 'transport_tpg.FirestoreUserCreds409Retry'
 examples:
   - name: 'firestore_user_creds_basic'
     primary_resource_id: 'my-user-creds'

--- a/mmv1/third_party/terraform/transport/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates.go
@@ -445,6 +445,15 @@ func FirestoreIndex409Retry(err error) (bool, string) {
 	return false, ""
 }
 
+func FirestoreUserCreds409Retry(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 409 {
+			return true, "The operation was aborted."
+		}
+	}
+	return false, ""
+}
+
 func IapClient409Operation(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "operation was aborted") {

--- a/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/transport/error_retry_predicates_test.go
@@ -204,6 +204,17 @@ func TestFirestoreIndex409_retryUnderlyingDataChanged(t *testing.T) {
 	}
 }
 
+func TestFirestoreUserCreds409Retry(t *testing.T) {
+	err := googleapi.Error{
+		Code: 409,
+		Body: "The operation was aborted.",
+	}
+	isRetryable, _ := FirestoreUserCreds409Retry(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}
+
 func TestIs403ConcurrentOperationsQuotaError_retryable(t *testing.T) {
 	err := googleapi.Error{
 		Code: 403,


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firestore: retried on 409 errors in `google_firestore_user_creds` resource
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27737