### PR TITLE
compute: added support for resource level iam policy to FirewallPolicy

### DIFF
--- a/mmv1/products/compute/FirewallPolicy.yaml
+++ b/mmv1/products/compute/FirewallPolicy.yaml
@@ -51,6 +51,8 @@ examples:
       policy_name: 'my-policy'
     test_env_vars:
       org_id: 'ORG_ID'
+iam_policy:
+  parent_resource_attribute: 'name'
 parameters:
 properties:
   - name: 'creationTimestamp'

--- a/mmv1/products/compute/NetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/NetworkFirewallPolicy.yaml
@@ -39,6 +39,8 @@ examples:
     primary_resource_id: 'policy'
     vars:
       policy_name: 'tf-test-policy'
+iam_policy:
+  parent_resource_attribute: 'name'
 parameters:
 properties:
   - name: 'creationTimestamp'

--- a/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicy.yaml
@@ -42,6 +42,8 @@ examples:
     primary_resource_id: 'policy'
     vars:
       policy_name: 'rnf-policy'
+iam_policy:
+  parent_resource_attribute: 'name'
 parameters:
   - name: 'region'
     type: String


### PR DESCRIPTION
Fix b/475675077.

```release-note:new-resource
`google_compute_firewall_policy_iam_binding`
```
```release-note:new-resource
`google_compute_firewall_policy_iam_member`
```
```release-note:new-resource
`google_compute_firewall_policy_iam_policy`
```
```release-note:new-resource
`google_compute_network_firewall_policy_iam_binding`
```
```release-note:new-resource
`google_compute_network_firewall_policy_iam_member`
```
```release-note:new-resource
`google_compute_network_firewall_policy_iam_policy`
```
```release-note:new-resource
`google_compute_region_network_firewall_policy_iam_binding`
```
```release-note:new-resource
`google_compute_region_network_firewall_policy_iam_member`
```
```release-note:new-resource
`google_compute_region_network_firewall_policy_iam_policy`
```
