### PR TITLE
Dataplex-DataAsset: Directing to correct API resource name for the terraform resource

### DIFF
--- a/mmv1/products/dataplex/DataProductDataAsset.yaml
+++ b/mmv1/products/dataplex/DataProductDataAsset.yaml
@@ -13,6 +13,8 @@
 
 ---
 name: DataProductDataAsset
+api_resource_type_kind: DataAsset
+cai_resource_kind: DataAsset
 description: |
   A data asset resource that can be packaged and shared via a data product.
 references:


### PR DESCRIPTION
This PR modifies the API resource type of DataProductDataAsset to correct `dataplex.googleapis.com/DataAsset`. This is required for internal compliance monitoring which is incorrectly identifying the deprecated `DataAsset` terraform resource to be `dataplex.googleapis.com/DataAsset`.

```release-note:none
dataplex: pointed DataProductDataAsset to correct API resource DataAsset
```
