### PR TITLE
appengine: Add app_engine_bundled_services and make fields immutable

### DIFF
--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -74,6 +74,15 @@ samples:
           org_id: ORG_ID
         ignore_read_extra:
           - delete_service_on_destroy
+  - name: app_engine_standard_app_version_bundled_services
+    primary_resource_id: gae-std-app-ver-bundled
+    steps:
+      - name: app_engine_standard_app_version_bundled_services
+        resource_id_vars:
+          project_id: tf-test-project
+          service_id: bundled-service
+          bucket_name: tf-test-gae-bkt-bundled
+          sa_email: gae-sa
 virtual_fields:
   - name: noop_on_destroy
     description: |
@@ -125,6 +134,10 @@ properties:
     type: Boolean
     description: |
       Allows App Engine second generation runtimes to access the legacy bundled services.
+      Cannot specify both `app_engine_apis` and 'app_engine_bundled_services` together.
+    immutable: true
+    conflicts:
+      - app_engine_bundled_services
   - name: runtimeApiVersion
     type: String
     description: |
@@ -443,3 +456,27 @@ properties:
           **Note:** When managing the number of instances at runtime through the App Engine Admin API or the (now deprecated) Python 2
           Modules API set_num_instances() you must use `lifecycle.ignore_changes = ["manual_scaling"[0].instances]` to prevent drift detection.
         required: true
+  - name: 'appEngineBundledServices'
+    type: Array
+    description: |
+     A list of legacy bundled services to enable for this version on an App Engine second-generation runtime.
+     Cannot specify both `app_engine_apis` and 'app_engine_bundled_services` together.
+    is_set: true
+    immutable: true
+    item_type:
+      type: Enum
+      enum_values:
+        - 'BUNDLED_SERVICE_TYPE_APP_IDENTITY_SERVICE'
+        - 'BUNDLED_SERVICE_TYPE_BLOBSTORE'
+        - 'BUNDLED_SERVICE_TYPE_CAPABILITY_SERVICE'
+        - 'BUNDLED_SERVICE_TYPE_DATASTORE_V3'
+        - 'BUNDLED_SERVICE_TYPE_IMAGES'
+        - 'BUNDLED_SERVICE_TYPE_MAIL'
+        - 'BUNDLED_SERVICE_TYPE_MEMCACHE'
+        - 'BUNDLED_SERVICE_TYPE_MODULES'
+        - 'BUNDLED_SERVICE_TYPE_SEARCH'
+        - 'BUNDLED_SERVICE_TYPE_TASKQUEUES'
+        - 'BUNDLED_SERVICE_TYPE_URLFETCH'
+        - 'BUNDLED_SERVICE_TYPE_USERS'
+    conflicts:
+      - app_engine_apis

--- a/mmv1/products/appengine/StandardAppVersion.yaml
+++ b/mmv1/products/appengine/StandardAppVersion.yaml
@@ -83,6 +83,8 @@ samples:
           service_id: bundled-service
           bucket_name: tf-test-gae-bkt-bundled
           sa_email: gae-sa
+        ignore_read_extra:
+          - delete_service_on_destroy
 virtual_fields:
   - name: noop_on_destroy
     description: |
@@ -458,11 +460,16 @@ properties:
         required: true
   - name: 'appEngineBundledServices'
     type: Array
+    # Developer Note: This field is write-only because the App Engine GET Admin API
+    # does not return it in the response (we use ignore_read: true to prevent state drift to null).
+    # It is marked is_set: true to represent the list as a set in Terraform so configuration
+    # ordering differences do not trigger spurious plans.
     description: |
-     A list of legacy bundled services to enable for this version on an App Engine second-generation runtime.
-     Cannot specify both `app_engine_apis` and 'app_engine_bundled_services` together.
+      A list of legacy bundled services to enable for this version on an App Engine second-generation runtime.
+      Cannot specify both `app_engine_apis` and `app_engine_bundled_services` together.
     is_set: true
     immutable: true
+    ignore_read: true
     item_type:
       type: Enum
       enum_values:

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
@@ -90,3 +90,4 @@ resource "google_storage_bucket_object" "object" {
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world.zip"
 }
+

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version.tf.tmpl
@@ -90,4 +90,3 @@ resource "google_storage_bucket_object" "object" {
   bucket = google_storage_bucket.bucket.name
   source = "./test-fixtures/hello-world.zip"
 }
-

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_bundled_services.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_bundled_services.tf.tmpl
@@ -55,6 +55,7 @@ resource "google_app_engine_standard_app_version" "{{$.PrimaryResourceId}}" {
 # Testing the app_engine_bundled_services field
   app_engine_bundled_services = ["BUNDLED_SERVICE_TYPE_MAIL", "BUNDLED_SERVICE_TYPE_DATASTORE_V3"]
 
+  delete_service_on_destroy = true
   service_account = google_service_account.service_account.email
 
   depends_on = [

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_bundled_services.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_standard_app_version_bundled_services.tf.tmpl
@@ -1,0 +1,64 @@
+resource "google_service_account" "service_account" {
+  account_id   = "{{index $.ResourceIdVars "sa_email"}}"
+  display_name = "Test Service Account for GAE"
+}
+
+resource "google_project_iam_member" "gae_api" {
+  project = google_service_account.service_account.project
+  role    = "roles/compute.networkUser"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_project_iam_member" "storage_viewer" {
+  project = google_service_account.service_account.project
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.service_account.email}"
+}
+
+resource "google_storage_bucket" "bucket" {
+  name     = "{{index $.ResourceIdVars "bucket_name"}}"
+  location = "US"
+}
+
+resource "google_storage_bucket_object" "requirements" {
+  name   = "requirements.txt"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/requirements.txt"
+}
+
+resource "google_storage_bucket_object" "main" {
+  name   = "main.py"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/main.py"
+}
+
+resource "google_app_engine_standard_app_version" "{{$.PrimaryResourceId}}" {
+  version_id   = "v1"
+  service      = "{{index $.ResourceIdVars "service_id"}}"
+  runtime      = "python310"
+
+  deployment {
+    files {
+      name       = "main.py"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.main.name}"
+    }
+    files {
+      name       = "requirements.txt"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.requirements.name}"
+    }
+  }
+
+  entrypoint {
+    shell = "gunicorn -b :$PORT main:app"
+  }
+
+# Testing the app_engine_bundled_services field
+  app_engine_bundled_services = ["BUNDLED_SERVICE_TYPE_MAIL", "BUNDLED_SERVICE_TYPE_DATASTORE_V3"]
+
+  service_account = google_service_account.service_account.email
+
+  depends_on = [
+    google_project_iam_member.gae_api,
+    google_project_iam_member.storage_viewer,
+  ]
+}

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
@@ -348,3 +348,179 @@ resource "google_storage_bucket_object" "main" {
   source = "./test-fixtures/hello-world-flask/main.py"
 }`, context)
 }
+
+func TestAccAppEngineStandardAppVersion_updateBundledServices(t *testing.T) {
+	t.Skip("https://github.com/hashicorp/terraform-provider-google/issues/18936")
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":          envvar.GetTestOrgFromEnv(t),
+		"billing_account": envvar.GetTestBillingAccountFromEnv(t),
+		"random_suffix":   acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"time": {},
+		},
+		CheckDestroy: testAccCheckAppEngineStandardAppVersionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppEngineStandardAppVersion_bundledServices(context),
+			},
+			{
+				ResourceName:            "google_app_engine_standard_app_version.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"env_variables", "deployment", "entrypoint", "service", "noop_on_destroy"},
+			},
+			{
+				Config: testAccAppEngineStandardAppVersion_bundledServicesUpdate(context),
+			},
+			{
+				ResourceName:            "google_app_engine_standard_app_version.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"env_variables", "deployment", "entrypoint", "service", "noop_on_destroy"},
+			},
+		},
+	})
+}
+
+func testAccAppEngineStandardAppVersion_bundledServices(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "my_project" {
+  name = "tf-test-appeng-std%{random_suffix}"
+  project_id = "tf-test-appeng-std%{random_suffix}"
+  org_id = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
+resource "google_project_service" "project" {
+  project = google_project.my_project.project_id
+  service = "appengine.googleapis.com"
+  disable_dependent_services = false
+}
+
+resource "google_app_engine_standard_app_version" "foo" {
+  project    = google_project_service.project.project
+  version_id = "v1"
+  service    = "default"
+  runtime    = "python310"
+
+  app_engine_bundled_services = ["BUNDLED_SERVICE_TYPE_MAIL", "BUNDLED_SERVICE_TYPE_USERS"]
+
+  entrypoint {
+    shell = "gunicorn -b :$PORT main:app"
+  }
+
+  deployment {
+    files {
+      name = "main.py"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.main.name}"
+    }
+    files {
+      name = "requirements.txt"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.requirements.name}"
+    }
+  }
+
+  instance_class = "F2"
+  noop_on_destroy = true
+}
+
+resource "google_storage_bucket" "bucket" {
+  project  = google_project.my_project.project_id
+  name     = "tf-test-%{random_suffix}-standard-ae-bucket"
+  location = "US"
+}
+
+resource "google_storage_bucket_object" "requirements" {
+  name   = "requirements.txt"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/requirements.txt"
+}
+
+resource "google_storage_bucket_object" "main" {
+  name   = "main.py"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/main.py"
+}
+`, context)
+}
+
+func testAccAppEngineStandardAppVersion_bundledServicesUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_project" "my_project" {
+  name = "tf-test-appeng-std%{random_suffix}"
+  project_id = "tf-test-appeng-std%{random_suffix}"
+  org_id = "%{org_id}"
+  billing_account = "%{billing_account}"
+  deletion_policy = "DELETE"
+}
+
+resource "google_app_engine_application" "app" {
+  project     = google_project.my_project.project_id
+  location_id = "us-central"
+}
+
+resource "google_project_service" "project" {
+  project = google_project.my_project.project_id
+  service = "appengine.googleapis.com"
+  disable_dependent_services = false
+}
+
+resource "google_app_engine_standard_app_version" "foo" {
+  project    = google_project_service.project.project
+  version_id = "v1"
+  service    = "default"
+  runtime    = "python310"
+
+  app_engine_bundled_services = ["mail", "user"]
+
+  entrypoint {
+    shell = "gunicorn -b :$PORT main:app"
+  }
+
+  deployment {
+    files {
+      name = "main.py"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.main.name}"
+    }
+    files {
+      name = "requirements.txt"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.requirements.name}"
+    }
+  }
+
+  instance_class = "F2"
+  noop_on_destroy = true
+}
+
+resource "google_storage_bucket" "bucket" {
+  project  = google_project.my_project.project_id
+  name     = "tf-test-%{random_suffix}-standard-ae-bucket"
+  location = "US"
+}
+
+resource "google_storage_bucket_object" "requirements" {
+  name   = "requirements.txt"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/requirements.txt"
+}
+
+resource "google_storage_bucket_object" "main" {
+  name   = "main.py"
+  bucket = google_storage_bucket.bucket.name
+  source = "./test-fixtures/hello-world-flask/main.py"
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
+++ b/mmv1/third_party/terraform/services/appengine/resource_app_engine_standard_app_version_test.go
@@ -6,10 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/appengine"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/storage"
-	_ "github.com/hashicorp/terraform-provider-google/google/services/vpcaccess"
 )
 
 func TestAccAppEngineStandardAppVersion_update(t *testing.T) {
@@ -87,7 +83,7 @@ resource "google_app_engine_standard_app_version" "foo" {
   project    = google_project_service.project.project
   version_id = "v1"
   service    = "default"
-  runtime    = "python38"
+  runtime    = "python310"
 
   entrypoint {
     shell = "gunicorn -b :$PORT main:app"
@@ -204,7 +200,7 @@ resource "google_app_engine_standard_app_version" "foo" {
   project    = google_project_service.project.project
   version_id = "v1"
   service    = "default"
-  runtime    = "python38"
+  runtime    = "python310"
 
   vpc_access_connector {
     name           = "${google_vpc_access_connector.bar.id}"
@@ -297,7 +293,7 @@ resource "google_app_engine_standard_app_version" "foo" {
   project    = google_project_service.project.project
   version_id = "v1"
   service    = "default"
-  runtime    = "python38"
+  runtime    = "python310"
 
   entrypoint {
     shell = "gunicorn -b :$PORT main:app"


### PR DESCRIPTION
⚠️ **Note to Reviewers:** Please hold the merge of this PR until internal launch turbo/800262 is approved and the field is publically available.

Add `app_engine_bundled_services` in `google_app_engine_standard_app_version`.

### Changes
* Promotes `app_engine_bundled_services` to GA (added enums, conflicts, and description mappings).
* Marks both `app_engine_apis` and `app_engine_bundled_services` as `immutable: true` (`ForceNew: true` in the generated schema) to match GAE Version API immutability constraints.
* Adds a new acceptance test case verification step.

```release-note:enhancement
appengine: added `app_engine_bundled_services` field to `google_app_engine_standard_app_version` resource
```