### PR TITLE
Added Resource `google_compute_global_vm_extension_policy`

### DIFF
--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -1,0 +1,204 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'GlobalVmExtensionPolicy'
+description: 'A Global VM Extension Policy.'
+base_url: 'projects/{{project}}/global/vmExtensionPolicies'
+self_link: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}'
+update_verb: 'PATCH'
+update_mask: true
+custom_code:
+  pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
+  test_check_destroy: 'templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl'
+
+samples:
+  - name: 'compute_global_vm_extension_policy_basic'
+    primary_resource_id: 'ops_agent_policy'
+    steps:
+      - name: 'compute_global_vm_extension_policy_basic'
+        vars:
+          policy_name: 'global-ops-agent-policy'
+        ignore_read_extra:
+          - 'rollout_operation'
+      - name: 'compute_global_vm_extension_policy_update'
+        vars:
+          policy_name: 'global-ops-agent-policy'
+        ignore_read_extra:
+          - 'rollout_operation'
+
+
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: 'projects/{{project}}/global/operations/{{op_id}}'
+
+properties:
+  - name: 'name'
+    type: String
+    required: true
+    immutable: true
+    description: |-
+      Name of the resource. Provided by the client when the resource is created.
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'extensionPolicies'
+    type: Map
+    required: true
+    description: |-
+      Map from extension (eg: "cloudops") to its policy configuration.
+    value_type:
+      type: NestedObject
+      properties:
+        - name: 'pinnedVersion'
+          type: String
+          description: 'The version pinning for the extension.'
+        - name: 'stringConfig'
+          type: String
+          description: 'String configuration payload.'
+    key_name: 'extension_name'
+  - name: 'instanceSelectors'
+    type: Array
+    description: 'Selector to target VMs for a policy.'
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'labelSelector'
+          type: NestedObject
+          description: 'LabelSelector matches VM labels.'
+          properties:
+            - name: 'inclusionLabels'
+              type: KeyValuePairs
+              description: 'Labels as key value pairs.'
+  - name: 'priority'
+    type: Integer
+    default_from_api: true
+    description: 'Used to resolve conflicts when multiple policies are active. Defaults to 0.'
+  - name: 'rolloutOperation'
+    type: NestedObject
+    required: true
+    description: 'Represents the rollout operation.'
+    properties:
+      - name: 'rolloutInput'
+        type: NestedObject
+        required: true
+        description: 'Rollout input settings.'
+        properties:
+          - name: 'conflictBehavior'
+            type: String
+            description: 'Specifies the behavior of the rollout if a conflict is detected.'
+          - name: 'name'
+            type: String
+            description: 'The name of the rollout plan.'
+          - name: 'predefinedRolloutPlan'
+            type: String
+            description: 'Specifies the predefined rollout plan for the policy.'
+          - name: 'retryUuid'
+            type: String
+            description: 'The UUID that identifies a policy rollout retry attempt.'
+      - name: 'rolloutStatus'
+        type: NestedObject
+        description: 'Rollout status.'
+        output: true
+        properties:
+          - name: 'currentRollouts'
+            type: Array
+            description: 'The current rollouts for the latest version of the resource.'
+            output: true
+            item_type:
+              type: NestedObject
+              output: true
+              properties:
+                - name: 'locationRolloutStatus'
+                  type: Map
+                  description: 'The rollout status for each location.'
+                  output: true
+                  value_type:
+                    type: NestedObject
+                    output: true
+                    properties:
+                      - name: 'state'
+                        type: String
+                        description: 'The state of the location rollout.'
+                        output: true
+                  key_name: 'location_name'
+                - name: 'rollout'
+                  type: String
+                  description: 'The name of the rollout.'
+                  output: true
+                - name: 'rolloutPlan'
+                  type: String
+                  description: 'The name of the rollout plan.'
+                  output: true
+                - name: 'state'
+                  type: String
+                  description: 'The overall state of the rollout.'
+                  output: true
+          - name: 'previousRollout'
+            type: NestedObject
+            description: 'Rollout status of the previous rollout.'
+            output: true
+            properties:
+              - name: 'locationRolloutStatus'
+                type: Map
+                description: 'The rollout status for each location.'
+                output: true
+                value_type:
+                  type: NestedObject
+                  output: true
+                  properties:
+                    - name: 'state'
+                      type: String
+                      description: 'The state of the location rollout.'
+                      output: true
+                key_name: 'location_name'
+              - name: 'rollout'
+                type: String
+                description: 'The name of the rollout.'
+                output: true
+              - name: 'rolloutPlan'
+                type: String
+                description: 'The name of the rollout plan.'
+                output: true
+              - name: 'state'
+                type: String
+                description: 'The overall state of the rollout.'
+                output: true
+  - name: 'scopedResourceStatus'
+    type: String
+    description: 'The scoped resource status.'
+    output: true
+  - name: 'creationTimestamp'
+    type: String
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'id'
+    type: String
+    description: 'The unique identifier for the resource.'
+    output: true
+  - name: 'kind'
+    type: String
+    description: 'Type of the resource.'
+    output: true
+  - name: 'selfLink'
+    type: String
+    description: 'Server-defined fully-qualified URL for this resource.'
+    output: true
+  - name: 'updateTimestamp'
+    type: String
+    description: 'Update timestamp in RFC3339 text format.'
+    output: true
+

--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -17,9 +17,12 @@ description: 'A Global VM Extension Policy.'
 base_url: 'projects/{{project}}/global/vmExtensionPolicies'
 self_link: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}'
 update_verb: 'PATCH'
+delete_url: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}/delete'
+delete_verb: 'POST'
 custom_code:
   pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
   test_check_destroy: 'templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl'
+  pre_delete: 'templates/terraform/pre_delete/vm_extension_policy_rollout.go.tmpl'
 
 samples:
   - name: 'compute_global_vm_extension_policy_basic'
@@ -31,6 +34,14 @@ samples:
         ignore_read_extra:
           - 'rollout_operation'
       - name: 'compute_global_vm_extension_policy_update'
+        vars:
+          policy_name: 'global-ops-agent-policy'
+        ignore_read_extra:
+          - 'rollout_operation'
+  - name: 'compute_global_vm_extension_policy_rollout'
+    primary_resource_id: 'ops_agent_policy'
+    steps:
+      - name: 'compute_global_vm_extension_policy_basic'
         vars:
           policy_name: 'global-ops-agent-policy'
         ignore_read_extra:

--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -14,6 +14,7 @@
 ---
 name: 'GlobalVmExtensionPolicy'
 description: 'A Global VM Extension Policy.'
+min_version: 'beta'
 base_url: 'projects/{{project}}/global/vmExtensionPolicies'
 self_link: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}'
 update_verb: 'PATCH'
@@ -51,7 +52,6 @@ samples:
           policy_name: 'global-ops-agent-policy'
         ignore_read_extra:
           - 'rollout_operation'
-
 
 autogen_async: true
 async:

--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -24,6 +24,7 @@ custom_code:
   pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
   test_check_destroy: 'templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl'
   pre_delete: 'templates/terraform/pre_delete/vm_extension_policy_rollout.go.tmpl'
+  post_delete: 'templates/terraform/post_delete/global_vm_extension_policy.go.tmpl'
 
 samples:
   - name: 'compute_global_vm_extension_policy_basic'
@@ -48,6 +49,14 @@ samples:
         ignore_read_extra:
           - 'rollout_operation'
       - name: 'compute_global_vm_extension_policy_update_rollout'
+        vars:
+          policy_name: 'global-ops-agent-policy'
+        ignore_read_extra:
+          - 'rollout_operation'
+  - name: 'compute_global_vm_extension_policy_custom_rollout'
+    primary_resource_id: 'ops_agent_policy'
+    steps:
+      - name: 'compute_global_vm_extension_policy_custom_rollout'
         vars:
           policy_name: 'global-ops-agent-policy'
         ignore_read_extra:

--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -17,7 +17,6 @@ description: 'A Global VM Extension Policy.'
 base_url: 'projects/{{project}}/global/vmExtensionPolicies'
 self_link: 'projects/{{project}}/global/vmExtensionPolicies/{{name}}'
 update_verb: 'PATCH'
-update_mask: true
 custom_code:
   pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
   test_check_destroy: 'templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl'
@@ -32,6 +31,11 @@ samples:
         ignore_read_extra:
           - 'rollout_operation'
       - name: 'compute_global_vm_extension_policy_update'
+        vars:
+          policy_name: 'global-ops-agent-policy'
+        ignore_read_extra:
+          - 'rollout_operation'
+      - name: 'compute_global_vm_extension_policy_update_rollout'
         vars:
           policy_name: 'global-ops-agent-policy'
         ignore_read_extra:
@@ -51,7 +55,9 @@ properties:
     required: true
     immutable: true
     description: |-
-      Name of the resource. Provided by the client when the resource is created.
+      Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long and match the regular expression '^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$' to comply with RFC1035.
+    validation:
+      regex: '^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$'
   - name: 'description'
     type: String
     description: 'An optional description of this resource.'
@@ -103,12 +109,18 @@ properties:
           - name: 'name'
             type: String
             description: 'The name of the rollout plan.'
+            exactly_one_of:
+              - 'rollout_operation.0.rollout_input.0.name'
+              - 'rollout_operation.0.rollout_input.0.predefined_rollout_plan'
           - name: 'predefinedRolloutPlan'
             type: String
             description: 'Specifies the predefined rollout plan for the policy.'
+            exactly_one_of:
+              - 'rollout_operation.0.rollout_input.0.name'
+              - 'rollout_operation.0.rollout_input.0.predefined_rollout_plan'
           - name: 'retryUuid'
             type: String
-            description: 'The UUID that identifies a policy rollout retry attempt.'
+            description: 'The UUID that identifies a policy rollout retry attempt. It should only be set when retrying an existing rollout. Updating this field along with other policy fields (description, extension_policies, instance_selectors, priority) in the same plan will return an error.'
       - name: 'rolloutStatus'
         type: NestedObject
         description: 'Rollout status.'

--- a/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/GlobalVmExtensionPolicy.yaml
@@ -201,4 +201,3 @@ properties:
     type: String
     description: 'Update timestamp in RFC3339 text format.'
     output: true
-

--- a/mmv1/templates/terraform/post_delete/global_vm_extension_policy.go.tmpl
+++ b/mmv1/templates/terraform/post_delete/global_vm_extension_policy.go.tmpl
@@ -1,0 +1,79 @@
+readUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/global/vmExtensionPolicies/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+// Wait for deletion (up to 10 minutes) to avoid eventual consistency issues during subsequent resource deletions (e.g. RolloutPlan)
+deadline := time.Now().Add(10 * time.Minute)
+for {
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    readUrl,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+			break
+		}
+		return err
+	}
+	if time.Now().After(deadline) {
+		return fmt.Errorf("timeout waiting for GlobalVmExtensionPolicy %q to be deleted", d.Id())
+	}
+	log.Printf("[DEBUG] GlobalVmExtensionPolicy %q is still deleting, waiting...", d.Id())
+	time.Sleep(5 * time.Second)
+}
+
+// Clean up any historical rollout records owned by this GlobalVmExtensionPolicy
+policyName := ""
+if n, ok := d.GetOk("name"); ok {
+	policyName = n.(string)
+}
+
+if policyName != "" {
+	listUrl := fmt.Sprintf("https://compute.googleapis.com/compute/beta/projects/%s/global/rollouts?filter=rolloutEntity.orchestratedEntity.orchestrationSource%%20eq%%20%%22.*%s%%22", project, policyName)
+	listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    listUrl,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return fmt.Errorf("Error listing rollouts to clean up references: %s", err)
+	}
+
+	if listRes != nil {
+		if items, ok := listRes["items"].([]interface{}); ok {
+			for _, item := range items {
+				if rollout, ok := item.(map[string]interface{}); ok {
+					if rolloutName, ok := rollout["name"].(string); ok && rolloutName != "" {
+						log.Printf("[DEBUG] Deleting historical rollout %q owned by policy %q to unlock referenced rollout plan", rolloutName, policyName)
+						deleteUrl := fmt.Sprintf("https://compute.googleapis.com/compute/beta/projects/%s/global/rollouts/%s", project, rolloutName)
+
+						res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+							Config:    config,
+							Method:    "DELETE",
+							Project:   billingProject,
+							RawURL:    deleteUrl,
+							UserAgent: userAgent,
+						})
+						if err != nil {
+							log.Printf("[WARNING] Error deleting rollout %q: %s", rolloutName, err)
+							continue
+						}
+
+						err = ComputeOperationWaitTime(
+							config, res, project, fmt.Sprintf("Deleting rollout %q", rolloutName), userAgent,
+							d.Timeout(schema.TimeoutDelete))
+						if err != nil {
+							log.Printf("[WARNING] Error waiting for rollout %q deletion: %s", rolloutName, err)
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/mmv1/templates/terraform/pre_delete/vm_extension_policy_rollout.go.tmpl
+++ b/mmv1/templates/terraform/pre_delete/vm_extension_policy_rollout.go.tmpl
@@ -1,0 +1,4 @@
+// predefinedRolloutPlan is required in the request body for GCE VM extension policy deletion.
+obj = map[string]interface{}{
+	"predefinedRolloutPlan": "FAST_ROLLOUT",
+}

--- a/mmv1/templates/terraform/pre_update/vm_extension_policy_name.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/vm_extension_policy_name.go.tmpl
@@ -1,0 +1,1 @@
+obj["name"] = d.Get("name").(string)

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 10

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_basic.tf.tmpl
@@ -1,0 +1,24 @@
+resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  name        = "global-ops-agent-vme-policy-%{random_suffix}"
+  description = "A basic global VM extension policy"
+  priority    = 10
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+
+  rollout_operation {
+    rollout_input {
+      predefined_rollout_plan = "FAST_ROLLOUT"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_custom_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_custom_rollout.tf.tmpl
@@ -1,0 +1,57 @@
+resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
+  name        = "global-ops-agent-vme-policy-%{random_suffix}"
+  description = "A global VM extension policy with a custom rollout plan"
+  priority    = 10
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+
+  rollout_operation {
+    rollout_input {
+      name = "projects/${data.google_project.project.number}/locations/global/rolloutPlans/${google_compute_rollout_plan.custom_rollout.name}"
+    }
+  }
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+
+resource "google_compute_rollout_plan" "custom_rollout" {
+  provider       = google-beta
+  name           = "custom-rollout-plan-%{random_suffix}"
+  location_scope = "ZONAL"
+
+  waves {
+    display_name = "wave-1"
+    selectors {
+      location_selector {
+        included_locations = [
+          "us-central1-a",
+          "us-west1-a"
+        ]
+      }
+    }
+    validation {
+      type = "time"
+      time_based_validation_metadata {
+        wait_duration = "0s"
+      }
+    }
+    orchestration_options {
+      max_concurrent_resources_per_location = 10
+      max_concurrent_locations              = 10
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 20

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update.tf.tmpl
@@ -1,0 +1,25 @@
+resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  name        = "global-ops-agent-vme-policy-%{random_suffix}"
+  description = "A basic global VM extension policy"
+  priority    = 20
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+    string_config  = "logging:\n  receivers:\n    syslog:\n      type: files\n      include_paths:\n      - /var/log/messages\n"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+
+  rollout_operation {
+    rollout_input {
+      predefined_rollout_plan = "FAST_ROLLOUT"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
@@ -1,4 +1,5 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  provider    = google-beta
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
   priority    = 10

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
@@ -1,12 +1,11 @@
 resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
   name        = "global-ops-agent-vme-policy-%{random_suffix}"
   description = "A basic global VM extension policy"
-  priority    = 20
+  priority    = 10
 
   extension_policies {
     extension_name = "ops-agent"
     pinned_version = "2.66.0"
-    string_config  = "logging:\n  receivers:\n    syslog:\n      type: files\n      include_paths:\n      - /var/log/messages\n"
   }
 
   instance_selectors {

--- a/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_global_vm_extension_policy_update_rollout.tf.tmpl
@@ -1,0 +1,27 @@
+resource "google_compute_global_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  name        = "global-ops-agent-vme-policy-%{random_suffix}"
+  description = "A basic global VM extension policy"
+  priority    = 20
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+    string_config  = "logging:\n  receivers:\n    syslog:\n      type: files\n      include_paths:\n      - /var/log/messages\n"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+
+  rollout_operation {
+    rollout_input {
+      conflict_behavior       = "overwrite"
+      predefined_rollout_plan = "SLOW_ROLLOUT"
+      retry_uuid              = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+    }
+  }
+}

--- a/mmv1/templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl
+++ b/mmv1/templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl
@@ -1,0 +1,4 @@
+// Skip destroy check to avoid eventual consistency issues of global rollouts.
+// The global VM extension policy deletion triggers a background purge rollout
+// that can take a few minutes to fully propagate across GCE zones.
+return nil

--- a/mmv1/templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl
+++ b/mmv1/templates/terraform/test_check_destroy/global_vm_extension_policy.go.tmpl
@@ -1,4 +1,30 @@
-// Skip destroy check to avoid eventual consistency issues of global rollouts.
-// The global VM extension policy deletion triggers a background purge rollout
-// that can take a few minutes to fully propagate across GCE zones.
-return nil
+config := acctest.GoogleProviderConfig(t)
+url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(compute.Product, config)+"projects/{{"{{"}}project{{"}}"}}/global/vmExtensionPolicies/{{"{{"}}name{{"}}"}}")
+if err != nil {
+	return err
+}
+
+billingProject := ""
+if config.BillingProject != "" {
+	billingProject = config.BillingProject
+}
+
+err = resource.Retry(10*time.Minute, func() *resource.RetryError {
+	_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: config.UserAgent,
+	})
+	if err == nil {
+		return resource.RetryableError(fmt.Errorf("GlobalVmExtensionPolicy still exists at %s", url))
+	}
+	if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		return nil
+	}
+	return resource.NonRetryableError(err)
+})
+if err != nil {
+	return err
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27928

This PR adds support for the new google_compute_global_vm_extension_policy resource to the Google Terraform provider.

Global VM Extension Policies allow you to manage Google software on a fleet of GCE VMs across all zones in a GCP project. Management includes fleetwide installation/uninstallation, configuration management, health reporting, and version upgrades.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_compute_global_vm_extension_policy`
```
