### PR TITLE
`.teamcity`: set `teamcity.buildQueue.allowMerging=false` parameter

### DIFF
--- a/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/projects/root_project.kt
@@ -68,6 +68,7 @@ fun googleCloudRootProject(allConfig: AllContextParameters): Project {
 
         params {
             readOnlySettings()
+            param("teamcity.buildQueue.allowMerging", "false")
         }
     }
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

this should resolve Global Sweepers being moved to the top of the queue due to [Build Queue Optimization being done by TeamCity](https://www.jetbrains.com/help/teamcity/working-with-build-queue.html#Build+Queue+Optimization+by+TeamCity), this comes from reviewing the following [TeamCity forum page](https://teamcity-support.jetbrains.com/hc/en-us/community/posts/206811835-How-to-fool-the-Build-queue-optimizer)

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
