### PR TITLE
Add exascaleDbStorageVault and storageManagementType fields to CloudV…

### DIFF
--- a/mmv1/products/oracledatabase/CloudVmCluster.yaml
+++ b/mmv1/products/oracledatabase/CloudVmCluster.yaml
@@ -113,6 +113,24 @@ samples:
           # See: https://github.com/hashicorp/terraform-provider-google/issues/20599
           cloud_vm_cluster_id: fmt.Sprintf("ofake-tf-test-vmcluster-full-%s", acctest.RandString(t, 10))
           cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-full-%s", acctest.RandString(t, 10))
+  - name: oracledatabase_cloud_vmcluster_exascale
+    primary_resource_id: my_vmcluster
+    steps:
+      - name: oracledatabase_cloud_vmcluster_exascale
+        resource_id_vars:
+          project: my-project
+          cloud_vm_cluster_id: my-instance
+          cloud_exadata_infrastructure_id: my-exadata
+          exascale_db_storage_vault_id: my-vault
+          deletion_protection: "true"
+        ignore_read_extra:
+          - deletion_protection
+        test_vars_overrides:
+          deletion_protection: "false"
+          project: '"oci-terraform-testing-prod"'
+          cloud_vm_cluster_id: fmt.Sprintf("ofake-tf-test-vmcluster-exascale-%s", acctest.RandString(t, 10))
+          cloud_exadata_infrastructure_id: fmt.Sprintf("ofake-tf-test-exadata-for-vmcluster-exascale-%s", acctest.RandString(t, 10))
+          exascale_db_storage_vault_id: fmt.Sprintf("ofake-tf-test-vault-for-vmcluster-exascale-%s", acctest.RandString(t, 10))
 virtual_fields:
   - name: deletion_protection
     type: Boolean
@@ -300,6 +318,15 @@ properties:
         type: String
         description: 'OCI Cluster name. '
         default_from_api: true
+      - name: storageManagementType
+        type: String
+        description: |-
+          The storage management type of the VM Cluster.
+          Possible values:
+          STORAGE_MANAGEMENT_TYPE_UNSPECIFIED
+          ASM
+          EXASCALE
+        output: true
   - name: labels
     type: KeyValueLabels
     description: 'Labels or tags associated with the VM Cluster. '
@@ -364,3 +391,11 @@ properties:
           PARTIALLY_CONNECTED
           DISCONNECTED
           UNKNOWN
+  - name: exascaleDbStorageVault
+    type: String
+    description: |-
+      The name of ExascaleDbStorageVault associated with the VM Cluster.
+      Format:
+      projects/{project}/locations/{location}/exascaleDbStorageVaults/{exascale_db_storage_vault}
+    immutable: true
+    diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName

--- a/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/oracledatabase/oracledatabase_cloud_vmcluster_exascale.tf.tmpl
@@ -1,0 +1,83 @@
+resource "google_oracle_database_cloud_vm_cluster" "{{$.PrimaryResourceId}}" {
+  cloud_vm_cluster_id    = "{{index $.ResourceIdVars "cloud_vm_cluster_id"}}"
+  display_name           = "{{index $.ResourceIdVars "cloud_vm_cluster_id"}} displayname"
+  location               = "us-east4"
+  project                = "{{index $.ResourceIdVars "project"}}"
+  exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.id
+  network                = data.google_compute_network.default.id
+  cidr                   = "10.5.0.0/24"
+  backup_subnet_cidr     = "10.6.0.0/24"
+
+  exascale_db_storage_vault = google_oracle_database_exascale_db_storage_vault.vault.name
+
+  properties {
+    license_type    = "LICENSE_INCLUDED"
+    ssh_public_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCz1X2744t+6vRLmE5u6nHi6/QWh8bQDgHmd+OIxRQIGA/IWUtCs2FnaCNZcqvZkaeyjk5v0lTA/n+9jvO42Ipib53athrfVG8gRt8fzPL66C6ZqHq+6zZophhrCdfJh/0G4x9xJh5gdMprlaCR1P8yAaVvhBQSKGc4SiIkyMNBcHJ5YTtMQMTfxaB4G1sHZ6SDAY9a6Cq/zNjDwfPapWLsiP4mRhE5SSjJX6l6EYbkm0JeLQg+AbJiNEPvrvDp1wtTxzlPJtIivthmLMThFxK7+DkrYFuLvN5AHUdo9KTDLvHtDCvV70r8v0gafsrKkM/OE9Jtzoo0e1N/5K/ZdyFRbAkFT4QSF3nwpbmBWLf2Evg//YyEuxnz4CwPqFST2mucnrCCGCVWp1vnHZ0y30nM35njLOmWdRDFy5l27pKUTwLp02y3UYiiZyP7d3/u5pKiN4vC27VuvzprSdJxWoAvluOiDeRh+/oeQDowxoT/Oop8DzB9uJmjktXw8jyMW2+Rpg+ENQqeNgF1OGlEzypaWiRskEFlkpLb4v/s3ZDYkL1oW0Nv/J8LTjTOTEaYt2Udjoe9x2xWiGnQixhdChWuG+MaoWffzUgx1tsVj/DBXijR5DjkPkrA1GA98zd3q8GKEaAdcDenJjHhNYSd4+rE9pIsnYn7fo5X/tFfcQH1XQ== nobody@google.com"]
+    cpu_core_count  = "4"
+    gi_version      = "23.0.0.0"
+    hostname_prefix = "hostname1"
+
+    # Required fields for Exascale-based VM Clusters:
+    memory_size_gb          = 60
+    db_node_storage_size_gb = 120
+    db_server_ocids         = [
+      data.google_oracle_database_db_servers.db_servers.db_servers.0.properties.0.ocid,
+      data.google_oracle_database_db_servers.db_servers.db_servers.1.properties.0.ocid
+    ]
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+
+  depends_on = [google_oracle_database_cloud_exadata_infrastructure_exascale_config.exascale_config]
+}
+
+resource "google_oracle_database_cloud_exadata_infrastructure" "infra" {
+  cloud_exadata_infrastructure_id = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}}"
+  display_name                    = "{{index $.ResourceIdVars "cloud_exadata_infrastructure_id"}} displayname"
+  location                        = "us-east4"
+  project                         = "{{index $.ResourceIdVars "project"}}"
+  properties {
+    shape         = "Exadata.X9M"
+    compute_count = "2"
+    storage_count = "3"
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+}
+
+resource "google_oracle_database_cloud_exadata_infrastructure_exascale_config" "exascale_config" {
+  cloud_exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.cloud_exadata_infrastructure_id
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+  total_storage_size_gb        = 10240
+}
+
+resource "google_oracle_database_exascale_db_storage_vault" "vault" {
+  exascale_db_storage_vault_id = "{{index $.ResourceIdVars "exascale_db_storage_vault_id"}}"
+  display_name                 = "{{index $.ResourceIdVars "exascale_db_storage_vault_id"}} displayname"
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+
+  exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.name
+
+  depends_on = [google_oracle_database_cloud_exadata_infrastructure_exascale_config.exascale_config]
+
+  properties {
+    exascale_db_storage_details {
+      total_size_gbs = 2048
+    }
+  }
+
+  deletion_protection = "{{index $.ResourceIdVars "deletion_protection"}}"
+}
+
+data "google_compute_network" "default" {
+  name    = "new"
+  project = "{{index $.ResourceIdVars "project"}}"
+}
+
+data "google_oracle_database_db_servers" "db_servers" {
+  location                     = "us-east4"
+  project                      = "{{index $.ResourceIdVars "project"}}"
+  cloud_exadata_infrastructure = google_oracle_database_cloud_exadata_infrastructure.infra.cloud_exadata_infrastructure_id
+}


### PR DESCRIPTION
### Description

This PR introduces support for configuring VM Clusters on top of dedicated Exascale DB Storage Vaults using the `exascale_db_storage_vault` parameter in `google_oracle_database_cloud_vm_cluster`.

It adds two new fields:
1. `exascale_db_storage_vault` (ResourceRef, Optional, ForceNew): Associates the VM Cluster with a dedicated storage vault.
2. `storage_management_type` (String, Output-only): Displays the storage system used (`ASM` or `EXASCALE`).

It also registers a new end-to-end integration test sample:
`oracledatabase_cloud_vmcluster_exascale` which provisions hardware, configures Exascale, carves out a storage vault, and deploys the Exascale VM cluster on top of it.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28172

### Release Note
```release-note:enhancement
oracledatabase: Added support for configuring Exascale-based VM clusters on top of dedicated storage vaults via the `exascale_db_storage_vault` parameter and `storage_management_type` to determine if VM Cluster is ASM or EXASCALE in `google_oracle_database_cloud_vm_cluster`
```