### PR TITLE
Dataplex-DataProduct: Adding icon support for DataProduct

### DIFF
--- a/mmv1/products/dataplex/DataProduct.yaml
+++ b/mmv1/products/dataplex/DataProduct.yaml
@@ -122,6 +122,14 @@ properties:
   - name: description
     type: String
     description: Description of the data product.
+  - name: icon
+    type: String
+    description: |
+      Base64 encoded image representing the data product. Max Size: 3.0MiB
+      Expected image dimensions are 512x512 pixels, however the API only
+      performs validation on size of the encoded data.
+      Note: For byte fields, the content of the fields are base64-encoded (which
+      increases the size of the data by 33-36%) when using JSON on the wire.
   - name: ownerEmails
     type: Array
     item_type:

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
@@ -23,7 +23,7 @@ func TestAccDataplexDataProduct_update(t *testing.T) {
 			{
 				// STEP 1: Initial Creation
 				Config: testAccDataplexDataProduct_basic(context),
-                Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataplex_data_product.example", "icon", "c29tZSBkYXRh"),
 				),
 			},

--- a/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
+++ b/mmv1/third_party/terraform/services/dataplex/resource_dataplex_data_product_test.go
@@ -23,6 +23,9 @@ func TestAccDataplexDataProduct_update(t *testing.T) {
 			{
 				// STEP 1: Initial Creation
 				Config: testAccDataplexDataProduct_basic(context),
+                Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dataplex_data_product.example", "icon", "c29tZSBkYXRh"),
+				),
 			},
 			{
 				ResourceName:      "google_dataplex_data_product.example",
@@ -42,6 +45,9 @@ func TestAccDataplexDataProduct_update(t *testing.T) {
 						plancheck.ExpectResourceAction("google_dataplex_data_product.example", plancheck.ResourceActionUpdate),
 					},
 				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dataplex_data_product.example", "icon", "dXBkYXRlZCBkYXRh"),
+				),
 			},
 			{
 				ResourceName:      "google_dataplex_data_product.example",
@@ -64,6 +70,7 @@ resource "google_dataplex_data_product" "example" {
   data_product_id = "%{data_product_id}"
   display_name    = "initial display name"
   owner_emails    = ["terraform-test@google.com"]
+  icon            = "c29tZSBkYXRh"
 }
 `, context)
 }
@@ -76,6 +83,7 @@ resource "google_dataplex_data_product" "example" {
   display_name    = "updated display name"
   description     = "updated description"
   owner_emails    = ["updated-owner@google.com"]
+  icon            = "dXBkYXRlZCBkYXRh"
 
   labels = {
     env = "test"


### PR DESCRIPTION
Added support for icon field in Dataplex DataProduct. 

```release-note:enhancement
dataplex: added `icon` field to `google_dataplex_data_product` resource
```
