### PR TITLE
Migrated metadata in order to remove the google.golang.org/api/comput…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
@@ -95,8 +95,14 @@ func FlattenMetadata(metadata *compute.Metadata) map[string]interface{} {
 	return metadataMap
 }
 
-func resourceInstanceMetadata(d tpgresource.TerraformResourceData) (*compute.Metadata, error) {
-	m := &compute.Metadata{}
+// resourceInstanceMetadata builds the instance metadata as a JSON-shaped
+// map[string]interface{} mirroring the compute.Metadata API type (camelCase
+// keys: "items" -> [{"key", "value"}], "fingerprint"). Empty values are omitted
+// to mirror the Apiary struct's omitempty tags, so the marshaled request body is
+// byte-identical whether the map is sent directly or round-tripped through the
+// typed struct via resourceInstanceMetadataTyped.
+func resourceInstanceMetadata(d tpgresource.TerraformResourceData) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
 	mdMap := d.Get("metadata").(map[string]interface{})
 	if v, ok := d.GetOk("metadata_startup_script"); ok && v.(string) != "" {
 		if w, ok := mdMap["startup-script"]; ok {
@@ -108,7 +114,7 @@ func resourceInstanceMetadata(d tpgresource.TerraformResourceData) (*compute.Met
 		mdMap["startup-script"] = v
 	}
 	if len(mdMap) > 0 {
-		m.Items = make([]*compute.MetadataItems, 0, len(mdMap))
+		items := make([]interface{}, 0, len(mdMap))
 		var keys []string
 		for k := range mdMap {
 			keys = append(keys, k)
@@ -116,17 +122,36 @@ func resourceInstanceMetadata(d tpgresource.TerraformResourceData) (*compute.Met
 		sort.Strings(keys)
 		for _, k := range keys {
 			v := mdMap[k].(string)
-			m.Items = append(m.Items, &compute.MetadataItems{
-				Key:   k,
-				Value: &v,
+			items = append(items, map[string]interface{}{
+				"key":   k,
+				"value": v,
 			})
 		}
+		m["items"] = items
 
 		// Set the fingerprint. If the metadata has never been set before
-		// then this will just be blank.
-		m.Fingerprint = d.Get("metadata_fingerprint").(string)
+		// then this will just be blank, in which case we omit it to mirror
+		// the compute.Metadata omitempty behaviour.
+		if fp := d.Get("metadata_fingerprint").(string); fp != "" {
+			m["fingerprint"] = fp
+		}
 	}
 
+	return m, nil
+}
+
+// resourceInstanceMetadataTyped adapts the map-based resourceInstanceMetadata
+// output to the typed *compute.Metadata still required by callers that build
+// Apiary request structs directly.
+func resourceInstanceMetadataTyped(d tpgresource.TerraformResourceData) (*compute.Metadata, error) {
+	mdMap, err := resourceInstanceMetadata(d)
+	if err != nil {
+		return nil, err
+	}
+	m := &compute.Metadata{}
+	if err := convertViaJSON(mdMap, m); err != nil {
+		return nil, err
+	}
 	return m, nil
 }
 {{- if ne $.TargetVersionName "ga" }}
@@ -169,22 +194,35 @@ func flattenPartnerMetadata(partnerMetadata map[string]interface{}) (map[string]
 	return partnerMetadataMap, nil
 }
 
-func convertPartnerMetadataToCompute(pm map[string]interface{}) (map[string]compute.StructuredEntries, error) {
-	result := make(map[string]compute.StructuredEntries)
+// convertPartnerMetadataToCompute builds the partner metadata as a JSON-shaped
+// map[string]interface{} mirroring the compute.StructuredEntries API type (each
+// value is the parsed entries object, or an empty object for nil). The typed
+// adapter convertPartnerMetadataToComputeTyped round-trips this through
+// map[string]compute.StructuredEntries for callers that build Apiary structs.
+func convertPartnerMetadataToCompute(pm map[string]interface{}) (map[string]interface{}, error) {
+	result := make(map[string]interface{})
 	for key, value := range pm {
 		if value == nil {
-			result[key] = compute.StructuredEntries{}
+			result[key] = map[string]interface{}{}
 			continue
 		}
-		seBytes, err := json.Marshal(value)
-		if err != nil {
-			return nil, err
-		}
-		var se compute.StructuredEntries
-		if err := json.Unmarshal(seBytes, &se); err != nil {
-			return nil, err
-		}
-		result[key] = se
+		result[key] = value
+	}
+	return result, nil
+}
+
+// convertPartnerMetadataToComputeTyped adapts the map-based
+// convertPartnerMetadataToCompute output to the typed
+// map[string]compute.StructuredEntries still required by callers that build
+// Apiary request structs directly.
+func convertPartnerMetadataToComputeTyped(pm map[string]interface{}) (map[string]compute.StructuredEntries, error) {
+	pmMap, err := convertPartnerMetadataToCompute(pm)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]compute.StructuredEntries)
+	if err := convertViaJSON(pmMap, &result); err != nil {
+		return nil, err
 	}
 	return result, nil
 }

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance.go.tmpl
@@ -1871,7 +1871,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 		return nil, fmt.Errorf("Error creating params: %s", err)
 	}
 
-	metadata, err := resourceInstanceMetadata(d)
+	metadata, err := resourceInstanceMetadataTyped(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating metadata: %s", err)
 	}
@@ -1881,7 +1881,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *trans
 	if err != nil {
 		return nil, fmt.Errorf("Error creating partner metadata: %s", err)
 	}
-	PartnerMetadata, err := convertPartnerMetadataToCompute(partnerMetadataMap)
+	PartnerMetadata, err := convertPartnerMetadataToComputeTyped(partnerMetadataMap)
 	if err != nil {
 		return nil, fmt.Errorf("Error converting partner metadata: %s", err)
 	}
@@ -2646,14 +2646,9 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if d.HasChange("metadata") {
-		metadata, err := resourceInstanceMetadata(d)
+		metadataBody, err := resourceInstanceMetadata(d)
 		if err != nil {
 			return fmt.Errorf("Error parsing metadata: %s", err)
-		}
-
-		metadataBody, err := tpgresource.ConvertToMap(metadata)
-		if err != nil {
-			return fmt.Errorf("Error converting metadata: %s", err)
 		}
 
 		metadataInstanceUrl, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances/{{"{{"}}name{{"}}"}}")

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -1668,7 +1668,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	metadata, err := resourceInstanceMetadata(d)
+	metadata, err := resourceInstanceMetadataTyped(d)
 	if err != nil {
 		return err
 	}
@@ -1677,7 +1677,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	PartnerMetadata, err := convertPartnerMetadataToCompute(partnerMetadataMap)
+	PartnerMetadata, err := convertPartnerMetadataToComputeTyped(partnerMetadataMap)
 	if err != nil {
 		return err
 	}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -1342,7 +1342,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 	if err != nil {
 		return err
 	}
-	PartnerMetadata, err := convertPartnerMetadataToCompute(partnerMetadataMap)
+	PartnerMetadata, err := convertPartnerMetadataToComputeTyped(partnerMetadataMap)
 	if err != nil {
 		return err
 	}
@@ -1399,11 +1399,7 @@ func resourceComputeRegionInstanceTemplateCreate(d *schema.ResourceData, meta in
 		instanceProperties["keyRevocationActionType"] = v
 	}
 	if metadata != nil {
-		metadataMap, err := tpgresource.ConvertToMap(metadata)
-		if err != nil {
-			return fmt.Errorf("Error converting metadata: %s", err)
-		}
-		instanceProperties["metadata"] = metadataMap
+		instanceProperties["metadata"] = metadata
 	}
 	if networkPerformanceConfig != nil {
 		instanceProperties["networkPerformanceConfig"] = networkPerformanceConfig

--- a/mmv1/third_party/tgc/services/compute/compute_instance.go.tmpl
+++ b/mmv1/third_party/tgc/services/compute/compute_instance.go.tmpl
@@ -129,7 +129,7 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		}
 	}
 
-	metadata, err := resourceInstanceMetadata(d)
+	metadata, err := resourceInstanceMetadataTyped(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating metadata: %s", err)
 	}

--- a/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/compute/compute_instance_tfplan2cai.go
@@ -121,7 +121,7 @@ func expandComputeInstance(project string, d tpgresource.TerraformResourceData, 
 		return nil, fmt.Errorf("Error creating params: %s", err)
 	}
 
-	metadata, err := resourceInstanceMetadata(d)
+	metadata, err := resourceInstanceMetadataTyped(d)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating metadata: %s", err)
 	}


### PR DESCRIPTION
…e/v0.beta dependency

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:note
compute: migrated `google_compute_metadata`  to use direct HTTP rather than a client library
```
