### PR TITLE
feat(modelarmor):add filter version selector support

### DIFF
--- a/mmv1/products/modelarmor/Template.yaml
+++ b/mmv1/products/modelarmor/Template.yaml
@@ -98,6 +98,22 @@ samples:
           template_metadata_custom_llm_response_safety_error_code: 401
           template_metadata_enforcement_type: '"INSPECT_ONLY"'
           template_metadata_filter_version_selector_alias: '"FILTER_VERSION_ALIAS_LATEST"'
+  - name: modelarmor_template_filter_version_selector
+    primary_resource_id: template-filter-version-selector
+    steps:
+      - name: modelarmor_template_filter_version_selector
+        resource_id_vars:
+          templateId: modelarmor5
+          location: us-central1
+          filter_config_rai_settings_rai_filters_0_filter_type: HATE_SPEECH
+          filter_config_rai_settings_rai_filters_0_confidence_level: HIGH
+          template_metadata_filter_version_selector_version: v1
+        test_vars_overrides:
+          templateId: '"modelarmor5"'
+          location: '"us-central1"'
+          filter_config_rai_settings_rai_filters_0_filter_type: '"HATE_SPEECH"'
+          filter_config_rai_settings_rai_filters_0_confidence_level: '"HIGH"'
+          template_metadata_filter_version_selector_version: '"v1"'
   - name: modelarmor_template_label
     primary_resource_id: template-label-advanced-config
     steps:
@@ -324,6 +340,8 @@ properties:
         properties:
           - name: alias
             type: String
+            conflicts:
+              - template_metadata.0.filter_version_selector.0.version
             description: |-
               A predefined filter version alias. The template automatically follows the
               version this alias points to.
@@ -332,6 +350,8 @@ properties:
               FILTER_VERSION_ALIAS_LATEST
           - name: version
             type: String
+            conflicts:
+              - template_metadata.0.filter_version_selector.0.alias
             description: |-
               Pins the template to a specific, immutable filter version. Expected
               format is a case-sensitive string such as 'v1' or 'v2'.

--- a/mmv1/products/modelarmor/Template.yaml
+++ b/mmv1/products/modelarmor/Template.yaml
@@ -82,6 +82,7 @@ samples:
           template_metadata_custom_prompt_safety_error_message: This is a custom error message for prompt
           template_metadata_custom_llm_response_safety_error_code: 401
           template_metadata_enforcement_type: INSPECT_ONLY
+          template_metadata_filter_version_selector_alias: FILTER_VERSION_ALIAS_LATEST
         test_vars_overrides:
           templateId: '"modelarmor3"'
           location: '"us-central1"'
@@ -96,6 +97,7 @@ samples:
           template_metadata_custom_prompt_safety_error_message: '"This is a custom error message for prompt"'
           template_metadata_custom_llm_response_safety_error_code: 401
           template_metadata_enforcement_type: '"INSPECT_ONLY"'
+          template_metadata_filter_version_selector_alias: '"FILTER_VERSION_ALIAS_LATEST"'
   - name: modelarmor_template_label
     primary_resource_id: template-label-advanced-config
     steps:
@@ -314,3 +316,22 @@ properties:
           Possible values:
           INSPECT_ONLY
           INSPECT_AND_BLOCK
+      - name: filterVersionSelector
+        type: NestedObject
+        description: |-
+          Selects the filter version to use for this template. Set exactly one of
+          'alias' or 'version'.
+        properties:
+          - name: alias
+            type: String
+            description: |-
+              A predefined filter version alias. The template automatically follows the
+              version this alias points to.
+              Possible values:
+              FILTER_VERSION_ALIAS_STABLE
+              FILTER_VERSION_ALIAS_LATEST
+          - name: version
+            type: String
+            description: |-
+              Pins the template to a specific, immutable filter version. Expected
+              format is a case-sensitive string such as 'v1' or 'v2'.

--- a/mmv1/templates/terraform/custom_flatten/modelarmor_template_template_metadata.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/modelarmor_template_template_metadata.go.tmpl
@@ -14,6 +14,22 @@ func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.Reso
     transformed["custom_llm_response_safety_error_code"] = original["customLlmResponseSafetyErrorCode"]
     transformed["custom_llm_response_safety_error_message"] = original["customLlmResponseSafetyErrorMessage"]
     transformed["enforcement_type"] = original["enforcementType"]
+    transformed["filter_version_selector"] =
+        flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}FilterVersionSelector(original["filterVersionSelector"], d, config)
+    return []interface{}{transformed}
+}
+
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}FilterVersionSelector(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+    if v == nil {
+        return nil
+    }
+    original, ok := v.(map[string]interface{})
+    if !ok {
+        return nil
+    }
+    transformed := make(map[string]interface{})
+    transformed["alias"] = original["alias"]
+    transformed["version"] = original["version"]
     return []interface{}{transformed}
 }
 

--- a/mmv1/templates/terraform/samples/services/modelarmor/modelarmor_template_filter_version_selector.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/modelarmor/modelarmor_template_filter_version_selector.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_model_armor_template" "template-filter-version-selector" {
+  location    = "{{index $.ResourceIdVars "location"}}"
+  template_id = "{{index $.ResourceIdVars "templateId"}}"
+
+  filter_config {
+    rai_settings {
+      rai_filters {
+        filter_type      = "{{index $.ResourceIdVars "filter_config_rai_settings_rai_filters_0_filter_type"}}"
+        confidence_level = "{{index $.ResourceIdVars "filter_config_rai_settings_rai_filters_0_confidence_level"}}"
+      }
+    }
+  }
+  template_metadata {
+    filter_version_selector {
+      version = "{{index $.ResourceIdVars "template_metadata_filter_version_selector_version"}}"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/modelarmor/modelarmor_template_template_metadata.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/modelarmor/modelarmor_template_template_metadata.tf.tmpl
@@ -22,5 +22,8 @@ resource "google_model_armor_template" "template-template-metadata" {
     custom_prompt_safety_error_message       = "{{index $.ResourceIdVars "template_metadata_custom_prompt_safety_error_message"}}"
     custom_llm_response_safety_error_code    = {{index $.ResourceIdVars "template_metadata_custom_llm_response_safety_error_code"}}
     enforcement_type                         = "{{index $.ResourceIdVars "template_metadata_enforcement_type"}}"
+    filter_version_selector {
+      alias = "{{index $.ResourceIdVars "template_metadata_filter_version_selector_alias"}}"
+    }
   }
 }


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#27890


Adds filter version selection to `google_model_armor_template` by exposing the API's `templateMetadata.filterVersionSelector` as a new `filter_version_selector` block. Set either a version alias (`FILTER_VERSION_ALIAS_STABLE` / `FILTER_VERSION_ALIAS_LATEST`) or a pinned version (e.g. `v2`); omitting it keeps the API default (Stable).

```hcl
template_metadata {
  filter_version_selector {
    alias = "FILTER_VERSION_ALIAS_LATEST"
  }
}
```

The block mirrors the API's `filterVersionSelector` oneof ([guide](https://docs.cloud.google.com/model-armor/set-filter-version)) rather than the flat `filter_version` string suggested in the issue — keeping `alias` and `version` as distinct, mutually exclusive fields and passing values straight through, so `alias` takes the API's enum values (`FILTER_VERSION_ALIAS_LATEST`, not `LATEST`) with no provider-side translation to drift out of sync.

```release-note:enhancement
modelarmor: added `template_metadata.filter_version_selector` to `google_model_armor_template`
```
