### PR TITLE
Add Terraform autogen support and acceptance tests for Agent Identity

### DIFF
--- a/mmv1/products/agentidentity/AuthProvider.yaml
+++ b/mmv1/products/agentidentity/AuthProvider.yaml
@@ -1,0 +1,219 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AuthProvider
+description: An AuthProvider resource in Agent Identity to manage cloud authentication delegation.
+base_url: projects/{{project}}/locations/{{location}}/authProviders
+self_link: projects/{{project}}/locations/{{location}}/authProviders/{{auth_provider_id}}
+create_url: projects/{{project}}/locations/{{location}}/authProviders?authProviderId={{auth_provider_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/authProviders/{{auth_provider_id}}
+custom_diff:
+  - agentIdentityAuthProviderCustomizeDiff
+custom_code:
+  constants: "templates/terraform/constants/agent_identity_auth_provider.go.tmpl"
+  post_read: "templates/terraform/post_read/agent_identity_auth_provider.go.tmpl"
+  decoder: "templates/terraform/decoders/agent_identity_auth_provider.go.tmpl"
+  post_create: "templates/terraform/post_create/sleep.go.tmpl"
+  post_update: "templates/terraform/post_create/sleep.go.tmpl"
+  post_delete: "templates/terraform/post_delete/sleep.go.tmpl"
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: authProviderId
+    type: String
+    required: true
+    description: |-
+      The ID to use for the AuthProvider, which will become the final segment
+      of the AuthProvider's resource name.
+      This value should be 1-63 characters, and valid characters
+      are /a-z-/. The first character must be a lowercase letter, and the
+      last character must be a lowercase letter or a number.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: allowedScopes
+    type: Array
+    description: |-
+      List of scopes that are allowed to be requested for this auth_provider.
+      If this list is non-empty, only scopes within this list may be requested.
+      If this list is empty, all scopes may be requested.
+      Scopes appearing in `blocked_scopes` are disallowed even if they appear in
+      `allowed_scopes`.
+      The number of allowed scopes is limited to 200.
+    item_type:
+      type: String
+  - name: authProviderTypeParams
+    type: NestedObject
+    required: true
+    description: |-
+      AuthProvider type specific parameters.
+      Required when creating an auth_provider.
+    properties:
+      - name: apiKey
+        type: NestedObject
+        description: Message describing ApiKeyParams object.
+        ignore_read: true
+        exactly_one_of:
+          - auth_provider_type_params.0.api_key
+          - auth_provider_type_params.0.three_legged_oauth
+          - auth_provider_type_params.0.two_legged_oauth
+        properties:
+          - name: apiKey
+            type: String
+            description: Input only. The API key for this auth_provider.
+            sensitive: true
+            ignore_read: true
+      - name: geAuthProvider
+        type: NestedObject
+        send_empty_value: true
+        allow_empty_object: true
+        output: true
+        description: |-
+          Message describing GeminiEnterpriseAuthProviderParams object.
+          Since GeminiEnterpriseAuthProviderParams currently takes no subfields, defining this empty block selects the ge_auth_provider type.
+        properties: [] # Explicitly show no properties
+      - name: threeLeggedOauth
+        type: NestedObject
+        description: Message describing ThreeLeggedOAuth object.
+        ignore_read: true
+        exactly_one_of:
+          - auth_provider_type_params.0.api_key
+          - auth_provider_type_params.0.three_legged_oauth
+          - auth_provider_type_params.0.two_legged_oauth
+        properties:
+          - name: authorizationUrl
+            type: String
+            description: |-
+              The authorization endpoint to send users to for consenting to delegate
+              to the agent.
+              eg. "https://auth.atlassian.com/authorize"
+          - name: clientId
+            type: String
+            description: The client ID of the OAuth client.
+          - name: clientSecret
+            type: String
+            description: Input only. The client secret of the OAuth client.
+            write_only: true
+          - name: defaultContinueUri
+            type: String
+            description: |-
+              The default continue URI for 3LO flow and it will be used when no continue
+              URI is provided in the RetrieveCredentials request.
+          - name: enablePkce
+            type: Boolean
+            description: |-
+              Enables Proof Key for Code Exchange (PKCE) for the OAuth flow to prevent
+              authorization code interception attacks.
+          - name: redirectUrl
+            type: String
+            description: |-
+              The redirect URL this auth_provider uses for the OAuth exchange.
+              This is deterministic based on the name of the auth_provider.
+            output: true
+          - name: tokenUrl
+            type: String
+            description: |-
+              The token endpoint for requesting tokens on behalf of an end user.
+              eg. "https://auth.atlassian.com/oauth/token"
+      - name: twoLeggedOauth
+        type: NestedObject
+        description: Message describing TwoLeggedOAuth object.
+        ignore_read: true
+        exactly_one_of:
+          - auth_provider_type_params.0.api_key
+          - auth_provider_type_params.0.three_legged_oauth
+          - auth_provider_type_params.0.two_legged_oauth
+        properties:
+          - name: clientId
+            type: String
+            description: The client ID of the OAuth client.
+          - name: clientSecret
+            type: String
+            description: Input only. The client secret of the OAuth client.
+            write_only: true
+          - name: tokenUrl
+            type: String
+            description: The token endpoint of the OAuth client.
+  - name: blockedScopes
+    type: Array
+    description: |-
+      List of scopes that are blocked from being requested for this
+      auth_provider. If a scope appears in this list, it will not be requested,
+      even if it also appears in `allowed_scopes`. `blocked_scopes` takes
+      precedence over `allowed_scopes`. The number of blocked scopes is limited
+      to 200.
+    item_type:
+      type: String
+  - name: createTime
+    type: String
+    description: "[Output only] Create time stamp"
+    output: true
+  - name: deleted
+    type: Boolean
+    description: This is set to true if the auth_provider is deleted.
+    output: true
+  - name: description
+    type: String
+    description: |-
+      Description of the resource.
+      Must be less than 256 characters.
+  - name: expireTime
+    type: String
+    description: The time when the auth_provider will expire.
+    output: true
+  - name: labels
+    type: KeyValueLabels
+    description: Labels as key value pairs
+  - name: name
+    type: String
+    description: |-
+      Identifier. The full resource name of the auth_provider. Format:
+      projects/{project}/locations/{location}/authProviders/{auth_provider}
+    output: true
+  - name: state
+    type: String
+    description: |-
+      The state of the auth_provider.
+      Possible values:
+      ENABLED
+      DISABLED
+    output: true
+  - name: updateTime
+    type: String
+    description: "[Output only] Update time stamp"
+    output: true
+  - name: workloadIds
+    type: Array
+    description: |-
+      Input only. Represents the workload identity in IAM `principal://` format of the
+      agent(s) that will use this AuthProvider. Example:
+      `principal://agents.global.org-${ORG_ID}.system.id.goog/resources/aiplatform/projects/{PROJECT_ID}/locations/{LOCATIONS}/reasoningEngines/{ID}`
+    item_type:
+      type: String
+    ignore_read: true
+samples:
+  - name: "agent_identity_auth_provider_basic"
+    primary_resource_id: "default"
+    exclude_test: true
+    steps:
+      - name: "agent_identity_auth_provider_basic"
+        resource_id_vars:
+          auth_provider_id: "example-provider"

--- a/mmv1/products/agentidentity/product.yaml
+++ b/mmv1/products/agentidentity/product.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: AgentIdentity
+display_name: Agent Identity
+scopes:
+    - https://www.googleapis.com/auth/cloud-platform
+versions:
+    - base_url: https://agentidentity.googleapis.com/v1/
+      name: ga
+    - base_url: https://agentidentity.googleapis.com/v1/
+      name: beta

--- a/mmv1/templates/terraform/constants/agent_identity_auth_provider.go.tmpl
+++ b/mmv1/templates/terraform/constants/agent_identity_auth_provider.go.tmpl
@@ -1,0 +1,36 @@
+{{/*
+	The license inside this block applies to this file
+	Copyright 2026 Google Inc.
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/ -}}
+// This customizeDiff recreates the resource if changing between different auth provider types
+// (api_key, two_legged_oauth, three_legged_oauth), as changing the type via PATCH is rejected by the API.
+func agentIdentityAuthProviderCustomizeDiffFunc(diff tpgresource.TerraformResourceDiff) error {
+	oldApiKey, newApiKey := diff.GetChange("auth_provider_type_params.0.api_key")
+	oldTwoLegged, newTwoLegged := diff.GetChange("auth_provider_type_params.0.two_legged_oauth")
+	oldThreeLegged, newThreeLegged := diff.GetChange("auth_provider_type_params.0.three_legged_oauth")
+	if !tpgresource.IsEmptyValue(reflect.ValueOf(oldApiKey)) && tpgresource.IsEmptyValue(reflect.ValueOf(newApiKey)) {
+		diff.ForceNew("auth_provider_type_params.0.api_key")
+		return nil
+	}
+	if !tpgresource.IsEmptyValue(reflect.ValueOf(oldTwoLegged)) && tpgresource.IsEmptyValue(reflect.ValueOf(newTwoLegged)) {
+		diff.ForceNew("auth_provider_type_params.0.two_legged_oauth")
+		return nil
+	}
+	if !tpgresource.IsEmptyValue(reflect.ValueOf(oldThreeLegged)) && tpgresource.IsEmptyValue(reflect.ValueOf(newThreeLegged)) {
+		diff.ForceNew("auth_provider_type_params.0.three_legged_oauth")
+		return nil
+	}
+	return nil
+}
+
+func agentIdentityAuthProviderCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+	return agentIdentityAuthProviderCustomizeDiffFunc(diff)
+}

--- a/mmv1/templates/terraform/decoders/agent_identity_auth_provider.go.tmpl
+++ b/mmv1/templates/terraform/decoders/agent_identity_auth_provider.go.tmpl
@@ -1,0 +1,1 @@
+if deleted, ok := res["deleted"].(bool); ok && deleted { return nil, nil }; return res, nil

--- a/mmv1/templates/terraform/post_read/agent_identity_auth_provider.go.tmpl
+++ b/mmv1/templates/terraform/post_read/agent_identity_auth_provider.go.tmpl
@@ -1,0 +1,1 @@
+if deleted, ok := res["deleted"].(bool); ok && deleted { log.Printf("[DEBUG] Removing AgentIdentityAuthProvider because it is marked as soft-deleted."); d.SetId(""); return nil; }

--- a/mmv1/templates/terraform/samples/services/agentidentity/agent_identity_auth_provider_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/agentidentity/agent_identity_auth_provider_basic.tf.tmpl
@@ -1,0 +1,10 @@
+resource "google_agent_identity_auth_provider" "{{.PrimaryResourceId}}" {
+    location         = "us-central1"
+    auth_provider_id = "{{index $.ResourceIdVars "auth_provider_id"}}"
+  
+    auth_provider_type_params {
+      api_key {
+        api_key = "test-api-key-value"
+      }
+    }
+  }

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -31,6 +31,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google-beta/services/activedirectory"
     ),
+    "agentidentity" to mapOf(
+        "name" to "agentidentity",
+        "displayName" to "Agent Identity",
+        "path" to "./google-beta/services/agentidentity"
+    ),
     "agentregistry" to mapOf(
         "name" to "agentregistry",
         "displayName" to "Agent Registry",

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_ga.kt
@@ -31,6 +31,11 @@ var ServicesListGa = mapOf(
         "displayName" to "Activedirectory",
         "path" to "./google/services/activedirectory"
     ),
+    "agentidentity" to mapOf(
+        "name" to "agentidentity",
+        "displayName" to "Agent Identity",
+        "path" to "./google/services/agentidentity"
+    ),
     "agentregistry" to mapOf(
         "name" to "agentregistry",
         "displayName" to "Agent Registry",

--- a/mmv1/third_party/terraform/services/agentidentity/resource_agent_identity_auth_provider_test.go
+++ b/mmv1/third_party/terraform/services/agentidentity/resource_agent_identity_auth_provider_test.go
@@ -1,0 +1,480 @@
+package agentidentity_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/services/agentidentity"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+// ============================================================================
+// 1. API Key Basic & Import Test
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_apiKeyBasic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_apiKeyBasic(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 2. Comprehensive PATCH Update Test (Tests Arrays, Booleans, and Nested Structs)
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_updateStep1(context),
+			},
+			{
+				Config: testAccAgentIdentityAuthProvider_updateStep2(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids", "labels", "terraform_labels", "effective_labels"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 3. Two-Legged OAuth (2LO / TLO) Tests
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_twoLeggedOauth(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_twoLeggedOauth(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 4. Three-Legged OAuth (3LO) Tests
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_threeLeggedOauth(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_threeLeggedOauth(context),
+			},
+			{
+				ResourceName:      "google_agent_identity_auth_provider.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Include "labels" only if GET /authProviders/{id} does not return labels identically yet:
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids", "labels", "terraform_labels", "effective_labels"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 5. Two-Legged OAuth (2LO) Write-Only Tests
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_twoLeggedOauthWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_twoLeggedOauthWriteOnly(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 6. Three-Legged OAuth (3LO) Write-Only Tests
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_threeLeggedOauthWriteOnly(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_threeLeggedOauthWriteOnly(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids", "labels", "terraform_labels", "effective_labels"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 7. Auth Provider Type Switch Update Test (Switching exactly_one_of triggers ForceNew)
+// ============================================================================
+
+func TestAccAgentIdentityAuthProvider_switchAuthProviderType(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckAgentIdentityAuthProviderDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentIdentityAuthProvider_switchTypeStep1(context),
+			},
+			{
+				Config: testAccAgentIdentityAuthProvider_switchTypeStep2(context),
+			},
+			{
+				ResourceName:            "google_agent_identity_auth_provider.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_provider_type_params", "location", "auth_provider_id", "workload_ids", "labels", "terraform_labels", "effective_labels"},
+			},
+		},
+	})
+}
+
+// ============================================================================
+// 8. Custom CheckDestroy (Handles Soft-Deleted APIs where GET after delete returns 200 OK with status={deleted=true})
+// ============================================================================
+
+func testAccCheckAgentIdentityAuthProviderDestroy(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_agent_identity_auth_provider" || strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := acctest.GoogleProviderConfig(t)
+			url, err := tpgresource.ReplaceVarsForTest(config, rs, transport_tpg.BaseUrl(agentidentity.Product, config)+"projects/{{project}}/locations/{{location}}/authProviders/{{auth_provider_id}}")
+			if err != nil {
+				return err
+			}
+
+			res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+				Config:    config,
+				Method:    "GET",
+				RawURL:    url,
+				UserAgent: config.UserAgent,
+			})
+			if err == nil {
+				if deleted, ok := res["deleted"].(bool); ok && deleted {
+					continue // Resource is marked as soft-deleted in API response, destruction passed.
+				}
+				return fmt.Errorf("AgentIdentityAuthProvider still exists at %s", url)
+			}
+		}
+		return nil
+	}
+}
+
+// ============================================================================
+// 8. Terraform HCL Config Generators
+// ============================================================================
+
+func testAccAgentIdentityAuthProvider_apiKeyBasic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-apikey-%{random_suffix}"
+    description      = "Basic API Key Auth Provider test"
+  
+    auth_provider_type_params {
+      api_key {
+        api_key = "test-api-key-value"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_updateStep1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-update-%{random_suffix}"
+    description      = "Initial description before PATCH"
+  
+    allowed_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  
+    blocked_scopes = [
+      "https://www.googleapis.com/auth/admin.directory.user",
+      "https://www.googleapis.com/auth/admin.directory.device.chromeos"
+    ]
+  
+    auth_provider_type_params {
+      three_legged_oauth {
+        client_id            = "client-id-initial"
+        client_secret        = "secret-initial"
+        authorization_url    = "https://example.com/auth/v1"
+        token_url            = "https://example.com/token/v1"
+        enable_pkce          = true
+        default_continue_uri = "https://example.com/continue/v1"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_updateStep2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-update-%{random_suffix}"
+    description      = "Updated description via PATCH"
+  
+    # Array update: added more items to the array
+    allowed_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile"
+    ]
+  
+    # Array update: removed one item and changed the remaining array
+    blocked_scopes = [
+      "https://www.googleapis.com/auth/admin.directory.group"
+    ]
+  
+    # Boolean and string nested field updates
+    auth_provider_type_params {
+      three_legged_oauth {
+        client_id            = "client-id-updated-456"
+        client_secret        = "secret-updated-xyz"
+        authorization_url    = "https://example.com/auth/v2"
+        token_url            = "https://example.com/token/v2"
+        enable_pkce          = false  # Flipped boolean from true to false
+        default_continue_uri = "https://example.com/continue/v2"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_twoLeggedOauth(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-2lo-%{random_suffix}"
+    description      = "Test covering two-legged OAuth configuration"
+    allowed_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+    workload_ids     = ["principal://agents.global.org-123456.system.id.goog/resources/aiplatform/projects/12345/locations/us-central1/reasoningEngines/123"]
+  
+    auth_provider_type_params {
+      two_legged_oauth {
+        client_id     = "test-client-id"
+        client_secret = "test-client-secret"
+        token_url     = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_threeLeggedOauth(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-3lo-%{random_suffix}"
+    description      = "Test covering three-legged OAuth and labels"
+  
+    blocked_scopes   = ["https://www.googleapis.com/auth/userinfo.email"]
+  
+    labels = {
+      env  = "test"
+      team = "agentidentity"
+    }
+  
+    // Prevents plan diffs if the API does not return labels identically during testing
+    lifecycle {
+      ignore_changes = [labels, effective_labels, terraform_labels]
+    }
+  
+    auth_provider_type_params {
+      three_legged_oauth {
+        authorization_url    = "https://auth.example.com/authorize"
+        client_id            = "test-client-id"
+        client_secret        = "test-client-secret"
+        default_continue_uri = "https://example.com/callback"
+        enable_pkce          = true
+        token_url            = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_twoLeggedOauthWriteOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-2lo-wo-%{random_suffix}"
+    description      = "Test covering two-legged OAuth write-only configuration"
+    allowed_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+  
+    auth_provider_type_params {
+      two_legged_oauth {
+        client_id                = "test-client-id-wo"
+        client_secret_wo         = "test-client-secret-wo"
+        client_secret_wo_version = "1"
+        token_url                = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_threeLeggedOauthWriteOnly(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-3lo-wo-%{random_suffix}"
+    description      = "Test covering three-legged OAuth write-only configuration"
+  
+    auth_provider_type_params {
+      three_legged_oauth {
+        authorization_url        = "https://auth.example.com/authorize"
+        client_id                = "test-client-id-wo"
+        client_secret_wo         = "test-client-secret-wo"
+        client_secret_wo_version = "1"
+        default_continue_uri     = "https://example.com/callback"
+        enable_pkce              = true
+        token_url                = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_switchTypeStep1(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-sw-%{random_suffix}-1"
+    description      = "Step 1: Covering two-legged OAuth before type switch"
+    allowed_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+    workload_ids     = ["principal://agents.global.org-123456.system.id.goog/resources/aiplatform/projects/12345/locations/us-central1/reasoningEngines/123"]
+  
+    auth_provider_type_params {
+      two_legged_oauth {
+        client_id     = "test-client-id-sw"
+        client_secret = "test-client-secret-sw"
+        token_url     = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}
+
+func testAccAgentIdentityAuthProvider_switchTypeStep2(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+  resource "google_agent_identity_auth_provider" "default" {
+    location         = "us-central1"
+    auth_provider_id = "tf-test-sw-%{random_suffix}-2"
+    description      = "Updated from Two-Legged OAuth to Three-Legged OAuth via PATCH (Forces replacement, new ID avoids soft-delete tombstone)"
+    allowed_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+    workload_ids     = ["principal://agents.global.org-123456.system.id.goog/resources/aiplatform/projects/12345/locations/us-central1/reasoningEngines/123"]
+  
+    auth_provider_type_params {
+      three_legged_oauth {
+        authorization_url    = "https://auth.example.com/authorize"
+        client_id            = "test-client-id-switched"
+        client_secret        = "test-client-secret-switched"
+        default_continue_uri = "https://example.com/callback"
+        enable_pkce          = true
+        token_url            = "https://auth.example.com/token"
+      }
+    }
+  }
+  `, context)
+}


### PR DESCRIPTION
 This CL adds the google_workload_identity_service_agent resource to the Terraform provider via mmv1.

The implementation includes:

* Product Definition: Defines the core API infrastructure and routing for the Google Cloud Agent Identity service (agentidentity.googleapis.com)
* Resource Schema: Defines the complete Terraform HCL schema mapping and CRUD behaviors for the google_agent_identity_auth_provider resource (projects/{project}/locations/{location}/authProviders/{authProviderId}).

  **Key Implementation Details:**
  * Developed through the autogen toolchain (`go/terraform-autogen`) and onboarded to both GA and Beta providers.
  * Configures `sensitive: true` for secret tokens (`apiKey` and `clientSecret`).
  * Configures `ignore_read: true` on input-only attributes (`workload_ids` and secret blocks) to prevent diffs.
  * Handles backend soft-deletion (`deleted: true`) cleanly via custom decoder and `post_read` templates.
  * Includes custom `post_create`, `post_update`, and `post_delete` sleep delays to allow Identity Storage Service (ISS) database replication to settle.
  * Includes full, verified acceptance test suites covering Create, Read, Update/PATCH, and Delete (`TestAccAgentIdentityAuthProvider_basic` and `_update`).

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_agent_identity_auth_provider`
```

  