### PR TITLE
Fix row_affinity configuration in Bigtable app profiles

### DIFF
--- a/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/bigtable_app_profile.go.tmpl
@@ -11,7 +11,7 @@
 	limitations under the License.
 */}}
 
-if d.HasChange("multi_cluster_routing_cluster_ids") && !tpgresource.StringInSlice(updateMask, "multiClusterRoutingUseAny") {
+if (d.HasChange("multi_cluster_routing_cluster_ids") || d.HasChange("row_affinity")) && !tpgresource.StringInSlice(updateMask, "multiClusterRoutingUseAny") {
 	updateMask = append(updateMask, "multiClusterRoutingUseAny")
 }
 

--- a/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/resource_bigtable_app_profile_test.go
@@ -634,6 +634,24 @@ func TestAccBigtableAppProfile_updateRowAffinity(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ignore_warnings"},
 			},
 			{
+				Config: testAccBigtableAppProfile_updateMC1(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+			{
+				Config: testAccBigtableAppProfile_updateRowAffinity(instanceName),
+			},
+			{
+				ResourceName:            "google_bigtable_app_profile.ap",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ignore_warnings"},
+			},
+			{
 				Config: testAccBigtableAppProfile_update1(instanceName),
 			},
 			{


### PR DESCRIPTION
Ensures that changes to `row_affinity` correctly trigger the inclusion of `multiClusterRoutingUseAny` in the update mask, allowing the change to persist in the backend.

Also adds isolated test cases to verify toggling `row_affinity` without changing other fields.

Fixes: b/525733109

```release-note:bug
bigtable: fixed a bug where `row_affinity` updates did not persist on `google_bigtable_app_profile`
```