### PR TITLE
Fix google_compute_project_metadata_item panic on empty metadata (b/4…

### DIFF
--- a/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/metadata.go.tmpl
@@ -75,7 +75,14 @@ func flattenMetadataBeta(metadata *compute.Metadata) map[string]string {
 		return metadataMap
 	}
 	for _, item := range metadata.Items {
-		metadataMap[item.Key] = *item.Value
+		if item == nil {
+			continue
+		}
+		if item.Value == nil {
+			metadataMap[item.Key] = ""
+		} else {
+			metadataMap[item.Key] = *item.Value
+		}
 	}
 	return metadataMap
 }
@@ -90,7 +97,14 @@ func FlattenMetadata(metadata *compute.Metadata) map[string]interface{} {
 		return metadataMap
 	}
 	for _, item := range metadata.Items {
-		metadataMap[item.Key] = *item.Value
+		if item == nil {
+			continue
+		}
+		if item.Value == nil {
+			metadataMap[item.Key] = ""
+		} else {
+			metadataMap[item.Key] = *item.Value
+		}
 	}
 	return metadataMap
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/
If your PR is still work in progress, please create it in draft mode.
Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->
This PR fixes a nil pointer dereference (panic) in `google_compute_project_metadata` and `google_compute_project_metadata_item` when GCE project metadata contains keys with empty/nil values. 
We added null-checks to the `FlattenMetadata` and `flattenMetadataBeta` helper functions inside the compute services metadata templates to ensure that nil items or nil value pointers are safely caught and represented as empty strings (`""`) rather than triggering a crash.

Fixes: b/423360651

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: Fixed a panic in `google_compute_project_metadata` and `google_compute_project_metadata_item` when project common instance metadata items contain null/empty values.
```
