### PR TITLE
compute: fix preview=false updates for OrganizationSecurityPolicyRule

### DIFF
--- a/mmv1/products/compute/OrganizationSecurityPolicyRule.yaml
+++ b/mmv1/products/compute/OrganizationSecurityPolicyRule.yaml
@@ -327,6 +327,7 @@ properties:
                 type: String
   - name: 'preview'
     type: Boolean
+    send_empty_value: true
     description: |
       If set to true, the specified action is not enforced.
   - name: 'redirectOptions'


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#27885

## Summary

This change adds `send_empty_value: true` to the `preview` field of
`OrganizationSecurityPolicyRule`.

Without this annotation, the generated Terraform provider treats
`preview = false` as an empty value and omits it from create and update
requests. As a result, users cannot reliably update a rule from:

```hcl
preview = true
```

to

```hcl
preview = false
```

because the PATCH request does not include the `preview` field.

## Root cause

The generated provider code used the condition:

```go
!tpgresource.IsEmptyValue(reflect.ValueOf(v))
```

Since `IsEmptyValue()` considers the boolean value `false` to be empty,
`preview = false` was filtered out and never added to the request body.

Adding `send_empty_value: true` causes Magic Modules to generate:

```go
ok || !reflect.DeepEqual(v, previewProp)
```

which preserves explicitly configured `false` values.

```release-note:bug
compute: fixed an issue where `preview = false` updates for `google_compute_organization_security_policy_rule` were omitted from API requests.
```

## Verification

- Added `send_empty_value: true` to the `preview` property in `OrganizationSecurityPolicyRule.yaml`.
- Regenerated the Terraform provider.
- Verified that the generated `resource_compute_organization_security_policy_rule.go`
  now includes `preview` whenever it is explicitly configured, including `false`.
- Verified that the generated behavior now matches the existing implementation for
  `SecurityPolicyRule` and `RegionSecurityPolicyRule`.

## Background

I initially investigated this issue in hashicorp/terraform-provider-google and opened hashicorp/terraform-provider-google#28000.

As suggested by @melinath  in that PR, this fix has been moved to Magic Modules since the provider code is generated from this repository.