### PR TITLE
`resourceidentity/mmv1`: add `flatten_object` properties for identity value extraction

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -711,7 +711,20 @@ func (r Resource) IdentityProperties() []*Type {
 	}
 	importFormat := r.ExtractIdentifiers(ImportIdFormats(r.ImportFormat, identities, r.BaseUrl)[0])
 	optionalValues := map[string]bool{"project": false, "zone": false, "region": false}
+
+	// Collapse any nested objects marked with flatten_object so that identifiers
+	// nested under them (e.g. datasetReference.datasetId -> dataset_id) are
+	// matched against the import format.
+	allProps := make([]*Type, 0)
 	for _, p := range r.AllProperties() {
+		if p.FlattenObject {
+			allProps = google.Concat(allProps, p.RootProperties())
+		} else {
+			allProps = append(allProps, p)
+		}
+	}
+
+	for _, p := range allProps {
 		if slices.Contains(importFormat, google.Underscore(p.Name)) {
 			props = append(props, p)
 			optionalValues[p.Name] = true

--- a/mmv1/api/resource_test.go
+++ b/mmv1/api/resource_test.go
@@ -884,3 +884,43 @@ func TestResource_TestDependencies(t *testing.T) {
 		})
 	}
 }
+
+// TestIdentityPropertiesFlattenObject ensures that identifiers nested under a
+// property marked with flatten_object (e.g. datasetReference.datasetId ->
+// dataset_id) are collapsed and included in the identity schema. Without this,
+// importing by resource identity panics because the identifier is missing from
+// the generated identity schema.
+func TestIdentityPropertiesFlattenObject(t *testing.T) {
+	t.Parallel()
+
+	res := &api.Resource{
+		Name:            "Dataset",
+		BaseUrl:         "projects/{{project}}/datasets",
+		ImportFormat:    []string{"projects/{{project}}/datasets/{{dataset_id}}"},
+		ProductMetadata: &api.Product{Name: "BigQuery"},
+	}
+	res.Properties = []*api.Type{
+		{
+			Name:             "datasetReference",
+			Type:             "NestedObject",
+			FlattenObject:    true,
+			ResourceMetadata: res,
+			Properties: []*api.Type{
+				{
+					Name:     "datasetId",
+					Type:     "String",
+					Required: true,
+				},
+			},
+		},
+	}
+
+	got := make([]string, 0)
+	for _, p := range res.IdentityProperties() {
+		got = append(got, p.Name)
+	}
+
+	if !slices.Contains(got, "datasetId") {
+		t.Errorf("expected IdentityProperties to include flattened identifier \"datasetId\", got %v", got)
+	}
+}

--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -43,8 +43,6 @@ custom_code:
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
 custom_diff:
   - 'customCollationDiff'
-# exluding resource_identity due to dataset_id field
-exclude_identity_generation: true
 exclude_sweeper: true
 examples:
   - name: 'bigquery_dataset_basic'


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Initially we only focused on `AllProperties` when working on resource identity mmv1 generation, however there is a case with `bigquery_dataset` where `dataset_id` resulted in a failure due to the `dataset_id` field being set in root AFTER performing the rendering logic of `flatten_nested: true`.

From my understanding the following is what happens:
1. initial schema is generated with the desired properties set in `metadata.yaml` of the resource file (in-memory)
2. a second pass through is performed to allow for schema modification to be done (`flatten_object: true`) resulting in `dataset_id` to be extracted from `datasetReference` and moved to root of the schema.

The assumption initially was done path 2 is what identity would see but this was not the case. The new logic added into `IdentityProperties` properly enters values that are set as `flatten_nested` before looping through the value checks for `import_format`

This PR also includes support of resource identity for `bigquery_dataset` with the following test including the new `ImportWithResourceIdentity` test step:
```hcl
󰀵 mau  …/terraform-provider-google   main $!⇣   v1.26.1   12:47   envchain GCLOUD make testacc TEST=./google/services/bigquery TESTARGS='-run=TestAccBigQueryDataset_bigqueryDatasetBasicExample' 
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/bigquery -v -run=TestAccBigQueryDataset_bigqueryDatasetBasicExample -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccBigQueryDataset_bigqueryDatasetBasicExample
=== PAUSE TestAccBigQueryDataset_bigqueryDatasetBasicExample
=== CONT  TestAccBigQueryDataset_bigqueryDatasetBasicExample
--- PASS: TestAccBigQueryDataset_bigqueryDatasetBasicExample (38.29s)
PASS
ok      github.com/hashicorp/terraform-provider-google/google/services/bigquery 39.623s

```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
