### PR TITLE
bigqueryreservation: add principal field to ReservationAssignment

### DIFF
--- a/mmv1/products/bigqueryreservation/ReservationAssignment.yaml
+++ b/mmv1/products/bigqueryreservation/ReservationAssignment.yaml
@@ -60,6 +60,16 @@ samples:
           reservation_name: 'example-reservation'
         test_env_vars:
           project: 'PROJECT_NAME'
+  - name: 'bigquery_reservation_assignment_full_with_principal'
+    primary_resource_id: 'assignment'
+    exclude_basic_doc: true
+    steps:
+      - name: 'bigquery_reservation_assignment_full_with_principal'
+        resource_id_vars:
+          reservation_name: 'example-reservation'
+        test_env_vars:
+          project: 'PROJECT_NAME'
+          service_account: 'SERVICE_ACCT'
 parameters:
   - name: 'location'
     type: String
@@ -91,6 +101,14 @@ properties:
     description: |
       Types of job, which could be specified when using the reservation. Possible values: JOB_TYPE_UNSPECIFIED, PIPELINE, QUERY, CONTINUOUS
     required: true
+  - name: 'principal'
+    type: String
+    description: |
+      Optional. Represents the principal for this assignment. If not empty, jobs run by this principal will utilize the associated reservation. Otherwise, jobs will fall back to using the reservation assigned to the project, folder, or organization (in that order). If no reservation is assigned at any of these levels, on-demand capacity will be used. The supported formats are:
+      * `principal://goog/subject/USER_EMAIL_ADDRESS` for users,
+      * `principal://iam.googleapis.com/projects/-/serviceAccounts/SA_EMAIL_ADDRESS` for service accounts,
+      * `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/subject/SUBJECT_ID` for workload identity pool identities.
+      * The special value `unknown_or_deleted_user` represents principals which cannot be read from the user info service, for example deleted users.
   - name: 'state'
     type: String
     description: |

--- a/mmv1/templates/terraform/samples/services/bigqueryreservation/bigquery_reservation_assignment_full_with_principal.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/bigqueryreservation/bigquery_reservation_assignment_full_with_principal.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_bigquery_reservation" "basic" {
+  name  = "{{index $.ResourceIdVars "reservation_name"}}"
+  project = "{{index $.TestEnvVars "project"}}"
+  location = "us-central1"
+  slot_capacity = 0
+  ignore_idle_slots = false
+}
+
+resource "google_bigquery_reservation_assignment" "{{$.PrimaryResourceId}}" {
+  assignee  = "projects/{{index $.TestEnvVars "project"}}"
+  job_type = "QUERY"
+  location = "us-central1"
+  principal = "principal://iam.googleapis.com/projects/-/serviceAccounts/{{index $.TestEnvVars "service_account"}}"
+  reservation = google_bigquery_reservation.basic.id
+}


### PR DESCRIPTION

## Summary

This is a re-submission of #17080, which was closed without merge.

The purpose is to support [User-specific assignments](https://docs.cloud.google.com/bigquery/docs/reservations-assignments#user-specific_assignments) by adding the `principal` field to `google_bigquery_reservation_assignment`. As of June 30, 2026, the feature has been officially released as [Public Preview](https://cloud.google.com/bigquery/docs/release-notes#June_30_2026), and the field is now explicitly present in the [v1 REST API discovery document](https://bigqueryreservation.googleapis.com/$discovery/rest?version=v1). Based on this, we have set this to GA field (not `min_version: beta`).

Changes:
- Add `principal` field to `ReservationAssignment` resource. Description is taken verbatim from the v1 discovery document.
- Add new example `bigquery_reservation_assignment_full_with_principal` (with corresponding test) to cover the `principal` field. A separate example is used rather than modifying the existing `_full` example, as `principal`-based assignment is a distinct usage pattern.

## Testing

The provider was built locally from this branch and tested with `dev_overrides`. Resource creation with `principal` set to a service account principal was verified to succeed end-to-end.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
bigqueryreservation: added `principal` field to `google_bigquery_reservation_assignment` resource
```
