### PR TITLE
sql: allow multiple deny_maintenance_period blocks on google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -370,7 +370,6 @@ func ResourceSqlDatabaseInstance() *schema.Resource {
 						"deny_maintenance_period": {
 							Type:     schema.TypeList,
 							Optional: true,
-							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"end_date": {

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2802,6 +2802,14 @@ func TestAccSQLDatabaseInstance_DenyMaintenancePeriod(t *testing.T) {
 				Config: testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig(databaseName, endDate, startDate, time),
 			},
 			{
+				Config: testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig_multiple(databaseName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_sql_database_instance.instance", plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
 				ResourceName:            "google_sql_database_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -5631,6 +5639,30 @@ resource "google_sql_database_instance" "instance" {
     }
   }
 }`, databaseName, endDate, startDate, time)
+}
+
+func testGoogleSqlDatabaseInstance_DenyMaintenancePeriodConfig_multiple(databaseName string) string {
+	return fmt.Sprintf(`
+
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-central1"
+  database_version    = "MYSQL_5_7"
+  deletion_protection = false
+  settings {
+    tier = "db-custom-4-26624"
+    deny_maintenance_period {
+      end_date     	= "2022-12-5"
+      start_date	= "2022-10-5"
+      time 		= "00:00:00"
+    }
+    deny_maintenance_period {
+      end_date     	= "2023-12-5"
+      start_date	= "2023-10-5"
+      time 		= "00:00:00"
+    }
+  }
+}`, databaseName)
 }
 
 func testGoogleSqlDatabaseInstance_DefaultEdition(databaseName, databaseVersion, tier string) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -533,7 +533,7 @@ The optional `settings.data_cache_config` subblock supports:
 
 * `data_cache_enabled` - (Optional) Whether data cache is enabled for the instance. Defaults to `true` for MYSQL Enterprise Plus and PostgreSQL Enterprise Plus instances only. For SQL Server Enterprise Plus instances it defaults to `false`.
 
-The optional `settings.deny_maintenance_period` subblock supports:
+The optional `settings.deny_maintenance_period` subblock (multiple blocks can be defined to configure more than one deny period per year) supports:
 
 * `end_date` - (Required) "deny maintenance period" end date. If the year of the end date is empty, the year of the start date also must be empty. In this case, it means the no maintenance interval recurs every year. The date is in format yyyy-m-dd (the month is without leading zeros)i.e., 2020-1-01, or 2020-11-01, or mm-dd, i.e., 11-01
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28195.

The Cloud SQL Admin API models `Settings.denyMaintenancePeriods` as an array, and GCP's docs state multiple deny maintenance periods can be configured per year (https://cloud.google.com/sql/docs/mysql/maintenance: "You can set multiple deny maintenance periods in a year"). `deny_maintenance_period` on `google_sql_database_instance` was incorrectly capped at `MaxItems: 1` in the Terraform schema, even though the expand/flatten functions already loop over the full list with no single-item assumptions. This removes the artificial cap and extends the acceptance test to cover an update from one block to two.

Removing `MaxItems` is not a breaking change, so no breaking-change process is needed.

Release note: 
```release-note:bug
sql: allowed multiple `deny_maintenance_period` blocks on `google_sql_database_instance`
```
