### PR TITLE
Promote agent_sandbox_config to GA

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -103,8 +103,8 @@ var (
 		"addons_config.0.slice_controller_config",
 		"addons_config.0.pod_snapshot_config",
 		"addons_config.0.slurm_operator_config",
-	{{- if ne $.TargetVersionName "ga" }}
 		"addons_config.0.agent_sandbox_config",
+	{{- if ne $.TargetVersionName "ga" }}
 		"addons_config.0.istio_config",
 		"addons_config.0.kalm_config",
 	{{- end }}
@@ -702,7 +702,6 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-						{{- if ne $.TargetVersionName "ga" }}
 						"agent_sandbox_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -720,7 +719,6 @@ func ResourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-						{{- end }}
 					},
 				},
 			},
@@ -6050,7 +6048,6 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := config["agent_sandbox_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.AgentSandboxConfig = &container.AgentSandboxConfig{
@@ -6058,7 +6055,6 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 			ForceSendFields: []string{"Enabled"},
 		}
 	}
-{{- end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 	if v, ok := config["istio_config"]; ok && len(v.([]interface{})) > 0 {
@@ -7814,7 +7810,6 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		}
 	}
 
-{{ if ne $.TargetVersionName `ga` -}}
 	if c.AgentSandboxConfig != nil {
 		result["agent_sandbox_config"] = []map[string]interface{}{
 			{
@@ -7822,7 +7817,6 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 			},
 		}
 	}
-{{- end }}
 
 {{ if ne $.TargetVersionName `ga` -}}
 	if c.IstioConfig != nil {
@@ -9335,7 +9329,6 @@ func clusterAcceleratorNetworkProfileCustomizeDiff(_ context.Context, diff *sche
 	return nil
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func expandAgentSandboxConfig(v interface{}) *container.AgentSandboxConfig {
     l := v.([]interface{})
     if len(l) == 0 || l[0] == nil {
@@ -9357,7 +9350,6 @@ func flattenAgentSandboxConfig(v *container.AgentSandboxConfig) []interface{} {
         },
     }
 }
-{{- end }}
 
 func init() {
 	registry.Schema{

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -13,9 +13,7 @@ cai_asset_name_formats:
   - {{"//container.googleapis.com/projects/{{project}}/locations/{{location}}/clusters/{{name}}"}}
   - {{"//container.googleapis.com/projects/{{project}}/zones/{{location}}/clusters/{{name}}"}}
 fields:
-{{- if ne $.TargetVersionName "ga" }}
   - api_field: 'addonsConfig.agentSandboxConfig.enabled'
-{{- end }}
   - field: 'addons_config.cloudrun_config.disabled'
     api_field: 'addonsConfig.cloudRunConfig.disabled'
   - field: 'addons_config.cloudrun_config.load_balancer_type'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -291,7 +291,6 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 	})
 }
 
-{{ if ne $.TargetVersionName `ga` -}}
 func TestAccContainerCluster_agentSandbox(t *testing.T) {
 	t.Parallel()
 
@@ -351,7 +350,6 @@ resource "google_container_cluster" "primary" {
 }
 `, clusterName, networkName, subnetworkName, enabled)
 }
-{{- end }}
 
 func TestAccContainerCluster_withDeletionProtection(t *testing.T) {
 	t.Parallel()

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -480,7 +480,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
     It is enabled by default;
     set `disabled = true` to disable.
 
-* `agent_sandbox_config` - (Optional, Beta) Configuration for the Agent Sandbox addon. Structure is documented below:
+* `agent_sandbox_config` - (Optional) Configuration for the Agent Sandbox addon. Structure is documented below:
     * `enabled` - (Required) Whether the Agent Sandbox addon is enabled.
 
 * `http_load_balancing` - (Optional) The status of the HTTP (L7) load balancing


### PR DESCRIPTION
This PR promotes the `agent_sandbox_config` addon under `addons_config` in the `google_container_cluster` resource to General Availability (GA). 

Previously, support for this field was added under a target version restriction that limited it to non-GA (Beta) versions. By removing the `{{- if ne $.TargetVersionName "ga" }}` guards, this configuration becomes available in both the GA and Beta downstream providers.

#### Changes:
1. **Schema & Code Generators**:
   - In `mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl`:
     - Promoted `"addons_config.0.agent_sandbox_config"` inside `addonsConfigKeys` by removing the non-GA target version guard.
     - Removed the non-GA restriction `{{- if ne $.TargetVersionName "ga" }}` around `"agent_sandbox_config"` schema field definition, its expander, and flattener functions.
2. **CAI Asset Fields**:
   - In `mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl`:
     - Removed target version checks around `addonsConfig.agentSandboxConfig.enabled` api field.
3. **Acceptance Tests**:
   - In `mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl`:
     - Promoted the `TestAccContainerCluster_agentSandbox` E2E acceptance test to GA by removing the non-GA check.
4. **Documentation**:
   - In `mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown`:
     - Changed the field description for `agent_sandbox_config` to remove the `Beta` marker, labeling it as `Optional` instead of `Optional, Beta`.

#### References:
- Fixes/References: **[b/512603653](https://b.corp.google.com/issues/512603653)**
- Previous PR: **#17592**

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: promoted `agent_sandbox_config` addon field under `addons_config` in `google_container_cluster` to GA
```