### PR TITLE
Add google_project_iam_custom_role list resource

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_iam_custom_role.go
@@ -1,0 +1,140 @@
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package resourcemanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	iam "google.golang.org/api/iam/v1"
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/services/iambeta"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_project_iam_custom_role",
+		ProductName: "resourcemanager",
+		Func:        NewGoogleProjectIamCustomRoleListResource,
+	}.Register()
+}
+
+type GoogleProjectIamCustomRoleListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+// GoogleProjectIamCustomRoleListModel matches [ListResourceMetadata.ListConfigFields] (tfsdk names and types).
+type GoogleProjectIamCustomRoleListModel struct {
+	Project types.String `tfsdk:"project"`
+}
+
+func NewGoogleProjectIamCustomRoleListResource() list.ListResource {
+	listR := &GoogleProjectIamCustomRoleListResource{}
+	listR.TypeName = "google_project_iam_custom_role"
+	listR.SDKv2Resource = ResourceGoogleProjectIamCustomRole()
+	listR.ListConfigFields = []tpgresource.ListConfigField{{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true}}
+	return listR
+}
+
+func (listR *GoogleProjectIamCustomRoleListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	var data GoogleProjectIamCustomRoleListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	project := tpgresource.GetResourceNameFromSelfLink(listR.GetProject(data.Project))
+
+	errProjectIamCustomRoleListStreamClosed := errors.New("stream closed")
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListProjectIamCustomRoles(listR.Client, project, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "title", "role_id"); err != nil {
+				return err
+			}
+
+			if !push(result) {
+				return errProjectIamCustomRoleListStreamClosed
+			}
+			return nil
+		})
+		// A closed stream is not an error: return without pushing again.
+		if err == nil || errors.Is(err, errProjectIamCustomRoleListStreamClosed) {
+			return
+		}
+		diags.AddError("API Error", err.Error())
+		result := listReq.NewListResult(ctx)
+		result.Diagnostics = diags
+		push(result)
+	}
+}
+
+func ListProjectIamCustomRoles(config *transport_tpg.Config, project string, callback func(rd *schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+	if project == "" {
+		return fmt.Errorf("project must be set")
+	}
+
+	d := ResourceGoogleProjectIamCustomRole().Data(&terraform.InstanceState{})
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("error setting project on temporary resource data: %w", err)
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(iambeta.Product, config)+"projects/{{project}}/roles?view=FULL")
+	if err != nil {
+		return err
+	}
+
+	billingProject := project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:         config,
+		TempData:       d,
+		Resource:       ResourceGoogleProjectIamCustomRole(),
+		ListURL:        url,
+		BillingProject: billingProject,
+		UserAgent:      userAgent,
+		ItemName:       "roles",
+		Flattener: func(res map[string]interface{}, d *schema.ResourceData, _ *transport_tpg.Config) error {
+			var role iam.Role
+			if err := tpgresource.Convert(res, &role); err != nil {
+				return fmt.Errorf("error converting role: %w", err)
+			}
+			d.SetId(role.Name)
+			project := extractProjectFromProjectIamCustomRoleID(role.Name)
+			return FlattenProjectIamCustomRole(d, &role, project)
+		},
+		Callback: func(rd *schema.ResourceData) error {
+			return callback(rd)
+		},
+	})
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/list_google_project_iam_custom_role_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/list_google_project_iam_custom_role_test.go
@@ -1,0 +1,73 @@
+package resourcemanager_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
+)
+
+func TestAccProjectIamCustomRoleListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	roleID := "tfTestRole" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectIamCustomRoleList_prereq(roleID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_iam_custom_role.test", "role_id", roleID),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccProjectIamCustomRoleListQuery(project),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_project_iam_custom_role.all_in_project", map[string]knownvalue.Check{
+						"role_id": knownvalue.StringExact(roleID),
+						"project": knownvalue.StringExact(project),
+					}),
+					querycheck.ExpectLengthAtLeast("google_project_iam_custom_role.all_in_project", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccProjectIamCustomRoleList_prereq(roleID string) string {
+	return fmt.Sprintf(`
+resource "google_project_iam_custom_role" "test" {
+  role_id     = %q
+  title       = "Test List Role"
+  permissions = ["iam.roles.list"]
+}
+`, roleID)
+}
+
+func testAccProjectIamCustomRoleListQuery(project string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_project_iam_custom_role" "all_in_project" {
+  provider = google
+
+  config {
+    project = %q
+  }
+}
+`, project)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -86,6 +86,21 @@ func ResourceGoogleProjectIamCustomRole() *schema.Resource {
 			//UDP schema end
 		},
 		UseJSONNumber: true,
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"role_id": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
 	}
 }
 
@@ -136,6 +151,12 @@ func resourceGoogleProjectIamCustomRoleCreate(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Unable to verify whether custom project role %s already exists and must be undeleted: %v", roleId, err)
 	}
 
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": project,
+		"role_id": tpgresource.GetResourceNameFromSelfLink(d.Id()),
+	}); err != nil {
+		return err
+	}
 	return resourceGoogleProjectIamCustomRoleRead(d, meta)
 }
 
@@ -198,11 +219,13 @@ func FlattenProjectIamCustomRole(d *schema.ResourceData, role *iam.Role, project
 		return fmt.Errorf("Error setting project: %s", err)
 	}
 
-	return nil
+	return tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": project,
+		"role_id": tpgresource.GetResourceNameFromSelfLink(role.Name),
+	})
 }
 
 func resourceGoogleProjectIamCustomRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-
 	if tpgresource.DeletionPolicyPreUpdate(d, ResourceGoogleProjectIamCustomRole) {
 		return ResourceGoogleProjectIamCustomRole().Read(d, meta)
 	}
@@ -242,6 +265,13 @@ func resourceGoogleProjectIamCustomRoleUpdate(d *schema.ResourceData, meta inter
 	}
 
 	d.Partial(false)
+	project := extractProjectFromProjectIamCustomRoleID(d.Id())
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project": project,
+		"role_id": tpgresource.GetResourceNameFromSelfLink(d.Id()),
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/iambeta"
@@ -51,6 +52,34 @@ func TestAccProjectIamCustomRole_basic(t *testing.T) {
 				ResourceName:      "google_project_iam_custom_role.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccProjectIamCustomRole_importWithIdentity exercises plannable import using the resource identity block (Terraform 1.12+).
+func TestAccProjectIamCustomRole_importWithIdentity(t *testing.T) {
+	t.Parallel()
+
+	roleId := "tfIamCustomRole" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckGoogleProjectIamCustomRoleDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectIamCustomRole_basic(roleId),
+				Check: resource.TestCheckResourceAttr(
+					"google_project_iam_custom_role.foo", "role_id", roleId),
+			},
+			{
+				ResourceName:    "google_project_iam_custom_role.foo",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_project_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_project_iam_custom_role.html.markdown
@@ -1,0 +1,51 @@
+---
+subcategory: "Cloud Platform"
+description: |-
+  List project-level Google Cloud IAM custom roles for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_project_iam_custom_role (list)
+
+Lists project-level IAM **custom roles** for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_project_iam_custom_role`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_custom_role)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_project_iam_custom_role" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "other-project"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID to list IAM custom roles from. If unset, the provider's
+  configured default project is used (same idea as the managed resource).
+
+## Results
+
+By default each result includes **resource identity** for `google_project_iam_custom_role` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/block/import#identity)):
+
+* `role_id` - The IAM custom role ID (required for identity).
+* `project` - Project ID when applicable.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_project_iam_custom_role` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_custom_role#attributes-reference)
+(for example `title`, `name`, `description`, `stage`, `deleted`, and `permissions`).

--- a/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -85,6 +85,18 @@ import {
 }
 ```
 
+In Terraform v1.12.0 and later, use an [`identity` block](https://developer.hashicorp.com/terraform/language/block/import#identity) to import Custom Roles using identity values. For example:
+
+```tf
+import {
+  identity = {
+    project = "{{project}}"
+    role_id = "{{role_id}}"
+  }
+  to = google_project_iam_custom_role.default
+}
+```
+
 When using the [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import), Custom Roles can be imported using one of the formats above. For example:
 
 ```


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28161

Adds a new list resource `google_project_iam_custom_role` for Terraform 1.14+ `terraform query` support. This allows users to list all project-level IAM custom roles.

### Details

- Adds identity schema to `google_project_iam_custom_role` managed resource
- Adds list resource implementation for `google_project_iam_custom_role`
- Adds acceptance test `TestAccProjectIamCustomRoleListResource_queryIdentity`
- Adds documentation for the list resource

### Release Note Template for Downstream PRs (will be copied)
```release-note:enhancement
resourcemanager: added `google_project_iam_custom_role` list resource for `terraform query` support
```