### PR TITLE
fix(magician): rename functions to match Google's developer's word list

### DIFF
--- a/.ci/magician/cmd/sandbox_sanity_test.go
+++ b/.ci/magician/cmd/sandbox_sanity_test.go
@@ -42,16 +42,16 @@ func TestSandboxInitialization(t *testing.T) {
 
 func TestSandboxInterceptor_AllowedCommand(t *testing.T) {
 	sb := newSandbox(t)
-	sb.RequireWhitelist()
+	sb.RequireAllowlist()
 	_, err := sb.Runner.Run("touch", []string{"test_file.txt"}, nil)
 	if err != nil {
-		t.Fatalf("Expected whitelisted command to succeed, got: %v", err)
+		t.Fatalf("Expected allowlisted command to succeed, got: %v", err)
 	}
 }
 
 func TestSandboxInterceptor_MockOverridesAllowed(t *testing.T) {
 	sb := newSandbox(t)
-	sb.RequireWhitelist()
+	sb.RequireAllowlist()
 	sb.Runner.WriteFile("echo", "#!/bin/bash\necho 'intercepted echo'")
 	os.Chmod(filepath.Join(sb.Dir, "echo"), 0755)
 
@@ -60,13 +60,13 @@ func TestSandboxInterceptor_MockOverridesAllowed(t *testing.T) {
 		t.Fatalf("Expected mocked command to succeed, got: %v", err)
 	}
 	if !strings.Contains(output, "intercepted echo") {
-		t.Errorf("Expected sandbox mock to override whitelist, got: %s", output)
+		t.Errorf("Expected sandbox mock to override allowlist, got: %s", output)
 	}
 }
 
 func TestSandboxInterceptor_UnhandledCommandPanics(t *testing.T) {
 	sb := newSandbox(t)
-	sb.RequireWhitelist()
+	sb.RequireAllowlist()
 	_, err := sb.Runner.Run("curl", []string{"http://example.com"}, nil)
 	if err == nil {
 		t.Fatalf("Expected unhandled command to return error, but it succeeded")

--- a/.ci/magician/cmd/sandbox_test.go
+++ b/.ci/magician/cmd/sandbox_test.go
@@ -115,7 +115,7 @@ func (s *sandbox) AllowPassthrough(commands ...string) {
 	}
 }
 
-func (s *sandbox) RequireWhitelist() {
+func (s *sandbox) RequireAllowlist() {
 	if runner, ok := s.Runner.(*interceptingRunner); ok {
 		runner.strictMode = true
 	}

--- a/.ci/magician/cmd/wait_for_commit_test.go
+++ b/.ci/magician/cmd/wait_for_commit_test.go
@@ -87,6 +87,8 @@ func TestExecWaitForCommit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			sb := newSandbox(t)
+			sb.RequireAllowlist()
+			sb.AllowPassthrough("git")
 			originDir := t.TempDir()
 			sb.Runner.MustRun("git", []string{"init", "--bare", "-b", "main", originDir}, nil)
 			sb.Runner.MustRun("git", []string{"remote", "add", "origin", originDir}, nil)


### PR DESCRIPTION
Update the testing sandbox interceptor functions (`RequireWhitelist` to `RequireAllowlist`) and associated error strings to comply with Google's language guidelines.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
