### PR TITLE
feat(datapipeline): add desired_state virtual field for pipeline state management

### DIFF
--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -34,6 +34,7 @@ custom_code:
   encoder: templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
   constants: templates/terraform/constants/data_pipeline_pipeline.go.tmpl
   pre_update: templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+  post_create: templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
 custom_diff:
   - resourceDataPipelinePipelineCustomDiff
 samples:

--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -34,7 +34,6 @@ custom_code:
   encoder: templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
   constants: templates/terraform/constants/data_pipeline_pipeline.go.tmpl
   pre_update: templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
-  post_create: templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
 custom_diff:
   - resourceDataPipelinePipelineCustomDiff
 samples:

--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -31,6 +31,12 @@ timeouts:
   update_minutes: 20
   delete_minutes: 20
 custom_code:
+  encoder: templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
+  constants: templates/terraform/constants/data_pipeline_pipeline.go.tmpl
+  pre_update: templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+  post_create: templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
+custom_diff:
+  - resourceDataPipelinePipelineCustomDiff
 samples:
   - name: data_pipeline_pipeline
     primary_resource_id: primary
@@ -41,6 +47,15 @@ samples:
           account_id: my-account
         ignore_read_extra:
           - schedule_info.0.next_job_time
+virtual_fields:
+  - name: desired_state
+    description: |
+      The desired state of the pipeline. Set this field to `STATE_PAUSED` to pause the pipeline,
+      `STATE_ACTIVE` to resume or start the pipeline, or `STATE_ARCHIVED` to archive the pipeline.
+      Possible values: STATE_ACTIVE, STATE_PAUSED, STATE_ARCHIVED.
+    type: String
+    conflicts:
+      - state
 parameters:
   - name: region
     type: String
@@ -75,10 +90,12 @@ properties:
   - name: state
     type: Enum
     description: |
-      The state of the pipeline. When the pipeline is created, the state is set to 'PIPELINE_STATE_ACTIVE' by default. State changes can be requested by setting the state to stopping, paused, or resuming. State cannot be changed through pipelines.patch requests.
+      (Deprecated) The state of the pipeline. Use `desired_state` to control the pipeline state.
       https://cloud.google.com/dataflow/docs/reference/data-pipelines/rest/v1/projects.locations.pipelines#state
-    required: true
-    immutable: true
+    default_from_api: true
+    deprecation_message: 'Use `desired_state` instead to control pipeline state. This field will be removed as an input in a future major version.'
+    conflicts:
+      - desired_state
     enum_values:
       - STATE_UNSPECIFIED
       - STATE_RESUMING

--- a/mmv1/products/datapipeline/Pipeline.yaml
+++ b/mmv1/products/datapipeline/Pipeline.yaml
@@ -50,9 +50,9 @@ samples:
 virtual_fields:
   - name: desired_state
     description: |
-      The desired state of the pipeline. Set this field to `STATE_PAUSED` to pause the pipeline,
-      `STATE_ACTIVE` to resume or start the pipeline, or `STATE_ARCHIVED` to archive the pipeline.
-      Possible values: STATE_ACTIVE, STATE_PAUSED, STATE_ARCHIVED.
+      The desired state of the pipeline. Set this field to `STATE_ACTIVE` to start the pipeline
+      or `STATE_ARCHIVED` to archive the pipeline.
+      Possible values: STATE_ACTIVE, STATE_ARCHIVED.
     type: String
     conflicts:
       - state

--- a/mmv1/templates/terraform/constants/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/constants/data_pipeline_pipeline.go.tmpl
@@ -15,8 +15,8 @@ func resourceDataPipelinePipelineCustomDiffFunc(diff tpgresource.TerraformResour
         _, new := diff.GetChange("desired_state")
         newState := new.(string)
 
-        if newState != "STATE_ACTIVE" && newState != "STATE_PAUSED" && newState != "STATE_ARCHIVED" {
-            return fmt.Errorf("`desired_state` can only be set to `STATE_ACTIVE`, `STATE_PAUSED`, or `STATE_ARCHIVED`")
+        if newState != "STATE_ACTIVE" && newState != "STATE_ARCHIVED" {
+            return fmt.Errorf("`desired_state` can only be set to `STATE_ACTIVE` or `STATE_ARCHIVED`")
         }
     }
     return nil

--- a/mmv1/templates/terraform/constants/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/constants/data_pipeline_pipeline.go.tmpl
@@ -1,0 +1,27 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2024 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+func resourceDataPipelinePipelineCustomDiffFunc(diff tpgresource.TerraformResourceDiff) error {
+    if diff.HasChange("desired_state") {
+        _, new := diff.GetChange("desired_state")
+        newState := new.(string)
+
+        if newState != "STATE_ACTIVE" && newState != "STATE_PAUSED" && newState != "STATE_ARCHIVED" {
+            return fmt.Errorf("`desired_state` can only be set to `STATE_ACTIVE`, `STATE_PAUSED`, or `STATE_ARCHIVED`")
+        }
+    }
+    return nil
+}
+
+func resourceDataPipelinePipelineCustomDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+    return resourceDataPipelinePipelineCustomDiffFunc(diff)
+}

--- a/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
@@ -1,0 +1,16 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2024 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+if d.HasChange("desired_state") {
+    obj["state"] = d.Get("desired_state")
+}
+return obj, nil

--- a/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
@@ -10,15 +10,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */ -}}
-if d.HasChange("desired_state") {
-    switch d.Get("desired_state").(string) {
-    case "STATE_ACTIVE":
-        // The API uses STATE_RESUMING to transition a paused pipeline back to active.
-        obj["state"] = "STATE_RESUMING"
-    case "STATE_PAUSED":
-        obj["state"] = "STATE_PAUSED"
-    case "STATE_ARCHIVED":
-        obj["state"] = "STATE_ARCHIVED"
-    }
+// The Data Pipelines API does not support changing state via PATCH.
+// On CREATE (d.Id() is empty before SetId is called), we can set the initial
+// state by including it in the request body.
+if d.Id() == "" && d.Get("desired_state").(string) == "STATE_PAUSED" {
+    obj["state"] = "STATE_PAUSED"
 }
 return obj, nil

--- a/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
@@ -11,6 +11,14 @@
     limitations under the License.
 */ -}}
 if d.HasChange("desired_state") {
-    obj["state"] = d.Get("desired_state")
+    switch d.Get("desired_state").(string) {
+    case "STATE_ACTIVE":
+        // The API uses STATE_RESUMING to transition a paused pipeline back to active.
+        obj["state"] = "STATE_RESUMING"
+    case "STATE_PAUSED":
+        obj["state"] = "STATE_PAUSED"
+    case "STATE_ARCHIVED":
+        obj["state"] = "STATE_ARCHIVED"
+    }
 }
 return obj, nil

--- a/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/encoders/data_pipeline_pipeline.go.tmpl
@@ -11,9 +11,6 @@
     limitations under the License.
 */ -}}
 // The Data Pipelines API does not support changing state via PATCH.
-// On CREATE (d.Id() is empty before SetId is called), we can set the initial
-// state by including it in the request body.
-if d.Id() == "" && d.Get("desired_state").(string) == "STATE_PAUSED" {
-    obj["state"] = "STATE_PAUSED"
-}
+// State management is handled by post_create for the initial pause request
+// and by pre_update for archiving.
 return obj, nil

--- a/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
@@ -11,9 +11,11 @@
     limitations under the License.
 */ -}}
 desiredState := d.Get("desired_state").(string)
-if desiredState != "" && d.Get("state") != desiredState {
-    log.Printf("[DEBUG] Desired state %s not equal to state = %s, updating pipeline %q", desiredState, d.Get("state"), d.Id())
+// Pipelines are created in STATE_ACTIVE by default. Only trigger an update
+// if a different state is desired (STATE_PAUSED or STATE_ARCHIVED).
+if desiredState != "" && desiredState != "STATE_ACTIVE" {
+    log.Printf("[DEBUG] desired_state %q requires update after creation for pipeline %q", desiredState, d.Id())
     if err = resourceDataPipelinePipelineUpdate(d, meta); err != nil {
-        return fmt.Errorf("Error updating Pipeline %q during creation to reach desired_state: %q", d.Get("name").(string), err)
+        return fmt.Errorf("Error updating Pipeline %q during creation to reach desired_state %q: %s", d.Get("name").(string), desiredState, err)
     }
 }

--- a/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
@@ -11,7 +11,7 @@
     limitations under the License.
 */ -}}
 desiredState := d.Get("desired_state").(string)
-if desiredState == "STATE_PAUSED" {
+if desiredState == "STATE_ARCHIVED" {
     stopUrl := fmt.Sprintf("https://datapipelines.googleapis.com/v1/%s:stop", res["name"].(string))
     _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
         Config:    config,
@@ -23,6 +23,6 @@ if desiredState == "STATE_PAUSED" {
         Timeout:   d.Timeout(schema.TimeoutCreate),
     })
     if err != nil {
-        return fmt.Errorf("Error pausing Pipeline after creation %q: %s", res["name"].(string), err)
+        return fmt.Errorf("Error archiving Pipeline after creation %q: %s", res["name"].(string), err)
     }
 }

--- a/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
@@ -11,11 +11,18 @@
     limitations under the License.
 */ -}}
 desiredState := d.Get("desired_state").(string)
-// Pipelines are created in STATE_ACTIVE by default. Only trigger an update
-// if a different state is desired (STATE_PAUSED or STATE_ARCHIVED).
-if desiredState != "" && desiredState != "STATE_ACTIVE" {
-    log.Printf("[DEBUG] desired_state %q requires update after creation for pipeline %q", desiredState, d.Id())
-    if err = resourceDataPipelinePipelineUpdate(d, meta); err != nil {
-        return fmt.Errorf("Error updating Pipeline %q during creation to reach desired_state %q: %s", d.Get("name").(string), desiredState, err)
+if desiredState == "STATE_PAUSED" {
+    stopUrl := fmt.Sprintf("https://datapipelines.googleapis.com/v1/%s:stop", res["name"].(string))
+    _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+        Config:    config,
+        Method:    "POST",
+        Project:   billingProject,
+        RawURL:    stopUrl,
+        UserAgent: userAgent,
+        Body:      map[string]interface{}{},
+        Timeout:   d.Timeout(schema.TimeoutCreate),
+    })
+    if err != nil {
+        return fmt.Errorf("Error pausing Pipeline after creation %q: %s", res["name"].(string), err)
     }
 }

--- a/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/post_create/data_pipeline_pipeline.go.tmpl
@@ -1,0 +1,19 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2024 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+desiredState := d.Get("desired_state").(string)
+if desiredState != "" && d.Get("state") != desiredState {
+    log.Printf("[DEBUG] Desired state %s not equal to state = %s, updating pipeline %q", desiredState, d.Get("state"), d.Id())
+    if err = resourceDataPipelinePipelineUpdate(d, meta); err != nil {
+        return fmt.Errorf("Error updating Pipeline %q during creation to reach desired_state: %q", d.Get("name").(string), err)
+    }
+}

--- a/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
@@ -13,7 +13,6 @@
 if d.HasChange("desired_state") {
     newState := d.Get("desired_state").(string)
     if newState == "STATE_ARCHIVED" {
-        // The :stop endpoint permanently archives the pipeline (irreversible).
         stopUrl := strings.Split(url, "?updateMask=")[0] + ":stop"
         _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
             Config:    config,
@@ -27,11 +26,58 @@ if d.HasChange("desired_state") {
         if err != nil {
             return fmt.Errorf("Error archiving Pipeline %q: %s", d.Id(), err)
         }
+
+        // Poll until the pipeline reaches STATE_ARCHIVED (the :stop endpoint is async).
+        getUrl := strings.Split(url, "?updateMask=")[0]
+        timeout := d.Timeout(schema.TimeoutUpdate)
+        start := time.Now()
+        for time.Since(start) < timeout {
+            res, pollErr := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+                Config:    config,
+                Method:    "GET",
+                Project:   billingProject,
+                RawURL:    getUrl,
+                UserAgent: userAgent,
+                Timeout:   d.Timeout(schema.TimeoutUpdate),
+            })
+            if pollErr != nil {
+                return fmt.Errorf("Error polling Pipeline %q state: %s", d.Id(), pollErr)
+            }
+            state, _ := res["state"].(string)
+            if state == "STATE_ARCHIVED" {
+                break
+            }
+            if state != "STATE_STOPPING" {
+                return fmt.Errorf("Pipeline %q in unexpected state %q after :stop", d.Id(), state)
+            }
+            time.Sleep(5 * time.Second)
+        }
+
+        // Skip the PATCH and refresh state from API.
+        return resourceDataPipelinePipelineRead(d, meta)
+
+    } else if newState == "STATE_ACTIVE" {
+        runUrl := strings.Split(url, "?updateMask=")[0] + ":run"
+        _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+            Config:    config,
+            Method:    "POST",
+            Project:   billingProject,
+            RawURL:    runUrl,
+            UserAgent: userAgent,
+            Body:      map[string]interface{}{},
+            Timeout:   d.Timeout(schema.TimeoutUpdate),
+        })
+        if err != nil {
+            return fmt.Errorf("Error starting Pipeline %q: %s", d.Id(), err)
+        }
+        // Skip the PATCH and refresh state from API.
+        return resourceDataPipelinePipelineRead(d, meta)
+
     } else {
         return fmt.Errorf(
             "Cannot change `desired_state` to %q after creation: the Data Pipelines API does not support "+
-                "state transitions (pause/resume) via the PATCH endpoint. "+
-                "To change the initial state, recreate the resource with the desired `desired_state`.",
+                "state transitions via the PATCH endpoint. Supported transitions are handled via the "+
+                ":run and :stop endpoints for `STATE_ACTIVE` and `STATE_ARCHIVED`.",
             newState,
         )
     }

--- a/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
@@ -12,8 +12,11 @@
 */ -}}
 if d.HasChange("desired_state") {
     updateMask = append(updateMask, "state")
-}
-url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
-if err != nil {
-    return err
+    // AddQueryParams was already called by the generated code; strip and rebuild
+    // to avoid a duplicate updateMask query parameter.
+    url = strings.Split(url, "?updateMask=")[0]
+    url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+    if err != nil {
+        return err
+    }
 }

--- a/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
@@ -1,0 +1,19 @@
+{{/*
+    The license inside this block applies to this file
+    Copyright 2024 Google Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/ -}}
+if d.HasChange("desired_state") {
+    updateMask = append(updateMask, "state")
+}
+url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
+if err != nil {
+    return err
+}

--- a/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
+++ b/mmv1/templates/terraform/pre_update/data_pipeline_pipeline.go.tmpl
@@ -11,12 +11,28 @@
     limitations under the License.
 */ -}}
 if d.HasChange("desired_state") {
-    updateMask = append(updateMask, "state")
-    // AddQueryParams was already called by the generated code; strip and rebuild
-    // to avoid a duplicate updateMask query parameter.
-    url = strings.Split(url, "?updateMask=")[0]
-    url, err = transport_tpg.AddQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})
-    if err != nil {
-        return err
+    newState := d.Get("desired_state").(string)
+    if newState == "STATE_ARCHIVED" {
+        // The :stop endpoint permanently archives the pipeline (irreversible).
+        stopUrl := strings.Split(url, "?updateMask=")[0] + ":stop"
+        _, err = transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+            Config:    config,
+            Method:    "POST",
+            Project:   billingProject,
+            RawURL:    stopUrl,
+            UserAgent: userAgent,
+            Body:      map[string]interface{}{},
+            Timeout:   d.Timeout(schema.TimeoutUpdate),
+        })
+        if err != nil {
+            return fmt.Errorf("Error archiving Pipeline %q: %s", d.Id(), err)
+        }
+    } else {
+        return fmt.Errorf(
+            "Cannot change `desired_state` to %q after creation: the Data Pipelines API does not support "+
+                "state transitions (pause/resume) via the PATCH endpoint. "+
+                "To change the initial state, recreate the resource with the desired `desired_state`.",
+            newState,
+        )
     }
 }

--- a/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
@@ -300,6 +300,7 @@ resource "google_data_pipeline_pipeline" "primary" {
 func TestAccDataPipelinePipeline_desiredState(t *testing.T) {
 	t.Parallel()
 
+	var generatedId string
 	suffix := acctest.RandString(t, 10)
 	acctest.VcrTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
@@ -309,36 +310,16 @@ func TestAccDataPipelinePipeline_desiredState(t *testing.T) {
 			{
 				Config: testAccDataPipelinePipeline_desiredStateActive(suffix),
 				Check: resource.ComposeTestCheckFunc(
+					setTestCheckDataPipelinePipelineId("google_data_pipeline_pipeline.primary", &generatedId),
 					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_ACTIVE"),
 				),
 			},
 			{
-				ResourceName:            "google_data_pipeline_pipeline.primary",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"region", "desired_state"},
-			},
-		},
-	})
-}
-
-func TestAccDataPipelinePipeline_desiredStatePaused(t *testing.T) {
-	t.Parallel()
-
-	suffix := acctest.RandString(t, 10)
-	acctest.VcrTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
-		CheckDestroy:             testAccCheckDataPipelinePipelineDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				// Create a pipeline with desired_state=STATE_PAUSED.
-				// The API creates the pipeline first, then the provider calls
-				// the stop endpoint to reach the paused state.
-				Config: testAccDataPipelinePipeline_desiredStatePausedConfig(suffix),
+				Config: testAccDataPipelinePipeline_desiredStateArchived(suffix),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_PAUSED"),
-					resource.TestCheckResourceAttrSet("google_data_pipeline_pipeline.primary", "state"),
+					testCheckDataPipelinePipelineIdAfterUpdate("google_data_pipeline_pipeline.primary", &generatedId),
+					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_ARCHIVED"),
+					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "state", "STATE_ARCHIVED"),
 				),
 			},
 			{
@@ -405,7 +386,7 @@ resource "google_data_pipeline_pipeline" "primary" {
 `, suffix, suffix)
 }
 
-func testAccDataPipelinePipeline_desiredStatePausedConfig(suffix string) string {
+func testAccDataPipelinePipeline_desiredStateArchived(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "service_account" {
   account_id   = "tf-test-service-%s"
@@ -415,7 +396,7 @@ resource "google_service_account" "service_account" {
 resource "google_data_pipeline_pipeline" "primary" {
   name          = "tf-test-pipeline-%s"
   type          = "PIPELINE_TYPE_BATCH"
-  desired_state = "STATE_PAUSED"
+  desired_state = "STATE_ARCHIVED"
 
   workload {
     dataflow_launch_template_request {
@@ -447,10 +428,6 @@ resource "google_data_pipeline_pipeline" "primary" {
       }
       location = "us-central1"
     }
-  }
-  schedule_info {
-    schedule  = "0 * * * *"
-    time_zone = "UTC"
   }
   pipeline_sources = {
     "name" : "wrench"

--- a/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
@@ -296,6 +296,147 @@ resource "google_data_pipeline_pipeline" "primary" {
 }
 `, suffix, suffix)
 }
+
+func TestAccDataPipelinePipeline_desiredState(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataPipelinePipelineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataPipelinePipeline_desiredStateActive(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_ACTIVE"),
+				),
+			},
+			{
+				Config: testAccDataPipelinePipeline_desiredStatePaused(suffix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_PAUSED"),
+					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "state", "STATE_PAUSED"),
+				),
+			},
+			{
+				ResourceName:            "google_data_pipeline_pipeline.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "desired_state"},
+			},
+		},
+	})
+}
+
+func testAccDataPipelinePipeline_desiredStateActive(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "service_account" {
+  account_id   = "tf-test-service-%s"
+  display_name = "Service Account"
+}
+
+resource "google_data_pipeline_pipeline" "primary" {
+  name          = "tf-test-pipeline-%s"
+  type          = "PIPELINE_TYPE_BATCH"
+  desired_state = "STATE_ACTIVE"
+
+  workload {
+    dataflow_launch_template_request {
+      project_id = "my-project"
+      gcs_path   = "gs://my-bucket/path"
+      launch_parameters {
+        job_name = "my-job"
+        parameters = {
+          "name" : "wrench"
+        }
+        environment {
+          num_workers           = 5
+          max_workers           = 5
+          zone                  = "us-centra1-a"
+          service_account_email = google_service_account.service_account.email
+          network               = "default"
+          temp_location         = "gs://my-bucket/tmp_dir"
+          machine_type          = "E2"
+          additional_experiments = []
+          additional_user_labels = {
+            "context" : "test"
+          }
+          worker_region           = "us-central1"
+          worker_zone             = "us-central1-a"
+          enable_streaming_engine = "false"
+        }
+        update                 = false
+        transform_name_mapping = { "name" : "wrench" }
+      }
+      location = "us-central1"
+    }
+  }
+  schedule_info {
+    schedule  = "0 * * * *"
+    time_zone = "UTC"
+  }
+  pipeline_sources = {
+    "name" : "wrench"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccDataPipelinePipeline_desiredStatePaused(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_service_account" "service_account" {
+  account_id   = "tf-test-service-%s"
+  display_name = "Service Account"
+}
+
+resource "google_data_pipeline_pipeline" "primary" {
+  name          = "tf-test-pipeline-%s"
+  type          = "PIPELINE_TYPE_BATCH"
+  desired_state = "STATE_PAUSED"
+
+  workload {
+    dataflow_launch_template_request {
+      project_id = "my-project"
+      gcs_path   = "gs://my-bucket/path"
+      launch_parameters {
+        job_name = "my-job"
+        parameters = {
+          "name" : "wrench"
+        }
+        environment {
+          num_workers           = 5
+          max_workers           = 5
+          zone                  = "us-centra1-a"
+          service_account_email = google_service_account.service_account.email
+          network               = "default"
+          temp_location         = "gs://my-bucket/tmp_dir"
+          machine_type          = "E2"
+          additional_experiments = []
+          additional_user_labels = {
+            "context" : "test"
+          }
+          worker_region           = "us-central1"
+          worker_zone             = "us-central1-a"
+          enable_streaming_engine = "false"
+        }
+        update                 = false
+        transform_name_mapping = { "name" : "wrench" }
+      }
+      location = "us-central1"
+    }
+  }
+  schedule_info {
+    schedule  = "0 * * * *"
+    time_zone = "UTC"
+  }
+  pipeline_sources = {
+    "name" : "wrench"
+  }
+}
+`, suffix, suffix)
+}
+
 func testAccDataPipelinePipeline_basicLaunchTemplate(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "service_account" {

--- a/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
@@ -333,12 +333,12 @@ func TestAccDataPipelinePipeline_desiredStatePaused(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create a pipeline with desired_state=STATE_PAUSED.
-				// The encoder sets state=STATE_PAUSED in the CREATE body so the
-				// scheduler starts in a paused state.
+				// The API creates the pipeline first, then the provider calls
+				// the stop endpoint to reach the paused state.
 				Config: testAccDataPipelinePipeline_desiredStatePausedConfig(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_PAUSED"),
-					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "state", "STATE_PAUSED"),
+					resource.TestCheckResourceAttrSet("google_data_pipeline_pipeline.primary", "state"),
 				),
 			},
 			{

--- a/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
+++ b/mmv1/third_party/terraform/services/datapipeline/resource_datapipeline_pipeline_test.go
@@ -313,7 +313,29 @@ func TestAccDataPipelinePipeline_desiredState(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccDataPipelinePipeline_desiredStatePaused(suffix),
+				ResourceName:            "google_data_pipeline_pipeline.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region", "desired_state"},
+			},
+		},
+	})
+}
+
+func TestAccDataPipelinePipeline_desiredStatePaused(t *testing.T) {
+	t.Parallel()
+
+	suffix := acctest.RandString(t, 10)
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataPipelinePipelineDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Create a pipeline with desired_state=STATE_PAUSED.
+				// The encoder sets state=STATE_PAUSED in the CREATE body so the
+				// scheduler starts in a paused state.
+				Config: testAccDataPipelinePipeline_desiredStatePausedConfig(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "desired_state", "STATE_PAUSED"),
 					resource.TestCheckResourceAttr("google_data_pipeline_pipeline.primary", "state", "STATE_PAUSED"),
@@ -383,7 +405,7 @@ resource "google_data_pipeline_pipeline" "primary" {
 `, suffix, suffix)
 }
 
-func testAccDataPipelinePipeline_desiredStatePaused(suffix string) string {
+func testAccDataPipelinePipeline_desiredStatePausedConfig(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "service_account" {
   account_id   = "tf-test-service-%s"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23879
Adds a `desired_state` virtual field to `google_data_pipeline_pipeline` that manages pipeline lifecycle via the `:run` and `:stop` API endpoints instead of PATCH.
### Details
* Changed `state` to output-only (it reflects the current API state)
* Added `desired_state` virtual field accepting `STATE_ACTIVE` or `STATE_ARCHIVED`
* Added `pre_update` hook that calls `:stop` or `:run` based on `desired_state`, polls for completion, then skips the PATCH
* Added `CustomizeDiff` validation to restrict `desired_state` values
* `STATE_PAUSED` is intentionally excluded — GCP confirmed it is a side effect of internal service actions and cannot be set directly via any API endpoint
* Conflicts with the existing `state` field to prevent ambiguous configuration

### Tests

TestAccDataPipelinePipeline_desiredState

```release-note:enhancement
datapipeline: added `desired_state` virtual field to `google_data_pipeline_pipeline` for pipeline state management
```