### PR TITLE
Add google_vector_search_index resource

### DIFF
--- a/mmv1/products/vectorsearch/Index.yaml
+++ b/mmv1/products/vectorsearch/Index.yaml
@@ -1,0 +1,188 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Index
+description: |-
+  An Index defines an approximate nearest-neighbor search structure over a
+  field of a Vector Search Collection.
+base_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/indexes
+self_link: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/indexes/{{index_id}}
+create_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/indexes?indexId={{index_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/indexes/{{index_id}}
+timeouts:
+  insert_minutes: 90
+  update_minutes: 60
+  delete_minutes: 60
+async:
+  operation:
+    timeouts:
+      insert_minutes: 90
+      update_minutes: 60
+      delete_minutes: 60
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - update
+    - delete
+  result:
+    resource_inside_response: true
+autogen_status: SW5kZXg=
+autogen_async: true
+samples:
+  - name: vectorsearch_index_basic
+    primary_resource_id: example-index
+    steps:
+      - name: vectorsearch_index_basic
+        resource_id_vars:
+          index_id: example-index
+          collection_id: example-collection
+  - name: vectorsearch_index_dedicated
+    primary_resource_id: example-dedicated-index
+    steps:
+      - name: vectorsearch_index_dedicated
+        resource_id_vars:
+          index_id: example-dedicated-index
+          collection_id: example-dedicated-collection
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: collectionId
+    type: String
+    required: true
+    description: |-
+      The ID of the parent Collection.
+    immutable: true
+    url_param_only: true
+  - name: indexId
+    type: String
+    required: true
+    description: |-
+      ID of the Index to create.
+      The id must be 1-63 characters long, and comply with
+      [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
+      Specifically, it must be 1-63 characters long and match the regular
+      expression `[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?`.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: Identifier. name of resource
+    output: true
+  - name: createTime
+    type: String
+    description: '[Output only] Create time stamp'
+    output: true
+  - name: updateTime
+    type: String
+    description: '[Output only] Update time stamp'
+    output: true
+  - name: displayName
+    type: String
+    description: User-specified display name of the index
+  - name: description
+    type: String
+    description: User-specified description of the index
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs.
+  - name: distanceMetric
+    type: Enum
+    description: |-
+      Distance metric used for indexing. If not specified, will default to
+      `DOT_PRODUCT`.
+    immutable: true
+    default_from_api: true
+    enum_values:
+      - 'DOT_PRODUCT'
+      - 'COSINE_DISTANCE'
+  - name: indexField
+    type: String
+    required: true
+    immutable: true
+    description: The collection schema field to index.
+  - name: filterFields
+    type: Array
+    immutable: true
+    description: The fields to push into the index to enable fast ANN inline filtering.
+    item_type:
+      type: String
+  - name: storeFields
+    type: Array
+    immutable: true
+    description: The fields to push into the index to enable inline data retrieval.
+    item_type:
+      type: String
+  - name: dedicatedInfrastructure
+    type: NestedObject
+    default_from_api: true
+    description: |-
+      Dedicated infrastructure for the index. This field belongs to the
+      `infra_type` oneof; if omitted, the server populates it with the
+      default `PERFORMANCE_OPTIMIZED` mode and an autoscaling spec of
+      `min_replica_count=2`, `max_replica_count=2`.
+    properties:
+      - name: mode
+        type: Enum
+        immutable: true
+        default_from_api: true
+        description: |-
+          Mode of the dedicated infrastructure. Defaults to `PERFORMANCE_OPTIMIZED`.
+        enum_values:
+          - 'MODE_UNSPECIFIED'
+          - 'STORAGE_OPTIMIZED'
+          - 'PERFORMANCE_OPTIMIZED'
+      - name: autoscalingSpec
+        type: NestedObject
+        default_from_api: true
+        description: Autoscaling specification.
+        properties:
+          - name: minReplicaCount
+            type: Integer
+            default_from_api: true
+            description: |-
+              The minimum number of replicas. If not set or set to `0`, defaults
+              to `2`. Must be >= `1` and <= `1000`.
+          - name: maxReplicaCount
+            type: Integer
+            default_from_api: true
+            description: |-
+              The maximum number of replicas. Must be >= `min_replica_count`
+              and <= `1000`. If not set or set to `0`, defaults to the greater
+              of `min_replica_count` and `2` (or `5` for the v1beta version).
+  - name: denseScann
+    type: NestedObject
+    immutable: true
+    default_from_api: true
+    description: |-
+      Dense ScaNN index configuration. This field belongs to the
+      `index_type` oneof; if omitted, the server populates it with default
+      ScaNN settings.
+    properties:
+      - name: featureNormType
+        type: Enum
+        immutable: true
+        default_from_api: true
+        description: Feature norm type for the ScaNN index.
+        enum_values:
+          - 'FEATURE_NORM_TYPE_UNSPECIFIED'
+          - 'NONE'
+          - 'UNIT_L2_NORM'

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_basic.tf.tmpl
@@ -1,3 +1,12 @@
+# NOTE: For most workloads we recommend creating the Collection and the Index
+# in *separate* Terraform configurations (i.e. create and apply the Collection
+# first, ingest data via importDataObjects, and only then create the Index in a
+# second configuration). Once an Index exists on a Collection you can no longer
+# run importDataObjects for bulk ingestion of data objects on that Collection --
+# you are limited to creating data objects one at a time or in small online
+# batches. Defining both resources in the same Terraform file (as shown below)
+# is convenient for a quick start, but locks you into the online / batched
+# create path for any subsequent data ingestion.
 resource "google_vector_search_collection" "parent" {
   location      = "us-central1"
   collection_id = "{{index $.ResourceIdVars "collection_id"}}"

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_basic.tf.tmpl
@@ -1,0 +1,48 @@
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "{{index $.ResourceIdVars "collection_id"}}"
+
+  display_name = "My Awesome Collection"
+  description  = "This collection stores important data."
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "plot": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  vector_schema {
+    field_name = "text_embedding"
+    dense_vector {
+      dimensions = 768
+      vertex_embedding_config {
+        model_id      = "textembedding-gecko@003"
+        task_type     = "RETRIEVAL_DOCUMENT"
+        text_template = "Title: {title} ---- Plot: {plot}"
+      }
+    }
+  }
+}
+
+resource "google_vector_search_index" "{{$.PrimaryResourceId}}" {
+  location      = "us-central1"
+  collection_id = google_vector_search_collection.parent.collection_id
+  index_id      = "{{index $.ResourceIdVars "index_id"}}"
+
+  display_name    = "My Awesome Index"
+  description     = "ScaNN index over text_embedding."
+  index_field     = "text_embedding"
+  distance_metric = "DOT_PRODUCT"
+
+  dense_scann {
+    feature_norm_type = "UNIT_L2_NORM"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_dedicated.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_dedicated.tf.tmpl
@@ -1,3 +1,12 @@
+# NOTE: For most workloads we recommend creating the Collection and the Index
+# in *separate* Terraform configurations (i.e. create and apply the Collection
+# first, ingest data via importDataObjects, and only then create the Index in a
+# second configuration). Once an Index exists on a Collection you can no longer
+# run importDataObjects for bulk ingestion of data objects on that Collection --
+# you are limited to creating data objects one at a time or in small online
+# batches. Defining both resources in the same Terraform file (as shown below)
+# is convenient for a quick start, but locks you into the online / batched
+# create path for any subsequent data ingestion.
 resource "google_vector_search_collection" "parent" {
   location      = "us-central1"
   collection_id = "{{index $.ResourceIdVars "collection_id"}}"

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_dedicated.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_index_dedicated.tf.tmpl
@@ -1,0 +1,58 @@
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "{{index $.ResourceIdVars "collection_id"}}"
+
+  display_name = "My Awesome Collection"
+  description  = "Parent collection for a dedicated-infrastructure index."
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  vector_schema {
+    field_name = "text_embedding"
+    dense_vector {
+      dimensions = 768
+      vertex_embedding_config {
+        model_id      = "textembedding-gecko@003"
+        task_type     = "RETRIEVAL_DOCUMENT"
+        text_template = "Title: {title}"
+      }
+    }
+  }
+}
+
+resource "google_vector_search_index" "{{$.PrimaryResourceId}}" {
+  location      = "us-central1"
+  collection_id = google_vector_search_collection.parent.collection_id
+  index_id      = "{{index $.ResourceIdVars "index_id"}}"
+
+  display_name    = "My Dedicated Index"
+  description     = "Index served on dedicated infrastructure with autoscaling."
+  index_field     = "text_embedding"
+  distance_metric = "COSINE_DISTANCE"
+  filter_fields   = ["category"]
+  store_fields    = ["title"]
+
+  dense_scann {
+    feature_norm_type = "UNIT_L2_NORM"
+  }
+
+  dedicated_infrastructure {
+    mode = "PERFORMANCE_OPTIMIZED"
+    autoscaling_spec {
+      min_replica_count = 2
+      max_replica_count = 5
+    }
+  }
+}

--- a/mmv1/third_party/terraform/services/vectorsearch/resource_vector_search_index_test.go
+++ b/mmv1/third_party/terraform/services/vectorsearch/resource_vector_search_index_test.go
@@ -1,0 +1,172 @@
+package vectorsearch_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/vectorsearch"
+)
+
+func TestAccVectorSearchIndex_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVectorSearchIndex_basic(context),
+			},
+			{
+				ResourceName:            "google_vector_search_index.example-index",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"collection_id", "index_id", "labels", "location", "terraform_labels"},
+			},
+			{
+				Config: testAccVectorSearchIndex_updated(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_vector_search_index.example-index", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_vector_search_index.example-index",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"collection_id", "index_id", "labels", "location", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccVectorSearchIndex_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "tf-test-example-collection-id%{random_suffix}"
+
+  display_name = "My Awesome Collection"
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  vector_schema {
+    field_name = "text_embedding"
+    dense_vector {
+      dimensions = 768
+      vertex_embedding_config {
+        model_id      = "textembedding-gecko@003"
+        task_type     = "RETRIEVAL_DOCUMENT"
+        text_template = "Title: {title}"
+      }
+    }
+  }
+}
+
+resource "google_vector_search_index" "example-index" {
+  location      = "us-central1"
+  collection_id = google_vector_search_collection.parent.collection_id
+  index_id      = "tf-test-example-index-id%{random_suffix}"
+
+  display_name    = "My Awesome Index"
+  description     = "Original description."
+  index_field     = "text_embedding"
+  distance_metric = "DOT_PRODUCT"
+
+  labels = {
+    env  = "dev"
+    team = "my-team"
+  }
+
+  dense_scann {
+    feature_norm_type = "UNIT_L2_NORM"
+  }
+
+  dedicated_infrastructure {
+    mode = "PERFORMANCE_OPTIMIZED"
+    autoscaling_spec {
+      min_replica_count = 2
+      max_replica_count = 4
+    }
+  }
+}
+`, context)
+}
+
+func testAccVectorSearchIndex_updated(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "tf-test-example-collection-id%{random_suffix}"
+
+  display_name = "My Awesome Collection"
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  vector_schema {
+    field_name = "text_embedding"
+    dense_vector {
+      dimensions = 768
+      vertex_embedding_config {
+        model_id      = "textembedding-gecko@003"
+        task_type     = "RETRIEVAL_DOCUMENT"
+        text_template = "Title: {title}"
+      }
+    }
+  }
+}
+
+resource "google_vector_search_index" "example-index" {
+  location      = "us-central1"
+  collection_id = google_vector_search_collection.parent.collection_id
+  index_id      = "tf-test-example-index-id%{random_suffix}"
+
+  display_name    = "My Updated Awesome Index"
+  description     = "Updated description."
+  index_field     = "text_embedding"
+  distance_metric = "DOT_PRODUCT"
+
+  labels = {
+    env = "dev"
+  }
+
+  dense_scann {
+    feature_norm_type = "UNIT_L2_NORM"
+  }
+
+  dedicated_infrastructure {
+    mode = "PERFORMANCE_OPTIMIZED"
+    autoscaling_spec {
+      min_replica_count = 3
+      max_replica_count = 6
+    }
+  }
+}
+`, context)
+}


### PR DESCRIPTION
This PR introduces support for the Vector Search Index feature. This allows users to manage Vector Search Indexes declaratively using Terraform.

API reference: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search-2/reference/rest/v1/projects.locations.collections.indexes/create

```release-note:new-resource
`google_vector_search_index`
```
