### PR TITLE
discoveryengine: add acl_enabled to google_discovery_engine_data_store

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -100,6 +100,13 @@ samples:
       - name: 'discoveryengine_datastore_advanced_site_search_config'
         resource_id_vars:
           data_store_id: 'data-store-id'
+  - name: 'discoveryengine_datastore_acl_config'
+    primary_resource_id: 'acl_config'
+    exclude_basic_doc: true
+    steps:
+      - name: 'discoveryengine_datastore_acl_config'
+        resource_id_vars:
+          data_store_id: 'data-store-id'
 parameters:
   - name: 'location'
     type: String
@@ -190,6 +197,16 @@ properties:
       - 'NO_CONTENT'
       - 'CONTENT_REQUIRED'
       - 'PUBLIC_WEBSITE'
+  - name: 'aclEnabled'
+    type: Boolean
+    description: |
+      Immutable. Whether data in the DataStore has ACL information. If set to `true`,
+      the source data must have ACL. ACL will be ingested when data is ingested by
+      DocumentService.ImportDocuments methods. When ACL is enabled for the DataStore,
+      Document can't be accessed by calling DocumentService.GetDocument or
+      DocumentService.ListDocuments. Currently ACL is only supported in the `GENERIC`
+      industry vertical with non-`PUBLIC_WEBSITE` content config.
+    immutable: true
   - name: 'advancedSiteSearchConfig'
     type: NestedObject
     description: |

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_acl_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_acl_config.tf.tmpl
@@ -7,4 +7,10 @@ resource "google_discovery_engine_data_store" "acl_config" {
   solution_types               = ["SOLUTION_TYPE_SEARCH"]
   create_advanced_site_search  = false
   acl_enabled                  = true
+
+  document_processing_config {
+    default_parsing_config {
+      digital_parsing_config {}
+    }
+  }
 }

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_acl_config.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_acl_config.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_discovery_engine_data_store" "acl_config" {
+  location                     = "global"
+  data_store_id                = "{{index $.ResourceIdVars "data_store_id"}}"
+  display_name                 = "tf-test-acl-datastore"
+  industry_vertical            = "GENERIC"
+  content_config               = "CONTENT_REQUIRED"
+  solution_types               = ["SOLUTION_TYPE_SEARCH"]
+  create_advanced_site_search  = false
+  acl_enabled                  = true
+}

--- a/mmv1/third_party/terraform/services/discoveryengine/data_source_discovery_engine_data_store_test.go
+++ b/mmv1/third_party/terraform/services/discoveryengine/data_source_discovery_engine_data_store_test.go
@@ -29,6 +29,7 @@ func TestAccDataSourceGoogleDiscoveryEngineDataStore_basic(t *testing.T) {
 						[]string{
 							"create_advanced_site_search",
 							"skip_default_schema_creation",
+							"acl_enabled",
 						},
 					),
 				),
@@ -58,6 +59,7 @@ func TestAccDataSourceGoogleDiscoveryEngineDataStore_byDisplayName(t *testing.T)
 						[]string{
 							"create_advanced_site_search",
 							"skip_default_schema_creation",
+							"acl_enabled",
 						},
 					),
 				),


### PR DESCRIPTION
Adds the `acl_enabled` field to `google_discovery_engine_data_store`.

`DataStore.aclEnabled` is a create-time, immutable field of the Discovery Engine v1 API, but it is not currently exposed by the provider. Without it, users who need an ACL-enabled data store (so search enforces document-level permissions per end user) must create the data store out-of-band via the REST API / `null_resource`, outside Terraform state. This adds it as an immutable boolean.

`document_processing_config` (layout parsing + layout-based chunking) is already supported, so this single field is the remaining gap for provisioning an ACL-enabled, layout-parsed data store entirely in Terraform.

Closes hashicorp/terraform-provider-google#19566

### Changes
- `mmv1/products/discoveryengine/DataStore.yaml`: new immutable `acl_enabled` property.
- New sample/test `discoveryengine_datastore_acl_config` (GENERIC vertical, `CONTENT_REQUIRED`, `acl_enabled = true`).

```release-note:enhancement
discoveryengine: added `acl_enabled` field to `google_discovery_engine_data_store` resource
```