### PR TITLE
tgc-revival: Ignore shareSettings in compute reservation since it is missing in CAI

### DIFF
--- a/mmv1/products/compute/Reservation.yaml
+++ b/mmv1/products/compute/Reservation.yaml
@@ -173,6 +173,7 @@ properties:
     description: |
       The share setting for reservations.
     default_from_api: true
+    is_missing_in_cai: true
     properties:
       - name: 'shareType'
         type: Enum


### PR DESCRIPTION
Resolves[ integration test failures](https://github.com/GoogleCloudPlatform/terraform-google-conversion/commits/main/) for google_compute_reservation due to share_settings.share_type being missing in CAI asset payload. Marks the property as is_missing_in_cai: true.


```
--- FAIL: TestAccComputeReservation/TestAccComputeReservation_sharedReservationBasicExample/step1 (0.22s)
           assert_test_files.go:138: TestAccComputeReservation_sharedReservationBasicExample_step1: Failed after 5 attempts. First real error: retryable: missing fields: [share_settings.share_type]

```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```