### PR TITLE
compute: add target_type and target_forwarding_rules to google_compute_region_network_firewall_policy_with_rules

### DIFF
--- a/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
+++ b/mmv1/products/compute/RegionNetworkFirewallPolicyWithRules.yaml
@@ -356,6 +356,26 @@ properties:
             not exist. If this is unspecified, the firewall policy rule will be
             enabled.
           min_version: 'beta'
+        - name: 'targetType'
+          type: Enum
+          description: |
+            Target types of the firewall policy rule.
+            Default value is INSTANCES.
+            When target_type is INTERNAL_MANAGED_LB, target_forwarding_rules must be set.
+          required: false
+          default_from_api: true
+          enum_values:
+            - 'INSTANCES'
+            - 'INTERNAL_MANAGED_LB'
+        - name: 'targetForwardingRules'
+          type: Array
+          required: false
+          description: |
+            A list of forwarding rules to which this rule applies.
+            This field allows you to control which load balancers get this rule.
+            This can only be specified when the target_type is INTERNAL_MANAGED_LB.
+          item_type:
+            type: String
   - name: 'predefinedRules'
     type: Array
     description: A list of firewall policy pre-defined rules.
@@ -649,6 +669,21 @@ properties:
             enabled.
           min_version: 'beta'
           output: true
+        - name: 'targetType'
+          type: Enum
+          description: |
+            Target types of the firewall policy rule.
+          output: true
+          enum_values:
+            - 'INSTANCES'
+            - 'INTERNAL_MANAGED_LB'
+        - name: 'targetForwardingRules'
+          type: Array
+          description: |
+            A list of forwarding rules to which this rule applies.
+          output: true
+          item_type:
+            type: String
   - name: 'fingerprint'
     type: Fingerprint
     description: Fingerprint of the resource. This field is used internally during updates of this resource.

--- a/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_region_network_firewall_policy_with_rules_full.tf.tmpl
@@ -51,6 +51,23 @@ resource "google_compute_region_network_firewall_policy_with_rules" "{{$.Primary
       }
       disabled = true
     }
+
+  rule {
+    description = "internal managed lb rule"
+    priority    = 3000
+    action      = "allow"
+    direction   = "INGRESS"
+
+    target_type = "INTERNAL_MANAGED_LB"
+
+    match {
+      src_ip_ranges = ["10.0.0.0/8"]
+
+      layer4_config {
+        ip_protocol = "tcp"
+      }
+    }
+  }
 }
 
 resource "google_network_security_address_group" "address_group_1" {


### PR DESCRIPTION
Adds `target_type` and `target_forwarding_rules` fields to the `rule` block of
`google_compute_region_network_firewall_policy_with_rules`, matching the existing
support in `google_compute_region_network_firewall_policy_rule`.

Fixes hashicorp/terraform-provider-google#27855

```release-note:enhancement
`google_compute_region_network_firewall_policy_with_rules` - added `target_type` and `target_forwarding_rules` to the `rule` block
```