### PR TITLE
fix(compute): detect in-place edits to google_compute_security_policy rules

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy.go.tmpl
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -755,19 +756,71 @@ func resourceComputeSecurityPolicyRulePreconfiguredWafConfigExclusionFieldParams
 	}
 }
 
-// resourceComputeSecurityPolicyRuleHash hashes security policy rules by priority and action.
-// Using only priority causes hash collisions when two rules share the same priority (which
-// the API rejects, but which users may write transiently), causing schema.Set to silently
-// drop one rule and bypass the duplicate-priority validation in rulesCustomizeDiff.
-// Including action ensures distinct rules always produce distinct hashes while still
-// excluding volatile optional fields (description, preview, match sub-fields) that the
-// API may return as empty strings instead of nil, preventing unnecessary rule recreation.
+// resourceComputeSecurityPolicyRuleHash hashes a security policy rule by every field
+// that defines its behavior. Because `rule` is a schema.Set, this hash IS the element's
+// identity: any field left out of the hash is invisible to change detection. Hashing on
+// priority+action alone made schema.Set treat an edited rule as unchanged whenever the
+// edit kept the same priority and action -- e.g. changing match.expr.expression,
+// rate_limit_options.rate_limit_threshold.count, preconfigured_waf_config,
+// redirect_options or header_action -- so d.HasChange("rule") returned false and the
+// update was silently skipped (hashicorp/terraform-provider-google#27936).
+//
+// We therefore serialize the whole decoded rule canonically instead of enumerating a
+// subset of fields. This is safe against the churn that motivated the historical
+// priority+action-only hash (hashicorp/terraform-provider-google#16882 -- the API echoes
+// some optional values back as empty rather than nil): the hash runs on the
+// schema-decoded set element for both config and refreshed state, so leaf values are
+// always their schema zero value (never nil) and share identical Go types, while the
+// flatten* helpers already normalize the empty blocks the API echoes back down to nil.
+// An unchanged rule therefore hashes identically whether it originates from config or a
+// read, while any genuine edit -- at any depth -- changes the hash.
 func resourceComputeSecurityPolicyRuleHash(v interface{}) int {
-	raw := v.(map[string]interface{})
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%d-", raw["priority"].(int)))
-	buf.WriteString(fmt.Sprintf("%s-", raw["action"].(string)))
+	serializeSecurityPolicyRuleForHash(&buf, v)
 	return tpgresource.Hashcode(buf.String())
+}
+
+// serializeSecurityPolicyRuleForHash writes a deterministic representation of a
+// schema-decoded value into buf. Map keys are emitted in sorted order and schema.Set
+// members are sorted, so two rules that are semantically equal always produce the same
+// bytes regardless of Go map iteration order or set element ordering.
+func serializeSecurityPolicyRuleForHash(buf *bytes.Buffer, v interface{}) {
+	switch val := v.(type) {
+	case *schema.Set:
+		members := make([]string, 0, val.Len())
+		for _, item := range val.List() {
+			var b bytes.Buffer
+			serializeSecurityPolicyRuleForHash(&b, item)
+			members = append(members, b.String())
+		}
+		sort.Strings(members)
+		buf.WriteString("[")
+		buf.WriteString(strings.Join(members, ","))
+		buf.WriteString("]")
+	case []interface{}:
+		buf.WriteString("[")
+		for _, item := range val {
+			serializeSecurityPolicyRuleForHash(buf, item)
+			buf.WriteString(",")
+		}
+		buf.WriteString("]")
+	case map[string]interface{}:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteString("{")
+		for _, k := range keys {
+			buf.WriteString(k)
+			buf.WriteString(":")
+			serializeSecurityPolicyRuleForHash(buf, val[k])
+			buf.WriteString(";")
+		}
+		buf.WriteString("}")
+	default:
+		buf.WriteString(fmt.Sprintf("%v", val))
+	}
 }
 
 func rulesCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_internal_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_security_policy_internal_test.go
@@ -1,0 +1,219 @@
+package compute
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// newSecurityPolicyRuleForHash returns a fully-populated, schema-decoded rule map,
+// matching the shape produced after schema decoding / flattenSecurityPolicyRules. Every
+// call returns an independent copy so callers can mutate it freely.
+func newSecurityPolicyRuleForHash() map[string]interface{} {
+	return map[string]interface{}{
+		"priority":    int(1000),
+		"action":      "rate_based_ban",
+		"preview":     false,
+		"description": "a rule",
+		"match": []interface{}{
+			map[string]interface{}{
+				"versioned_expr": "SRC_IPS_V1",
+				"config": []interface{}{
+					map[string]interface{}{
+						"src_ip_ranges": schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8", "192.168.0.0/16"}),
+					},
+				},
+				"expr": []interface{}{
+					map[string]interface{}{
+						"expression": "origin.region_code == 'US'",
+					},
+				},
+				"expr_options": []interface{}{
+					map[string]interface{}{
+						"recaptcha_options": []interface{}{
+							map[string]interface{}{
+								"action_token_site_keys":  []interface{}{"action-key-1"},
+								"session_token_site_keys": []interface{}{"session-key-1"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"preconfigured_waf_config": []interface{}{
+			map[string]interface{}{
+				"exclusion": []interface{}{
+					map[string]interface{}{
+						"request_header": []interface{}{
+							map[string]interface{}{"operator": "STARTS_WITH", "value": "x-"},
+						},
+						"request_cookie":      []interface{}{},
+						"request_uri":         []interface{}{},
+						"request_query_param": []interface{}{},
+						"target_rule_set":     "rce-stable",
+						"target_rule_ids":     schema.NewSet(schema.HashString, []interface{}{"owasp-crs-v030001-id941120-xss"}),
+					},
+				},
+			},
+		},
+		"rate_limit_options": []interface{}{
+			map[string]interface{}{
+				"rate_limit_threshold": []interface{}{
+					map[string]interface{}{"count": int(100), "interval_sec": int(60)},
+				},
+				"ban_threshold": []interface{}{
+					map[string]interface{}{"count": int(1000), "interval_sec": int(300)},
+				},
+				"conform_action":      "allow",
+				"exceed_action":       "deny(403)",
+				"enforce_on_key":      "IP",
+				"enforce_on_key_name": "",
+				"enforce_on_key_configs": []interface{}{
+					map[string]interface{}{"enforce_on_key_type": "IP", "enforce_on_key_name": ""},
+				},
+				"ban_duration_sec": int(600),
+				"exceed_redirect_options": []interface{}{
+					map[string]interface{}{"type": "EXTERNAL_302", "target": "https://example.com"},
+				},
+			},
+		},
+		"redirect_options": []interface{}{
+			map[string]interface{}{"type": "EXTERNAL_302", "target": "https://example.com"},
+		},
+		"header_action": []interface{}{
+			map[string]interface{}{
+				"request_headers_to_adds": []interface{}{
+					map[string]interface{}{"header_name": "X-Goog-Test", "header_value": "true"},
+				},
+			},
+		},
+	}
+}
+
+// nestedMap descends into a []interface{}-wrapped block (MaxItems: 1) at each key in path
+// and returns the innermost map, so tests can mutate a single deeply-nested leaf.
+func nestedMap(t *testing.T, rule map[string]interface{}, path ...string) map[string]interface{} {
+	t.Helper()
+	cur := rule
+	for _, key := range path {
+		list, ok := cur[key].([]interface{})
+		if !ok || len(list) == 0 {
+			t.Fatalf("path element %q is not a non-empty block", key)
+		}
+		cur, ok = list[0].(map[string]interface{})
+		if !ok {
+			t.Fatalf("path element %q does not contain a map", key)
+		}
+	}
+	return cur
+}
+
+// TestUnitComputeSecurityPolicyRuleHash_detectsFieldEdits asserts that editing any
+// behavior-defining field changes the rule hash. Before the fix, editing a field other
+// than priority/action left the hash unchanged, so schema.Set treated the edited rule as
+// identical and d.HasChange("rule") missed the change
+// (hashicorp/terraform-provider-google#27936).
+func TestUnitComputeSecurityPolicyRuleHash_detectsFieldEdits(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]func(rule map[string]interface{}){
+		"action":      func(r map[string]interface{}) { r["action"] = "deny(403)" },
+		"preview":     func(r map[string]interface{}) { r["preview"] = true },
+		"description": func(r map[string]interface{}) { r["description"] = "changed" },
+		"match.versioned_expr": func(r map[string]interface{}) {
+			nestedMap(t, r, "match")["versioned_expr"] = ""
+		},
+		"match.expr.expression": func(r map[string]interface{}) {
+			nestedMap(t, r, "match", "expr")["expression"] = "origin.region_code == 'CA'"
+		},
+		"match.config.src_ip_ranges": func(r map[string]interface{}) {
+			nestedMap(t, r, "match", "config")["src_ip_ranges"] = schema.NewSet(schema.HashString, []interface{}{"10.0.0.0/8"})
+		},
+		"match.expr_options.recaptcha_options.action_token_site_keys": func(r map[string]interface{}) {
+			nestedMap(t, r, "match", "expr_options", "recaptcha_options")["action_token_site_keys"] = []interface{}{"action-key-2"}
+		},
+		"preconfigured_waf_config.exclusion.target_rule_set": func(r map[string]interface{}) {
+			nestedMap(t, r, "preconfigured_waf_config", "exclusion")["target_rule_set"] = "sqli-stable"
+		},
+		"preconfigured_waf_config.exclusion.target_rule_ids": func(r map[string]interface{}) {
+			nestedMap(t, r, "preconfigured_waf_config", "exclusion")["target_rule_ids"] = schema.NewSet(schema.HashString, []interface{}{"owasp-crs-v030001-id941130-xss"})
+		},
+		"preconfigured_waf_config.exclusion.request_header.value": func(r map[string]interface{}) {
+			nestedMap(t, r, "preconfigured_waf_config", "exclusion", "request_header")["value"] = "y-"
+		},
+		// The reviewer's specific concern: the rate limit threshold and its count / interval.
+		"rate_limit_options.rate_limit_threshold.count": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options", "rate_limit_threshold")["count"] = int(200)
+		},
+		"rate_limit_options.rate_limit_threshold.interval_sec": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options", "rate_limit_threshold")["interval_sec"] = int(120)
+		},
+		"rate_limit_options.ban_threshold.count": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options", "ban_threshold")["count"] = int(2000)
+		},
+		"rate_limit_options.conform_action": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options")["conform_action"] = "deny"
+		},
+		"rate_limit_options.exceed_action": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options")["exceed_action"] = "deny(429)"
+		},
+		"rate_limit_options.enforce_on_key": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options")["enforce_on_key"] = "HTTP_HEADER"
+		},
+		"rate_limit_options.enforce_on_key_name": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options")["enforce_on_key_name"] = "X-Custom"
+		},
+		"rate_limit_options.enforce_on_key_configs.enforce_on_key_type": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options", "enforce_on_key_configs")["enforce_on_key_type"] = "HTTP_COOKIE"
+		},
+		"rate_limit_options.ban_duration_sec": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options")["ban_duration_sec"] = int(1200)
+		},
+		"rate_limit_options.exceed_redirect_options.target": func(r map[string]interface{}) {
+			nestedMap(t, r, "rate_limit_options", "exceed_redirect_options")["target"] = "https://changed.example.com"
+		},
+		"redirect_options.type": func(r map[string]interface{}) {
+			nestedMap(t, r, "redirect_options")["type"] = "GOOGLE_RECAPTCHA"
+		},
+		"redirect_options.target": func(r map[string]interface{}) {
+			nestedMap(t, r, "redirect_options")["target"] = "https://changed.example.com"
+		},
+		"header_action.request_headers_to_adds.header_name": func(r map[string]interface{}) {
+			nestedMap(t, r, "header_action", "request_headers_to_adds")["header_name"] = "X-Goog-Other"
+		},
+		"header_action.request_headers_to_adds.header_value": func(r map[string]interface{}) {
+			nestedMap(t, r, "header_action", "request_headers_to_adds")["header_value"] = "false"
+		},
+	}
+
+	base := resourceComputeSecurityPolicyRuleHash(newSecurityPolicyRuleForHash())
+
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			rule := newSecurityPolicyRuleForHash()
+			mutate(rule)
+			if got := resourceComputeSecurityPolicyRuleHash(rule); got == base {
+				t.Errorf("editing %s did not change the rule hash (%d); the edit would be silently skipped", name, got)
+			}
+		})
+	}
+}
+
+// TestUnitComputeSecurityPolicyRuleHash_stable asserts that two independently-built but
+// semantically identical rules hash identically. This guards against churn / spurious
+// recreation (hashicorp/terraform-provider-google#16882), including set members supplied
+// in different orders.
+func TestUnitComputeSecurityPolicyRuleHash_stable(t *testing.T) {
+	t.Parallel()
+
+	a := newSecurityPolicyRuleForHash()
+
+	b := newSecurityPolicyRuleForHash()
+	// Same IP ranges, different insertion order: a set hash must be order-independent.
+	nestedMap(t, b, "match", "config")["src_ip_ranges"] = schema.NewSet(schema.HashString, []interface{}{"192.168.0.0/16", "10.0.0.0/8"})
+
+	if resourceComputeSecurityPolicyRuleHash(a) != resourceComputeSecurityPolicyRuleHash(b) {
+		t.Errorf("semantically identical rules produced different hashes: %d != %d",
+			resourceComputeSecurityPolicyRuleHash(a), resourceComputeSecurityPolicyRuleHash(b))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a missed-diff regression where editing an existing `google_compute_security_policy` `rule` in place – keeping the same `priority` and `action` but changing another field – produces **no plan diff**, so the change is never applied.

Fixes hashicorp/terraform-provider-google#27936

## Root cause

`rule` is a `TypeSet`. hashicorp/terraform-provider-google#16882 was fixed (hashicorp/terraform-provider-google#27754) by giving the set a custom hash keyed on **`priority` + `action` only**, to stop spurious recreation caused by the API returning some optional fields as empty strings instead of `nil`.

Consequence: two rules with the same `priority`+`action` but different content hash identically, so `schema.Set` treats an edited rule as the same element. The entire rule update path in `resourceComputeSecurityPolicyUpdate` is gated by `d.HasChange("rule")` and `oSet.Contains(rule)` – both hash-based – so an in-place edit makes `HasChange` return `false` and the update is silently skipped. `terraform plan` reports "No changes" even when the live rule differs from config (also not surfaced by `-refresh-only`).

## Fix

Serialize the **whole decoded rule** canonically (sorted map keys, sorted set members) and hash that, so every field at any depth contributes to the hash – `rate_limit_options` (incl. `rate_limit_threshold.count`/`interval_sec`), `preconfigured_waf_config`, `redirect_options`, `header_action`, `match.expr_options`, etc., not just a hand-picked subset.

This stays safe against the churn that motivated the narrow `priority`+`action` hash (hashicorp/terraform-provider-google#16882): the hash runs on the **schema-decoded** element for both config and refreshed state, so leaf values are always their schema zero value (never `nil`) with identical Go types, while the `flatten*` helpers already normalize the empty blocks the API echoes back down to `nil`. An unchanged rule therefore hashes identically whether it comes from config or a read, while any genuine edit changes the hash and triggers the existing in-place `patchRule` path.

## Reproduction

```hcl
resource "google_compute_security_policy" "p" {
  name = "tf-issue-27936"
  rule {
    action   = "deny(403)"
    priority = 220
    match { expr { expression = "request.path.contains('/a')" } }
  }
  rule {
    action   = "allow"
    priority = 2147483647
    match { versioned_expr = "SRC_IPS_V1"
            config { src_ip_ranges = ["*"] } }
  }
}
```

Apply, then change the priority-220 expression to `request.method != 'OPTIONS' && request.path.contains('/a')`. Before: `No changes`. After: a plan that updates the rule in place. The same now holds for edits confined to `rate_limit_options`, `preconfigured_waf_config`, `redirect_options` and `header_action`.

## Testing

- Added `resource_compute_security_policy_internal_test.go` unit tests:
  - `TestUnitComputeSecurityPolicyRuleHash_detectsFieldEdits` – 24 cases, each mutating a single field (incl. `rate_limit_options.rate_limit_threshold.count`/`interval_sec`) and asserting the hash changes.
  - `TestUnitComputeSecurityPolicyRuleHash_stable` – semantically identical rules, with set members supplied in different order, hash identically (churn / set-order-independence guard).
- Verified by generating the beta provider and running the suite: **26 passed**.
- `gofmt`-clean.
- Existing `TestAccComputeSecurityPolicy_*` update acceptance tests exercise the in-place path end-to-end against the API in CI.

## Release Note

```release-note:bug
compute: fixed an issue where in-place edits to an existing `google_compute_security_policy` `rule` (e.g. `match.expr.expression`, `rate_limit_options`) that kept the same `priority` and `action` produced no diff and were not applied
```

