### PR TITLE
bigqueryreservation: add `labels` field to `google_bigquery_reservation`

### DIFF
--- a/mmv1/products/bigqueryreservation/Reservation.yaml
+++ b/mmv1/products/bigqueryreservation/Reservation.yaml
@@ -259,3 +259,8 @@ properties:
     resource: ReservationGroup
     imports: name
     diff_suppress_func: tpgresource.CompareSelfLinkOrResourceName
+  - name: labels
+    type: KeyValueLabels
+    description: |
+      The labels associated with this reservation. You can use these to
+      organize and group your reservations.

--- a/mmv1/templates/terraform/samples/services/bigqueryreservation/bigquery_reservation_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/bigqueryreservation/bigquery_reservation_basic.tf.tmpl
@@ -10,4 +10,7 @@ resource "google_bigquery_reservation" "{{$.PrimaryResourceId}}" {
 	autoscale {
    	  max_slots = 100
     }
+	labels = {
+	  "environment" = "production"
+	}
 }

--- a/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/bigqueryreservation/resource_bigquery_reservation_test.go.tmpl
@@ -74,6 +74,80 @@ func TestAccBigqueryReservation_withScalingMode_update(t *testing.T) {
 
 {{ end }}
 
+func TestAccBigqueryReservation_labels_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryReservation_labels_basic(context),
+			},
+			{
+				ResourceName:            "google_bigquery_reservation.reservation",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+			{
+				Config: testAccBigqueryReservation_labels_update(context),
+			},
+			{
+				ResourceName:            "google_bigquery_reservation.reservation",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccBigqueryReservation_labels_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+  name              = "tf-test-reservation-%{random_suffix}"
+  location          = "us-west2"
+  slot_capacity     = 0
+  edition           = "ENTERPRISE"
+  ignore_idle_slots = true
+
+  autoscale {
+    max_slots = 100
+  }
+
+  labels = {
+    "environment" = "test"
+    "team"        = "analytics"
+  }
+}
+`, context)
+}
+
+func testAccBigqueryReservation_labels_update(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+  name              = "tf-test-reservation-%{random_suffix}"
+  location          = "us-west2"
+  slot_capacity     = 0
+  edition           = "ENTERPRISE"
+  ignore_idle_slots = true
+
+  autoscale {
+    max_slots = 100
+  }
+
+  labels = {
+    "environment" = "production"
+  }
+}
+`, context)
+}
+
 func TestAccBigqueryReservation_reservationGroup_update(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/25304.

This PR adds a `labels` field to the `google_bigquery_reservation` resource. The BigQuery Reservation v1 API already supports a [`labels` map on the Reservation resource](https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1/projects.locations.reservations#Reservation), but the Terraform provider does not expose it. Exposing labels enables cost allocation via billing export label filters when multiple teams' reservations are managed in a single admin project.

## Changes

- `mmv1/products/bigqueryreservation/Reservation.yaml`: add `labels` (`KeyValueLabels`). The resource already uses `update_mask: true` / `update_verb: PATCH`, so `labels`, `terraform_labels` and `effective_labels` handling is fully generated with no custom code.
- `bigquery_reservation_basic.tf.tmpl`: add `labels` to the documented sample.
- `resource_bigquery_reservation_test.go.tmpl`: add `TestAccBigqueryReservation_labels_update` covering create → update → import (with `ImportStateVerifyIgnore` for `labels`/`terraform_labels`), following the pattern from #15463 (eventarc channel labels).

## Local verification

- `make provider VERSION=ga PRODUCT=bigqueryreservation` succeeds; generated diff includes the labels schema, `tpgresource.SetLabelsDiff`, and `labels` in the PATCH update mask.
- `go build`, `go vet`, and `gofmt` pass on the generated `google/services/bigqueryreservation` package.

Note: an earlier draft of this change exists as jbbqqf/magic-modules#4, but it was only opened on a personal fork and has been inactive; this PR is a complete version including tests and docs.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigqueryreservation: added `labels` field to `google_bigquery_reservation` resource
```
