### PR TITLE
artifactregistry: remove `repository.mode` plan-time validation

### DIFF
--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -416,14 +416,10 @@ properties:
           - RELEASE
           - SNAPSHOT
   - name: mode
-    type: Enum
+    type: String
     description: The mode configures the repository to serve artifacts from different sources.
     immutable: true
     default_value: STANDARD_REPOSITORY
-    enum_values:
-      - STANDARD_REPOSITORY
-      - VIRTUAL_REPOSITORY
-      - REMOTE_REPOSITORY
   - name: virtualRepositoryConfig
     type: NestedObject
     description: Configuration specific for a Virtual Repository.

--- a/mmv1/products/artifactregistry/Repository.yaml
+++ b/mmv1/products/artifactregistry/Repository.yaml
@@ -432,14 +432,10 @@ properties:
           - RELEASE
           - SNAPSHOT
   - name: mode
-    type: Enum
+    type: String
     description: The mode configures the repository to serve artifacts from different sources.
     immutable: true
     default_value: STANDARD_REPOSITORY
-    enum_values:
-      - STANDARD_REPOSITORY
-      - VIRTUAL_REPOSITORY
-      - REMOTE_REPOSITORY
   - name: virtualRepositoryConfig
     type: NestedObject
     description: Configuration specific for a Virtual Repository.


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Changes `mode` field type from enum to string, removing enum value validation.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/23234

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
artifactregistry: remove plan-time validation for `mode` on `google_artifact_registry_repository`
```
