### PR TITLE
Add conflicts validation to PolicyOrchestrator selectors

### DIFF
--- a/mmv1/products/osconfigv2/PolicyOrchestrator.yaml
+++ b/mmv1/products/osconfigv2/PolicyOrchestrator.yaml
@@ -44,6 +44,10 @@ async:
   include_project: false
 autogen_status: UG9saWN5T3JjaGVzdHJhdG9y
 autogen_async: true
+custom_diff:
+  - policyOrchestratorCustomizeDiff
+custom_code:
+  constants: templates/terraform/constants/osconfigv2_policy_orchestrator.go.tmpl
 samples:
   - name: osconfigv2_policy_orchestrator_basic
     primary_resource_id: policy_orchestrator

--- a/mmv1/products/osconfigv2/PolicyOrchestratorForFolder.yaml
+++ b/mmv1/products/osconfigv2/PolicyOrchestratorForFolder.yaml
@@ -45,6 +45,8 @@ async:
   include_project: true
 autogen_status: UG9saWN5T3JjaGVzdHJhdG9yRm9yRm9sZGVy
 autogen_async: true
+custom_diff:
+  - policyOrchestratorCustomizeDiff
 samples:
   - name: osconfigv2_policy_orchestrator_for_folder_basic
     primary_resource_id: policy_orchestrator_for_folder

--- a/mmv1/products/osconfigv2/PolicyOrchestratorForOrganization.yaml
+++ b/mmv1/products/osconfigv2/PolicyOrchestratorForOrganization.yaml
@@ -45,6 +45,8 @@ async:
   include_project: true
 autogen_status: UG9saWN5T3JjaGVzdHJhdG9yRm9yT3JnYW5pemF0aW9u
 autogen_async: true
+custom_diff:
+  - policyOrchestratorCustomizeDiff
 samples:
   - name: osconfigv2_policy_orchestrator_for_organization_basic
     primary_resource_id: policy_orchestrator_for_organization

--- a/mmv1/templates/terraform/constants/osconfigv2_policy_orchestrator.go.tmpl
+++ b/mmv1/templates/terraform/constants/osconfigv2_policy_orchestrator.go.tmpl
@@ -1,0 +1,38 @@
+func policyOrchestratorCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	v, ok := diff.GetOk("orchestration_scope.0.selectors")
+	if !ok {
+		return nil
+	}
+	selectors, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	for _, rawSelector := range selectors {
+		if rawSelector == nil {
+			continue
+		}
+		selector, ok := rawSelector.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		hasLocation := false
+		if val, ok := selector["location_selector"]; ok && val != nil {
+			if list, ok := val.([]any); ok && len(list) > 0 {
+				hasLocation = true
+			}
+		}
+
+		hasHierarchy := false
+		if val, ok := selector["resource_hierarchy_selector"]; ok && val != nil {
+			if list, ok := val.([]any); ok && len(list) > 0 {
+				hasHierarchy = true
+			}
+		}
+
+		if hasLocation && hasHierarchy {
+			return fmt.Errorf("only one of orchestration_scope.selectors.location_selector or orchestration_scope.selectors.resource_hierarchy_selector can be set")
+		}
+	}
+	return nil
+}

--- a/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_test.go
+++ b/mmv1/third_party/terraform/services/osconfigv2/resource_os_config_v2_policy_orchestrator_test.go
@@ -1,6 +1,7 @@
 package osconfigv2_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -146,6 +147,78 @@ resource "google_os_config_v2_policy_orchestrator" "policy_orchestrator" {
     }
     labels = {
         state = "active"
+    }
+}
+`, context)
+}
+
+func TestAccOSConfigV2PolicyOrchestrator_conflictingSelectors(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccOSConfigV2PolicyOrchestrator_conflictingSelectors(context),
+				ExpectError: regexp.MustCompile("only one of orchestration_scope.selectors.location_selector or orchestration_scope.selectors.resource_hierarchy_selector can be set"),
+			},
+		},
+	})
+}
+
+func testAccOSConfigV2PolicyOrchestrator_conflictingSelectors(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_os_config_v2_policy_orchestrator" "policy_orchestrator" {
+    policy_orchestrator_id = "tf-test-test-po%{random_suffix}"
+    
+    state = "ACTIVE"
+    action = "UPSERT"
+
+    orchestration_scope {
+        selectors {
+            location_selector {
+                included_locations = ["us-central1-a"]
+            }
+            resource_hierarchy_selector {
+                included_folders = ["folders/12345"]
+            }
+        }
+    }
+
+    orchestrated_resource {
+        id = "tf-test-test-orchestrated-resource%{random_suffix}"
+        os_policy_assignment_v1_payload {
+            os_policies {
+                id = "tf-test-os-policy%{random_suffix}"
+                mode = "VALIDATION"
+                resource_groups {
+                    resources {
+                        id = "resource-tf"
+                        file {
+                            content = "file-content-tf"
+                            path = "file-path-tf-1"
+                            state = "PRESENT"
+                        }
+                    }
+                }
+            }
+            instance_filter {
+                inventories {
+                    os_short_name = "windows-10"
+                }
+            }
+            rollout {
+                disruption_budget {
+                    percent = 100
+                }
+                min_wait_duration = "60s"
+            }
+        }
     }
 }
 `, context)


### PR DESCRIPTION
This PR adds `conflicts` validation between `resource_hierarchy_selector` and `location_selector` in the `google_os_config_v2_policy_orchestrator` resource and its folder/organization variants.

These two selectors are mutually exclusive in the OS Config v2 API. Currently, if both are configured, the provider attempts to send both, leading to API errors. Adding `ConflictsWith` to the schema allows Terraform to validate this client-side during `terraform plan` or `terraform validate` and fail early.

The change was verified by generating the provider code locally and ensuring `ConflictsWith` is correctly populated in the schema, and verifying that the provider compiles successfully.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27473

```release-note:bug
osconfig: added client-side validation to ensure `resource_hierarchy_selector` and `location_selector` are not set at the same time in `google_os_config_v2_policy_orchestrator`, `google_os_config_v2_policy_orchestrator_for_folder` and `google_os_config_v2_policy_orchestrator_for_organization`.
```
