### PR TITLE
bigtable: Fix bigtable_custom_endpoint ignoring config and dropping gRPC endpoints

### DIFF
--- a/mmv1/third_party/terraform/services/bigtable/client.go
+++ b/mmv1/third_party/terraform/services/bigtable/client.go
@@ -3,7 +3,8 @@ package bigtable
 import (
 	"context"
 	"log"
-	"os"
+	"net"
+	"strings"
 
 	"cloud.google.com/go/bigtable"
 	"golang.org/x/oauth2"
@@ -14,68 +15,93 @@ import (
 )
 
 type ClientFactory struct {
+	BasePath            string
+	AdminBasePath       string
+	UniverseDomain      string
 	GRPCLoggingOptions  []option.ClientOption
 	UserAgent           string
 	TokenSource         oauth2.TokenSource
 	BillingProject      string
 	UserProjectOverride bool
+	RequestReason       string
 }
 
-func (s ClientFactory) NewInstanceAdminClient(project string) (*bigtable.InstanceAdminClient, error) {
+// toGRPCEndpoint converts an HTTP-style base URL (e.g. "https://foo.googleapis.com/")
+// into the "host:port" form that gRPC's option.WithEndpoint requires. If the host
+// has no explicit port, the default TLS port (443) is appended — gRPC's dialer
+// rejects a port-less address with "missing port in address".
+func toGRPCEndpoint(url string) string {
+	endpoint := strings.TrimPrefix(url, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	if _, _, err := net.SplitHostPort(endpoint); err != nil {
+		endpoint = net.JoinHostPort(endpoint, "443")
+	}
+	return endpoint
+}
+
+func (s ClientFactory) getClientOptions(isDataClient bool) []option.ClientOption {
 	var opts []option.ClientOption
-	if requestReason := os.Getenv("CLOUDSDK_CORE_REQUEST_REASON"); requestReason != "" {
-		opts = append(opts, option.WithRequestReason(requestReason))
+	if s.RequestReason != "" {
+		opts = append(opts, option.WithRequestReason(s.RequestReason))
 	}
 
 	if s.UserProjectOverride && s.BillingProject != "" {
 		opts = append(opts, option.WithQuotaProject(s.BillingProject))
 	}
 
+	if s.UniverseDomain != "" {
+		opts = append(opts, option.WithUniverseDomain(s.UniverseDomain))
+	}
+
+	if isDataClient && s.BasePath != "" {
+		basePath := s.BasePath
+		// The bigtable_custom_endpoint provider field targets the Admin API, so a
+		// custom endpoint often looks like "https://bigtableadmin.example/". Rewrite
+		// the "bigtableadmin." host prefix to "bigtable." for the Data API client so
+		// operators only need to configure a single endpoint. Endpoints that already
+		// use a distinct Data-API host (or a non-standard prefix) are left alone.
+		if strings.HasPrefix(strings.TrimPrefix(strings.TrimPrefix(basePath, "https://"), "http://"), "bigtableadmin.") {
+			basePath = strings.Replace(basePath, "bigtableadmin.", "bigtable.", 1)
+		}
+		opts = append(opts, option.WithEndpoint(toGRPCEndpoint(basePath)))
+	} else if !isDataClient && s.AdminBasePath != "" {
+		opts = append(opts, option.WithEndpoint(toGRPCEndpoint(s.AdminBasePath)))
+	}
+
 	opts = append(opts, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
 	opts = append(opts, s.GRPCLoggingOptions...)
 
+	return opts
+}
+
+func (s ClientFactory) NewInstanceAdminClient(project string) (*bigtable.InstanceAdminClient, error) {
+	opts := s.getClientOptions(false)
 	return bigtable.NewInstanceAdminClient(context.Background(), project, opts...)
 }
 
 func (s ClientFactory) NewAdminClient(project, instance string) (*bigtable.AdminClient, error) {
-	var opts []option.ClientOption
-	if requestReason := os.Getenv("CLOUDSDK_CORE_REQUEST_REASON"); requestReason != "" {
-		opts = append(opts, option.WithRequestReason(requestReason))
-	}
-
-	if s.UserProjectOverride && s.BillingProject != "" {
-		opts = append(opts, option.WithQuotaProject(s.BillingProject))
-	}
-
-	opts = append(opts, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
-	opts = append(opts, s.GRPCLoggingOptions...)
-
+	opts := s.getClientOptions(false)
 	return bigtable.NewAdminClient(context.Background(), project, instance, opts...)
 }
 
 func (s ClientFactory) NewClient(project, instance string) (*bigtable.Client, error) {
-	var opts []option.ClientOption
-	if requestReason := os.Getenv("CLOUDSDK_CORE_REQUEST_REASON"); requestReason != "" {
-		opts = append(opts, option.WithRequestReason(requestReason))
-	}
-
-	if s.UserProjectOverride && s.BillingProject != "" {
-		opts = append(opts, option.WithQuotaProject(s.BillingProject))
-	}
-
-	opts = append(opts, option.WithTokenSource(s.TokenSource), option.WithUserAgent(s.UserAgent))
-	opts = append(opts, s.GRPCLoggingOptions...)
-
+	opts := s.getClientOptions(true)
 	return bigtable.NewClient(context.Background(), project, instance, opts...)
 }
 
 func NewClientFactory(c *transport_tpg.Config, userAgent string) *ClientFactory {
+	baseUrl := transport_tpg.BaseUrl(Product, c)
 	bigtableClientFactory := &ClientFactory{
+		BasePath:            transport_tpg.RemoveBasePathVersion(baseUrl),
+		AdminBasePath:       transport_tpg.RemoveBasePathVersion(baseUrl),
+		UniverseDomain:      c.UniverseDomain,
 		UserAgent:           userAgent,
 		TokenSource:         c.TokenSource,
 		GRPCLoggingOptions:  c.GRPCLoggingOptions,
 		BillingProject:      c.BillingProject,
 		UserProjectOverride: c.UserProjectOverride,
+		RequestReason:       c.RequestReason,
 	}
 
 	return bigtableClientFactory

--- a/mmv1/third_party/terraform/services/bigtable/client_test.go
+++ b/mmv1/third_party/terraform/services/bigtable/client_test.go
@@ -1,0 +1,71 @@
+package bigtable_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/provider"
+	"github.com/hashicorp/terraform-provider-google/google/services/bigtable"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func TestClientFactoryPropagatesEndpoints(t *testing.T) {
+	cfg := &transport_tpg.Config{
+		UniverseDomain: "apis-tpczero.goog",
+		CustomEndpoints: map[string]string{
+			"bigtable_custom_endpoint": "https://bigtableadmin.apis-tpczero.goog/v2/",
+		},
+	}
+
+	factory := bigtable.NewClientFactory(cfg, "test-agent")
+
+	if factory.UniverseDomain != "apis-tpczero.goog" {
+		t.Errorf("Expected UniverseDomain 'apis-tpczero.goog', got '%s'", factory.UniverseDomain)
+	}
+
+	expectedPath := "https://bigtableadmin.apis-tpczero.goog/"
+	if factory.AdminBasePath != expectedPath {
+		t.Errorf("Expected AdminBasePath '%s', got '%s'", expectedPath, factory.AdminBasePath)
+	}
+	if factory.BasePath != expectedPath {
+		t.Errorf("Expected BasePath '%s', got '%s'", expectedPath, factory.BasePath)
+	}
+}
+
+func TestClientFactoryPropagatesRequestReason(t *testing.T) {
+	expectedReason := "test-request-reason"
+	cfg := &transport_tpg.Config{
+		RequestReason: expectedReason,
+	}
+
+	factory := bigtable.NewClientFactory(cfg, "test-agent")
+
+	if factory.RequestReason != expectedReason {
+		t.Errorf("Expected RequestReason '%s', got '%s'", expectedReason, factory.RequestReason)
+	}
+}
+
+func TestClientFactoryPropagatesRequestReasonFromEnv(t *testing.T) {
+	expectedReason := "env-request-reason"
+	t.Setenv("CLOUDSDK_CORE_REQUEST_REASON", expectedReason)
+
+	// Create empty schema.ResourceData using the SDK Provider schema
+	emptyConfigMap := map[string]interface{}{}
+	d := schema.TestResourceDataRaw(t, provider.Provider().Schema, emptyConfigMap)
+
+	err := transport_tpg.HandleSDKDefaults(d)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	cfg := &transport_tpg.Config{}
+	if v, ok := d.GetOk("request_reason"); ok {
+		cfg.RequestReason = v.(string)
+	}
+
+	factory := bigtable.NewClientFactory(cfg, "test-agent")
+
+	if factory.RequestReason != expectedReason {
+		t.Errorf("Expected RequestReason '%s' from env, got '%s'", expectedReason, factory.RequestReason)
+	}
+}


### PR DESCRIPTION
Recreate PR https://github.com/GoogleCloudPlatform/magic-modules/pull/16958 and fix the endpoint issue it introduced.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/26764

This PR resolves an issue where the Google Cloud Terraform provider drops the bigtable_custom_endpoint and universe_domain when provisioning Bigtable resources because native gRPC clients are initialized instead of the standard HTTP clients.

Changes:

Mapped the parsed bigtable_custom_endpoint variable to config.BigtableAdminBasePath in config.go (and the config.go.tmpl).
Updated the BigtableClientFactory to accept both BasePath (Data) and AdminBasePath (Admin), and UniverseDomain.
Stripped the standard https:// prefix and trailing slashes from the endpoints before initializing the native gRPC clients via option.WithEndpoint().
Applied option.WithUniverseDomain() when a Universe Domain is configured.
Adapted the Data API endpoint prefix (bigtableadmin. -> bigtable.) conditionally to preserve distinct Data endpoints if they are ever split in the schema.

```release-note:bug
bigtable: fixed an issue where `bigtable_custom_endpoint` and `universe_domain` were ignored when creating Bigtable resources.
```