### PR TITLE
Promote IAP Agent, MCP Server and Endpoint resources to GA

### DIFF
--- a/mmv1/products/agentregistry/Binding.yaml
+++ b/mmv1/products/agentregistry/Binding.yaml
@@ -37,7 +37,7 @@ async:
 examples:
   - name: agent_registry_binding_basic
     primary_resource_id: default
-    skip_func: acctest.SkipTestUntil(t, "2026-09-30")
+    skip_func: acctest.SkipTestUntil(t, "2026-09-30") # Wait for google_iam_connectors_connector to graduate from tpg-nightly
     vars:
       binding: ar-binding
     test_env_vars:

--- a/mmv1/products/agentregistry/Binding.yaml
+++ b/mmv1/products/agentregistry/Binding.yaml
@@ -1,0 +1,122 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Binding
+base_url: projects/{{project}}/locations/{{location}}/bindings
+self_link: projects/{{project}}/locations/{{location}}/bindings/{{binding_id}}
+create_url: projects/{{project}}/locations/{{location}}/bindings?bindingId={{binding_id}}
+update_verb: PATCH
+update_mask: true
+description: |
+  Represents a user-defined Binding.
+id_format: projects/{{project}}/locations/{{location}}/bindings/{{binding_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/bindings/{{binding_id}}
+autogen_async: true
+async:
+  type: OpAsync
+  actions:
+    - create
+    - delete
+    - update
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+examples:
+  - name: agent_registry_binding_basic
+    primary_resource_id: default
+    skip_func: acctest.SkipTestUntil(t, "2026-09-30")
+    vars:
+      binding: ar-binding
+    test_env_vars:
+      project: PROJECT_NAME
+parameters:
+  - name: location
+    type: String
+    description: |
+      The location of the resource.
+    required: true
+    url_param_only: true
+  - name: bindingId
+    type: String
+    description: |
+      The name of the Binding.
+    required: true
+    url_param_only: true
+properties:
+  - name: displayName
+    type: String
+    description: |
+      User-defined display name for the Binding.
+  - name: description
+    type: String
+    description: |
+      The description of the Binding.
+  - name: source
+    type: NestedObject
+    required: true
+    description: |
+      The source of the Binding.
+    properties:
+      - name: identifier
+        type: String
+        required: true
+        description: |
+          The identifier of the source Agent. Format: `urn:agent:{publisher}:{namespace}:{name}`
+  - name: target
+    type: NestedObject
+    required: true
+    description: |
+      The target of the Binding.
+    properties:
+      - name: identifier
+        type: String
+        required: true
+        description: |
+          The identifier of the target Agent, MCP Server, or Endpoint. Format:
+          * `urn:agent:{publisher}:{namespace}:{name}`
+          * `urn:mcp:{publisher}:{namespace}:{name}`
+          * `urn:endpoint:{publisher}:{namespace}:{name}`
+  - name: authProviderBinding
+    type: NestedObject
+    required: true
+    description: |
+      The auth provider of the Binding.
+    properties:
+      - name: authProvider
+        type: String
+        required: true
+        description: |
+          The resource name of the target auth provider.
+      - name: scopes
+        type: Array
+        description: |
+          The list of OAuth2 scopes of the auth provider.
+        item_type:
+          type: String
+      - name: continueUri
+        type: String
+        description: |
+          The continue URI of the auth provider.
+  - name: createTime
+    type: Time
+    description: |
+      The timestamp when the resource was created.
+    output: true
+  - name: updateTime
+    type: Time
+    description: |
+      The timestamp when the resource was updated.
+    output: true

--- a/mmv1/products/agentregistry/Service.yaml
+++ b/mmv1/products/agentregistry/Service.yaml
@@ -1,0 +1,173 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: Service
+base_url: projects/{{project}}/locations/{{location}}/services
+self_link: projects/{{project}}/locations/{{location}}/services/{{service_id}}
+create_url: projects/{{project}}/locations/{{location}}/services?serviceId={{service_id}}
+update_verb: PATCH
+update_mask: true
+description: |
+  Service manages a service in a management boundary
+id_format: projects/{{project}}/locations/{{location}}/services/{{service_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/services/{{service_id}}
+autogen_async: true
+async:
+  type: OpAsync
+  actions:
+    - create
+    - delete
+    - update
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+examples:
+  - name: agent_registry_service_basic
+    primary_resource_id: default
+    vars:
+      service: service
+  - name: agent_registry_service_mcp_server
+    primary_resource_id: default
+    vars:
+      service: service
+parameters:
+  - name: location
+    type: String
+    description: |
+      The location of the resource.
+    required: true
+    url_param_only: true
+  - name: serviceId
+    type: String
+    description: |
+      The name of the Service.
+    required: true
+    url_param_only: true
+properties:
+  - name: displayName
+    type: String
+    description: |
+      User-defined display name for the Service. Can have a maximum length of 63 characters.
+  - name: description
+    type: String
+    description: |
+      The description of the Service.
+  - name: interfaces
+    type: Array
+    description: |
+      The connection details for the Service.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: url
+          type: String
+          required: true
+          description: |
+            The destination URL.
+        - name: protocolBinding
+          type: Enum
+          required: true
+          enum_values:
+            - JSONRPC
+            - GRPC
+            - HTTP_JSON
+          description: |
+            The protocol binding of the interface.
+  - name: agentSpec
+    type: NestedObject
+    exactly_one_of:
+      - agent_spec
+      - mcp_server_spec
+      - endpoint_spec
+    description: |
+      The spec of the Agent. When set, the type of the Service is Agent.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        enum_values:
+          - NO_SPEC
+          - A2A_AGENT_CARD
+        description: |
+          The type of the Agent spec content.
+      - name: content
+        type: String
+        state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+          return s }
+        custom_expand: templates/terraform/custom_expand/json_schema.tmpl
+        custom_flatten: templates/terraform/custom_flatten/json_schema.tmpl
+        validation:
+          function: validation.StringIsJSON
+        description: |
+          The content of the Agent spec in the JSON format. This payload is validated against the schema for the specified type.
+  - name: mcpServerSpec
+    type: NestedObject
+    exactly_one_of:
+      - agent_spec
+      - mcp_server_spec
+      - endpoint_spec
+    description: |
+      The spec of the MCP Server. When set, the type of the Service is MCP Server.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        enum_values:
+          - NO_SPEC
+          - TOOL_SPEC
+        description: |
+          The type of the MCP Server spec content.
+      - name: content
+        type: String
+        state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v);
+          return s }
+        custom_expand: templates/terraform/custom_expand/json_schema.tmpl
+        custom_flatten: templates/terraform/custom_flatten/json_schema.tmpl
+        validation:
+          function: validation.StringIsJSON
+        description: |
+          The content of the MCP Server spec. This payload is validated against the schema for the specified type.
+  - name: endpointSpec
+    type: NestedObject
+    exactly_one_of:
+      - agent_spec
+      - mcp_server_spec
+      - endpoint_spec
+    description: |
+      The spec of the Endpoint. When set, the type of the Service is Endpoint.
+    properties:
+      - name: type
+        type: Enum
+        required: true
+        enum_values:
+          - NO_SPEC
+        description: |
+          The type of the Endpoint spec content.
+  - name: registryResource
+    type: String
+    description: |
+      The resource name of the resulting Agent, MCP Server, or Endpoint.
+    output: true
+  - name: createTime
+    type: Time
+    description: |
+      The timestamp when the resource was created.
+    output: true
+  - name: updateTime
+    type: Time
+    description: |
+      The timestamp when the resource was updated.
+    output: true

--- a/mmv1/products/agentregistry/product.yaml
+++ b/mmv1/products/agentregistry/product.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AgentRegistry
+display_name: Agent Registry
+versions:
+  - name: ga
+    base_url: https://agentregistry.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform

--- a/mmv1/products/iap/AgentRegistryAgent.yaml
+++ b/mmv1/products/iap/AgentRegistryAgent.yaml
@@ -1,0 +1,52 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: AgentRegistryAgent
+description: |
+  Only used to generate IAM resources
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+  - '{{agent_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: data.google_agent_registry_agent
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: agent_id
+  iam_conditions_request_type: REQUEST_BODY
+exclude_tgc: true
+examples:
+  - name: agent_registry_agent_basic
+    primary_resource_id: default
+    vars:
+      agent_id: agent-id
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: The location of the resource.
+properties:
+  - name: agent_id
+    type: String
+    required: true
+    description: The id of the agent.

--- a/mmv1/products/iap/AgentRegistryEndpoint.yaml
+++ b/mmv1/products/iap/AgentRegistryEndpoint.yaml
@@ -1,0 +1,53 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: AgentRegistryEndpoint
+description: |
+  Only used to generate IAM resources
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: data.google_agent_registry_endpoint
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: endpoint_id
+  iam_conditions_request_type: REQUEST_BODY
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+  - '{{endpoint_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+exclude_tgc: true
+examples:
+  - name: agent_registry_endpoint_basic
+    primary_resource_id: default
+    vars:
+      endpoint_id: endpoint-id
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: The location of the resource.
+properties:
+  - name: endpoint_id
+    type: String
+    required: true
+    description: The id of the Endpoint.

--- a/mmv1/products/iap/AgentRegistryMcpServer.yaml
+++ b/mmv1/products/iap/AgentRegistryMcpServer.yaml
@@ -1,0 +1,53 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: AgentRegistryMcpServer
+description: |
+  Only used to generate IAM resources
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+docs:
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+  - '{{mcp_server_id}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: data.google_agent_registry_mcp_server
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: mcp_server_id
+  iam_conditions_request_type: REQUEST_BODY
+exclude_tgc: true
+examples:
+  - name: agent_registry_mcp_server_basic
+    primary_resource_id: default
+    vars:
+      mcp_server_id: mcp-server-id
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: The location of the resource.
+properties:
+  - name: mcp_server_id
+    type: String
+    required: true
+    description: The id of the MCP Server.

--- a/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
@@ -1,0 +1,4 @@
+data "google_agent_registry_agent" "default" {
+  location = "us-central1"
+  filter = "displayName:Workspace Agent"
+}

--- a/mmv1/templates/terraform/examples/agent_registry_binding_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_binding_basic.tf.tmpl
@@ -1,0 +1,36 @@
+resource "google_agent_registry_binding" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  binding_id   = "{{index $.Vars "binding"}}"
+  display_name = "My Binding"
+  description  = "My GA agent registry binding"
+
+  source {
+    identifier = data.google_agent_registry_agent.default.urn
+  }
+
+  target {
+    identifier = data.google_agent_registry_agent.default.urn
+  }
+
+  auth_provider_binding {
+    auth_provider = google_iam_connectors_connector.default.id
+    scopes        = ["https://www.googleapis.com/auth/cloud-platform"]
+    continue_uri  = "https://example.com/continue"
+  }
+
+  depends_on = [google_iam_connectors_connector.default]
+}
+
+data "google_agent_registry_agent" "default" {
+  location = "global"
+  filter   = "displayName:Workspace Agent"
+}
+
+resource "google_iam_connectors_connector" "default" {
+  location       = "us-central1"
+  connector_id   = "{{index $.Vars "binding"}}"
+
+  connector_type_params {
+    connector_version = "projects/{{index $.TestEnvVars "project"}}/locations/global/providers/gcp/connectors/pubsub/versions/1"
+  }
+}

--- a/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
@@ -1,0 +1,4 @@
+data "google_agent_registry_endpoint" "default" {
+  location = "us-central1"
+  endpoint_id = "agentregistry-00000000-0000-0000-64c7-1e6dd8448684"
+}

--- a/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
@@ -1,0 +1,4 @@
+data "google_agent_registry_mcp_server" "default" {
+  location = "us-central1"
+  filter = "displayName:Best_AI_Agent"
+}

--- a/mmv1/templates/terraform/examples/agent_registry_service_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_service_basic.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_agent_registry_service" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  service_id   = "{{index $.Vars "service"}}"
+  description  = "My basic agent registry service"
+  display_name = "My Service"
+
+  interfaces {
+    url              = "https://www.google.com/{{index $.Vars "service"}}"
+    protocol_binding = "GRPC"
+  }
+
+  agent_spec {
+    type = "NO_SPEC"
+  }
+}

--- a/mmv1/templates/terraform/examples/agent_registry_service_mcp_server.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_service_mcp_server.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_agent_registry_service" "{{$.PrimaryResourceId}}" {
+  location     = "us-central1"
+  service_id   = "{{index $.Vars "service"}}"
+  description  = "My MCP agent registry service"
+  display_name = "My Service"
+
+  interfaces {
+    url              = "https://example.com"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type    = "TOOL_SPEC"
+    content = "{\"tools\":[]}"
+  }
+}

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -31,6 +31,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google-beta/services/activedirectory"
     ),
+    "agentregistry" to mapOf(
+        "name" to "agentregistry",
+        "displayName" to "Agent Registry",
+        "path" to "./google-beta/services/agentregistry"
+    ),
     "alloydb" to mapOf(
         "name" to "alloydb",
         "displayName" to "Alloydb",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -31,6 +31,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google/services/activedirectory"
     ),
+    "agentregistry" to mapOf(
+        "name" to "agentregistry",
+        "displayName" to "Agent Registry",
+        "path" to "./google/services/agentregistry"
+    ),
     "alloydb" to mapOf(
         "name" to "alloydb",
         "displayName" to "Alloydb",

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent.go
@@ -1,0 +1,396 @@
+package agentregistry
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceAgentRegistryAgent() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAgentRegistryAgentRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The location of the resource.`,
+			},
+			"agent_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filter"},
+				Description:   `The unique identifier for the Agent.`,
+			},
+			"filter": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"agent_id"},
+				Description:   `A filter string that identifies a unique Agent.`,
+			},
+			"protocols": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The connection details for the Agent.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type of the protocol.",
+						},
+						"protocol_version": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The version of the protocol, for example, the A2A Agent Card version.",
+						},
+						"interfaces": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: `The connection details for the Agent.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"url": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The destination URL.`,
+									},
+									"protocol_binding": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The protocol binding of the interface.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the Agent.`,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Obtained from the A2A Agent Card. The display name of the Agent.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Obtained from the A2A Agent Card. The description of the Agent.`,
+			},
+			"version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Obtained from the A2A Agent Card. Contains the version of the Agent.`,
+			},
+			"framework": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The OSS agent framework used to develop the agent. Currently supported values: "google-adk", "langchain", "langgraph", "ag2", "llama-index", "custom".`,
+			},
+			"skills": {
+				Type:        schema.TypeList, // Object
+				Computed:    true,
+				Description: `Obtained from the A2A Agent Card. Skills represent the ability of an agent. It is largely a descriptive concept but represents a more focused set of behaviors that the agent is likely to succeed at.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A unique identifier for the agent's skill.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A human readable name for the agent's skill.",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "A more detailed description of the skill.",
+						},
+						"tags": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "A set of keywords describing the skills.  Example:  [[\"cooking\", \"customer support\", \"billing\"]]",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"examples": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "Example prompts or scenarios that this skill can handle. Provides a hint to the client on how to use the skill. Example: [[\"I need a recipe for bread\"]]",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"attributes": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `Attributes of the Agent.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Create time.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Update time.`,
+			},
+		},
+	}
+}
+
+func dataSourceAgentRegistryAgentRead(d *schema.ResourceData, meta any) error {
+	config := (meta.(*transport_tpg.Config))
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("fetching project for Agent: %v", err)
+	}
+
+	// A non-nil billing_project indicates no error, and should be used.
+	billingProject, _ := tpgresource.GetBillingProject(d, config)
+
+	var res map[string]interface{}
+	var id string
+	if _, ok := d.GetOk("agent_id"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/agents/{{agent_id}}")
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/agents/{{agent_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry Agent %q", d.Get("agent_id")), id)
+		}
+	} else if filter, ok := d.GetOk("filter"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/agents")
+		if err != nil {
+			return err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
+		if err != nil {
+			return err
+		}
+
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry Agent w/ filter %q", filter), id)
+		}
+
+		lResp, _ := resp["agents"].([]interface{})
+
+		if len(lResp) != 1 {
+			location := d.Get("location")
+			if len(lResp) == 0 {
+				return fmt.Errorf("did not find an Agent in projects/%v/locations/%v matching filter %v", project, location, filter)
+			} else {
+				return fmt.Errorf("found %v Agent in projects/%v/locations/%v matching filter %v. Must match exactly 1", len(lResp), project, location, filter)
+			}
+		}
+
+		res = lResp[0].(map[string]interface{})
+
+		err = d.Set("agent_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string)))
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/agents/{{agent_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+	} else {
+		return fmt.Errorf("one of agent_id or filter must be set")
+	}
+
+	err = d.Set("urn", res["agentId"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("display_name", res["displayName"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("description", res["description"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("version", res["version"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("framework", res["framework"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("protocols", flattenAgentRegistryAgentProtocols(res["protocols"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("skills", flattenAgentRegistryAgentSkills(res["skills"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("attributes", flattenAgentRegistryAgentAttributes(res["attributes"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("create_time", res["createTime"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("update_time", res["updateTime"])
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+
+	return nil
+}
+
+func flattenAgentRegistryAgentProtocols(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"type":             rawMap["type"],
+			"protocol_version": rawMap["protocolVersion"],
+			"interfaces":       flattenAgentRegistryAgentProtocolsInterfaces(rawMap["interfaces"], d, config),
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryAgentProtocolsInterfaces(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"url":              rawMap["url"],
+			"protocol_binding": rawMap["protocolBinding"],
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryAgentSkills(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"id":          rawMap["id"],
+			"name":        rawMap["name"],
+			"description": rawMap["description"],
+			"tags":        rawMap["tags"],
+			"examples":    rawMap["examples"],
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryAgentAttributes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	m := v.(map[string]interface{})
+	transformed := map[string]string{}
+	for k, v := range m {
+		j, _ := json.Marshal(v)
+		transformed[k] = string(j)
+	}
+
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_agent_registry_agent",
+		ProductName: "agentregistry",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceAgentRegistryAgent(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent_test.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent_test.go
@@ -1,0 +1,92 @@
+package agentregistry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourceAgentRegistryAgent_basic(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	displayName := "tf-test-agent-" + randomSuffix
+	context := map[string]interface{}{
+		"service":       "tf-test-service-" + randomSuffix,
+		"display_name":  displayName,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAgentRegistryAgent_serviceOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccDataSourceAgentRegistryAgent_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_agent.default", "create_time"),
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_agent.default", "update_time"),
+					resource.TestCheckResourceAttr("data.google_agent_registry_agent.default", "display_name", displayName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAgentRegistryAgent_serviceOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/%{service}"
+    protocol_binding = "GRPC"
+  }
+
+  agent_spec {
+    type = "NO_SPEC"
+  }
+}
+`, context)
+}
+
+func testAccDataSourceAgentRegistryAgent_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/%{service}"
+    protocol_binding = "GRPC"
+  }
+
+  agent_spec {
+    type = "NO_SPEC"
+  }
+}
+
+data "google_agent_registry_agent" "default" {
+  location = "us-central1"
+  filter   = "displayName=\"%{display_name}\""
+
+  depends_on = [google_agent_registry_service.default]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint.go
@@ -1,0 +1,273 @@
+package agentregistry
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceAgentRegistryEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAgentRegistryEndpointRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The location of the resource.`,
+			},
+			"endpoint_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filter"},
+				Description:   `The unique identifier for the Endpoint.`,
+			},
+			"filter": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"endpoint_id"},
+				Description:   `A filter string that identifies a unique endpoint.`,
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the Endpoint.`,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The display name of the endpoint.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the endpoint.`,
+			},
+			"interfaces": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The connection details for the Endpoint.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The destination URL.`,
+						},
+						"protocol_binding": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The protocol binding of the interface.`,
+						},
+					},
+				},
+			},
+			"attributes": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `Attributes of the Endpoint.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Create time.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Update time.`,
+			},
+		},
+	}
+}
+
+func dataSourceAgentRegistryEndpointRead(d *schema.ResourceData, meta any) error {
+	config := (meta.(*transport_tpg.Config))
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("fetching project for Endpoint: %v", err)
+	}
+
+	// A non-nil billing_project indicates no error, and should be used.
+	billingProject, _ := tpgresource.GetBillingProject(d, config)
+
+	var res map[string]interface{}
+	var id string
+	if _, ok := d.GetOk("endpoint_id"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/endpoints/{{endpoint_id}}")
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/endpoints/{{endpoint_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry Endpoint %q", d.Get("endpoint_id")), id)
+		}
+	} else if filter, ok := d.GetOk("filter"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/endpoints")
+		if err != nil {
+			return err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
+		if err != nil {
+			return err
+		}
+
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry Endpoint w/ filter %q", filter), id)
+		}
+
+		lResp, _ := resp["endpoints"].([]interface{})
+
+		if len(lResp) != 1 {
+			location := d.Get("location")
+			if len(lResp) == 0 {
+				return fmt.Errorf("did not find an Endpoint in projects/%v/locations/%v matching filter %v", project, location, filter)
+			} else {
+				return fmt.Errorf("found %v Endpoint in projects/%v/locations/%v matching filter %v. Must match exactly 1", len(lResp), project, location, filter)
+			}
+		}
+
+		res = lResp[0].(map[string]interface{})
+
+		err = d.Set("endpoint_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string)))
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/endpoints/{{endpoint_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+	} else {
+		return fmt.Errorf("one of endpoint_id or filter must be set")
+	}
+
+	err = d.Set("urn", res["endpointId"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("display_name", res["displayName"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("description", res["description"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("interfaces", flattenAgentRegistryEndpointInterfaces(res["interfaces"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("attributes", flattenAgentRegistryEndpointAttributes(res["attributes"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("create_time", res["createTime"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("update_time", res["updateTime"])
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+
+	return nil
+}
+
+func flattenAgentRegistryEndpointInterfaces(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"url":              rawMap["url"],
+			"protocol_binding": rawMap["protocolBinding"],
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryEndpointAttributes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	m := v.(map[string]interface{})
+	transformed := map[string]string{}
+	for k, v := range m {
+		j, _ := json.Marshal(v)
+		transformed[k] = string(j)
+	}
+
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_agent_registry_endpoint",
+		ProductName: "agentregistry",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceAgentRegistryEndpoint(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint_test.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint_test.go
@@ -1,0 +1,92 @@
+package agentregistry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourceAgentRegistryEndpoint_basic(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	displayName := "tf-test-endpoint-" + randomSuffix
+	context := map[string]interface{}{
+		"service":       "tf-test-service-" + randomSuffix,
+		"display_name":  displayName,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAgentRegistryEndpoint_serviceOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccDataSourceAgentRegistryEndpoint_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_endpoint.default", "create_time"),
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_endpoint.default", "update_time"),
+					resource.TestCheckResourceAttr("data.google_agent_registry_endpoint.default", "display_name", displayName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAgentRegistryEndpoint_serviceOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/%{service}"
+    protocol_binding = "GRPC"
+  }
+
+  endpoint_spec {
+    type = "NO_SPEC"
+  }
+}
+`, context)
+}
+
+func testAccDataSourceAgentRegistryEndpoint_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/%{service}"
+    protocol_binding = "GRPC"
+  }
+
+  endpoint_spec {
+    type = "NO_SPEC"
+  }
+}
+
+data "google_agent_registry_endpoint" "default" {
+  location = "us-central1"
+  filter   = "displayName=\"%{display_name}\""
+
+  depends_on = [google_agent_registry_service.default]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server.go
@@ -1,0 +1,371 @@
+package agentregistry
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceAgentRegistryMcpServer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAgentRegistryMcpServerRead,
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"location": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `The location of the resource.`,
+			},
+			"mcp_server_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"filter"},
+				Description:   `The unique identifier for the MCP server.`,
+			},
+			"filter": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"mcp_server_id"},
+				Description:   `A filter string that identifies a unique MCP server.`,
+			},
+			"urn": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The URN of the MCP Server.`,
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The display name of the MCP Server.`,
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The description of the MCP Server.`,
+			},
+			"interfaces": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: `The connection details for the MCP Server.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"url": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The destination URL.`,
+						},
+						"protocol_binding": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `The protocol binding of the interface.`,
+						},
+					},
+				},
+			},
+			"tools": {
+				Type:        schema.TypeList, // Object
+				Computed:    true,
+				Description: `A list of tools available with the MCP Server.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The name of the tool",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The description of the tool",
+						},
+						"annotations": {
+							Type:        schema.TypeList, // Object
+							Computed:    true,
+							Description: "Additional tool information.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"title": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "A human-readable title for the tool",
+									},
+									"destructive_hint": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "If true, the tool may perform destructive updates to its environment. If false, the tool performs only additive updates.",
+									},
+									"idempotent_hint": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "If true, calling the tool repeatedly with the same arguments will have no additional effect on the its environment",
+									},
+									"open_world_hint": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "If true, this tool may interact with an “open world” of external entities. If false, the tool’s domain of interaction is closed. For example, the world of a web search tool is open, whereas that of a memory tool is not",
+									},
+									"read_only_hint": {
+										Type:        schema.TypeBool,
+										Computed:    true,
+										Description: "If true, the tool does not modify its environment.",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"attributes": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `Attributes of the MCP Server.`,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Create time.`,
+			},
+			"update_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `Update time.`,
+			},
+		},
+	}
+}
+
+func dataSourceAgentRegistryMcpServerRead(d *schema.ResourceData, meta any) error {
+	config := (meta.(*transport_tpg.Config))
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("fetching project for MCP Server: %v", err)
+	}
+
+	// A non-nil billing_project indicates no error, and should be used.
+	billingProject, _ := tpgresource.GetBillingProject(d, config)
+
+	var res map[string]interface{}
+	var id string
+	if _, ok := d.GetOk("mcp_server_id"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/mcpServers/{{mcp_server_id}}")
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/mcpServers/{{mcp_server_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+
+		res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry MCP Server %q", d.Get("mcp_server_id")), id)
+		}
+	} else if filter, ok := d.GetOk("filter"); ok {
+		url, err := tpgresource.ReplaceVars(d, config, "{{AgentRegistryBasePath}}projects/{{project}}/locations/{{location}}/mcpServers")
+		if err != nil {
+			return err
+		}
+
+		url, err = transport_tpg.AddQueryParams(url, map[string]string{"filter": filter.(string)})
+		if err != nil {
+			return err
+		}
+
+		resp, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   cmp.Or(billingProject, project),
+			RawURL:    url,
+			UserAgent: userAgent,
+			Timeout:   d.Timeout(schema.TimeoutRead),
+			Headers:   http.Header{},
+		})
+		if err != nil {
+			return transport_tpg.HandleDataSourceNotFoundError(err, d, fmt.Sprintf("AgentRegistry MCP Server w/ filter %q", filter), id)
+		}
+
+		lResp, _ := resp["mcpServers"].([]interface{})
+
+		if len(lResp) != 1 {
+			location := d.Get("location")
+			if len(lResp) == 0 {
+				return fmt.Errorf("did not find an MCP Server in projects/%v/locations/%v matching filter %v", project, location, filter)
+			} else {
+				return fmt.Errorf("found %v MCP servers in projects/%v/locations/%v matching filter %v. Must match exactly 1", len(lResp), project, location, filter)
+			}
+		}
+
+		res = lResp[0].(map[string]interface{})
+
+		err = d.Set("mcp_server_id", tpgresource.GetResourceNameFromSelfLink(res["name"].(string)))
+		if err != nil {
+			return err
+		}
+
+		id, err = tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/mcpServers/{{mcp_server_id}}")
+		if err != nil {
+			return fmt.Errorf("constructing id: %v", err)
+		}
+	} else {
+		return fmt.Errorf("one of mcp_server_id or filter must be set")
+	}
+
+	err = d.Set("urn", res["mcpServerId"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("display_name", res["displayName"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("description", res["description"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("interfaces", flattenAgentRegistryMcpServerInterfaces(res["interfaces"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("tools", flattenAgentRegistryMcpServerTools(res["tools"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("attributes", flattenAgentRegistryMcpServerAttributes(res["attributes"], d, config))
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("create_time", res["createTime"])
+	if err != nil {
+		return err
+	}
+
+	err = d.Set("update_time", res["updateTime"])
+	if err != nil {
+		return err
+	}
+
+	d.SetId(id)
+
+	return nil
+}
+
+func flattenAgentRegistryMcpServerInterfaces(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"url":              rawMap["url"],
+			"protocol_binding": rawMap["protocolBinding"],
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryMcpServerTools(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0, len(l))
+	for _, raw := range l {
+		rawMap := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"name":        rawMap["name"],
+			"description": rawMap["description"],
+			"annotations": flattenAgentRegistryMcpServerToolsAnnotations(rawMap["annotations"], d, config),
+		})
+	}
+
+	return transformed
+}
+
+func flattenAgentRegistryMcpServerToolsAnnotations(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+
+	transformed := map[string]interface{}{
+		"title":            original["title"],
+		"destructive_hint": original["destructiveHint"],
+		"idempotent_hint":  original["idempotentHint"],
+		"open_world_hint":  original["openWorldHint"],
+		"read_only_hint":   original["readOnlyHint"],
+	}
+
+	return []interface{}{transformed}
+}
+
+func flattenAgentRegistryMcpServerAttributes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+
+	m := v.(map[string]interface{})
+	transformed := map[string]string{}
+	for k, v := range m {
+		j, _ := json.Marshal(v)
+		transformed[k] = string(j)
+	}
+
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_agent_registry_mcp_server",
+		ProductName: "agentregistry",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceAgentRegistryMcpServer(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server_test.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server_test.go
@@ -1,0 +1,92 @@
+package agentregistry_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccDataSourceAgentRegistryMcpServer_basic(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	displayName := "tf-test-mcp-server-" + randomSuffix
+	context := map[string]interface{}{
+		"service":       "tf-test-service-" + randomSuffix,
+		"display_name":  displayName,
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAgentRegistryMcpServer_serviceOnly(context),
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						time.Sleep(10 * time.Second)
+						return nil
+					},
+				),
+			},
+			{
+				Config: testAccDataSourceAgentRegistryMcpServer_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_mcp_server.default", "create_time"),
+					resource.TestCheckResourceAttrSet("data.google_agent_registry_mcp_server.default", "update_time"),
+					resource.TestCheckResourceAttr("data.google_agent_registry_mcp_server.default", "display_name", displayName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAgentRegistryMcpServer_serviceOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/api/%{service}"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type = "NO_SPEC"
+  }
+}
+`, context)
+}
+
+func testAccDataSourceAgentRegistryMcpServer_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "%{display_name}"
+  interfaces {
+    url = "https://www.google.com/api/%{service}"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type = "NO_SPEC"
+  }
+}
+
+data "google_agent_registry_mcp_server" "default" {
+  location = "us-central1"
+  filter   = "displayName=\"%{display_name}\""
+
+  depends_on = [google_agent_registry_service.default]
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/agentregistry/resource_agent_registry_service_test.go
+++ b/mmv1/third_party/terraform/services/agentregistry/resource_agent_registry_service_test.go
@@ -37,7 +37,7 @@ func TestAccAgentRegistryService_update(t *testing.T) {
 	randomSuffix := acctest.RandString(t, 10)
 	context := map[string]interface{}{
 		"random_suffix": randomSuffix,
-		"service":       "service" + randomSuffix,
+		"service":       "tf-test-service-" + randomSuffix,
 	}
 
 	acctest.VcrTest(t, resource.TestCase{

--- a/mmv1/third_party/terraform/services/agentregistry/resource_agent_registry_service_test.go
+++ b/mmv1/third_party/terraform/services/agentregistry/resource_agent_registry_service_test.go
@@ -1,0 +1,102 @@
+package agentregistry_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+	"google.golang.org/api/googleapi"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	_ = fmt.Sprintf
+	_ = log.Print
+	_ = strconv.Atoi
+	_ = strings.Trim
+	_ = time.Now
+	_ = resource.TestMain
+	_ = terraform.NewState
+	_ = envvar.TestEnvVar
+	_ = tpgresource.SetLabels
+	_ = transport_tpg.Config{}
+	_ = googleapi.Error{}
+)
+
+func TestAccAgentRegistryService_update(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+	context := map[string]interface{}{
+		"random_suffix": randomSuffix,
+		"service":       "service" + randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentRegistryServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentRegistryService_update(context),
+			},
+			{
+				ResourceName:            "google_agent_registry_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "service_id"},
+			},
+			{
+				Config: testAccAgentRegistryService_agentRegistryServiceBasicExample(context),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_agent_registry_service.default", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				ResourceName:            "google_agent_registry_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "service_id"},
+			},
+			{
+				Config: testAccAgentRegistryService_update(context),
+			},
+			{
+				ResourceName:            "google_agent_registry_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "service_id"},
+			},
+		},
+	})
+}
+
+func testAccAgentRegistryService_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "%{service}"
+
+  display_name = "My Updated Service"
+
+  interfaces {
+    url = "https://www.google.com/api/%{random_suffix}"
+    protocol_binding = "GRPC"
+  }
+
+  agent_spec {
+    type = "NO_SPEC"
+  }
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/agent_registry_agent.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/agent_registry_agent.html.markdown
@@ -1,0 +1,56 @@
+---
+subcategory: "Agent Registry"
+description: |-
+  Get information about an Agent Registry Agent
+---
+
+# google_agent_registry_agent
+
+Get information about an Agent Registry Agent.
+
+## Example Usage
+
+```hcl
+data "google_agent_registry_agent" "default" {
+  location = "us-central1"
+  agent_id = "apphub-00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the resource.
+
+- - -
+
+* `agent_id` - (Optional) The unique identifier for the Agent. This or `filter` must be set.
+
+* `filter` - (Optional) A filter string that identifies a unique Agent. This or `agent_id` must be set.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+* `urn` - The URN of the Agent.
+* `protocols` - The connection details for the Agent.
+* `protocols.0.type` - The type of the protocol.
+* `protocols.0.protocol_version` - The version of the protocol, for example, the A2A Agent Card version.
+* `protocols.0.interfaces` - The connection details for the Agent.
+* `protocols.0.interfaces.0.url` - The destination URL.
+* `protocols.0.interfaces.0.protocol_binding` - The protocol binding of the interface.
+* `display_name` - Obtained from the A2A Agent Card. The display name of the Agent.
+* `description` - Obtained from the A2A Agent Card. The description of the Agent.
+* `version` - Obtained from the A2A Agent Card. Contains the version of the Agent.
+* `framework` - The OSS Agent framework used to develop the Agent. Currently supported values: "google-adk", "langchain", "langgraph", "ag2", "llama-index", "custom".
+* `skills` - Obtained from the A2A Agent Card. Skills represent the ability of an Agent. It is largely a descriptive concept but represents a more focused set of behaviors that the Agent is likely to succeed at.
+* `skills.0.id` - A unique identifier for the Agent's skill.
+* `skills.0.name` - A human readable name for the Agent's skill.
+* `skills.0.description` - A more detailed description of the skill.
+* `skills.0.tags` - A set of keywords describing the skills.  Example:  [["cooking", "customer support", "billing"]]
+* `skills.0.examples` - Example prompts or scenarios that this skill can handle. Provides a hint to the client on how to use the skill. Example: [["I need a recipe for bread"]]
+* `attributes` - Attributes of the Agent.
+* `create_time` - Create time.
+* `update_time` - Update time.

--- a/mmv1/third_party/terraform/website/docs/d/agent_registry_endpoint.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/agent_registry_endpoint.html.markdown
@@ -1,0 +1,45 @@
+---
+subcategory: "Agent Registry"
+description: |-
+  Get information about an Agent Registry Endpoint
+---
+
+# google_agent_registry_endpoint
+
+Get information about an Agent Registry Endpoint.
+
+## Example Usage
+
+```hcl
+data "google_agent_registry_endpoint" "default" {
+  location = "us-central1"
+  endpoint_id = "apphub-00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the resource.
+
+- - -
+
+* `endpoint_id` - (Optional) The unique identifier for the Endpoint. This or `filter` must be set.
+
+* `filter` - (Optional) A filter string that identifies a unique Endpoint. This or `endpoint_id` must be set.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+* `urn` - The URN of the Endpoint.
+* `display_name` - The display name of the Endpoint.
+* `description` - The description of the Endpoint.
+* `interfaces` - The connection details for the Endpoint.
+* `interfaces.0.url` - The destination URL.
+* `interfaces.0.protocol_binding` - The protocol binding of the interface.
+* `attributes` - Attributes of the Endpoint.
+* `create_time` - Create time.
+* `update_time` - Update time.

--- a/mmv1/third_party/terraform/website/docs/d/agent_registry_mcp_server.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/agent_registry_mcp_server.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Agent Registry"
+description: |-
+  Get information about an Agent Registry MCP Server
+---
+
+# google_agent_registry_mcp_server
+
+Get information about an Agent Registry MCP Server.
+
+## Example Usage
+
+```hcl
+data "google_agent_registry_mcp_server" "default" {
+  location      = "us-central1"
+  mcp_server_id = "apphub-00000000-0000-0000-0000-000000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the resource.
+
+- - -
+
+* `mcp_server_id` - (Optional) The unique identifier for the MCP Server. This or `filter` must be set.
+
+* `filter` - (Optional) A filter string that identifies a unique MCP server. This or `mcp_server_id` must be set.
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+* `urn` - The URN of the MCP Server.
+* `display_name` - The display name of the MCP Server.
+* `description` - The description of the MCP Server.
+* `interfaces` - The connection details for the MCP Server.
+* `interfaces.0.url` - The destination URL.
+* `interfaces.0.protocol_binding` - The protocol binding of the interface.
+* `tools` - A list of tools available with the MCP Server.
+* `tools.0.name` - The name of the tool.
+* `tools.0.description` - The description of the tool.
+* `tools.0.annotations` - Additional tool information.
+* `tools.0.annotations.title` - A human-readable title for the tool.
+* `tools.0.annotations.destructive_hint` - If true, the tool may perform destructive updates to its environment. If false, the tool performs only additive updates.
+* `tools.0.annotations.idempotent_hint` - If true, calling the tool repeatedly with the same arguments will have no additional effect on the its environment.
+* `tools.0.annotations.open_world_hint` - If true, this tool may interact with an “open world” of external entities. If false, the tool’s domain of interaction is closed. For example, the world of a web search tool is open, whereas that of a memory tool is not
+* `tools.0.annotations.read_only_hint` - If true, the tool does not modify its environment.
+* `attributes` - Attributes of the Agent.
+* `create_time` - Create time.
+* `update_time` - Update time.


### PR DESCRIPTION
Promote IAP Agent Registry resources to GA

Key Modifications:
* **Promote IAP resources**: Introduce IAP Agent, MCP Server, and Endpoint resources to the GA provider.
* **Add example templates**: Add terraform example templates to fetch the parent agent registry data sources.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_iap_agent_registry_agent_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_policy` 
```

```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_policy` 
```

```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_policy` 
```
