### PR TITLE
Made UrlParamOnly fields not be considered provider-only

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -1457,7 +1457,7 @@ func (t *Type) ProviderOnly() bool {
 		return true
 	}
 
-	if t.UrlParamOnly || t.ClientSide {
+	if t.ClientSide {
 		return true
 	}
 


### PR DESCRIPTION
This simplifies the common case of  fields being marked as url_param_only

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
