### PR TITLE
GA on failed healthcheck

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager.go.tmpl
@@ -361,14 +361,8 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							Default:      "REPAIR",
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REPAIR", "DO_NOTHING"}, true),
-{{ if eq $.TargetVersionName `ga` -}}
-							Description:  `Default behavior for all instance or health check failures.`,
-{{- end }}
-{{ if ne $.TargetVersionName `ga` -}}
 							Description:  `Specifies the action that a MIG performs on a failed VM. If the value of the "on_failed_health_check" field is DEFAULT_ACTION, then the same action also applies to the VMs on which your application fails a health check. Valid values are: REPAIR, DO_NOTHING. If REPAIR (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG. If DO_NOTHING, then MIG does not repair a failed VM.`,
-{{- end }}
 						},
-{{ if ne $.TargetVersionName `ga` -}}
 						"on_failed_health_check": {
 							Type:		  schema.TypeString,
 							Default:      "DEFAULT_ACTION",
@@ -376,7 +370,6 @@ func ResourceComputeInstanceGroupManager() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"DEFAULT_ACTION", "REPAIR", "DO_NOTHING"}, true),
 							Description:  `Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are: DEFAULT_ACTION, DO_NOTHING, REPAIR. If DEFAULT_ACTION (default), then MIG uses the same action configured for the  "default_action_on_failure" field. If DO_NOTHING, then MIG does not repair unhealthy VM. If REPAIR, then MIG automatically repairs an unhealthy VM by recreating it.`,
 						},
-{{- end }}
 						"force_update_on_repair": {
 							Type:         schema.TypeString,
 							Default:      "NO",
@@ -1827,10 +1820,7 @@ func expandInstanceLifecyclePolicy(configured []interface{}) *compute.InstanceGr
 		data := raw.(map[string]interface{})
 		instanceLifecyclePolicy.ForceUpdateOnRepair = data["force_update_on_repair"].(string)
 		instanceLifecyclePolicy.DefaultActionOnFailure = data["default_action_on_failure"].(string)
-
-		{{ if ne $.TargetVersionName `ga` -}}
 		instanceLifecyclePolicy.OnFailedHealthCheck = data["on_failed_health_check"].(string)
-		{{- end }}
 
 		{{- if ne $.TargetVersionName `ga` }}
 		instanceLifecyclePolicy.OnRepair = expandOnRepair(data["on_repair"].([]any))
@@ -1845,10 +1835,7 @@ func expandInstanceLifecyclePolicyV2(configured []interface{}) map[string]interf
 		data := raw.(map[string]interface{})
 		instanceLifecyclePolicy["forceUpdateOnRepair"] = data["force_update_on_repair"].(string)
 		instanceLifecyclePolicy["defaultActionOnFailure"] = data["default_action_on_failure"].(string)
-
-		{{ if ne $.TargetVersionName `ga` -}}
 		instanceLifecyclePolicy["onFailedHealthCheck"] = data["on_failed_health_check"].(string)
-		{{- end }}
 
 		{{- if ne $.TargetVersionName `ga` }}
 		instanceLifecyclePolicy["onRepair"] = expandOnRepairV2(data["on_repair"].([]any))
@@ -2135,10 +2122,7 @@ func flattenInstanceLifecyclePolicy(instanceLifecyclePolicy *compute.InstanceGro
 		ilp := map[string]interface{}{}
 		ilp["force_update_on_repair"] = instanceLifecyclePolicy.ForceUpdateOnRepair
 		ilp["default_action_on_failure"] = instanceLifecyclePolicy.DefaultActionOnFailure
-
-		{{ if ne $.TargetVersionName `ga` -}}
 		ilp["on_failed_health_check"] = instanceLifecyclePolicy.OnFailedHealthCheck
-		{{- end }}
 
 		{{ if ne $.TargetVersionName `ga` -}}
 		ilp["on_repair"] = flattenOnRepair(instanceLifecyclePolicy.OnRepair)
@@ -2155,10 +2139,7 @@ func flattenInstanceLifecyclePolicyV2(raw interface{}) []map[string]interface{} 
 		ilp := map[string]interface{}{}
 		ilp["force_update_on_repair"] = stringFromMap(instanceLifecyclePolicy, "forceUpdateOnRepair")
 		ilp["default_action_on_failure"] = stringFromMap(instanceLifecyclePolicy, "defaultActionOnFailure")
-
-		{{ if ne $.TargetVersionName `ga` -}}
 		ilp["on_failed_health_check"] = stringFromMap(instanceLifecyclePolicy, "onFailedHealthCheck")
-		{{- end }}
 
 		{{ if ne $.TargetVersionName `ga` -}}
 		ilp["on_repair"] = flattenOnRepairV2(instanceLifecyclePolicy["onRepair"])

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_meta.yaml.tmpl
@@ -24,9 +24,7 @@ fields:
   - api_field: 'id'
     field: 'instance_group_manager_id'
   - api_field: 'instanceLifecyclePolicy.defaultActionOnFailure'
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'instanceLifecyclePolicy.onFailedHealthCheck'
-{{- end }}
   - api_field: 'instanceLifecyclePolicy.forceUpdateOnRepair'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'instanceLifecyclePolicy.onRepair.allowChangingZone'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_group_manager_test.go.tmpl
@@ -174,10 +174,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Config: testAccInstanceGroupManager_update(template1, target1, description, igm),
 				Check: resource.ComposeTestCheckFunc(
 					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "DO_NOTHING"),
-
-					       {{- if ne $.TargetVersionName "ga" }}
 					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
-					       {{- end }}
 
 					       {{- if ne $.TargetVersionName "ga" }}
 					       resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "NO"),
@@ -194,10 +191,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Config: testAccInstanceGroupManager_update2(template1, target1, target2, template2, description, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-
-					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-					{{- end }}
 
 					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_repair.0.allow_changing_zone", "NO"),
@@ -214,9 +208,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 				Config: testAccInstanceGroupManager_update3(template1, target1, target2, template2, description2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-{{- if ne $.TargetVersionName "ga" }}
           resource.TestCheckResourceAttr("google_compute_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-{{- end }}
 				),
 			},
 			{
@@ -895,9 +887,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
   instance_lifecycle_policy {
     force_update_on_repair = "YES"
     default_action_on_failure = "DO_NOTHING"
-{{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "DO_NOTHING"
-{{- end }}
   }
 }
 `, template, target, description, igm)
@@ -1003,10 +993,7 @@ resource "google_compute_instance_group_manager" "igm-update" {
   instance_lifecycle_policy {
     force_update_on_repair = "NO"
     default_action_on_failure = "REPAIR"
-
-    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "REPAIR"
-    {{- end }}
 
     {{- if ne $.TargetVersionName "ga" }}
     on_repair {
@@ -2117,9 +2104,7 @@ resource "google_compute_instance_group_manager" "igm-basic" {
   instance_lifecycle_policy {
     force_update_on_repair = "YES"
     default_action_on_failure = "REPAIR"
-{{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "REPAIR"
-{{- end }}
   }
   wait_for_instances = true
   wait_for_instances_status = "UPDATED"

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -2256,7 +2256,7 @@ func flattenRegionInstanceLifecyclePolicy(raw interface{}) []map[string]interfac
 	entry := map[string]interface{}{
 		"force_update_on_repair":    ilp["forceUpdateOnRepair"],
 		"default_action_on_failure": ilp["defaultActionOnFailure"],
-		"on_failed_health_check" = ilp["onFailedHealthCheck"]
+		"on_failed_health_check": ilp["onFailedHealthCheck"],
 	}
 {{- if ne $.TargetVersionName "ga" }}
 	if onRepair, ok := ilp["onRepair"].(map[string]interface{}); ok && onRepair != nil {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager.go.tmpl
@@ -585,14 +585,8 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Default:      "REPAIR",
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REPAIR", "DO_NOTHING"}, true),
-{{ if eq $.TargetVersionName `ga` -}}
-							Description:  `Default behavior for all instance or health check failures.`,
-{{- end }}
-{{ if ne $.TargetVersionName `ga` -}}
 							Description:  `Specifies the action that a MIG performs on a failed VM. If the value of the "on_failed_health_check" field is DEFAULT_ACTION, then the same action also applies to the VMs on which your application fails a health check. Valid values are: REPAIR, DO_NOTHING. If REPAIR (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG. If DO_NOTHING, then MIG does not repair a failed VM.`,
-{{- end }}
 						},
-{{ if ne $.TargetVersionName `ga` -}}
 						"on_failed_health_check": {
 							Type:		   schema.TypeString,
 							Default:       "DEFAULT_ACTION",
@@ -600,7 +594,6 @@ func ResourceComputeRegionInstanceGroupManager() *schema.Resource {
 							ValidateFunc:  validation.StringInSlice([]string{"DEFAULT_ACTION", "REPAIR", "DO_NOTHING"}, true),
 							Description:  `Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid values are: DEFAULT_ACTION, DO_NOTHING, REPAIR. If DEFAULT_ACTION (default), then MIG uses the same action configured for the  "default_action_on_failure" field. If DO_NOTHING, then MIG does not repair unhealthy VM. If REPAIR, then MIG automatically repairs an unhealthy VM by recreating it.`,
 						},
-{{- end }}
 						"force_update_on_repair": {
 							Type:         schema.TypeString,
 							Default:      "NO",
@@ -2263,9 +2256,9 @@ func flattenRegionInstanceLifecyclePolicy(raw interface{}) []map[string]interfac
 	entry := map[string]interface{}{
 		"force_update_on_repair":    ilp["forceUpdateOnRepair"],
 		"default_action_on_failure": ilp["defaultActionOnFailure"],
+		"on_failed_health_check" = ilp["onFailedHealthCheck"]
 	}
 {{- if ne $.TargetVersionName "ga" }}
-	entry["on_failed_health_check"] = ilp["onFailedHealthCheck"]
 	if onRepair, ok := ilp["onRepair"].(map[string]interface{}); ok && onRepair != nil {
 		onRepairEntry := map[string]any{"allow_changing_zone": onRepair["allowChangingZone"]}
 		entry["on_repair"] = []map[string]any{onRepairEntry}

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_meta.yaml.tmpl
@@ -108,9 +108,7 @@ fields:
   - api_field: 'id'
     field: 'instance_group_manager_id'
   - api_field: 'instanceLifecyclePolicy.defaultActionOnFailure'
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'instanceLifecyclePolicy.onFailedHealthCheck'
-{{- end }}
   - api_field: 'instanceLifecyclePolicy.forceUpdateOnRepair'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'instanceLifecyclePolicy.onRepair.allowChangingZone'

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_group_manager_test.go.tmpl
@@ -93,10 +93,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update(template1, target1, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "DO_NOTHING"),
-
-					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "DO_NOTHING"),
-					{{- end }}
 
 					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "NO"),
@@ -115,10 +112,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-
-					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-					{{- end }}
 
 					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "YES"),
@@ -137,10 +131,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_update3(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.default_action_on_failure", "REPAIR"),
-
-					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.on_failed_health_check", "REPAIR"),
-					{{- end }}
 
 					{{- if ne $.TargetVersionName "ga" }}
 					resource.TestCheckResourceAttr("google_compute_region_instance_group_manager.igm-update", "instance_lifecycle_policy.0.force_update_on_repair", "YES"),
@@ -819,10 +810,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
     {{- end }}
 
     default_action_on_failure = "DO_NOTHING"
-
-    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "DO_NOTHING"
-    {{- end }}
   }
 }
 `, template, target, igm)
@@ -930,10 +918,7 @@ resource "google_compute_region_instance_group_manager" "igm-update" {
 
   instance_lifecycle_policy {
     default_action_on_failure = "REPAIR"
-
-    {{- if ne $.TargetVersionName "ga" }}
     on_failed_health_check = "REPAIR"
-    {{- end }}
 
     {{- if ne $.TargetVersionName "ga" }}
     force_update_on_repair = "YES"

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -312,7 +312,7 @@ update_policy {
 instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
-  on_failed_health_check    = "DO_NOTHING"   //google-beta only
+  on_failed_health_check    = "DO_NOTHING"
   on_repair {                                //google-beta only
     allow_changing_zone      = "YES"
   }
@@ -321,7 +321,7 @@ instance_lifecycle_policy {
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Specifies the action that a MIG performs on a failed VM. If the value of the `on_failed_health_check` field is `DEFAULT_ACTION`, then the same action also applies to the VMs on which your application fails a health check. Valid options are: `DO_NOTHING`, `REPAIR`. If `DO_NOTHING`, then MIG does not repair a failed VM. If `REPAIR` (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG.
-* `on_failed_health_check` - (Optional, Beta), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG.
+* `on_failed_health_check` - (Optional), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG.
 * `on_repair` - (Optional, [Beta](../guides/provider_versions.html.markdown)), Configuration for VM repairs in the MIG. Structure is [documented below](#nested_on_repair).
 - - -
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -267,7 +267,7 @@ update_policy {
 instance_lifecycle_policy {
   force_update_on_repair    = "YES"
   default_action_on_failure = "DO_NOTHING"
-  on_failed_health_check    = "DO_NOTHING"   //google-beta only
+  on_failed_health_check    = "DO_NOTHING"
   on_repair {                                //google-beta only
     allow_changing_zone      = "YES"
   }
@@ -276,7 +276,7 @@ instance_lifecycle_policy {
 
 * `force_update_on_repair` - (Optional), Specifies whether to apply the group's latest configuration when repairing a VM. Valid options are: `YES`, `NO`. If `YES` and you updated the group's instance template or per-instance configurations after the VM was created, then these changes are applied when VM is repaired. If `NO` (default), then updates are applied in accordance with the group's update policy type.
 * `default_action_on_failure` - (Optional), Specifies the action that a MIG performs on a failed VM. If the value of the `on_failed_health_check` field is `DEFAULT_ACTION`, then the same action also applies to the VMs on which your application fails a health check. Valid options are: `DO_NOTHING`, `REPAIR`. If `DO_NOTHING`, then MIG does not repair a failed VM. If `REPAIR` (default), then MIG automatically repairs a failed VM by recreating it. For more information, see about repairing VMs in a MIG.
-* `on_failed_health_check` - (Optional, Beta), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG. 
+* `on_failed_health_check` - (Optional), Specifies the action that a MIG performs on an unhealthy VM. A VM is marked as unhealthy when the application running on that VM fails a health check. Valid options are: `DEFAULT_ACTION`, `DO_NOTHING`, `REPAIR`. If `DEFAULT_ACTION` (default), then MIG uses the same action configured for the  `default_action_on_failure` field. If `DO_NOTHING`, then MIG does not repair unhealthy VM. If `REPAIR`, then MIG automatically repairs an unhealthy VM by recreating it. For more information, see about repairing VMs in a MIG. 
 * `on_repair` - (Optional, [Beta](../guides/provider_versions.html.markdown)), Configuration for VM repairs in the MIG. Structure is [documented below](#nested_on_repair).
 - - -
 


### PR DESCRIPTION
This promotes Compute (R)IGM.InstanceLifecyclePolicy.OnFailedHealthCheck functionalities in V1.

All the IGM and RIGM tests have been ran and pass.

fixes https://github.com/hashicorp/terraform-provider-google/issues/27886

If this PR is for Terraform, I acknowledge that I have:

Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
[Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran make test and make lint to ensure it passes unit and linter tests.
Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/main/third_party/terraform/tests) (for handwritten resources or update tests).
[Ran](https://github.com/hashicorp/terraform-provider-google/blob/main/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `instance_lifecycle_policy.on_failed_health_check` field in resources `google_compute_instance_group_manager` and `google_compute_region_instance_group_manager` (ga)
```
