### PR TITLE
docs: clarify google_sql_database_instance edition default (PG16 → ENTERPRISE_PLUS) and tier/edition compatibility

### DIFF
--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -431,9 +431,16 @@ The `settings` block supports:
 
 * `tier` - (Required) The machine type to use. See [tiers](https://cloud.google.com/sql/docs/admin-api/v1beta4/tiers)
     for more details and supported versions. Postgres supports only shared-core machine types,
-    and custom machine types such as `db-custom-2-13312`. See the [Custom Machine Type Documentation](https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#create) to learn about specifying custom machine types.
+    and custom machine types such as `db-custom-2-13312`. See the [Custom Machine Type Documentation](https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#create) to learn about specifying custom machine types. Note that shared-core and custom machine types are valid only under the `ENTERPRISE` edition; PostgreSQL 16+ instances default to `ENTERPRISE_PLUS` when `edition` is unset (see the `edition` argument below).
 
-* `edition` - (Optional) The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`.
+* `edition` - (Optional) The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`. If `edition`
+    is not set, the Cloud SQL API determines the default based on `database_version`: instances with
+    `database_version` `POSTGRES_16` or later default to `ENTERPRISE_PLUS`, while all others default to
+    `ENTERPRISE`. Note that `ENTERPRISE_PLUS` supports only predefined `db-perf-optimized-N-*` machine
+    types (the `N2`/`C4A` series); shared-core and custom tiers such as `db-g1-small`, `db-f1-micro`, and
+    `db-custom-*` require `edition = "ENTERPRISE"`. Omitting `edition` on a PostgreSQL 16+ instance while
+    setting a shared-core or custom `tier` therefore fails at create time with
+    `Invalid Tier (...) for (ENTERPRISE_PLUS) Edition`.
 
 * `user_labels` - (Optional) A set of key/value user label pairs to assign to the instance.
 


### PR DESCRIPTION
### Summary

Docs-only clarification for `google_sql_database_instance`. The `edition` argument doc currently reads only:

> `edition` - (Optional) The edition of the instance, can be `ENTERPRISE` or `ENTERPRISE_PLUS`.

It does not mention that, since the client-side `ENTERPRISE` default was removed (#19977), omitting `edition` lets the Cloud SQL **API** choose the default — and for `POSTGRES_16`+ that default is `ENTERPRISE_PLUS`. `ENTERPRISE_PLUS` accepts only `db-perf-optimized-N-*` (N2/C4A) tiers, so a config that sets a shared-core or custom `tier` (`db-g1-small`, `db-f1-micro`, `db-custom-*`) **without** `edition` now fails at apply with:

```
Error 400: Invalid request: Invalid Tier (db-g1-small) for (ENTERPRISE_PLUS) Edition.
Use a predefined Tier like db-perf-optimized-N-* instead.
```

The existing `tier` doc actively points PostgreSQL users at exactly those shared-core/custom tiers, with no cross-reference to the edition interaction — so the docs steer users into the failure. This was reported in hashicorp/terraform-provider-google#20498 (closed without a docs fix), where the community-confirmed remediation is `edition = "ENTERPRISE"`.

This PR adds that context to both the `edition` and `tier` argument descriptions. No code/schema change.

### Release Note

```release-note:none
```
