### PR TITLE
Add enable_ssh to Dataproc Cluster IdentityConfig

### DIFF
--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster.go
@@ -1636,9 +1636,14 @@ by Dataproc`,
 											Schema: map[string]*schema.Schema{
 												"user_service_account_mapping": {
 													Type:        schema.TypeMap,
-													Required:    true,
+													Optional:    true,
 													Elem:        &schema.Schema{Type: schema.TypeString},
 													Description: `User to service account mappings for multi-tenancy.`,
+												},
+												"enable_ssh": {
+													Type:        schema.TypeBool,
+													Optional:    true,
+													Description: `Whether to enable SSH access for the cluster.`,
 												},
 											},
 										},
@@ -2635,6 +2640,10 @@ func expandIdentityConfig(cfg map[string]interface{}) *dataproc.IdentityConfig {
 		}
 		conf.UserServiceAccountMapping = m
 	}
+	if v, ok := cfg["enable_ssh"]; ok {
+		conf.EnableSsh = v.(bool)
+		conf.ForceSendFields = append(conf.ForceSendFields, "EnableSsh")
+	}
 	return conf
 }
 
@@ -3425,6 +3434,7 @@ func flattenIdentityConfig(d *schema.ResourceData, ifg *dataproc.IdentityConfig)
 	}
 	data := map[string]interface{}{
 		"user_service_account_mapping": d.Get("cluster_config.0.security_config.0.identity_config.0.user_service_account_mapping").(map[string]interface{}),
+		"enable_ssh":                   ifg.EnableSsh,
 	}
 
 	return []map[string]interface{}{data}

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_meta.yaml
@@ -99,6 +99,7 @@ fields:
   - field: 'cluster_config.security_config.kerberos_config.truststore_password_uri'
   - field: 'cluster_config.security_config.kerberos_config.truststore_uri'
   - field: 'cluster_config.security_config.identity_config.user_service_account_mapping'
+  - field: 'cluster_config.security_config.identity_config.enable_ssh'
   - field: 'cluster_config.software_config.image_version'
   - field: 'cluster_config.software_config.optional_components'
   - field: 'cluster_config.software_config.override_properties'

--- a/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
+++ b/mmv1/third_party/terraform/services/dataproc/resource_dataproc_cluster_test.go
@@ -1320,6 +1320,7 @@ func TestAccDataprocCluster_withIdentityConfig(t *testing.T) {
 				Config: testAccDataprocCluster_withIdentityConfig(rnd, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.identity_config", &cluster),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.identity_config", "cluster_config.0.security_config.0.identity_config.0.enable_ssh", "true"),
 				),
 			},
 		},
@@ -3424,6 +3425,7 @@ resource "google_dataproc_cluster" "identity_config" {
         user_service_account_mapping = {
           "bob@company.com" = "bob-sa@iam.gserviceaccouts.com"
         }
+        enable_ssh = true
       }
     }
   }


### PR DESCRIPTION
This PR adds the optional `enable_ssh` field to Dataproc Cluster's `identity_config`, allowing users to enable/disable SSH access for the cluster.

Related changes:
- Adds `enable_ssh` field to `IdentityConfig` schema and meta.
- Updates expand/flatten functions to handle the new field.
- Updates `TestAccDataprocCluster_withIdentityConfig` to test the new field.

```release-note:enhancement
dataproc: added `enable_ssh` field to `google_dataproc_cluster` resource
```
