### PR TITLE
Add inspect_config.min_likelihood_per_info_type field to data_loss_prevention_inspect_template

### DIFF
--- a/mmv1/products/dlp/InspectTemplate.yaml
+++ b/mmv1/products/dlp/InspectTemplate.yaml
@@ -139,6 +139,42 @@ properties:
           - POSSIBLE
           - LIKELY
           - VERY_LIKELY
+      - name: minLikelihoodPerInfoType
+        type: Array
+        description: |
+          Minimum likelihood per infotype. For each infotype, a user can specify a minimum likelihood.
+          The system only returns a finding if its likelihood is above this threshold. If this field
+          is not set, the system uses the InspectConfig min_likelihood.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: infoType
+              type: NestedObject
+              description: |
+                Type of information the likeliness threshold applies to. Only one likelihood per info_type should be provided.
+                If InfoTypeLikelihood does not have an info_type, the configuration fails.
+              properties:
+                - name: name
+                  type: String
+                  description: |
+                    Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
+                    at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                  required: true
+                - name: version
+                  type: String
+                  description: |
+                    Version name for this InfoType.
+            - name: minLikelihood
+              type: Enum
+              description: |
+                Only returns findings equal or above this threshold. See https://cloud.google.com/dlp/docs/likelihood for more info.
+              required: true
+              enum_values:
+                - VERY_UNLIKELY
+                - UNLIKELY
+                - POSSIBLE
+                - LIKELY
+                - VERY_LIKELY
       - name: limits
         type: NestedObject
         description: Configuration to control the number of findings returned.

--- a/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_inspect_template_test.go
+++ b/mmv1/third_party/terraform/services/datalossprevention/resource_data_loss_prevention_inspect_template_test.go
@@ -1334,3 +1334,116 @@ resource "google_data_loss_prevention_inspect_template" "basic" {
 }
 `, context)
 }
+
+func TestAccDataLossPreventionInspectTemplate_dlpInspectTemplate_minLikelihoodPerInfoType(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"project": envvar.GetTestProjectFromEnv(),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckDataLossPreventionInspectTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withMinLikelihoodPerInfoType(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_inspect_template.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withMinLikelihoodPerInfoTypeUpdate(context),
+			},
+			{
+				ResourceName:      "google_data_loss_prevention_inspect_template.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withMinLikelihoodPerInfoType(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+	parent = "projects/%{project}"
+	description = "Description"
+	display_name = "Display"
+
+	inspect_config {
+		info_types {
+			name = "EMAIL_ADDRESS"
+		}
+		info_types {
+			name    = "PERSON_NAME"
+			version = "latest"
+		}
+		info_types {
+			name = "LAST_NAME"
+		}
+		info_types {
+			name = "DOMAIN_NAME"
+		}
+		info_types {
+			name = "PHONE_NUMBER"
+		}
+		info_types {
+			name = "FIRST_NAME"
+		}
+		min_likelihood_per_info_type {
+			info_type {
+				name    = "PERSON_NAME"
+				version = "latest"
+			}
+			min_likelihood = "UNLIKELY"
+		}
+	}
+}
+`, context)
+}
+
+func testAccDataLossPreventionInspectTemplate_dlpInspectTemplate_withMinLikelihoodPerInfoTypeUpdate(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_data_loss_prevention_inspect_template" "basic" {
+	parent = "projects/%{project}"
+	description = "Updated"
+	display_name = "Different"
+
+	inspect_config {
+		info_types {
+			name    = "PERSON_NAME"
+			version = "latest"
+		}
+		info_types {
+			name = "LAST_NAME"
+		}
+		info_types {
+			name = "DOMAIN_NAME"
+		}
+		info_types {
+			name = "PHONE_NUMBER"
+		}
+		info_types {
+			name = "FIRST_NAME"
+		}
+		min_likelihood_per_info_type {
+			info_type {
+				name    = "PERSON_NAME"
+				version = "latest"
+			}
+			min_likelihood = "POSSIBLE"
+		}
+		min_likelihood_per_info_type {
+			info_type {
+				name    = "PHONE_NUMBER"
+			}
+			min_likelihood = "VERY_LIKELY"
+		}
+	}
+}
+`, context)
+}


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dlp: added `inspect_config.min_likelihood_per_info_type` to `google_data_loss_prevention_inspect_template`
```
