### PR TITLE
feat(compute): Add instance group manager bulk per instance config re…

### DIFF
--- a/mmv1/products/compute/BulkPerInstanceConfig.yaml
+++ b/mmv1/products/compute/BulkPerInstanceConfig.yaml
@@ -1,0 +1,92 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: 'BulkPerInstanceConfig'
+api_resource_type_kind: InstanceGroupManager
+api_variant_patterns:
+  - 'projects/{project}/zones/{zone}/instanceGroupManagers/{instanceGroupManager}'
+description: |
+  A config defined for multiple managed instances that belong to an instance group manager with target_size_policy.mode=BULK.
+references:
+  guides:
+    'Official Documentation': 'https://cloud.google.com/compute/docs/instance-groups/bulk-create-instances-in-mig'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers'
+docs:
+base_url: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}'
+id_format: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}'
+import_format:
+  - 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}'
+self_link: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/listManagedInstances'
+create_url: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/createInstances'
+read_verb: 'POST'
+delete_url: 'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/deleteInstances'
+delete_verb: 'POST'
+mutex: 'instanceGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}'
+immutable: true
+timeouts:
+  insert_minutes: 20
+  delete_minutes: 20
+async:
+  actions: ['create', 'delete']
+  type: 'OpAsync'
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: false
+custom_code:
+  decoder: 'templates/terraform/decoders/compute_bulk_per_instance_config.go.tmpl'
+  custom_delete: 'templates/terraform/custom_delete/compute_bulk_per_instance_config.go.tmpl'
+examples:
+  - name: 'compute_bulk_per_instance_config'
+    primary_resource_id: 'bulk-igm-per-instance-config'
+    vars:
+      template_name: 'bulk-igm-template'
+      igm_name: 'bulk-igm'
+parameters:
+  - name: 'zone'
+    type: ResourceRef
+    description: |
+      Zone where the containing instance group manager is located
+    url_param_only: true
+    required: false
+    immutable: true
+    default_from_api: true
+    custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
+    resource: 'Zone'
+    imports: 'name'
+  - name: 'instanceGroupManager'
+    type: ResourceRef
+    description: |
+      The instance group manager this instance config is part of.
+    url_param_only: true
+    required: true
+    immutable: true
+    resource: 'InstanceGroupManager'
+    imports: 'name'
+properties:
+  - name: 'instances'
+    type: Array
+    is_set: true
+    description: |
+      The list of per-instance configs.
+    immutable: true
+    item_type:
+      type: NestedObject
+      #The properties of the object can be extended in the future.
+      properties:
+        - name: 'name'
+          type: String
+          description: |
+            The name for this per-instance config and its corresponding instance.
+          required: true
+          immutable: true

--- a/mmv1/templates/terraform/custom_delete/compute_bulk_per_instance_config.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/compute_bulk_per_instance_config.go.tmpl
@@ -1,0 +1,113 @@
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+  return err
+}
+
+zone, err := tpgresource.GetZone(d, config)
+if err != nil {
+	return fmt.Errorf("Error fetching zone for BulkPerInstanceConfig: %s", err)
+}
+
+var instanceUrls []string
+var instanceNames []string
+if v, ok := d.GetOk("instances"); ok {
+	// Cast directly to []interface{} since it is defined as an Array (TypeList)
+	if lst, isList := v.([]interface{}); isList {
+		for _, raw := range lst {
+			if instance, isMap := raw.(map[string]interface{}); isMap {
+				// Safely assert the name as a string
+				if name, isString := instance["name"].(string); isString {
+					instanceNames = append(instanceNames, name)
+					// Construct the instance URL required by the DeleteInstances API
+          instanceUrls = append(instanceUrls, fmt.Sprintf("zones/%s/instances/%s", zone, name))
+				}
+			}
+		}
+	}
+}
+
+
+if len(instanceUrls) > 0 {
+
+  	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroupManagers/{{"{{"}}instance_group_manager{{"}}"}}/deleteInstances")
+  	if err != nil {
+  		return err
+  	}
+
+
+  	obj := map[string]any{
+  		"instances": instanceUrls,
+  	}
+
+  	headers := make(http.Header)
+
+  	log.Printf("[DEBUG] Deleting instances %#v", instanceUrls)
+  	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+  		Config:    config,
+  		Method:    "POST",
+  		Project:   project,
+  		RawURL:    url,
+  		UserAgent: userAgent,
+  		Body:      obj,
+  		Timeout:   d.Timeout(schema.TimeoutDelete),
+  		Headers:   headers,
+  	})
+
+  	if err != nil {
+  		return fmt.Errorf("Error deleting instances %#v: %s", instanceNames, err)
+  	}
+  	err = ComputeOperationWaitTime(
+  		config, res, project, "Deleting instances", userAgent,
+  		d.Timeout(schema.TimeoutDelete))
+
+  	if err != nil {
+  		return fmt.Errorf("Error deleting instances %#v: %s", instanceNames, err)
+  	}
+
+	// Poll listManagedInstances until deleted instances are gone
+	listUrl, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{"{{"}}project{{"}}"}}/zones/{{"{{"}}zone{{"}}"}}/instanceGroupManagers/{{"{{"}}instance_group_manager{{"}}"}}/listManagedInstances")
+	if err != nil {
+		return err
+	}
+
+	err = retry.RetryContext(context.Background(), d.Timeout(schema.TimeoutDelete), func() *retry.RetryError {
+		listRes, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "POST",
+			Project:   project,
+			RawURL:    listUrl,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return retry.NonRetryableError(fmt.Errorf("Error listing managed instances: %s", err))
+		}
+
+		if managedInstances, ok := listRes["managedInstances"]; ok && managedInstances != nil {
+			original := managedInstances.([]interface{})
+			for _, raw := range original {
+				if raw == nil {
+					continue
+				}
+				rawMap := raw.(map[string]interface{})
+				if name, ok := rawMap["name"].(string); ok {
+					for _, deletedName := range instanceNames {
+						if name == deletedName {
+							log.Printf("[DEBUG] Instance %s still present in the MIG, retrying...", deletedName)
+							return retry.RetryableError(fmt.Errorf("Instance %s still present in the MIG", deletedName))
+						}
+					}
+				}
+			}
+		}
+
+		log.Printf("[DEBUG] All deleted instances have been successfully removed from MIG")
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error waiting for instances to be deleted: %s", err)
+	}
+}
+
+log.Printf("[DEBUG] Finished deleting BulkPerInstanceConfig %s", d.Id())
+return nil

--- a/mmv1/templates/terraform/decoders/compute_bulk_per_instance_config.go.tmpl
+++ b/mmv1/templates/terraform/decoders/compute_bulk_per_instance_config.go.tmpl
@@ -1,0 +1,22 @@
+if managedInstances, ok := res["managedInstances"]; ok && managedInstances != nil {
+    original := managedInstances.([]interface{})
+    transformed := make([]interface{}, 0, len(original))
+
+    for _, raw := range original {
+      if raw == nil {
+        continue
+      }
+
+      rawMap := raw.(map[string]interface{})
+      transformedMap := make(map[string]interface{})
+
+      // Extract the name.
+      if name, ok := rawMap["name"]; ok {
+        transformedMap["name"] = name
+      }
+
+      transformed = append(transformed, transformedMap)
+    }
+    res["instances"] = transformed
+}
+return res, nil

--- a/mmv1/templates/terraform/examples/compute_bulk_per_instance_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/compute_bulk_per_instance_config.tf.tmpl
@@ -1,0 +1,49 @@
+data "google_compute_image" "my_image" {
+  family  = "debian-12"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "bulk-igm" {
+  name         = "{{index $.Vars "template_name"}}"
+  machine_type = "e2-medium"
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_instance_group_manager" "bulk-igm" {
+  description        = "Terraform test bulk instance group manager"
+  name               = "{{index $.Vars "igm_name"}}"
+  zone               = "us-central1-a"
+  base_instance_name = "bulk-igm"
+
+  version {
+    name              = "prod"
+    instance_template = google_compute_instance_template.bulk-igm.self_link
+  }
+
+  lifecycle {
+    # Bulk per-instance configs manage the number of instances, so ignore target_size changes.
+    ignore_changes = [target_size]
+  }
+}
+
+resource "google_compute_bulk_per_instance_config" "{{$.PrimaryResourceId}}" {
+  zone                   = google_compute_instance_group_manager.bulk-igm.zone
+  instance_group_manager = google_compute_instance_group_manager.bulk-igm.name
+
+  instances {
+    name = "per-instance-config-instance-1"
+  }
+
+  instances {
+    name = "per-instance-config-instance-2"
+  }
+}


### PR DESCRIPTION
This PR introduces a new virtual resource for instance group managers: BulkPerInstanceConfig.

In this version it accepts only instance names which makes it possible to call instanceGroupManagers.CreateInstances with more than 1 instance in a single call. So far it was limited to a single PerInstanceConfig.

BulkPerInstanceConfig is immutable and on each modification it will call instanceGroupManagers.DeleteInstances on Destroy and instanceGroupManagers.CreateInstances on Create. Thanks to that Update is not implemented.

instance group manager should be configured to ignore target_size changes, as BulkPerInstanceConfig modifies this value.



<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_compute_bulk_per_instance_config`
```
