### PR TITLE
artifactregistry: add `google_artifact_registry_project_config` for platform logs

### DIFF
--- a/mmv1/products/artifactregistry/ProjectConfig.yaml
+++ b/mmv1/products/artifactregistry/ProjectConfig.yaml
@@ -50,9 +50,18 @@ async:
     resource_inside_response: false
 custom_code:
   encoder: 'templates/terraform/encoders/location_from_region.go.tmpl'
-examples:
+samples:
   - name: 'artifact_registry_project_config'
     primary_resource_id: 'my-config'
+    steps:
+      # Step 1 -> create test
+      - name: 'artifact_registry_project_config'
+        vars:
+          severity_level: 'INFO'
+      # Step 2 -> update test (in-place update of severity_level)
+      - name: 'artifact_registry_project_config'
+        vars:
+          severity_level: 'WARNING'
 parameters:
   - name: 'location'
     type: String

--- a/mmv1/products/artifactregistry/ProjectConfig.yaml
+++ b/mmv1/products/artifactregistry/ProjectConfig.yaml
@@ -1,0 +1,97 @@
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'ProjectConfig'
+description: |-
+  The Artifact Registry project config, used to configure platform logs that
+  apply to a project.
+references:
+  guides:
+    'Access and use platform logs': 'https://cloud.google.com/artifact-registry/docs/platform-logs'
+  api: 'https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations/getProjectConfig'
+docs:
+  note: |-
+    A project config is automatically created for a given location. Creating a
+    resource of this type will acquire and update the resource that already
+    exists at the location. Deleting this resource will remove the config from
+    your Terraform state but leave the resource as is.
+id_format: 'projects/{{project}}/locations/{{location}}/projectConfig'
+base_url: 'projects/{{project}}/locations/{{location}}/projectConfig'
+self_link: 'projects/{{project}}/locations/{{location}}/projectConfig'
+import_format:
+  - 'projects/{{project}}/locations/{{location}}/projectConfig'
+create_url: 'projects/{{project}}/locations/{{location}}/projectConfig?updateMask=platformLogsConfig'
+create_verb: 'PATCH'
+update_url: 'projects/{{project}}/locations/{{location}}/projectConfig?updateMask=platformLogsConfig'
+update_verb: 'PATCH'
+exclude_delete: true
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['']
+  type: 'OpAsync'
+  # necessary to compile
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+custom_code:
+  encoder: 'templates/terraform/encoders/location_from_region.go.tmpl'
+examples:
+  - name: 'artifact_registry_project_config'
+    primary_resource_id: 'my-config'
+parameters:
+  - name: 'location'
+    type: String
+    description: |
+      The name of the location this config is located in.
+    url_param_only: true
+    required: false
+    immutable: true
+    default_from_api: true
+  - name: 'name'
+    type: String
+    description: |-
+      The name of the project's config.
+      Always of the form: projects/{project}/locations/{location}/projectConfig
+    output: true
+properties:
+  - name: 'platformLogsConfig'
+    type: NestedObject
+    description: |-
+      Configuration for platform logs.
+    properties:
+      - name: 'loggingState'
+        type: Enum
+        description: |-
+          The state of the platform logs: enabled or disabled.
+        enum_values:
+          - 'ENABLED'
+          - 'DISABLED'
+      - name: 'severityLevel'
+        type: Enum
+        description: |-
+          The severity level for the logs. Logs will be generated if their
+          severity level is >= than the value of the severity level mentioned here.
+        enum_values:
+          - 'DEBUG'
+          - 'INFO'
+          - 'NOTICE'
+          - 'WARNING'
+          - 'ERROR'
+          - 'CRITICAL'
+          - 'ALERT'
+          - 'EMERGENCY'

--- a/mmv1/templates/terraform/examples/artifact_registry_project_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/artifact_registry_project_config.tf.tmpl
@@ -1,0 +1,7 @@
+resource "google_artifact_registry_project_config" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  platform_logs_config {
+    logging_state  = "ENABLED"
+    severity_level = "INFO"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/artifactregistry/artifact_registry_project_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/artifactregistry/artifact_registry_project_config.tf.tmpl
@@ -2,6 +2,6 @@ resource "google_artifact_registry_project_config" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   platform_logs_config {
     logging_state  = "ENABLED"
-    severity_level = "INFO"
+    severity_level = "{{index $.Vars "severity_level"}}"
   }
 }


### PR DESCRIPTION
Adds a new resource `google_artifact_registry_project_config` that manages the Artifact Registry [project config](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations/getProjectConfig) — a project+location singleton — exposing its nested `platformLogsConfig` so [platform logs](https://cloud.google.com/artifact-registry/docs/platform-logs) can be enabled/disabled and given a severity threshold via Terraform.

Modeled on the sibling `google_artifact_registry_vpcsc_config`: the config always exists per location, so create/update are PATCH (with a hardcoded `updateMask=platformLogsConfig`), and the resource is acquire-and-update with a state-only delete (`exclude_delete`).

Resolves https://github.com/hashicorp/terraform-provider-google/issues/27747

Example:
```hcl
resource "google_artifact_registry_project_config" "config" {
  location = "us-central1"
  platform_logs_config {
    logging_state  = "ENABLED"
    severity_level = "INFO"
  }
}
```

```release-note:new-resource
`google_artifact_registry_project_config`
```
