### PR TITLE
agentregistry: Resolve computed name field GA launch blockers

### DIFF
--- a/mmv1/products/agentregistry/Binding.yaml
+++ b/mmv1/products/agentregistry/Binding.yaml
@@ -58,6 +58,11 @@ parameters:
     required: true
     url_param_only: true
 properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Service.
+    output: true
   - name: displayName
     type: String
     description: |

--- a/mmv1/products/agentregistry/Service.yaml
+++ b/mmv1/products/agentregistry/Service.yaml
@@ -61,6 +61,11 @@ parameters:
     required: true
     url_param_only: true
 properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Service.
+    output: true
   - name: displayName
     type: String
     description: |


### PR DESCRIPTION
Add support for the output-only 'name' field on both Service and Binding resources to resolve the field-level launch blockers.

This resolves the Terraform Field-Level Launch Blockers for agentregistry.googleapis.com:

agentregistry.googleapis.com/Service (name)
agentregistry.googleapis.com/Binding (name)

```release-note:enhancement
agentregistry: added `name` field to `google_agent_registry_service` resource
```

```release-note:enhancement
agentregistry: added `name` field to `google_agent_registry_binding` resource
```