### PR TITLE
New data source: google_data_catalog_taxonomy

### DIFF
--- a/mmv1/third_party/terraform/services/datacatalog/data_source_google_data_catalog_taxonomy.go
+++ b/mmv1/third_party/terraform/services/datacatalog/data_source_google_data_catalog_taxonomy.go
@@ -1,0 +1,127 @@
+package datacatalog
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceGoogleDataCatalogTaxonomy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleDataCatalogTaxonomyRead,
+
+		Schema: map[string]*schema.Schema{
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"activated_policy_types": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleDataCatalogTaxonomyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region := d.Get("region").(string)
+	displayName := d.Get("display_name").(string)
+	url := fmt.Sprintf("%sprojects/%s/locations/%s/taxonomies", transport_tpg.BaseUrl(Product, config), project, region)
+
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+	if err != nil {
+		return err
+	}
+
+	taxonomiesRaw, ok := res["taxonomies"]
+	if !ok {
+		return fmt.Errorf("No taxonomy found with display_name %q in project %s, region %s", displayName, project, region)
+	}
+
+	taxonomies, ok := taxonomiesRaw.([]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected taxonomies response format")
+	}
+
+	for _, taxonomyRaw := range taxonomies {
+		taxonomy, ok := taxonomyRaw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if taxonomy["displayName"] == displayName {
+			d.SetId(taxonomy["name"].(string))
+
+			if err := d.Set("name", taxonomy["name"]); err != nil {
+				return fmt.Errorf("Error setting name: %s", err)
+			}
+			if err := d.Set("display_name", taxonomy["displayName"]); err != nil {
+				return fmt.Errorf("Error setting display_name: %s", err)
+			}
+			if err := d.Set("description", taxonomy["description"]); err != nil {
+				return fmt.Errorf("Error setting description: %s", err)
+			}
+			if err := d.Set("activated_policy_types", taxonomy["activatedPolicyTypes"]); err != nil {
+				return fmt.Errorf("Error setting activated_policy_types: %s", err)
+			}
+			if err := d.Set("project", project); err != nil {
+				return fmt.Errorf("Error setting project: %s", err)
+			}
+			if err := d.Set("region", region); err != nil {
+				return fmt.Errorf("Error setting region: %s", err)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No taxonomy found with display_name %q in project %s, region %s", displayName, project, region)
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_data_catalog_taxonomy",
+		ProductName: "datacatalog",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceGoogleDataCatalogTaxonomy(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/datacatalog/data_source_google_data_catalog_taxonomy_test.go
+++ b/mmv1/third_party/terraform/services/datacatalog/data_source_google_data_catalog_taxonomy_test.go
@@ -1,0 +1,51 @@
+package datacatalog_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/datacatalog"
+)
+
+func TestAccDataSourceGoogleDataCatalogTaxonomy_basic(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := acctest.RandString(t, 10)
+
+	context := map[string]interface{}{
+		"random_suffix": randomSuffix,
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleDataCatalogTaxonomy_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.google_data_catalog_taxonomy.test", "name", "google_data_catalog_taxonomy.test", "name"),
+					resource.TestCheckResourceAttrPair("data.google_data_catalog_taxonomy.test", "description", "google_data_catalog_taxonomy.test", "description"),
+					resource.TestCheckResourceAttrPair("data.google_data_catalog_taxonomy.test", "activated_policy_types.#", "google_data_catalog_taxonomy.test", "activated_policy_types.#"),
+					resource.TestCheckResourceAttrPair("data.google_data_catalog_taxonomy.test", "project", "google_data_catalog_taxonomy.test", "project"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleDataCatalogTaxonomy_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_catalog_taxonomy" "test" {
+  display_name           = "tf_test_%{random_suffix}"
+  description            = "A test taxonomy"
+  activated_policy_types = ["FINE_GRAINED_ACCESS_CONTROL"]
+  region                 = "us-central1"
+}
+
+data "google_data_catalog_taxonomy" "test" {
+  display_name = google_data_catalog_taxonomy.test.display_name
+  region       = google_data_catalog_taxonomy.test.region
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/data_catalog_taxonomy.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/data_catalog_taxonomy.html.markdown
@@ -1,0 +1,49 @@
+---
+subcategory: "Data Catalog"
+description: |-
+  Get information about a Google Data Catalog Taxonomy.
+---
+
+# google_data_catalog_taxonomy
+
+Get information about a Google Data Catalog Taxonomy. For more information see
+[the official documentation](https://cloud.google.com/data-catalog/docs)
+and
+[API](https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.taxonomies).
+
+## Example Usage
+
+```hcl
+data "google_data_catalog_taxonomy" "example" {
+  display_name = "my_taxonomy"
+  region       = "us-central1"
+}
+
+resource "google_data_catalog_policy_tag" "example" {
+  taxonomy     = data.google_data_catalog_taxonomy.example.id
+  display_name = "example_policy_tag"
+  description  = "A policy tag"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `display_name` - (Required) The user-defined name of the taxonomy to look up.
+
+* `region` - (Required) The region the taxonomy is located in.
+
+* `project` - (Optional) The project in which the taxonomy exists. If not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - The full resource name of the taxonomy in the format `projects/{project}/locations/{region}/taxonomies/{taxonomy_id}`.
+
+* `name` - The full resource name of the taxonomy.
+
+* `description` - The description of the taxonomy.
+
+* `activated_policy_types` - A list of policy types activated for this taxonomy.


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#9491

Adds a new `google_data_catalog_taxonomy` data source that allows users to look up an existing Data Catalog taxonomy by `display_name` and `region`, for use when creating policy tags against an existing taxonomy.

### Details

- Handwritten data source that calls the `projects.locations.taxonomies.list` API and filters by `displayName`
- Returns the taxonomy's full resource name, description, and activated policy types
- Adds acceptance test `TestAccDataSourceGoogleDataCatalogTaxonomy_basic`
- Adds documentation

### Release Note Template for Downstream PRs (will be copied)
```release-note:new-datasource
`google_data_catalog_taxonomy`
```