### PR TITLE
fix(vertexai): in-place replica-count updates for EndpointWithModelGa…

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1387,7 +1387,7 @@ func (r Resource) Updatable() bool {
 	if !r.Immutable {
 		return true
 	}
-	for _, p := range r.AllPropertiesInVersion() {
+	for _, p := range r.AllNestedProperties(r.RootProperties()) {
 		if p.UpdateUrl != "" {
 			return true
 		}

--- a/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
+++ b/mmv1/products/vertexai/EndpointWithModelGardenDeployment.yaml
@@ -30,6 +30,7 @@ create_url: projects/{{project}}/locations/{{location}}:deploy
 id_format: projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}
 timeouts:
   insert_minutes: 180
+  update_minutes: 20
   delete_minutes: 20
 exclude_import: true # the resource does not support import
 async:
@@ -44,6 +45,7 @@ async:
 exclude_read: true
 autogen_status: RW5kcG9pbnRXaXRoTW9kZWxHYXJkZW5EZXBsb3ltZW50
 custom_code:
+  custom_update: templates/terraform/custom_update/vertex_ai_endpoint_with_model_garden_deployment.go.tmpl
   post_create: templates/terraform/post_create/resource_vertexai_endpoint_with_model_garden_deployment.go.tmpl
   custom_delete: templates/terraform/custom_delete/resource_vertexai_endpoint_with_model_garden_deployment.go.tmpl
 samples:
@@ -1025,7 +1027,8 @@ properties:
 
               If traffic increases, it may dynamically be deployed onto more replicas,
               and as traffic decreases, some of these extra replicas may be freed.
-            immutable: true
+            update_url: 'projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}:mutateDeployedModel'
+            update_verb: 'POST'
             required: true
           - name: maxReplicaCount
             type: Integer
@@ -1042,7 +1045,8 @@ properties:
               quotas. Specifically, you will be charged for (max_replica_count *
               number of cores in the selected machine type) and (max_replica_count *
               number of GPUs per replica in the selected machine type).
-            immutable: true
+            update_url: 'projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}:mutateDeployedModel'
+            update_verb: 'POST'
           - name: requiredReplicaCount
             type: Integer
             description: |-
@@ -1052,6 +1056,8 @@ properties:
               available_replica_count reaches required_replica_count, and the rest of
               the replicas will be retried. If not set, the default
               required_replica_count will be min_replica_count.
+            update_url: 'projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}:mutateDeployedModel'
+            update_verb: 'POST'
           - name: autoscalingMetricSpecs
             type: Array
             description: |-
@@ -1075,7 +1081,8 @@ properties:
               autoscaling_metric_specs.metric_name
               to `aiplatform.googleapis.com/prediction/online/cpu/utilization` and
               autoscaling_metric_specs.target to `80`.
-            immutable: true
+            update_url: 'projects/{{project}}/locations/{{location}}/endpoints/{{endpoint}}:mutateDeployedModel'
+            update_verb: 'POST'
             item_type:
               type: NestedObject
               properties:

--- a/mmv1/templates/terraform/custom_update/vertex_ai_endpoint_with_model_garden_deployment.go.tmpl
+++ b/mmv1/templates/terraform/custom_update/vertex_ai_endpoint_with_model_garden_deployment.go.tmpl
@@ -1,0 +1,102 @@
+{{/*
+	The license inside this block applies to this file.
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+// `config` is declared in the enclosing generated Update body; do not redeclare.
+userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+if err != nil {
+	return err
+}
+
+billingProject := ""
+project, err := tpgresource.GetProject(d, config)
+if err != nil {
+	return fmt.Errorf("Error fetching project for EndpointWithModelGardenDeployment: %s", err)
+}
+billingProject = project
+if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+	billingProject = bp
+}
+
+deployedModelId, _ := d.Get("deployed_model_id").(string)
+if deployedModelId == "" {
+	return fmt.Errorf("cannot update EndpointWithModelGardenDeployment %q: deployed_model_id is empty (resource may be in an inconsistent state)", d.Id())
+}
+
+dedicatedResources := map[string]interface{}{}
+updateMask := []string{}
+
+if d.HasChange("deploy_config.0.dedicated_resources.0.min_replica_count") {
+	dedicatedResources["minReplicaCount"] = d.Get("deploy_config.0.dedicated_resources.0.min_replica_count")
+	updateMask = append(updateMask, "dedicatedResources.minReplicaCount")
+}
+if d.HasChange("deploy_config.0.dedicated_resources.0.max_replica_count") {
+	dedicatedResources["maxReplicaCount"] = d.Get("deploy_config.0.dedicated_resources.0.max_replica_count")
+	updateMask = append(updateMask, "dedicatedResources.maxReplicaCount")
+}
+if d.HasChange("deploy_config.0.dedicated_resources.0.required_replica_count") {
+	dedicatedResources["requiredReplicaCount"] = d.Get("deploy_config.0.dedicated_resources.0.required_replica_count")
+	updateMask = append(updateMask, "dedicatedResources.requiredReplicaCount")
+}
+if d.HasChange("deploy_config.0.dedicated_resources.0.autoscaling_metric_specs") {
+	expanded, err := expandVertexAIEndpointWithModelGardenDeploymentDeployConfigDedicatedResourcesAutoscalingMetricSpecs(
+		d.Get("deploy_config.0.dedicated_resources.0.autoscaling_metric_specs"), d, config)
+	if err != nil {
+		return err
+	}
+	dedicatedResources["autoscalingMetricSpecs"] = expanded
+	updateMask = append(updateMask, "dedicatedResources.autoscalingMetricSpecs")
+}
+
+if len(updateMask) == 0 {
+	return resourceVertexAIEndpointWithModelGardenDeploymentRead(d, meta)
+}
+
+body := map[string]interface{}{
+	"deployedModel": map[string]interface{}{
+		"id":                 deployedModelId,
+		"dedicatedResources": dedicatedResources,
+	},
+	"updateMask": strings.Join(updateMask, ","),
+}
+
+url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}VertexAIBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/endpoints/{{"{{"}}endpoint{{"}}"}}:mutateDeployedModel")
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Updating EndpointWithModelGardenDeployment %q via mutateDeployedModel with mask %q", d.Id(), strings.Join(updateMask, ","))
+
+headers := make(http.Header)
+res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+	Config:    config,
+	Method:    "POST",
+	Project:   billingProject,
+	RawURL:    url,
+	UserAgent: userAgent,
+	Body:      body,
+	Timeout:   d.Timeout(schema.TimeoutUpdate),
+	Headers:   headers,
+})
+if err != nil {
+	return fmt.Errorf("Error updating EndpointWithModelGardenDeployment %q: %s", d.Id(), err)
+}
+
+err = VertexAIOperationWaitTime(
+	config, res, project, "Updating EndpointWithModelGardenDeployment", userAgent,
+	d.Timeout(schema.TimeoutUpdate))
+if err != nil {
+	return fmt.Errorf("Error waiting to update EndpointWithModelGardenDeployment %q: %s", d.Id(), err)
+}
+
+log.Printf("[DEBUG] Finished updating EndpointWithModelGardenDeployment %q", d.Id())
+
+return resourceVertexAIEndpointWithModelGardenDeploymentRead(d, meta)

--- a/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_with_model_garden_deployment_test.go
+++ b/mmv1/third_party/terraform/services/vertexai/resource_vertex_ai_endpoint_with_model_garden_deployment_test.go
@@ -321,3 +321,149 @@ func testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t *tes
 		return nil
 	}
 }
+
+func TestAccVertexAIEndpointWithModelGardenDeployment_updateReplicaCountInPlace(t *testing.T) {
+	t.Parallel()
+	t.Skip("b/514579514 for manual test logs")
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	var endpointBefore, endpointAfter string
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIEndpointWithModelGardenDeployment_updateReplicaCountInPlace(context, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_vertex_ai_endpoint_with_model_garden_deployment.test_inplace",
+						"deploy_config.0.dedicated_resources.0.max_replica_count", "2"),
+					captureEndpointAttribute(
+						"google_vertex_ai_endpoint_with_model_garden_deployment.test_inplace",
+						"endpoint", &endpointBefore),
+				),
+			},
+			{
+				Config: testAccVertexAIEndpointWithModelGardenDeployment_updateReplicaCountInPlace(context, 3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"google_vertex_ai_endpoint_with_model_garden_deployment.test_inplace",
+						"deploy_config.0.dedicated_resources.0.max_replica_count", "3"),
+					captureEndpointAttribute(
+						"google_vertex_ai_endpoint_with_model_garden_deployment.test_inplace",
+						"endpoint", &endpointAfter),
+					func(s *terraform.State) error {
+						if endpointBefore == "" || endpointAfter == "" {
+							return fmt.Errorf("endpoint id not captured (before=%q after=%q)",
+								endpointBefore, endpointAfter)
+						}
+						if endpointBefore != endpointAfter {
+							return fmt.Errorf(
+								"endpoint id changed across in-place update (before=%q after=%q); "+
+									"resource was recreated instead of mutated in place",
+								endpointBefore, endpointAfter)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testAccVertexAIEndpointWithModelGardenDeployment_updateReplicaCountInPlace(context map[string]interface{}, maxReplicas int) string {
+	context["max_replicas"] = maxReplicas
+	return acctest.Nprintf(`
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test_inplace" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula = true
+  }
+
+  deploy_config {
+    dedicated_resources {
+      machine_spec {
+        machine_type      = "g2-standard-12"
+        accelerator_type  = "NVIDIA_L4"
+        accelerator_count = 1
+      }
+      min_replica_count = 1
+      max_replica_count = %{max_replicas}
+    }
+  }
+}
+`, context)
+}
+
+func TestAccVertexAIEndpointWithModelGardenDeployment_machineTypeStillForcesReplacement(t *testing.T) {
+	t.Parallel()
+	t.Skip("b/514579514 for manual test logs")
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckVertexAIEndpointWithModelGardenDeploymentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVertexAIEndpointWithModelGardenDeployment_machineType(context, "g2-standard-12"),
+			},
+			{
+				Config:             testAccVertexAIEndpointWithModelGardenDeployment_machineType(context, "g2-standard-16"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccVertexAIEndpointWithModelGardenDeployment_machineType(context map[string]interface{}, machineType string) string {
+	context["machine_type"] = machineType
+	return acctest.Nprintf(`
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "test_machine_type" {
+  publisher_model_name = "publishers/google/models/paligemma@paligemma-224-float32"
+  location             = "us-central1"
+
+  model_config {
+    accept_eula = true
+  }
+
+  deploy_config {
+    dedicated_resources {
+      machine_spec {
+        machine_type      = "%{machine_type}"
+        accelerator_type  = "NVIDIA_L4"
+        accelerator_count = 1
+      }
+      min_replica_count = 1
+      max_replica_count = 1
+    }
+  }
+}
+`, context)
+}
+
+func captureEndpointAttribute(resourceName, attr string, dest *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		v, ok := rs.Primary.Attributes[attr]
+		if !ok || v == "" {
+			return fmt.Errorf("attribute %q is empty on %s", attr, resourceName)
+		}
+		*dest = v
+		return nil
+	}
+}


### PR DESCRIPTION
The resource is declared `immutable: true`, so any change to
`min_replica_count`, `max_replica_count`, `required_replica_count`, or
`autoscaling_metric_specs` destroys and recreates the underlying Endpoint.
With `dedicated_endpoint_enabled = true` this also rotates the dedicated
DNS, breaking every prediction client that hardcodes it.
The v1 API supports in-place updates for exactly those four fields via
[endpoints:mutateDeployedModel][1]. This PR wires that path through MM:
* YAML: drop `immutable: true` and add `update_url` + `update_verb: POST`
  on the four fields under `deploy_config.dedicated_resources`. Per-field
  `update_url` makes `IsForceNew()` return false for just those leaves;
  every other field stays immutable.
* New `custom_update` template builds a minimal `MutateDeployedModelRequest`
  with a tight `updateMask` from `d.HasChange(...)`, POSTs to
  `:mutateDeployedModel`, waits on the LRO, then calls Read.
* `Resource.Updatable()` in `mmv1/api/resource.go`: walk nested properties
  so an `update_url` on a deeply-nested field actually enables Update
  generation. Without this, the generator emitted the no-op `Update`
  fallback even though the schema correctly omitted `ForceNew`.
* Add `update_minutes: 20` to the resource `timeouts`. The block previously
  only declared `insert`/`delete`, defaulting Update to 0m and making
  `VertexAIOperationWaitTime` bail immediately.
* Two acceptance tests:
  * `_updateReplicaCountInPlace` — apply max=2, capture endpoint id, apply
    max=3, assert id unchanged.
  * `_machineTypeStillForcesReplacement` — regression guard that immutable
    fields still trigger replacement.
The drift-detection defect (no-op Read from `exclude_read: true`) is a
separate concern and will be fixed in a follow-up.
[1]: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.endpoints/mutateDeployedModel
Fixes the destroy-and-recreate half of hashicorp/terraform-provider-google#27250
```release-note:bug
vertexai: fixed `google_vertex_ai_endpoint_with_model_garden_deployment` destroying and recreating the endpoint when `min_replica_count`, `max_replica_count`, `required_replica_count`, or `autoscaling_metric_specs` changed; these fields are now updated in place via `endpoints:mutateDeployedModel`
```