### PR TITLE
Fallback to async timeouts if top level timeouts are not specified

### DIFF
--- a/mmv1/api/resource.go
+++ b/mmv1/api/resource.go
@@ -1337,7 +1337,7 @@ func (r Resource) PackageName() string {
 // general defined timeouts, or default Timeouts
 func (r Resource) GetTimeouts() *Timeouts {
 	timeoutsFiltered := r.Timeouts
-	if timeoutsFiltered == nil {
+	if timeoutsFiltered == nil || timeoutsFiltered.IsZero() {
 		if async := r.GetAsync(); async != nil && async.Operation != nil {
 			timeoutsFiltered = async.Operation.Timeouts
 		}

--- a/mmv1/products/firebaseapphosting/Build.yaml
+++ b/mmv1/products/firebaseapphosting/Build.yaml
@@ -33,6 +33,8 @@ async:
   operation:
     timeouts:
       insert_minutes: 20
+      update_minutes: 20
+      delete_minutes: 20
     base_url: '{{op_id}}'
   actions:
     - create

--- a/mmv1/products/firebaseapphosting/DefaultDomain.yaml
+++ b/mmv1/products/firebaseapphosting/DefaultDomain.yaml
@@ -32,6 +32,7 @@ async:
     timeouts:
       insert_minutes: 20
       update_minutes: 20
+      delete_minutes: 20
     base_url: '{{op_id}}'
   actions:
     - create

--- a/mmv1/products/firebaseapphosting/Domain.yaml
+++ b/mmv1/products/firebaseapphosting/Domain.yaml
@@ -28,6 +28,7 @@ async:
   type: PollAsync
   operation:
     timeouts:
+      insert_minutes: 20
       update_minutes: 20
       delete_minutes: 20
     base_url: '{{op_id}}'

--- a/mmv1/products/observability/FolderSettings.yaml
+++ b/mmv1/products/observability/FolderSettings.yaml
@@ -29,6 +29,7 @@ async:
     timeouts:
       insert_minutes: 10
       update_minutes: 10
+      delete_minutes: 20
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true

--- a/mmv1/products/observability/OrganizationSettings.yaml
+++ b/mmv1/products/observability/OrganizationSettings.yaml
@@ -29,6 +29,7 @@ async:
     timeouts:
       insert_minutes: 10
       update_minutes: 10
+      delete_minutes: 20
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true

--- a/mmv1/products/observability/ProjectSettings.yaml
+++ b/mmv1/products/observability/ProjectSettings.yaml
@@ -29,6 +29,7 @@ async:
     timeouts:
       insert_minutes: 10
       update_minutes: 10
+      delete_minutes: 20
     base_url: '{{op_id}}'
   result:
     resource_inside_response: true

--- a/mmv1/templates/terraform/resource.go.tmpl
+++ b/mmv1/templates/terraform/resource.go.tmpl
@@ -119,11 +119,11 @@ func Resource{{ $.ResourceName -}}() *schema.Resource {
 {{- end}}
 
         Timeouts: &schema.ResourceTimeout {
-            Create: schema.DefaultTimeout({{ $.Timeouts.InsertMinutes -}} * time.Minute),
+            Create: schema.DefaultTimeout({{ $.GetTimeouts.InsertMinutes -}} * time.Minute),
 {{- if or (or $.Updatable $.RootLabels) $.VirtualFields }}
-            Update: schema.DefaultTimeout({{ $.Timeouts.UpdateMinutes -}} * time.Minute),
+            Update: schema.DefaultTimeout({{ $.GetTimeouts.UpdateMinutes -}} * time.Minute),
 {{- end}}
-            Delete: schema.DefaultTimeout({{ $.Timeouts.DeleteMinutes -}} * time.Minute),
+            Delete: schema.DefaultTimeout({{ $.GetTimeouts.DeleteMinutes -}} * time.Minute),
         },
 {{ if $.SchemaVersion }}
         SchemaVersion: {{ $.SchemaVersion -}},

--- a/mmv1/templates/terraform/resource.html.markdown.tmpl
+++ b/mmv1/templates/terraform/resource.html.markdown.tmpl
@@ -161,11 +161,11 @@ In addition to the arguments listed above, the following computed attributes are
 This resource provides the following
 [Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options:
 
-- `create` - Default is {{$.Timeouts.InsertMinutes}} minutes.
+- `create` - Default is {{$.GetTimeouts.InsertMinutes}} minutes.
 {{- if or $.Updatable $.RootLabels }}
-- `update` - Default is {{$.Timeouts.UpdateMinutes}} minutes.
+- `update` - Default is {{$.GetTimeouts.UpdateMinutes}} minutes.
 {{- end }}
-- `delete` - Default is {{$.Timeouts.DeleteMinutes}} minutes.
+- `delete` - Default is {{$.GetTimeouts.DeleteMinutes}} minutes.
 {{ if $.ProductMetadata.Version.RepEnabled }}
 ## Regional Endpoint Policies
 

--- a/mmv1/templates/terraform/resource_fw.go.tmpl
+++ b/mmv1/templates/terraform/resource_fw.go.tmpl
@@ -270,7 +270,7 @@ func (r *{{$.ResourceName}}FWResource) Create(ctx context.Context, req resource.
     obj["{{ $prop.ApiName -}}"] = {{ $prop.ApiName -}}Prop
 {{- end }}
 
-    createTimeout, diags := data.Timeouts.Create(ctx, {{ $.Timeouts.InsertMinutes }}*time.Minute)
+    createTimeout, diags := data.Timeouts.Create(ctx, {{ $.GetTimeouts.InsertMinutes }}*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -487,7 +487,7 @@ func (r *{{$.ResourceName}}FWResource) Update(ctx context.Context, req resource.
 	}
 {{- end }}
 
-    updateTimeout, diags := plan.Timeouts.Update(ctx, {{ $.Timeouts.UpdateMinutes }}*time.Minute)
+    updateTimeout, diags := plan.Timeouts.Update(ctx, {{ $.GetTimeouts.UpdateMinutes }}*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -629,7 +629,7 @@ func (r *{{$.ResourceName}}FWResource) Delete(ctx context.Context, req resource.
 
 	obj := make(map[string]interface{})
 
-    deleteTimeout, diags := data.Timeouts.Delete(ctx, {{ $.Timeouts.DeleteMinutes }}*time.Minute)
+    deleteTimeout, diags := data.Timeouts.Delete(ctx, {{ $.GetTimeouts.DeleteMinutes }}*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
gemini: fixed truncated timeouts in `google_gemini_code_tools_setting`, `google_gemini_data_sharing_with_google_setting_binding`, `google_gemini_gemini_gcp_enablement_setting_binding`, and `google_gemini_release_channel_setting_binding`
```

```release-note:bug
observability: fixed unintentionally long timeouts in `google_observability_folder_settings`, `google_observability_organization_settings`, and `google_observability_project_settings`
```

```release-note:bug
oracledatabase: fixed truncated timeouts in `google_oracle_database_exadb_vm_cluster`, `google_oracle_database_goldengate_connection`, and `google_oracle_database_odb_subnet`
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28175
