### PR TITLE
Add support for enforce_new_sql_network_architecture flag in google_s…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -263,6 +263,13 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 				Optional:    true,
 				Description: `Used to block Terraform from deleting a SQL Instance. Defaults to true.`,
 			},
+			"enforce_new_sql_network_architecture": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: sqlNetworkArchitectureDiffSuppress,
+				Description:      `Whether to enforce the new SQL network architecture.`,
+			},
 			"final_backup_description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1676,6 +1683,12 @@ func pitrSupportDbCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 	return nil
 }
 
+func sqlNetworkArchitectureDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// If the state is true and the config is false, suppress the diff.
+	// This follows the gcloud pattern where the flag is an irreversible opt-in.
+	return old == "true" && new == "false"
+}
+
 func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
@@ -1722,6 +1735,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		DatabaseVersion:      databaseVersion,
 		MasterInstanceName:   d.Get("master_instance_name").(string),
 		ReplicaConfiguration: expandReplicaConfiguration(d.Get("replica_configuration").([]interface{})),
+	}
+
+	if d.Get("enforce_new_sql_network_architecture").(bool) {
+		instance.SqlNetworkArchitecture = "NEW_NETWORK_ARCHITECTURE"
 	}
 
 	cloneContext, cloneSourceInstance := expandCloneContext(d.Get("clone").([]interface{}))
@@ -2499,6 +2516,9 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("instance_type", instance.InstanceType); err != nil {
 		return fmt.Errorf("Error setting instance_type: %s", err)
 	}
+	if err := d.Set("enforce_new_sql_network_architecture", instance.SqlNetworkArchitecture == "NEW_NETWORK_ARCHITECTURE"); err != nil {
+		return fmt.Errorf("Error setting enforce_new_sql_network_architecture: %s", err)
+	}
 	if err := d.Set("node_count", instance.NodeCount); err != nil {
 		return fmt.Errorf("Error setting node_count: %s", err)
 	}
@@ -2650,6 +2670,29 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		})
 		if err != nil {
 			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", instance.Name, err)
+		}
+		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+		err = resourceSqlDatabaseInstanceRead(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("enforce_new_sql_network_architecture") && d.Get("enforce_new_sql_network_architecture").(bool) {
+		instance = &sqladmin.DatabaseInstance{SqlNetworkArchitecture: "NEW_NETWORK_ARCHITECTURE"}
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() (rerr error) {
+				op, rerr = NewClient(config, userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()
+				return rerr
+			},
+			Timeout:              d.Timeout(schema.TimeoutUpdate),
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
+		})
+		if err != nil {
+			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", d.Get("name").(string), err)
 		}
 		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -265,11 +265,10 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 				Description: `Used to block Terraform from deleting a SQL Instance. Defaults to true.`,
 			},
 			"enforce_new_sql_network_architecture": {
-				Type:             schema.TypeBool,
-				Optional:         true,
-				Computed:         true,
-				DiffSuppressFunc: sqlNetworkArchitectureDiffSuppress,
-				Description:      `Whether to enforce the new SQL network architecture.`,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: `Whether to enforce the new SQL network architecture.`,
 			},
 			"final_backup_description": {
 				Type:        schema.TypeString,
@@ -1682,12 +1681,6 @@ func pitrSupportDbCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 		return fmt.Errorf("point_in_time_recovery_enabled is only available for the following %v. You may want to consider using binary_log_enabled instead and remove point_in_time_recovery_enabled (removing point_in_time_recovery_enabled and adding binary_log_enabled will enable pitr for MYSQL)", dbVersionPitrValid)
 	}
 	return nil
-}
-
-func sqlNetworkArchitectureDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// If the state is true and the config is false, suppress the diff.
-	// This follows the gcloud pattern where the flag is an irreversible opt-in.
-	return old == "true" && new == "false"
 }
 
 func sqlNetworkArchitectureCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -246,6 +246,7 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 			nodeCountCustomDiff,
 			autoUpgradeEnabledCustomizeDiff,
 			activeDirectoryCustomizeDiff,
+			sqlNetworkArchitectureCustomizeDiff,
 			tpgresource.DefaultProviderDeletionPolicy("DELETE"),
 		),
 
@@ -1689,6 +1690,13 @@ func sqlNetworkArchitectureDiffSuppress(k, old, new string, d *schema.ResourceDa
 	return old == "true" && new == "false"
 }
 
+func sqlNetworkArchitectureCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if d.Id() != "" && d.HasChange("enforce_new_sql_network_architecture") {
+		return fmt.Errorf("enforce_new_sql_network_architecture can only be set during resource creation")
+	}
+	return nil
+}
+
 func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
@@ -2670,29 +2678,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		})
 		if err != nil {
 			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", instance.Name, err)
-		}
-		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
-		if err != nil {
-			return err
-		}
-		err = resourceSqlDatabaseInstanceRead(d, meta)
-		if err != nil {
-			return err
-		}
-	}
-
-	if d.HasChange("enforce_new_sql_network_architecture") && d.Get("enforce_new_sql_network_architecture").(bool) {
-		instance = &sqladmin.DatabaseInstance{SqlNetworkArchitecture: "NEW_NETWORK_ARCHITECTURE"}
-		err = transport_tpg.Retry(transport_tpg.RetryOptions{
-			RetryFunc: func() (rerr error) {
-				op, rerr = NewClient(config, userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()
-				return rerr
-			},
-			Timeout:              d.Timeout(schema.TimeoutUpdate),
-			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
-		})
-		if err != nil {
-			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", d.Get("name").(string), err)
 		}
 		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -74,6 +74,8 @@ fields:
   - api_field: 'replicaConfiguration.mysqlReplicaConfiguration.verifyServerCertificate'
     field: 'replica_configuration.verify_server_certificate'
   - api_field: 'replicaNames'
+  - api_field: 'sqlNetworkArchitecture'
+    field: 'enforce_new_sql_network_architecture'
   - api_field: 'replicationCluster.drReplica'
   - api_field: 'replicationCluster.failoverDrReplicaName'
   - api_field: 'replicationCluster.psaWriteEndpoint'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -285,12 +285,8 @@ func TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
-				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, false),
-				Check: resource.ComposeTestCheckFunc(
-					// Verify that even though we set it to false in HCL, the state stays true
-					// and no diff was generated (otherwise this step would fail or show a plan).
-					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "true"),
-				),
+				Config:      testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, false),
+				ExpectError: regexp.MustCompile("enforce_new_sql_network_architecture can only be set during resource creation"),
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -262,6 +262,40 @@ func TestAccSqlDatabaseInstance_basicSecondGen(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(t *testing.T) {
+	t.Parallel()
+
+	instanceName := "tf-test-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, false),
+				Check: resource.ComposeTestCheckFunc(
+					// Verify that even though we set it to false in HCL, the state stays true
+					// and no diff was generated (otherwise this step would fail or show a plan).
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_basicMSSQL(t *testing.T) {
 	t.Parallel()
 
@@ -9989,3 +10023,20 @@ func testGoogleSqlDatabaseInstanceCheckNodeCount(t *testing.T, instance string, 
 		return nil
 	}
 }
+
+func testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName string, enforce bool) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-central1"
+  database_version = "POSTGRES_14"
+  enforce_new_sql_network_architecture = %t
+  settings {
+    tier = "db-f1-micro"
+  }
+
+  deletion_protection =  false
+}
+`, instanceName, enforce)
+}
+

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -296,6 +296,30 @@ func TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitectureError(t *testing.T) {
+	t.Parallel()
+
+	instanceName := "tf-test-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "false"),
+				),
+			},
+			{
+				Config:      testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, true),
+				ExpectError: regexp.MustCompile("enforce_new_sql_network_architecture can only be set during resource creation"),
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_basicMSSQL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Support `enforce_new_sql_network_architecture` flag in `google_sql_database_instance`

## Description
This pull request adds support for the enforce_new_sql_network_architecture parameter to the google_sql_database_instance resource.

The enforce_new_sql_network_architecture attribute is a boolean field that allows users to opt-in to the new SQL network architecture. This flag is restricted to resource creation only. Once a resource is created, this attribute cannot be modified; any attempt to enable it post-creation will result in a configuration error. This aligns with the irreversible nature of the feature in the underlying API.

To provide a smooth user experience, a custom diff suppression function is used so that users can safely remove the flag from their configuration after the resource has been created without triggering a perpetual diff or plan error.

## Changes

1. Resource Implementation
   * mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl:
     * Added the schema definition for enforce_new_sql_network_architecture.
     * Implemented sqlNetworkArchitectureCustomizeDiff: This ensures the flag is only configurable during creation. It throws a clear error if an update is attempted on an existing resource.
     * Retained sqlNetworkArchitectureDiffSuppress: Allows the state to remain true even if the user removes the flag from their HCL after creation, preventing unnecessary plan noise.
     * Updated resourceSqlDatabaseInstanceCreate to set the API field SqlNetworkArchitecture to "NEW_NETWORK_ARCHITECTURE".
     * Updated resourceSqlDatabaseInstanceRead to correctly populate the Terraform state from the API response.
     * Removed Update Logic: Deleted the previous .Instances.Patch logic for this flag, as updates are now explicitly disallowed via CustomizeDiff.

  2. Metadata Mapping
   * mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl:
     * Mapped the API field sqlNetworkArchitecture to the Terraform field enforce_new_sql_network_architecture.

  3. Tests
   * mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl:
     * Updated TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture to verify successful creation and state persistence.
     * Added TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitectureError: A new test case that specifically verifies that attempting to enable the flag on an existing instance returns the expected validation
       error.
***

```release-note:enhancement
sql: added `enforce_new_sql_network_architecture` field to `google_sql_database_instance` resource (create-only)
```

