### PR TITLE
compute: fix omission of explicit 0 values in BackendService cdn_policy TTLs

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -100,6 +100,20 @@ samples:
         resource_id_vars:
           backend_service_name: 'backend-service'
           http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_zero_ttl'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'backend_service_cache_zero_ttl'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_omitted_ttl'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'backend_service_cache_omitted_ttl'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          http_health_check_name: 'health-check'
   - name: 'backend_service_cache_bypass_cache_on_request_headers'
     primary_resource_id: 'default'
     steps:
@@ -777,16 +791,19 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'clientTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -770,16 +770,19 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        send_empty_value: true
       - name: 'maxTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'clientTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        send_empty_value: true
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
+  health_checks = [google_compute_http_health_check.default.self_link]
+  enable_cdn    = true
+  cdn_policy {
+    cache_mode   = "CACHE_ALL_STATIC"
+    signed_url_cache_max_age_sec = 7200
+    # TTLs are omitted complimentary to backend_service_cache_zero_ttl
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
+  health_checks = [google_compute_http_health_check.default.self_link]
+  enable_cdn    = true
+  cdn_policy {
+    cache_mode   = "CACHE_ALL_STATIC"
+    default_ttl  = 0
+    client_ttl   = 0
+    max_ttl      = 0
+    signed_url_cache_max_age_sec = 7200
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}


### PR DESCRIPTION
This PR fixes a bug where explicitly setting `default_ttl`, `max_ttl`, or `client_ttl` to `0` inside the `cdn_policy` block of `google_compute_backend_service` or `google_compute_region_backend_service` resulted in the value being omitted from the JSON payload sent to the API (zero-value omission), causing the API to apply its own defaults instead of the requested `0`.

**Changes:**

1. Added **`send_empty_value: true`** to `defaultTtl`, `maxTtl`, and `clientTtl` fields in both `BackendService.yaml` and `RegionBackendService.yaml`. This ensures that explicit `0` values are preserved in the JSON payload instead of being skipped by `tpgresource.IsEmptyValue`.

2. Added **two new acceptance tests** to verify this behavior:
- `backend_service_cache_zero_ttl`: Verifies explicit `0` values are sent and preserved.
- `backend_service_cache_omitted_ttl`: Verifies that omitting the fields (complimentary behavior) still works as expected (omitted from payload, allowing API defaults).

**Linked Issues:**
Fixes https://issuetracker.google.com/issues/498433517


**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed omission of explicit `0` values for `default_ttl`, `max_ttl`, and `client_ttl` in `cdn_policy` for `google_compute_backend_service` and `google_compute_region_backend_service`
```
