### PR TITLE
Add exadataInfrastructure field and sample to ExascaleDbStorageVault

### DIFF
--- a/mmv1/products/oracledatabase/ExascaleDbStorageVault.yaml
+++ b/mmv1/products/oracledatabase/ExascaleDbStorageVault.yaml
@@ -21,6 +21,10 @@ create_url: projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults?
 id_format: projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults/{{exascale_db_storage_vault_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults/{{exascale_db_storage_vault_id}}
+timeouts:
+  insert_minutes: 120
+  update_minutes: 60
+  delete_minutes: 60
 async:
   type: OpAsync
   operation:
@@ -77,6 +81,22 @@ samples:
           # As a result these resources are not sweepable
           # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
           exascale_db_storage_vault_id: fmt.Sprintf("ofake-tf-test-storage-vault-full-%s", acctest.RandString(t, 10))
+  - name: oracledatabase_exascale_db_storage_vault_dedicated_exadata_infrastructure
+    primary_resource_id: my_storage_vault
+    steps:
+      - name: oracledatabase_exascale_db_storage_vault_dedicated_exadata_infrastructure
+        resource_id_vars:
+          project: my-project
+          cloud_exadata_infrastructure_id: my-infra
+          exascale_db_storage_vault_id: my-instance
+          deletion_protection: true
+        ignore_read_extra:
+          - deletion_protection
+        test_vars_overrides:
+          deletion_protection: "false"
+          project: '"oci-terraform-testing-prod"'
+          cloud_exadata_infrastructure_id: 'fmt.Sprintf("ofake-tf-configured-exadata-%s", acctest.RandString(t, 10))'
+          exascale_db_storage_vault_id: 'fmt.Sprintf("ofake-tf-test-vault-on-exadata-%s", acctest.RandString(t, 10))'
 virtual_fields:
   - name: deletion_protection
     type: Boolean
@@ -134,6 +154,15 @@ properties:
       Format:
       projects/{project}/locations/{location}/exascaleDbStorageVaults/{exascale_db_storage_vault}
     output: true
+  - name: exadataInfrastructure
+    type: ResourceRef
+    description: |
+      The Exadata Infrastructure resource on which ExascaleDbStorageVault resource is created.
+      In the format: projects/{project}/locations/{region}/cloudExadataInfrastructures/{cloud_extradata_infrastructure}
+    resource: CloudExadataInfrastructure
+    imports: name
+    immutable: true
+    diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
   - name: properties
     type: NestedObject
     description: |-

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_exascale_db_storage_vault_dedicated_exadata_infrastructure.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_exascale_db_storage_vault_dedicated_exadata_infrastructure.tf.tmpl
@@ -1,0 +1,40 @@
+resource "google_oracle_database_cloud_exadata_infrastructure" "infra" {
+  cloud_exadata_infrastructure_id = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}}"
+  display_name                    = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}} displayname"
+  location                        = "us-east4"
+  project                         = "{{index $.ResourceIdVars "project"}}"
+
+  properties {
+    shape         = "Exadata.X9M"
+    compute_count = "2"
+    storage_count = "3"
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+}
+
+resource "google_oracle_database_cloud_exadata_infrastructure_exascale_config" "exascale_config" {
+  cloud_exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.cloud_exadata_infrastructure_id
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+  total_storage_size_gb        = 10240
+}
+
+resource "google_oracle_database_exascale_db_storage_vault" "{{$.PrimaryResourceId}}" {
+  exascale_db_storage_vault_id = "{{index $.ResourceIdVars "exascale_db_storage_vault_id"}}"
+  display_name                 = "{{index $.ResourceIdVars "exascale_db_storage_vault_id"}} displayname"
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+
+  exadata_infrastructure       = google_oracle_database_cloud_exadata_infrastructure.infra.name
+
+  depends_on = [google_oracle_database_cloud_exadata_infrastructure_exascale_config.exascale_config]
+
+  properties {
+    exascale_db_storage_details {
+      total_size_gbs = 2048
+    }
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+}


### PR DESCRIPTION
### Description

This PR adds support for linking a `google_oracle_database_exascale_db_storage_vault` resource to a dedicated Oracle Cloud Exadata Infrastructure via the new `exadata_infrastructure` field.

This maps to the `exadataInfrastructure` parameter on the Oracle Database `exascaleDbStorageVaults` API endpoint.

Additionally, this PR:
1. Adds a dedicated test sample `oracledatabase_exascale_db_storage_vault_dedicated_exadata_infrastructure` verifying creation, import, and teardown lifecycles.
2. Increases the test vault size to `2048` GB (`total_size_gbs = 2048`) to meet the minimum size requirement for dedicated Exadata instances.
3. Exposes the top-level `timeouts` configuration block in the resource schema to allow HCL timeout overrides.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28171

### Release Note

```release-note:enhancement
oracledatabase: added `exadata_infrastructure` field to `google_oracle_database_exascale_db_storage_vault` resource
```

