### PR TITLE
google_chronicle_rule: suppress trailing-newline permadiff on `text`

### DIFF
--- a/mmv1/products/chronicle/Rule.yaml
+++ b/mmv1/products/chronicle/Rule.yaml
@@ -53,6 +53,7 @@ examples:
     exclude_import_test: true
 
 custom_code:
+  constants: 'templates/terraform/constants/chronicle_rule.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/chronicle_rule.go.tmpl'
 
 virtual_fields:
@@ -107,6 +108,7 @@ properties:
       Rule Id is the ID of the Rule.
   - name: text
     type: String
+    diff_suppress_func: 'chronicleRuleTextDiffSuppress'
     description: |-
       The YARA-L content of the rule.
       Populated in FULL view.

--- a/mmv1/templates/terraform/constants/chronicle_rule.go.tmpl
+++ b/mmv1/templates/terraform/constants/chronicle_rule.go.tmpl
@@ -1,0 +1,8 @@
+// chronicleRuleTextDiffSuppress treats two YARA-L rule bodies as equal when
+// they differ only by trailing newline characters. The Chronicle Rules API
+// silently appends a trailing "\n" to every stored rule body, so a rule
+// submitted as `}` is read back as `}\n`, which would otherwise show as a
+// permanent diff on every plan (see hashicorp/terraform-provider-google#27881).
+func chronicleRuleTextDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.TrimRight(old, "\n") == strings.TrimRight(new, "\n")
+}


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#27881.

## Summary

The Chronicle Rules API silently appends a trailing `\n` to every stored rule body. Because the provider does not normalise this, every plan after a successful `terraform apply` shows the same phantom diff on every `google_chronicle_rule` — the reporter sees it across all 1,126 rules they manage with Terraform.

Reproduction (paraphrased from the linked issue):

> before (read back from Chronicle API/state): rule text ends with `}\n`
> after (from local config files): rule text ends with `}`
>
> The Chronicle API is appending a trailing `\n` to the rule text when storing it. The provider does not normalise this when comparing state to config, causing a permanent diff on every plan.

## Fix

Add a small resource-specific diff suppressor on `google_chronicle_rule.text` that trims trailing `\n` from both sides before comparing:

```go
func chronicleRuleTextDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
    return strings.TrimRight(old, "\n") == strings.TrimRight(new, "\n")
}
```

This mirrors the existing `custom_code.constants` + `diff_suppress_func` wiring already used by `google_chronicle_rule_deployment.run_frequency` (`templates/terraform/constants/chronicle_rule_deployment.go.tmpl`).

The suppress logic is intentionally narrow:

- A config without a trailing newline matches the API value that has one (the reported case).
- Multiple trailing newlines collapse to the same canonical form, so `"…}\n\n"` and `"…}\n"` are still treated as equal.
- Any other character difference inside the rule body (including a CRLF inside the body, leading whitespace, or content edits) still surfaces as a diff.

## Tests

The existing fixtures `chronicle_rule_basic.tf.tmpl`, `chronicle_rule_with_data_access_scope.tf.tmpl`, and `chronicle_rule_with_force_deletion.tf.tmpl` author the `text` field via `<<-EOT … EOT` heredocs, which implicitly add a trailing newline. They currently pass by coincidence (the API's trailing `\n` happens to match the heredoc's). With this change they continue to pass because the suppressor normalises both directions. Happy to add an acceptance fixture that authors `text` *without* a trailing newline — typically the more interesting regression case — if reviewers would like one.

## Release Note

```release-note:bug
chronicle: suppressed a permadiff on `google_chronicle_rule.text` caused by the Chronicle API appending a trailing newline to every stored rule body
```
