### PR TITLE
Support Resource Manager tags on Cloud Run v2 Service and Job creation

### DIFF
--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -159,6 +159,15 @@ samples:
           cloud_run_job_name: cloudrun-job
         ignore_read_extra:
           - deletion_protection
+  - name: cloudrunv2_job_tags
+    primary_resource_id: default
+    exclude_test: true
+    steps:
+      - name: cloudrunv2_job_tags
+        resource_id_vars:
+          cloud_run_job_name: cloudrun-job
+        ignore_read_extra:
+          - deletion_protection
 virtual_fields:
   - name: deletion_protection
     description: |

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -797,6 +797,14 @@ properties:
         type: String
         description: A reason for the execution condition.
         output: true
+  - name: tags
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true
   - name: conditions
     type: Array
     description: The Conditions of all other associated sub-resources. They contain additional diagnostics information in case the Job does not reach its desired state. See comments in reconciling for additional information on `reconciliation` process in Cloud Run.

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -273,6 +273,14 @@ properties:
       All system annotations in v1 now have a corresponding field in v2 Service.
 
       This field follows Kubernetes annotations' namespacing, limits, and rules.
+  - name: 'tags'
+    type: KeyValuePairs
+    description: |
+      A map of resource manager tags.
+      Resource manager tag keys and values have the same definition as resource manager tags.
+      Keys must be in the format tagKeys/{tag_key_id}, and values are in the format tagValues/{tag_value_id}.
+    immutable: true
+    ignore_read: true
   - name: 'createTime'
     type: Time
     description: |-

--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -213,6 +213,15 @@ samples:
           'deletion_protection': 'false'
         ignore_read_extra:
           - 'deletion_protection'
+  - name: 'cloudrunv2_service_tags'
+    primary_resource_id: 'default'
+    exclude_test: true
+    steps:
+      - name: 'cloudrunv2_service_tags'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        ignore_read_extra:
+          - 'deletion_protection'
 virtual_fields:
   - name: 'deletion_protection'
     description: |

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_tags.tf.tmpl
@@ -1,0 +1,15 @@
+resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.Vars "cloud_run_job_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+  tags = {
+    "tagKeys/1234" = "tagValues/5678"
+  }
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_job_tags.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_cloud_run_v2_job" "{{$.PrimaryResourceId}}" {
-  name     = "{{index $.Vars "cloud_run_job_name"}}"
+  name     = "{{index $.ResourceIdVars "cloud_run_job_name"}}"
   location = "us-central1"
   deletion_protection = false
   tags = {

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_tags.tf.tmpl
@@ -1,0 +1,13 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  name     = "{{index $.Vars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+  tags = {
+    "tagKeys/1234" = "tagValues/5678"
+  }
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_tags.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_tags.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
-  name     = "{{index $.Vars "cloud_run_service_name"}}"
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
   location = "us-central1"
   deletion_protection = false
   tags = {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
@@ -11,6 +11,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/compute"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/cloudrunv2"
     "github.com/hashicorp/terraform-provider-google/google/envvar"
+	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 )
 
 func TestAccCloudRunV2Job_cloudrunv2JobFullUpdate(t *testing.T) {
@@ -480,12 +481,15 @@ func testAccCloudRunV2Job_cloudrunv2JobWithNfsVolume(context map[string]interfac
 func TestAccCloudRunV2Job_cloudrunv2JobWithTags(t *testing.T) {
   t.Parallel()
 
-  tagKey := acctest.BootstrapSharedTestTagKey(t, "cloud-run-tagkey")
+  org := envvar.GetTestOrgFromEnv(t)
+  tagKeyResult := tags.BootstrapSharedTestTagKeyDetails(t, "cloud-run-tagkey", "organizations/"+org, make(map[string]interface{}))
+  sharedTagkey := tagKeyResult["shared_tag_key"]
+  tagValueResult := tags.BootstrapSharedTestTagValueDetails(t, "cloud-run-tagvalue", sharedTagkey, org)
+
   context := map[string]interface{}{}
-  context["org"] = envvar.GetTestOrgFromEnv(t)
   context["random_suffix"] = acctest.RandString(t, 10)
-  context["tagKey"] = tagKey
-  context["tagValue"] = acctest.BootstrapSharedTestTagValue(t, "cloud-run-tagvalue", tagKey)
+  context["tag_key_id"] = tagKeyResult["name"]
+  context["tag_value_id"] = tagValueResult["name"]
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck: func() { acctest.AccTestPreCheck(t) },
@@ -512,7 +516,7 @@ resource "google_cloud_run_v2_job" "default" {
   location = "us-central1"
   deletion_protection = false
   tags = {
-    "%{org}/%{tagKey}" = "%{tagValue}"
+    "%{tag_key_id}" = "%{tag_value_id}"
   }
   template {
     template {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_job_test.go.tmpl
@@ -477,6 +477,54 @@ func testAccCloudRunV2Job_cloudrunv2JobWithNfsVolume(context map[string]interfac
 }
 
 
+func TestAccCloudRunV2Job_cloudrunv2JobWithTags(t *testing.T) {
+  t.Parallel()
+
+  tagKey := acctest.BootstrapSharedTestTagKey(t, "cloud-run-tagkey")
+  context := map[string]interface{}{}
+  context["org"] = envvar.GetTestOrgFromEnv(t)
+  context["random_suffix"] = acctest.RandString(t, 10)
+  context["tagKey"] = tagKey
+  context["tagValue"] = acctest.BootstrapSharedTestTagValue(t, "cloud-run-tagvalue", tagKey)
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck: func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2JobDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunV2Job_cloudrunv2JobWithTags(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_job.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"location", "launch_stage", "deletion_protection", "tags"},
+      },
+    },
+  })
+}
+
+func testAccCloudRunV2Job_cloudrunv2JobWithTags(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_job" "default" {
+  name     = "tf-test-cloudrun-tags-job%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
+  template {
+    template {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/job"
+      }
+    }
+  }
+}
+`, context)
+}
+
 func TestAccCloudRunV2Job_cloudrunv2JobTCPProbesUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -16,6 +16,7 @@ import (
 	_ "github.com/hashicorp/terraform-provider-google/google/services/networkservices"
   "github.com/hashicorp/terraform-provider-google/google/envvar"
 	"github.com/hashicorp/terraform-provider-google/google/services/cloudrunv2"
+	"github.com/hashicorp/terraform-provider-google/google/services/tags"
 )
 
 func TestAccCloudRunV2WorkerPool_vpcAccess_basic(t *testing.T) {
@@ -1720,12 +1721,15 @@ resource "google_project_iam_member" "logs_writer" {
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithTags(t *testing.T) {
   t.Parallel()
 
-  tagKey := acctest.BootstrapSharedTestTagKey(t, "cloud-run-tagkey")
+  org := envvar.GetTestOrgFromEnv(t)
+  tagKeyResult := tags.BootstrapSharedTestTagKeyDetails(t, "cloud-run-tagkey", "organizations/"+org, make(map[string]interface{}))
+  sharedTagkey := tagKeyResult["shared_tag_key"]
+  tagValueResult := tags.BootstrapSharedTestTagValueDetails(t, "cloud-run-tagvalue", sharedTagkey, org)
+
   context := map[string]interface{}{}
-  context["org"] = envvar.GetTestOrgFromEnv(t)
   context["random_suffix"] = acctest.RandString(t, 10)
-  context["tagKey"] = tagKey
-  context["tagValue"] = acctest.BootstrapSharedTestTagValue(t, "cloud-run-tagvalue", tagKey)
+  context["tag_key_id"] = tagKeyResult["name"]
+  context["tag_value_id"] = tagValueResult["name"]
 
   acctest.VcrTest(t, resource.TestCase{
     PreCheck: func() { acctest.AccTestPreCheck(t) },
@@ -1752,7 +1756,7 @@ resource "google_cloud_run_v2_service" "default" {
   location = "us-central1"
   deletion_protection = false
   tags = {
-    "%{org}/%{tagKey}" = "%{tagValue}"
+    "%{tag_key_id}" = "%{tag_value_id}"
   }
   template {
     containers {

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1717,6 +1717,52 @@ resource "google_project_iam_member" "logs_writer" {
 `, context)
 }
 
+func TestAccCloudRunV2Service_cloudrunv2ServiceWithTags(t *testing.T) {
+  t.Parallel()
+
+  tagKey := acctest.BootstrapSharedTestTagKey(t, "cloud-run-tagkey")
+  context := map[string]interface{}{}
+  context["org"] = envvar.GetTestOrgFromEnv(t)
+  context["random_suffix"] = acctest.RandString(t, 10)
+  context["tagKey"] = tagKey
+  context["tagValue"] = acctest.BootstrapSharedTestTagValue(t, "cloud-run-tagvalue", tagKey)
+
+  acctest.VcrTest(t, resource.TestCase{
+    PreCheck: func() { acctest.AccTestPreCheck(t) },
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithTags(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"annotations", "deletion_protection", "labels", "location", "name", "terraform_labels", "tags"},
+      },
+    },
+  })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithTags(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  name     = "tf-test-cloudrun-tags-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  tags = {
+    "%{org}/%{tagKey}" = "%{tagValue}"
+  }
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+`, context)
+}
+
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithManualScaling(t *testing.T) {
   t.Parallel()
   context := map[string]interface{} {


### PR DESCRIPTION
## Summary
- add tags support for Cloud Run v2 Service and Job creation
- add acceptance tests for service/job tag creation and import behavior
- add example configurations for the new tags field

## Release Note
```release-note:enhancement
cloudrunv2: added `tags` field to `google_cloud_run_v2_service` and `google_cloud_run_v2_job` resources to allow setting tags for services and jobs at creation time.
```
