### PR TITLE
Flexible Catalog support on BigLakeIceberg Catalog

### DIFF
--- a/mmv1/products/biglakeiceberg/IcebergCatalog.yaml
+++ b/mmv1/products/biglakeiceberg/IcebergCatalog.yaml
@@ -60,6 +60,15 @@ samples:
         test_env_vars:
           GOOGLE_BILLING_PROJECT: PROJECT
           USER_PROJECT_OVERRIDE: "true"
+  - name: biglake_iceberg_catalog_biglake
+    primary_resource_id: my_iceberg_catalog
+    steps:
+      - name: biglake_iceberg_catalog_biglake
+        resource_id_vars:
+          name: my_iceberg_catalog
+        test_env_vars:
+          GOOGLE_BILLING_PROJECT: PROJECT
+          USER_PROJECT_OVERRIDE: "true"
 parameters:
   - name: name
     type: String
@@ -99,17 +108,22 @@ properties:
   - name: catalog_type
     api_name: catalog-type
     type: Enum
-    description: The catalog type of the IcebergCatalog. Currently only supports the type for Google Cloud Storage Buckets.
+    description: The catalog type of the IcebergCatalog.
     required: true
     immutable: true
     output: false
     enum_values:
       - CATALOG_TYPE_GCS_BUCKET
+      - CATALOG_TYPE_BIGLAKE
   - name: default_location
     api_name: default-location
     type: String
-    description: Output only. The default storage location for the catalog, e.g., `gs://my-bucket`.
-    output: true
+    description: |
+      The default storage location for the catalog, e.g., `gs://my-bucket`.
+      Output only when the catalog type is CATALOG_TYPE_GCS_BUCKET.
+      Required when the catalog type is CATALOG_TYPE_BIGLAKE.
+    required: false
+    default_from_api: true
   - name: storage_regions
     api_name: storage-regions
     type: Array
@@ -147,3 +161,20 @@ properties:
             - STATE_SECONDARY
     description: Output only. The replicas for the catalog metadata.
     output: true
+  - name: restricted_locations_config
+    api_name: restricted-locations-config
+    type: NestedObject
+    description: |
+      Configuration for the additional GCS locations that are permitted for use
+      by resources within this catalog.
+    default_from_api: true
+    properties:
+      - name: restricted_locations
+        api_name: restricted-locations
+        type: Array
+        item_type:
+          type: String
+        description: |
+          A list of GCS locations (e.g., `gs://my-other-bucket/...`) that are
+          permitted for use by resources within this catalog. Each entry can be
+          either a GCS bucket or a path within it.

--- a/mmv1/templates/terraform/custom_update/biglake_iceberg_catalog_update.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/biglake_iceberg_catalog_update.go.tmpl
@@ -18,6 +18,19 @@ if err != nil {
 } else if v, ok := d.GetOkExists("credential_mode"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, credentialModeProp)) {
   obj["credential-mode"] = credentialModeProp
 }
+defaultLocationProp, err := expandBiglakeIcebergIcebergCatalogDefaultLocation(d.Get("default_location"), d, config)
+if err != nil {
+  return err
+} else if v, ok := d.GetOkExists("default_location"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, defaultLocationProp)) {
+  obj["default-location"] = defaultLocationProp
+}
+
+restrictedLocationsConfigProp, err := expandBiglakeIcebergIcebergCatalogRestrictedLocationsConfig(d.Get("restricted_locations_config"), d, config)
+if err != nil {
+  return err
+} else if v, ok := d.GetOkExists("restricted_locations_config"); !tpgresource.IsEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, restrictedLocationsConfigProp)) {
+  obj["restricted-locations-config"] = restrictedLocationsConfigProp
+}
 
 url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}BiglakeIcebergBasePath{{"}}"}}iceberg/v1/restcatalog/extensions/projects/{{"{{"}}project{{"}}"}}/catalogs/{{"{{"}}name{{"}}"}}")
 if err != nil {
@@ -34,11 +47,23 @@ updateMask := []string{}
 if d.HasChange("credential_mode") {
   updateMask = append(updateMask, "credential_mode")
 }
+
+if d.HasChange("default_location") {
+  updateMask = append(updateMask, "default_location")
+}
+
+if d.HasChange("restricted_locations_config") {
+  updateMask = append(updateMask, "restricted_locations_config")
+}
+
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars
 // won't set it
 url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
 if err != nil {
   return err
+}
+if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
+  billingProject = parts[1]
 }
 
 // err == nil indicates that the billing_project value was found

--- a/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_catalog_biglake.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/biglakeiceberg/biglake_iceberg_catalog_biglake.tf.tmpl
@@ -1,0 +1,26 @@
+resource "google_storage_bucket" "default_bucket" {
+  name                        = "{{index $.ResourceIdVars "name"}}-default"
+  location                    = "us-central1"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_storage_bucket" "restricted_bucket" {
+  name                        = "{{index $.ResourceIdVars "name"}}-restricted"
+  location                    = "us-central1"
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+resource "google_biglake_iceberg_catalog" "{{$.PrimaryResourceId}}" {
+    name             = "{{index $.ResourceIdVars "name"}}"
+    catalog_type     = "CATALOG_TYPE_BIGLAKE"
+    credential_mode  = "CREDENTIAL_MODE_VENDED_CREDENTIALS"
+    default_location = "gs://${google_storage_bucket.default_bucket.name}"
+    restricted_locations_config {
+      restricted_locations = [
+        "gs://${google_storage_bucket.default_bucket.name}",
+        "gs://${google_storage_bucket.restricted_bucket.name}",
+      ]
+    }
+}


### PR DESCRIPTION
Adds CATALOG_TYPE_BIGLAKE support to the BigLake IcebergCatalog resource:
- New `restricted_locations_config` block with a `restricted_locations` list (maps to the API's `restricted-locations-config.restricted-locations`)
- `default_location` becomes settable (required for CATALOG_TYPE_BIGLAKE, output-only for CATALOG_TYPE_GCS_BUCKET)
- `CATALOG_TYPE_BIGLAKE` enum value
- custom update logic for default_location / restricted_locations_config
- new biglake sample that provisions real GCS buckets

These are all the changes necessary for Flexible Catalogs on BigLake Catalogs. It's a bit of an assortment from an API perspective.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
biglakeiceberg: Added `CATALOG_TYPE_BIGLAKE` enum to `catalog_type` field and added `restricted_locations_config.restricted_locations` field in `google_biglake_iceberg_catalog ` resource
```
