### PR TITLE
Add IAM policy support for google_iap_agent_registry_mcp_server

### DIFF
--- a/mmv1/products/iap/AgentRegistryMcpServer.yaml
+++ b/mmv1/products/iap/AgentRegistryMcpServer.yaml
@@ -1,0 +1,58 @@
+---
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: AgentRegistryMcpServer
+description: |
+  Only used to generate IAM resources
+docs:
+base_url: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcpServerId}}
+self_link: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcpServerId}}
+iam_policy:
+  method_name_separator: ':'
+  parent_resource_type: google_project_service
+  parent_is_resource_id: true
+  fetch_iam_policy_verb: POST
+  allowed_iam_role: roles/iap.egressor
+  parent_resource_attribute: mcp_server_id
+  sample_config_body: templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl
+  iam_conditions_request_type: REQUEST_BODY
+# This resource is only used to generate IAM resources. They do not correspond to real
+# GCP resources, and should not be used to generate anything other than IAM support.
+exclude_resource: true
+id_format: projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcpServerId}}
+import_format:
+  - projects/{{project}}/locations/{{location}}/iap_web/agentRegistry/mcpServers/{{mcpServerId}}
+  - '{{mcpServerId}}'
+timeouts:
+  insert_minutes: 20
+  update_minutes: 20
+  delete_minutes: 20
+exclude_tgc: true
+samples:
+  - name: project
+    primary_resource_id: project_service
+    steps:
+      - name: project
+        config_path: templates/terraform/samples/services/iap/iap_existing_project_mcp_server.tf.tmpl
+        test_env_vars:
+          project: PROJECT_NAME
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: The location of the resource.
+properties:
+  - name: mcpServerId
+    type: String
+    description: The ID of the MCP Server.
+    required: true

--- a/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl
+++ b/mmv1/templates/terraform/iam/example_config_body/iap_agent_registry_mcp_server.tf.tmpl
@@ -1,0 +1,3 @@
+  project = "%{project}"
+  location = "us-central1"
+  mcp_server_id = basename(google_agent_registry_service.default.registry_resource)

--- a/mmv1/templates/terraform/samples/services/iap/iap_existing_project_mcp_server.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/iap/iap_existing_project_mcp_server.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_agent_registry_service" "default" {
+  location     = "us-central1"
+  service_id   = "tf-test-mcp-%{random_suffix}"
+  description  = "My MCP agent registry service for IAM test"
+  display_name = "My Service"
+
+  interfaces {
+    url              = "https://tf-test-mcp-%{random_suffix}.example.com"
+    protocol_binding = "JSONRPC"
+  }
+
+  mcp_server_spec {
+    type    = "TOOL_SPEC"
+    content = "{\"tools\":[]}"
+  }
+}


### PR DESCRIPTION
This change adds a new resources under the IAP product to support IAM policy configurations:
- google_iap_agent_registry_mcp_server_iam

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_policy`
```

```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_binding`
```

```release-note:new-resource
`google_iap_agent_registry_endpoint_iam_member`
```
