### PR TITLE
fix(generator): Filter third-party services by active products

### DIFF
--- a/mmv1/main.go
+++ b/mmv1/main.go
@@ -124,7 +124,7 @@ func GenerateProducts(product, resource, providerName, version, outputPath, base
 	// In order to only copy/compile files once per provider this must be called outside
 	// of the products loop. Create an MMv1 provider with an arbitrary product (the first loaded).
 	providerToGenerate := newProvider(providerName, version, productsForVersion[0], startTime, wrappedFS)
-	providerToGenerate.CopyCommonFiles(outputPath, generateCode, generateDocs)
+	providerToGenerate.CopyCommonFiles(outputPath, productsForVersion, generateCode, generateDocs)
 
 	if generateCode {
 		providerToGenerate.CompileCommonFiles(outputPath, productsForVersion, "")

--- a/mmv1/provider/provider.go
+++ b/mmv1/provider/provider.go
@@ -9,7 +9,7 @@ import (
 
 type Provider interface {
 	Generate(string, string, bool, bool)
-	CopyCommonFiles(outputFolder string, generateCode, generateDocs bool)
+	CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool)
 	CompileCommonFiles(outputFolder string, products []*api.Product, overridePath string)
 }
 

--- a/mmv1/provider/terraform.go
+++ b/mmv1/provider/terraform.go
@@ -445,16 +445,16 @@ func (t *Terraform) FullResourceName(object api.Resource) string {
 	return fmt.Sprintf("%s_%s", productName, google.Underscore(object.Name))
 }
 
-func (t Terraform) CopyCommonFiles(outputFolder string, generateCode, generateDocs bool) {
+func (t Terraform) CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool) {
 	log.Printf("Copying common files for %s", ProviderName(t))
 
-	files := t.getCommonCopyFiles(t.TargetVersionName, generateCode, generateDocs)
+	files := t.getCommonCopyFiles(t.TargetVersionName, products, generateCode, generateDocs)
 	t.CopyFileList(outputFolder, files, generateCode)
 }
 
 // To copy a new folder, add the folder to foldersCopiedToRootDir or foldersCopiedToGoogleDir.
 // To copy a file, add the file to singleFiles
-func (t Terraform) getCommonCopyFiles(versionName string, generateCode, generateDocs bool) map[string]string {
+func (t Terraform) getCommonCopyFiles(versionName string, products []*api.Product, generateCode, generateDocs bool) map[string]string {
 	// key is the target file and value is the source file
 	commonCopyFiles := make(map[string]string, 0)
 
@@ -493,7 +493,6 @@ func (t Terraform) getCommonCopyFiles(versionName string, generateCode, generate
 			"third_party/terraform/fwvalidators",
 			"third_party/terraform/provider",
 			"third_party/terraform/registry",
-			"third_party/terraform/services",
 			"third_party/terraform/sweeper",
 			"third_party/terraform/test-fixtures",
 			"third_party/terraform/tpgdclresource",
@@ -511,6 +510,17 @@ func (t Terraform) getCommonCopyFiles(versionName string, generateCode, generate
 	for _, folder := range foldersCopiedToGoogleDir {
 		files := t.getCopyFilesInFolder(folder, googleDir)
 		maps.Copy(commonCopyFiles, files)
+	}
+
+	// Copy services folders only for active products
+	if generateCode {
+		for _, p := range products {
+			serviceFolder := fmt.Sprintf("third_party/terraform/services/%s", strings.ToLower(p.Name))
+			if t.dirExists(serviceFolder) {
+				files := t.getCopyFilesInFolder(serviceFolder, googleDir)
+				maps.Copy(commonCopyFiles, files)
+			}
+		}
 	}
 
 	// Case 3: When copy a single file, save the target as key and source as value to the map singleFiles
@@ -597,14 +607,14 @@ func (t Terraform) CopyFileList(outputFolder string, files map[string]string, ge
 func (t Terraform) CompileCommonFiles(outputFolder string, products []*api.Product, overridePath string) {
 	log.Printf("Generating common files for %s", ProviderName(t))
 	t.generateResourcesForVersion(products)
-	files := t.getCommonCompileFiles(t.TargetVersionName)
+	files := t.getCommonCompileFiles(t.TargetVersionName, products)
 	templateData := NewTemplateData(outputFolder, t.TargetVersionName, t.templateFS)
 	t.CompileFileList(outputFolder, files, *templateData, products)
 }
 
 // To compile a new folder, add the folder to foldersCompiledToRootDir or foldersCompiledToGoogleDir.
 // To compile a file, add the file to singleFiles
-func (t Terraform) getCommonCompileFiles(versionName string) map[string]string {
+func (t Terraform) getCommonCompileFiles(versionName string, products []*api.Product) map[string]string {
 	// key is the target file and the value is the source file
 	commonCompileFiles := make(map[string]string, 0)
 
@@ -628,7 +638,6 @@ func (t Terraform) getCommonCompileFiles(versionName string) map[string]string {
 		"third_party/terraform/fwresource",
 		"third_party/terraform/fwtransport",
 		"third_party/terraform/provider",
-		"third_party/terraform/services",
 		"third_party/terraform/sweeper",
 		"third_party/terraform/test-fixtures",
 		"third_party/terraform/tpgdclresource",
@@ -644,6 +653,15 @@ func (t Terraform) getCommonCompileFiles(versionName string) map[string]string {
 	for _, folder := range foldersCompiledToGoogleDir {
 		files := t.getCompileFilesInFolder(folder, googleDir)
 		maps.Copy(commonCompileFiles, files)
+	}
+
+	// Compile services folders only for active products
+	for _, p := range products {
+		serviceFolder := fmt.Sprintf("third_party/terraform/services/%s", strings.ToLower(p.Name))
+		if t.dirExists(serviceFolder) {
+			files := t.getCompileFilesInFolder(serviceFolder, googleDir)
+			maps.Copy(commonCompileFiles, files)
+		}
 	}
 
 	// Case 3: When compile a single file, save the target as key and source as value to the map singleFiles
@@ -1063,4 +1081,12 @@ type ProviderWithProducts struct {
 	Terraform
 	Compiler string
 	Products []*api.Product
+}
+
+func (t Terraform) dirExists(path string) bool {
+	fi, err := fs.Stat(t.templateFS, path)
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
 }

--- a/mmv1/provider/terraform_oics.go
+++ b/mmv1/provider/terraform_oics.go
@@ -127,6 +127,6 @@ func (toics TerraformOiCS) CompileCommonFiles(outputFolder string, products []*a
 
 }
 
-func (toics TerraformOiCS) CopyCommonFiles(outputFolder string, generateCode, generateDocs bool) {
+func (toics TerraformOiCS) CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool) {
 
 }

--- a/mmv1/provider/terraform_tgc.go
+++ b/mmv1/provider/terraform_tgc.go
@@ -352,7 +352,7 @@ func retrieveListOfManuallyDefinedTestsFromFile(fsys fs.FS, file string) []strin
 	return tests
 }
 
-func (tgc TerraformGoogleConversion) CopyCommonFiles(outputFolder string, generateCode, generateDocs bool) {
+func (tgc TerraformGoogleConversion) CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool) {
 	log.Printf("Copying common files for tgc.")
 
 	if !generateCode {

--- a/mmv1/provider/terraform_tgc_cai2hcl.go
+++ b/mmv1/provider/terraform_tgc_cai2hcl.go
@@ -56,7 +56,7 @@ func (cai2hcl CaiToTerraformConversion) Generate(outputFolder, resourceToGenerat
 func (cai2hcl CaiToTerraformConversion) CompileCommonFiles(outputFolder string, products []*api.Product, overridePath string) {
 }
 
-func (cai2hcl CaiToTerraformConversion) CopyCommonFiles(outputFolder string, generateCode, generateDocs bool) {
+func (cai2hcl CaiToTerraformConversion) CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool) {
 	if !generateCode {
 		return
 	}

--- a/mmv1/provider/terraform_tgc_next.go
+++ b/mmv1/provider/terraform_tgc_next.go
@@ -238,7 +238,7 @@ func (tgc TerraformGoogleConversionNext) CompileFileList(outputFolder string, fi
 	}
 }
 
-func (tgc TerraformGoogleConversionNext) CopyCommonFiles(outputFolder string, generateCode, generateDocs bool) {
+func (tgc TerraformGoogleConversionNext) CopyCommonFiles(outputFolder string, products []*api.Product, generateCode, generateDocs bool) {
 	if !generateCode {
 		return
 	}

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_access_token_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_access_token_test.go.tmpl
@@ -10,7 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+{{- if ne $.TargetVersionName "ga" }}
 	_ "github.com/hashicorp/terraform-provider-google/google/services/firebase"
+{{- end }}
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_scopes_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_scopes_test.go.tmpl
@@ -9,7 +9,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+{{- if ne $.TargetVersionName "ga" }}
 	_ "github.com/hashicorp/terraform-provider-google/google/services/firebase"
+{{- end }}
 	"github.com/hashicorp/terraform-provider-google/google/transport"
 )
 

--- a/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
+++ b/mmv1/third_party/terraform/fwprovider/framework_provider_user_project_override_test.go.tmpl
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/firebase"
 {{ if ne $.TargetVersionName `ga` -}}
+	_ "github.com/hashicorp/terraform-provider-google/google/services/firebase"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	ptu "github.com/hashicorp/terraform-provider-google/google/provider/testutils"
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/
If your PR is still work in progress, please create it in draft mode.
-->
### Description
This PR fixes a bug in the Magic Modules generator where handwritten files for Beta-only (or version-restricted) services were being leaked into the GA provider, causing compilation failures - [example](https://github.com/GoogleCloudPlatform/magic-modules/actions/runs/27573851029/job/81516939914).
#### The Problem
When introducing a new Beta-only service (such as the upcoming `agentregistry`) that includes handwritten files in `third_party/terraform/services/<service_name>/` (e.g., `agent_registry_operation.go`), the GitHub Actions "Provider Build and Unit Test" job fails during the GA provider compilation with:
undefined: Product



#### The Cause
1.  During GA provider generation, the Beta-only service is correctly **not** generated, meaning `product.go` (which defines the `Product` variable) is not created in the GA provider.
2.  However, the generator's `CopyCommonFiles` and `CompileCommonFiles` methods were blindly copying/compiling the entire `third_party/terraform/services/` directory to the downstream provider.
3.  This resulted in the Beta-only service's handwritten files (like `agent_registry_operation.go`) being copied to the GA provider (`google/services/agentregistry/`).
4.  Since these handwritten files commonly reference the `Product` variable (which doesn't exist in GA for this service), the GA provider failed to compile.
#### The Solution
This PR modifies the generator to only copy and compile third-party service files for products that are actually active in the target version being generated:
1.  **Updated Signatures:** Updated `CopyCommonFiles` in the `Provider` interface and all its implementations to accept the list of active `products []*api.Product`.
2.  **Filtered Copying:** Modified `getCommonCopyFiles` in `terraform.go` to remove the global `third_party/terraform/services` copy. Instead, it now iterates through the active `products` and only copies `third_party/terraform/services/<product_name>` if it exists.
3.  **Filtered Compilation:** Modified `getCommonCompileFiles` in `terraform.go` similarly to only compile templates for active products.
4.  **Helper Added:** Introduced a `dirExists` helper in `terraform.go` to safely check if a service directory exists in the template filesystem before attempting to copy/compile it (as some services do not have handwritten files).
This ensures that the GA provider remains completely free of any Beta-only service code, preventing compilation leaks.
### Test/Verification Results
Verified locally by running:
1.  `make provider VERSION=ga` (GA Generation) -> Verified that the `google/services/agentregistry` directory is **no longer created** in the GA provider, resolving the compilation leak.
2.  `make provider VERSION=beta` (Beta Generation) -> Verified that the `google-beta/services/agentregistry` directory is **correctly created** and contains all generated and handwritten files.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```