### PR TITLE
Dataplex-DataProductDataAsset: Add output-only name field to DataProductDataAsset

### DIFF
--- a/mmv1/products/dataplex/DataProductDataAsset.yaml
+++ b/mmv1/products/dataplex/DataProductDataAsset.yaml
@@ -52,6 +52,10 @@ samples:
         test_env_vars:
           project_name: PROJECT_NAME
 parameters:
+  - name: name
+    type: String
+    output: true
+    description: The relative resource name of the data asset.
   - name: location
     type: String
     required: true


### PR DESCRIPTION
Added support for icon field in Dataplex DataProduct. 

```release-note:enhancement
dataplex: added `name` field to `google_dataplex_data_product_data_asset` resource
```
