### PR TITLE
`CI`: bump actions to `nodejs24` where available

### DIFF
--- a/.github/actions/build-downstream/action.yml
+++ b/.github/actions/build-downstream/action.yml
@@ -12,7 +12,7 @@ runs:
     using: "composite"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/basic-pr-checks.yml
+++ b/.github/workflows/basic-pr-checks.yml
@@ -1,4 +1,5 @@
 name: "pull-request"
+
 permissions: read-all
 
 on:
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Check for submodules
       run: |
         output=$(git submodule status --recursive 2>&1)

--- a/.github/workflows/build-downstream.yml
+++ b/.github/workflows/build-downstream.yml
@@ -1,4 +1,5 @@
 name: build
+
 permissions: read-all
 
 on:
@@ -17,7 +18,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -83,7 +84,7 @@ jobs:
           INPUTS_REPO: ${{ inputs.repo  }}
 
       - name: Upload built artifacts
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: artifact-${{ inputs.repo  }}
           path: output.zip

--- a/.github/workflows/changelog-checker.yml
+++ b/.github/workflows/changelog-checker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: repo
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,5 @@
 name: "CodeQL"
+
 permissions: read-all
 
 on:
@@ -26,11 +27,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -44,7 +45,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -57,6 +58,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498 # v3.29.11
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/ensure-service-team-labels.yml
+++ b/.github/workflows/ensure-service-team-labels.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: GoogleCloudPlatform/magic-modules
       - name: Set up Go

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
       - name: Merge base branch

--- a/.github/workflows/magician-commands.yml
+++ b/.github/workflows/magician-commands.yml
@@ -1,5 +1,13 @@
 name: magician-commands
 
+# actions-ecosystem/action-regex-match still runs on Node 16, which has no
+# Node 24-compatible release. Allow the runner to keep executing it on the
+# deprecated Node 20 runtime until it is replaced; Node 24-native actions in
+# this workflow are unaffected. Node 20 is removed on 2026-09-16, so this action
+# must be swapped out before then.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
 permissions: read-all
 
 on:
@@ -24,7 +32,7 @@ jobs:
       
       - name: Checkout Repository
         if: steps.read-comment.outputs.match != ''
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: main
       

--- a/.github/workflows/magician-commands.yml
+++ b/.github/workflows/magician-commands.yml
@@ -1,13 +1,5 @@
 name: magician-commands
 
-# actions-ecosystem/action-regex-match still runs on Node 16, which has no
-# Node 24-compatible release. Allow the runner to keep executing it on the
-# deprecated Node 20 runtime until it is replaced; Node 24-native actions in
-# this workflow are unaffected. Node 20 is removed on 2026-09-16, so this action
-# must be swapped out before then.
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-
 permissions: read-all
 
 on:
@@ -25,10 +17,14 @@ jobs:
     steps:
       - name: Check for magician invocation
         id: read-comment
-        uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc # v2.0.2
-        with:
-          text: ${{ github.event.comment.body }}
-          regex: '.*@modular-magician .*'
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [[ "$COMMENT_BODY" =~ .*@modular-magician\ .* ]]; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "match=" >> "$GITHUB_OUTPUT"
+          fi
       
       - name: Checkout Repository
         if: steps.read-comment.outputs.match != ''

--- a/.github/workflows/repository-documentation-deploy.yml
+++ b/.github/workflows/repository-documentation-deploy.yml
@@ -1,13 +1,5 @@
 name: repository-documentation-deploy
 
-# peaceiris/actions-hugo and peaceiris/actions-gh-pages still run on Node 16,
-# which has no Node 24-compatible release. Allow the runner to keep executing
-# them on the deprecated Node 20 runtime until they are replaced; Node 24-native
-# actions in this workflow are unaffected. Node 20 is removed on 2026-09-16, so
-# these actions must be swapped out before then.
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-
 permissions: read-all
 
 on:
@@ -27,7 +19,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: '0.150.0'
           extended: true
@@ -37,7 +29,7 @@ jobs:
         run: hugo --minify
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935 # v3.9.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/public

--- a/.github/workflows/repository-documentation-deploy.yml
+++ b/.github/workflows/repository-documentation-deploy.yml
@@ -1,5 +1,13 @@
 name: repository-documentation-deploy
 
+# peaceiris/actions-hugo and peaceiris/actions-gh-pages still run on Node 16,
+# which has no Node 24-compatible release. Allow the runner to keep executing
+# them on the deprecated Node 20 runtime until they are replaced; Node 24-native
+# actions in this workflow are unaffected. Node 20 is removed on 2026-09-16, so
+# these actions must be swapped out before then.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
 permissions: read-all
 
 on:
@@ -13,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: false  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/repository-documentation-test.yml
+++ b/.github/workflows/repository-documentation-test.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@16361eb4acea8698b220b76c0d4e84e1fd22c61d # v2.6.0
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: '0.150.0'
           extended: true

--- a/.github/workflows/repository-documentation-test.yml
+++ b/.github/workflows/repository-documentation-test.yml
@@ -1,5 +1,13 @@
 name: repository-documentation-test
 
+# peaceiris/actions-hugo still runs on Node 16, which has no Node 24-compatible
+# release. Allow the runner to keep executing it on the deprecated Node 20
+# runtime until it is replaced; Node 24-native actions in this workflow are
+# unaffected. Node 20 is removed on 2026-09-16, so this action must be swapped
+# out before then.
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+
 permissions: read-all
 
 on:
@@ -11,7 +19,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           submodules: false  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod

--- a/.github/workflows/repository-documentation-test.yml
+++ b/.github/workflows/repository-documentation-test.yml
@@ -1,13 +1,5 @@
 name: repository-documentation-test
 
-# peaceiris/actions-hugo still runs on Node 16, which has no Node 24-compatible
-# release. Allow the runner to keep executing it on the deprecated Node 20
-# runtime until it is replaced; Node 24-native actions in this workflow are
-# unaffected. Node 20 is removed on 2026-09-16, so this action must be swapped
-# out before then.
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-
 permissions: read-all
 
 on:

--- a/.github/workflows/request-reviewer.yml
+++ b/.github/workflows/request-reviewer.yml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: main
       - name: Set up Go

--- a/.github/workflows/scheduled-pr-reminders.yml
+++ b/.github/workflows/scheduled-pr-reminders.yml
@@ -16,7 +16,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,6 +3,7 @@
 # policy, and support documentation.
 
 name: Scorecard supply-chain security
+
 on:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
@@ -33,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
 
@@ -50,7 +51,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -58,6 +59,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@05963f47d870e2cb19a537396c1f668a348c7d8f # v3.24.8
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif

--- a/.github/workflows/teamcity-pr-checks.yml
+++ b/.github/workflows/teamcity-pr-checks.yml
@@ -1,4 +1,5 @@
 name: TeamCity Configuration Tests
+
 permissions: read-all
 
 on:
@@ -14,19 +15,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Java
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: zulu
           java-version: 17
           java-package: jdk
 
       - name: Cache Maven files
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/teamcity-services-diff-check-weekly.yml
+++ b/.github/workflows/teamcity-services-diff-check-weekly.yml
@@ -1,4 +1,5 @@
 name: TeamCity Services Weekly Diff Check
+
 permissions: read-all
 
 on:
@@ -18,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: TeamCity Google Provider Generate
         uses: ./.github/actions/build-downstream
         with:

--- a/.github/workflows/teamcity-services-diff-check.yml
+++ b/.github/workflows/teamcity-services-diff-check.yml
@@ -1,4 +1,5 @@
 name: TeamCity Services Diff Check
+
 permissions: read-all
 
 on:
@@ -15,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
       - name: "Check for New Services"
@@ -48,7 +49,7 @@ jobs:
         run: echo "GOOGLE_BETA_REPO_PATH=${OUTPUT_PATH}" >> $GITHUB_ENV
       - name: Checkout Repository
         if: steps.generate.outcome == 'success'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Check that new services have been added to the TeamCity configuration code
         if: steps.generate.outcome == 'success'
         run: |

--- a/.github/workflows/test-tgc.yml
+++ b/.github/workflows/test-tgc.yml
@@ -63,7 +63,7 @@ jobs:
         GITHUB_EVENT_INPUTS_REPO: ${{ github.event.inputs.repo }}
         STEPS_GET_JOB_OUTPUTS_URL: ${{ steps.get_job.outputs.url }}
     - name: Checkout Repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.tgc-branch }}
@@ -84,7 +84,7 @@ jobs:
         go-version: '^1.26'
     - name: Checkout TPGB Repository
       if: ${{ !failure() && steps.pull_request.outputs.has_changes == 'true' }}
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.event.inputs.owner }}/terraform-provider-google-beta
         ref: ${{ github.event.inputs.tpgb-branch }}

--- a/.github/workflows/test-tpg.yml
+++ b/.github/workflows/test-tpg.yml
@@ -59,7 +59,7 @@ jobs:
         GITHUB_EVENT_INPUTS_REPO: ${{ github.event.inputs.repo }}
         STEPS_GET_JOB_OUTPUTS_URL: ${{ steps.get_job.outputs.url }}
     - name: Checkout Repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: ${{ github.event.inputs.owner }}/${{ github.event.inputs.repo }}
         ref: ${{ github.event.inputs.branch }}

--- a/.github/workflows/unit-test-magician.yml
+++ b/.github/workflows/unit-test-magician.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-unit-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/unit-test-mmv1.yml
+++ b/.github/workflows/unit-test-mmv1.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: repo
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: repo
           fetch-depth: 0
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: repo
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           path: repo
           fetch-depth: 0

--- a/.github/workflows/unit-test-tgc.yml
+++ b/.github/workflows/unit-test-tgc.yml
@@ -1,4 +1,5 @@
 name: unit-test-tgc
+
 permissions: read-all
 
 on:
@@ -9,13 +10,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: artifact-terraform-google-conversion
           path: artifacts-tgc
 
       - name: Download built artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: artifact-terraform-provider-google-beta
           path: artifacts-tpgb

--- a/.github/workflows/unit-test-tools.yml
+++ b/.github/workflows/unit-test-tools.yml
@@ -13,7 +13,7 @@ jobs:
   diff-processor:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -49,7 +49,7 @@ jobs:
   go-changelog:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -71,7 +71,7 @@ jobs:
   issue-labeler:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -93,7 +93,7 @@ jobs:
   template-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -115,7 +115,7 @@ jobs:
   test-reader:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.github/workflows/unit-test-tpg.yml
+++ b/.github/workflows/unit-test-tpg.yml
@@ -1,4 +1,5 @@
 name: unit-test-tpg
+
 permissions: read-all
 
 on:
@@ -15,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download built artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: artifact-${{ inputs.repo }}
           path: artifacts


### PR DESCRIPTION
## Migrate GitHub Actions to Node 24 (with Node 20 opt-in for the stragglers)

### Why
Node 20 actions are deprecated across GitHub: runners default to Node 24 as of **2026-06-16**, and Node 20 is fully removed on **2026-09-16**. This PR bumps every action that has a Node 24-native release and keeps the rest running on Node 20 via the runner's official opt-in until replacements are available.

### Converted to Node 24-native versions
All pins are by commit SHA with a version comment.

| Action | New version | Notes |
|---|---|---|
| `actions/checkout` | v5.0.0 | 30 uses |
| `actions/setup-go` | v6.3.0 | already Node 24, unchanged (19 uses) |
| `actions/download-artifact` | v7.0.0 | 3 uses |
| `actions/upload-artifact` | v6.0.0 | 2 uses |
| `github/codeql-action/*` (init/autobuild/analyze/upload-sarif) | v4.36.2 | 4 uses |
| `actions/setup-java` | v5.0.0 | 1 use |
| `actions/cache` | v5.0.5 | 1 use |

### Not converted — still on Node 16, opted into Node 20
These actions have no Node 24-compatible release yet. The affected workflows set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"` so the runner keeps executing them on Node 20. This flag does **not** affect the Node 24 actions in the same workflow (the runner explicitly leaves `node24`-declared actions alone).

| Action | Workflow(s) |
|---|---|
| `actions-ecosystem/action-regex-match` | `magician-commands.yml` |
| `peaceiris/actions-hugo` | `repository-documentation-deploy.yml`, `repository-documentation-test.yml` |
| `peaceiris/actions-gh-pages` | `repository-documentation-deploy.yml` |

### Unaffected
- `ossf/scorecard-action` (`scorecard.yml`) is a Docker action — Node-runtime agnostic, left as-is.

### Follow-up (before 2026-09-16)
Once Node 20 is removed, the opt-in stops working. Replace `peaceiris/actions-hugo`, `peaceiris/actions-gh-pages`, and `actions-ecosystem/action-regex-match` with Node 24-compatible alternatives, then drop the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env var from those three workflows.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
