### PR TITLE
apigee: fix continue_on_error = false dropped on flowhook create

### DIFF
--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook.go
@@ -102,7 +102,9 @@ func resourceApigeeFlowhookCreate(d *schema.ResourceData, meta interface{}) erro
 	continue_on_errorProp, err := expandApigeeFlowhookContinueOnError(d.Get("continue_on_error"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("continue_on_error"); !tpgresource.IsEmptyValue(reflect.ValueOf(continue_on_errorProp)) && (ok || !reflect.DeepEqual(v, continue_on_errorProp)) {
+	} else if continueOnErrorRaw := d.GetRawConfig().GetAttr("continue_on_error"); !continueOnErrorRaw.IsNull() {
+		// Only send continue_on_error when explicitly set, so a configured `false`
+		// is preserved instead of being dropped by the IsEmptyValue() guard.
 		obj["continueOnError"] = continue_on_errorProp
 	}
 

--- a/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
+++ b/mmv1/third_party/terraform/services/apigee/resource_apigee_flowhook_test.go
@@ -23,9 +23,10 @@ func TestAccApigeeFlowhook_apigeeFlowhookTestExample(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"org_id":          envvar.GetTestOrgFromEnv(t),
-		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(t, 10),
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"billing_account":   envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"continue_on_error": true,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{
@@ -38,6 +39,46 @@ func TestAccApigeeFlowhook_apigeeFlowhookTestExample(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccApigeeFlowhook_apigeeFlowhookTestExample(context),
+			},
+			{
+				ResourceName:            "google_apigee_flowhook.flowhook_test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+// TestAccApigeeFlowhook_continueOnErrorFalse is a regression test for
+// continue_on_error = false being dropped from the create request, which caused
+// Apigee to fall back to its server-side default of true and produced a
+// perpetual diff. It asserts the API stores false and that the plan is stable.
+func TestAccApigeeFlowhook_continueOnErrorFalse(t *testing.T) {
+	acctest.SkipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":            envvar.GetTestOrgFromEnv(t),
+		"billing_account":   envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":     acctest.RandString(t, 10),
+		"continue_on_error": false,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckApigeeFlowhookDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigeeFlowhook_apigeeFlowhookTestExample(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_apigee_flowhook.flowhook_test", "continue_on_error", "false"),
+					testAccCheckApigeeFlowhookContinueOnError(t, "google_apigee_flowhook.flowhook_test", false),
+				),
 			},
 			{
 				ResourceName:            "google_apigee_flowhook.flowhook_test",
@@ -140,9 +181,54 @@ resource "google_apigee_flowhook" "flowhook_test" {
 	flow_hook_point = "PreProxyFlowHook"
 	sharedflow = google_apigee_sharedflow.test_apigee_sharedflow.name
 	description = "test flowhook"
-	continue_on_error = true
+	continue_on_error = %{continue_on_error}
   }
 `, context)
+}
+
+// testAccCheckApigeeFlowhookContinueOnError reads the flow hook from the Apigee
+// API and asserts that continueOnError matches the expected value. This guards
+// against the create path dropping continue_on_error = false.
+func testAccCheckApigeeFlowhookContinueOnError(t *testing.T, resourceName string, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		config := acctest.GoogleProviderConfig(t)
+
+		url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(apigee.Product, config)+"organizations/{{org_id}}/environments/{{environment}}/flowhooks/{{flow_hook_point}}")
+		if err != nil {
+			return err
+		}
+
+		billingProject := ""
+		if config.BillingProject != "" {
+			billingProject = config.BillingProject
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   billingProject,
+			RawURL:    url,
+			UserAgent: config.UserAgent,
+		})
+		if err != nil {
+			return fmt.Errorf("error reading flowhook at %s: %s", url, err)
+		}
+
+		got, ok := res["continueOnError"].(bool)
+		if !ok {
+			return fmt.Errorf("continueOnError missing or not a bool in API response for %s", url)
+		}
+		if got != expected {
+			return fmt.Errorf("continueOnError = %t, want %t at %s", got, expected, url)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckApigeeFlowhookDestroyProducer(t *testing.T) func(s *terraform.State) error {


### PR DESCRIPTION
The google_apigee_flowhook create path guarded continueOnError with the standard IsEmptyValue() check, which treats a bool false as empty. A configured continue_on_error = false was therefore omitted from the create request, so Apigee applied its server-side default of true. Because the field is ForceNew, this produced a permanent true -> false diff that endlessly recreated the flow hook.

Only send continueOnError when it is explicitly set in configuration, detected via d.GetRawConfig(), so a configured false is preserved while an omitted value still relies on the schema default. Add an acceptance test that sets continue_on_error = false and asserts the API stores false.

Note: the existing TestAccApigeeFlowhook_apigeeFlowhookTestExample test was only lightly adjusted to parameterize continue_on_error (the value still defaults to true), so its behavior is unchanged.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
`google_apigee_flowhook`: fixed `continue_on_error = false` being ignored on create
```
