### PR TITLE
agentregistry: Resolve endpointSpec.content field GA launch blockers

### DIFF
--- a/mmv1/products/agentregistry/Binding.yaml
+++ b/mmv1/products/agentregistry/Binding.yaml
@@ -58,6 +58,11 @@ parameters:
     required: true
     url_param_only: true
 properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Binding.
+    output: true
   - name: displayName
     type: String
     description: |

--- a/mmv1/products/agentregistry/Service.yaml
+++ b/mmv1/products/agentregistry/Service.yaml
@@ -49,7 +49,7 @@ samples:
           service: service
   - name: agent_registry_service_endpoint
     primary_resource_id: default
-    skip_func: acctest.SkipTestUntil(t, "2026-09-30")
+    skip_func: acctest.SkipTestUntil(t, "2026-09-30") # OPENAPI_SPEC is not supported by the production GA API yet
     steps:
       - name: agent_registry_service_endpoint
         resource_id_vars:

--- a/mmv1/products/agentregistry/Service.yaml
+++ b/mmv1/products/agentregistry/Service.yaml
@@ -47,6 +47,13 @@ samples:
       - name: agent_registry_service_mcp_server
         resource_id_vars:
           service: service
+  - name: agent_registry_service_endpoint
+    primary_resource_id: default
+    skip_func: acctest.SkipTestUntil(t, "2026-09-30")
+    steps:
+      - name: agent_registry_service_endpoint
+        resource_id_vars:
+          service: service
 parameters:
   - name: location
     type: String
@@ -61,6 +68,11 @@ parameters:
     required: true
     url_param_only: true
 properties:
+  - name: name
+    type: String
+    description: |
+      The resource name of the Service.
+    output: true
   - name: displayName
     type: String
     description: |
@@ -156,8 +168,18 @@ properties:
         required: true
         enum_values:
           - NO_SPEC
+          - OPENAPI_SPEC
         description: |
           The type of the Endpoint spec content.
+      - name: content
+        type: String
+        state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
+        custom_expand: templates/terraform/custom_expand/json_schema.tmpl
+        custom_flatten: templates/terraform/custom_flatten/json_schema.tmpl
+        validation:
+          function: validation.StringIsJSON
+        description: |
+          The content of the Endpoint spec.
   - name: registryResource
     type: String
     description: |

--- a/mmv1/templates/terraform/samples/services/agentregistry/agent_registry_service_endpoint.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/agentregistry/agent_registry_service_endpoint.tf.tmpl
@@ -1,0 +1,16 @@
+  resource "google_agent_registry_service" "{{$.PrimaryResourceId}}" {
+    location     = "us-central1"
+    service_id   = "{{index $.ResourceIdVars "service"}}"
+    description  = "My Endpoint Agent Registry Service"
+    display_name = "My Service"
+  
+    interfaces {
+      url              = "https://example.com"
+      protocol_binding = "HTTP_JSON"
+    }
+  
+    endpoint_spec {
+      type    = "OPENAPI_SPEC"
+      content = "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"My API\",\"version\":\"1.0.0\"},\"paths\":{}}"
+    }
+  }


### PR DESCRIPTION
Add support for the 'content' field and 'OPENAPI_SPEC' enum on 'endpointSpec' to resolve the field-level launch blockers.

This resolves the Terraform Field-Level Launch Blockers for agentregistry.googleapis.com:

agentregistry.googleapis.com/Service (endpointSpec.content.fields)

```release-note:enhancement
agentregistry: added `endpoint_spec` field to `google_agent_registry_service` resource
```