### PR TITLE
Configure consistent root and async timeouts for Oracle Database resources

### DIFF
--- a/mmv1/products/oracledatabase/ExadbVmCluster.yaml
+++ b/mmv1/products/oracledatabase/ExadbVmCluster.yaml
@@ -22,6 +22,10 @@ update_verb: PATCH
 id_format: projects/{{project}}/locations/{{location}}/exadbVmClusters/{{exadb_vm_cluster_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/exadbVmClusters/{{exadb_vm_cluster_id}}
+timeouts:
+  insert_minutes: 120
+  update_minutes: 60
+  delete_minutes: 60
 async:
   type: OpAsync
   operation:

--- a/mmv1/products/oracledatabase/GoldengateConnection.yaml
+++ b/mmv1/products/oracledatabase/GoldengateConnection.yaml
@@ -21,6 +21,10 @@ create_url: projects/{{project}}/locations/{{location}}/goldengateConnections?go
 id_format: projects/{{project}}/locations/{{location}}/goldengateConnections/{{goldengate_connection_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/goldengateConnections/{{goldengate_connection_id}}
+timeouts:
+  insert_minutes: 30
+  update_minutes: 30
+  delete_minutes: 30
 async:
   type: OpAsync
   operation:

--- a/mmv1/products/oracledatabase/GoldengateConnectionAssignment.yaml
+++ b/mmv1/products/oracledatabase/GoldengateConnectionAssignment.yaml
@@ -27,6 +27,10 @@ timeouts:
   delete_minutes: 60
 async:
   operation:
+    timeouts:
+      insert_minutes: 60
+      update_minutes: 60
+      delete_minutes: 60
     base_url: '{{op_id}}'
   actions:
     - create

--- a/mmv1/products/oracledatabase/GoldengateDeployment.yaml
+++ b/mmv1/products/oracledatabase/GoldengateDeployment.yaml
@@ -28,6 +28,10 @@ timeouts:
 async:
   type: OpAsync
   operation:
+    timeouts:
+      insert_minutes: 60
+      update_minutes: 60
+      delete_minutes: 60
     base_url: '{{op_id}}'
   actions:
     - create

--- a/mmv1/products/oracledatabase/OdbNetwork.yaml
+++ b/mmv1/products/oracledatabase/OdbNetwork.yaml
@@ -24,6 +24,10 @@ create_url: projects/{{project}}/locations/{{location}}/odbNetworks?odbNetworkId
 id_format: projects/{{project}}/locations/{{location}}/odbNetworks/{{odb_network_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/odbNetworks/{{odb_network_id}}
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
 async:
   type: OpAsync
   operation:

--- a/mmv1/products/oracledatabase/OdbSubnet.yaml
+++ b/mmv1/products/oracledatabase/OdbSubnet.yaml
@@ -24,6 +24,10 @@ create_url: projects/{{project}}/locations/{{location}}/odbNetworks/{{odbnetwork
 id_format: projects/{{project}}/locations/{{location}}/odbNetworks/{{odbnetwork}}/odbSubnets/{{odb_subnet_id}}
 import_format:
   - projects/{{project}}/locations/{{location}}/odbNetworks/{{odbnetwork}}/odbSubnets/{{odb_subnet_id}}
+timeouts:
+  insert_minutes: 90
+  update_minutes: 90
+  delete_minutes: 90
 async:
   type: OpAsync
   operation:


### PR DESCRIPTION
### Description

This PR ensures that all asynchronous resources under the `oracledatabase` product have consistent default timeouts configured at both:

1. **The root-level (schema defaults & docs):** Setting the explicit schema-level default presets to prevent falling back to the standard 20-minute client-side limit, and ensuring these correct values are generated in the registry documentation.
2. **The async operation-level (LRO polling limit):** Defining the actual polling duration limit used by the Go client LRO waiting logic.

This alignment prevents out-of-the-box runtime failures where the client-side context is cancelled at $20\text{ minutes}$ (the fallback schema default) while the asynchronous resource is still successfully provisioning on the backend.

The following resources have been updated to ensure matching timeouts:
* `OdbNetwork`: Add root timeouts matching async (20m).
* `ExadbVmCluster`: Add root timeouts matching async (120m/60m/60m).
* `GoldengateConnection`: Add root timeouts matching async (30m).
* `OdbSubnet`: Add root timeouts matching async (90m).
* `GoldengateDeployment`: Add async timeouts matching root (60m).
* `GoldengateConnectionAssignment`: Add async timeouts matching root (60m).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28202

### Release Note

```release-note:enhancement
oracledatabase: Fixed early client-side timeouts and aligned default schema timeouts with backend async polling limits on `google_oracle_database_exadb_vm_cluster`, `google_oracle_database_odb_network`, `google_oracle_database_odb_subnet`, `google_oracle_database_goldengate_connection`, `google_oracle_database_goldengate_deployment`, and `google_oracle_database_goldengate_connection_assignment`.
```