### PR TITLE
privilegedaccessmanager: fix permadiff on entitlements with no approval workflow

### DIFF
--- a/mmv1/products/privilegedaccessmanager/Entitlement.yaml
+++ b/mmv1/products/privilegedaccessmanager/Entitlement.yaml
@@ -127,6 +127,10 @@ properties:
       The approvals needed before access will be granted to a requester.
       No approvals will be needed if this field is null. Different types of approval workflows that can be used to gate privileged access granting.
     immutable: true
+    # This flattener is entirely handwritten and must be updated with any new field or subfield.
+    # Solves a permadiff when the API returns `{"approvalWorkflow": {"manualApprovals": {}}}`
+    # for entitlements created without an approval workflow.
+    custom_flatten: templates/terraform/custom_flatten/privileged_access_manager_entitlement_approval_workflow.go.tmpl
     properties:
       - name: manualApprovals
         type: NestedObject

--- a/mmv1/templates/terraform/custom_flatten/privileged_access_manager_entitlement_approval_workflow.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/privileged_access_manager_entitlement_approval_workflow.go.tmpl
@@ -1,0 +1,150 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflow(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["manual_approvals"] =
+		flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovals(original["manualApprovals"], d, config)
+
+	// begin handwritten code (all other parts of this file are forked from generated code)
+	// solve for the following diff when no approval workflow is configured:
+	//
+	// - approval_workflow {
+	//   - manual_approvals = null
+	// }
+	//
+	// the PAM API returns the field as:
+	//
+	// "approvalWorkflow": {
+	//   "manualApprovals": {}
+	// },
+	//
+	// for entitlements that were created without an approval workflow (for example via
+	// gcloud or the Cloud console). the outer `len(original) == 0` guard above does not
+	// fire because the `manualApprovals` key is present, and the inner flattener returns
+	// nil for the empty `manualApprovals` object. without this guard the resource ends
+	// up with a phantom `approval_workflow = [{manual_approvals = null}]` block in state,
+	// which cannot be reconciled with any user configuration (`manual_approvals` is
+	// Required, `manual_approvals.steps` has MinItems: 1, and `approval_workflow` is
+	// ForceNew), producing a permanent destroy+recreate diff.
+	//
+	// if any new sibling field is added under approvalWorkflow, this block must be updated
+	// to also check that the new field is nil before short-circuiting.
+	if transformed["manual_approvals"] == nil {
+		return nil
+	}
+	// end handwritten code
+
+	return []interface{}{transformed}
+}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovals(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["require_approver_justification"] =
+		flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsRequireApproverJustification(original["requireApproverJustification"], d, config)
+	transformed["steps"] =
+		flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsSteps(original["steps"], d, config)
+	return []interface{}{transformed}
+}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsRequireApproverJustification(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsSteps(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"approvers":                 flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApprovers(original["approvers"], d, config),
+			"approvals_needed":          flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApprovalsNeeded(original["approvalsNeeded"], d, config),
+			"approver_email_recipients": flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApproverEmailRecipients(original["approverEmailRecipients"], d, config),
+{{- if ne $.ResourceMetadata.TargetVersionName "ga" }}
+			"id":                        flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsId(original["id"], d, config),
+{{- end }}
+		})
+	}
+	return transformed
+}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApprovers(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"principals": flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApproversPrincipals(original["principals"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApproversPrincipals(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	return schema.NewSet(schema.HashString, v.([]interface{}))
+}
+
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApprovalsNeeded(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	// Handles the string fixed64 format
+	if strVal, ok := v.(string); ok {
+		if intVal, err := tpgresource.StringToFixed64(strVal); err == nil {
+			return intVal
+		}
+	}
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
+}
+
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsApproverEmailRecipients(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	return schema.NewSet(schema.HashString, v.([]interface{}))
+}
+{{ if ne $.ResourceMetadata.TargetVersionName "ga" }}
+func flattenPrivilegedAccessManagerEntitlementApprovalWorkflowManualApprovalsStepsId(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/privilegedaccessmanager/resource_privileged_access_manager_entitlement_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/privilegedaccessmanager/resource_privileged_access_manager_entitlement_test.go.tmpl
@@ -10,6 +10,32 @@ import (
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 )
 
+func TestAccPrivilegedAccessManagerEntitlement_noApprovalWorkflow(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+		"project_name":  envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckPrivilegedAccessManagerEntitlementDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivilegedAccessManagerEntitlement_noApprovalWorkflow(context),
+			},
+			{
+				ResourceName:            "google_privileged_access_manager_entitlement.tfentitlement",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"location", "entitlement_id", "parent"},
+			},
+		},
+	})
+}
+
 func TestAccPrivilegedAccessManagerEntitlement_privilegedAccessManagerEntitlementProjectExample_update(t *testing.T) {
 	t.Parallel()
 
@@ -200,6 +226,32 @@ resource "google_privileged_access_manager_entitlement" "tfentitlement" {
       }
     }
   }
+}
+`, context)
+}
+
+func testAccPrivilegedAccessManagerEntitlement_noApprovalWorkflow(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_privileged_access_manager_entitlement" "tfentitlement" {
+    entitlement_id = "tf-test-example-entitlement%{random_suffix}"
+    location = "global"
+    max_request_duration = "43200s"
+    parent = "projects/%{project_name}"
+    requester_justification_config {
+      unstructured {}
+    }
+    eligible_users {
+      principals = ["group:test@google.com"]
+    }
+    privileged_access {
+      gcp_iam_access {
+        role_bindings {
+          role = "roles/storage.admin"
+        }
+        resource = "//cloudresourcemanager.googleapis.com/projects/%{project_name}"
+        resource_type = "cloudresourcemanager.googleapis.com/Project"
+      }
+    }
 }
 `, context)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28070

Adds a `custom_flatten` on `approvalWorkflow` so that the resource no longer carries
a phantom empty `approval_workflow` block in state when the entitlement was created
without an approval workflow. Follows the same pattern as
`mmv1/templates/terraform/custom_flatten/appengine_standardappversion_automatic_scaling_handlenil.go.tmpl`.

```release-note:bug
privilegedaccessmanager: fixed a permadiff on `google_privileged_access_manager_entitlement` for entitlements created without an approval workflow
```