### PR TITLE
Fix ignore node count changes

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -1994,7 +1994,7 @@ func TestAccContainerCluster_regionalWithNodePool(t *testing.T) {
 				ResourceName:		 "google_container_cluster.regional",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
-				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes"},
+				ImportStateVerifyIgnore: []string{"deletion_protection", "ignore_node_count_changes", "node_pool.0.ignore_node_count_changes", "node_pool.0.managed_instance_group_urls"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -1482,16 +1482,17 @@ func flattenNodePool(d *schema.ResourceData, config *transport_tpg.Config, np *c
 		}
 	}
 	nodePool := map[string]interface{}{
-		"name":                np.Name,
-		"name_prefix":         d.Get(prefix + "name_prefix"),
-		"initial_node_count":  np.InitialNodeCount,
-		"node_locations":      schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(np.Locations)),
-		"node_count":          nodeCount,
-		"node_config":         flattenNodeConfig(np.Config, d.Get(prefix + "node_config")),
-		"instance_group_urls": igmUrls,
+		"name":                      np.Name,
+		"name_prefix":               d.Get(prefix + "name_prefix"),
+		"initial_node_count":        np.InitialNodeCount,
+		"node_locations":            schema.NewSet(schema.HashString, tpgresource.ConvertStringArrToInterface(np.Locations)),
+		"node_count":                nodeCount,
+		"node_config":               flattenNodeConfig(np.Config, d.Get(prefix + "node_config")),
+		"instance_group_urls":       igmUrls,
 		"managed_instance_group_urls": managedIgmUrls,
-		"version":             np.Version,
-		"network_config":      flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),
+		"version":                   np.Version,
+		"network_config":            flattenNodeNetworkConfig(np.NetworkConfig, d, prefix),
+		"ignore_node_count_changes": d.Get(prefix + "ignore_node_count_changes"),
 	}
 
 	if np.Autoscaling != nil {


### PR DESCRIPTION

### Description
Fixes a bug where GKE clusters with inline `node_pool` blocks failed post-apply idempotency plan checks (non-empty plan error) if they configured the newly added `ignore_node_count_changes = true` flag.

The virtual field `ignore_node_count_changes` was not populated in the handwritten `flattenNodePool` function, causing it to default to `false` during reads and triggering a plan difference on subsequent runs. This PR updates `flattenNodePool` to retrieve and preserve the flag value from the state.

Additionally, this PR updates the acceptance test `TestAccContainerCluster_regionalWithNodePool` (which enables `ignore_node_count_changes`) to ignore `node_pool.0.managed_instance_group_urls` during import verification. When `ignore_node_count_changes = true` is set, the initial state lacks these URLs by design, but importing the resource without HCL context naturally retrieves them, causing an import state verification mismatch.

### Release Note

```release-note:container
bugfix: Fixed a bug where configuring `ignore_node_count_changes` inside inline `node_pool` blocks of `google_container_cluster` resulted in non-empty plans on subsequent runs.
```