### PR TITLE
feat: add traffic_routing_config to composer beta resource

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment.go.tmpl
@@ -374,6 +374,26 @@ func ResourceComposerEnvironment() *schema.Resource {
 										ValidateFunc:     validateComposerInternalIpv4CidrBlock,
 										Description:      `IPv4 cidr range that will be used by Composer internal components.`,
 									},
+{{- if ne $.TargetVersionName "ga" }}
+									"traffic_routing_config": {
+										Type:        schema.TypeList,
+										Optional:    true,
+										Computed:    true,
+										MaxItems:    1,
+										Description: `Traffic routing configuration for Cloud Composer environment.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"cloud_run_functions_routing": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													Computed:     true,
+													ValidateFunc: validation.StringInSlice([]string{"DIRECT", "VIA_NETWORK_ATTACHMENT"}, false),
+													Description:  `Traffic routing mode for Cloud Run functions. Possible values: ["DIRECT", "VIA_NETWORK_ATTACHMENT"]`,
+												},
+											},
+										},
+									},
+{{- end }}
 								},
 							},
 						},
@@ -1295,6 +1315,23 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+{{ if ne $.TargetVersionName `ga` -}}
+		if d.HasChange("config.0.node_config.0.traffic_routing_config") {
+			patchObj := &composer.Environment{
+				Config: &composer.EnvironmentConfig{
+					NodeConfig: &composer.NodeConfig{},
+				},
+			}
+			if config != nil && config.NodeConfig != nil {
+				patchObj.Config.NodeConfig.TrafficRoutingConfig = config.NodeConfig.TrafficRoutingConfig
+			}
+			err = resourceComposerEnvironmentPatchField("config.nodeConfig.trafficRoutingConfig", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
+{{- end }}
+
 		if d.HasChange("config.0.software_config.0.image_version") {
 			patchObj := &composer.Environment{
 				Config: &composer.EnvironmentConfig{
@@ -1714,9 +1751,9 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["dag_gcs_prefix"] = envCfg.DagGcsPrefix
 	transformed["node_count"] = envCfg.NodeCount
 	transformed["airflow_uri"] = envCfg.AirflowUri
-	transformed["node_config"] = flattenComposerEnvironmentConfigNodeConfig(envCfg.NodeConfig)
 	transformed["software_config"] = flattenComposerEnvironmentConfigSoftwareConfig(envCfg.SoftwareConfig)
 	imageVersion := envCfg.SoftwareConfig.ImageVersion
+	transformed["node_config"] = flattenComposerEnvironmentConfigNodeConfig(envCfg.NodeConfig, imageVersion)
 	if !isComposer3(imageVersion){
 		transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
 	}
@@ -1970,7 +2007,7 @@ func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.P
 	return []interface{}{transformed}
 }
 
-func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) interface{} {
+func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig, imageVersion string) interface{} {
 	if nodeCfg == nil {
 		return nil
 	}
@@ -1990,6 +2027,11 @@ func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) in
 	transformed["tags"] = flattenComposerEnvironmentConfigNodeConfigTags(nodeCfg.Tags)
 	transformed["ip_allocation_policy"] = flattenComposerEnvironmentConfigNodeConfigIPAllocationPolicy(nodeCfg.IpAllocationPolicy)
 	transformed["composer_internal_ipv4_cidr_block"] = nodeCfg.ComposerInternalIpv4CidrBlock
+{{- if ne $.TargetVersionName "ga" }}
+	if isComposer3(imageVersion) {
+		transformed["traffic_routing_config"] = flattenComposerEnvironmentConfigNodeConfigTrafficRoutingConfig(nodeCfg.TrafficRoutingConfig)
+	}
+{{- end }}
 	return []interface{}{transformed}
 }
 
@@ -2006,6 +2048,17 @@ func flattenComposerEnvironmentConfigNodeConfigIPAllocationPolicy(ipPolicy *comp
 
 	return []interface{}{transformed}
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func flattenComposerEnvironmentConfigNodeConfigTrafficRoutingConfig(cfg *composer.TrafficRoutingConfig) interface{} {
+	if cfg == nil {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["cloud_run_functions_routing"] = cfg.CloudRunFunctionsRouting
+	return []interface{}{transformed}
+}
+{{- end }}
 
 func flattenComposerEnvironmentConfigNodeConfigOauthScopes(v interface{}) interface{} {
 	if v == nil {
@@ -2645,8 +2698,37 @@ func expandComposerEnvironmentConfigNodeConfig(v interface{}, d *schema.Resource
 		transformed.ComposerInternalIpv4CidrBlock = transformedComposerInternalIpv4CidrBlock.(string)
 	}
 
+{{ if ne $.TargetVersionName `ga` -}}
+	transformedTrafficRoutingConfig, err := expandComposerEnvironmentTrafficRoutingConfig(original["traffic_routing_config"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.TrafficRoutingConfig = transformedTrafficRoutingConfig
+{{- end }}
+
 	return transformed, nil
 }
+
+{{ if ne $.TargetVersionName `ga` -}}
+func expandComposerEnvironmentTrafficRoutingConfig(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (*composer.TrafficRoutingConfig, error) {
+	if v == nil {
+		return nil, nil
+	}
+	l, ok := v.([]interface{})
+	if !ok || len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := &composer.TrafficRoutingConfig{}
+
+	if v, ok := original["cloud_run_functions_routing"]; ok && v != nil {
+		transformed.CloudRunFunctionsRouting = v.(string)
+	}
+
+	return transformed, nil
+}
+{{- end }}
 
 func expandComposerEnvironmentIPAllocationPolicy(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) (*composer.IPAllocationPolicy, error) {
 	l := v.([]interface{})
@@ -3138,6 +3220,7 @@ func versionValidationCustomizeDiffFunc(ctx context.Context, d *schema.ResourceD
 		"config.0.master_authorized_networks_config": false,
 		"config.0.node_config.0.composer_network_attachment": true, // allowed only in composer 3
 		"config.0.node_config.0.composer_internal_ipv4_cidr_block": true,
+		"config.0.node_config.0.traffic_routing_config": true,
 		"config.0.software_config.0.web_server_plugins_mode": true,
 		"config.0.enable_private_environment": true,
 		"config.0.enable_private_builds_only": true,

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_meta.yaml.tmpl
@@ -38,6 +38,7 @@ fields:
   - api_field: 'config.nodeConfig.machineType'
 {{- if ne $.TargetVersionName "ga" }}
   - api_field: 'config.nodeConfig.maxPodsPerNode'
+  - api_field: 'config.nodeConfig.trafficRoutingConfig.cloudRunFunctionsRouting'
 {{- end }}
   - api_field: 'config.nodeConfig.network'
   - api_field: 'config.nodeConfig.oauthScopes'

--- a/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_environment_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/services/kms"
 	"github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -1122,6 +1124,48 @@ func TestAccComposerEnvironmentComposer3_usesUnsupportedField_expectError(t *tes
 			{
 				Config:      testAccComposerEnvironmentComposer3_usesUnsupportedField(envName),
 				ExpectError: errorRegExp,
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironmentComposer3_trafficRoutingConfig(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(reflect.TypeOf(transport_tpg.Config{}).PkgPath(), "google-beta") {
+		t.Skip("skipping beta-only test in GA provider")
+	}
+
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, acctest.RandInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, acctest.RandInt(t))
+	subnetwork := network + "-1"
+	serviceAccount := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironmentComposer3_trafficRouting(envName, network, subnetwork, serviceAccount, "DIRECT"),
+			},
+			{
+				Config: testAccComposerEnvironmentComposer3_trafficRouting(envName, network, subnetwork, serviceAccount, "VIA_NETWORK_ATTACHMENT"),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO: Remove this check if firewall rules bug gets fixed by Composer.
+
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironmentComposer3_trafficRouting(envName, network, subnetwork, serviceAccount, "VIA_NETWORK_ATTACHMENT"),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
 			},
 		},
 	})
@@ -2945,6 +2989,56 @@ resource "google_compute_subnetwork" "test" {
   network       = google_compute_network.test.self_link
 }
 `, serviceAccount, name, network, subnetwork)
+}
+
+func testAccComposerEnvironmentComposer3_trafficRouting(name, network, subnetwork, serviceAccount, routingMode string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+resource "google_service_account" "test" {
+  account_id   = "%s"
+  display_name = "Test Service Account for Composer Environment"
+}
+resource "google_project_iam_member" "composer-worker" {
+  project = data.google_project.project.project_id
+  role    = "roles/composer.worker"
+  member  = "serviceAccount:${google_service_account.test.email}"
+}
+
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+    node_config {
+      network    = google_compute_network.test.id
+      subnetwork = google_compute_subnetwork.test.id
+      service_account = google_service_account.test.name
+      traffic_routing_config {
+        cloud_run_functions_routing = "%s"
+      }
+    }
+    software_config {
+      image_version = "composer-3-airflow-2"
+    }
+    enable_private_environment = true
+  }
+  depends_on = [google_project_iam_member.composer-worker]
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
+}
+`, serviceAccount, name, routingMode, network, subnetwork)
 }
 
 // WARNING: This is not actually a check and is a terrible clean-up step because Composer Environments

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -598,6 +598,20 @@ block supports:
   /20 IPv4 cidr range that will be used by the environment's internal
   components. Cannot be updated.
 
+* `traffic_routing_config` -
+  (Optional, [Beta](../guides/provider_versions.html.markdown),
+  Managed Airflow (Gen 3) only)
+  Traffic routing configuration for Cloud Composer environment.
+  Structure is [documented below](#nested_traffic_routing_config).
+
+
+<a name="nested_traffic_routing_config"></a>The `traffic_routing_config` block supports:
+
+* `cloud_run_functions_routing` -
+  (Optional, [Beta](../guides/provider_versions.html.markdown))
+  Traffic routing mode for Cloud Run functions. Possible values: `DIRECT`, `VIA_NETWORK_ATTACHMENT`.
+  If unspecified, defaults to `DIRECT`.
+
 <a name="nested_software_config_gen_3"></a>The `software_config` block supports:
 
 * `airflow_config_overrides` -


### PR DESCRIPTION
Adds support for Cloud Run traffic routing configuration in Cloud Composer 3 (Managed Airflow Gen 3) environments for the beta provider version.

This feature allows customers to specify whether traffic to Cloud Run components should be routed `DIRECT` (default) or `VIA_NETWORK_ATTACHMENT` (through the environment's PSC network attachment).

More context: https://docs.cloud.google.com/composer/docs/composer-3/connect-vpc-network#cloud-run-traffic

```release-note:enhancement
composer: added `config.node_config.traffic_routing_config` argument to `google_composer_environment` resource (beta)
```
