### PR TITLE
monitoring: wait for metric descriptor updates to propagate before returning

### DIFF
--- a/mmv1/products/monitoring/MetricDescriptor.yaml
+++ b/mmv1/products/monitoring/MetricDescriptor.yaml
@@ -34,13 +34,14 @@ timeouts:
 async:
   type: PollAsync
   actions: [create, update, delete]
-  check_response_func_existence: transport_tpg.PollCheckForExistence
+  check_response_func_existence: 'PollCheckMetricDescriptorUpdate(d)'
   check_response_func_absence: transport_tpg.PollCheckForAbsence
   suppress_error: false
   target_occurrences: 20
 error_retry_predicates:
   - transport_tpg.IsMonitoringConcurrentEditError
 custom_code:
+  constants: templates/terraform/constants/monitoring_metric_descriptor.go.tmpl
   custom_import: templates/terraform/custom_import/self_link_as_name.tmpl
 samples:
   - name: monitoring_metric_descriptor_basic

--- a/mmv1/templates/terraform/constants/monitoring_metric_descriptor.go.tmpl
+++ b/mmv1/templates/terraform/constants/monitoring_metric_descriptor.go.tmpl
@@ -1,0 +1,28 @@
+// PollCheckMetricDescriptorUpdate returns a poll check that waits until the
+// metric descriptor returned by the API reflects the desired mutable values.
+//
+// The Monitoring API has no in-place update for metric descriptors: an "update"
+// is a create (POST) that upserts the descriptor, and the change to mutable
+// fields such as description and display_name propagates with a delay. Polling
+// only for the descriptor's existence therefore succeeds against stale data and
+// leaves a permanent diff after apply. This check keeps polling until the read
+// value matches the configured description and display_name.
+func PollCheckMetricDescriptorUpdate(d *schema.ResourceData) transport_tpg.PollCheckResponseFunc {
+	return func(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+		if respErr != nil {
+			if transport_tpg.IsGoogleApiErrorWithCode(respErr, 404) {
+				return transport_tpg.PendingStatusPollResult("not found")
+			}
+			return transport_tpg.ErrorPollResult(respErr)
+		}
+
+		if want, ok := d.GetOk("description"); ok && resp["description"] != want.(string) {
+			return transport_tpg.PendingStatusPollResult("waiting for updated description to propagate")
+		}
+		if want, ok := d.GetOk("display_name"); ok && resp["displayName"] != want.(string) {
+			return transport_tpg.PendingStatusPollResult("waiting for updated display_name to propagate")
+		}
+
+		return transport_tpg.SuccessPollResult()
+	}
+}


### PR DESCRIPTION
### Summary

`google_monitoring_metric_descriptor` has no in-place update operation. An "update" is generated as a `POST v3/projects/{{project}}/metricDescriptors` that upserts the descriptor, and changes to mutable fields such as `description` and `display_name` propagate with a delay on the Monitoring API.

The async config polled only for the descriptor's **existence** (`transport_tpg.PollCheckForExistence`). Because the descriptor already exists, that poll succeeds immediately against stale data, and the subsequent read stores the old values — producing a permanent diff after apply.

This is the deterministic nightly failure of `TestAccMonitoringMetricDescriptor_update` (Step 3/6):

```
After applying this test step, the non-refresh plan was not empty.
  ~ resource "google_monitoring_metric_descriptor" "basic" {
      ~ description  = "initial description" -> "updated description"
      ~ display_name = "initial display name" -> "updated display name"
  }
Plan: 0 to add, 1 to change, 0 to destroy.
```

### Changes

- Add a custom poll check `PollCheckMetricDescriptorUpdate` (new constants template `constants/monitoring_metric_descriptor.go.tmpl`) that keeps polling until the read descriptor reflects the configured `description` and `display_name`.
- Wire it via `async.check_response_func_existence` in `MetricDescriptor.yaml` (used by both create and update). Existence/404 handling is preserved.

This follows the existing pattern of polling for the written value to become visible before returning (e.g. Cloud Run's `PollCheckKnativeStatusFunc`, and service-account update polling).

```release-note:bug
monitoring: fixed a permanent diff on `google_monitoring_metric_descriptor` after updating `description` or `display_name`, by waiting for the updated values to propagate before completing the apply
```
