### PR TITLE
sql: add switch_transaction_logs_to_cloud_storage_enabled to google_sql_database_instance

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -1156,6 +1156,11 @@ API (for read pools, effective_availability_type may differ from availability_ty
 				Description:      `The MySQL, PostgreSQL or SQL Server version to use. Supported values include MYSQL_5_6, MYSQL_5_7, MYSQL_8_0, MYSQL_8_4, POSTGRES_9_6, POSTGRES_10, POSTGRES_11, POSTGRES_12, POSTGRES_13, POSTGRES_14, POSTGRES_15, POSTGRES_16, POSTGRES_17, POSTGRES_18, SQLSERVER_2022_STANDARD, SQLSERVER_2022_ENTERPRISE, SQLSERVER_2022_EXPRESS, SQLSERVER_2022_WEB, SQLSERVER_2025_STANDARD, SQLSERVER_2025_ENTERPRISE, SQLSERVER_2025_EXPRESS, SQLSERVER_2025_WEB. Database Version Policies includes an up-to-date reference of supported versions.`,
 				DiffSuppressFunc: databaseVersionDiffSuppress,
 			},
+			"switch_transaction_logs_to_cloud_storage_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `When set to true, Cloud SQL instances can switch storing point-in-time recovery transaction logs from a data disk to Cloud Storage, freeing up data disk space and enabling longer retention windows. This is an input-only field that is not persisted in the API.`,
+			},
 			"encryption_key_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -1754,6 +1759,9 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	if _, ok := d.GetOk("node_count"); ok {
 		instance.NodeCount = int64(d.Get("node_count").(int))
+	}
+	if v, ok := d.GetOk("switch_transaction_logs_to_cloud_storage_enabled"); ok {
+		instance.SwitchTransactionLogsToCloudStorageEnabled = v.(bool)
 	}
 	if _, ok := d.GetOk("root_password_wo_version"); ok {
 		instance.RootPassword = tpgresource.GetRawConfigAttributeAsString(d, "root_password_wo")
@@ -2949,6 +2957,11 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 				PsaWriteEndpoint: psaWriteEndpoint,
 			}
 		}
+	}
+
+	// switch_transaction_logs_to_cloud_storage_enabled is input-only; send it only when toggled.
+	if d.HasChange("switch_transaction_logs_to_cloud_storage_enabled") {
+		instance.SwitchTransactionLogsToCloudStorageEnabled = d.Get("switch_transaction_logs_to_cloud_storage_enabled").(bool)
 	}
 
 	err = transport_tpg.Retry(transport_tpg.RetryOptions{

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -92,6 +92,7 @@ fields:
   - api_field: 'serverCaCert.expirationTime'
   - api_field: 'serverCaCert.sha1Fingerprint'
   - api_field: 'serviceAccountEmailAddress'
+  - api_field: 'switchTransactionLogsToCloudStorageEnabled'
   - api_field: 'settings.activationPolicy'
   - api_field: 'settings.activeDirectoryConfig.adminCredentialSecretName'
   - api_field: 'settings.activeDirectoryConfig.dnsServers'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -2525,6 +2525,75 @@ func TestAccSqlDatabaseInstance_AutoUpgradeEnabled(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_switchTransactionLogsToCloudStorage(t *testing.T) {
+	t.Parallel()
+
+	databaseName := "tf-test-" + acctest.RandString(t, 10)
+	testId := "sql-instance-txlog-switch-1"
+	addressName := tpgcompute.BootstrapSharedTestGlobalAddress(t, testId)
+	networkName := servicenetworking.BootstrapSharedServiceNetworkingConnection(t, testId)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_switchTransactionLogsToCloudStorage(databaseName, networkName, addressName, false),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password", "switch_transaction_logs_to_cloud_storage_enabled", "settings.0.version"},
+			},
+			{
+				// Flip the flag on an existing instance: PITR transaction logs move to Cloud Storage.
+				Config: testGoogleSqlDatabaseInstance_switchTransactionLogsToCloudStorage(databaseName, networkName, addressName, true),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "root_password", "switch_transaction_logs_to_cloud_storage_enabled", "settings.0.version"},
+			},
+		},
+	})
+}
+
+func testGoogleSqlDatabaseInstance_switchTransactionLogsToCloudStorage(databaseName, networkName, addressRangeName string, switchEnabled bool) string {
+	return fmt.Sprintf(`
+data "google_compute_network" "servicenet" {
+  name = "%s"
+}
+
+resource "google_sql_database_instance" "instance" {
+  name                = "%s"
+  region              = "us-central1"
+  database_version    = "MYSQL_8_0"
+  deletion_protection = false
+  root_password       = "rand-pwd-%s"
+
+  switch_transaction_logs_to_cloud_storage_enabled = %t
+
+  settings {
+    tier              = "db-g1-small"
+    availability_type = "ZONAL"
+    ip_configuration {
+      ipv4_enabled       = "false"
+      private_network    = data.google_compute_network.servicenet.self_link
+      allocated_ip_range = "%s"
+    }
+    backup_configuration {
+      enabled            = true
+      start_time         = "00:00"
+      binary_log_enabled = true
+    }
+  }
+}
+`, networkName, databaseName, databaseName, switchEnabled, addressRangeName)
+}
+
 func TestAccSqlDatabaseInstance_EnableGoogleDataplexIntegration(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -355,6 +355,8 @@ SQL Server version to use. Supported values include `MYSQL_5_6`,
 [Database Version Policies](https://cloud.google.com/sql/docs/db-versions)
 includes an up-to-date reference of supported versions.
 
+* `switch_transaction_logs_to_cloud_storage_enabled` - (Optional) When set to `true`, Cloud SQL instances can switch storing point-in-time recovery transaction logs from a data disk to Cloud Storage, freeing up data disk space and enabling longer retention windows. This is an input-only field that is not persisted in the API.
+
 * `name` - (Optional, Computed) The name of the instance. If the name is left
     blank, Terraform will randomly generate one when the instance is first
     created. This is done because after a name is used, it cannot be reused for


### PR DESCRIPTION
Adds the input-only `switch_transaction_logs_to_cloud_storage_enabled` field to `google_sql_database_instance`.

When set to `true`, Cloud SQL moves the point-in-time recovery (PITR) transaction logs from the instance's data disk to Cloud Storage. This frees up data-disk space (avoiding disk-full pressure from log growth), enables longer log retention windows, and reduces storage cost. The field is [input-only](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances#DatabaseInstance) in the Cloud SQL Admin API and is sent on both create and update.

### Test
Added `TestAccSqlDatabaseInstance_switchTransactionLogsToCloudStorage`, which creates a MySQL 8.0 instance (private IP, PITR/binary logging enabled) with the flag off, then flips it on. Passing locally:

```
--- PASS: TestAccSqlDatabaseInstance_switchTransactionLogsToCloudStorage (622.59s)
```

```release-note:enhancement
sql: added `switch_transaction_logs_to_cloud_storage_enabled` field to `google_sql_database_instance`
```