### PR TITLE
Time_sleep resource is added to wait for 120 seconds after the application is created, to allow for IAM permission propagation before creating the firewall rule.

### DIFF
--- a/mmv1/products/appengine/FirewallRule.yaml
+++ b/mmv1/products/appengine/FirewallRule.yaml
@@ -45,6 +45,7 @@ custom_code:
 samples:
   - name: app_engine_firewall_rule_basic
     primary_resource_id: rule
+    external_providers: [time]
     steps:
       - name: app_engine_firewall_rule_basic
         resource_id_vars:

--- a/mmv1/templates/terraform/samples/services/appengine/app_engine_firewall_rule_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/appengine/app_engine_firewall_rule_basic.tf.tmpl
@@ -11,9 +11,18 @@ resource "google_app_engine_application" "app" {
   location_id = "us-central"
 }
 
+# Wait for 5 minutes seconds to ensure IAM permission propagation completes
+resource "time_sleep" "wait_300_seconds" {
+  depends_on = [google_app_engine_application.app]
+  create_duration = "300s"
+}
+
+
 resource "google_app_engine_firewall_rule" "rule" {
   project      = google_app_engine_application.app.project
   priority     = 1000
   action       = "ALLOW"
   source_range = "*"
+
+  depends_on = [time_sleep.wait_300_seconds]
 }


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/26273

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
