### PR TITLE
fix(compute): `enable_proxy_protocol` not being disableable on `google_compute_service_attachment`

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -262,6 +262,7 @@ properties:
       address data in TCP connections that traverse proxies on their way to
       destination servers.
     required: true
+    send_empty_value: true
   - name: 'domainNames'
     type: Array
     description: |


### PR DESCRIPTION
### Summary

  On `google_compute_service_attachment`, `enable_proxy_protocol` cannot be updated
  from `true` to `false` in place. The plan shows the change, `apply` reports success,
  but the live resource keeps `enableProxyProtocol = true`, and every subsequent plan
  re-shows the same `true -> false` diff (a permanent no-op loop).

  ### Steps to reproduce

  ```hcl
  resource "google_compute_service_attachment" "psc" {
    name                  = "example-sa"
    region                = "us-central1"
    connection_preference = "ACCEPT_AUTOMATIC"
    nat_subnets           = [google_compute_subnetwork.nat.id]
    target_service        = google_compute_forwarding_rule.producer.id
    enable_proxy_protocol = true
  }
```

  1. apply (creates with enable_proxy_protocol = true).
  2. Change enable_proxy_protocol to false, apply.
  3. Plan shows ~ enable_proxy_protocol = true -> false; apply completes successfully.
  4. The API still reports enableProxyProtocol: true, and re-planning shows the same diff again.