### PR TITLE
Fix GCE instance update issue where initializeParams is sent for exis…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/compute_instance_helpers.go.tmpl
@@ -1598,3 +1598,14 @@ func flattenComputeInstanceSourceEncryptionKey(v map[string]interface{}) []map[s
 		},
 	}
 }
+
+func stripInitializeParams(instanceMap map[string]interface{}) {
+	if disks, ok := instanceMap["disks"].([]interface{}); ok {
+		for _, rawDisk := range disks {
+			if disk, ok := rawDisk.(map[string]interface{}); ok {
+				delete(disk, "initializeParams")
+			}
+		}
+	}
+}
+

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -2615,6 +2615,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 				instMap["description"] = d.Get("description").(string)
 
+				stripInitializeParams(instMap)
+
 				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 					Config:    config,
 					Method:    "PUT",
@@ -2718,6 +2720,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				}
 				patchedPM := resourceInstancePatchPartnerMetadata(d, currentPM)
 				instMap["partnerMetadata"] = patchedPM
+
+				stripInitializeParams(instMap)
 
 				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 					Config:    config,
@@ -2827,6 +2831,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("Error converting params: %s", err)
 				}
 				instMap["params"] = paramsMap
+
+				stripInitializeParams(instMap)
 
 				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 					Config:    config,
@@ -3670,6 +3676,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 				instMap["canIpForward"] = d.Get("can_ip_forward").(bool)
 
+				stripInitializeParams(instMap)
+
 				res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 					Config:    config,
 					Method:    "PUT",
@@ -4001,6 +4009,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 						return fmt.Errorf("Error converting advanced_machine_features: %s", err)
 					}
 					instMap["advancedMachineFeatures"] = featuresMap
+
+					stripInitializeParams(instMap)
 
 					res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 						Config:    config,

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_test.go.tmpl
@@ -3007,6 +3007,9 @@ func TestAccComputeInstance_hyperdiskBootDisk_provisioned_iops_throughput(t *tes
 				Config: testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput(context),
 			},
 			computeInstanceImportStep(context["zone"].(string), context["instance_name"].(string), []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput_update(context),
+			},
 		},
 	})
 }
@@ -14238,3 +14241,36 @@ resource "google_compute_instance" "foobar" {
 `, context)
 }
 {{- end }}
+
+func testAccComputeInstanceHyperDiskBootDiskProvisionedIopsThroughput_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+data "google_compute_image" "my_image" {
+  family    = "ubuntu-2204-lts"
+  project   = "ubuntu-os-cloud"
+}
+
+data "google_project" "project" {}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%{instance_name}"
+  machine_type = "h3-standard-88"
+  zone         = "%{zone}"
+  description  = "updated description"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+      provisioned_iops = %{provisioned_iops}
+      provisioned_throughput = %{provisioned_throughput}
+      type = "hyperdisk-balanced"
+      size = 100
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+`, context)
+}
+


### PR DESCRIPTION
Fixes validation errors during `google_compute_instance` updates for VMs using `hyperdisk-balanced` boot disks.
### Problem Description
When performing updates on a `google_compute_instance`, the provider performs a GET-modify-PUT flow. The GCE API returns `initializeParams` in its GET responses for existing attached disks under certain conditions. When this payload is sent back during `instances.update` PUT requests, GCE's backend validator parses `initializeParams` as a disk creation/modification action, failing with:
`Provisioned IOPS cannot be specified with disk type pd-balanced`
### Solution
This PR strips the `initializeParams` block from all disks in the instance map (`instMap`) prior to sending GCE `instances.update` PUT requests. Since `initializeParams` is input-only and cannot be updated on existing disks, removing it is safe and backward compatible.
### Verification
Modified `TestAccComputeInstance_hyperdiskBootDisk_provisioned_iops_throughput` to include an update step (description change), and verified that it builds and passes successfully.
Resolves: b/509846156

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed a validation error on `google_compute_instance` (`Provisioned IOPS cannot be specified with disk type pd-balanced`) that occurred during updates on instances with Hyperdisk Balanced boot disks.
```