### PR TITLE
Change scopeTenancyPool requirement to optional

### DIFF
--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -286,7 +286,7 @@ properties:
           - name: scopeTenancyPool
             type: String
             description: 'Pool to be used for Workload Identity. This pool in trust-domain mode is used with Fleet Tenancy, so that sameness can be enforced. ex: projects/example/locations/global/workloadidentitypools/custompool'
-            required: true
+            required: false
   - name: fleetDefaultMemberConfig
     type: NestedObject
     description: Optional. Fleet Default Membership Configuration.


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
gkehub2: make field `spec.workloadidentity.scopeTenancyPool` in resource `google_gke_hub_feature` not required.
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28003