### PR TITLE
remove extra characters at end of google_folder_iam_member list docs file name

### DIFF
--- a/mmv1/third_party/terraform/website/docs/list-resources/google_folder_iam_member.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_folder_iam_member.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+  List IAM member bindings for a Google Cloud folder for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_folder_iam_member (list)
+
+Lists IAM **member bindings** for a Google Cloud folder for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_folder_iam_member`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_folder_iam)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_folder_iam_member" "all" {
+  provider = google
+
+  config {
+    folder = "folders/123456789"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `folder` - (Required) Folder ID to list IAM member from.
+  For example, `folders/123456789`
+
+* `role` - (Optional) If set, only bindings with this exact role are returned.
+  For example, `roles/editor`. If unset, bindings for all roles are returned.
+
+* `member` - (Optional) If set, only bindings where this principle is a member
+  are returned. For example, `user:jane@example.com`. If unset, bindings for 
+  all roles are returned.
+
+
+## Results
+
+By default each result includes **resource identity** for `google_folder_iam_member` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `folder` - Folder ID the binding belongs to.
+* `role` - The Iam role, e.g. `roles/editor`.
+* `member` The principal, e.g. `user:jane@example.com`.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_folder_iam_member` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_folder_iam#attributes-reference)
+(for example `etag`and `condition` where present in state).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

should resolve the following CI error we get in our [PR cloud builds](https://console.cloud.google.com/cloud-build/builds/42615ce1-4c5a-4d32-bb04-9a749e034789?project=graphite-docker-images):
```hcl
Step #12 - "tpgb-base": fatal: pathspec 'website/docs/list-resources/google_folder_iam_member.html.markdown\342\200\216' did not match any files
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
