### PR TITLE
fix: Fix enforce field in google_securityposture_posture always being…

### DIFF
--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -47,6 +47,7 @@ async:
     resource_inside_response: false
 custom_code:
   constants: 'templates/terraform/constants/posture.go.tmpl'
+  encoder: 'templates/terraform/encoders/securityposture_posture.go.tmpl'
 custom_diff:
   - 'revisionIdCustomizeDiff'
 samples:

--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -127,6 +127,7 @@ properties:
     output: true
   - name: 'policySets'
     type: Array
+    is_set: true
     description: |
       List of policy sets for the posture.
     required: true
@@ -146,6 +147,7 @@ properties:
             Description of the policy set.
         - name: 'policies'
           type: Array
+          is_set: true
           description: |
             List of security policy
           required: true

--- a/mmv1/products/securityposture/Posture.yaml
+++ b/mmv1/products/securityposture/Posture.yaml
@@ -127,7 +127,6 @@ properties:
     output: true
   - name: 'policySets'
     type: Array
-    is_set: true
     description: |
       List of policy sets for the posture.
     required: true
@@ -147,7 +146,6 @@ properties:
             Description of the policy set.
         - name: 'policies'
           type: Array
-          is_set: true
           description: |
             List of security policy
           required: true

--- a/mmv1/templates/terraform/encoders/securityposture_posture.go.tmpl
+++ b/mmv1/templates/terraform/encoders/securityposture_posture.go.tmpl
@@ -1,0 +1,29 @@
+if policySets, ok := obj["policySets"].([]interface{}); ok {
+	for _, ps := range policySets {
+		if psMap, ok := ps.(map[string]interface{}); ok {
+			if policies, ok := psMap["policies"].([]interface{}); ok {
+				for _, p := range policies {
+					if pMap, ok := p.(map[string]interface{}); ok {
+						if constraint, ok := pMap["constraint"].(map[string]interface{}); ok {
+							if opc, ok := constraint["orgPolicyConstraint"].(map[string]interface{}); ok {
+								if rules, ok := opc["policyRules"].([]interface{}); ok {
+									for _, r := range rules {
+										if rule, ok := r.(map[string]interface{}); ok {
+											_, isList := rule["values"]
+											_, hasAllow := rule["allowAll"]
+											_, hasDeny := rule["denyAll"]
+											if isList || hasAllow || hasDeny {
+												delete(rule, "enforce") // enforce is only valid for boolean constraints
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+return obj, nil

--- a/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
@@ -26,7 +26,7 @@ resource "google_securityposture_posture" "posture_1" {
             policy_id = "resource_locations_policy"
             constraint {
                 org_policy_constraint {
-                    canned_constraint_id = "constraints/gcp.resourceLocations"
+                    canned_constraint_id = "gcp.resourceLocations"
                     policy_rules {
                         values {
                             allowed_values = ["in:us-locations"]

--- a/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
@@ -19,6 +19,23 @@ resource "google_securityposture_posture" "posture_1" {
             }
         }
     }
+    policy_sets {
+        policy_set_id = "list_constraint_policy_set"
+        description   = "set of org policies with a list constraint"
+        policies {
+            policy_id = "resource_locations_policy"
+            constraint {
+                org_policy_constraint {
+                    canned_constraint_id = "constraints/gcp.resourceLocations"
+                    policy_rules {
+                        values {
+                            allowed_values = ["in:us-locations"]
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 resource "google_securityposture_posture_deployment" "{{$.PrimaryResourceId}}" {

--- a/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
+++ b/mmv1/templates/terraform/examples/securityposture_posture_deployment_basic.tf.tmpl
@@ -5,21 +5,6 @@ resource "google_securityposture_posture" "posture_1" {
     state       = "ACTIVE"
     description = "a new posture"
     policy_sets {
-        policy_set_id = "org_policy_set"
-        description   = "set of org policies"
-        policies {
-            policy_id = "policy_1"
-            constraint {
-                org_policy_constraint {
-                    canned_constraint_id = "storage.uniformBucketLevelAccess"
-                    policy_rules {
-                        enforce = true
-                    }
-                }
-            }
-        }
-    }
-    policy_sets {
         policy_set_id = "list_constraint_policy_set"
         description   = "set of org policies with a list constraint"
         policies {
@@ -36,7 +21,23 @@ resource "google_securityposture_posture" "posture_1" {
             }
         }
     }
+    policy_sets {
+        policy_set_id = "org_policy_set"
+        description   = "set of org policies"
+        policies {
+            policy_id = "policy_1"
+            constraint {
+                org_policy_constraint {
+                    canned_constraint_id = "storage.uniformBucketLevelAccess"
+                    policy_rules {
+                        enforce = true
+                    }
+                }
+            }
+        }
+    }
 }
+
 
 resource "google_securityposture_posture_deployment" "{{$.PrimaryResourceId}}" {
     posture_deployment_id = "{{index $.Vars "deployment_id"}}"

--- a/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
@@ -90,4 +90,21 @@ resource "google_securityposture_posture" "{{$.PrimaryResourceId}}"{
       }
     }
   }
+  policy_sets {
+    policy_set_id = "list_constraint_policy_set"
+    description   = "set of org policies with a list constraint"
+    policies {
+      policy_id = "resource_locations_policy"
+      constraint {
+        org_policy_constraint {
+          canned_constraint_id = "constraints/gcp.resourceLocations"
+          policy_rules {
+            values {
+              allowed_values = ["in:us-locations"]
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
@@ -5,6 +5,23 @@ resource "google_securityposture_posture" "{{$.PrimaryResourceId}}"{
   state       = "ACTIVE"
   description = "a new posture"
   policy_sets {
+    policy_set_id = "list_constraint_policy_set"
+    description   = "set of org policies with a list constraint"
+    policies {
+      policy_id = "resource_locations_policy"
+      constraint {
+        org_policy_constraint {
+          canned_constraint_id = "gcp.resourceLocations"
+          policy_rules {
+            values {
+              allowed_values = ["in:us-locations"]
+            }
+          }
+        }
+      }
+    }
+  }
+  policy_sets {
     policy_set_id = "org_policy_set"
     description   = "set of org policies"
     policies {
@@ -90,21 +107,5 @@ resource "google_securityposture_posture" "{{$.PrimaryResourceId}}"{
       }
     }
   }
-  policy_sets {
-    policy_set_id = "list_constraint_policy_set"
-    description   = "set of org policies with a list constraint"
-    policies {
-      policy_id = "resource_locations_policy"
-      constraint {
-        org_policy_constraint {
-          canned_constraint_id = "gcp.resourceLocations"
-          policy_rules {
-            values {
-              allowed_values = ["in:us-locations"]
-            }
-          }
-        }
-      }
-    }
-  }
+
 }

--- a/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securityposture/securityposture_posture_basic.tf.tmpl
@@ -97,7 +97,7 @@ resource "google_securityposture_posture" "{{$.PrimaryResourceId}}"{
       policy_id = "resource_locations_policy"
       constraint {
         org_policy_constraint {
-          canned_constraint_id = "constraints/gcp.resourceLocations"
+          canned_constraint_id = "gcp.resourceLocations"
           policy_rules {
             values {
               allowed_values = ["in:us-locations"]


### PR DESCRIPTION
Fix enforce field in google_securityposture_posture always being sent even for boolean constraints, which makes API call to fail with error.

Example config
```
resource "google_securityposture_posture" "posture1"{
  posture_id  = "posture_example"
  parent      = "organizations/123"
  location    = "global"
  state       = "ACTIVE"
  description = "a new posture"
  policy_sets {
    policy_set_id = "list_constraint_policy_set"
    description   = "set of org policies with a list constraint to reproduce bug"
    policies {
      policy_id = "resource_locations_policy"
      constraint {
        org_policy_constraint {
          canned_constraint_id = "constraints/gcp.resourceLocations"
          policy_rules {
            values {
              allowed_values = ["in:us-locations"]
            }
          }
        }
      }
    }
  }
}
```

Error:
```
│ Error: Error creating Posture: googleapi: Error 400: Invalid value at 'posture.policy_sets[2].policies[0].constraint.org_policy_constraint.policy_rules[0]' (oneof), oneof field 'kind' is already set. Cannot set 'values'
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.BadRequest",
│     "fieldViolations": [
│       {
│         "description": "Invalid value at 'posture.policy_sets[2].policies[0].constraint.org_policy_constraint.policy_rules[0]' (oneof), oneof field 'kind' is already set. Cannot set 'values'",
│         "field": "posture.policy_sets[2].policies[0].constraint.org_policy_constraint.policy_rules[0]"
│       }
│     ]
│   }
│ ]
│ 
│   with google_securityposture_posture.posture1,
│   on main.tf line 1, in resource "google_securityposture_posture" "posture1":
│    1: resource "google_securityposture_posture" "posture1"{
│ 
```

Issue was introduced in [PR-16796](https://github.com/GoogleCloudPlatform/magic-modules/pull/16796)
Fix proposed [here](https://github.com/GoogleCloudPlatform/magic-modules/pull/17147#issuecomment-4813864361)


```release-note:bug
securityposture: Fixed a bug where the `enforce` field in `google_securityposture_posture` was always set, causing failures for list constraints.
```
