### PR TITLE
Add list resource for google_dns_managed_zone

### DIFF
--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
@@ -173,9 +173,24 @@ func ListDnsManagedZones(config *transport_tpg.Config, project string, callback 
 				return fmt.Errorf("error setting project on temporary resource data: %w", err)
 			}
 			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone.Name))
+
 			if err := managedZoneSchema.Read(rd, config); err != nil {
 				return err
 			}
+			if err := rd.Set("name", managedZone.Name); err != nil {
+				return fmt.Errorf("error setting name on temporary resource data: %w", err)
+			}
+			if err := rd.Set("project", project); err != nil {
+				return fmt.Errorf("error setting project on temporary resource data: %w", err)
+			}
+
+			if err := tpgresource.SetResourceIdentityAttributes(rd, map[string]interface{}{
+				"name":    managedZone.Name,
+				"project": project,
+			}); err != nil {
+				return fmt.Errorf("error setting identity: %w", err)
+			}
+
 			if err := callback(rd); err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
@@ -1,0 +1,192 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	googledns "google.golang.org/api/dns/v1"
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_dns_managed_zone",
+		ProductName: "dns",
+		Func:        NewGoogleDnsManagedZoneListResource,
+	}.Register()
+}
+
+type GoogleDnsManagedZoneResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleDnsManagedZoneListModel struct {
+	Project types.String `tfsdk:"project"`
+}
+
+func NewGoogleDnsManagedZoneListResource() list.ListResource {
+	listR := &GoogleDnsManagedZoneResource{}
+	listR.TypeName = "google_dns_managed_zone"
+	listR.SDKv2Resource = ResourceDNSManagedZone()
+	listR.ListConfigFields = []tpgresource.ListConfigField{{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true}}
+	return listR
+}
+
+func (listR *GoogleDnsManagedZoneResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	listR.ListResourceMetadata.Metadata(ctx, req, resp)
+
+	resp.ResourceBehavior = resource.ResourceBehavior{
+		MutableIdentity: true,
+	}
+}
+
+func (listR *GoogleDnsManagedZoneResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
+	var data GoogleDnsManagedZoneListModel
+	diags := req.Config.Get(ctx, &data)
+
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	if listR.Client == nil {
+		diags = append(diags, frameworkdiag.NewErrorDiagnostic(
+			"provider not configured",
+			"The Google provider client is not available; ensure the provider is configured.",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	tempData := listR.SDKv2Resource.Data(&terraform.InstanceState{})
+	if !data.Project.IsNull() && !data.Project.IsUnknown() {
+		if err := tempData.Set("project", data.Project.ValueString()); err != nil {
+			diags.AddError("Failed to set project", err.Error())
+			stream.Results = list.ListResultsStreamDiagnostics(diags)
+			return
+		}
+	}
+
+	project, err := tpgresource.GetProject(tempData, listR.Client)
+	if err != nil {
+		diags.AddError("Failed to resolve project", err.Error())
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		var streamDiags frameworkdiag.Diagnostics
+
+		err := ListDnsManagedZones(listR.Client, project, func(rd *schema.ResourceData) error {
+			result := req.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, req.IncludeResource, &result, rd); err != nil {
+				streamDiags.AddError("Failed to set result", err.Error())
+				return err
+			}
+
+			if !push(result) {
+				return errors.New("stream closed")
+			}
+			return nil
+		})
+
+		if err != nil {
+			if err.Error() == "stream closed" {
+				return
+			}
+			streamDiags.AddError("API Error listing DNS managed zones", fmt.Sprintf("Failed to list DNS managed zones in project %q: %v", project, err))
+			result := req.NewListResult(ctx)
+			result.Diagnostics = streamDiags
+			push(result)
+			return
+		}
+
+		if streamDiags.HasError() {
+			stream.Results = list.ListResultsStreamDiagnostics(streamDiags)
+		}
+	}
+}
+
+func ListDnsManagedZones(config *transport_tpg.Config, project string, callback func(*schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+
+	managedZoneSchema := ResourceDNSManagedZone()
+	tempData := managedZoneSchema.Data(&terraform.InstanceState{})
+	if project != "" {
+		if err := tempData.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(tempData, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(tempData, config, "{{DNSBasePath}}projects/{{project}}/managedZones")
+	if err != nil {
+		return err
+	}
+
+	queryParams := make(map[string]string)
+	for {
+		reqURL, err := transport_tpg.AddQueryParams(url, queryParams)
+		if err != nil {
+			return err
+		}
+
+		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+			Config:    config,
+			Method:    "GET",
+			Project:   project,
+			RawURL:    reqURL,
+			UserAgent: userAgent,
+		})
+		if err != nil {
+			return err
+		}
+
+		var listResp googledns.ManagedZonesListResponse
+		if err := tpgresource.Convert(res, &listResp); err != nil {
+			return fmt.Errorf("error parsing DNS managed zone list response: %w", err)
+		}
+
+		for _, managedZone := range listResp.ManagedZones {
+			rd := managedZoneSchema.Data(&terraform.InstanceState{})
+			if err := rd.Set("name", managedZone.Name); err != nil {
+				return fmt.Errorf("error setting name on temporary resource data: %w", err)
+			}
+			if err := rd.Set("project", project); err != nil {
+				return fmt.Errorf("error setting project on temporary resource data: %w", err)
+			}
+			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone.Name))
+			if err := managedZoneSchema.Read(rd, config); err != nil {
+				return err
+			}
+			if err := callback(rd); err != nil {
+				return err
+			}
+		}
+
+		if listResp.NextPageToken == "" {
+			break
+		}
+
+		queryParams["pageToken"] = listResp.NextPageToken
+	}
+
+	return nil
+}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
@@ -18,6 +18,8 @@ import (
 	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
 )
 
+var errStreamClosed = errors.New("stream closed")
+
 func init() {
 	registry.FrameworkListResource{
 		Name:        "google_dns_managed_zone",
@@ -96,13 +98,15 @@ func (listR *GoogleDnsManagedZoneResource) List(ctx context.Context, req list.Li
 			}
 
 			if !push(result) {
-				return errors.New("stream closed")
+				// A closed stream means the consumer has enough results; stop cleanly.
+				return errStreamClosed
 			}
 			return nil
 		})
 
 		if err != nil {
-			if err.Error() == "stream closed" {
+			// Stream closure is expected and should not be reported as an API error.
+			if errors.Is(err, errStreamClosed) {
 				return
 			}
 			streamDiags.AddError("API Error listing DNS managed zones", fmt.Sprintf("Failed to list DNS managed zones in project %q: %v", project, err))
@@ -172,11 +176,11 @@ func ListDnsManagedZones(config *transport_tpg.Config, project string, callback 
 			if err := rd.Set("project", project); err != nil {
 				return fmt.Errorf("error setting project on temporary resource data: %w", err)
 			}
-			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone.Name))
 
 			if err := managedZoneSchema.Read(rd, config); err != nil {
 				return err
 			}
+			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone.Name))
 			if err := rd.Set("name", managedZone.Name); err != nil {
 				return fmt.Errorf("error setting name on temporary resource data: %w", err)
 			}

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone.go
@@ -7,11 +7,9 @@ import (
 
 	frameworkdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/list"
-	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	googledns "google.golang.org/api/dns/v1"
 
 	"github.com/hashicorp/terraform-provider-google/google/registry"
 	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
@@ -42,14 +40,6 @@ func NewGoogleDnsManagedZoneListResource() list.ListResource {
 	listR.SDKv2Resource = ResourceDNSManagedZone()
 	listR.ListConfigFields = []tpgresource.ListConfigField{{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true}}
 	return listR
-}
-
-func (listR *GoogleDnsManagedZoneResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	listR.ListResourceMetadata.Metadata(ctx, req, resp)
-
-	resp.ResourceBehavior = resource.ResourceBehavior{
-		MutableIdentity: true,
-	}
 }
 
 func (listR *GoogleDnsManagedZoneResource) List(ctx context.Context, req list.ListRequest, stream *list.ListResultsStream) {
@@ -92,7 +82,7 @@ func (listR *GoogleDnsManagedZoneResource) List(ctx context.Context, req list.Li
 		err := ListDnsManagedZones(listR.Client, project, func(rd *schema.ResourceData) error {
 			result := req.NewListResult(ctx)
 
-			if err := listR.SetResult(ctx, req.IncludeResource, &result, rd); err != nil {
+			if err := listR.SetResult(ctx, req.IncludeResource, &result, rd, "name"); err != nil {
 				streamDiags.AddError("Failed to set result", err.Error())
 				return err
 			}
@@ -145,67 +135,29 @@ func ListDnsManagedZones(config *transport_tpg.Config, project string, callback 
 		return err
 	}
 
-	queryParams := make(map[string]string)
-	for {
-		reqURL, err := transport_tpg.AddQueryParams(url, queryParams)
-		if err != nil {
-			return err
-		}
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:    config,
+		TempData:  tempData,
+		Resource:  managedZoneSchema,
+		ListURL:   url,
+		Filter:    "",
+		ItemName:  "managedZones",
+		UserAgent: userAgent,
+		Flattener: func(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+			name, _ := res["name"].(string)
 
-		res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
-			Config:    config,
-			Method:    "GET",
-			Project:   project,
-			RawURL:    reqURL,
-			UserAgent: userAgent,
-		})
-		if err != nil {
-			return err
-		}
+			d.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, name))
 
-		var listResp googledns.ManagedZonesListResponse
-		if err := tpgresource.Convert(res, &listResp); err != nil {
-			return fmt.Errorf("error parsing DNS managed zone list response: %w", err)
-		}
-
-		for _, managedZone := range listResp.ManagedZones {
-			rd := managedZoneSchema.Data(&terraform.InstanceState{})
-			if err := rd.Set("name", managedZone.Name); err != nil {
-				return fmt.Errorf("error setting name on temporary resource data: %w", err)
-			}
-			if err := rd.Set("project", project); err != nil {
-				return fmt.Errorf("error setting project on temporary resource data: %w", err)
-			}
-
-			if err := managedZoneSchema.Read(rd, config); err != nil {
+			if err := ResourceDNSManagedZoneFlatten(d, config, res, config, project, "", "", "", nil); err != nil {
 				return err
 			}
-			rd.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, managedZone.Name))
-			if err := rd.Set("name", managedZone.Name); err != nil {
-				return fmt.Errorf("error setting name on temporary resource data: %w", err)
-			}
-			if err := rd.Set("project", project); err != nil {
-				return fmt.Errorf("error setting project on temporary resource data: %w", err)
+
+			if err := d.Set("project", project); err != nil {
+				return fmt.Errorf("error setting project: %w", err)
 			}
 
-			if err := tpgresource.SetResourceIdentityAttributes(rd, map[string]interface{}{
-				"name":    managedZone.Name,
-				"project": project,
-			}); err != nil {
-				return fmt.Errorf("error setting identity: %w", err)
-			}
-
-			if err := callback(rd); err != nil {
-				return err
-			}
-		}
-
-		if listResp.NextPageToken == "" {
-			break
-		}
-
-		queryParams["pageToken"] = listResp.NextPageToken
-	}
-
-	return nil
+			return nil
+		},
+		Callback: callback,
+	})
 }

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
@@ -3,14 +3,17 @@ package dns_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	tpgdns "github.com/hashicorp/terraform-provider-google/google/services/dns"
 )
 
 func TestAccDnsManagedZoneListResource_queryIdentity(t *testing.T) {
@@ -34,6 +37,7 @@ func TestAccDnsManagedZoneListResource_queryIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "project", project),
 					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "name", zoneName),
 					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "dns_name", dnsName),
+					testAccCheckDnsManagedZoneVisibleInList(t, project, zoneName),
 				),
 			},
 			{
@@ -49,6 +53,38 @@ func TestAccDnsManagedZoneListResource_queryIdentity(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDnsManagedZoneVisibleInList(t *testing.T, project, zoneName string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		config := acctest.GoogleProviderConfig(t)
+
+		observedNames := make([]string, 0)
+		err := resource.Retry(30*time.Second, func() *resource.RetryError {
+			resp, err := tpgdns.NewClient(config, config.UserAgent).ManagedZones.List(project).Do()
+			if err != nil {
+				return resource.RetryableError(fmt.Errorf("error listing managed zones for project %q: %w", project, err))
+			}
+
+			observedNames = observedNames[:0]
+			for _, zone := range resp.ManagedZones {
+				if zone == nil {
+					continue
+				}
+				observedNames = append(observedNames, zone.Name)
+				if zone.Name == zoneName {
+					return nil
+				}
+			}
+
+			return resource.RetryableError(fmt.Errorf("managed zone %q not visible yet; currently observed zones: %v", zoneName, observedNames))
+		})
+		if err != nil {
+			return fmt.Errorf("managed zone %q did not become query-visible before list step in project %q; last observed zones: %v; retry error: %w", zoneName, project, observedNames, err)
+		}
+
+		return nil
+	}
 }
 
 func testAccDnsManagedZoneListResource_basic(name, dnsName string) string {

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
@@ -40,11 +40,11 @@ func TestAccDnsManagedZoneListResource_queryIdentity(t *testing.T) {
 				Query:  true,
 				Config: testAccDnsManagedZoneListQuery(project),
 				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("google_dns_managed_zone.all", 1),
 					querycheck.ExpectIdentity("google_dns_managed_zone.all", map[string]knownvalue.Check{
 						"name":    knownvalue.StringExact(zoneName),
 						"project": knownvalue.StringExact(project),
 					}),
-					querycheck.ExpectLengthAtLeast("google_dns_managed_zone.all", 1),
 				},
 			},
 		},

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
@@ -103,7 +103,7 @@ provider "google" {}
 
 list "google_dns_managed_zone" "all" {
   provider = google
-
+  limit = 1000
   config {
     project = %q
   }

--- a/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
+++ b/mmv1/third_party/terraform/services/dns/list_google_dns_managed_zone_test.go
@@ -1,0 +1,76 @@
+package dns_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+)
+
+func TestAccDnsManagedZoneListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	zoneName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	dnsName := fmt.Sprintf("tf-test-%s.hashicorptest.com.", acctest.RandString(t, 10))
+	project := envvar.GetTestProjectFromEnv()
+	t.Logf("Using project %s for testing", project)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsManagedZoneListResource_basic(zoneName, dnsName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "project", project),
+					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "name", zoneName),
+					resource.TestCheckResourceAttr("google_dns_managed_zone.foobar", "dns_name", dnsName),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccDnsManagedZoneListQuery(project),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectIdentity("google_dns_managed_zone.all", map[string]knownvalue.Check{
+						"name":    knownvalue.StringExact(zoneName),
+						"project": knownvalue.StringExact(project),
+					}),
+					querycheck.ExpectLengthAtLeast("google_dns_managed_zone.all", 1),
+				},
+			},
+		},
+	})
+}
+
+func testAccDnsManagedZoneListResource_basic(name, dnsName string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "foobar" {
+  name       = %q
+  dns_name   = %q
+  visibility = "public"
+}
+`, name, dnsName)
+}
+
+func testAccDnsManagedZoneListQuery(project string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_dns_managed_zone" "all" {
+  provider = google
+
+  config {
+    project = %q
+  }
+}
+`, project)
+}

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_dns_managed_zone.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_dns_managed_zone.html.markdown
@@ -1,0 +1,50 @@
+---
+subcategory: "Cloud DNS"
+page_title: "google_dns_managed_zone"
+description: |-
+  Lists DNS managed zones in a project.
+---
+
+# google_dns_managed_zone (list)
+
+Lists **DNS managed zones** in a Google Cloud project for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+**`.tfquery.hcl`** files. Results correspond to existing
+[`google_dns_managed_zone`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone)
+managed resources.
+
+For how list resources work in this provider, file layout, Terraform version requirements, and
+shared `list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_dns_managed_zone" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "my-project"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID whose DNS managed zones are listed. If unset, the provider's
+  configured default project is used.
+
+## Results
+
+By default each result includes **resource identity** for `google_dns_managed_zone` (see
+[Resource identity](https://developer.hashicorp.com/terraform/language/resources/identities)):
+
+* `name` - Managed zone name.
+* `project` - Project ID.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_dns_managed_zone` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone#attributes-reference).


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#26903

Adds a new list resource `google_dns_managed_zone` for Terraform 1.14+ `terraform query` support. This allows users to list all DNS managed zones in a project.

### Details
- Adds list resource implementation for `google_dns_managed_zone`
- Adds acceptance test `TestAccDnsManagedZoneListResource_queryIdentity`
- Adds documentation for the list resource

### Release Note Template for Downstream PRs (will be copied)

```release-note:new-list-resource
`google_dns_managed_zone`
```