### PR TITLE
Promote IAP LocationWeb and AgentRegistry resources to GA

### DIFF
--- a/mmv1/products/iap/AgentRegistry.yaml
+++ b/mmv1/products/iap/AgentRegistry.yaml
@@ -16,7 +16,6 @@ description: |
   Only used to generate IAM resources
 docs:
 base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry
-min_version: beta
 self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry
 iam_policy:
   method_name_separator: ':'
@@ -41,11 +40,11 @@ timeouts:
   delete_minutes: 20
 exclude_tgc: true
 samples:
-  - name: iap_project_beta
+  - name: project
     primary_resource_id: project_service
     external_providers: [time]
     steps:
-      - name: iap_project_beta
+      - name: project
         test_env_vars:
           org_id: ORG_ID
 parameters:

--- a/mmv1/products/iap/LocationWeb.yaml
+++ b/mmv1/products/iap/LocationWeb.yaml
@@ -16,7 +16,6 @@ description: |
   Only used to generate IAM resources
 docs:
 base_url: projects/{{project}}/locations/{{location}}/iap_web
-min_version: beta
 self_link: projects/{{project}}/locations/{{location}}/iap_web
 iam_policy:
   method_name_separator: ':'
@@ -41,11 +40,11 @@ timeouts:
   delete_minutes: 20
 exclude_tgc: true
 samples:
-  - name: iap_project_beta
+  - name: project
     primary_resource_id: project_service
     external_providers: [time]
     steps:
-      - name: iap_project_beta
+      - name: project
         test_env_vars:
           org_id: ORG_ID
 parameters:

--- a/mmv1/templates/terraform/samples/services/iap/project.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iap/project.tf.tmpl
@@ -1,5 +1,4 @@
 resource "google_project" "project" {
-  provider   = google-beta
   project_id = "tf-test%{random_suffix}"
   name       = "tf-test%{random_suffix}"
   org_id     = "%{org_id}"
@@ -13,7 +12,6 @@ resource "time_sleep" "wait_60_seconds" {
 }
 
 resource "google_project_service" "project_service" {
-  provider   = google-beta
   project    = google_project.project.project_id
   service    = "iap.googleapis.com"
 


### PR DESCRIPTION
Promote IAP LocationWeb and AgentRegistry resources from beta to GA

Key Modifications:
* **GA Promotion**: Promotes Identity-Aware Proxy (IAP) `LocationWeb` and `AgentRegistry` resources to GA by removing the beta version constraints.
* **Template Renaming and  Cleanup**: Renames the template file and removes the explicit `google-beta` provider configurations.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_iap_location_web_iam_binding`
```
```release-note:new-resource
`google_iap_location_web_iam_member` 
```
```release-note:new-resource
`google_iap_location_web_iam_policy`
```
```release-note:new-resource
`google_iap_agent_registry_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_iam_policy` 
```
