### PR TITLE
fix (compute): `enable_proxy_protocol` not being disableable on `google_compute_service_attachment`.

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -262,6 +262,7 @@ properties:
       address data in TCP connections that traverse proxies on their way to
       destination servers.
     required: true
+    send_empty_value: true
   - name: 'domainNames'
     type: Array
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
@@ -73,10 +73,12 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 					"google_compute_service_attachment.psc_ilb_service_attachment", "enable_proxy_protocol", "false"),
 			},
 			{
-				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"target_service", "region"},
+				ResourceName:      "google_compute_service_attachment.psc_ilb_service_attachment",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// send_propagated_connection_limit_if_zero is a virtual field with no API
+				// representation, so it can't be reconstructed on import.
+				ImportStateVerifyIgnore: []string{"target_service", "region", "send_propagated_connection_limit_if_zero"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
@@ -35,7 +35,7 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 			{
-				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, true, -1),
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, true, -1, true),
 			},
 			{
 				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
@@ -44,7 +44,7 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 			{
-				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, -1),
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, -1, true),
 			},
 			{
 				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
@@ -53,12 +53,30 @@ func TestAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(t *test
 				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 			{
-				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, 0),
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, 0, true),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectNonEmptyPlan(),
 					},
 				},
+			},
+			{
+				// Regression test: disabling enable_proxy_protocol after it was enabled must
+				// actually be sent to the API (it's a zero-valued bool), not silently dropped.
+				Config: testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context, false, 0, false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("google_compute_service_attachment.psc_ilb_service_attachment", plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: resource.TestCheckResourceAttr(
+					"google_compute_service_attachment.psc_ilb_service_attachment", "enable_proxy_protocol", "false"),
+			},
+			{
+				ResourceName:            "google_compute_service_attachment.psc_ilb_service_attachment",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"target_service", "region"},
 			},
 		},
 	})
@@ -342,7 +360,7 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
 `, context)
 }
 
-func testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context map[string]interface{}, preventDestroy bool, propagatedConnectionLimit int) string {
+func testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context map[string]interface{}, preventDestroy bool, propagatedConnectionLimit int, enableProxyProtocol bool) string {
 	context["lifecycle_block"] = ""
 	if preventDestroy {
 		context["lifecycle_block"] = `
@@ -350,6 +368,8 @@ func testAccComputeServiceAttachment_serviceAttachmentBasicExampleUpdate(context
 			prevent_destroy = true
 		}`
 	}
+
+	context["enable_proxy_protocol"] = enableProxyProtocol
 
 	switch {
 	case propagatedConnectionLimit == 0:
@@ -369,7 +389,7 @@ resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
   region      = "us-west2"
   description = "A service attachment configured with Terraforms"
 
-  enable_proxy_protocol    = true
+  enable_proxy_protocol    = %{enable_proxy_protocol}
   connection_preference    = "ACCEPT_MANUAL"
   nat_subnets              = [google_compute_subnetwork.psc_ilb_nat.id]
   target_service           = google_compute_forwarding_rule.psc_ilb_target_service.id


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
compute: added `send_empty_value` field to `enableProxyProtocol` on `ServiceAttachment` resource
```
