### PR TITLE
New Resource: google_cloudbuild_gitlab_config

### DIFF
--- a/mmv1/products/cloudbuild/GitLabConfig.yaml
+++ b/mmv1/products/cloudbuild/GitLabConfig.yaml
@@ -1,0 +1,171 @@
+---
+# Copyright 2024 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: GitLabConfig
+description: |
+  GitLabConfig represents the configuration for a GitLab integration.
+deprecation_message: >-
+  `google_cloudbuild_gitlab_config` is deprecated and will be removed in a future major version.
+  Use `google_cloudbuildv2_connection` with `gitlab_config` instead.
+references:
+  guides:
+    Connect to a GitLab host: https://cloud.google.com/build/docs/automating-builds/gitlab/connect-host-gitlab
+  api: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.gitLabConfigs
+base_url: projects/{{project}}/locations/{{location}}/gitLabConfigs
+self_link: projects/{{project}}/locations/{{location}}/gitLabConfigs/{{config_id}}
+create_url: projects/{{project}}/locations/{{location}}/gitLabConfigs?gitLabConfigId={{config_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/gitLabConfigs/{{config_id}}
+async:
+  operation:
+    base_url: '{{op_id}}'
+  result:
+    resource_inside_response: true
+autogen_async: true
+include_in_tgc_next: true
+custom_code:
+  encoder: templates/terraform/encoders/cloudbuild_gitlab_config.go.tmpl
+  post_create: templates/terraform/post_create/cloudbuild_gitlab_config.go.tmpl
+  pre_update: templates/terraform/pre_update/cloudbuild_gitlab_config.go.tmpl
+  post_update: templates/terraform/post_update/cloudbuild_gitlab_config.go.tmpl
+samples:
+  - name: cloudbuild_gitlab_config
+    primary_resource_id: gitlab-config
+    steps:
+      - name: cloudbuild_gitlab_config
+        resource_id_vars:
+          config_id: gitlab-config
+  - name: cloudbuild_gitlab_config_enterprise
+    primary_resource_id: gitlab-enterprise-config
+    exclude_test: true
+    steps:
+      - name: cloudbuild_gitlab_config_enterprise
+        resource_id_vars:
+          config_id: gitlab-enterprise-config
+  - name: cloudbuild_gitlab_config_repositories
+    primary_resource_id: gitlab-config-with-repos
+    exclude_test: true
+    steps:
+      - name: cloudbuild_gitlab_config_repositories
+        resource_id_vars:
+          config_id: gitlab-config-with-repos
+parameters:
+  - name: config_id
+    type: String
+    required: true
+    description: |
+      The ID to use for the GitLabConfig, which will become the final component of the GitLabConfig's resource name.
+    immutable: true
+    url_param_only: true
+  - name: location
+    type: String
+    required: true
+    description: |
+      The location of this GitLab config.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: |
+      The resource name for the config.
+    output: true
+  - name: username
+    type: String
+    description: |
+      Username of the GitLab.com or GitLab Enterprise account Cloud Build will use.
+  - name: secrets
+    type: NestedObject
+    required: true
+    description: |
+      Secret Manager secrets needed by the config.
+    properties:
+      - name: apiAccessTokenVersion
+        type: String
+        required: true
+        description: |
+          The resource name for the api access token's secret version.
+      - name: apiKeyVersion
+        type: String
+        required: true
+        description: |
+          Immutable. API Key that will be attached to webhook requests from GitLab to Cloud Build.
+        immutable: true
+      - name: readAccessTokenVersion
+        type: String
+        required: true
+        description: |
+          The resource name for the read access token's secret version.
+      - name: webhookSecretVersion
+        type: String
+        required: true
+        description: |
+          Immutable. The resource name for the webhook secret's secret version. Once this field has been set, it cannot be changed.
+          If you need to change it, please create another GitLabConfig.
+        immutable: true
+  - name: webhookKey
+    type: String
+    description: |
+      Output only. UUID included in webhook requests. The UUID is used to look up the corresponding config.
+    output: true
+  - name: createTime
+    type: String
+    description: |
+      Output only. Time when the config was created.
+    output: true
+  - name: connectedRepositories
+    type: Array
+    description: |
+      Connected GitLab.com or GitLab Enterprise repositories for this config.
+    is_set: true
+    item_type:
+      type: NestedObject
+      properties:
+        - name: id
+          type: String
+          required: true
+          description: |
+            Identifier for the repository. example: "namespace/project-slug", namespace is usually the username or group ID.
+        - name: webhookId
+          type: Integer
+          description: |
+            Output only. The ID of the webhook that was created for receiving events from this repo.
+          output: true
+  - name: enterpriseConfig
+    type: NestedObject
+    description: |
+      Optional. GitLab Enterprise config.
+    properties:
+      - name: hostUri
+        type: String
+        description: |
+          Immutable. The URI of the GitLab Enterprise host.
+        immutable: true
+      - name: serviceDirectoryConfig
+        type: NestedObject
+        description: |
+          The Service Directory configuration to be used when reaching out to the GitLab Enterprise instance.
+        properties:
+          - name: service
+            type: String
+            required: true
+            description: |
+              The Service Directory service name. Format: projects/{project}/locations/{location}/namespaces/{namespace}/services/{service}.
+      - name: sslCa
+        type: String
+        description: |
+          The SSL certificate to use in requests to GitLab Enterprise instances.

--- a/mmv1/products/cloudbuild/GitLabConfig.yaml
+++ b/mmv1/products/cloudbuild/GitLabConfig.yaml
@@ -38,27 +38,21 @@ custom_code:
   post_create: templates/terraform/post_create/cloudbuild_gitlab_config.go.tmpl
   pre_update: templates/terraform/pre_update/cloudbuild_gitlab_config.go.tmpl
   post_update: templates/terraform/post_update/cloudbuild_gitlab_config.go.tmpl
-samples:
+examples:
   - name: cloudbuild_gitlab_config
     primary_resource_id: gitlab-config
-    steps:
-      - name: cloudbuild_gitlab_config
-        resource_id_vars:
-          config_id: gitlab-config
+    vars:
+      config_id: gitlab-config
   - name: cloudbuild_gitlab_config_enterprise
     primary_resource_id: gitlab-enterprise-config
+    vars:
+      config_id: gitlab-enterprise-config
     exclude_test: true
-    steps:
-      - name: cloudbuild_gitlab_config_enterprise
-        resource_id_vars:
-          config_id: gitlab-enterprise-config
   - name: cloudbuild_gitlab_config_repositories
     primary_resource_id: gitlab-config-with-repos
+    vars:
+      config_id: gitlab-config-with-repos
     exclude_test: true
-    steps:
-      - name: cloudbuild_gitlab_config_repositories
-        resource_id_vars:
-          config_id: gitlab-config-with-repos
 parameters:
   - name: config_id
     type: String

--- a/mmv1/products/cloudbuild/GitLabConfig.yaml
+++ b/mmv1/products/cloudbuild/GitLabConfig.yaml
@@ -32,7 +32,6 @@ async:
   result:
     resource_inside_response: true
 autogen_async: true
-include_in_tgc_next: true
 custom_code:
   encoder: templates/terraform/encoders/cloudbuild_gitlab_config.go.tmpl
   post_create: templates/terraform/post_create/cloudbuild_gitlab_config.go.tmpl

--- a/mmv1/products/cloudbuild/GitLabConfig.yaml
+++ b/mmv1/products/cloudbuild/GitLabConfig.yaml
@@ -21,7 +21,7 @@ references:
   api: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.gitLabConfigs
 base_url: projects/{{project}}/locations/{{location}}/gitLabConfigs
 self_link: projects/{{project}}/locations/{{location}}/gitLabConfigs/{{config_id}}
-create_url: projects/{{project}}/locations/{{location}}/gitLabConfigs?gitLabConfigId={{config_id}}
+create_url: projects/{{project}}/locations/{{location}}/gitLabConfigs?gitlabConfigId={{config_id}}
 update_mask: true
 update_verb: PATCH
 import_format:
@@ -57,6 +57,7 @@ parameters:
   - name: config_id
     type: String
     required: true
+    api_name: gitlabConfigId
     description: |
       The ID to use for the GitLabConfig, which will become the final component of the GitLabConfig's resource name.
     immutable: true

--- a/mmv1/products/cloudbuild/GitLabConfig.yaml
+++ b/mmv1/products/cloudbuild/GitLabConfig.yaml
@@ -1,4 +1,3 @@
----
 # Copyright 2024 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +15,6 @@
 name: GitLabConfig
 description: |
   GitLabConfig represents the configuration for a GitLab integration.
-deprecation_message: >-
-  `google_cloudbuild_gitlab_config` is deprecated and will be removed in a future major version.
-  Use `google_cloudbuildv2_connection` with `gitlab_config` instead.
 references:
   guides:
     Connect to a GitLab host: https://cloud.google.com/build/docs/automating-builds/gitlab/connect-host-gitlab

--- a/mmv1/templates/terraform/encoders/cloudbuild_gitlab_config.go.tmpl
+++ b/mmv1/templates/terraform/encoders/cloudbuild_gitlab_config.go.tmpl
@@ -1,0 +1,3 @@
+// connectedRepositories is needed for batchCreate on the config after creation.
+delete(obj, "connectedRepositories")
+return obj, nil

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
-    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    config_id = "{{index $.Vars "config_id"}}"
     location = "us-central1"
     secrets {
         api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
@@ -1,4 +1,4 @@
-resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
     config_id = "{{index $.ResourceIdVars "config_id"}}"
     location = "us-central1"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    location = "us-central1"
+    secrets {
+        api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        api_key_version = "projects/myProject/secrets/myApiKey/versions/1"
+        read_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        webhook_secret_version = "projects/myProject/secrets/myWebhookSecret/versions/1"
+    }
+}

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
-    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    config_id = "{{index $.Vars "config_id"}}"
     location = "us-central1"
     secrets {
         api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
@@ -1,0 +1,14 @@
+resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    location = "us-central1"
+    secrets {
+        api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        api_key_version = "projects/myProject/secrets/myApiKey/versions/1"
+        read_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        webhook_secret_version = "projects/myProject/secrets/myWebhookSecret/versions/1"
+    }
+    enterprise_config {
+        host_uri = "https://gitlab.example.com"
+        ssl_ca = "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
+    }
+}

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_enterprise.tf.tmpl
@@ -1,4 +1,4 @@
-resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
     config_id = "{{index $.ResourceIdVars "config_id"}}"
     location = "us-central1"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
-    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    config_id = "{{index $.Vars "config_id"}}"
     location = "us-central1"
     secrets {
         api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
@@ -1,4 +1,4 @@
-resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+resource "google_cloudbuild_git_lab_config" "{{$.PrimaryResourceId}}" {
     config_id = "{{index $.ResourceIdVars "config_id"}}"
     location = "us-central1"
     secrets {

--- a/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
+++ b/mmv1/templates/terraform/examples/cloudbuild_gitlab_config_repositories.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_cloudbuild_gitlab_config" "{{$.PrimaryResourceId}}" {
+    config_id = "{{index $.ResourceIdVars "config_id"}}"
+    location = "us-central1"
+    secrets {
+        api_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        api_key_version = "projects/myProject/secrets/myApiKey/versions/1"
+        read_access_token_version = "projects/myProject/secrets/myGitLabPAT/versions/1"
+        webhook_secret_version = "projects/myProject/secrets/myWebhookSecret/versions/1"
+    }
+    connected_repositories {
+        id = "my-group/my-project"
+    }
+    connected_repositories {
+        id = "my-group/another-project"
+    }
+}

--- a/mmv1/templates/terraform/post_create/cloudbuild_gitlab_config.go.tmpl
+++ b/mmv1/templates/terraform/post_create/cloudbuild_gitlab_config.go.tmpl
@@ -1,0 +1,50 @@
+log.Printf("[DEBUG] Finished creating GitLabConfig without connected repos: %q: %#v", d.Id(), res)
+
+if v, ok := d.GetOkExists("connected_repositories"); !tpgresource.IsEmptyValue(reflect.ValueOf(connectedRepositoriesProp)) && (ok || !reflect.DeepEqual(v, connectedRepositoriesProp)) {
+    connectedReposPropArray, ok := connectedRepositoriesProp.([]interface{})
+    if !ok {
+        return fmt.Errorf("Error reading connected_repositories")
+    }
+
+    requests := make([]interface{}, len(connectedReposPropArray))
+    for i := 0; i < len(connectedReposPropArray); i++ {
+        connectedRepo := make(map[string]interface{})
+        connectedRepo["parent"] = id
+        connectedRepo["repo"] = connectedReposPropArray[i]
+
+        connectedRepoRequest := make(map[string]interface{})
+        connectedRepoRequest["parent"] = id
+        connectedRepoRequest["gitLabConnectedRepository"] = connectedRepo
+        
+        requests[i] = connectedRepoRequest
+    }
+    obj = make(map[string]interface{})
+    obj["requests"] = requests
+
+    url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}CloudBuildBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/gitLabConfigs/{{"{{"}}config_id{{"}}"}}/connectedRepositories:batchCreate")
+    if err != nil {
+        return err
+    }
+
+    res, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config: config,
+        Method: "POST",
+        Project: billingProject,
+        RawURL: url,
+        UserAgent: userAgent,
+        Body: obj,
+        Timeout: d.Timeout(schema.TimeoutCreate),
+    })
+    if err != nil {
+        return fmt.Errorf("Error creating connected_repositories: %s", err)
+    }
+
+    err = CloudBuildOperationWaitTime(
+        config, res, project, "Creating connected_repositories on GitLabConfig", userAgent,
+        d.Timeout(schema.TimeoutCreate))
+    if err != nil {
+        return fmt.Errorf("Error waiting to create connected_repositories: %s", err)
+    }
+} else {
+    log.Printf("[DEBUG] No connected repositories found to create: %#v", connectedRepositoriesProp)
+}

--- a/mmv1/templates/terraform/post_update/cloudbuild_gitlab_config.go.tmpl
+++ b/mmv1/templates/terraform/post_update/cloudbuild_gitlab_config.go.tmpl
@@ -1,0 +1,86 @@
+if d.HasChange("connected_repositories") {
+	o, n := d.GetChange("connected_repositories")
+	oReposSet, ok := o.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("Error reading old connected repositories")
+	}
+	nReposSet, ok := n.(*schema.Set)
+	if !ok {
+		return fmt.Errorf("Error reading new connected repositories")
+	}
+
+	removeRepos := oReposSet.Difference(nReposSet).List()
+	createRepos := nReposSet.Difference(oReposSet).List()
+
+	url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}CloudBuildBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/gitLabConfigs/{{"{{"}}config_id{{"}}"}}:removeGitLabConnectedRepository")
+	if err != nil {
+		return err
+	}
+
+	// send remove repo requests.
+	for _, repo := range removeRepos {
+		obj := make(map[string]interface{})
+		obj["connectedRepository"] = repo
+		_, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config: config,
+			Method: "POST",
+			Project: billingProject,
+			RawURL: url,
+			UserAgent: userAgent,
+			Body: obj,
+			Timeout: d.Timeout(schema.TimeoutCreate),
+		})
+		if err != nil {
+			return fmt.Errorf("Error removing connected_repositories: %s", err)
+		}
+	}
+
+	// if repos to create, prepare and send batchCreate request
+	if len(createRepos) > 0 {
+		parent, err := tpgresource.ReplaceVars(d, config, "projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/gitLabConfigs/{{"{{"}}config_id{{"}}"}}")
+		if err != nil {
+			return fmt.Errorf("Error constructing id: %s", err)
+		}
+		var requests []interface{}
+		for _, repo := range createRepos {
+			connectedRepo := make(map[string]interface{})
+			connectedRepo["parent"] = parent
+			connectedRepo["repo"] = repo
+
+			connectedRepoRequest := make(map[string]interface{})
+			connectedRepoRequest["parent"] = parent
+			connectedRepoRequest["gitLabConnectedRepository"] = connectedRepo
+
+			requests = append(requests, connectedRepoRequest)
+		}
+		obj = make(map[string]interface{})
+		obj["requests"] = requests
+
+		url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}CloudBuildBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/gitLabConfigs/{{"{{"}}config_id{{"}}"}}/connectedRepositories:batchCreate")
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config: config,
+			Method: "POST",
+			Project: billingProject,
+			RawURL: url,
+			UserAgent: userAgent,
+			Body: obj,
+			Timeout: d.Timeout(schema.TimeoutCreate),
+		})
+		if err != nil {
+			return fmt.Errorf("Error creating connected_repositories: %s", err)
+		}
+
+		err = CloudBuildOperationWaitTime(
+			config, res, project, "Updating connected_repositories on GitLabConfig", userAgent,
+			d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("Error waiting to create connected_repositories: %s", err)
+		}
+	}
+} else {
+	log.Printf("[DEBUG] connected_repositories have no changes")
+}

--- a/mmv1/templates/terraform/pre_update/cloudbuild_gitlab_config.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/cloudbuild_gitlab_config.go.tmpl
@@ -1,0 +1,16 @@
+// remove connectedRepositories from updateMask
+for i, field := range updateMask {
+    if field == "connectedRepositories" {
+        updateMask = append(updateMask[:i], updateMask[i+1:]...)
+        break
+    }
+}
+// reconstruct url
+url, err = tpgresource.ReplaceVars(d, config, "{{"{{"}}CloudBuildBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/gitLabConfigs/{{"{{"}}config_id{{"}}"}}")
+if err != nil {
+    return err
+}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+    return err
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26660

This adds a new `google_cloudbuild_gitlab_config` resource for managing Cloud Build GitLab configurations, modeled after the existing `google_cloudbuild_bitbucket_server_config` resource.

Changes in this PR:
* New MMv1 resource definition for `GitLabConfig` in the `cloudbuild` product
* Custom encoder/post_create/pre_update/post_update templates for `connectedRepositories` handling
* Example configurations for basic, enterprise, and connected repository use cases

**Release Note Template for Downstream PRs (will be copied)**
See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
cloudbuild: added `google_cloudbuild_gitlab_config` resource