### PR TITLE
Bugfix/add missing update mask for additional_options in datastream mongodb connection profile

### DIFF
--- a/mmv1/templates/terraform/pre_update/datastream_connection_profile.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/datastream_connection_profile.go.tmpl
@@ -24,6 +24,9 @@ if d.HasChange("mongodb_profile.0.replica_set") {
 if d.HasChange("mongodb_profile.0.host_addresses") {
     updateMask = append(updateMask, "mongodbProfile.hostAddresses")
 }
+if d.HasChange("mongodb_profile.0.additional_options") {
+    updateMask = append(updateMask, "mongodbProfile.additionalOptions")
+}
 
 // Override the previous setting of updateMask to include state.
 // updateMask is a URL parameter but not present in the schema, so ReplaceVars

--- a/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
+++ b/mmv1/third_party/terraform/services/datastream/resource_datastream_connection_profile_test.go
@@ -730,7 +730,8 @@ resource "google_datastream_connection_profile" "default" {
       secret_manager_stored_client_key = google_secret_manager_secret_version.client_key_secret_version.id
     }
 	additional_options = {
-		readPreference = "secondary"
+		readPreference   = "primary"  // <-- Changed
+		connectTimeoutMS = "5000"     // <-- Added
 	}
     standard_connection_format {
       direct_connection = true


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

This pull request adds an update mask for the `mongodbProfile.additionalOptions` field in `google_datastream_connection_profile` resource.

My previous pull request https://github.com/GoogleCloudPlatform/magic-modules/pull/17910 added support for `additional_options` map in `mongodb_profile` in `google_datastream_connection_profile` resource. This worked well for creating new connection profile(s), but updating `additional_options` on an existing connection profile via `terraform apply` failed with the following error:
```log
Error: Error updating ConnectionProfile "projects/REDACTED/locations/europe-west3/connectionProfiles/test-mongodb-additional-options-source": googleapi: Error 400: Update mask contains no eligible fields to update: mongodb_profile
```

The error is caused by a missing update mask for the new `additional_options` map.

I've additionally tested the changes made in this pull request locally:
1. built and installed the provider locally:
    ```sh
    make provider VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"

    cd $GOPATH/src/github.com/hashicorp/terraform-provider-google
    make build
    ```
1. created the following development override:
    ```tfrc
    provider_installation {
      dev_overrides {
        "hashicorp/google" = "/Users/ft/go/bin"
      }
      direct {}
    }
    ```
1. applied the changes:
    ```sh
    TF_CLI_CONFIG_FILE="./tf-dev-override.tfrc" terraform apply
    ```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug
datastream: fixed a bug in update functionality in `google_datastream_connection_profile` `mongodb_profile.additional_options`
```

fixes https://github.com/hashicorp/terraform-provider-google/issues/27750