### PR TITLE
refactor: extract FlattenProjectIamCustomRole from Read function

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_project_iam_custom_role.go
@@ -159,7 +159,21 @@ func resourceGoogleProjectIamCustomRoleRead(d *schema.ResourceData, meta interfa
 		return transport_tpg.HandleNotFoundError(err, d, d.Id())
 	}
 
-	if err := d.Set("role_id", tpgresource.GetResourceNameFromSelfLink(role.Name)); err != nil {
+	if err := FlattenProjectIamCustomRole(d, role, project); err != nil {
+		return err
+	}
+
+	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func FlattenProjectIamCustomRole(d *schema.ResourceData, role *iam.Role, project string) error {
+	roleID := tpgresource.GetResourceNameFromSelfLink(role.Name)
+
+	if err := d.Set("role_id", roleID); err != nil {
 		return fmt.Errorf("Error setting role_id: %s", err)
 	}
 	if err := d.Set("title", role.Title); err != nil {
@@ -182,10 +196,6 @@ func resourceGoogleProjectIamCustomRoleRead(d *schema.ResourceData, meta interfa
 	}
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error setting project: %s", err)
-	}
-
-	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil {
-		return err
 	}
 
 	return nil


### PR DESCRIPTION
Extracts the field-setting logic from `resourceGoogleProjectIamCustomRoleRead` into an exported `FlattenProjectIamCustomRole` function. This enables reuse by the upcoming list resource (#18128) without duplicating code.

No behavior change, pure refactor.

### Details

- Extracts `FlattenProjectIamCustomRole` from the Read function
- Read function now calls the shared flattener
- List resource PR (#18128) will call this same function, eliminating duplicate flatten logic

```release-note:none
```