### PR TITLE
Add list resource to `compute_instance`

### DIFF
--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package compute
 
 import (
@@ -96,7 +93,7 @@ func (listR *GoogleComputeInstanceListResource) List(ctx context.Context, listRe
 	}
 }
 
-func flattenComputeInstanceListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+func flattenComputeInstanceListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config, project string) error {
 	var instance compute.Instance
 	if err := tpgresource.Convert(res, &instance); err != nil {
 		return fmt.Errorf("error converting compute instance list response: %w", err)
@@ -105,7 +102,6 @@ func flattenComputeInstanceListItem(res map[string]interface{}, d *schema.Resour
 		return fmt.Errorf("missing name in compute instance list response")
 	}
 
-	project := d.Get("project").(string)
 	zone := tpgresource.GetResourceNameFromSelfLink(instance.Zone)
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))
@@ -150,8 +146,10 @@ func ListComputeInstances(config *transport_tpg.Config, project, zone string, ca
 		ListURL:        url,
 		BillingProject: billingProject,
 		UserAgent:      userAgent,
-		ItemName:       "items",
-		Flattener:      flattenComputeInstanceListItem,
-		Callback:       callback,
+		ItemName: "items",
+		Flattener: func(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+			return flattenComputeInstanceListItem(res, d, config, project)
+		},
+		Callback: callback,
 	})
 }

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
@@ -1,6 +1,3 @@
-// Copyright (c) IBM Corp. 2014, 2026
-// SPDX-License-Identifier: MPL-2.0
-
 package compute
 
 import (
@@ -70,11 +67,8 @@ func (listR *GoogleComputeInstanceListResource) List(ctx context.Context, listRe
 		return
 	}
 
-	project := listR.GetProject(data.Project)
-	zone := listR.GetZone(data.Zone)
-
 	stream.Results = func(push func(list.ListResult) bool) {
-		err := ListComputeInstances(listR.Client, project, zone, func(rd *schema.ResourceData) error {
+		err := ListComputeInstances(listR.Client, listR.GetProject(data.Project), listR.GetZone(data.Zone), func(rd *schema.ResourceData) error {
 			result := listReq.NewListResult(ctx)
 			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
 				return err
@@ -149,7 +143,6 @@ func ListComputeInstances(config *transport_tpg.Config, project, zone string, ca
 		ListURL:        url,
 		BillingProject: billingProject,
 		UserAgent:      userAgent,
-		ItemName: "items",
 		Flattener: func(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
 			return flattenComputeInstanceListItem(res, d, config, project)
 		},

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
@@ -1,0 +1,157 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package compute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+{{ if eq $.TargetVersionName `ga` }}
+	"google.golang.org/api/compute/v1"
+{{- else }}
+	compute "google.golang.org/api/compute/v0.beta"
+{{- end }}
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_compute_instance",
+		ProductName: "compute",
+		Func:        NewGoogleComputeInstanceListResource,
+	}.Register()
+}
+
+type GoogleComputeInstanceListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleComputeInstanceListModel struct {
+	Project types.String `tfsdk:"project"`
+	Zone    types.String `tfsdk:"zone"`
+}
+
+func NewGoogleComputeInstanceListResource() list.ListResource {
+	listR := &GoogleComputeInstanceListResource{}
+	listR.TypeName = "google_compute_instance"
+	listR.SDKv2Resource = ResourceComputeInstance()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "zone", Kind: tpgresource.ListConfigKindString, Optional: true},
+	}
+	return listR
+}
+
+func (listR *GoogleComputeInstanceListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	errStreamClosed := errors.New("stream closed")
+
+	var data GoogleComputeInstanceListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	project := listR.GetProject(data.Project)
+	zone := listR.GetZone(data.Zone)
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListComputeInstances(listR.Client, project, zone, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
+				return err
+			}
+			if !push(result) {
+				return errStreamClosed
+			}
+			return nil
+		})
+		if err != nil {
+			if errors.Is(err, errStreamClosed) {
+				return
+			}
+			diags.AddError("API Error", err.Error())
+			result := listReq.NewListResult(ctx)
+			result.Diagnostics = diags
+			push(result)
+		}
+	}
+}
+
+func flattenComputeInstanceListItem(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+	var instance compute.Instance
+	if err := tpgresource.Convert(res, &instance); err != nil {
+		return fmt.Errorf("error converting compute instance list response: %w", err)
+	}
+	if instance.Name == "" {
+		return fmt.Errorf("missing name in compute instance list response")
+	}
+
+	project := d.Get("project").(string)
+	zone := tpgresource.GetResourceNameFromSelfLink(instance.Zone)
+
+	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, zone, instance.Name))
+	return populateComputeInstanceResourceData(d, &instance, project, zone, config)
+}
+
+func ListComputeInstances(config *transport_tpg.Config, project, zone string, callback func(rd *schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	d := ResourceComputeInstance().Data(&terraform.InstanceState{})
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+	if zone != "" {
+		if err := d.Set("zone", zone); err != nil {
+			return fmt.Errorf("error setting zone on temporary resource data: %w", err)
+		}
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ComputeBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instances")
+	if err != nil {
+		return err
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	billingProject := ""
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:         config,
+		TempData:       d,
+		Resource:       ResourceComputeInstance(),
+		ListURL:        url,
+		BillingProject: billingProject,
+		UserAgent:      userAgent,
+		ItemName:       "items",
+		Flattener:      flattenComputeInstanceListItem,
+		Callback:       callback,
+	})
+}

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance.go.tmpl
@@ -1,3 +1,6 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
 package compute
 
 import (

--- a/mmv1/third_party/terraform/services/compute/list_google_compute_instance_test.go
+++ b/mmv1/third_party/terraform/services/compute/list_google_compute_instance_test.go
@@ -1,0 +1,90 @@
+package compute_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccComputeInstanceListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	zone := envvar.GetTestZoneFromEnv()
+	name := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceListBasic(zone, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_compute_instance.test", "name", name),
+					resource.TestCheckResourceAttr("google_compute_instance.test", "zone", zone),
+					resource.TestCheckResourceAttr("google_compute_instance.test", "project", project),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccComputeInstanceListQuery(project, zone),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_compute_instance.all_in_zone", map[string]knownvalue.Check{
+						"name":    knownvalue.StringExact(name),
+						"zone":    knownvalue.StringExact(zone),
+						"project": knownvalue.StringExact(project),
+					}),
+					querycheck.ExpectLengthAtLeast("google_compute_instance.all_in_zone", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccComputeInstanceListBasic(zone, name string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance" "test" {
+  name         = %q
+  zone         = %q
+  machine_type = "e2-micro"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {}
+  }
+}
+`, name, zone)
+}
+
+func testAccComputeInstanceListQuery(project, zone string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_compute_instance" "all_in_zone" {
+  provider = google
+
+  config {
+    project = %q
+    zone    = %q
+  }
+}
+`, project, zone)
+}

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_compute_instance.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Compute Engine"
+description: |-
+  List Google Compute Engine VM instances in a project and zone for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_compute_instance (list)
+
+Lists Google Compute Engine **VM instances** in a project and zone for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_compute_instance`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_compute_instance" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "my-project"
+
+    # Optional. Defaults to the provider zone when omitted.
+    # zone = "us-central1-a"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID to list VM instances from. If unset, the provider's configured
+  default project is used, matching the managed resource behavior.
+
+* `zone` - (Optional) Zone to list VM instances from. If unset, the provider's configured
+  default zone is used, matching the managed resource behavior.
+
+## Results
+
+By default each result includes **resource identity** for `google_compute_instance` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity)):
+
+* `name` - Instance name.
+* `project` - Project ID.
+* `zone` - Zone.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_compute_instance` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attributes-reference).


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This adds handwritten list-resource support for `google_compute_instance`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27996

Changes in this PR:
- add handwritten `google_compute_instance` list resource

## Testing

```bash
make testacc TEST=./google/services/compute/ TESTARGS='-run=TestAccComputeInstanceListResource_queryIdentity$'
sh -c "'/Users/tavasya/go/src/github.com/hashicorp/terraform-provider-google/scripts/gofmtcheck.sh'"
==> Checking that code complies with gofmt requirements...
go vet
TF_ACC_REFRESH_AFTER_APPLY=1 TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google/services/compute/ -v -run=TestAccComputeInstanceListResource_queryIdentity -timeout 240m -ldflags="-X=github.com/hashicorp/terraform-provider-google/version.ProviderVersion=acc"
=== RUN   TestAccComputeInstanceListResource_queryIdentity
=== PAUSE TestAccComputeInstanceListResource_queryIdentity
=== CONT  TestAccComputeInstanceListResource_queryIdentity
--- PASS: TestAccComputeInstanceListResource_queryIdentity (46.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-google/google/services/compute	47.591s

```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-list-resource
'google_compute_instance'
```
