### PR TITLE
Add catalogPublishingEnabled to Dataplex dataDocumentationSpec

### DIFF
--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -904,4 +904,4 @@ properties:
       - name: catalogPublishingEnabled
         type: Boolean
         description: |
-          If set, the latest DataScan job result will be published to Dataplex Catalog.
+          If set, the latest DataScan job result will be published to Knowledge Catalog.

--- a/mmv1/products/dataplex/Datascan.yaml
+++ b/mmv1/products/dataplex/Datascan.yaml
@@ -900,4 +900,8 @@ properties:
       - data_profile_spec
       - data_discovery_spec
       - data_documentation_spec
-    properties: []
+    properties:
+      - name: catalogPublishingEnabled
+        type: Boolean
+        description: |
+          If set, the latest DataScan job result will be published to Dataplex Catalog.

--- a/mmv1/templates/terraform/samples/services/dataplex/dataplex_datascan_documentation.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataplex/dataplex_datascan_documentation.tf.tmpl
@@ -74,7 +74,9 @@ resource "google_dataplex_datascan" "{{$.PrimaryResourceId}}" {
     }
   }
 
-  data_documentation_spec {}
+  data_documentation_spec {
+    catalog_publishing_enabled = true
+  }
 
   project = "{{index $.TestEnvVars "project_name"}}"
 }

--- a/mmv1/templates/terraform/schema_property.go.tmpl
+++ b/mmv1/templates/terraform/schema_property.go.tmpl
@@ -76,7 +76,7 @@ Default value: {{ .ItemType.DefaultValue -}}
   {{ end -}}
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{
-      {{- range $prop := .ResourceMetadata.OrderProperties $.UserProperties }}
+      {{- range $prop := .ResourceMetadata.OrderProperties .UserProperties }}
       {{template "SchemaFields" $prop}}
       {{- end }}
     },


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataplex: added `catalog_publishing_enabled` field to `google_dataplex_datascan` resource
```
