### PR TITLE
composer: stop logging user_workloads_secret data in debug logs

### DIFF
--- a/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.tmpl
+++ b/mmv1/third_party/terraform/services/composer/resource_composer_user_workloads_secret.go.tmpl
@@ -102,7 +102,7 @@ func resourceComposerUserWorkloadsSecretCreate(d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG] Creating new UserWorkloadsSecret %q", secretName.ParentName())
-	resp, err := NewClient(config, userAgent).Projects.Locations.Environments.UserWorkloadsSecrets.Create(secretName.ParentName(), secret).Do()
+	_, err = NewClient(config, userAgent).Projects.Locations.Environments.UserWorkloadsSecrets.Create(secretName.ParentName(), secret).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating UserWorkloadsSecret: %s", err)
 	}
@@ -113,8 +113,8 @@ func resourceComposerUserWorkloadsSecretCreate(d *schema.ResourceData, meta inte
 	}
 	d.SetId(id)
 
-	respJson, _ := resp.MarshalJSON()
-	log.Printf("[DEBUG] Finished creating UserWorkloadsSecret %q: %#v", d.Id(), string(respJson))
+	// The response body echoes the secret's "data" values, so only the id is logged.
+	log.Printf("[DEBUG] Finished creating UserWorkloadsSecret %q", d.Id())
 
 	return resourceComposerUserWorkloadsSecretRead(d, meta)
 }
@@ -179,16 +179,15 @@ func resourceComposerUserWorkloadsSecretUpdate(d *schema.ResourceData, meta inte
 			Data: tpgresource.ConvertStringMap(d.Get("data").(map[string]interface{})),
 		}
 
-		secretJson, _ := secret.MarshalJSON()
-		log.Printf("[DEBUG] Updating UserWorkloadsSecret %q: %s", d.Id(), string(secretJson))
+		// secret.Data holds the Sensitive secret values, so the body is not logged.
+		log.Printf("[DEBUG] Updating UserWorkloadsSecret %q", d.Id())
 
-		resp, err := NewClient(config, userAgent).Projects.Locations.Environments.UserWorkloadsSecrets.Update(secretName.ResourceName(), secret).Do()
+		_, err = NewClient(config, userAgent).Projects.Locations.Environments.UserWorkloadsSecrets.Update(secretName.ResourceName(), secret).Do()
 		if err != nil {
 			return err
 		}
 
-		respJson, _ := resp.MarshalJSON()
-		log.Printf("[DEBUG] Finished updating UserWorkloadsSecret %q: %s", d.Id(), string(respJson))
+		log.Printf("[DEBUG] Finished updating UserWorkloadsSecret %q", d.Id())
 	}
 
 	return nil


### PR DESCRIPTION
Repro: apply a change to `google_composer_user_workloads_secret.data` with `TF_LOG=DEBUG`; the base64 secret values show up in the provider debug log.

Cause: the update path marshals the whole `composer.UserWorkloadsSecret` (including the `data` map, which the schema marks `Sensitive: true`) and logs it, and both create and update also log the marshaled API response. The SDK redacts `data` from plan/state, but `log.Printf` bypasses that redaction.

Fix: drop the marshaled bodies from those DEBUG lines and log only the resource id, so the secret material never reaches the logs.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: fixed `google_composer_user_workloads_secret` writing the secret `data` values into provider debug logs
```

