### PR TITLE
Flags to reduce long GKE plans due to high node pool counts 

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2936,6 +2936,12 @@ func ResourceContainerCluster() *schema.Resource {
 	//UDP schema start
             "deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
 	//UDP schema end
+			"ignore_node_count_drift": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `When true, the provider ignores external changes (drift) to the node count by skipping GCE API queries to the Instance Group Managers. This is a performance optimization for large clusters that saves API quota. Setting this to true will result in missing managed_instance_group_urls in the state for all node pools in the cluster.`,
+			},
 		},
 	}
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2936,7 +2936,7 @@ func ResourceContainerCluster() *schema.Resource {
 	//UDP schema start
             "deletion_policy": tpgresource.DeletionPolicySchemaEntry("DELETE"),
 	//UDP schema end
-			"ignore_node_count_drift": {
+			"ignore_node_count_changes": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -2123,7 +2123,6 @@ func ResourceContainerCluster() *schema.Resource {
 			"skip_node_pool_refresh": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: `If true, the provider will not refresh the inline node_pool state from the API during cluster reads. Set this to true only when all node pools are managed via separate google_container_node_pool resources; it substantially improves plan/apply performance on clusters with a high node pool count. Must not be set to true when inline node_pool blocks are defined on this resource.`,
 			},
 
@@ -2939,7 +2938,6 @@ func ResourceContainerCluster() *schema.Resource {
 			"ignore_node_count_changes": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				Description: `When true, the provider ignores external changes (drift) to the node count by skipping GCE API queries to the Instance Group Managers. This is a performance optimization for large clusters that saves API quota. Setting this to true will result in missing managed_instance_group_urls in the state for all node pools in the cluster.`,
 			},
 		},

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -244,6 +244,7 @@ func ResourceContainerCluster() *schema.Resource {
 			containerClusterSurgeSettingsCustomizeDiff,
 			containerClusterEnableK8sBetaApisCustomizeDiff,
 			containerClusterNodeVersionCustomizeDiff,
+			containerClusterSkipNodePoolRefreshCustomizeDiff,
 			tpgresource.SetDiffForLabelsWithCustomizedName("resource_labels"),
 			clusterAcceleratorNetworkProfileCustomizeDiff,
 		),
@@ -2117,6 +2118,13 @@ func ResourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				Description: `If true, deletes the default node pool upon cluster creation. If you're using google_container_node_pool resources with no default node pool, this should be set to true, alongside setting initial_node_count to at least 1.`,
 				ConflictsWith: []string{"enable_autopilot"},
+			},
+
+			"skip_node_pool_refresh": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: `If true, the provider will not refresh the inline node_pool state from the API during cluster reads. Set this to true only when all node pools are managed via separate google_container_node_pool resources; it substantially improves plan/apply performance on clusters with a high node pool count. Must not be set to true when inline node_pool blocks are defined on this resource.`,
 			},
 
 			"control_plane_endpoints_config": {
@@ -7835,6 +7843,15 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 }
 
 func flattenClusterNodePools(d *schema.ResourceData, config *transport_tpg.Config, c []*container.NodePool) ([]map[string]interface{}, error) {
+	// Performance escape hatch: when the user opts in via skip_node_pool_refresh,
+	// do not materialize the (potentially huge) inline node_pool list into state.
+	// A CustomizeDiff guard prevents this combining with inline node_pool blocks.
+	// Users who flip this on accept that cluster.node_pool will read as empty.
+	if v, ok := d.GetOk("skip_node_pool_refresh"); ok && v.(bool) {
+		log.Printf("[DEBUG] Skipping flattenClusterNodePools because skip_node_pool_refresh=true.")
+		return nil, nil
+	}
+
 	nodePools := make([]map[string]interface{}, 0, len(c))
 
 	for i, np := range c {
@@ -9117,6 +9134,28 @@ func containerClusterEnableK8sBetaApisCustomizeDiffFunc(d tpgresource.TerraformR
 func containerClusterNodeVersionCustomizeDiff(_ context.Context,diff *schema.ResourceDiff, meta interface{}) error {
 	// separate func to allow unit testing
 	return containerClusterNodeVersionCustomizeDiffFunc(diff)
+}
+
+// containerClusterSkipNodePoolRefreshCustomizeDiff errors at plan time if the
+// user enables skip_node_pool_refresh while also declaring inline node_pool
+// blocks. Without this guard, the inline blocks would diff against the empty
+// state produced by the skip path and trigger ForceNew cluster replacement.
+func containerClusterSkipNodePoolRefreshCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	if !diff.Get("skip_node_pool_refresh").(bool) {
+		return nil
+	}
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+	nodePool := rawConfig.GetAttr("node_pool")
+	if nodePool.IsNull() || !nodePool.IsKnown() {
+		return nil
+	}
+	if nodePool.LengthInt() > 0 {
+		return fmt.Errorf("skip_node_pool_refresh cannot be true when inline node_pool blocks are defined; use google_container_node_pool resources instead, or unset skip_node_pool_refresh")
+	}
+	return nil
 }
 
 func containerClusterNodeVersionCustomizeDiffFunc(diff tpgresource.TerraformResourceDiff) error {

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -671,17 +671,20 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 	}
 
 	cases := []struct {
-		name              string
-		d                 *schema.ResourceData
-		c                 []*container.NodePool
-		expected          []map[string]interface{}
-		expectError       bool
-		nodePoolsInConfig []interface{}
-		skipRefresh       bool
+		name        string
+		d           *schema.ResourceData
+		c           []*container.NodePool
+		expected    []map[string]interface{}
+		expectError bool
 	}{
 		{
 			name: "Default path flattens API node pools",
-			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"node_pool": []interface{}{
+					map[string]interface{}{"name": "pool-1"},
+					map[string]interface{}{"name": "pool-2"},
+				},
+			}),
 			c: []*container.NodePool{
 				&container.NodePool{Name: "pool-1"},
 				&container.NodePool{Name: "pool-2"},
@@ -713,58 +716,45 @@ func TestUnitFlattenClusterNodePools(t *testing.T) {
 				},
 			},
 			expectError: false,
-			nodePoolsInConfig: []interface{}{
-				map[string]interface{}{"name": "pool-1"},
-				map[string]interface{}{"name": "pool-2"},
-			},
 		},
 		{
-			name:              "Empty node_pools from API",
-			d:                 schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
-			c:                 []*container.NodePool{},
-			expected:          []map[string]interface{}{},
-			expectError:       false,
-			nodePoolsInConfig: []interface{}{map[string]interface{}{"name": "default-pool"}},
+			name: "Empty node_pools from API",
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"node_pool": []interface{}{map[string]interface{}{"name": "default-pool"}},
+			}),
+			c:           []*container.NodePool{},
+			expected:    []map[string]interface{}{},
+			expectError: false,
 		},
 		{
 			name: "skip_node_pool_refresh=true overrides populated state",
-			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"node_pool": []interface{}{
+					map[string]interface{}{"name": "pool-1"},
+					map[string]interface{}{"name": "pool-2"},
+				},
+				"skip_node_pool_refresh": true,
+			}),
 			c: []*container.NodePool{
 				&container.NodePool{Name: "pool-1"},
 				&container.NodePool{Name: "pool-2"},
 			},
 			expected:    nil,
 			expectError: false,
-			nodePoolsInConfig: []interface{}{
-				map[string]interface{}{"name": "pool-1"},
-				map[string]interface{}{"name": "pool-2"},
-			},
-			skipRefresh: true,
 		},
 		{
-			name:              "skip_node_pool_refresh=true with empty state",
-			d:                 schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
-			c:                 []*container.NodePool{&container.NodePool{Name: "pool-1"}},
-			expected:          nil,
-			expectError:       false,
-			nodePoolsInConfig: nil,
-			skipRefresh:       true,
+			name: "skip_node_pool_refresh=true with empty state",
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"skip_node_pool_refresh": true,
+			}),
+			c:           []*container.NodePool{&container.NodePool{Name: "pool-1"}},
+			expected:    nil,
+			expectError: false,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.nodePoolsInConfig != nil {
-				if err := tc.d.Set("node_pool", tc.nodePoolsInConfig); err != nil {
-					t.Fatalf("Error setting node_pool: %v", err)
-				}
-			}
-			if tc.skipRefresh {
-				if err := tc.d.Set("skip_node_pool_refresh", true); err != nil {
-					t.Fatalf("Error setting skip_node_pool_refresh: %v", err)
-				}
-			}
-
 			config := &transport_tpg.Config{}
 			result, err := flattenClusterNodePools(tc.d, config, tc.c)
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_internal_test.go.tmpl
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 {{ if eq $.TargetVersionName `ga` }}
 	"google.golang.org/api/container/v1"
@@ -601,6 +602,183 @@ func TestContainerCluster_flattenUserManagedKeysConfig(t *testing.T) {
 			got := flattenUserManagedKeysConfig(tc.config)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("flattenUserManagedKeysConfig(%s) returned unexpected diff. +got, -want:\n%s", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestUnitFlattenClusterNodePools(t *testing.T) {
+	t.Parallel()
+
+	// A mock schema for the resource that contains node_pool and skip_node_pool_refresh.
+	resourceSchema := map[string]*schema.Schema{
+		"skip_node_pool_refresh": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"node_pool": {
+			Type: schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"name_prefix": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"initial_node_count": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+					"node_locations": {
+						Type:     schema.TypeSet,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+					"node_count": {
+						Type:     schema.TypeInt,
+						Optional: true,
+					},
+					"node_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"machine_type": {Type: schema.TypeString}}},
+					},
+					"instance_group_urls": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{Type: schema.TypeString},
+					},
+					"managed_instance_group_urls": {
+						Type: schema.TypeList,
+						Elem: &schema.Schema{Type: schema.TypeString},
+					},
+					"version": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+					"network_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"create_pod_range": {Type: schema.TypeBool}}},
+					},
+				},
+			},
+			Optional: true,
+		},
+	}
+
+	cases := []struct {
+		name              string
+		d                 *schema.ResourceData
+		c                 []*container.NodePool
+		expected          []map[string]interface{}
+		expectError       bool
+		nodePoolsInConfig []interface{}
+		skipRefresh       bool
+	}{
+		{
+			name: "Default path flattens API node pools",
+			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			c: []*container.NodePool{
+				&container.NodePool{Name: "pool-1"},
+				&container.NodePool{Name: "pool-2"},
+			},
+			expected: []map[string]interface{}{
+				{
+					"name":                        "pool-1",
+					"name_prefix":                 "",
+					"initial_node_count":          int64(0),
+					"node_locations":              schema.NewSet(schema.HashString, []interface{}{}),
+					"node_count":                  0,
+					"node_config":                 []map[string]interface{}{},
+					"instance_group_urls":         []string{},
+					"managed_instance_group_urls": []string{},
+					"version":                     "",
+					"network_config":              []map[string]interface{}{},
+				},
+				{
+					"name":                        "pool-2",
+					"name_prefix":                 "",
+					"initial_node_count":          int64(0),
+					"node_locations":              schema.NewSet(schema.HashString, []interface{}{}),
+					"node_count":                  0,
+					"node_config":                 []map[string]interface{}{},
+					"instance_group_urls":         []string{},
+					"managed_instance_group_urls": []string{},
+					"version":                     "",
+					"network_config":              []map[string]interface{}{},
+				},
+			},
+			expectError: false,
+			nodePoolsInConfig: []interface{}{
+				map[string]interface{}{"name": "pool-1"},
+				map[string]interface{}{"name": "pool-2"},
+			},
+		},
+		{
+			name:              "Empty node_pools from API",
+			d:                 schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			c:                 []*container.NodePool{},
+			expected:          []map[string]interface{}{},
+			expectError:       false,
+			nodePoolsInConfig: []interface{}{map[string]interface{}{"name": "default-pool"}},
+		},
+		{
+			name: "skip_node_pool_refresh=true overrides populated state",
+			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			c: []*container.NodePool{
+				&container.NodePool{Name: "pool-1"},
+				&container.NodePool{Name: "pool-2"},
+			},
+			expected:    nil,
+			expectError: false,
+			nodePoolsInConfig: []interface{}{
+				map[string]interface{}{"name": "pool-1"},
+				map[string]interface{}{"name": "pool-2"},
+			},
+			skipRefresh: true,
+		},
+		{
+			name:              "skip_node_pool_refresh=true with empty state",
+			d:                 schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			c:                 []*container.NodePool{&container.NodePool{Name: "pool-1"}},
+			expected:          nil,
+			expectError:       false,
+			nodePoolsInConfig: nil,
+			skipRefresh:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.nodePoolsInConfig != nil {
+				if err := tc.d.Set("node_pool", tc.nodePoolsInConfig); err != nil {
+					t.Fatalf("Error setting node_pool: %v", err)
+				}
+			}
+			if tc.skipRefresh {
+				if err := tc.d.Set("skip_node_pool_refresh", true); err != nil {
+					t.Fatalf("Error setting skip_node_pool_refresh: %v", err)
+				}
+			}
+
+			config := &transport_tpg.Config{}
+			result, err := flattenClusterNodePools(tc.d, config, tc.c)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(result, tc.expected); diff != "" {
+					t.Errorf("flattenClusterNodePools(%s) returned unexpected diff. +got, -want:\n%s", tc.name, diff)
+				}
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -444,6 +444,8 @@ fields:
     api_field: 'nodePools.autoscaling.totalMaxNodeCount'
   - field: 'node_pool.autoscaling.total_min_node_count'
     api_field: 'nodePools.autoscaling.totalMinNodeCount'
+  - field: 'node_pool.ignore_node_count_drift'
+    provider_only: true
   - field: 'node_pool.initial_node_count'
     api_field: 'nodePools.initialNodeCount'
   - field: 'node_pool.instance_group_urls'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -908,3 +908,5 @@ fields:
   - api_field: 'workloadIdentityConfig.workloadPool'
   - field: 'deletion_policy'
     provider_only: true
+  - field: 'skip_node_pool_refresh'
+    provider_only: true

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -910,3 +910,5 @@ fields:
     provider_only: true
   - field: 'skip_node_pool_refresh'
     provider_only: true
+  - field: 'ignore_node_count_drift'
+    provider_only: true

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -444,7 +444,7 @@ fields:
     api_field: 'nodePools.autoscaling.totalMaxNodeCount'
   - field: 'node_pool.autoscaling.total_min_node_count'
     api_field: 'nodePools.autoscaling.totalMinNodeCount'
-  - field: 'node_pool.ignore_node_count_drift'
+  - field: 'node_pool.ignore_node_count_changes'
     provider_only: true
   - field: 'node_pool.initial_node_count'
     api_field: 'nodePools.initialNodeCount'
@@ -912,5 +912,5 @@ fields:
     provider_only: true
   - field: 'skip_node_pool_refresh'
     provider_only: true
-  - field: 'ignore_node_count_drift'
+  - field: 'ignore_node_count_changes'
     provider_only: true

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1994,7 +1994,7 @@ func TestAccContainerCluster_regionalWithNodePool(t *testing.T) {
 				ResourceName:		 "google_container_cluster.regional",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"deletion_protection"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -18538,6 +18538,36 @@ func TestAccContainerCluster_withTaintConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_skipNodePoolRefresh(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	poolName := fmt.Sprintf("tf-test-pool-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.#", "0"),
+				),
+			},
+			{
+				Config: testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.#", "1"),
+					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.0.name", poolName),
+				),
+			},
+		},
+	})
+}
+
 func testAccContainerCluster_withTaintConfig(cluster, networkName, subnetworkName, behavior string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -18659,4 +18689,33 @@ resource "google_container_cluster" "cluster" {
   deletion_protection = false
 }
 `, cluster, networkName, subnetworkName, behavior)
+}
+
+func testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName string, skipRefresh bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  network             = "%s"
+  subnetwork          = "%s"
+  deletion_protection = false
+
+  # We must delete the default node pool to ensure we only have our standalone node pool
+  remove_default_node_pool = true
+
+  skip_node_pool_refresh = %t
+}
+
+resource "google_container_node_pool" "extra" {
+  name       = "%s"
+  location   = "us-central1-a"
+  cluster    = google_container_cluster.primary.name
+  node_count = 1
+
+  node_config {
+    machine_type = "e2-medium"
+  }
+}
+`, clusterName, networkName, subnetworkName, skipRefresh, poolName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -9441,12 +9441,12 @@ resource "google_container_cluster" "regional" {
 
   node_pool {
     name = "%s"
-    ignore_node_count_drift = true
+    ignore_node_count_changes = true
   }
   network    = "%s"
   subnetwork = "%s"
 
-  ignore_node_count_drift = true
+  ignore_node_count_changes = true
   deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -18541,10 +18541,9 @@ func TestAccContainerCluster_withTaintConfig(t *testing.T) {
 func TestAccContainerCluster_skipNodePoolRefresh(t *testing.T) {
 	t.Parallel()
 
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	poolName := fmt.Sprintf("tf-test-pool-%s", acctest.RandString(t, 10))
-	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+	suffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", suffix)
+	poolName := fmt.Sprintf("tf-test-pool-%s", suffix)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -18552,13 +18551,13 @@ func TestAccContainerCluster_skipNodePoolRefresh(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName, true),
+				Config: testAccContainerCluster_skipNodePoolRefresh(suffix, clusterName, poolName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.#", "0"),
 				),
 			},
 			{
-				Config: testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName, false),
+				Config: testAccContainerCluster_skipNodePoolRefresh(suffix, clusterName, poolName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.#", "1"),
 					resource.TestCheckResourceAttr("google_container_cluster.primary", "node_pool.0.name", poolName),
@@ -18691,15 +18690,47 @@ resource "google_container_cluster" "cluster" {
 `, cluster, networkName, subnetworkName, behavior)
 }
 
-func testAccContainerCluster_skipNodePoolRefresh(clusterName, poolName, networkName, subnetworkName string, skipRefresh bool) string {
+func testAccContainerCluster_skipNodePoolRefresh(suffix, clusterName, poolName string, skipRefresh bool) string {
 	return fmt.Sprintf(`
+resource "google_compute_network" "custom" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "custom" {
+  name          = "tf-test-subnet-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom.id
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.1.0.0/16"
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.2.0.0/20"
+  }
+}
+
 resource "google_container_cluster" "primary" {
   name                = "%s"
   location            = "us-central1-a"
   initial_node_count  = 1
-  network             = "%s"
-  subnetwork          = "%s"
+  network             = google_compute_network.custom.id
+  subnetwork          = google_compute_subnetwork.custom.id
   deletion_protection = false
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  node_config {
+    preemptible  = true
+    machine_type = "e2-medium"
+  }
 
   # We must delete the default node pool to ensure we only have our standalone node pool
   remove_default_node_pool = true
@@ -18714,8 +18745,9 @@ resource "google_container_node_pool" "extra" {
   node_count = 1
 
   node_config {
+    preemptible  = true
     machine_type = "e2-medium"
   }
 }
-`, clusterName, networkName, subnetworkName, skipRefresh, poolName)
+`, suffix, suffix, clusterName, skipRefresh, poolName)
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -18727,11 +18727,6 @@ resource "google_container_cluster" "primary" {
     services_secondary_range_name = "services"
   }
 
-  node_config {
-    preemptible  = true
-    machine_type = "e2-medium"
-  }
-
   # We must delete the default node pool to ensure we only have our standalone node pool
   remove_default_node_pool = true
 

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -9441,10 +9441,12 @@ resource "google_container_cluster" "regional" {
 
   node_pool {
     name = "%s"
+    ignore_node_count_drift = true
   }
   network    = "%s"
   subnetwork = "%s"
 
+  ignore_node_count_drift = true
   deletion_protection = false
 }
 `, cluster, nodePool, networkName, subnetworkName)

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -701,7 +701,12 @@ var schemaNodePool = map[string]*schema.Schema{
 			},
 		},
 	},
-	
+	"ignore_node_count_drift": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: `When true, the provider ignores external changes (drift) to the node count by skipping GCE API queries to the Instance Group Managers. This is a performance optimization for large clusters that saves API quota. Setting this to true will result in missing managed_instance_group_urls in the state.`,
+	},
 }
 
 type NodePoolInformation struct {
@@ -1425,37 +1430,51 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		return nil, err
 	}
 
-	// Node pools don't expose the current node count in their API, so read the
-	// instance groups instead. They should all have the same size, but in case a resize
-	// failed or something else strange happened, we'll just use the average size.
 	size := 0
 	igmUrls := []string{}
 	managedIgmUrls := []string{}
-	for _, url := range np.InstanceGroupUrls {
-		// retrieve instance group manager (InstanceGroupUrls are actually URLs for InstanceGroupManagers)
-		matches := instanceGroupManagerURL.FindStringSubmatch(url)
-		if len(matches) < 4 {
-			return nil, fmt.Errorf("Error reading instance group manage URL '%q'", url)
-		}
-        if strings.HasPrefix("gk3", matches[3]) {
-            // IGM is autopilot so we know it will not be found, skip it
-            continue
-        }
-		if err := igmCache.refreshIfNeeded(d, config, userAgent, np.Name, url); err != nil {
-			return nil, err
-		}
-		igm, ok := igmCache.get(matches[0])
-		if !ok {
-		    // The IGM URL is stale; don't include it
-		    continue
-		}
-		size += int(igm.TargetSize)
-		igmUrls = append(igmUrls, url)
-		managedIgmUrls = append(managedIgmUrls, igm.InstanceGroup)
-	}
 	nodeCount := 0
-	if len(igmUrls) > 0 {
-		nodeCount = size / len(igmUrls)
+
+	ignoreNodeCountDrift := d.Get(prefix + "ignore_node_count_drift").(bool) || d.Get("ignore_node_count_drift").(bool)
+
+	if ignoreNodeCountDrift {
+		log.Printf("[DEBUG] Skipping IGM fetch for node pool %q due to ignore_node_count_drift = true", np.Name)
+		if v, ok := d.GetOkExists(prefix + "node_count"); ok {
+			nodeCount = v.(int)
+		} else {
+			nodeCount = int(np.InitialNodeCount)
+		}
+		// When ignoring, we might not get exact matching IGMs but we can still pass the unvalidated list from API
+		// or leave them empty. Passing the API URLs to igmUrls at least populates them for basic usage.
+		for _, url := range np.InstanceGroupUrls {
+			igmUrls = append(igmUrls, url)
+		}
+	} else {
+		for _, url := range np.InstanceGroupUrls {
+			// retrieve instance group manager (InstanceGroupUrls are actually URLs for InstanceGroupManagers)
+			matches := instanceGroupManagerURL.FindStringSubmatch(url)
+			if len(matches) < 4 {
+				return nil, fmt.Errorf("Error reading instance group manage URL '%q'", url)
+			}
+			if strings.HasPrefix("gk3", matches[3]) {
+				// IGM is autopilot so we know it will not be found, skip it
+				continue
+			}
+			if err := igmCache.refreshIfNeeded(d, config, userAgent, np.Name, url); err != nil {
+				return nil, err
+			}
+			igm, ok := igmCache.get(matches[0])
+			if !ok {
+				// The IGM URL is stale; don't include it
+				continue
+			}
+			size += int(igm.TargetSize)
+			igmUrls = append(igmUrls, url)
+			managedIgmUrls = append(managedIgmUrls, igm.InstanceGroup)
+		}
+		if len(igmUrls) > 0 {
+			nodeCount = size / len(igmUrls)
+		}
 	}
 	nodePool := map[string]interface{}{
 		"name":                np.Name,

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -704,7 +704,6 @@ var schemaNodePool = map[string]*schema.Schema{
 	"ignore_node_count_changes": {
 		Type:        schema.TypeBool,
 		Optional:    true,
-		Default:     false,
 		Description: `When true, the provider ignores external changes (drift) to the node count by skipping GCE API queries to the Instance Group Managers. This is a performance optimization for large clusters that saves API quota. Setting this to true will result in missing managed_instance_group_urls in the state.`,
 	},
 }

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1435,7 +1435,13 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 	managedIgmUrls := []string{}
 	nodeCount := 0
 
-	ignoreNodeCountDrift := d.Get(prefix + "ignore_node_count_drift").(bool) || d.Get("ignore_node_count_drift").(bool)
+	var ignoreNodeCountDrift bool
+	if v := d.Get(prefix + "ignore_node_count_drift"); v != nil {
+		ignoreNodeCountDrift = v.(bool)
+	}
+	if v := d.Get("ignore_node_count_drift"); v != nil {
+		ignoreNodeCountDrift = ignoreNodeCountDrift || v.(bool)
+	}
 
 	if ignoreNodeCountDrift {
 		log.Printf("[DEBUG] Skipping IGM fetch for node pool %q due to ignore_node_count_drift = true", np.Name)

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -701,7 +701,7 @@ var schemaNodePool = map[string]*schema.Schema{
 			},
 		},
 	},
-	"ignore_node_count_drift": {
+	"ignore_node_count_changes": {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
@@ -1435,16 +1435,16 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 	managedIgmUrls := []string{}
 	nodeCount := 0
 
-	var ignoreNodeCountDrift bool
-	if v := d.Get(prefix + "ignore_node_count_drift"); v != nil {
-		ignoreNodeCountDrift = v.(bool)
+	var ignoreNodeCountChanges bool
+	if v := d.Get(prefix + "ignore_node_count_changes"); v != nil {
+		ignoreNodeCountChanges = v.(bool)
 	}
-	if v := d.Get("ignore_node_count_drift"); v != nil {
-		ignoreNodeCountDrift = ignoreNodeCountDrift || v.(bool)
+	if v := d.Get("ignore_node_count_changes"); v != nil {
+		ignoreNodeCountChanges = ignoreNodeCountChanges || v.(bool)
 	}
 
-	if ignoreNodeCountDrift {
-		log.Printf("[DEBUG] Skipping IGM fetch for node pool %q due to ignore_node_count_drift = true", np.Name)
+	if ignoreNodeCountChanges {
+		log.Printf("[DEBUG] Skipping IGM fetch for node pool %q due to ignore_node_count_changes = true", np.Name)
 		if v, ok := d.GetOkExists(prefix + "node_count"); ok {
 			nodeCount = v.(int)
 		} else {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -165,7 +165,7 @@ func getCacheTTL() time.Duration {
 	if os.Getenv("VCR_PATH") != "" && os.Getenv("VCR_MODE") != "" {
 		return 0 * time.Second
 	}
-	return 30 * time.Second
+	return 5 * time.Minute
 }
 
 var (

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
@@ -20,8 +20,12 @@ import (
 func TestUnitFlattenNodePool(t *testing.T) {
 	t.Parallel()
 
+	// nodeCountFromAPI is the size the prepopulated IGM cache reports; the
+	// standard-flow case expects flattenNodePool to surface exactly this.
+	const nodeCountFromAPI = 5
+
 	resourceSchema := map[string]*schema.Schema{
-		"ignore_node_count_drift": {
+		"ignore_node_count_changes": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,
@@ -61,7 +65,7 @@ func TestUnitFlattenNodePool(t *testing.T) {
 		expectedManagedIgmUrls []string
 	}{
 		{
-			name: "Standard flow (ignore_node_count_drift=false) fetches from IGM",
+			name: "Standard flow (ignore_node_count_changes=false) fetches from IGM",
 			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
 			np: &container.NodePool{
 				Name: "pool-1",
@@ -71,7 +75,7 @@ func TestUnitFlattenNodePool(t *testing.T) {
 				Locations: []string{"us-central1-a"},
 			},
 			prepopulateCache:  true,
-			expectedNodeCount: 5,
+			expectedNodeCount: nodeCountFromAPI,
 			expectedIgmUrls: []string{
 				"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
 			},
@@ -80,9 +84,9 @@ func TestUnitFlattenNodePool(t *testing.T) {
 			},
 		},
 		{
-			name: "Skip flow (ignore_node_count_drift=true) reads from state",
+			name: "Skip flow (ignore_node_count_changes=true) reads from state",
 			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-				"ignore_node_count_drift": true,
+				"ignore_node_count_changes": true,
 				"node_count":              10,
 			}),
 			np: &container.NodePool{
@@ -99,9 +103,9 @@ func TestUnitFlattenNodePool(t *testing.T) {
 			expectedManagedIgmUrls: []string{}, // Unpopulated because IGM query was skipped
 		},
 		{
-			name: "Skip flow (ignore_node_count_drift=true) falls back to InitialNodeCount when no state",
+			name: "Skip flow (ignore_node_count_changes=true) falls back to InitialNodeCount when no state",
 			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-				"ignore_node_count_drift": true,
+				"ignore_node_count_changes": true,
 			}),
 			np: &container.NodePool{
 				Name:              "pool-1",
@@ -126,7 +130,7 @@ func TestUnitFlattenNodePool(t *testing.T) {
 				igmCache.instanceGroupManagers["projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp"] = &instanceGroupManagerWithUpdateTime{
 					instanceGroupManager: &compute.InstanceGroupManager{
 						Name:          "gke-pool-1-grp",
-						TargetSize:    5,
+						TargetSize:    nodeCountFromAPI,
 						InstanceGroup: "https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroups/gke-pool-1-grp",
 						SelfLink:      "https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
 					},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_internal_test.go.tmpl
@@ -1,0 +1,164 @@
+package container
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+
+{{ if eq $.TargetVersionName `ga` }}
+	compute "google.golang.org/api/compute/v1"
+	container "google.golang.org/api/container/v1"
+{{ else }}
+	compute "google.golang.org/api/compute/v0.beta"
+	container "google.golang.org/api/container/v1beta1"
+{{ end }}
+)
+
+func TestUnitFlattenNodePool(t *testing.T) {
+	t.Parallel()
+
+	resourceSchema := map[string]*schema.Schema{
+		"ignore_node_count_drift": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"node_count": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"initial_node_count": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"node_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"machine_type": {Type: schema.TypeString}}},
+		},
+		"name_prefix": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"network_config": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Resource{Schema: map[string]*schema.Schema{"create_pod_range": {Type: schema.TypeBool}}},
+		},
+	}
+
+	cases := []struct {
+		name                   string
+		d                      *schema.ResourceData
+		np                     *container.NodePool
+		prepopulateCache       bool
+		expectedNodeCount      int
+		expectedIgmUrls        []string
+		expectedManagedIgmUrls []string
+	}{
+		{
+			name: "Standard flow (ignore_node_count_drift=false) fetches from IGM",
+			d:    schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{}),
+			np: &container.NodePool{
+				Name: "pool-1",
+				InstanceGroupUrls: []string{
+					"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
+				},
+				Locations: []string{"us-central1-a"},
+			},
+			prepopulateCache:  true,
+			expectedNodeCount: 5,
+			expectedIgmUrls: []string{
+				"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
+			},
+			expectedManagedIgmUrls: []string{
+				"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroups/gke-pool-1-grp",
+			},
+		},
+		{
+			name: "Skip flow (ignore_node_count_drift=true) reads from state",
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"ignore_node_count_drift": true,
+				"node_count":              10,
+			}),
+			np: &container.NodePool{
+				Name:              "pool-1",
+				InitialNodeCount:  3,
+				InstanceGroupUrls: []string{"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp"},
+				Locations:         []string{"us-central1-a"},
+			},
+			prepopulateCache:  false, // Cache is empty, proving we skipped the API fetch
+			expectedNodeCount: 10,
+			expectedIgmUrls: []string{
+				"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
+			},
+			expectedManagedIgmUrls: []string{}, // Unpopulated because IGM query was skipped
+		},
+		{
+			name: "Skip flow (ignore_node_count_drift=true) falls back to InitialNodeCount when no state",
+			d: schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
+				"ignore_node_count_drift": true,
+			}),
+			np: &container.NodePool{
+				Name:              "pool-1",
+				InitialNodeCount:  3,
+				InstanceGroupUrls: []string{"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp"},
+				Locations:         []string{"us-central1-a"},
+			},
+			prepopulateCache:  false,
+			expectedNodeCount: 3,
+			expectedIgmUrls: []string{
+				"https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
+			},
+			expectedManagedIgmUrls: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prepopulate cache if requested
+			if tc.prepopulateCache {
+				igmCache.mutex.Lock()
+				igmCache.instanceGroupManagers["projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp"] = &instanceGroupManagerWithUpdateTime{
+					instanceGroupManager: &compute.InstanceGroupManager{
+						Name:          "gke-pool-1-grp",
+						TargetSize:    5,
+						InstanceGroup: "https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroups/gke-pool-1-grp",
+						SelfLink:      "https://www.googleapis.com/compute/v1/projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp",
+					},
+					updateTime: time.Now(),
+				}
+				igmCache.mutex.Unlock()
+
+				// Clean up cache after the test case
+				defer func() {
+					igmCache.mutex.Lock()
+					delete(igmCache.instanceGroupManagers, "projects/ci-project/zones/us-central1-a/instanceGroupManagers/gke-pool-1-grp")
+					igmCache.mutex.Unlock()
+				}()
+			}
+
+			config := &transport_tpg.Config{}
+			result, err := flattenNodePool(tc.d, config, tc.np, "")
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if result["node_count"] != tc.expectedNodeCount {
+				t.Errorf("Expected node_count %d, got %v", tc.expectedNodeCount, result["node_count"])
+			}
+
+			if diff := cmp.Diff(result["instance_group_urls"], tc.expectedIgmUrls); diff != "" {
+				t.Errorf("instance_group_urls returned unexpected diff. +got, -want:\n%s", diff)
+			}
+
+			if diff := cmp.Diff(result["managed_instance_group_urls"], tc.expectedManagedIgmUrls); diff != "" {
+				t.Errorf("managed_instance_group_urls returned unexpected diff. +got, -want:\n%s", diff)
+			}
+		})
+	}
+}

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
@@ -348,3 +348,5 @@ fields:
   - api_field: 'version'
   - field: 'deletion_policy'
     provider_only: true
+  - field: 'ignore_node_count_drift'
+    provider_only: true

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_meta.yaml.tmpl
@@ -348,5 +348,5 @@ fields:
   - api_field: 'version'
   - field: 'deletion_policy'
     provider_only: true
-  - field: 'ignore_node_count_drift'
+  - field: 'ignore_node_count_changes'
     provider_only: true

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -16,6 +16,12 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	"github.com/hashicorp/terraform-provider-google/google/services/tags"
+
+{{ if eq $.TargetVersionName "ga" }}
+	gke "google.golang.org/api/container/v1"
+{{- else }}
+	gke "google.golang.org/api/container/v1beta1"
+{{- end }}
 )
 
 func TestAccContainerNodePool_basic(t *testing.T) {
@@ -7056,6 +7062,89 @@ func TestAccContainerNodePool_acceleratorNetworkProfile_Lifecycle(t *testing.T) 
 			},
 		},
 	})
+}
+
+func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	poolName := fmt.Sprintf("tf-test-pool-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
+				),
+			},
+			{
+				PreConfig: func() { testAccResizeNodePoolExternally(t, clusterName, poolName, 3) },
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, true),
+				PlanOnly: true,
+			},
+			{
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName string, count int, ignoreDrift bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  network             = "%s"
+  subnetwork          = "%s"
+  deletion_protection = false
+  remove_default_node_pool = true
+}
+
+resource "google_container_node_pool" "np" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  node_count         = %d
+  ignore_node_count_drift = %t
+
+  node_config {
+    machine_type = "e2-medium"
+  }
+}
+`, clusterName, networkName, subnetworkName, poolName, count, ignoreDrift)
+}
+
+func testAccResizeNodePoolExternally(t *testing.T, clusterName, poolName string, size int64) {
+	config := acctest.GoogleProviderConfig(t)
+	userAgent := "terraform-provider-google-test"
+	location := "us-central1-a"
+	fqName := fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", 
+		config.Project, location, clusterName, poolName)
+	
+	req := &gke.SetNodePoolSizeRequest{
+		NodeCount: size,
+	}
+	
+	gkeClient := container.NewClient(config, userAgent)
+	op, err := gkeClient.Projects.Locations.Clusters.NodePools.SetSize(fqName, req).Do()
+	if err != nil {
+		t.Fatalf("Failed to resize node pool externally: %s", err)
+	}
+	
+	err = container.ContainerOperationWait(config, op, config.Project, location, "resizing node pool externally", userAgent, 20)
+	if err != nil {
+		t.Fatalf("Failed waiting for external GKE resize operation: %s", err)
+	}
 }
 
 func TestAccContainerNodePool_withTaintConfig(t *testing.T) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -7065,7 +7065,7 @@ func TestAccContainerNodePool_acceleratorNetworkProfile_Lifecycle(t *testing.T) 
 	})
 }
 
-func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
+func TestAccContainerNodePool_ignoreNodeCountChanges(t *testing.T) {
 	t.Parallel()
 
 	suffix := acctest.RandString(t, 10)
@@ -7078,18 +7078,18 @@ func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, true),
+				Config: testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName, 2, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
 				),
 			},
 			{
 				PreConfig: func() { testAccResizeNodePoolExternally(t, clusterName, poolName, 3) },
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, true),
+				Config: testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName, 2, true),
 				PlanOnly: true,
 			},
 			{
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, false),
+				Config: testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName, 2, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
 				),
@@ -7098,7 +7098,7 @@ func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName string, count int, ignoreDrift bool) string {
+func testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName string, count int, ignoreChanges bool) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "custom" {
   name                    = "tf-test-network-%s"
@@ -7143,14 +7143,14 @@ resource "google_container_node_pool" "np" {
   location           = "us-central1-a"
   cluster            = google_container_cluster.cluster.name
   node_count         = %d
-  ignore_node_count_drift = %t
+  ignore_node_count_changes = %t
 
   node_config {
     preemptible  = true
     machine_type = "e2-medium"
   }
 }
-`, suffix, suffix, clusterName, poolName, count, ignoreDrift)
+`, suffix, suffix, clusterName, poolName, count, ignoreChanges)
 }
 
 func testAccResizeNodePoolExternally(t *testing.T, clusterName, poolName string, size int64) {

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -7089,6 +7089,16 @@ func TestAccContainerNodePool_ignoreNodeCountChanges(t *testing.T) {
 				PlanOnly: true,
 			},
 			{
+				// Step 3: Flip ignore_node_count_changes to false and set node_count = 3 (matching GKE cloud state).
+				// This registers the flag update and aligns HCL with the actual GKE size.
+				Config: testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName, 3, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "3"),
+				),
+			},
+			{
+				// Step 4: Now that drift detection is active (flag is false in state), set node_count = 2.
+				// This detects the difference (3 -> 2) and resizes the GKE Node Pool back to 2.
 				Config: testAccContainerNodePool_ignoreNodeCountChanges(suffix, clusterName, poolName, 2, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -7134,11 +7134,6 @@ resource "google_container_cluster" "cluster" {
     services_secondary_range_name = "services"
   }
 
-  node_config {
-    preemptible  = true
-    machine_type = "e2-medium"
-  }
-
   remove_default_node_pool = true
 }
 

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -7169,7 +7170,7 @@ func testAccResizeNodePoolExternally(t *testing.T, clusterName, poolName string,
 		t.Fatalf("Failed to resize node pool externally: %s", err)
 	}
 	
-	err = container.ContainerOperationWait(config, op, config.Project, location, "resizing node pool externally", userAgent, 20)
+	err = container.ContainerOperationWait(config, op, config.Project, location, "resizing node pool externally", userAgent, 20 * time.Minute)
 	if err != nil {
 		t.Fatalf("Failed waiting for external GKE resize operation: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -7067,10 +7067,9 @@ func TestAccContainerNodePool_acceleratorNetworkProfile_Lifecycle(t *testing.T) 
 func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
 	t.Parallel()
 
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	poolName := fmt.Sprintf("tf-test-pool-%s", acctest.RandString(t, 10))
-	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
-	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+	suffix := acctest.RandString(t, 10)
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", suffix)
+	poolName := fmt.Sprintf("tf-test-pool-%s", suffix)
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -7078,18 +7077,18 @@ func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerNodePoolDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, true),
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
 				),
 			},
 			{
 				PreConfig: func() { testAccResizeNodePoolExternally(t, clusterName, poolName, 3) },
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, true),
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, true),
 				PlanOnly: true,
 			},
 			{
-				Config: testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName, 2, false),
+				Config: testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName, 2, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.np", "node_count", "2"),
 				),
@@ -7098,15 +7097,48 @@ func TestAccContainerNodePool_ignoreNodeCountDrift(t *testing.T) {
 	})
 }
 
-func testAccContainerNodePool_ignoreNodeCountDrift(clusterName, poolName, networkName, subnetworkName string, count int, ignoreDrift bool) string {
+func testAccContainerNodePool_ignoreNodeCountDrift(suffix, clusterName, poolName string, count int, ignoreDrift bool) string {
 	return fmt.Sprintf(`
+resource "google_compute_network" "custom" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "custom" {
+  name          = "tf-test-subnet-%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom.id
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.1.0.0/16"
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.2.0.0/20"
+  }
+}
+
 resource "google_container_cluster" "cluster" {
   name                = "%s"
   location            = "us-central1-a"
   initial_node_count  = 1
-  network             = "%s"
-  subnetwork          = "%s"
+  network             = google_compute_network.custom.id
+  subnetwork          = google_compute_subnetwork.custom.id
   deletion_protection = false
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  node_config {
+    preemptible  = true
+    machine_type = "e2-medium"
+  }
+
   remove_default_node_pool = true
 }
 
@@ -7118,10 +7150,11 @@ resource "google_container_node_pool" "np" {
   ignore_node_count_drift = %t
 
   node_config {
+    preemptible  = true
     machine_type = "e2-medium"
   }
 }
-`, clusterName, networkName, subnetworkName, poolName, count, ignoreDrift)
+`, suffix, suffix, clusterName, poolName, count, ignoreDrift)
 }
 
 func testAccResizeNodePoolExternally(t *testing.T, clusterName, poolName string, size int64) {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -283,6 +283,8 @@ region are guaranteed to support the same version.
     to say "these are the _only_ node pools associated with this cluster", use the
     [google_container_node_pool](container_node_pool.html) resource instead of this property.
 
+* `skip_node_pool_refresh` - (Optional) Whether to skip refreshing the GKE cluster's inline node pool list during read operations. Setting this to `true` prevents the provider from querying GKE API for node pools, resolving long plan times on clusters with a large number of node pools. **Warning:** When enabled, the cluster's `node_pool` attribute in the Terraform state will remain empty (`[]`), even if node pools exist externally. This flag cannot be set to `true` if you define inline `node_pool` blocks in your configuration; doing so will result in a validation error during plan.
+
 * `node_pool_auto_config` - (Optional) Node pool configs that apply to auto-provisioned node pools in
     [autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison) clusters and
     [node auto-provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)-enabled clusters. Structure is [documented below](#nested_node_pool_auto_config).

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -196,7 +196,7 @@ for more information.
     See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison)
     for available features.
 
-* `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the GKE node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
+* `ignore_node_count_changes` - (Optional) Whether to ignore external changes (drift) to the GKE node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
 
 * `initial_node_count` - (Optional) The number of nodes to create in this
 cluster's default node pool. In regional or multi-zonal clusters, this is the
@@ -284,7 +284,7 @@ region are guaranteed to support the same version.
     cluster creation without deleting and recreating the entire cluster. Unless you absolutely need the ability
     to say "these are the _only_ node pools associated with this cluster", use the
     [google_container_node_pool](container_node_pool.html) resource instead of this property.
-    * `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
+    * `ignore_node_count_changes` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
 
 * `skip_node_pool_refresh` - (Optional) Whether to skip refreshing the GKE cluster's inline node pool list during read operations. Setting this to `true` prevents the provider from querying GKE API for node pools, resolving long plan times on clusters with a large number of node pools. **Warning:** When enabled, the cluster's `node_pool` attribute in the Terraform state will remain empty (`[]`), even if node pools exist externally. This flag cannot be set to `true` if you define inline `node_pool` blocks in your configuration; doing so will result in a validation error during plan.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -284,6 +284,7 @@ region are guaranteed to support the same version.
     cluster creation without deleting and recreating the entire cluster. Unless you absolutely need the ability
     to say "these are the _only_ node pools associated with this cluster", use the
     [google_container_node_pool](container_node_pool.html) resource instead of this property.
+    * `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
 
 * `skip_node_pool_refresh` - (Optional) Whether to skip refreshing the GKE cluster's inline node pool list during read operations. Setting this to `true` prevents the provider from querying GKE API for node pools, resolving long plan times on clusters with a large number of node pools. **Warning:** When enabled, the cluster's `node_pool` attribute in the Terraform state will remain empty (`[]`), even if node pools exist externally. This flag cannot be set to `true` if you define inline `node_pool` blocks in your configuration; doing so will result in a validation error during plan.
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -196,6 +196,8 @@ for more information.
     See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison)
     for available features.
 
+* `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the GKE node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
+
 * `initial_node_count` - (Optional) The number of nodes to create in this
 cluster's default node pool. In regional or multi-zonal clusters, this is the
 number of nodes per zone. Must be set if `node_pool` is not set. If you're using

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -111,6 +111,8 @@ resource "google_container_cluster" "primary" {
 * `autoscaling` - (Optional) Configuration required by cluster autoscaler to adjust
     the size of the node pool to the current cluster usage. Structure is [documented below](#nested_autoscaling).
 
+* `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
+
 * `initial_node_count` - (Optional) The initial number of nodes for the pool. In
     regional or multi-zonal clusters, this is the number of nodes per zone. Changing
     this will force recreation of the resource. WARNING: Resizing your node pool manually

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -111,7 +111,7 @@ resource "google_container_cluster" "primary" {
 * `autoscaling` - (Optional) Configuration required by cluster autoscaler to adjust
     the size of the node pool to the current cluster usage. Structure is [documented below](#nested_autoscaling).
 
-* `ignore_node_count_drift` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
+* `ignore_node_count_changes` - (Optional) Whether to ignore external changes (drift) to the node count (e.g. from GKE autoscaling). Setting this to `true` skips querying Compute Engine Instance Group Managers (IGMs) to determine the current node count on read, which can save API quota and speed up plans on large clusters. Unlike Terraform core's `lifecycle { ignore_changes = [node_count] }`, this allows configuration-driven scaling updates in your HCL while still ignoring runtime autoscaling drift.
 
 * `initial_node_count` - (Optional) The initial number of nodes for the pool. In
     regional or multi-zonal clusters, this is the number of nodes per zone. Changing


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

# Description

This PR introduces virtual flags to GKE resources to reduce Terraform plan times and API queries on large clusters.

## Key Changes

* **Added `skip_node_pool_refresh` flag:** A new parameter on `google_container_cluster` that resolves long plan times for clusters with many node pools by skipping GKE API queries to fetch node pools during reads. When enabled, the cluster's `node_pool` attribute is written as an empty list in the state. A `CustomizeDiff` validation rule is included to block setting this flag to `true` if inline `node_pool` blocks are defined in the configuration.
* **Increased IGM Cache TTL:** Increased the in-memory TTL for GKE Node Pool and Instance Group Manager (IGM) caches from 30 seconds to 5 minutes.
* **Added `ignore_node_count_changes` flag:** A new parameter for GKE Cluster and Node Pool resources. When `true`, it bypasses GCE API queries to fetch active node counts from IGMs. Unlike Terraform core's `lifecycle.ignore_changes`, it ignores external autoscaler drift while still allowing updates via HCL config changes.

## Testing
* Manual verification of flipping `skip_node_pool_refresh` from `false` -> `true` and removal of the `node_pool` list: gpaste/5967702920396800
* Acceptance tests `TestAccContainerCluster_skipNodePoolRefresh` and `TestAccContainerNodePool_ignoreNodeCountChanges` pass locally
* Unit tests `TestUnitFlattenClusterNodePools` and `TestUnitFlattenNodePool` pass locally


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `skip_node_pool_refresh` field to `google_container_cluster` resource. When set to true, the `google_container_cluster` skips refreshing and setting `node_pools` from the API, resolving long plan times on clusters with a large number of node pools. Note that this results in `node_pools` being set to an empty list in state
```

```release-note:enhancement
container: improved GKE node pool read performance by caching instance group metadata longer
```

```release-note:enhancement
container: added `ignore_node_count_changes` field to `google_container_cluster` and `google_container_node_pool` resources. When set to true, the provider ignores drift via external node count changes and skips related IGM API queries, resolving long plan times on clusters with a large number of instance groups.
```
