### PR TITLE
Add containerMaxLogWorkers to node config

### DIFF
--- a/mmv1/third_party/terraform/services/container/node_config.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/node_config.go.tmpl
@@ -876,6 +876,12 @@ func schemaNodeConfig() *schema.Schema {
 								Optional:    true,
 								Description: `Defines the maximum number of container log files that can be present for a container.`,
 							},
+							"container_max_log_workers": {
+								Type:         schema.TypeInt,
+								Optional:     true,
+								ValidateFunc: validation.IntBetween(1, 10),
+								Description:  `Defines the maximum number of container log workers.`,
+							},
 							"image_gc_low_threshold_percent": {
 							        Type:        schema.TypeInt,
 								Optional:    true,
@@ -2054,6 +2060,9 @@ func expandKubeletConfig(v interface{}) *container.NodeKubeletConfig {
 	if containerLogMaxFiles, ok := cfg["container_log_max_files"]; ok {
     	        kConfig.ContainerLogMaxFiles = int64(containerLogMaxFiles.(int))
         }
+	if containerMaxLogWorkers, ok := cfg["container_max_log_workers"]; ok {
+		kConfig.ContainerMaxLogWorkers = int64(containerMaxLogWorkers.(int))
+	}
 	if imageGcLowThresholdPercent, ok := cfg["image_gc_low_threshold_percent"]; ok {
     	        kConfig.ImageGcLowThresholdPercent = int64(imageGcLowThresholdPercent.(int))
 	}
@@ -3315,6 +3324,7 @@ func flattenKubeletConfig(c *container.NodeKubeletConfig) []map[string]interface
 			"pod_pids_limit":                         c.PodPidsLimit,
 			"container_log_max_size":                 c.ContainerLogMaxSize,
 			"container_log_max_files":                c.ContainerLogMaxFiles,
+			"container_max_log_workers":              c.ContainerMaxLogWorkers,
 			"image_gc_low_threshold_percent":         c.ImageGcLowThresholdPercent,
 			"image_gc_high_threshold_percent":        c.ImageGcHighThresholdPercent,
 			"image_minimum_gc_age":                   c.ImageMinimumGcAge,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -9768,6 +9768,7 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
     kubelet_config {
       pod_pids_limit                        = 1024
       container_log_max_files               = 4
+      container_max_log_workers             = 4
       single_process_oom_kill               = true
       max_parallel_image_pulls              = 5
       eviction_max_pod_grace_period_seconds = 200
@@ -9822,6 +9823,7 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings" {
       cpu_cfs_quota_period                   = "%s"
       insecure_kubelet_readonly_port_enabled = "%s"
       pod_pids_limit                         = %v
+      container_max_log_workers             = 6
       single_process_oom_kill                = true
       max_parallel_image_pulls               = 5
       eviction_max_pod_grace_period_seconds  = 200
@@ -9892,6 +9894,7 @@ resource "google_container_cluster" "with_node_config_kubelet_config_settings_in
       machine_type = "n1-standard-1"
       kubelet_config {
         max_parallel_image_pulls               = 5
+        container_max_log_workers             = 4
         eviction_max_pod_grace_period_seconds  = 200
         eviction_soft {
           memory_available = "200Mi"

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool_test.go.tmpl
@@ -892,7 +892,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "None", "best-effort", "pod", "100ms", networkName, subnetworkName, "TRUE", "100Mi", "1m", "10m", true, true, 2048, 10, 10, 85, "100s"),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "None", "best-effort", "pod", "100ms", networkName, subnetworkName, "TRUE", "100Mi", "1m", "10m", true, true, 2048, 10, 10, 85, 4, "100s"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acctest.ExpectNoDelete(),
@@ -911,6 +911,8 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
                                                 "node_config.0.kubelet_config.0.container_log_max_size", "100Mi"),
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
                                                 "node_config.0.kubelet_config.0.container_log_max_files", "10"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
+                                                "node_config.0.kubelet_config.0.container_max_log_workers", "4"),
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
                                                 "node_config.0.kubelet_config.0.image_gc_low_threshold_percent", "10"),
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
@@ -937,7 +939,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "Static", "single-numa-node", "container", "", networkName, subnetworkName, "FALSE", "200Mi", "30s", "", false, true, 1024, 5, 50, 80, "60s"),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "", "Static", "single-numa-node", "container", "", networkName, subnetworkName, "FALSE", "200Mi", "30s", "", false, true, 1024, 5, 50, 80, 6, "60s"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						acctest.ExpectNoDelete(),
@@ -955,6 +957,8 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.topology_manager.0.scope", "container"),
+					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
+						"node_config.0.kubelet_config.0.container_max_log_workers", "6"),
 					resource.TestCheckResourceAttr("google_container_node_pool.with_kubelet_config",
 						"node_config.0.kubelet_config.0.crash_loop_back_off.0.max_container_restart_period", "60s"),
 				),
@@ -984,7 +988,7 @@ func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
 		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "", "", "", "100us", networkName, subnetworkName,"TRUE", "", "", "", false, true, 1024, 2, 70, 75, "300s"),
+				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "", "", "", "100us", networkName, subnetworkName,"TRUE", "", "", "", false, true, 1024, 2, 70, 75, 4, "300s"),
 				ExpectError: regexp.MustCompile(`.*to be one of \["?static"? "?none"? "?"?\].*`),
 			},
 		},
@@ -4107,7 +4111,7 @@ resource "google_container_node_pool" "with_sandbox_config" {
 `, cluster, networkName, subnetworkName, np)
 }
 
-func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, memoryManagerPolicy, topologyManagerPolicy, topologyManagerScope, period, networkName, subnetworkName, insecureKubeletReadonlyPortEnabled, containerLogMaxSize, imageMinimumGcAge, imageMaximumGcAge string, quota, singleProcessOomKill bool, podPidsLimit, containerLogMaxFiles, imageGcLowThresholdPercent, imageGcHighThresholdPercent int, maxContainerRestart string) string {
+func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, memoryManagerPolicy, topologyManagerPolicy, topologyManagerScope, period, networkName, subnetworkName, insecureKubeletReadonlyPortEnabled, containerLogMaxSize, imageMinimumGcAge, imageMaximumGcAge string, quota, singleProcessOomKill bool, podPidsLimit, containerLogMaxFiles, imageGcLowThresholdPercent, imageGcHighThresholdPercent, containerMaxLogWorkers int, maxContainerRestart string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -4148,6 +4152,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
       pod_pids_limit                         = %d
       container_log_max_size                 = %q
       container_log_max_files                = %d
+      container_max_log_workers             = %d
       image_gc_low_threshold_percent         = %d
       image_gc_high_threshold_percent        = %d
       image_minimum_gc_age                   = %q
@@ -4191,7 +4196,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
     logging_variant = "DEFAULT"
   }
 }
-`, cluster, networkName, subnetworkName, np, policy, memoryManagerPolicy, topologyManagerPolicy, topologyManagerScope, quota, period, insecureKubeletReadonlyPortEnabled, podPidsLimit, containerLogMaxSize, containerLogMaxFiles, imageGcLowThresholdPercent, imageGcHighThresholdPercent, imageMinimumGcAge, imageMaximumGcAge, singleProcessOomKill, maxContainerRestart)
+`, cluster, networkName, subnetworkName, np, policy, memoryManagerPolicy, topologyManagerPolicy, topologyManagerScope, quota, period, insecureKubeletReadonlyPortEnabled, podPidsLimit, containerLogMaxSize, containerLogMaxFiles, containerMaxLogWorkers, imageGcLowThresholdPercent, imageGcHighThresholdPercent, imageMinimumGcAge, imageMaximumGcAge, singleProcessOomKill, maxContainerRestart)
 }
 
 func testAccContainerNodePool_withLinuxNodeConfig(cluster, np, tcpMem, networkName, subnetworkName string) string {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1623,6 +1623,8 @@ such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 
 * `container_log_max_files` - (Optional) Defines the maximum number of container log files that can be present for a container. The integer must be between 2 and 10, inclusive.
 
+* `container_max_log_workers` - (Optional) Defines the maximum number of container log workers. The integer must be between 1 and 10, inclusive.
+
 * `image_gc_low_threshold_percent` - (Optional) Defines the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The integer must be between 10 and 85, inclusive.
 
 * `image_gc_high_threshold_percent` - (Optional) Defines the percent of disk usage after which image garbage collection is always run. The integer must be between 10 and 85, inclusive.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR adds support for the `containerMaxLogWorkers` kubelet configuration flag in GKE Node Config.
* Surfaced `container_max_log_workers` in `kubelet_config` schema.
* Added expander/flattener logic.
* Added unit tests for cluster and node pool resources.
* Updated documentation.
    
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `container_max_log_workers` field to `google_container_cluster` and `google_container_node_pool` resources
```