### PR TITLE
bigquery: allow clearing dataset default_collation to empty

### DIFF
--- a/mmv1/products/bigquery/Dataset.yaml
+++ b/mmv1/products/bigquery/Dataset.yaml
@@ -41,8 +41,6 @@ include_in_tgc_next: true
 custom_code:
   constants: 'templates/terraform/constants/bigquery_dataset.go.tmpl'
   pre_read: 'templates/terraform/pre_read/bigquery_dataset.go.tmpl'
-custom_diff:
-  - 'customCollationDiff'
 generate_list_resource: true
 exclude_sweeper: true
 samples:
@@ -464,7 +462,6 @@ properties:
       The following values are supported:
       - 'und:ci': undetermined locale, case insensitive.
       - '': empty string. Default to case-sensitive behavior.
-    default_from_api: true
     send_empty_value: true
     custom_expand: 'templates/terraform/custom_expand/bigquery_dataset_default_collation.go.tmpl'
   - name: 'storageBillingModel'

--- a/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
+++ b/mmv1/templates/terraform/constants/bigquery_dataset.go.tmpl
@@ -30,26 +30,6 @@ func validateDefaultTableExpirationMs(v interface{}, k string) (ws []string, err
     return
 }
 
-func customCollationDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	// 1. Check if the configuration is explicitly set to an empty string.
-	// We use GetRawConfig to see what the user actually wrote,
-	// before the SDK "fills in" computed values.
-	conf := d.GetRawConfig()
-	if !conf.IsNull() && conf.GetAttr("default_collation").IsKnown() && !conf.GetAttr("default_collation").IsNull() {
-		val := conf.GetAttr("default_collation").AsString()
-
-		// 2. If config is "", but the state (old value) is NOT "", force an update.
-		old, _ := d.GetChange("default_collation")
-		if old != "" && val == "" {
-			// THIS is what goes inside the block:
-			if err := d.SetNew("default_collation", ""); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 {{- if ne $.ProductMetadata.Compiler "terraformgoogleconversion-codegen" }}
 // bigqueryDatasetAccessHash is a custom hash function for the access block.
 // It normalizes


### PR DESCRIPTION
Fixes a chronic nightly test failure in `TestAccBigQueryDataset_collationUpdate` (failing ~83% of recent runs on the Google Beta nightly-test branch — 49 failures / 10 passes over the last ~60 days, failing essentially every nightly for weeks).

## Test history
TeamCity test history: https://hashicorp.teamcity.com/test/8347509247226202175?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS&tab=testDetails

## Validation build (TeamCity, Upstream MM Testing)
Triggered on `refs/heads/auto-pr-18140` (scoped to `TestAccBigQueryDataset_collationUpdate`):
https://hashicorp.teamcity.com/buildConfiguration/TerraformProviders_GoogleCloud_GOOGLE_BETA_MMUPSTREAMTESTS_GOOGLEBETA_PACKAGE_BIGQUERY/696388

## Root cause
The test creates a dataset with `default_collation = "und:ci"`, then updates `default_collation` back to `""` and asserts the value is cleared. It always failed with `expected "", got "und:ci"`.

TeamCity debug logs show **no update PUT is ever sent** in the clearing step. `default_collation` was `Optional + Computed` (via `default_from_api: true`), and the legacy Terraform Plugin SDK reinterprets an empty-string value on a Computed attribute as "unset":

```
[DEBUG] A computed value with the empty string as the new value and a non-empty
        old value was found. Interpreting the empty string as "unset" ...
.default_collation: planned value cty.UnknownVal(cty.String) does not match
        config value cty.StringVal("") nor prior value cty.StringVal("und:ci")
```

So even though `customCollationDiff` called `SetNew("default_collation", "")`, the SDK turned it into an unknown/computed value, no diff was produced, no PUT was sent, and the post-apply read returned the unchanged `und:ci`.

Verified directly against the BigQuery API:
- Creating a dataset **without** `defaultCollation` returns it **absent** (no server-assigned default).
- `PUT` with `"defaultCollation": ""` clears the value and an immediate read-back returns `""` (the API is consistent here — there was no eventual-consistency problem).

## Fix
Remove `default_from_api: true` from `default_collation` so the field is `Optional` (not `Computed`). The SDK no longer reinterprets the empty string as "unset", a normal diff is produced, and (with `send_empty_value: true`) the clearing `PUT` is sent and reflected in state. Because the API returns no `defaultCollation` when a dataset is created without one, dropping `default_from_api` does not introduce a permadiff for users who never set the field.

Also remove the now-unnecessary `customCollationDiff` custom diff: it existed only to force the clearing diff, relies on `SetNew` (valid only on computed keys), and errors once the field is no longer computed.

Verified by running `TestAccBigQueryDataset_collationUpdate` against a real project (PASS).

```release-note:bug
bigquery: fixed inability to clear `default_collation` on `google_bigquery_dataset` (setting it back to an empty string is now sent to the API)
```
