### PR TITLE
Added missing update_mask parameter to update operation

### DIFF
--- a/mmv1/products/vmwareengine/PrivateCloud.yaml
+++ b/mmv1/products/vmwareengine/PrivateCloud.yaml
@@ -22,6 +22,7 @@ base_url: projects/{{project}}/locations/{{location}}/privateClouds
 self_link: projects/{{project}}/locations/{{location}}/privateClouds/{{name}}
 create_url: projects/{{project}}/locations/{{location}}/privateClouds?privateCloudId={{name}}
 delete_url: projects/{{project}}/locations/{{location}}/privateClouds/{{name}}
+update_mask: true
 update_verb: PATCH
 import_format:
   - projects/{{project}}/locations/{{location}}/privateClouds/{{name}}
@@ -56,6 +57,7 @@ custom_code:
   constants: templates/terraform/constants/vmwareengine_private_cloud.go.tmpl
   pre_create: templates/terraform/pre_create/vmwareengine_private_cloud.go.tmpl
   post_create: templates/terraform/post_create/private_cloud.go.tmpl
+  pre_update: templates/terraform/pre_update/vmwareengine_private_cloud.go.tmpl
   post_update: templates/terraform/post_update/private_cloud.go.tmpl
   pre_delete: templates/terraform/pre_delete/vmwareengine_private_cloud.go.tmpl
   post_delete: templates/terraform/post_delete/private_cloud.go.tmpl

--- a/mmv1/templates/terraform/pre_update/vmwareengine_private_cloud.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/vmwareengine_private_cloud.go.tmpl
@@ -1,0 +1,14 @@
+// managementCluster is updated via its own separate endpoint.
+// We remove it from the update mask of the PrivateCloud resource update.
+var filteredUpdateMask []string
+for _, mask := range updateMask {
+	if mask != "managementCluster" {
+		filteredUpdateMask = append(filteredUpdateMask, mask)
+	}
+}
+updateMask = filteredUpdateMask
+
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+	return err
+}


### PR DESCRIPTION
Added update_mask parameter for update private cloud request b/529713679

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
vmwareengine: added correct `update_mask` value to `google_vmwareengine_private_cloud` updates
```
