### PR TITLE
container: invalidate stale IGM cache after node pool resize

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -158,6 +158,12 @@ func (instanceGroupManagerCache *instanceGroupManagerCache) needsRefresh(fullyQu
 	return time.Since(igm.updateTime) > instanceGroupManagerCache.ttl
 }
 
+func (instanceGroupManagerCache *instanceGroupManagerCache) remove(fullyQualifiedName string) {
+	instanceGroupManagerCache.mutex.Lock()
+	defer instanceGroupManagerCache.mutex.Unlock()
+	delete(instanceGroupManagerCache.instanceGroupManagers, fullyQualifiedName)
+}
+
 // We need to set ttl to 0 to disable caching in VCR testing.
 // This ensure all NP/MIG LIST requests are made consistently,
 // preventing non-deterministic behavior that would break VCR.
@@ -1791,6 +1797,16 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 		if err := retryWhileIncompatibleOperation(timeout, npLockKey, updateF); err != nil {
 				return err
+		}
+		// The node pool size changed, so any cached InstanceGroupManager target sizes for
+		// this node pool are now stale. Invalidate them so the subsequent read fetches the
+		// new size from the API instead of returning a stale cached value.
+		if igmUrls, ok := d.GetOk(prefix + "instance_group_urls"); ok {
+			for _, u := range igmUrls.([]interface{}) {
+				if key := instanceGroupManagerURL.FindString(u.(string)); key != "" {
+					igmCache.remove(key)
+				}
+			}
 		}
 		log.Printf("[INFO] GKE node pool %s size has been updated to %d", name, newSize)
 	}


### PR DESCRIPTION
Fixes a chronic nightly test failure in `TestAccContainerNodePool_ignoreNodeCountChanges` (failing 100% of recent runs on the Google Beta nightly-test branch).

## Test history
This test has been failing **deterministically** on `refs/heads/nightly-test` — not a flake.

TeamCity test history: https://hashicorp.teamcity.com/test/32444599296022190?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&tab=testDetails

## Validation build (TeamCity, Upstream MM Testing)
Validated on `refs/heads/auto-pr-18134`: **PASS** (`--- PASS: TestAccContainerNodePool_ignoreNodeCountChanges (1568.23s)`, 0 failures).

Build: https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_CONTAINER/695924

## Root cause
`google_container_node_pool` reads the node pool's `node_count` from a per-zone cache of `InstanceGroupManager`s (`igmCache`), populated by a List call and guarded by a TTL (5m outside VCR). After a size change via `SetNodePoolSize`, only the node-pool cache (`npCache`) was invalidated — the `igmCache` was not. The Read that runs immediately after an update could therefore serve a **stale** `TargetSize` and report the pre-resize `node_count`.

This is exactly what breaks the test: at Step 3 it flips `ignore_node_count_changes` to `false` and sets `node_count = 3` (the pool was previously resized externally to 3). The update resizes correctly, but the post-update Read returns the stale cached size (`2`), so the check `node_count == 3` fails.

## Fix
- Add an `instanceGroupManagerCache.remove` method, mirroring the existing `npCache.remove`.
- After a successful `SetNodePoolSize` in `nodePoolUpdate`, invalidate this node pool's IGM cache entries (derived from `instance_group_urls`) so the subsequent Read fetches the new target size from the API instead of a stale cached value.

```release-note:bug
container: fixed a bug where `google_container_node_pool` could report a stale `node_count` immediately after a resize due to a cached instance group manager target size
```
