### PR TITLE
test: Fix flaky Firestore Timestamp field test

### DIFF
--- a/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.tmpl
+++ b/mmv1/templates/terraform/custom_check_destroy/firestore_field.go.tmpl
@@ -23,6 +23,10 @@ if err != nil {
 		// We do not return the error in this case - destroy was successful
 		return nil
 	}
+	if e.Code == 404 && regexp.MustCompile(`Project .* or database .* does not exist`).MatchString(e.Message) {
+		// The project or database does not exist, which means the resource is destroyed.
+		return nil
+	}
 
 	// Return err in all other cases
 	return err

--- a/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
+++ b/mmv1/templates/terraform/samples/base_configs/test_file.go.tmpl
@@ -28,6 +28,7 @@ package {{ $.Res.PackageName }}_test
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -59,6 +60,7 @@ import (
 var (
 	_ = fmt.Sprintf
 	_ = log.Print
+	_ = regexp.MatchString
 	_ = strconv.Atoi
 	_ = strings.Trim
 	_ = time.Now


### PR DESCRIPTION
Tests were failing because they incorrectly interpreted a 404 on the project or database as indicating the field might still be around. This can happen if the database is deleted before we check if the timestamp field still exists.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27593

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
