### PR TITLE
Routine tvf submission

### DIFF
--- a/mmv1/products/bigquery/Routine.yaml
+++ b/mmv1/products/bigquery/Routine.yaml
@@ -149,6 +149,7 @@ properties:
           enum_values:
             - 'FIXED_TYPE'
             - 'ANY_TYPE'
+            - 'FIXED_TABLE'
         - name: 'mode'
           type: Enum
           description: |
@@ -175,6 +176,31 @@ properties:
           custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
           validation:
             function: 'validation.StringIsJSON'
+        - name: 'tableType'
+          type: NestedObject
+          description: |
+            If argumentKind is FIXED_TABLE, a schema for the table type.
+          properties:
+            - name: 'columns'
+              type: Array
+              description: |
+                The columns in the table type.
+              item_type:
+                type: NestedObject
+                properties:
+                  - name: 'name'
+                    type: String
+                    description: |
+                      The name of the column.
+                  - name: 'type'
+                    type: String
+                    description: |
+                      A JSON schema for the data type of the column.
+                    state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
+                    custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
+                    custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'
+                    validation:
+                      function: 'validation.StringIsJSON'
   - name: 'returnType'
     type: String
     description: |

--- a/mmv1/products/bigquery/Routine.yaml
+++ b/mmv1/products/bigquery/Routine.yaml
@@ -49,6 +49,12 @@ examples:
     vars:
       dataset_id: 'dataset_id'
       routine_id: 'routine_id'
+  - name: 'bigquery_routine_table_type'
+    primary_resource_id: 'sproc'
+    primary_resource_name: 'fmt.Sprintf("tf_test_dataset_id%s", context["random_suffix"]), fmt.Sprintf("tf_test_table_id%s", context["random_suffix"])'
+    vars:
+      dataset_id: 'dataset_id'
+      routine_id: 'routine_id'
   - name: 'bigquery_routine_pyspark'
     primary_resource_id: 'pyspark'
     vars:
@@ -195,7 +201,13 @@ properties:
                   - name: 'type'
                     type: String
                     description: |
-                      A JSON schema for the data type of the column.
+                      A JSON schema for the data type of the column.Required unless argumentKind = ANY_TYPE.
+                      ~>**NOTE**: Because this field expects a JSON string, any changes to the string
+                      will create a diff, even if the JSON itself hasn't changed. If the API returns
+                      a different value for the same schema, e.g. it switched the order of values
+                      or replaced STRUCT field type with RECORD field type, we currently cannot
+                      suppress the recurring diff this causes. As a workaround, we recommend using
+                      the schema as returned by the API.
                     state_func: 'func(v interface{}) string { s, _ := structure.NormalizeJsonString(v); return s }'
                     custom_flatten: 'templates/terraform/custom_flatten/json_schema.tmpl'
                     custom_expand: 'templates/terraform/custom_expand/json_schema.tmpl'

--- a/mmv1/products/bigquery/Routine.yaml
+++ b/mmv1/products/bigquery/Routine.yaml
@@ -201,7 +201,7 @@ properties:
                   - name: 'type'
                     type: String
                     description: |
-                      A JSON schema for the data type of the column.Required unless argumentKind = ANY_TYPE.
+                      A JSON schema for the data type of the column. Required unless argumentKind = ANY_TYPE.
                       ~>**NOTE**: Because this field expects a JSON string, any changes to the string
                       will create a diff, even if the JSON itself hasn't changed. If the API returns
                       a different value for the same schema, e.g. it switched the order of values

--- a/mmv1/templates/terraform/examples/bigquery_routine_table_type.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_routine_table_type.tf.tmpl
@@ -1,0 +1,23 @@
+resource "google_bigquery_dataset" "test" {
+	dataset_id = "{{index $.Vars "dataset_id"}}"
+}
+
+resource "google_bigquery_routine" "sproc" {
+  dataset_id      = google_bigquery_dataset.test.dataset_id
+  routine_id      = "{{index $.Vars "routine_id"}}"
+  routine_type    = "TABLE_VALUED_FUNCTION"
+  language        = "SQL"
+  description     = "Gets every row from a table."
+  definition_body = "SELECT * FROM t1"
+
+  arguments {
+    name          = "t1"
+    argument_kind = "FIXED_TABLE"
+    table_type {
+      columns {
+        name = "year"
+        type = jsonencode({ "typeKind" : "INT64" })
+      }
+    }
+  }
+}

--- a/mmv1/templates/terraform/examples/bigquery_routine_table_type.tf.tmpl
+++ b/mmv1/templates/terraform/examples/bigquery_routine_table_type.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_bigquery_dataset" "test" {
-	dataset_id = "{{index $.Vars "dataset_id"}}"
+  dataset_id = "{{index $.Vars "dataset_id"}}"
 }
 
 resource "google_bigquery_routine" "sproc" {

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_routine_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_routine_test.go
@@ -379,7 +379,7 @@ func TestAccBigQueryRoutine_bigqueryRoutineTableTypeUpdate(t *testing.T) {
 func testAccBigQueryRoutine_bigqueryRoutineTableTypeUpdate(context map[string]interface{}) string {
 	return acctest.Nprintf(`
 resource "google_bigquery_dataset" "test" {
-	dataset_id = "tf_test_dataset_id%{random_suffix}"
+  dataset_id = "tf_test_dataset_id%{random_suffix}"
 }
 
 resource "google_bigquery_routine" "sproc" {
@@ -398,7 +398,7 @@ resource "google_bigquery_routine" "sproc" {
         name = "year1"
         type = jsonencode({ "typeKind" : "INT64" })
       }
-        columns {
+      columns {
         name = "year2"
         type = jsonencode({ "typeKind" : "INT64" })
       }

--- a/mmv1/third_party/terraform/services/bigquery/resource_bigquery_routine_test.go
+++ b/mmv1/third_party/terraform/services/bigquery/resource_bigquery_routine_test.go
@@ -364,7 +364,7 @@ func TestAccBigQueryRoutine_bigqueryRoutineTableTypeUpdate(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-      {
+			{
 				Config: testAccBigQueryRoutine_bigqueryRoutineTableTypeUpdate(context),
 			},
 			{


### PR DESCRIPTION
To support Table Parameterized TVFs through Terraform, a TableType field was introduced and a enum field for argumentKind as "FIXED_TABLE".

```release-note:enhancement
bigquery: added `table_type` field to `google_bigquery_routine` resource
```