### PR TITLE
Add list resource support to `google_project`

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
@@ -1,0 +1,134 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"google.golang.org/api/cloudresourcemanager/v1"
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_project",
+		ProductName: "resourcemanager",
+		Func:        NewGoogleProjectListResource,
+	}.Register()
+}
+
+
+type GoogleProjectListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleProjectListModel struct {
+	Filter types.String `tfsdk:"filter"`
+}
+
+func NewGoogleProjectListResource() list.ListResource {
+	listR := &GoogleProjectListResource{}
+	listR.TypeName = "google_project"
+	listR.SDKv2Resource = ResourceGoogleProject()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "filter", Kind: tpgresource.ListConfigKindString, Optional: true},
+	}
+	return listR
+}
+
+func (listR *GoogleProjectListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	errProjectListStreamClosed := errors.New("stream closed")
+
+	var data GoogleProjectListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	filter := data.Filter.ValueString()
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListProjects(listR.Client, filter, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
+				return err
+			}
+
+			if !push(result) {
+				return errProjectListStreamClosed
+			}
+			return nil
+		})
+		if err != nil {
+			if errors.Is(err, errProjectListStreamClosed) {
+				return
+			}
+			diags.AddError("API Error", err.Error())
+			result := listReq.NewListResult(ctx)
+			result.Diagnostics = diags
+			push(result)
+		}
+	}
+}
+
+func flattenProjectListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+	var p cloudresourcemanager.Project
+	if err := tpgresource.Convert(res, &p); err != nil {
+		return fmt.Errorf("error converting project list response: %w", err)
+	}
+	if p.ProjectId == "" {
+		return fmt.Errorf("missing name in project list response")
+	}
+	d.SetId(fmt.Sprintf("projects/%s", p.ProjectId))
+	return populateGoogleProjectResourceData(d, &p, p.ProjectId, config)
+}
+
+func ListProjects(config *transport_tpg.Config, filter string, callback func(rd *schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	d := ResourceGoogleProject().Data(&terraform.InstanceState{})
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	domain := transport_tpg.GenerateUniverseDomainFromMeta(config)
+	url := fmt.Sprintf("https://cloudresourcemanager.%s/v1/projects", domain)
+
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:         config,
+		TempData:       d,
+		Resource:       ResourceGoogleProject(),
+		ListURL:        url,
+		Filter:         filter,
+		ItemName:       "projects",
+		UserAgent:      userAgent,
+		Flattener:      flattenProjectListItem,
+		Callback:       callback,
+	})
+}
+
+

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
@@ -98,7 +98,7 @@ func flattenProjectListItem(res map[string]interface{}, d *schema.ResourceData, 
 		return fmt.Errorf("error converting project list response: %w", err)
 	}
 	if p.ProjectId == "" {
-		return fmt.Errorf("missing name in project list response")
+		return fmt.Errorf("missing projectId in project list response")
 	}
 	d.SetId(fmt.Sprintf("projects/%s", p.ProjectId))
 	return populateGoogleProjectResourceData(d, &p, p.ProjectId, config)
@@ -115,7 +115,10 @@ func ListProjects(config *transport_tpg.Config, filter string, callback func(rd 
 		return err
 	}
 
-	domain := transport_tpg.GenerateUniverseDomainFromMeta(config)
+	domain := config.UniverseDomain
+	if domain == "" {
+		domain = "googleapis.com"
+	}
 	url := fmt.Sprintf("https://cloudresourcemanager.%s/v1/projects", domain)
 
 	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project.go
@@ -29,7 +29,6 @@ func init() {
 	}.Register()
 }
 
-
 type GoogleProjectListResource struct {
 	tpgresource.ListResourceMetadata
 }
@@ -122,16 +121,14 @@ func ListProjects(config *transport_tpg.Config, filter string, callback func(rd 
 	url := fmt.Sprintf("https://cloudresourcemanager.%s/v1/projects", domain)
 
 	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
-		Config:         config,
-		TempData:       d,
-		Resource:       ResourceGoogleProject(),
-		ListURL:        url,
-		Filter:         filter,
-		ItemName:       "projects",
-		UserAgent:      userAgent,
-		Flattener:      flattenProjectListItem,
-		Callback:       callback,
+		Config:    config,
+		TempData:  d,
+		Resource:  ResourceGoogleProject(),
+		ListURL:   url,
+		Filter:    filter,
+		ItemName:  "projects",
+		UserAgent: userAgent,
+		Flattener: flattenProjectListItem,
+		Callback:  callback,
 	})
 }
-
-

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_test.go
@@ -1,0 +1,58 @@
+package resourcemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+)
+
+// TestAccProjectListResource_queryIdentity lists projects via the
+// provider list resource API and asserts a known identity appears in the query
+// results (Terraform 1.14+).
+func TestAccProjectListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Query:  true,
+				Config: testAccProjectListQuery(project),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_project.all_in_project", map[string]knownvalue.Check{
+						"project_id": knownvalue.StringExact(project),
+					}),
+					querycheck.ExpectLengthAtLeast("google_project.all_in_project", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectListQuery(project string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_project" "all_in_project" {
+  provider = google
+
+  config {
+    filter = "id:%s"
+  }
+}
+`, project)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -211,6 +211,12 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	d.SetId(fmt.Sprintf("projects/%s", pid))
 
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project_id": pid,
+	}); err != nil {
+		return err
+	}
+
 	// Wait for the operation to complete
 	opAsMap, err := tpgresource.ConvertToMap(op)
 	if err != nil {
@@ -520,6 +526,11 @@ func resourceGoogleProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.Partial(false)
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project_id": pid,
+	}); err != nil {
+		return err
+	}
 	return resourceGoogleProjectRead(d, meta)
 }
 
@@ -570,6 +581,25 @@ func resourceGoogleProjectDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceProjectImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// Handle identity-based import (Terraform 1.12+ import blocks with resource identity).
+	// In this case d.Id() is empty and project_id is available via the identity block.
+	if d.Id() == "" {
+		identity, err := d.Identity()
+		if err != nil || identity == nil {
+			return nil, fmt.Errorf("Error getting identity for import: %v", err)
+		}
+		pidVal, ok := identity.GetOk("project_id")
+		if !ok {
+			return nil, fmt.Errorf("project_id must be set in the identity block for import")
+		}
+		pid := pidVal.(string)
+		d.SetId(fmt.Sprintf("projects/%s", pid))
+		if err := d.Set("auto_create_network", true); err != nil {
+			return nil, fmt.Errorf("Error setting auto_create_network: %s", err)
+		}
+		return []*schema.ResourceData{d}, nil
+	}
+
 	parts := strings.Split(d.Id(), "/")
 	pid := parts[len(parts)-1]
 	// Prevent importing via project number, this will cause issues later

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -337,9 +337,9 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	// Explicitly set client-side fields to default values if unset
 
-	if err := populateGoogleProjectResourceData(d, p, pid, config); err != nil {                          
-      return err
-  	} 
+	if err := populateGoogleProjectResourceData(d, p, pid, config); err != nil {
+		return err
+	}
 
 	var ba *cloudbilling.ProjectBillingInfo
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{
@@ -416,8 +416,8 @@ func populateGoogleProjectResourceData(d *schema.ResourceData, p *cloudresourcem
 		}
 	}
 	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
-          "project_id": pid,                                                                            
-    })
+		"project_id": pid,
+	})
 }
 
 func PrefixedProject(pid string) string {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -54,6 +54,18 @@ func ResourceGoogleProject() *schema.Resource {
 			State: resourceProjectImportState,
 		},
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
@@ -325,6 +337,43 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	// Explicitly set client-side fields to default values if unset
 
+	if err := populateGoogleProjectResourceData(d, p, pid, config); err != nil {                          
+      return err
+  	} 
+
+	var ba *cloudbilling.ProjectBillingInfo
+	err = transport_tpg.Retry(transport_tpg.RetryOptions{
+		RetryFunc: func() (reqErr error) {
+			ba, reqErr = tpgcloudbilling.NewClient(config, userAgent).Projects.GetBillingInfo(PrefixedProject(pid)).Do()
+			return reqErr
+		},
+		Timeout: d.Timeout(schema.TimeoutRead),
+	})
+	// Read the billing account
+	if err != nil && !transport_tpg.IsApiNotEnabledError(err) {
+		return fmt.Errorf("Error reading billing account for project %q: %v", PrefixedProject(pid), err)
+	} else if transport_tpg.IsApiNotEnabledError(err) {
+		log.Printf("[WARN] Billing info API not enabled, please enable it to read billing info about project %q: %s", pid, err.Error())
+	} else if ba.BillingAccountName != "" {
+		// BillingAccountName is contains the resource name of the billing account
+		// associated with the project, if any. For example,
+		// `billingAccounts/012345-567890-ABCDEF`. We care about the ID and not
+		// the `billingAccounts/` prefix, so we need to remove that. If the
+		// prefix ever changes, we'll validate to make sure it's something we
+		// recognize.
+		_ba := strings.TrimPrefix(ba.BillingAccountName, "billingAccounts/")
+		if ba.BillingAccountName == _ba {
+			return fmt.Errorf("Error parsing billing account for project %q. Expected value to begin with 'billingAccounts/' but got %s", PrefixedProject(pid), ba.BillingAccountName)
+		}
+		if err := d.Set("billing_account", _ba); err != nil {
+			return fmt.Errorf("Error setting billing_account: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func populateGoogleProjectResourceData(d *schema.ResourceData, p *cloudresourcemanager.Project, pid string, config *transport_tpg.Config) error {
 	if err := tpgresource.DeletionPolicyReadDefault(d, config, "PREVENT"); err != nil {
 		return err
 	}
@@ -366,37 +415,9 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 	}
-
-	var ba *cloudbilling.ProjectBillingInfo
-	err = transport_tpg.Retry(transport_tpg.RetryOptions{
-		RetryFunc: func() (reqErr error) {
-			ba, reqErr = tpgcloudbilling.NewClient(config, userAgent).Projects.GetBillingInfo(PrefixedProject(pid)).Do()
-			return reqErr
-		},
-		Timeout: d.Timeout(schema.TimeoutRead),
-	})
-	// Read the billing account
-	if err != nil && !transport_tpg.IsApiNotEnabledError(err) {
-		return fmt.Errorf("Error reading billing account for project %q: %v", PrefixedProject(pid), err)
-	} else if transport_tpg.IsApiNotEnabledError(err) {
-		log.Printf("[WARN] Billing info API not enabled, please enable it to read billing info about project %q: %s", pid, err.Error())
-	} else if ba.BillingAccountName != "" {
-		// BillingAccountName is contains the resource name of the billing account
-		// associated with the project, if any. For example,
-		// `billingAccounts/012345-567890-ABCDEF`. We care about the ID and not
-		// the `billingAccounts/` prefix, so we need to remove that. If the
-		// prefix ever changes, we'll validate to make sure it's something we
-		// recognize.
-		_ba := strings.TrimPrefix(ba.BillingAccountName, "billingAccounts/")
-		if ba.BillingAccountName == _ba {
-			return fmt.Errorf("Error parsing billing account for project %q. Expected value to begin with 'billingAccounts/' but got %s", PrefixedProject(pid), ba.BillingAccountName)
-		}
-		if err := d.Set("billing_account", _ba); err != nil {
-			return fmt.Errorf("Error setting billing_account: %s", err)
-		}
-	}
-
-	return nil
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+          "project_id": pid,                                                                            
+    })
 }
 
 func PrefixedProject(pid string) string {

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project.go
@@ -399,6 +399,11 @@ func populateGoogleProjectResourceData(d *schema.ResourceData, p *cloudresourcem
 	if err := tpgresource.SetLabels(p.Labels, d, "terraform_labels"); err != nil {
 		return fmt.Errorf("Error setting terraform_labels: %s", err)
 	}
+	if v := d.Get("terraform_labels").(map[string]interface{}); len(v) == 0 && len(p.Labels) > 0 {
+		if err := d.Set("terraform_labels", p.Labels); err != nil {
+			return fmt.Errorf("Error setting terraform_labels: %s", err)
+		}
+	}
 	if err := d.Set("effective_labels", p.Labels); err != nil {
 		return fmt.Errorf("Error setting effective_labels: %s", err)
 	}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -70,10 +70,18 @@ func TestAccProject_importBlockWithResourceIdentity(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "google_project.acceptance",
-				ImportState:             true,
-				ImportStateKind:         resource.ImportBlockWithResourceIdentity,
-				ImportStateVerifyIgnore: []string{"deletion_policy", "terraform_labels"},
+				// The import step config must use deletion_policy = "PREVENT" because
+				// DeletionPolicyReadDefault sets that value during import (it is a
+				// client-side field not stored in the GCP API). Using a mismatching
+				// value would cause a non-empty plan and fail the no-op import check.
+				ResourceName:    "google_project.acceptance",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				Config:          testAccProject_noAllowDestroy(pid, org),
+			},
+			{
+				// Reset deletion_policy to "DELETE" so the project can be cleaned up.
+				Config: testAccProject(pid, org),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -70,9 +70,10 @@ func TestAccProject_importBlockWithResourceIdentity(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:    "google_project.acceptance",
-				ImportState:     true,
-				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+				ResourceName:            "google_project.acceptance",
+				ImportState:             true,
+				ImportStateKind:         resource.ImportBlockWithResourceIdentity,
+				ImportStateVerifyIgnore: []string{"deletion_policy", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/cloudbilling"
@@ -44,6 +45,36 @@ func TestAccProject_createWithoutOrg(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
+			},
+		},
+	})
+}
+
+// Test that a Project resource can be imported using an identity block (Terraform 1.12+).
+func TestAccProject_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	org := envvar.GetTestOrgFromEnv(t)
+	pid := fmt.Sprintf("%s-%d", TestPrefix, acctest.RandInt(t))
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProject(pid, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+			{
+				ResourceName:            "google_project.acceptance",
+				ImportState:             true,
+				ImportStateKind:         resource.ImportBlockWithResourceIdentity,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_policy"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_test.go
@@ -70,11 +70,9 @@ func TestAccProject_importBlockWithResourceIdentity(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "google_project.acceptance",
-				ImportState:             true,
-				ImportStateKind:         resource.ImportBlockWithResourceIdentity,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"deletion_policy"},
+				ResourceName:    "google_project.acceptance",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_project.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_project.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+  List Google Cloud projects for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_project (list)
+
+Lists Google Cloud **projects** for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_project`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_project" "all" {
+  provider = google
+
+  config {
+    # Optional. Filter using the Cloud Resource Manager filter syntax.
+    # filter = "labels.env:prod"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `filter` - (Optional) A filter string using [Cloud Resource Manager filter syntax](https://cloud.google.com/resource-manager/reference/rest/v1/projects/list#query-parameters)
+  to narrow results (for example `id:my-project` or `labels.env:prod`).
+
+## Results
+
+By default each result includes **resource identity** for `google_project` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity)):
+
+* `project_id` - The unique, user-assigned ID of the project.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_project` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project#attributes-reference)
+(for example `name`, `number`, `org_id`, `folder_id`, and `labels`).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds handwritten list-resource support for `google_project`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27991

Changes in this PR:
- add handwritten `google_storage_bucket` list resource

## Testing

```bash
make testacc TEST=./google/services/resourcemanager/ TESTARGS='-run=TestAccProjectListResource_queryIdentity$'
sh -c "'/Users/tavasya/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/resourcemanager/ -v -run=TestAccProjectListResource_queryIdentity -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccProjectListResource_queryIdentity
=== PAUSE TestAccProjectListResource_queryIdentity
=== CONT  TestAccProjectListResource_queryIdentity
--- PASS: TestAccProjectListResource_queryIdentity (1.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/resourcemanager	5.697s

```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-list-resource
'google_project'
```
