### PR TITLE
dataproc: make policy_id immutable on AutoscalingPolicy

### DIFF
--- a/mmv1/products/dataproc/AutoscalingPolicy.yaml
+++ b/mmv1/products/dataproc/AutoscalingPolicy.yaml
@@ -60,6 +60,7 @@ properties:
     api_name: id
     type: String
     required: true
+    immutable: true
     description: |
       The policy id. The id must contain only letters (a-z, A-Z), numbers (0-9), underscores (_),
       and hyphens (-). Cannot begin or end with underscore or hyphen. Must consist of between


### PR DESCRIPTION
dataproc: make policy_id immutable on AutoscalingPolicy

Mark the `policy_id` property as immutable in the Magic Modules specification for the Dataproc `AutoscalingPolicy` resource.

### Description
Currently, when a user renames the `policy_id` of a `google_dataproc_autoscaling_policy` resource, the generated Terraform provider plans an incorrect in-place update. During execution, this always fails with an HTTP `404 Not Found` error. This occurs because the provider builds the update API request URL using the new `policy_id` (which does not exist yet), rather than forcing a resource replacement.

Since the Dataproc API does not support renaming or updating a policy's resource ID in-place, changing `policy_id` must force a resource replacement.

This patch adds the `immutable: true` tag to the `policy_id` property definition in the specification. This ensures that the generated Go provider schema contains the `ForceNew: true` constraint, forcing a correct destroy-and-recreate plan (`-/+`) upon renaming.

### References
* Resolves downstream provider issue: [hashicorp/terraform-provider-google#27818](https://github.com/hashicorp/terraform-provider-google/issues/27818)

---

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
dataproc: fixed a bug where changing `policy_id` on `google_dataproc_autoscaling_policy` planned an in-place update and failed; it now correctly forces resource replacement (destroy and recreate).
```
