### PR TITLE
sql: add include_replicas_for_major_version_upgrade to google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1185,6 +1185,11 @@ API (for read pools, effective_availability_type may differ from availability_ty
 				Optional:    true,
 				Description: `When set to true, Cloud SQL instances can switch storing point-in-time recovery transaction logs from a data disk to Cloud Storage, freeing up data disk space and enabling longer retention windows. This is an input-only field that is not persisted in the API.`,
 			},
+			"include_replicas_for_major_version_upgrade": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `When this parameter is set to true, Cloud SQL instances can perform in-place major version upgrades of read replicas along with the primary instance when 'database_version' is updated. This is an input-only field that is not persisted in the API and only takes effect during a major version upgrade.`,
+			},
 			"encryption_key_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -2738,7 +2743,10 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	// Check if the database version is being updated, because patching database version is an atomic operation and can not be
 	// performed with other fields, we first patch database version before updating the rest of the fields.
 	if d.HasChange("database_version") {
-		instance = &sqladmin.DatabaseInstance{DatabaseVersion: databaseVersion}
+		instance = &sqladmin.DatabaseInstance{
+			DatabaseVersion:                       databaseVersion,
+			IncludeReplicasForMajorVersionUpgrade: d.Get("include_replicas_for_major_version_upgrade").(bool),
+		}
 		err = transport_tpg.Retry(transport_tpg.RetryOptions{
 			RetryFunc: func() (rerr error) {
 				op, rerr = NewClient(config, userAgent).Instances.Patch(project, d.Get("name").(string), instance).Do()

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -27,6 +27,7 @@ fields:
   - field: 'final_backup_description'
   - api_field: 'ipAddresses.ipAddress'
     field: 'first_ip_address'
+  - api_field: 'includeReplicasForMajorVersionUpgrade'
   - api_field: 'instanceType'
   - api_field: 'ipAddresses.ipAddress'
     field: 'ip_address.ip_address'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2626,6 +2626,43 @@ func TestAccSqlDatabaseInstance_switchTransactionLogsToCloudStorage(t *testing.T
 	})
 }
 
+func TestAccSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+	testId := "sql-instance-major-upgrade-1"
+	addressName := tpgcompute.BootstrapSharedTestGlobalAddress(t, testId)
+	networkName := servicenetworking.BootstrapSharedServiceNetworkingConnection(t, testId)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade(databaseName, networkName, addressName, "MYSQL_8_0"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password", "include_replicas_for_major_version_upgrade", "replica_names", "settings.0.version"},
+			},
+			{
+				// Upgrade the primary's major version; with the flag set, the in-place upgrade
+				// propagates to the read replica automatically (the replica ignores database_version changes).
+				Config: testGoogleSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade(databaseName, networkName, addressName, "MYSQL_8_4"),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password", "include_replicas_for_major_version_upgrade", "replica_names", "settings.0.version"},
+			},
+		},
+	})
+}
+
 func testGoogleSqlDatabaseInstance_switchTransactionLogsToCloudStorage(databaseName, networkName, addressRangeName string, switchEnabled bool) string {
 	return fmt.Sprintf(`
 data "google_compute_network" "servicenet" {
@@ -8933,6 +8970,62 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, dbVersion, masterID, tier, autoUpgradeEnabled)
+}
+
+func testGoogleSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade(databaseName, networkName, addressRangeName, dbVersion string) string {
+	return fmt.Sprintf(`
+data "google_compute_network" "servicenet" {
+  name = "%s"
+}
+
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "%s"
+  deletion_protection = false
+  root_password       = "rand-pwd-%s"
+
+  include_replicas_for_major_version_upgrade = true
+
+  settings {
+    tier              = "db-g1-small"
+    availability_type = "ZONAL"
+    ip_configuration {
+      ipv4_enabled    = "false"
+      private_network = data.google_compute_network.servicenet.self_link
+    }
+    backup_configuration {
+      enabled            = true
+      start_time         = "00:00"
+      binary_log_enabled = true
+    }
+  }
+}
+
+resource "google_sql_database_instance" "replica" {
+  name                 = "%s-replica"
+  region               = "us-central1"
+  database_version     = "MYSQL_8_0"
+  master_instance_name = google_sql_database_instance.instance.name
+  deletion_protection  = false
+
+  settings {
+    tier              = "db-g1-small"
+    availability_type = "ZONAL"
+    ip_configuration {
+      ipv4_enabled       = "false"
+      private_network    = data.google_compute_network.servicenet.self_link
+      allocated_ip_range = "%s"
+    }
+  }
+
+  # When the primary is upgraded with include_replicas_for_major_version_upgrade,
+  # the replica is upgraded in place by the API; ignore the resulting version drift.
+  lifecycle {
+    ignore_changes = [database_version]
+  }
+}
+`, networkName, databaseName, dbVersion, databaseName, databaseName, addressRangeName)
 }
 
 func testGoogleSqlDatabaseInstance_EnableDataplexIntegration(masterID int, enableDataplexIntegration bool) string {

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -357,6 +357,8 @@ includes an up-to-date reference of supported versions.
 
 * `switch_transaction_logs_to_cloud_storage_enabled` - (Optional) When set to `true`, Cloud SQL instances can switch storing point-in-time recovery transaction logs from a data disk to Cloud Storage, freeing up data disk space and enabling longer retention windows. This is an input-only field that is not persisted in the API.
 
+* `include_replicas_for_major_version_upgrade` - (Optional) When this parameter is set to `true`, Cloud SQL instances can perform in-place major version upgrades of read replicas along with the primary instance when `database_version` is updated. This is an input-only field that is not persisted in the API and only takes effect during a major version upgrade.
+
 * `name` - (Optional, Computed) The name of the instance. If the name is left
     blank, Terraform will randomly generate one when the instance is first
     created. This is done because after a name is used, it cannot be reused for


### PR DESCRIPTION
Adds the input-only `include_replicas_for_major_version_upgrade` field to `google_sql_database_instance`.

When set to `true`, an in-place major version upgrade of the primary instance (triggered by a `database_version` change) also upgrades its read replicas in place. The field is [input-only](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance) in the Cloud SQL Admin API and is sent on the atomic `database_version` patch during update.

### Test
Added `TestAccSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade`, which creates a MySQL 8.0 primary + read replica on a private network, then upgrades the primary to 8.4 with the flag enabled (the replica ignores `database_version` drift so the server-side cascade isn't raced). Passing locally:

```
--- PASS: TestAccSqlDatabaseInstance_includeReplicasForMajorVersionUpgrade (1772.45s)
```

```release-note:enhancement
sql: added `include_replicas_for_major_version_upgrade` field to `google_sql_database_instance`
```