### PR TITLE
Fix zero value omission for BackendService CDN Policy TTLs

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -100,6 +100,20 @@ samples:
         resource_id_vars:
           backend_service_name: 'backend-service'
           http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_zero_ttl'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'backend_service_cache_zero_ttl'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          http_health_check_name: 'health-check'
+  - name: 'backend_service_cache_omitted_ttl'
+    primary_resource_id: 'default'
+    steps:
+      - name: 'backend_service_cache_omitted_ttl'
+        resource_id_vars:
+          backend_service_name: 'backend-service'
+          http_health_check_name: 'health-check'
   - name: 'backend_service_cache_bypass_cache_on_request_headers'
     primary_resource_id: 'default'
     steps:
@@ -777,16 +791,19 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'maxTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'clientTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -770,16 +770,19 @@ properties:
           Specifies the default TTL for cached content served by this origin for responses
           that do not have an existing valid TTL (max-age or s-max-age).
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'maxTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'clientTtl'
         type: Integer
         description: |
           Specifies the maximum allowed TTL for cached content served by this origin.
         default_from_api: true
+        custom_expand: 'templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl'
       - name: 'negativeCaching'
         type: Boolean
         description: |

--- a/mmv1/templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl
+++ b/mmv1/templates/terraform/custom_expand/backend_service_cdn_policy_ttl.go.tmpl
@@ -1,0 +1,25 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func expand{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d tpgresource.TerraformResourceData, config *transport_tpg.Config) (interface{}, error) {
+	// Custom expander to distinguish between explicitly set 0 and omitted TTL.
+	// Returning a pointer allows IsEmptyValue to return false for 0, while returning nil allows it to be dropped.
+	
+	path := "{{underscore $.ParentMetadata.Name}}.0.{{underscore $.Name}}"
+	
+	if val, ok := d.GetOkExists(path); ok {
+		iVal := val.(int)
+		return &iVal, nil
+	}
+	
+	return nil, nil
+}

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_http_health_check.default.self_link]
   enable_cdn    = true
   cdn_policy {
     cache_mode   = "CACHE_ALL_STATIC"

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_omitted_ttl.tf.tmpl
@@ -1,0 +1,17 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
+  health_checks = [google_compute_http_health_check.default.id]
+  enable_cdn    = true
+  cdn_policy {
+    cache_mode   = "CACHE_ALL_STATIC"
+    signed_url_cache_max_age_sec = 7200
+    # TTLs are omitted
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
@@ -1,6 +1,6 @@
 resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
   name          = "{{index $.ResourceIdVars "backend_service_name"}}"
-  health_checks = [google_compute_http_health_check.default.id]
+  health_checks = [google_compute_http_health_check.default.self_link]
   enable_cdn    = true
   cdn_policy {
     cache_mode   = "CACHE_ALL_STATIC"

--- a/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/backend_service_cache_zero_ttl.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_compute_backend_service" "{{$.PrimaryResourceId}}" {
+  name          = "{{index $.ResourceIdVars "backend_service_name"}}"
+  health_checks = [google_compute_http_health_check.default.id]
+  enable_cdn    = true
+  cdn_policy {
+    cache_mode   = "CACHE_ALL_STATIC"
+    default_ttl  = 0
+    client_ttl   = 0
+    max_ttl      = 0
+    signed_url_cache_max_age_sec = 7200
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "{{index $.ResourceIdVars "http_health_check_name"}}"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}


### PR DESCRIPTION
### Summary of changes:
1.  **Custom Expander Template:** Created `backend_service_cdn_policy_ttl.go.tmpl` using `d.GetOkExists` to distinguish between explicit `0` and omission. It returns a pointer `*int` which allows Terraform to distinguish `0` from `nil` (omitted).
2.  **YAML Updates:** Registered this custom expander in `BackendService.yaml` and `RegionBackendService.yaml` for `defaultTtl`, `maxTtl`, and `clientTtl`.
3.  **Tests Added:** Added `backend_service_cache_zero_ttl` and `backend_service_cache_omitted_ttl` samples to verify the fix and prevent regressions.
4.  **Verification:** All related tests passed, including the one that was failing with Option 2 (`TestAccComputeBackendService_backendServiceCacheIncludeHttpHeadersExample`), confirming that omitted TTLs are no longer implicitly sent as `0`.

### Linked Issues:
Fixes https://issuetracker.google.com/issues/498433517

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed omission of explicit `0` values for `default_ttl`, `max_ttl`, and `client_ttl` in `cdn_policy` for `google_compute_backend_service` and `google_compute_region_backend_service`
```
