### PR TITLE
Update class_methods documentation for Vertex AI Reasoning Engine

### DIFF
--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -251,6 +251,248 @@ properties:
         description: |
           Optional. Declarations for object class methods in OpenAPI
           specification format.
+
+          **Note**: When deploying via Terraform, this field must be populated manually.
+          Otherwise, client SDKs (like `agent_engines.get()`) will not be able to discover the methods, and calls to the engine (or A2A integrations) will fail.
+
+          Depending on the template/framework used (`agent_framework`), the required class methods and their parameters differ:
+
+          ### 1. Langchain Template
+          * `query` (api_mode = "sync" or empty)
+          * `stream_query` (api_mode = "stream")
+
+          Example for Langchain:
+          ```hcl
+          class_methods = jsonencode([
+            {
+              name        = "query"
+              api_mode    = "sync"
+              description = "Queries the reasoning engine"
+              parameters  = {
+                type       = "object"
+                required   = ["input"]
+                properties = {
+                  input = {
+                    type        = "string"
+                    description = "The input prompt"
+                  }
+                }
+              }
+            },
+            {
+              name        = "stream_query"
+              api_mode    = "stream"
+              description = "Streams queries from the reasoning engine"
+              parameters  = {
+                type       = "object"
+                required   = ["input"]
+                properties = {
+                  input = {
+                    type        = "string"
+                    description = "The input prompt"
+                  }
+                }
+              }
+            }
+          ])
+          ```
+
+          ### 2. Google ADK Template (Standard - No A2A)
+          For standard Google ADK (Agent Development Kit) deployments, you must define the following 11 methods:
+
+          Example for Standard ADK:
+          ```hcl
+          class_methods = jsonencode([
+            {
+              name        = "get_session"
+              api_mode    = ""
+              description = "Retrieve session by ID"
+              parameters  = {
+                type     = "object"
+                required = ["user_id", "session_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "async_get_session"
+              api_mode    = "async"
+              description = "Retrieve session asynchronously by ID"
+              parameters  = {
+                type     = "object"
+                required = ["user_id", "session_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "list_sessions"
+              api_mode    = ""
+              description = "List all sessions for a user"
+              parameters  = {
+                type     = "object"
+                required = ["user_id"]
+                properties = {
+                  user_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "async_list_sessions"
+              api_mode    = "async"
+              description = "List all sessions for a user asynchronously"
+              parameters  = {
+                type     = "object"
+                required = ["user_id"]
+                properties = {
+                  user_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "create_session"
+              api_mode    = ""
+              description = "Create a new session"
+              parameters  = {
+                type     = "object"
+                required = ["user_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                  state      = { type = "object" }
+                }
+              }
+            },
+            {
+              name        = "async_create_session"
+              api_mode    = "async"
+              description = "Create a new session asynchronously"
+              parameters  = {
+                type     = "object"
+                required = ["user_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                  state      = { type = "object" }
+                }
+              }
+            },
+            {
+              name        = "delete_session"
+              api_mode    = ""
+              description = "Delete session by ID"
+              parameters  = {
+                type     = "object"
+                required = ["user_id", "session_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "async_delete_session"
+              api_mode    = "async"
+              description = "Delete session asynchronously by ID"
+              parameters  = {
+                type     = "object"
+                required = ["user_id", "session_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                }
+              }
+            },
+            {
+              name        = "stream_query"
+              api_mode    = "stream"
+              description = "Stream queries from the agent"
+              parameters  = {
+                type     = "object"
+                required = ["message", "user_id"]
+                properties = {
+                  message    = { description = "Message string or object" }
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                  run_config = { type = "object" }
+                }
+              }
+            },
+            {
+              name        = "async_stream_query"
+              api_mode    = "async_stream"
+              description = "Stream queries asynchronously from the agent"
+              parameters  = {
+                type     = "object"
+                required = ["message", "user_id"]
+                properties = {
+                  message        = { description = "Message string or object" }
+                  user_id        = { type = "string" }
+                  session_id     = { type = "string" }
+                  session_events = { type = "array", items = { type = "object" } }
+                  run_config     = { type = "object" }
+                }
+              }
+            },
+            {
+              name        = "streaming_agent_run_with_events"
+              api_mode    = "async_stream"
+              description = "Stream agent run with events asynchronously"
+              parameters  = {
+                type     = "object"
+                required = ["request_json"]
+                properties = {
+                  request_json = { type = "string" }
+                }
+              }
+            }
+          ])
+          ```
+
+          ### 3. Google ADK Template (A2A-Enabled)
+          If the agent integrates with the Gemini Enterprise Agent Registry (A2A), you must inject the `a2a_agent_card` JSON metadata as a string **specifically inside the `async_create_session` method definition**:
+
+          Example for A2A-Enabled ADK:
+          ```hcl
+          locals {
+            # Construct the A2A endpoint URL
+            a2a_url = "https://us-central1-aiplatform.googleapis.com/v1/projects/my-project/locations/us-central1/reasoningEngines/my-agent/a2a"
+
+            agent_card = {
+              name                 = "my-agent"
+              description          = "A2A Agent"
+              version              = "1.0.0"
+              preferred_transport  = "HTTP_JSON"
+              supported_interfaces = [{ url = local.a2a_url, protocol_binding = "HTTP_JSON" }]
+              capabilities         = { streaming = true }
+            }
+          }
+
+          # In class_methods, append "a2a_agent_card" key ONLY to the "async_create_session" method:
+          class_methods = jsonencode([
+            # ... other 10 standard methods (same as Standard ADK) ...
+            {
+              name        = "async_create_session"
+              api_mode    = "async"
+              description = "Create a new session asynchronously"
+              parameters  = {
+                type     = "object"
+                required = ["user_id"]
+                properties = {
+                  user_id    = { type = "string" }
+                  session_id = { type = "string" }
+                  state      = { type = "object" }
+                }
+              }
+              # Inject the serialized Agent Card here
+              a2a_agent_card = jsonencode(local.agent_card)
+            }
+          ])
+          ```
         state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
         custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
         custom_expand: 'templates/terraform/custom_expand/json_value.tmpl'

--- a/mmv1/products/vertexai/ReasoningEngine.yaml
+++ b/mmv1/products/vertexai/ReasoningEngine.yaml
@@ -257,6 +257,10 @@ properties:
 
           Depending on the template/framework used (`agent_framework`), the required class methods and their parameters differ:
 
+          **Warning**: The configuration snippets below are illustrative, may not be exhaustive, and could stop working over time. For the most up-to-date method lists and schemas, please consult the respective SDK source code:
+          * For Google ADK: See [ADK Python SDK cli_deploy.py](https://github.com/google/adk-python/blob/68a780306e3bdd648a882ef34c0abf8e5148353e/src/google/adk/cli/cli_deploy.py#L109).
+          * For Langchain: See [Vertex AI Python SDK langchain.py](https://github.com/googleapis/python-aiplatform/blob/c8a38a085931b01f4d6071f0ab7a64cb42851829/agentplatform/agent_engines/templates/langchain.py#L642-L717).
+
           ### 1. Langchain Template
           * `query` (api_mode = "sync" or empty)
           * `stream_query` (api_mode = "stream")


### PR DESCRIPTION
Added a warning note to the class_methods description field in ReasoningEngine.yaml explaining that the field must be manually populated when deploying via Terraform.
 Provided copy-pasteable OpenAPI schema examples for both Langchain and Google ADK (standard and A2A-enabled) templates to guide developers on configuring their session and query methods.

TAG=agy
CONV=be6c81eb-54da-4866-a21b-5c86748e7bd8

```release-note:none
```
