### PR TITLE
fix(compute): `enable_proxy_protocol` not being disableable on `google_compute_service_attachment`

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -262,6 +262,7 @@ properties:
       address data in TCP connections that traverse proxies on their way to
       destination servers.
     required: true
+    send_empty_value: true
   - name: 'domainNames'
     type: Array
     description: |


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `send_empty_value` field to `enableProxyProtocol` on `ServiceAttachment` resource
```
