### PR TITLE
Fix terraform type mismatch on nested Eventarc Trigger conditions

### DIFF
--- a/mmv1/products/eventarc/Trigger.yaml
+++ b/mmv1/products/eventarc/Trigger.yaml
@@ -275,6 +275,7 @@ properties:
     type: KeyValuePairs
     description: Output only. The reason(s) why a trigger is in FAILED state.
     output: true
+    custom_flatten: templates/terraform/custom_flatten/eventarc_trigger_conditions_flatten.go.tmpl
   - name: eventDataContentType
     type: String
     description: Optional. EventDataContentType specifies the type of payload in MIME format that is expected from the CloudEvent data field. This is set to `application/json` if the value is not defined.

--- a/mmv1/templates/terraform/custom_flatten/eventarc_trigger_conditions_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/eventarc_trigger_conditions_flatten.go.tmpl
@@ -1,0 +1,46 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+func flatten{{$.GetPrefix}}{{$.TitlelizeProperty}}(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	original, ok := v.(map[string]interface{})
+	if !ok {
+		return v
+	}
+
+	flatConditions := make(map[string]string)
+	for k, rawVal := range original {
+		if rawVal == nil {
+			continue
+		}
+
+		if nestedMap, ok := rawVal.(map[string]interface{}); ok {
+			if message, exists := nestedMap["message"]; exists {
+				if msgStr, isStr := message.(string); isStr {
+					flatConditions[k] = msgStr
+					continue
+				}
+			}
+		}
+
+		if valStr, ok := rawVal.(string); ok {
+			flatConditions[k] = valStr
+		} else {
+			flatConditions[k] = fmt.Sprintf("%v", rawVal)
+		}
+	}
+
+	return flatConditions
+}

--- a/mmv1/third_party/terraform/services/eventarc/flatten_eventarc_trigger_conditions_test.go
+++ b/mmv1/third_party/terraform/services/eventarc/flatten_eventarc_trigger_conditions_test.go
@@ -1,0 +1,26 @@
+package eventarc
+
+import (
+	"testing"
+)
+
+func TestFlattenEventarcTriggerConditions(t *testing.T) {
+	mockApiResponse := map[string]interface{}{
+		"transport.pubsub.topic": map[string]interface{}{
+			"code":    "UNKNOWN",
+			"message": "Pub/Sub topic status is unknown. Try requesting the trigger description again.",
+		},
+	}
+
+	result := flattenEventarcTriggerConditions(mockApiResponse, nil, nil)
+
+	flatResult, ok := result.(map[string]string)
+	if !ok {
+		t.Fatalf("Flattener returned %T, expected map[string]string", result)
+	}
+
+	expectedMessage := "Pub/Sub topic status is unknown. Try requesting the trigger description again."
+	if flatResult["transport.pubsub.topic"] != expectedMessage {
+		t.Fatalf("Expected message %q, got %q", expectedMessage, flatResult["transport.pubsub.topic"])
+	}
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note: bug 
eventarc: added a custom flattener to fix a type mismatch when an `google_eventarc_trigger` resource returns non-empty `conditions`.
```
