### PR TITLE
Add support for google_oracle_database_cloud_exadata_infrastructure_exascale_config

### DIFF
--- a/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
+++ b/mmv1/products/oracledatabase/CloudExadataInfrastructureExascaleConfig.yaml
@@ -1,0 +1,79 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: CloudExadataInfrastructureExascaleConfig
+description: |
+  A resource to configure Exascale storage on an Oracle Cloud Exadata Infrastructure.
+
+  ~> **Note:** Oracle Database @ Google Cloud does not support deconfiguring Exascale storage on an Exadata Infrastructure.
+  Deleting this resource from Terraform state will only remove it from Terraform management; it will not delete or reset the Exascale configuration on the actual Exadata Infrastructure.
+self_link: projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure}}
+id_format: projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure}}
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure}}'
+create_url: projects/{{project}}/locations/{{location}}/cloudExadataInfrastructures/{{cloud_exadata_infrastructure}}:configureExascale
+create_verb: POST
+immutable: true
+timeouts:
+  insert_minutes: 120
+
+autogen_async: true
+async:
+  actions: ['create']
+  type: OpAsync
+  operation:
+    timeouts:
+      insert_minutes: 120
+    base_url: '{{op_id}}'
+
+custom_code:
+  custom_delete: templates/terraform/custom_delete/only_remove_from_state.go.tmpl
+  decoder: templates/terraform/decoders/oracledatabase_cloud_exadata_infrastructure_exascale_config.go.tmpl
+
+samples:
+  - name: oracledatabase_cloud_exadata_infrastructure_exascale_config_basic
+    primary_resource_id: my_exascale_config
+    steps:
+      - name: oracledatabase_cloud_exadata_infrastructure_exascale_config_basic
+        resource_id_vars:
+          project: my-project
+          cloud_exadata_infrastructure_id: my-infra
+          deletion_protection: true
+        ignore_read_extra:
+          - deletion_protection
+        test_vars_overrides:
+          deletion_protection: "false"
+          project: '"oci-terraform-testing-prod"'
+          cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-test-tf-configured-exadata-%s", acctest.RandString(t, 10))
+
+parameters:
+  - name: location
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+  - name: cloudExadataInfrastructure
+    type: ResourceRef
+    required: true
+    immutable: true
+    url_param_only: true
+    resource: CloudExadataInfrastructure
+    imports: name
+
+properties:
+  - name: totalStorageSizeGb
+    type: Integer
+    required: true
+    immutable: true
+    description: "The total storage to be allocated to Exascale in GBs."

--- a/mmv1/templates/terraform/decoders/oracledatabase_cloud_exadata_infrastructure_exascale_config.go.tmpl
+++ b/mmv1/templates/terraform/decoders/oracledatabase_cloud_exadata_infrastructure_exascale_config.go.tmpl
@@ -1,0 +1,13 @@
+properties, ok := res["properties"].(map[string]interface{})
+if !ok || properties == nil {
+	return nil, fmt.Errorf("properties not found in response")
+}
+
+exascaleConfig, ok := properties["exascaleConfig"].(map[string]interface{})
+if !ok || exascaleConfig == nil {
+	return nil, nil
+}
+
+res["totalStorageSizeGb"] = exascaleConfig["totalStorageSizeGb"]
+
+return res, nil

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_exadata_infrastructure_exascale_config_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_exadata_infrastructure_exascale_config_basic.tf.tmpl
@@ -1,0 +1,21 @@
+resource "google_oracle_database_cloud_exadata_infrastructure" "infra" {
+  cloud_exadata_infrastructure_id = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}}"
+  display_name                    = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}} displayname"
+  location                        = "us-east4"
+  project                         = "{{index $.ResourceIdVars "project"}}"
+  
+  properties {
+    shape         = "Exadata.X9M"
+    compute_count = "2"
+    storage_count = "3"
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+}
+
+resource "google_oracle_database_cloud_exadata_infrastructure_exascale_config" "{{$.PrimaryResourceId}}" {
+  cloud_exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.cloud_exadata_infrastructure_id
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+  total_storage_size_gb        = 10240
+}


### PR DESCRIPTION
### Description
This PR adds support for a new resource `google_oracle_database_cloud_exadata_infrastructure_exascale_config` to configure Exascale storage on an Oracle Cloud Exadata Infrastructure in Google Cloud.

This resource triggers a one-time setup action using the `configureExascale` POST method on the `cloudExadataInfrastructures` API endpoint. Deleting the resource removes it from the Terraform state without affecting the underlying infrastructure.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27921

### Release Note
```release-note:new-resource
`google_oracle_database_cloud_exadata_infrastructure_exascale_config` 
```

