### PR TITLE
Added Resource `google_compute_zonal_vm_extension_policy`

### DIFF
--- a/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
@@ -1,0 +1,113 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'ZoneVmExtensionPolicy'
+description: 'A Zone VM Extension Policy.'
+base_url: 'projects/{{project}}/zones/{{zone}}/vmExtensionPolicies'
+self_link: 'projects/{{project}}/zones/{{zone}}/vmExtensionPolicies/{{name}}'
+update_verb: 'PATCH'
+update_mask: true
+custom_code:
+  pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
+
+samples:
+  - name: 'compute_zone_vm_extension_policy_basic'
+    primary_resource_id: 'ops_agent_policy'
+    steps:
+      - name: 'compute_zone_vm_extension_policy_basic'
+        vars:
+          policy_name: 'zonal-ops-agent-policy'
+      - name: 'compute_zone_vm_extension_policy_update'
+        vars:
+          policy_name: 'zonal-ops-agent-policy'
+
+
+autogen_async: true
+async:
+  actions: ['create', 'delete', 'update']
+  type: 'OpAsync'
+  operation:
+    base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
+
+parameters:
+  - name: 'zone'
+    type: String
+    required: true
+    immutable: true
+    url_param_only: true
+    description: 'Name of the zone for this request.'
+
+properties:
+  - name: 'name'
+    type: String
+    required: true
+    immutable: true
+    description: |-
+      Name of the resource. Provided by the client when the resource is created.
+  - name: 'description'
+    type: String
+    description: 'An optional description of this resource.'
+  - name: 'extensionPolicies'
+    type: Map
+    required: true
+    description: |-
+      A map of extension names (for example, "ops-agent") to their corresponding policy configurations.
+    value_type:
+      type: NestedObject
+      properties:
+        - name: 'pinnedVersion'
+          type: String
+          description: 'The specific version of the extension to install.'
+        - name: 'stringConfig'
+          type: String
+          description: 'String-based configuration data for the extension.'
+    key_name: 'extension_name'
+  - name: 'instanceSelectors'
+    type: Array
+    description: 'Selectors to target VMs for this policy.'
+    item_type:
+      type: NestedObject
+      properties:
+        - name: 'labelSelector'
+          type: NestedObject
+          description: 'LabelSelector matches VM labels.'
+          properties:
+            - name: 'inclusionLabels'
+              type: KeyValuePairs
+              description: 'A map of key-value pairs representing VM labels.'
+  - name: 'priority'
+    type: Integer
+    default_from_api: true
+    description: 'Priority of this policy.'
+  - name: 'creationTimestamp'
+    type: String
+    description: 'Creation timestamp in RFC3339 text format.'
+    output: true
+  - name: 'id'
+    type: String
+    description: 'The unique identifier for the resource.'
+    output: true
+  - name: 'kind'
+    type: String
+    description: 'Type of the resource.'
+    output: true
+  - name: 'managedByGlobal'
+    type: Boolean
+    description: 'Indicates if this policy is managed by a global policy.'
+    output: true
+  - name: 'state'
+    type: String
+    description: 'Current state of the policy.'
+    output: true
+

--- a/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
@@ -110,4 +110,3 @@ properties:
     type: String
     description: 'Current state of the policy.'
     output: true
-

--- a/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
+++ b/mmv1/products/compute/ZoneVmExtensionPolicy.yaml
@@ -17,7 +17,6 @@ description: 'A Zone VM Extension Policy.'
 base_url: 'projects/{{project}}/zones/{{zone}}/vmExtensionPolicies'
 self_link: 'projects/{{project}}/zones/{{zone}}/vmExtensionPolicies/{{name}}'
 update_verb: 'PATCH'
-update_mask: true
 custom_code:
   pre_update: 'templates/terraform/pre_update/vm_extension_policy_name.go.tmpl'
 

--- a/mmv1/templates/terraform/pre_update/vm_extension_policy_name.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/vm_extension_policy_name.go.tmpl
@@ -1,0 +1,1 @@
+obj["name"] = d.Get("name").(string)

--- a/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_basic.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_compute_zone_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  name        = "zonal-ops-agent-vme-policy-%{random_suffix}"
+  zone        = "us-central1-a"
+  description = "A basic zonal VM extension policy"
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_basic.tf.tmpl
@@ -1,18 +1,9 @@
 resource "google_compute_zone_vm_extension_policy" "{{$.PrimaryResourceId}}" {
   name        = "zonal-ops-agent-vme-policy-%{random_suffix}"
   zone        = "us-central1-a"
-  description = "A basic zonal VM extension policy"
 
   extension_policies {
     extension_name = "ops-agent"
     pinned_version = "2.66.0"
-  }
-
-  instance_selectors {
-    label_selector {
-      inclusion_labels = {
-        env = "test"
-      }
-    }
   }
 }

--- a/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_update.tf.tmpl
@@ -6,7 +6,7 @@ resource "google_compute_zone_vm_extension_policy" "{{$.PrimaryResourceId}}" {
 
   extension_policies {
     extension_name = "ops-agent"
-    pinned_version = "2.66.0"
+    pinned_version = "2.67.0"
     string_config  = "logging:\n  receivers:\n    syslog:\n      type: files\n      include_paths:\n      - /var/log/messages\n"
   }
 

--- a/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/compute_zone_vm_extension_policy_update.tf.tmpl
@@ -1,0 +1,20 @@
+resource "google_compute_zone_vm_extension_policy" "{{$.PrimaryResourceId}}" {
+  name        = "zonal-ops-agent-vme-policy-%{random_suffix}"
+  zone        = "us-central1-a"
+  description = "A basic zonal VM extension policy"
+  priority    = 20
+
+  extension_policies {
+    extension_name = "ops-agent"
+    pinned_version = "2.66.0"
+    string_config  = "logging:\n  receivers:\n    syslog:\n      type: files\n      include_paths:\n      - /var/log/messages\n"
+  }
+
+  instance_selectors {
+    label_selector {
+      inclusion_labels = {
+        env = "test"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27928

This PR adds support for the new `google_compute_zonal_vm_extension_policy` resource to the Google Terraform provider.

Zonal VM Extension Policies allow you to manage Google software on a fleet of GCE VMs within a single zone in a GCP project. Management includes fleetwide installation/uninstallation, configuration management, health reporting, and version upgrades.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_compute_zonal_vm_extension_policy`
```
