### PR TITLE
network_services: add forwardAttributes field for service extensions

### DIFF
--- a/mmv1/products/networkservices/LbEdgeExtension.yaml
+++ b/mmv1/products/networkservices/LbEdgeExtension.yaml
@@ -168,6 +168,17 @@ properties:
                   If omitted, all headers are sent. Each element is a string indicating the header name.
                 item_type:
                   type: String
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of the Envoy attributes to forward to the extension server. The attributes
+                  provided here are included as part of the `ProcessingRequest.attributes` field
+                  (of type `map`), where the keys are the attribute names. Refer to the
+                  [documentation](https://docs.cloud.google.com/service-extensions/docs/attributes)
+                  for the names of attributes that can be forwarded. If omitted, no attributes
+                  are sent. Each element is a string indicating the attribute name.
+                item_type:
+                  type: String
   - name: 'loadBalancingScheme'
     type: Enum
     description: |

--- a/mmv1/products/networkservices/LbEdgeExtension.yaml
+++ b/mmv1/products/networkservices/LbEdgeExtension.yaml
@@ -179,6 +179,7 @@ properties:
                   are sent. Each element is a string indicating the attribute name.
                 item_type:
                   type: String
+                max_size: 16
   - name: 'loadBalancingScheme'
     type: Enum
     description: |

--- a/mmv1/products/networkservices/LbRouteExtension.yaml
+++ b/mmv1/products/networkservices/LbRouteExtension.yaml
@@ -219,6 +219,7 @@ properties:
                   are sent. Each element is a string indicating the attribute name.
                 item_type:
                   type: String
+                max_size: 16
               - name: 'supportedEvents'
                 type: Array
                 is_set: true

--- a/mmv1/products/networkservices/LbRouteExtension.yaml
+++ b/mmv1/products/networkservices/LbRouteExtension.yaml
@@ -208,6 +208,17 @@ properties:
                   If omitted, all headers are sent. Each element is a string indicating the header name.
                 item_type:
                   type: String
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of the Envoy attributes to forward to the extension server. The attributes
+                  provided here are included as part of the `ProcessingRequest.attributes` field
+                  (of type `map`), where the keys are the attribute names. Refer to the
+                  [documentation](https://docs.cloud.google.com/service-extensions/docs/attributes)
+                  for the names of attributes that can be forwarded. If omitted, no attributes
+                  are sent. Each element is a string indicating the attribute name.
+                item_type:
+                  type: String
               - name: 'supportedEvents'
                 type: Array
                 is_set: true

--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -191,6 +191,7 @@ properties:
                   are sent. Each element is a string indicating the attribute name.
                 item_type:
                   type: String
+                max_size: 16
               - name: 'supportedEvents'
                 type: Array
                 description: |

--- a/mmv1/products/networkservices/LbTrafficExtension.yaml
+++ b/mmv1/products/networkservices/LbTrafficExtension.yaml
@@ -180,6 +180,17 @@ properties:
                   If omitted, all headers are sent. Each element is a string indicating the header name.
                 item_type:
                   type: String
+              - name: 'forwardAttributes'
+                type: Array
+                description: |
+                  List of the Envoy attributes to forward to the extension server. The attributes
+                  provided here are included as part of the `ProcessingRequest.attributes` field
+                  (of type `map`), where the keys are the attribute names. Refer to the
+                  [documentation](https://docs.cloud.google.com/service-extensions/docs/attributes)
+                  for the names of attributes that can be forwarded. If omitted, no attributes
+                  are sent. Each element is a string indicating the attribute name.
+                item_type:
+                  type: String
               - name: 'supportedEvents'
                 type: Array
                 description: |

--- a/mmv1/templates/terraform/examples/network_services_lb_edge_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_edge_extension_basic.tf.tmpl
@@ -63,6 +63,7 @@ resource "google_network_services_lb_edge_extension" "{{$.PrimaryResourceId}}" {
       fail_open = false
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["custom-header"]
+      forward_attributes = ["request.host", "request.path"]
     }
   }
 

--- a/mmv1/templates/terraform/examples/network_services_lb_route_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_route_extension_basic.tf.tmpl
@@ -210,6 +210,7 @@ resource "google_network_services_lb_route_extension" "{{$.PrimaryResourceId}}" 
         fail_open = false
 
         forward_headers  = ["custom-header"]
+        forward_attributes = ["request.host", "request.path"]
 
         supported_events = ["REQUEST_HEADERS", "REQUEST_BODY", "REQUEST_TRAILERS"]
         request_body_send_mode = "BODY_SEND_MODE_FULL_DUPLEX_STREAMED"

--- a/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_services_lb_traffic_extension_basic.tf.tmpl
@@ -202,6 +202,7 @@ resource "google_network_services_lb_traffic_extension" "{{$.PrimaryResourceId}}
 
           supported_events = ["REQUEST_HEADERS"]
           forward_headers = ["custom-header"]
+          forward_attributes = ["request.host", "request.path"]
           metadata = {
             "key1" = "value1"
             "key2" = "value2"

--- a/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_edge_extension_test.go
+++ b/mmv1/third_party/terraform/services/networkservices/resource_network_services_lb_edge_extension_test.go
@@ -146,6 +146,7 @@ resource "google_network_services_lb_edge_extension" "default" {
       fail_open = false
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["custom-header"]
+      forward_attributes = ["request.host", "request.path"]
     }
   }
 
@@ -275,6 +276,7 @@ resource "google_network_services_lb_edge_extension" "default" {
       fail_open = false
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["custom-header"]
+      forward_attributes = ["request.host", "request.path", "request.scheme"]
     }
   }
 
@@ -291,6 +293,7 @@ resource "google_network_services_lb_edge_extension" "default" {
       fail_open = true
       supported_events = ["REQUEST_HEADERS"]
       forward_headers  = ["testing-header"]
+      forward_attributes = ["request.host"]
     }
   }
 


### PR DESCRIPTION
```release-note:enhancement
networkservices: added `forward_attributes` field to `google_network_services_lb_edge_extension`, `google_network_services_lb_route_extension`, and `google_network_services_lb_traffic_extension` resources
```