### PR TITLE
Add support for enforce_new_sql_network_architecture flag in google_s…

### DIFF
--- a/mmv1/third_party/terraform/services/sql/data_source_sql_database_instances.go
+++ b/mmv1/third_party/terraform/services/sql/data_source_sql_database_instances.go
@@ -147,6 +147,7 @@ func flattenDatasourceGoogleDatabaseInstancesList(fetchedInstances []*sqladmin.D
 		instance["available_maintenance_versions"] = rawInstance.AvailableMaintenanceVersions
 		instance["instance_type"] = rawInstance.InstanceType
 		instance["service_account_email_address"] = rawInstance.ServiceAccountEmailAddress
+		instance["enforce_new_sql_network_architecture"] = rawInstance.SqlNetworkArchitecture == "NEW_NETWORK_ARCHITECTURE"
 		instance["settings"] = flattenSettings(rawInstance.Settings, rawInstance.InstanceType, d)
 
 		if rawInstance.DiskEncryptionConfiguration != nil {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -263,6 +263,13 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 				Optional:    true,
 				Description: `Used to block Terraform from deleting a SQL Instance. Defaults to true.`,
 			},
+			"enforce_new_sql_network_architecture": {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: sqlNetworkArchitectureDiffSuppress,
+				Description:      `Whether to enforce the new SQL network architecture.`,
+			},
 			"final_backup_description": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -1676,6 +1683,12 @@ func pitrSupportDbCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 	return nil
 }
 
+func sqlNetworkArchitectureDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// If the state is true and the config is false, suppress the diff.
+	// This follows the gcloud pattern where the flag is an irreversible opt-in.
+	return old == "true" && new == "false"
+}
+
 func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*transport_tpg.Config)
 	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
@@ -1722,6 +1735,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		DatabaseVersion:      databaseVersion,
 		MasterInstanceName:   d.Get("master_instance_name").(string),
 		ReplicaConfiguration: expandReplicaConfiguration(d.Get("replica_configuration").([]interface{})),
+	}
+
+	if d.Get("enforce_new_sql_network_architecture").(bool) {
+		instance.SqlNetworkArchitecture = "NEW_NETWORK_ARCHITECTURE"
 	}
 
 	cloneContext, cloneSourceInstance := expandCloneContext(d.Get("clone").([]interface{}))
@@ -2499,6 +2516,9 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("instance_type", instance.InstanceType); err != nil {
 		return fmt.Errorf("Error setting instance_type: %s", err)
 	}
+	if err := d.Set("enforce_new_sql_network_architecture", instance.SqlNetworkArchitecture == "NEW_NETWORK_ARCHITECTURE"); err != nil {
+		return fmt.Errorf("Error setting enforce_new_sql_network_architecture: %s", err)
+	}
 	if err := d.Set("node_count", instance.NodeCount); err != nil {
 		return fmt.Errorf("Error setting node_count: %s", err)
 	}
@@ -2650,6 +2670,29 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		})
 		if err != nil {
 			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", instance.Name, err)
+		}
+		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+		err = resourceSqlDatabaseInstanceRead(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("enforce_new_sql_network_architecture") && d.Get("enforce_new_sql_network_architecture").(bool) {
+		instance = &sqladmin.DatabaseInstance{SqlNetworkArchitecture: "NEW_NETWORK_ARCHITECTURE"}
+		err = transport_tpg.Retry(transport_tpg.RetryOptions{
+			RetryFunc: func() (rerr error) {
+				op, rerr = NewClient(config, userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()
+				return rerr
+			},
+			Timeout:              d.Timeout(schema.TimeoutUpdate),
+			ErrorRetryPredicates: []transport_tpg.RetryErrorPredicateFunc{transport_tpg.IsSqlOperationInProgressError},
+		})
+		if err != nil {
+			return fmt.Errorf("Error, failed to patch instance settings for %s: %s", d.Get("name").(string), err)
 		}
 		err = SqlAdminOperationWaitTime(config, op, project, "Patch Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1684,8 +1684,10 @@ func pitrSupportDbCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v 
 }
 
 func sqlNetworkArchitectureDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// By default, new Cloud SQL instances created in projects created after August 2021 use the new network architecture.
 	// If the state is true and the config is false, suppress the diff.
 	// This follows the gcloud pattern where the flag is an irreversible opt-in.
+	// See https://docs.cloud.google.com/sql/docs/mysql/upgrade-cloud-sql-instance-new-network-architecture#new-arch
 	return old == "true" && new == "false"
 }
 
@@ -2681,6 +2683,9 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	// We check for HasChange because we only want to trigger the network architecture upgrade
+	// if the configuration has explicitly changed. We also check the current value to ensure
+	// it's true, as this is an irreversible opt-in.
 	if d.HasChange("enforce_new_sql_network_architecture") && d.Get("enforce_new_sql_network_architecture").(bool) {
 		instance = &sqladmin.DatabaseInstance{SqlNetworkArchitecture: "NEW_NETWORK_ARCHITECTURE"}
 		err = transport_tpg.Retry(transport_tpg.RetryOptions{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -74,6 +74,8 @@ fields:
   - api_field: 'replicaConfiguration.mysqlReplicaConfiguration.verifyServerCertificate'
     field: 'replica_configuration.verify_server_certificate'
   - api_field: 'replicaNames'
+  - api_field: 'sqlNetworkArchitecture'
+    field: 'enforce_new_sql_network_architecture'
   - api_field: 'replicationCluster.drReplica'
   - api_field: 'replicationCluster.failoverDrReplicaName'
   - api_field: 'replicationCluster.psaWriteEndpoint'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -262,6 +262,40 @@ func TestAccSqlDatabaseInstance_basicSecondGen(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(t *testing.T) {
+	t.Parallel()
+
+	instanceName := "tf-test-" + acctest.RandString(t, 10)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "true"),
+				),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName, false),
+				Check: resource.ComposeTestCheckFunc(
+					// Verify that even though we set it to false in HCL, the state stays true
+					// and no diff was generated (otherwise this step would fail or show a plan).
+					resource.TestCheckResourceAttr("google_sql_database_instance.instance", "enforce_new_sql_network_architecture", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccSqlDatabaseInstance_basicMSSQL(t *testing.T) {
 	t.Parallel()
 
@@ -9989,3 +10023,20 @@ func testGoogleSqlDatabaseInstanceCheckNodeCount(t *testing.T, instance string, 
 		return nil
 	}
 }
+
+func testAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture(instanceName string, enforce bool) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-central1"
+  database_version = "POSTGRES_14"
+  enforce_new_sql_network_architecture = %t
+  settings {
+    tier = "db-f1-micro"
+  }
+
+  deletion_protection =  false
+}
+`, instanceName, enforce)
+}
+

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -399,6 +399,11 @@ includes an up-to-date reference of supported versions.
 
   ~> **NOTE:** This flag only protects instances from deletion within Terraform. To protect your instances from accidental deletion across all surfaces (API, gcloud, Cloud Console and Terraform), use the API flag `settings.deletion_protection_enabled`.
 
+* `enforce_new_sql_network_architecture` - (Optional) Whether to enforce the new SQL network architecture. 
+    By default, new Cloud SQL instances created in projects created after August 2021 use the new network architecture. 
+    This follows the gcloud pattern where the flag is an irreversible opt-in.
+    See [official documentation](https://docs.cloud.google.com/sql/docs/mysql/upgrade-cloud-sql-instance-new-network-architecture#new-arch) for more details.
+
 * `final_backup_description` - (Optional) The description of final backup. Only set this field when `final_backup_config.enabled` is true.
 
 * `restore_backup_context` - (optional) The context needed to restore the database to a backup run. This field will


### PR DESCRIPTION
# Add support for `enforce_new_sql_network_architecture` flag in `google_sql_database_instance`

## Description

This PR adds support for the `enforce_new_sql_network_architecture` boolean field on the `google_sql_database_instance` resource. This allows users to enforce the new SQL network architecture (based on Tenancy Units instead of Umbrellas) for Cloud SQL database instances directly from Terraform.

### Key Changes
1. **Schema Addition**: Added `enforce_new_sql_network_architecture` as an optional, computed boolean field to the `google_sql_database_instance` resource schema.
2. **Irreversible Opt-In Behavior**: Implemented `sqlNetworkArchitectureDiffSuppress` which suppresses diffs when the resource is already on the new network architecture (`state == true`) but the user attempts to set it to `false` in configuration, adhering to the standard irreversible opt-in behavior.
3. **API Field Mapping**: Mapped `sqlNetworkArchitecture` in the API payload to the Terraform field name in `resource_sql_database_instance_meta.yaml.tmpl`.
4. **CRUD Integration**: 
   - **Create**: Sends `"NEW_NETWORK_ARCHITECTURE"` in the API request during instance creation if the flag is enabled.
   - **Read**: Reads the `sqlNetworkArchitecture` state from the instance and updates the schema field status accordingly.
   - **Update**: Performs a `Patch` request to enable the new network architecture if the field was toggled on.
5. **Acceptance Test**: Added `TestAccSqlDatabaseInstance_enforceNewSqlNetworkArchitecture` to verify create, import, and diff-suppression behaviors.

---

```release-note:enhancement
sql: added `enforce_new_sql_network_architecture` field to `google_sql_database_instance` resource (create-only)
```
