### PR TITLE
`bigquery`: add new `google_bigquery_dataset` list resource

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -43,6 +43,7 @@ custom_code:
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
 custom_diff:
   - 'customCollationDiff'
+generate_list_resource: true
 exclude_sweeper: true
 examples:
   - name: 'bigquery_dataset_basic'

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -1604,8 +1604,10 @@ if flattenedProp := flatten{{ if $.NestedQuery -}}Nested{{end}}{{ $.ResourceName
 {{- end}}
 {{- end}}
 {{if $.HasSelfLink -}}
-    if err = d.Set("self_link", tpgresource.ConvertSelfLinkToV1(res["selfLink"].(string))); err != nil {
-        return fmt.Errorf("Error reading {{ $.Name -}}: %s", err)
+    if selfLink, ok := res["selfLink"].(string); ok && selfLink != "" {
+        if err = d.Set("self_link", tpgresource.ConvertSelfLinkToV1(selfLink)); err != nil {
+            return fmt.Errorf("Error reading {{ $.Name -}}: %s", err)
+        }
     }
 {{- end }}
     return nil


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

When first running the test, we would receive a panic due to a interface conversion from nil -> string being attempted. This specific conversion was done on `selflink`. The field itself is found on all CRUD operations of `bigquery_dataset`, however when looking at the LIST method for the resource it's found that the `selflink` field is [not provided within the response of the LIST method](https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list) which cites the reason for the panic. To mitigate this i've added a nil-safe guard with `.HasSelfLink` to perform nil check prior to performing the string conversion. This results in the following passing test:

```hcl
󰀵 mau  …/magic-modules   list-resource-bigquery-dataset $!   12:42    cd /Users/mau/Dev/terraform-provider-google && envchain GCLOUD make testacc TEST=./google/services/bigquery TESTARGS='-run=TestAccBigQueryDatasetListQuery_generated'
sh -c "'/Users/mau/Dev/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/bigquery -v -run=TestAccBigQueryDatasetListQuery_generated -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccBigQueryDatasetListQuery_generated
=== PAUSE TestAccBigQueryDatasetListQuery_generated
=== CONT  TestAccBigQueryDatasetListQuery_generated
--- PASS: TestAccBigQueryDatasetListQuery_generated (49.20s)
PASS
ok      **github.com/hashicorp/terraform-provider-google/google/services/bigquery50.560s**
```

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-list-resource
`google_bigquery_dataset`
```
