### PR TITLE
firestore: tolerate 404 on google_firestore_field delete when parent database is gone

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.tmpl
@@ -16,6 +16,14 @@ res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 	UserAgent: config.UserAgent,
 })
 if err != nil {
+	if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		// The parent database (or project) no longer exists, so the field has
+		// definitely been destroyed along with it. This commonly happens during
+		// post-test destroy, where the database is torn down before this check
+		// runs. We do not return the error in this case - destroy was successful.
+		return nil
+	}
+
 	e := err.(*googleapi.Error)
 	if e.Code == 403 && strings.Contains(e.Message, "Cloud Firestore API has not been used in project") {
 		// The acceptance test has provisioned the resources under test in a new project, and the destroy check is seeing the

--- a/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.tmpl
+++ b/mmv1/templates/terraform/custom_delete/firestore_field_delete.go.tmpl
@@ -49,6 +49,13 @@ res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
 })
 
 if err != nil {
+	if transport_tpg.IsGoogleApiErrorWithCode(err, 404) {
+		// The parent database (or project) no longer exists, so there is no field
+		// configuration left to clear. This can happen when the parent database is
+		// destroyed before the field. Treat as a successful delete.
+		log.Printf("[DEBUG] Field %q parent database not found, treating as already deleted", d.Id())
+		return nil
+	}
 	return fmt.Errorf("Error deleting Field %q: %s", d.Id(), err)
 }
 


### PR DESCRIPTION
### Summary

`google_firestore_field` has no real DELETE operation — its custom delete clears the field's `indexConfig`/`ttlConfig` via a PATCH, and its `CheckDestroy` verifies teardown by GET-ing the field. When the parent Firestore database (or project) has already been destroyed, both requests return `404`, which was not tolerated.

During acceptance-test teardown the parent database is destroyed before the field's destroy check runs, so this surfaced every night as:

```
Error running post-test destroy, there may be dangling resources:
googleapi: Error 404: Project '...' or database 'tf-test-database-...' does not exist.
```

This affected the following Google Beta nightly tests:
- `TestAccFirestoreField_firestoreFieldTimestampEnterpriseExample`
- `TestAccFirestoreField_firestoreFieldTimestampWithTtlOffsetEnterpriseExample`
- `TestAccFirestoreField_firestoreFieldWildcardExample`

### Changes

- `custom_delete/firestore_field_delete.go.tmpl`: the field-clear PATCH now returns `nil` on a `404` (the parent database is gone, so there is nothing left to clear).
- `custom_check_destroy/firestore_field.go.tmpl`: the verification GET now treats a `404` as a successful destroy.

Both use the existing `transport_tpg.IsGoogleApiErrorWithCode(err, 404)` helper, matching the 404-on-delete tolerance pattern used by other resources.

```release-note:bug
firestore: fixed a bug where deleting `google_firestore_field` would fail with a 404 error when its parent database had already been deleted
```
