### PR TITLE
Add ForceSendFields for PSC DNS fields in SQL database instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -2064,14 +2064,21 @@ func expandPscAutoConnectionConfig(configured []interface{}) []*sqladmin.PscAuto
 func expandPscConfig(configured []interface{}) *sqladmin.PscConfig {
 	for _, _pscConfig := range configured {
 		_entry := _pscConfig.(map[string]interface{})
-		return &sqladmin.PscConfig{
-			PscEnabled:                 _entry["psc_enabled"].(bool),
-			PscAutoDnsEnabled:          _entry["psc_auto_dns_enabled"].(bool),
-			PscWriteEndpointDnsEnabled: _entry["psc_write_endpoint_dns_enabled"].(bool),
-			AllowedConsumerProjects:    tpgresource.ConvertStringArr(_entry["allowed_consumer_projects"].(*schema.Set).List()),
+		res := &sqladmin.PscConfig{
+			PscEnabled:              _entry["psc_enabled"].(bool),
+			AllowedConsumerProjects: tpgresource.ConvertStringArr(_entry["allowed_consumer_projects"].(*schema.Set).List()),
 			NetworkAttachmentUri:    _entry["network_attachment_uri"].(string),
 			PscAutoConnections:      expandPscAutoConnectionConfig(_entry["psc_auto_connections"].([]interface{})),
 		}
+		if v, ok := _entry["psc_auto_dns_enabled"]; ok {
+			res.PscAutoDnsEnabled = v.(bool)
+			res.ForceSendFields = append(res.ForceSendFields, "PscAutoDnsEnabled")
+		}
+		if v, ok := _entry["psc_write_endpoint_dns_enabled"]; ok {
+			res.PscWriteEndpointDnsEnabled = v.(bool)
+			res.ForceSendFields = append(res.ForceSendFields, "PscWriteEndpointDnsEnabled")
+		}
+		return res
 	}
 
 	return nil

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_internal_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_internal_test.go
@@ -1,9 +1,11 @@
 package sql
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 func TestMaintenanceVersionDiffSuppress(t *testing.T) {
@@ -219,6 +221,83 @@ func TestDatabaseVersionDiffSuppress(t *testing.T) {
 			t.Parallel()
 			if databaseVersionDiffSuppress("version", testCase.oldVersion, testCase.newVersion, nil) != testCase.shouldSuppressDiff {
 				t.Fatalf("%q => %q expect DiffSuppress to return %t", testCase.oldVersion, testCase.newVersion, testCase.shouldSuppressDiff)
+			}
+		})
+	}
+}
+
+func TestExpandPscConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Config   []interface{}
+		Expected *sqladmin.PscConfig
+	}{
+		"full psc config with force send fields": {
+			Config: []interface{}{
+				map[string]interface{}{
+					"psc_enabled":                    true,
+					"psc_auto_dns_enabled":           true,
+					"psc_write_endpoint_dns_enabled": false,
+					"allowed_consumer_projects":      schema.NewSet(schema.HashString, []interface{}{"project1"}),
+					"network_attachment_uri":         "uri1",
+					"psc_auto_connections":           []interface{}{},
+				},
+			},
+			Expected: &sqladmin.PscConfig{
+				PscEnabled:                 true,
+				PscAutoDnsEnabled:          true,
+				PscWriteEndpointDnsEnabled: false,
+				AllowedConsumerProjects:    []string{"project1"},
+				NetworkAttachmentUri:       "uri1",
+				PscAutoConnections:         []*sqladmin.PscAutoConnectionConfig{},
+				ForceSendFields:            []string{"PscAutoDnsEnabled", "PscWriteEndpointDnsEnabled"},
+			},
+		},
+		"both psc dns fields set to false": {
+			Config: []interface{}{
+				map[string]interface{}{
+					"psc_enabled":                    true,
+					"psc_auto_dns_enabled":           false,
+					"psc_write_endpoint_dns_enabled": false,
+					"allowed_consumer_projects":      schema.NewSet(schema.HashString, []interface{}{}),
+					"network_attachment_uri":         "",
+					"psc_auto_connections":           []interface{}{},
+				},
+			},
+			Expected: &sqladmin.PscConfig{
+				PscEnabled:                 true,
+				PscAutoDnsEnabled:          false,
+				PscWriteEndpointDnsEnabled: false,
+				AllowedConsumerProjects:    []string{},
+				NetworkAttachmentUri:       "",
+				PscAutoConnections:         []*sqladmin.PscAutoConnectionConfig{},
+				ForceSendFields:            []string{"PscAutoDnsEnabled", "PscWriteEndpointDnsEnabled"},
+			},
+		},
+		"psc dns fields missing from config": {
+			Config: []interface{}{
+				map[string]interface{}{
+					"psc_enabled":               true,
+					"allowed_consumer_projects": schema.NewSet(schema.HashString, []interface{}{}),
+					"network_attachment_uri":    "",
+					"psc_auto_connections":      []interface{}{},
+				},
+			},
+			Expected: &sqladmin.PscConfig{
+				PscEnabled:              true,
+				AllowedConsumerProjects: []string{},
+				NetworkAttachmentUri:    "",
+				PscAutoConnections:      []*sqladmin.PscAutoConnectionConfig{},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			res := expandPscConfig(tc.Config)
+			if !reflect.DeepEqual(res, tc.Expected) {
+				t.Fatalf("%s: expected %+v, got %+v", tn, tc.Expected, res)
 			}
 		})
 	}

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -609,9 +609,9 @@ The optional `settings.ip_configuration.psc_config` sublist supports:
 
 * `psc_enabled` - (Optional) Whether PSC connectivity is enabled for this instance.
 
-* `psc_auto_dns_enabled` - (Optional) Whether PSC auto DNS is enabled for this instance.
+* `psc_auto_dns_enabled` - (Optional) Whether PSC auto DNS is enabled for this instance. If a value is specified (including `false`), it will be sent to the API; otherwise, the server's default value will be used.
 
-* `psc_write_endpoint_dns_enabled` - (Optional) Whether PSC write endpoint DNS is enabled for this instance. This is only supported for Enterprise Plus edition instances.
+* `psc_write_endpoint_dns_enabled` - (Optional) Whether PSC write endpoint DNS is enabled for this instance. This is only supported for Enterprise Plus edition instances. If a value is specified (including `false`), it will be sent to the API; otherwise, the server's default value will be used.
 
 * `allowed_consumer_projects` - (Optional) List of consumer projects that are allow-listed for PSC connections to this instance. This instance can be connected to with PSC from any network in these projects. Each consumer project in this list may be represented by a project number (numeric) or by a project id (alphanumeric).
 


### PR DESCRIPTION
```release-note: bug
sql: fixed a bug where setting `psc_auto_dns_enabled` or `psc_write_endpoint_dns_enabled` to `false` in `google_sql_database_instance` was not taking effect.
```
