### PR TITLE
anchor service account validators in credential data sources

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_access_token.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_access_token.go
@@ -24,7 +24,7 @@ func DataSourceGoogleServiceAccountAccessToken() *schema.Resource {
 			"target_service_account": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: verify.ValidateRegexp("(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")"),
+				ValidateFunc: verify.ValidateRegexp("^(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")$"),
 			},
 			"access_token": {
 				Type:      schema.TypeString,
@@ -47,7 +47,7 @@ func DataSourceGoogleServiceAccountAccessToken() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidateRegexp(verify.ServiceAccountLinkRegex),
+					ValidateFunc: verify.ValidateRegexp("^" + verify.ServiceAccountLinkRegex + "$"),
 				},
 			},
 			"lifetime": {

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_credentials_internal_test.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_credentials_internal_test.go
@@ -1,0 +1,74 @@
+package resourcemanager
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type saValidationCase struct {
+	value       string
+	expectError bool
+}
+
+func runSAValidation(t *testing.T, name string, vf schema.SchemaValidateFunc, cases []saValidationCase) {
+	t.Helper()
+	for _, c := range cases {
+		_, errs := vf(c.value, name)
+		if c.expectError && len(errs) == 0 {
+			t.Errorf("%s: %q passed validation but was expected to fail", name, c.value)
+		}
+		if !c.expectError && len(errs) > 0 {
+			t.Errorf("%s: %q failed validation but was expected to pass: %v", name, c.value, errs)
+		}
+	}
+}
+
+func elemValidateFunc(t *testing.T, s *schema.Schema) schema.SchemaValidateFunc {
+	t.Helper()
+	elem, ok := s.Elem.(*schema.Schema)
+	if !ok {
+		t.Fatalf("expected *schema.Schema Elem, got %T", s.Elem)
+	}
+	return elem.ValidateFunc
+}
+
+// The target_service_account and delegates values flow verbatim into the
+// projects/-/serviceAccounts/{account} path of the iamcredentials calls, so the
+// validators must reject anything that is not exactly a service account
+// identifier (no traversal prefix, no extra path segments).
+func TestServiceAccountCredentialDataSources_targetValidation(t *testing.T) {
+	targetCases := []saValidationCase{
+		{value: "my-service@my-project.iam.gserviceaccount.com"},
+		{value: "123456789-compute@developer.gserviceaccount.com"},
+		{value: "my-project@appspot.gserviceaccount.com"},
+		{value: "attacker/../123456789-compute@developer.gserviceaccount.com", expectError: true},
+		{value: "123456789-compute@developer.gserviceaccount.com/../../projects/victim/serviceAccounts/svc", expectError: true},
+	}
+	delegateCases := []saValidationCase{
+		{value: "projects/-/serviceAccounts/my-service@my-project.iam.gserviceaccount.com"},
+		{value: "projects/-/serviceAccounts/123456789-compute@developer.gserviceaccount.com"},
+		{value: "evil/projects/-/serviceAccounts/my-service@my-project.iam.gserviceaccount.com", expectError: true},
+		{value: "projects/-/serviceAccounts/123456789-compute@developer.gserviceaccount.com/../../evil", expectError: true},
+	}
+
+	sources := map[string]*schema.Resource{
+		"access_token": DataSourceGoogleServiceAccountAccessToken(),
+		"id_token":     DataSourceGoogleServiceAccountIdToken(),
+		"jwt":          DataSourceGoogleServiceAccountJwt(),
+	}
+	for ds, res := range sources {
+		runSAValidation(t, ds+".target_service_account", res.Schema["target_service_account"].ValidateFunc, targetCases)
+		runSAValidation(t, ds+".delegates", elemValidateFunc(t, res.Schema["delegates"]), delegateCases)
+	}
+}
+
+func TestServiceAccountKeyDataSource_nameValidation(t *testing.T) {
+	vf := DataSourceGoogleServiceAccountKey().Schema["name"].ValidateFunc
+	cases := []saValidationCase{
+		{value: "projects/my-project/serviceAccounts/svcacct@my-project.iam.gserviceaccount.com/keys/abcd1234"},
+		{value: "../../../../projects/-/serviceAccounts/x@y.iam.gserviceaccount.com/keys/1", expectError: true},
+		{value: "projects/-/serviceAccounts/x@y.iam.gserviceaccount.com/keys/1/../../otherproj/keys/2", expectError: true},
+	}
+	runSAValidation(t, "name", vf, cases)
+}

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_id_token.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_id_token.go
@@ -33,14 +33,14 @@ func DataSourceGoogleServiceAccountIdToken() *schema.Resource {
 			"target_service_account": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: verify.ValidateRegexp("(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")"),
+				ValidateFunc: verify.ValidateRegexp("^(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")$"),
 			},
 			"delegates": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidateRegexp(verify.ServiceAccountLinkRegex),
+					ValidateFunc: verify.ValidateRegexp("^" + verify.ServiceAccountLinkRegex + "$"),
 				},
 			},
 			"include_email": {

--- a/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_jwt.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/data_source_google_service_account_jwt.go
@@ -34,14 +34,14 @@ func DataSourceGoogleServiceAccountJwt() *schema.Resource {
 			"target_service_account": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: verify.ValidateRegexp("(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")"),
+				ValidateFunc: verify.ValidateRegexp("^(" + strings.Join(verify.PossibleServiceAccountNames, "|") + ")$"),
 			},
 			"delegates": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: verify.ValidateRegexp(verify.ServiceAccountLinkRegex),
+					ValidateFunc: verify.ValidateRegexp("^" + verify.ServiceAccountLinkRegex + "$"),
 				},
 			},
 			"jwt": {

--- a/mmv1/third_party/terraform/verify/validation.go
+++ b/mmv1/third_party/terraform/verify/validation.go
@@ -51,7 +51,7 @@ var (
 	}
 	ServiceAccountLinkRegex = ServiceAccountLinkRegexPrefix + "(" + strings.Join(PossibleServiceAccountNames, "|") + ")"
 
-	ServiceAccountKeyNameRegex = ServiceAccountLinkRegexPrefix + "(.+)/keys/(.+)"
+	ServiceAccountKeyNameRegex = "^" + ServiceAccountLinkRegexPrefix + "([^/]+)/keys/([^/]+)$"
 
 	// Format of service accounts created through the API
 	CreatedServiceAccountNameRegex = fmt.Sprintf(RFC1035NameTemplate, "{4,28}") + "@" + ProjectNameInDNSFormRegex + "\\.iam\\.gserviceaccount\\.com$"

--- a/mmv1/third_party/terraform/verify/validation_test.go
+++ b/mmv1/third_party/terraform/verify/validation_test.go
@@ -381,3 +381,56 @@ func TestValidateTagKeyAllowedValuesRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateServiceAccountName(t *testing.T) {
+	// This is the anchored alternation the service account credential data
+	// sources (access_token / id_token / jwt) apply to target_service_account.
+	re := "^(" + strings.Join(PossibleServiceAccountNames, "|") + ")$"
+	cases := []StringValidationTestCase{
+		{TestName: "user managed", Value: "my-service@my-project.iam.gserviceaccount.com"},
+		{TestName: "compute default", Value: "123456789-compute@developer.gserviceaccount.com"},
+		{TestName: "app engine default", Value: "my-project@appspot.gserviceaccount.com"},
+
+		{TestName: "traversal prefix", Value: "attacker/../123456789-compute@developer.gserviceaccount.com", ExpectError: true},
+		{TestName: "trailing path segments", Value: "123456789-compute@developer.gserviceaccount.com/../../projects/victim/serviceAccounts/svc", ExpectError: true},
+		{TestName: "embedded newline", Value: "my-service@my-project.iam.gserviceaccount.com\nx@y.iam.gserviceaccount.com", ExpectError: true},
+	}
+
+	es := TestStringValidationCases(cases, ValidateRegexp(re))
+	if len(es) > 0 {
+		t.Errorf("Failed to validate service account names: %v", es)
+	}
+}
+
+func TestValidateServiceAccountLinkFull(t *testing.T) {
+	// Anchored form used for the delegates fields.
+	re := "^" + ServiceAccountLinkRegex + "$"
+	cases := []StringValidationTestCase{
+		{TestName: "user managed", Value: "projects/my-project/serviceAccounts/my-service@my-project.iam.gserviceaccount.com"},
+		{TestName: "compute default", Value: "projects/-/serviceAccounts/123456789-compute@developer.gserviceaccount.com"},
+
+		{TestName: "traversal prefix", Value: "evil/projects/-/serviceAccounts/my-service@my-project.iam.gserviceaccount.com", ExpectError: true},
+		{TestName: "trailing path segments", Value: "projects/-/serviceAccounts/123456789-compute@developer.gserviceaccount.com/../../evil", ExpectError: true},
+	}
+
+	es := TestStringValidationCases(cases, ValidateRegexp(re))
+	if len(es) > 0 {
+		t.Errorf("Failed to validate service account links: %v", es)
+	}
+}
+
+func TestValidateServiceAccountKeyName(t *testing.T) {
+	cases := []StringValidationTestCase{
+		{TestName: "valid", Value: "projects/my-project/serviceAccounts/svcacct@my-project.iam.gserviceaccount.com/keys/abcd1234"},
+		{TestName: "valid with unique id account", Value: "projects/my-project/serviceAccounts/123456789012345/keys/abcd1234"},
+
+		{TestName: "traversal prefix", Value: "../../../../projects/-/serviceAccounts/x@y.iam.gserviceaccount.com/keys/1", ExpectError: true},
+		{TestName: "trailing path segments", Value: "projects/-/serviceAccounts/x@y.iam.gserviceaccount.com/keys/1/../../otherproj/keys/2", ExpectError: true},
+		{TestName: "missing keys segment", Value: "projects/-/serviceAccounts/x@y.iam.gserviceaccount.com", ExpectError: true},
+	}
+
+	es := TestStringValidationCases(cases, ValidateRegexp(ServiceAccountKeyNameRegex))
+	if len(es) > 0 {
+		t.Errorf("Failed to validate service account key names: %v", es)
+	}
+}


### PR DESCRIPTION
Repro: give `target_service_account`, `delegates`, or `name` an interpolated value (module output or remote state) that merely contains a valid service account identifier, e.g. `../../../../projects/-/serviceAccounts/x@y.iam.gserviceaccount.com/keys/1`.
Cause: the SDK credential data sources validate with `verify.ValidateRegexp` over unanchored regexes (the `PossibleServiceAccountNames` alternation, `ServiceAccountLinkRegex`, `ServiceAccountKeyNameRegex`). `regexp.MatchString` is a substring search, so a `../` prefix or extra `/segments` still matches and the raw value then flows into the iamcredentials `GenerateAccessToken`/`GenerateIdToken`/`SignJwt` and IAM `Keys.Get` request paths, where reserved `{+name}` expansion keeps the slashes. `google_service_account_key` even re-checks `name` at read time with the same unanchored regex, so that guard was inert too.
Fix: anchor the validators to a full-string match (`^...$`, plus `[^/]+` per segment for the key name), which is what the framework `ServiceAccountEmailValidator` used by the ephemeral equivalents already does. Regression coverage added in `verify` and `resourcemanager`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: fixed validation of `target_service_account` and `delegates` in the `google_service_account_access_token`, `google_service_account_id_token`, and `google_service_account_jwt` data sources, and of `name` in the `google_service_account_key` data source, to reject identifiers that contain path separators
```
