### PR TITLE
backupdr: fix restore resource_manager_tags drop

### DIFF
--- a/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
+++ b/mmv1/templates/terraform/custom_create/backup_dr_restore_workload.go.tmpl
@@ -47,17 +47,41 @@ processGuestOsFeatures := func(gofList []interface{}) []map[string]interface{} {
     return nil
 }
 
-processLabels := func(val interface{}) map[string]string {
-    labels := make(map[string]string)
-    if labelMap, isMap := val.(map[string]interface{}); isMap {
-        for k, v := range labelMap {
+processKeyValueEntries := func(val interface{}) map[string]string {
+    entries := make(map[string]string)
+    if val == nil {
+        return nil
+    }
+    // Accept map and repeated key/value block representations.
+    if entryMap, isMap := val.(map[string]interface{}); isMap {
+        for k, v := range entryMap {
             if vStr, ok := v.(string); ok {
-                labels[k] = vStr
+                entries[k] = vStr
+            }
+        }
+    } else if s, isSet := val.(*schema.Set); isSet {
+        for _, raw := range s.List() {
+            if item, ok := raw.(map[string]interface{}); ok {
+                if k, ok1 := item["key"].(string); ok1 {
+                    if v, ok2 := item["value"].(string); ok2 {
+                        entries[k] = v
+                    }
+                }
+            }
+        }
+    } else if list, isList := val.([]interface{}); isList {
+        for _, raw := range list {
+            if item, ok := raw.(map[string]interface{}); ok {
+                if k, ok1 := item["key"].(string); ok1 {
+                    if v, ok2 := item["value"].(string); ok2 {
+                        entries[k] = v
+                    }
+                }
             }
         }
     }
-    if len(labels) > 0 {
-        return labels
+    if len(entries) > 0 {
+        return entries
     }
     return nil
 }
@@ -372,7 +396,7 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
         // --- Metadata & Labels ---
         // Labels
         if val, ok := m["labels"]; ok {
-            if labels := processLabels(val); labels != nil {
+            if labels := processKeyValueEntries(val); labels != nil {
                 props["labels"] = labels
             }
         }
@@ -597,16 +621,8 @@ if v, ok := d.GetOkExists("compute_instance_restore_properties"); ok {
             if pList[0] != nil {
                 p := pList[0].(map[string]interface{})
                 pObj := make(map[string]interface{})
-                if rmt, ok := p["resource_manager_tags"]; ok {
-                    rmtMap := make(map[string]string)
-                    if rmtMapVal, isMap := rmt.(map[string]interface{}); isMap {
-                        for k, v := range rmtMapVal {
-                            if vStr, ok := v.(string); ok {
-                                rmtMap[k] = vStr
-                            }
-                        }
-                    }
-                    if len(rmtMap) > 0 {
+                if rmtVal, ok := p["resource_manager_tags"]; ok {
+                    if rmtMap := processKeyValueEntries(rmtVal); rmtMap != nil {
                         pObj["resourceManagerTags"] = rmtMap
                     }
                 }
@@ -880,14 +896,14 @@ if v, ok := d.GetOkExists("disk_restore_properties"); ok {
         
         // Labels
         if val, ok := m["labels"]; ok {
-            if labels := processLabels(val); labels != nil {
+            if labels := processKeyValueEntries(val); labels != nil {
                 props["labels"] = labels
             }
         }
         
         // Resource manager tags
         if val, ok := m["resource_manager_tags"]; ok {
-            if rmtMap := processLabels(val); rmtMap != nil {
+            if rmtMap := processKeyValueEntries(val); rmtMap != nil {
                 props["resourceManagerTags"] = rmtMap
             }
         }

--- a/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_restore_workload_test.go
+++ b/mmv1/third_party/terraform/services/backupdr/resource_backup_dr_restore_workload_test.go
@@ -235,11 +235,15 @@ resource "google_backup_dr_restore_workload" "restore" {
 
   compute_instance_restore_properties {
     name         = "tf-test-restored-instance-%{random_suffix}"
-    machine_type = "projects/%{project}/zones/us-central1-a/machineTypes/e2-medium"
+	machine_type = "projects/%{project}/zones/us-central1-a/machineTypes/n1-standard-2"
     description  = "Restored instance with custom properties"
     
     can_ip_forward      = true
     deletion_protection = false
+
+    confidential_instance_config {
+      enable_confidential_compute = false
+    }
 
     labels {
       key   = "environment"
@@ -258,6 +262,13 @@ resource "google_backup_dr_restore_workload" "restore" {
 
     tags {
       items = ["web", "https-server", "restored"]
+    }
+
+    params {
+      resource_manager_tags {
+        key   = "tagKeys/281480326968824"
+        value = "tagValues/281478683714361"
+      }
     }
 
     network_interfaces {
@@ -358,6 +369,11 @@ resource "google_backup_dr_restore_workload" "restore" {
     name    = "tf-test-restored-regional-disk-%{random_suffix}"
     size_gb = 200
     type    = "projects/%{project}/regions/us-central1/diskTypes/pd-balanced"
+
+	resource_manager_tags {
+	  key   = "tagKeys/281480326968824"
+	  value = "tagValues/281478683714361"
+	}
   }
 }
 `, context)


### PR DESCRIPTION

```release-note:bug
backupdr: fixed issue where `google_backup_dr_restore_workload` dropped `resource_manager_tags` during restore requests, causing tags shown in plan to not be applied to restored resources
```