### PR TITLE
feat(vertexai): add customizationConfigs to google_vertex_ai_reasonin…

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -650,12 +650,18 @@ properties:
                     type: NestedObject
                     properties:
                       - name: 'managedMemoryTopic'
-                        type: String
+                        type: NestedObject
+                        # Note: exactly_one_of within array elements is not enforced client-side by MM; relies on backend API server validation.
                         exactly_one_of:
                           - managedMemoryTopic
                           - customMemoryTopic
                         description: |-
-                          Optional. Managed memory topic enum.
+                          Optional. Managed memory topic.
+                        properties:
+                          - name: 'managedTopicEnum'
+                            type: String
+                            description: |-
+                              Managed topic enum (e.g. USER_PREFERENCES, EXPLICIT_INSTRUCTIONS).
                       - name: 'customMemoryTopic'
                         type: NestedObject
                         description: |-
@@ -709,6 +715,7 @@ properties:
                         required: true
                       - name: 'memorySchema'
                         type: String
+                        api_name: 'schema'
                         description: |-
                           Optional. The memory schema defined as an OpenAPI Schema Object JSON string.
                         state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -629,3 +629,56 @@ properties:
             type: Boolean
             description: |-
               If true, no memory revisions will be created for any requests to the Memory Bank.
+          - name: 'customizationConfigs'
+            type: Array
+            description: |-
+              Optional. Customization configs for how Agent Engine sub-resources manage context at different scope levels.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'scopeKeys'
+                  type: Array
+                  description: |-
+                    Optional. List of scope keys that this customization config applies to.
+                  item_type:
+                    type: String
+                - name: 'memoryTopics'
+                  type: Array
+                  description: |-
+                    Optional. List of topics that the memory should be associated with.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'managedMemoryTopic'
+                        type: String
+                        exactly_one_of:
+                          - managedMemoryTopic
+                          - customMemoryTopic
+                        description: |-
+                          Optional. Managed memory topic enum.
+                      - name: 'customMemoryTopic'
+                        type: NestedObject
+                        description: |-
+                          Optional. Custom memory topic.
+                        properties:
+                          - name: 'label'
+                            type: String
+                            description: |-
+                              Label of custom memory topic.
+                          - name: 'description'
+                            type: String
+                            description: |-
+                              Description of custom memory topic.
+                - name: 'consolidationConfig'
+                  type: NestedObject
+                  description: |-
+                    Optional. Configuration for how many memory revisions Memory Bank considers when consolidating each memory candidate.
+                  properties:
+                    - name: 'revisionsPerCandidateCount'
+                      type: Integer
+                      description: |-
+                        Number of revisions to consider per candidate count.
+                - name: 'enableThirdPersonMemories'
+                  type: Boolean
+                  description: |-
+                    Optional. Generate memories in the third person if set to true.

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -682,3 +682,37 @@ properties:
                   type: Boolean
                   description: |-
                     Optional. Generate memories in the third person if set to true.
+          - name: 'structuredMemoryConfigs'
+            type: Array
+            description: |-
+              Optional. Structured memory configurations for Agent Engine sub-resources.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: 'scopeKeys'
+                  type: Array
+                  description: |-
+                    Optional. List of scope keys that this structured memory config applies to.
+                  item_type:
+                    type: String
+                - name: 'schemaConfigs'
+                  type: Array
+                  description: |-
+                    Optional. List of schema configs that this structured memory config applies to.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: 'id'
+                        type: String
+                        description: |-
+                          Required. Unique ID identifying the memory schema.
+                        required: true
+                      - name: 'memorySchema'
+                        type: String
+                        description: |-
+                          Optional. The memory schema defined as an OpenAPI Schema Object JSON string.
+                        state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                        custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                        custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'
+                        validation:
+                          function: 'validation.StringIsJSON'

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -13,16 +13,34 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
         embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
       }
       disable_memory_revisions = false
+
+      # 1. User-level Customization Config (Lifelong baseline)
       customization_configs {
         scope_keys                   = ["user_id"]
-        enable_third_person_memories = false
+        enable_third_person_memories = true
         consolidation_config {
           revisions_per_candidate_count = 1
         }
         memory_topics {
-          managed_memory_topic = "USER_PREFERENCES"
+          managed_memory_topic {
+            managed_topic_enum = "USER_PREFERENCES"
+          }
         }
       }
+
+      # 2. Session-level Customization Config (Transient scratchpad)
+      customization_configs {
+        scope_keys                   = ["user_id", "session_id"]
+        enable_third_person_memories = true
+        memory_topics {
+          custom_memory_topic {
+            label       = "session_scratchpad"
+            description = "Active consideration details, recent queries, and temporary workflow state."
+          }
+        }
+      }
+
+      # 1. Standard User Profile Schema (from official documentation)
       structured_memory_configs {
         scope_keys = ["user_id"]
         schema_configs {
@@ -30,9 +48,48 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
           memory_schema = jsonencode({
             type = "object"
             properties = {
+              name = {
+                type        = "string"
+                description = "Name of the user."
+              }
               technical_stack = {
                 type        = "string"
                 description = "Comma-separated list tools or languages used by the user."
+              }
+              primary_goal = {
+                type        = "string"
+                description = "The main objective the user is pursuing."
+              }
+              expertise_level = {
+                type        = "string"
+                description = "Current skill level (e.g., Junior, Senior)."
+              }
+              job_status = {
+                type        = "string"
+                description = "The job status of the individual"
+                enum        = ["unemployed", "part_time", "full_time", "student"]
+              }
+            }
+          })
+        }
+      }
+
+      # 2. Conversation Summary Schema (Demonstrating session scope)
+      structured_memory_configs {
+        scope_keys = ["user_id", "session_id"]
+        schema_configs {
+          id            = "conversation-summary"
+          memory_schema = jsonencode({
+            type = "object"
+            properties = {
+              main_topic = {
+                type        = "string"
+                description = "The primary topic of this specific chat session."
+              }
+              status = {
+                type        = "string"
+                description = "Current resolution state of the discussion."
+                enum        = ["open", "in_progress", "resolved"]
               }
             }
           })

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -13,6 +13,16 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
         embedding_model = "projects/${data.google_project.project.project_id}/locations/us-central1/publishers/google/models/text-embedding-005"
       }
       disable_memory_revisions = false
+      customization_configs {
+        scope_keys                   = ["user_id"]
+        enable_third_person_memories = false
+        consolidation_config {
+          revisions_per_candidate_count = 1
+        }
+        memory_topics {
+          managed_memory_topic = "USER_PREFERENCES"
+        }
+      }
       ttl_config {
         default_ttl = "86400s"
       }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -23,6 +23,21 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
           managed_memory_topic = "USER_PREFERENCES"
         }
       }
+      structured_memory_configs {
+        scope_keys = ["user_id"]
+        schema_configs {
+          id            = "user-profile"
+          memory_schema = jsonencode({
+            type = "object"
+            properties = {
+              technical_stack = {
+                type        = "string"
+                description = "Comma-separated list tools or languages used by the user."
+              }
+            }
+          })
+        }
+      }
       ttl_config {
         default_ttl = "86400s"
       }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_reasoning_engine_context_spec.tf.tmpl
@@ -46,26 +46,26 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
         schema_configs {
           id            = "user-profile"
           memory_schema = jsonencode({
-            type = "object"
+            type = "OBJECT"
             properties = {
               name = {
-                type        = "string"
+                type        = "STRING"
                 description = "Name of the user."
               }
               technical_stack = {
-                type        = "string"
+                type        = "STRING"
                 description = "Comma-separated list tools or languages used by the user."
               }
               primary_goal = {
-                type        = "string"
+                type        = "STRING"
                 description = "The main objective the user is pursuing."
               }
               expertise_level = {
-                type        = "string"
+                type        = "STRING"
                 description = "Current skill level (e.g., Junior, Senior)."
               }
               job_status = {
-                type        = "string"
+                type        = "STRING"
                 description = "The job status of the individual"
                 enum        = ["unemployed", "part_time", "full_time", "student"]
               }
@@ -80,14 +80,14 @@ resource "google_vertex_ai_reasoning_engine" "{{$.PrimaryResourceId}}" {
         schema_configs {
           id            = "conversation-summary"
           memory_schema = jsonencode({
-            type = "object"
+            type = "OBJECT"
             properties = {
               main_topic = {
-                type        = "string"
+                type        = "STRING"
                 description = "The primary topic of this specific chat session."
               }
               status = {
-                type        = "string"
+                type        = "STRING"
                 description = "Current resolution state of the discussion."
                 enum        = ["open", "in_progress", "resolved"]
               }


### PR DESCRIPTION
### Overview

Adds support for both scope-level customization configurations (`customization_configs`) and structured memory profiles (`structured_memory_configs`) inside `memory_bank_config` for Vertex AI Reasoning Engine (`google_vertex_ai_reasoning_engine`), aligning Terraform capabilities with the underlying backend API specifications.

### Changes Included

1. **Schema Update (`ReasoningEngine.yaml`)**:
   * Added `customization_configs` list block under `contextSpec.memoryBankConfig`.
   * Added `structured_memory_configs` list block supporting `scope_keys` and `schema_configs` (with OpenAPI JSON Schema string normalization via `memory_schema`).

2. **Acceptance Test Example**:
   * Updated `vertex_ai_reasoning_engine_context_spec.tf.tmpl` to verify both `customization_configs` and `structured_memory_configs` during live test execution.

---

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
vertex_ai: added `customization_configs` and `structured_memory_configs` fields to `google_vertex_ai_reasoning_engine` resource
```