### PR TITLE
Add vector search data object

### DIFF
--- a/mmv1/products/vectorsearch/DataObject.yaml
+++ b/mmv1/products/vectorsearch/DataObject.yaml
@@ -1,0 +1,161 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: DataObject
+description: |-
+  A DataObject is a single item of data (with optional vectors) stored in a
+  Vector Search Collection. Each DataObject conforms to the parent
+  Collection's `data_schema` and `vector_schema`.
+
+  For large datasets, prefer bulk ingestion via the `importDataObjects`
+  API before any Index is created on the Collection: once an Index exists,
+  `importDataObjects` is no longer available and DataObjects must be
+  created one at a time (as this resource does) or in small online
+  batches.
+base_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects
+self_link: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects/{{data_object_id}}
+create_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects?dataObjectId={{data_object_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects/{{data_object_id}}
+# NOTE: DataObject CRUD RPCs are synchronous (they return the resource
+# directly, not a google.longrunning.Operation), so this resource has NO
+# `async:` block and `autogen_async` is set to `false`.
+autogen_status: RGF0YU9iamVjdA==
+autogen_async: false
+samples:
+  - name: vectorsearch_data_object_basic
+    primary_resource_id: example-data-object
+    steps:
+      - name: vectorsearch_data_object_basic
+        resource_id_vars:
+          data_object_id: example-data-object
+          collection_id: example-collection
+  - name: vectorsearch_data_object_with_vectors
+    primary_resource_id: example-vectors-data-object
+    steps:
+      - name: vectorsearch_data_object_with_vectors
+        resource_id_vars:
+          data_object_id: example-vectors-data-object
+          collection_id: example-vectors-collection
+      # Update step: exercises in-place updates of the DataObject's
+      # `data` and `vectors` fields (the only mutable properties on
+      # google_vector_search_data_object).
+      - name: vectorsearch_data_object_with_vectors_update
+        resource_id_vars:
+          data_object_id: example-vectors-data-object
+          collection_id: example-vectors-collection
+parameters:
+  - name: location
+    type: String
+    required: true
+    description: Resource ID segment making up resource `name`. It identifies the resource within its parent collection as described in https://google.aip.dev/122.
+    immutable: true
+    url_param_only: true
+  - name: collectionId
+    type: String
+    required: true
+    description: |-
+      The ID of the parent Collection.
+    immutable: true
+    url_param_only: true
+  - name: dataObjectId
+    type: String
+    required: true
+    description: |-
+      ID of the DataObject to create.
+      The id must be 1-63 characters long, and comply with
+      [RFC1035](https://www.ietf.org/rfc/rfc1035.txt).
+      Specifically, it must be 1-63 characters long and match the regular
+      expression `[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?`.
+    immutable: true
+    url_param_only: true
+properties:
+  - name: name
+    type: String
+    description: Identifier. name of resource
+    output: true
+  - name: createTime
+    type: String
+    description: '[Output only] Create time stamp'
+    output: true
+  - name: updateTime
+    type: String
+    description: '[Output only] Update time stamp'
+    output: true
+  - name: data
+    type: String
+    description: |-
+      The JSON data of the DataObject. Must be a JSON object whose field
+      names match the fields defined in the parent Collection's
+      `data_schema`.
+    state_func: func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }
+    custom_flatten: templates/terraform/custom_flatten/json_schema.tmpl
+    custom_expand: templates/terraform/custom_expand/json_schema.tmpl
+    validation:
+      function: validation.StringIsJSON
+  - name: vectors
+    type: Map
+    key_name: field_name
+    default_from_api: true
+    description: |-
+      The vectors of the DataObject, keyed by the vector field name as
+      defined in the parent Collection's `vector_schema`.
+
+      If a vector field is configured with a `vertex_embedding_config` on
+      the Collection, the server will populate the vector automatically
+      from the corresponding text in `data` and the field should be
+      omitted here.
+    value_type:
+      type: NestedObject
+      properties:
+        - name: dense
+          type: NestedObject
+          description: A dense vector.
+          conflicts:
+            - sparse
+          properties:
+            - name: values
+              type: Array
+              required: true
+              description: The float values of the dense vector.
+              item_type:
+                type: Double
+        - name: sparse
+          type: NestedObject
+          description: A sparse vector.
+          conflicts:
+            - dense
+          properties:
+            - name: values
+              type: Array
+              required: true
+              description: The non-zero float values of the sparse vector.
+              item_type:
+                type: Double
+            - name: indices
+              type: Array
+              required: true
+              description: |-
+                The indices corresponding to the entries in `values`. Must
+                have the same length as `values`.
+              item_type:
+                type: Integer
+  - name: etag
+    type: String
+    description: |-
+      The etag of the DataObject, used for optimistic concurrency
+      control on updates and deletes.
+    default_from_api: true

--- a/mmv1/products/vectorsearch/DataObject.yaml
+++ b/mmv1/products/vectorsearch/DataObject.yaml
@@ -18,11 +18,25 @@ description: |-
   Vector Search Collection. Each DataObject conforms to the parent
   Collection's `data_schema` and `vector_schema`.
 
-  For large datasets, prefer bulk ingestion via the `importDataObjects`
-  API before any Index is created on the Collection: once an Index exists,
-  `importDataObjects` is no longer available and DataObjects must be
-  created one at a time (as this resource does) or in small online
-  batches.
+  This resource always issues one `CreateDataObject` request per Terraform
+  resource block. It does NOT use the `batchCreate` REST endpoint --
+  Terraform's resource lifecycle is inherently per-object, so batching
+  across resources is not modeled. When you use `for_each` or `count`,
+  Terraform will still issue individual requests, up to `-parallelism`
+  in parallel.
+
+  For ingesting more than a few hundred items, prefer one of the
+  following out-of-band paths instead of Terraform:
+
+    * `importDataObjects` (bulk ingest from Cloud Storage) -- highest
+      throughput, but only available *before* any Index is created on
+      the Collection.
+    * `batchCreate` (up to ~1000 items per call) -- available at any
+      time, but must be driven from your own client code, not Terraform.
+
+  Once an Index exists on the Collection, `importDataObjects` is no
+  longer available and DataObjects must be created via `CreateDataObject`
+  (as this resource does) or via `batchCreate`.
 base_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects
 self_link: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects/{{data_object_id}}
 create_url: projects/{{project}}/locations/{{location}}/collections/{{collection_id}}/dataObjects?dataObjectId={{data_object_id}}

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_basic.tf.tmpl
@@ -1,8 +1,14 @@
-# NOTE: For large datasets we recommend bulk ingestion via the
-# `importDataObjects` API on the Collection *before* creating any Index.
-# Once an Index exists on the Collection, `importDataObjects` is no
-# longer available and DataObjects must be created individually (as this
-# resource does) or in small online batches.
+# NOTE: This resource issues one CreateDataObject request per block.
+# It does NOT batch across resources. Terraform will parallelize a
+# 'for_each' up to '-parallelism', but each item is still a separate
+# HTTP call.
+#
+# For bulk ingestion of many items, prefer one of these out-of-band
+# paths instead of Terraform:
+#   * 'importDataObjects' (from Cloud Storage) -- highest throughput,
+#     but only available *before* any Index is created on the Collection.
+#   * 'batchCreate' (up to ~1000 items per call) -- available at any
+#     time, but must be driven from client code, not Terraform.
 resource "google_vector_search_collection" "parent" {
   location      = "us-central1"
   collection_id = "{{index $.ResourceIdVars "collection_id"}}"
@@ -37,10 +43,10 @@ EOF
   }
 }
 
-# Because the parent Collection's `text_embedding` field is configured
-# with a `vertex_embedding_config`, the server will populate the vector
-# automatically from `data.title` and `data.plot` -- no explicit
-# `vectors` block is required.
+# Because the parent Collection's 'text_embedding' field is configured
+# with a 'vertex_embedding_config', the server will populate the vector
+# automatically from 'data.title' and 'data.plot' -- no explicit
+# 'vectors' block is required.
 resource "google_vector_search_data_object" "{{$.PrimaryResourceId}}" {
   location       = "us-central1"
   collection_id  = google_vector_search_collection.parent.collection_id

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_basic.tf.tmpl
@@ -1,0 +1,53 @@
+# NOTE: For large datasets we recommend bulk ingestion via the
+# `importDataObjects` API on the Collection *before* creating any Index.
+# Once an Index exists on the Collection, `importDataObjects` is no
+# longer available and DataObjects must be created individually (as this
+# resource does) or in small online batches.
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "{{index $.ResourceIdVars "collection_id"}}"
+
+  display_name = "My Awesome Collection"
+  description  = "This collection stores important data."
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "plot": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  vector_schema {
+    field_name = "text_embedding"
+    dense_vector {
+      dimensions = 768
+      vertex_embedding_config {
+        model_id      = "text-embedding-005"
+        task_type     = "RETRIEVAL_DOCUMENT"
+        text_template = "Title: {title} ---- Plot: {plot}"
+      }
+    }
+  }
+}
+
+# Because the parent Collection's `text_embedding` field is configured
+# with a `vertex_embedding_config`, the server will populate the vector
+# automatically from `data.title` and `data.plot` -- no explicit
+# `vectors` block is required.
+resource "google_vector_search_data_object" "{{$.PrimaryResourceId}}" {
+  location       = "us-central1"
+  collection_id  = google_vector_search_collection.parent.collection_id
+  data_object_id = "{{index $.ResourceIdVars "data_object_id"}}"
+
+  data = jsonencode({
+    title = "The Matrix"
+    plot  = "A computer hacker learns about the true nature of reality."
+  })
+}

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors.tf.tmpl
@@ -1,8 +1,14 @@
-# NOTE: For large datasets we recommend bulk ingestion via the
-# `importDataObjects` API on the Collection *before* creating any Index.
-# Once an Index exists on the Collection, `importDataObjects` is no
-# longer available and DataObjects must be created individually (as this
-# resource does) or in small online batches.
+# NOTE: This resource issues one CreateDataObject request per block.
+# It does NOT batch across resources. Terraform will parallelize a
+# 'for_each' up to '-parallelism', but each item is still a separate
+# HTTP call.
+#
+# For bulk ingestion of many items, prefer one of these out-of-band
+# paths instead of Terraform:
+#   * 'importDataObjects' (from Cloud Storage) -- highest throughput,
+#     but only available *before* any Index is created on the Collection.
+#   * 'batchCreate' (up to ~1000 items per call) -- available at any
+#     time, but must be driven from client code, not Terraform.
 resource "google_vector_search_collection" "parent" {
   location      = "us-central1"
   collection_id = "{{index $.ResourceIdVars "collection_id"}}"

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors.tf.tmpl
@@ -1,0 +1,66 @@
+# NOTE: For large datasets we recommend bulk ingestion via the
+# `importDataObjects` API on the Collection *before* creating any Index.
+# Once an Index exists on the Collection, `importDataObjects` is no
+# longer available and DataObjects must be created individually (as this
+# resource does) or in small online batches.
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "{{index $.ResourceIdVars "collection_id"}}"
+
+  display_name = "My BYO-Embedding Collection"
+  description  = "Collection whose vectors are supplied by the client."
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  # Two vector fields, both without vertex_embedding_config -- the client
+  # (this Terraform config) is responsible for supplying vector values on
+  # each DataObject.
+  vector_schema {
+    field_name = "dense_embedding"
+    dense_vector {
+      dimensions = 4
+    }
+  }
+  vector_schema {
+    field_name = "sparse_embedding"
+    sparse_vector {}
+  }
+}
+
+resource "google_vector_search_data_object" "{{$.PrimaryResourceId}}" {
+  location       = "us-central1"
+  collection_id  = google_vector_search_collection.parent.collection_id
+  data_object_id = "{{index $.ResourceIdVars "data_object_id"}}"
+
+  data = jsonencode({
+    title    = "The Matrix"
+    category = "movie"
+  })
+
+  vectors {
+    field_name = "dense_embedding"
+    dense {
+      values = [0.11, 0.22, 0.33, 0.44]
+    }
+  }
+
+  vectors {
+    field_name = "sparse_embedding"
+    sparse {
+      values  = [0.9, 0.5, 0.1]
+      indices = [3, 17, 42]
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors_update.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vectorsearch/vectorsearch_data_object_with_vectors_update.tf.tmpl
@@ -1,0 +1,77 @@
+# NOTE: This resource issues one CreateDataObject request per block.
+# It does NOT batch across resources. Terraform will parallelize a
+# 'for_each' up to '-parallelism', but each item is still a separate
+# HTTP call.
+#
+# For bulk ingestion of many items, prefer one of these out-of-band
+# paths instead of Terraform:
+#   * 'importDataObjects' (from Cloud Storage) -- highest throughput,
+#     but only available *before* any Index is created on the Collection.
+#   * 'batchCreate' (up to ~1000 items per call) -- available at any
+#     time, but must be driven from client code, not Terraform.
+resource "google_vector_search_collection" "parent" {
+  location      = "us-central1"
+  collection_id = "{{index $.ResourceIdVars "collection_id"}}"
+
+  display_name = "My BYO-Embedding Collection"
+  description  = "Collection whose vectors are supplied by the client."
+
+  data_schema = <<EOF
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "category": {
+      "type": "string"
+    }
+  }
+}
+EOF
+
+  # Two vector fields, both without vertex_embedding_config -- the client
+  # (this Terraform config) is responsible for supplying vector values on
+  # each DataObject.
+  vector_schema {
+    field_name = "dense_embedding"
+    dense_vector {
+      dimensions = 4
+    }
+  }
+  vector_schema {
+    field_name = "sparse_embedding"
+    sparse_vector {}
+  }
+}
+
+# Update step: exercises in-place updates of the two mutable fields on
+# google_vector_search_data_object -- 'data' and 'vectors'. Both fields
+# above are changed relative to the create step. The identity fields
+# (location, collection_id, data_object_id) are unchanged so this is an
+# update, not a replace.
+resource "google_vector_search_data_object" "{{$.PrimaryResourceId}}" {
+  location       = "us-central1"
+  collection_id  = google_vector_search_collection.parent.collection_id
+  data_object_id = "{{index $.ResourceIdVars "data_object_id"}}"
+
+  data = jsonencode({
+    title    = "The Matrix Reloaded"
+    category = "sequel"
+  })
+
+  vectors {
+    field_name = "dense_embedding"
+    dense {
+      values = [0.55, 0.66, 0.77, 0.88]
+    }
+  }
+
+  vectors {
+    field_name = "sparse_embedding"
+    sparse {
+      values  = [0.4, 0.3, 0.2, 0.1]
+      indices = [1, 5, 9, 13]
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces support for the Vector Search Data Object feature. This allows users to manage Vector Search Data Objects declaratively using Terraform.

API reference: https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/vector-search-2/reference/rest/v1/projects.locations.collections.dataObjects/create

```release-note:new-resource
`google_vector_search_data_object`
```
