### PR TITLE
gkehub: add compliance_posture_config and labels to google_gke_hub_fleet

### DIFF
--- a/mmv1/products/gkehub2/Fleet.yaml
+++ b/mmv1/products/gkehub2/Fleet.yaml
@@ -55,6 +55,10 @@ properties:
     description: |
       A user-assigned display name of the Fleet. When present, it must be between 4 to 30 characters.
       Allowed characters are: lowercase and uppercase letters, numbers, hyphen, single-quote, double-quote, space, and exclamation point.
+  - name: labels
+    type: KeyValueLabels
+    description: |
+      Labels for this Fleet.
   - name: createTime
     type: Time
     description: |
@@ -136,3 +140,22 @@ properties:
               - VULNERABILITY_DISABLED
               - VULNERABILITY_BASIC
               - VULNERABILITY_ENTERPRISE
+      - name: compliancePostureConfig
+        type: NestedObject
+        description: Enable/Disable Compliance Posture features for the cluster.
+        properties:
+          - name: mode
+            type: Enum
+            description: Sets which mode to use for Compliance Posture features.
+            enum_values:
+              - DISABLED
+              - ENABLED
+          - name: complianceStandards
+            type: Array
+            description: List of enabled compliance standards.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: standard
+                  type: String
+                  description: Name of the compliance standard.

--- a/mmv1/templates/terraform/samples/services/gkehub2/gkehub_fleet_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/gkehub2/gkehub_fleet_basic.tf.tmpl
@@ -5,5 +5,11 @@ resource "google_gke_hub_fleet" "default" {
       mode = "DISABLED"
       vulnerability_mode = "VULNERABILITY_DISABLED"
     }
+    compliance_posture_config {
+      mode = "ENABLED"
+    }
+  }
+  labels = {
+    env = "prod"
   }
 }

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.tmpl
@@ -74,6 +74,12 @@ resource "google_gke_hub_fleet" "default" {
 		mode = "DISABLED"
 		vulnerability_mode = "VULNERABILITY_DISABLED"
 	}
+	compliance_posture_config {
+		mode = "DISABLED"
+	}
+  }
+  labels = {
+	env = "test"
   }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
 }
@@ -96,6 +102,15 @@ resource "google_gke_hub_fleet" "default" {
 		mode = "BASIC"
 		vulnerability_mode = "VULNERABILITY_BASIC"
 	}
+	compliance_posture_config {
+		mode = "ENABLED"
+		compliance_standards {
+			standard = "cis-gke"
+		}
+	}
+  }
+  labels = {
+	env = "prod"
   }
   depends_on = [time_sleep.wait_for_gkehub_enablement]
 }

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_fleet_test.go.tmpl
@@ -37,25 +37,28 @@ func TestAccGKEHub2Fleet_gkehubFleetBasicExample_update(t *testing.T) {
 				Config: testAccGKEHub2Fleet_basic(context),
 			},
 			{
-				ResourceName:      "google_gke_hub_fleet.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_hub_fleet.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEHub2Fleet_update(context),
 			},
 			{
-				ResourceName:      "google_gke_hub_fleet.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_hub_fleet.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEHub2Fleet_removedDefaultClusterConfig(context),
 			},
 			{
-				ResourceName:      "google_gke_hub_fleet.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_gke_hub_fleet.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})
@@ -105,7 +108,7 @@ resource "google_gke_hub_fleet" "default" {
 	compliance_posture_config {
 		mode = "ENABLED"
 		compliance_standards {
-			standard = "cis-gke"
+			standard = "cis-gke-v1.5.0"
 		}
 	}
   }


### PR DESCRIPTION
Adds two missing Fleet API fields to `google_gke_hub_fleet`:

- **`default_cluster_config.compliance_posture_config`** — `mode` (`DISABLED`/`ENABLED`) and `compliance_standards[].standard`. This is the third sibling of the already-supported `security_posture_config` and `binary_authorization_config` blocks under `defaultClusterConfig`.
- **`labels`** — standard fleet resource labels.

Both are GA fields on the Fleet resource ([API reference](https://cloud.google.com/kubernetes-engine/fleet-management/docs/reference/rest/v1/projects.locations.fleets)). The basic sample is extended to cover them.

Note: `google_gke_hub_fleet` is a per-project singleton (`fleets/default`) and its sample keeps `exclude_test: true`, consistent with the existing resource.

```release-note:enhancement
gkehub: added `default_cluster_config.compliance_posture_config` and `labels` to `google_gke_hub_fleet`
```