### PR TITLE
Add google_vertex_ai_model_garden_enable_model (beta) resource

### DIFF
--- a/mmv1/products/vertexai/ModelGardenEnableModel.yaml
+++ b/mmv1/products/vertexai/ModelGardenEnableModel.yaml
@@ -1,0 +1,89 @@
+# Copyright 2025 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: ModelGardenEnableModel
+api_resource_type_kind: PublisherModel
+description: |
+  Enables a Model Garden publisher model for a project so that it can be
+  deployed. This calls the synchronous
+  `ModelGardenService.EnableModel` method, which checks that the prerequisites
+  for the model are met (for example, a completed questionnaire and accepted
+  consents, or an active Private Offer) before enabling it.
+
+  ~> **Note:** The underlying API does not provide a way to disable a model
+  once it has been enabled, so destroying this resource only removes it from
+  Terraform state and does not affect the project's enablement status.
+references:
+  guides:
+    Use models in Model Garden: https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/use-models
+    Overview of Model Garden: https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models
+  api: https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.publishers.models/enableModel
+docs:
+# Only available in the v1beta1 (beta) API surface.
+min_version: beta
+base_url: projects/{{project}}/{{publisher_model_name}}:enableModel
+create_url: projects/{{project}}/{{publisher_model_name}}:enableModel
+self_link: projects/{{project}}/{{publisher_model_name}}
+id_format: projects/{{project}}/{{publisher_model_name}}
+immutable: true
+# EnableModel is a synchronous action-only method with no Read, Delete, or
+# Import support, so the lifecycle is create-only.
+exclude_read: true
+exclude_delete: true
+exclude_import: true
+exclude_sweeper: true
+timeouts:
+  insert_minutes: 20
+custom_code:
+  post_create: templates/terraform/post_create/resource_vertexai_model_garden_enable_model.go.tmpl
+examples:
+  - name: vertex_ai_model_garden_enable_model_basic
+    min_version: beta
+    primary_resource_id: enable
+    # Handwritten test required since the resource does not support read,
+    # delete, or import.
+    exclude_test: true
+    vars:
+      publisher_model_name: publishers/google/models/paligemma@paligemma-224-float32
+parameters:
+  - name: publisherModelName
+    type: String
+    description: |-
+      The resource name of the Model Garden publisher model to enable.
+      Format: `publishers/{publisher}/models/{publisher_model}`, optionally
+      with a version suffix, for example
+      `publishers/google/models/paligemma@paligemma-224-float32`.
+    min_version: beta
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: publisherEndpoint
+    type: String
+    description: |
+      Output only. The publisher endpoint that the project is enabled for.
+      Format:
+      `projects/{project}/locations/{location}/publishers/{publisher}/models/{publisher_model}`.
+    min_version: beta
+    output: true
+  - name: enablementState
+    type: Enum
+    description: |
+      Output only. The result of the model enablement.
+    min_version: beta
+    output: true
+    enum_values:
+      - ENABLEMENT_STATE_UNSPECIFIED
+      - ENABLEMENT_STATE_SUCCEEDED
+      - ENABLEMENT_STATE_FAILED

--- a/mmv1/templates/terraform/examples/vertex_ai_model_garden_enable_model_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_model_garden_enable_model_basic.tf.tmpl
@@ -1,9 +1,4 @@
 resource "google_vertex_ai_model_garden_enable_model" "{{$.PrimaryResourceId}}" {
   provider             = google-beta
-  project              = data.google_project.project.project_id
   publisher_model_name = "{{index $.Vars "publisher_model_name"}}"
-}
-
-data "google_project" "project" {
-  provider = google-beta
 }

--- a/mmv1/templates/terraform/examples/vertex_ai_model_garden_enable_model_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/vertex_ai_model_garden_enable_model_basic.tf.tmpl
@@ -1,0 +1,9 @@
+resource "google_vertex_ai_model_garden_enable_model" "{{$.PrimaryResourceId}}" {
+  provider             = google-beta
+  project              = data.google_project.project.project_id
+  publisher_model_name = "{{index $.Vars "publisher_model_name"}}"
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}

--- a/mmv1/templates/terraform/post_create/resource_vertexai_model_garden_enable_model.go.tmpl
+++ b/mmv1/templates/terraform/post_create/resource_vertexai_model_garden_enable_model.go.tmpl
@@ -1,0 +1,28 @@
+log.Printf("[DEBUG] Beginning post_create for Vertex AI Model Garden EnableModel %q", d.Id())
+
+// EnableModel is a synchronous method, so the create response (res) already
+// contains the EnableModelResponse body. Surface the output-only fields and
+// validate that the enablement actually succeeded.
+
+if enablementState, ok := res["enablementState"].(string); ok {
+	log.Printf("[DEBUG] EnableModel enablement state for %q: %s", d.Id(), enablementState)
+	if err := d.Set("enablement_state", enablementState); err != nil {
+		return fmt.Errorf("Error setting enablement_state: %s", err)
+	}
+	if enablementState == "ENABLEMENT_STATE_FAILED" {
+		// The API call returned successfully but reported that the model could
+		// not be enabled (e.g. unmet prerequisites). Fail the apply and clear
+		// the ID so the resource is not recorded as created.
+		d.SetId("")
+		return fmt.Errorf("Error enabling Model Garden model %q: API returned enablement state ENABLEMENT_STATE_FAILED", d.Get("publisher_model_name"))
+	}
+} else {
+	log.Printf("[WARN] No enablementState returned by enableModel for %q", d.Id())
+}
+
+if publisherEndpoint, ok := res["publisherEndpoint"].(string); ok {
+	log.Printf("[DEBUG] EnableModel publisher endpoint for %q: %s", d.Id(), publisherEndpoint)
+	if err := d.Set("publisher_endpoint", publisherEndpoint); err != nil {
+		return fmt.Errorf("Error setting publisher_endpoint: %s", err)
+	}
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go
@@ -1,0 +1,51 @@
+package vertexai_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+)
+
+// EnableModel is a beta-only, synchronous, action-only resource. It has no
+// Read, Delete, or Import support, so this test only verifies that an apply
+// succeeds and that the output-only fields are populated. There is no inverse
+// "disable" API, so destroying the resource is a no-op and CheckDestroy is
+// intentionally omitted.
+func TestAccVertexAIModelGardenEnableModel_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIModelGardenEnableModel_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"google_vertex_ai_model_garden_enable_model.enable", "enablement_state"),
+					resource.TestCheckResourceAttrSet(
+						"google_vertex_ai_model_garden_enable_model.enable", "publisher_endpoint"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVertexAIModelGardenEnableModel_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_vertex_ai_model_garden_enable_model" "enable" {
+  provider             = google-beta
+  project              = data.google_project.project.project_id
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go.tmpl
@@ -1,10 +1,12 @@
 package vertexai_test
+{{- if ne $.TargetVersionName "ga" }}
 
 import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
 // EnableModel is a beta-only, synchronous, action-only resource. It has no
@@ -16,6 +18,7 @@ func TestAccVertexAIModelGardenEnableModel_basic(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
+		"project_id":    envvar.GetTestProjectFromEnv(),
 		"random_suffix": acctest.RandString(t, 10),
 	}
 
@@ -40,12 +43,10 @@ func testAccVertexAIModelGardenEnableModel_basic(context map[string]interface{})
 	return acctest.Nprintf(`
 resource "google_vertex_ai_model_garden_enable_model" "enable" {
   provider             = google-beta
-  project              = data.google_project.project.project_id
+  project              = "%{project_id}"
   publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
-}
-
-data "google_project" "project" {
-  provider = google-beta
 }
 `, context)
 }
+
+{{ end }}

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_model_garden_enable_model_test.go.tmpl
@@ -24,7 +24,7 @@ func TestAccVertexAIModelGardenEnableModel_basic(t *testing.T) {
 
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVertexAIModelGardenEnableModel_basic(context),


### PR DESCRIPTION
## Summary

Adds a new beta-only resource `google_vertex_ai_model_garden_enable_model` that enables a Model Garden publisher model for a project via the synchronous `ModelGardenService.EnableModel` method (`POST .../publishers/*/models/*:enableModel`).

## Testing

- Generated the `google-beta` provider; `go build` and `go vet` are clean.
- Verified end-to-end against a real project with `terraform apply` (`enablement_state = "ENABLEMENT_STATE_SUCCEEDED"`, `publisher_endpoint` populated) and `terraform destroy` (no-op).
- A handwritten acceptance test `TestAccVertexAIModelGardenEnableModel_basic` is included. The test is handwritten (not generated) because the resource has no read/delete/import.

## Release Note

```release-note:new-resource
`google_vertex_ai_model_garden_enable_model`
```