### PR TITLE
Fix ogg version field in ggdeployment full test

### DIFF
--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_goldengate_deployment_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_goldengate_deployment_full.tf.tmpl
@@ -22,7 +22,6 @@ resource "google_oracle_database_goldengate_deployment" "{{$.PrimaryResourceId}}
       admin_username              = "admin"
       admin_password              = "123Abpassword!"
       deployment                  = "deployment"
-      ogg_version                 = "oggoracle:23.26.2.0.0_260417.1915_14223"
     }
 
     maintenance_window {


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/28068

This field gets unsupported quickly and fails the test if hardcoded. Hence removing it.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
oracledatabase: fixed `google_oracle_database_goldengate_deployment` test for `ogg_version` field
```
