### PR TITLE
Add IAP Agent, MCP Server and Endpoint resources to GA provider

### DIFF
--- a/mmv1/products/iap/AgentRegistryAgent.yaml
+++ b/mmv1/products/iap/AgentRegistryAgent.yaml
@@ -11,37 +11,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-name: AgentRegistryEndpoint
+name: AgentRegistryAgent
 description: |
   Only used to generate IAM resources
 # This resource is only used to generate IAM resources. They do not correspond to real
 # GCP resources, and should not be used to generate anything other than IAM support.
 exclude_resource: true
-docs:
-base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-iam_policy:
-  method_name_separator: ':'
-  parent_resource_type: data.google_agent_registry_endpoint
-  fetch_iam_policy_verb: POST
-  allowed_iam_role: roles/iap.egressor
-  parent_resource_attribute: endpoint_id
-  iam_conditions_request_type: REQUEST_BODY
-id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
 import_format:
-  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-  - '{{endpoint_id}}'
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/agents/{{agent_id}}
+  - '{{agent_id}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: data.google_agent_registry_agent
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: agent_id
+  iam_conditions_request_type: REQUEST_BODY
 exclude_tgc: true
 examples:
-  - name: agent_registry_endpoint_basic
+  - name: agent_registry_agent_basic
     primary_resource_id: default
     external_providers: [time]
     vars:
-      endpoint_id: endpoint-id
+      agent_id: agent-id
     test_env_vars:
       org_id: ORG_ID
 parameters:
@@ -50,7 +49,7 @@ parameters:
     required: true
     description: The location of the resource.
 properties:
-  - name: endpoint_id
+  - name: agent_id
     type: String
     required: true
-    description: The id of the Endpoint.
+    description: The id of the agent.

--- a/mmv1/products/iap/AgentRegistryMcpServer.yaml
+++ b/mmv1/products/iap/AgentRegistryMcpServer.yaml
@@ -11,37 +11,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-name: AgentRegistryEndpoint
+name: AgentRegistryMcpServer
 description: |
   Only used to generate IAM resources
 # This resource is only used to generate IAM resources. They do not correspond to real
 # GCP resources, and should not be used to generate anything other than IAM support.
 exclude_resource: true
 docs:
-base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-iam_policy:
-  method_name_separator: ':'
-  parent_resource_type: data.google_agent_registry_endpoint
-  fetch_iam_policy_verb: POST
-  allowed_iam_role: roles/iap.egressor
-  parent_resource_attribute: endpoint_id
-  iam_conditions_request_type: REQUEST_BODY
-id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
 import_format:
-  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/endpoints/{{endpoint_id}}
-  - '{{endpoint_id}}'
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcp_server_id}}
+  - '{{mcp_server_id}}'
 timeouts:
   insert_minutes: 20
   update_minutes: 20
   delete_minutes: 20
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: data.google_agent_registry_mcp_server
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: mcp_server_id
+  iam_conditions_request_type: REQUEST_BODY
 exclude_tgc: true
 examples:
-  - name: agent_registry_endpoint_basic
+  - name: agent_registry_mcp_server_basic
     primary_resource_id: default
     external_providers: [time]
     vars:
-      endpoint_id: endpoint-id
+      mcp_server_id: mcp-server-id
     test_env_vars:
       org_id: ORG_ID
 parameters:
@@ -50,7 +50,7 @@ parameters:
     required: true
     description: The location of the resource.
 properties:
-  - name: endpoint_id
+  - name: mcp_server_id
     type: String
     required: true
-    description: The id of the Endpoint.
+    description: The id of the MCP Server.

--- a/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_agent_basic.tf.tmpl
@@ -1,0 +1,43 @@
+resource "google_project" "project" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+  deletion_policy = "DELETE"
+}
+
+# Needed for CI tests for permissions to propagate
+resource "time_sleep" "wait_for_project_propagation" {
+  create_duration = "60s"
+
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "iap_service" {
+  project    = google_project.project.project_id
+  service    = "iap.googleapis.com"
+
+  depends_on = [time_sleep.wait_for_project_propagation]
+}
+
+resource "google_project_service" "agentregistry_service" {
+  project    = google_project.project.project_id
+  service    = "agentregistry.googleapis.com"
+
+  # Chain service resource calls to avoid cache misses during CI test replays
+  depends_on = [google_project_service.iap_service]
+}
+
+# Needed for CI tests for resource to propagate
+resource "time_sleep" "wait_for_agent_creation" {
+  create_duration = "60s"
+
+  depends_on = [google_project_service.agentregistry_service]
+}
+
+data "google_agent_registry_agent" "default" {
+  project    = google_project.project.project_id
+  location = "global"
+  filter = "displayName:Workspace Agent"
+
+  depends_on = [time_sleep.wait_for_agent_creation]
+}

--- a/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_endpoint_basic.tf.tmpl
@@ -1,0 +1,55 @@
+resource "google_project" "project" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+  deletion_policy = "DELETE"
+}
+
+# Needed for CI tests for permissions to propagate
+resource "time_sleep" "wait_for_project_propagation" {
+  create_duration = "60s"
+
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "iap_service" {
+  project    = google_project.project.project_id
+  service    = "iap.googleapis.com"
+
+  depends_on = [time_sleep.wait_for_project_propagation]
+}
+
+resource "google_project_service" "agentregistry_service" {
+  project    = google_project.project.project_id
+  service    = "agentregistry.googleapis.com"
+
+  # Chain service resource calls to avoid cache misses during CI test replays
+  depends_on = [google_project_service.iap_service]
+}
+
+resource "google_agent_registry_service" "endpoint_service" {
+  project    = google_project.project.project_id
+  location     = "us-central1"
+  service_id   = "tf-test-endpoint"
+  description  = "Test endpoint service"
+  display_name = "Test endpoint service"
+
+  interfaces {
+    url              = "https://www.google.com"
+    protocol_binding = "GRPC"
+  }
+
+  endpoint_spec {
+    type = "NO_SPEC"
+  }
+
+  depends_on = [google_project_service.agentregistry_service]
+}
+
+data "google_agent_registry_endpoint" "default" {
+  project    = google_project.project.project_id
+  location = "us-central1"
+  filter   = "displayName:Test endpoint service"
+
+  depends_on = [google_agent_registry_service.endpoint_service]
+}

--- a/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/agent_registry_mcp_server_basic.tf.tmpl
@@ -1,0 +1,56 @@
+resource "google_project" "project" {
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "%{org_id}"
+  deletion_policy = "DELETE"
+}
+
+# Needed for CI tests for permissions to propagate
+resource "time_sleep" "wait_for_project_propagation" {
+  create_duration = "60s"
+
+  depends_on = [google_project.project]
+}
+
+resource "google_project_service" "iap_service" {
+  project    = google_project.project.project_id
+  service    = "iap.googleapis.com"
+
+  depends_on = [time_sleep.wait_for_project_propagation]
+}
+
+resource "google_project_service" "agentregistry_service" {
+  project    = google_project.project.project_id
+  service    = "agentregistry.googleapis.com"
+
+  # Chain service resource calls to avoid cache misses during CI test replays
+  depends_on = [google_project_service.iap_service]
+}
+
+resource "google_agent_registry_service" "mcp_service" {
+  project    = google_project.project.project_id
+  location     = "us-central1"
+  service_id   = "tf-test-mcp"
+  description  = "Test MCP service"
+  display_name = "Test MCP service"
+
+  interfaces {
+    url              = "https://www.google.com"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type    = "TOOL_SPEC"
+    content = "{\"tools\":[]}"
+  }
+
+  depends_on = [google_project_service.agentregistry_service]
+}
+
+data "google_agent_registry_mcp_server" "default" {
+  project    = google_project.project.project_id
+  location = "us-central1"
+  filter   = "displayName:Test MCP service"
+
+  depends_on = [google_agent_registry_service.mcp_service]
+}

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_agent.go
@@ -31,6 +31,7 @@ func DataSourceAgentRegistryAgent() *schema.Resource {
 			"agent_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"filter"},
 				Description:   `The unique identifier for the Agent.`,

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_endpoint.go
@@ -32,6 +32,7 @@ func DataSourceAgentRegistryEndpoint() *schema.Resource {
 			"endpoint_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"filter"},
 				Description:   `The unique identifier for the Endpoint.`,

--- a/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server.go
+++ b/mmv1/third_party/terraform/services/agentregistry/data_source_agent_registry_mcp_server.go
@@ -32,6 +32,7 @@ func DataSourceAgentRegistryMcpServer() *schema.Resource {
 			"mcp_server_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Computed:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"filter"},
 				Description:   `The unique identifier for the MCP server.`,


### PR DESCRIPTION
Add IAP Agent Registry resources to GA provider.

Key Modifications:
* **Promote IAP resources**: Introduce IAP Agent, MCP Server, and Endpoint resources to the GA provider.
* **Add example templates**: Add terraform example templates to fetch the parent agent registry data sources.
* **Update data source schemas**: Mark identifier fields as computed to allow returning their values when querying by filter.

> Note: id fields of the data sources are marked as computed to allow setting filters for resources which are not created before the `terraform apply` run.  Prior to this, they were failing with the following error: https://gist.github.com/swamitagupta/b536fee037e8a233d4904906b33361a5


## Tests

Locally run acceptance tests:
* Agents: https://gist.github.com/swamitagupta/15d9a5977a5aac826779f62057fde91a
* MCP Servers:  https://gist.github.com/swamitagupta/63769e6482002f6abc2e73ffd04e2e7a
* Endpoints: https://gist.github.com/swamitagupta/37e68ecc2153e43c9cf1ecee6a558f2b

## Release Notes

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_iap_agent_registry_agent_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_agent_iam_policy` 
```

```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_policy` 
```

```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_binding`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_member`
```
```release-note:new-resource
`google_iap_agent_registry_mcp_server_iam_policy` 
```
