### PR TITLE
Add singular/plural Exascale DB Storage Vault data sources and update VM Clusters data source

### DIFF
--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_clusters.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_cloud_vm_clusters.go
@@ -96,18 +96,19 @@ func flattenOracleDatabaseCloudVmClusters(v interface{}, d *schema.ResourceData,
 	for _, raw := range l {
 		original := raw.(map[string]interface{})
 		transformed = append(transformed, map[string]interface{}{
-			"name":                   flattenOracleDatabaseCloudVmClusterName(original["name"], d, config),
-			"exadata_infrastructure": flattenOracleDatabaseCloudVmClusterExadataInfrastructure(original["exadataInfrastructure"], d, config),
-			"display_name":           flattenOracleDatabaseCloudVmClusterDisplayName(original["displayName"], d, config),
-			"gcp_oracle_zone":        flattenOracleDatabaseCloudVmClusterGcpOracleZone(original["gcpOracleZone"], d, config),
-			"properties":             flattenOracleDatabaseCloudVmClusterProperties(original["properties"], d, config),
-			"labels":                 flattenOracleDatabaseCloudVmClusterLabels(original["labels"], d, config),
-			"create_time":            flattenOracleDatabaseCloudVmClusterCreateTime(original["createTime"], d, config),
-			"cidr":                   flattenOracleDatabaseCloudVmClusterCidr(original["cidr"], d, config),
-			"backup_subnet_cidr":     flattenOracleDatabaseCloudVmClusterBackupSubnetCidr(original["backupSubnetCidr"], d, config),
-			"network":                flattenOracleDatabaseCloudVmClusterNetwork(original["network"], d, config),
-			"terraform_labels":       flattenOracleDatabaseCloudVmClusterTerraformLabels(original["labels"], d, config),
-			"effective_labels":       flattenOracleDatabaseCloudVmClusterEffectiveLabels(original["labels"], d, config),
+			"name":                      flattenOracleDatabaseCloudVmClusterName(original["name"], d, config),
+			"exadata_infrastructure":    flattenOracleDatabaseCloudVmClusterExadataInfrastructure(original["exadataInfrastructure"], d, config),
+			"display_name":              flattenOracleDatabaseCloudVmClusterDisplayName(original["displayName"], d, config),
+			"gcp_oracle_zone":           flattenOracleDatabaseCloudVmClusterGcpOracleZone(original["gcpOracleZone"], d, config),
+			"properties":                flattenOracleDatabaseCloudVmClusterProperties(original["properties"], d, config),
+			"labels":                    flattenOracleDatabaseCloudVmClusterLabels(original["labels"], d, config),
+			"create_time":               flattenOracleDatabaseCloudVmClusterCreateTime(original["createTime"], d, config),
+			"cidr":                      flattenOracleDatabaseCloudVmClusterCidr(original["cidr"], d, config),
+			"backup_subnet_cidr":        flattenOracleDatabaseCloudVmClusterBackupSubnetCidr(original["backupSubnetCidr"], d, config),
+			"network":                   flattenOracleDatabaseCloudVmClusterNetwork(original["network"], d, config),
+			"exascale_db_storage_vault": flattenOracleDatabaseCloudVmClusterExascaleDbStorageVault(original["exascaleDbStorageVault"], d, config),
+			"terraform_labels":          flattenOracleDatabaseCloudVmClusterTerraformLabels(original["labels"], d, config),
+			"effective_labels":          flattenOracleDatabaseCloudVmClusterEffectiveLabels(original["labels"], d, config),
 		})
 	}
 	return transformed

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault.go
@@ -1,0 +1,45 @@
+package oracledatabase
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceOracleDatabaseExascaleDbStorageVault() *schema.Resource {
+	dsSchema := tpgresource.DatasourceSchemaFromResourceSchema(ResourceOracleDatabaseExascaleDbStorageVault().Schema)
+	tpgresource.AddRequiredFieldsToSchema(dsSchema, "location", "exascale_db_storage_vault_id")
+	tpgresource.AddOptionalFieldsToSchema(dsSchema, "project")
+	return &schema.Resource{
+		Read:   dataSourceOracleDatabaseExascaleDbStorageVaultRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceOracleDatabaseExascaleDbStorageVaultRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults/{{exascale_db_storage_vault_id}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	err = resourceOracleDatabaseExascaleDbStorageVaultRead(d, meta)
+	if err != nil {
+		return err
+	}
+	d.SetId(id)
+
+	return nil
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_oracle_database_exascale_db_storage_vault",
+		ProductName: "oracledatabase",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceOracleDatabaseExascaleDbStorageVault(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault.go
@@ -26,11 +26,15 @@ func dataSourceOracleDatabaseExascaleDbStorageVaultRead(d *schema.ResourceData, 
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
+	d.SetId(id)
 	err = resourceOracleDatabaseExascaleDbStorageVaultRead(d, meta)
 	if err != nil {
 		return err
 	}
-	d.SetId(id)
+	if d.Id() == "" {
+		return fmt.Errorf("%s not found", id)
+	}
+	return nil
 
 	return nil
 }

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vault_test.go
@@ -1,0 +1,60 @@
+package oracledatabase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/oracledatabase"
+)
+
+func TestAccOracleDatabaseExascaleDbStorageVaultDataSource_basic(t *testing.T) {
+	t.Parallel()
+
+	vaultId := fmt.Sprintf("ofake-tf-test-vault-ds-%s", acctest.RandString(t, 10))
+
+	context := map[string]interface{}{
+		"vault_id": vaultId,
+		"project":  "oci-terraform-testing-prod",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOracleDatabaseExascaleDbStorageVaultDataSource_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vault.ds_vault", "name"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vault.ds_vault", "display_name"),
+					resource.TestCheckResourceAttr("data.google_oracle_database_exascale_db_storage_vault.ds_vault", "display_name", fmt.Sprintf("%s displayname", vaultId)),
+					resource.TestCheckResourceAttr("data.google_oracle_database_exascale_db_storage_vault.ds_vault", "properties.0.exascale_db_storage_details.0.total_size_gbs", "512"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOracleDatabaseExascaleDbStorageVaultDataSource_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_oracle_database_exascale_db_storage_vault" "vault" {
+  exascale_db_storage_vault_id = "%{vault_id}"
+  display_name                 = "%{vault_id} displayname"
+  location                     = "us-east4"
+  project                      = "%{project}"
+  properties {
+    exascale_db_storage_details {
+      total_size_gbs = 512
+    }
+  }
+  deletion_protection = false
+}
+
+data "google_oracle_database_exascale_db_storage_vault" "ds_vault" {
+  exascale_db_storage_vault_id = google_oracle_database_exascale_db_storage_vault.vault.exascale_db_storage_vault_id
+  location                     = google_oracle_database_exascale_db_storage_vault.vault.location
+  project                      = google_oracle_database_exascale_db_storage_vault.vault.project
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults.go
@@ -1,0 +1,118 @@
+package oracledatabase
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func DataSourceOracleDatabaseExascaleDbStorageVaults() *schema.Resource {
+	dsSchema := map[string]*schema.Schema{
+		"project": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The ID of the project in which the dataset is located. If it is not provided, the provider project is used.",
+		},
+		"location": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "location",
+		},
+		"exascale_db_storage_vaults": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: tpgresource.DatasourceSchemaFromResourceSchema(ResourceOracleDatabaseExascaleDbStorageVault().Schema),
+			},
+		},
+	}
+	return &schema.Resource{
+		Read:   dataSourceOracleDatabaseExascaleDbStorageVaultsRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceOracleDatabaseExascaleDbStorageVaultsRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*transport_tpg.Config)
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, transport_tpg.BaseUrl(Product, config)+"projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+
+	billingProject := ""
+	project, err := tpgresource.GetProject(d, config)
+	if err != nil {
+		return fmt.Errorf("Error fetching project for exascaleDbStorageVaults: %s", err)
+	}
+	billingProject = project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+	res, err := transport_tpg.SendRequest(transport_tpg.SendRequestOptions{
+		Config:    config,
+		Method:    "GET",
+		Project:   billingProject,
+		RawURL:    url,
+		UserAgent: userAgent,
+	})
+
+	if err != nil {
+		return fmt.Errorf("Error reading exascaleDbStorageVaults: %s", err)
+	}
+
+	if err := d.Set("project", project); err != nil {
+		return fmt.Errorf("Error setting exascaleDbStorageVaults project: %s", err)
+	}
+
+	if err := d.Set("exascale_db_storage_vaults", flattenOracleDatabaseExascaleDbStorageVaults(res["exascaleDbStorageVaults"], d, config)); err != nil {
+		return fmt.Errorf("Error setting exascaleDbStorageVaults: %s", err)
+	}
+
+	id, err := tpgresource.ReplaceVars(d, config, "projects/{{project}}/locations/{{location}}/exascaleDbStorageVaults")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return nil
+}
+
+func flattenOracleDatabaseExascaleDbStorageVaults(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+	l := v.([]interface{})
+	transformed := make([]map[string]interface{}, 0)
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		transformed = append(transformed, map[string]interface{}{
+			"name":                   flattenOracleDatabaseExascaleDbStorageVaultName(original["name"], d, config),
+			"display_name":           flattenOracleDatabaseExascaleDbStorageVaultDisplayName(original["displayName"], d, config),
+			"gcp_oracle_zone":        flattenOracleDatabaseExascaleDbStorageVaultGcpOracleZone(original["gcpOracleZone"], d, config),
+			"entitlement_id":         flattenOracleDatabaseExascaleDbStorageVaultEntitlementId(original["entitlementId"], d, config),
+			"properties":             flattenOracleDatabaseExascaleDbStorageVaultProperties(original["properties"], d, config),
+			"labels":                 flattenOracleDatabaseExascaleDbStorageVaultLabels(original["labels"], d, config),
+			"create_time":            flattenOracleDatabaseExascaleDbStorageVaultCreateTime(original["createTime"], d, config),
+			"exadata_infrastructure": flattenOracleDatabaseExascaleDbStorageVaultExadataInfrastructure(original["exadataInfrastructure"], d, config),
+			"terraform_labels":       flattenOracleDatabaseExascaleDbStorageVaultTerraformLabels(original["labels"], d, config),
+			"effective_labels":       flattenOracleDatabaseExascaleDbStorageVaultEffectiveLabels(original["labels"], d, config),
+		})
+	}
+	return transformed
+}
+
+func init() {
+	registry.Schema{
+		Name:        "google_oracle_database_exascale_db_storage_vaults",
+		ProductName: "oracledatabase",
+		Type:        registry.SchemaTypeDataSource,
+		Schema:      DataSourceOracleDatabaseExascaleDbStorageVaults(),
+	}.Register()
+}

--- a/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults_test.go
+++ b/mmv1/third_party/terraform/services/oracledatabase/data_source_oracle_database_exascale_db_storage_vaults_test.go
@@ -1,0 +1,59 @@
+package oracledatabase_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/oracledatabase"
+)
+
+func TestAccOracleDatabaseExascaleDbStorageVaultsDataSource_basic(t *testing.T) {
+	t.Parallel()
+
+	vaultId := fmt.Sprintf("ofake-tf-test-vault-ds-%s", acctest.RandString(t, 10))
+
+	context := map[string]interface{}{
+		"vault_id": vaultId,
+		"project":  "oci-terraform-testing-prod",
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOracleDatabaseExascaleDbStorageVaultsDataSource_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vaults.ds_vaults", "exascale_db_storage_vaults.#"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vaults.ds_vaults", "exascale_db_storage_vaults.0.name"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vaults.ds_vaults", "exascale_db_storage_vaults.0.display_name"),
+					resource.TestCheckResourceAttrSet("data.google_oracle_database_exascale_db_storage_vaults.ds_vaults", "exascale_db_storage_vaults.0.properties.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccOracleDatabaseExascaleDbStorageVaultsDataSource_basic(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_oracle_database_exascale_db_storage_vault" "vault" {
+  exascale_db_storage_vault_id = "%{vault_id}"
+  display_name                 = "%{vault_id} displayname"
+  location                     = "us-east4"
+  project                      = "%{project}"
+  properties {
+    exascale_db_storage_details {
+      total_size_gbs = 512
+    }
+  }
+  deletion_protection = false
+}
+
+data "google_oracle_database_exascale_db_storage_vaults" "ds_vaults" {
+  location = google_oracle_database_exascale_db_storage_vault.vault.location
+  project  = google_oracle_database_exascale_db_storage_vault.vault.project
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/website/docs/d/oracle_database_exascale_db_storage_vault.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/oracle_database_exascale_db_storage_vault.html.markdown
@@ -1,0 +1,37 @@
+---
+subcategory: "Oracle Database"
+description: |-
+  Get information about an ExascaleDbStorageVault.
+---
+
+# google_oracle_database_exascale_db_storage_vault
+
+Get information about an ExascaleDbStorageVault.
+
+For more information see the
+[API](https://cloud.google.com/oracle/database/docs/reference/rest/v1/projects.locations.exascaleDbStorageVaults).
+
+## Example Usage
+
+```hcl
+data "google_oracle_database_exascale_db_storage_vault" "my-vault"{
+  location                     = "us-east4"
+  exascale_db_storage_vault_id = "vault-id"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `exascale_db_storage_vault_id` - (Required) The ID of the ExascaleDbStorageVault.
+
+* `location` - (Required) The location of the resource.
+
+- - -
+* `project` - (Optional) The project to which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_oracle_database_exascale_db_storage_vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/oracle_database_exascale_db_storage_vault#argument-reference) resource for details of the available attributes.

--- a/mmv1/third_party/terraform/website/docs/d/oracle_database_exascale_db_storage_vaults.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/oracle_database_exascale_db_storage_vaults.html.markdown
@@ -1,0 +1,36 @@
+---
+subcategory: "Oracle Database"
+description: |-
+  List all ExascaleDbStorageVaults.
+---
+
+# google_oracle_database_exascale_db_storage_vaults
+
+List all ExascaleDbStorageVaults.
+
+For more information see the
+[API](https://cloud.google.com/oracle/database/docs/reference/rest/v1/projects.locations.exascaleDbStorageVaults).
+
+## Example Usage
+
+```hcl
+data "google_oracle_database_exascale_db_storage_vaults" "my_vaults"{
+  location = "us-east4"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The location of the resource.
+
+- - -
+* `project` - (Optional) The project to which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `exascale_db_storage_vaults` - A list of ExascaleDbStorageVaults. See [google_oracle_database_exascale_db_storage_vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/oracle_database_exascale_db_storage_vault#argument-reference) resource for details of the available attributes.


### PR DESCRIPTION
### Description

Expose the new singular and plural data sources for Exascale DB Storage Vaults and update existing VM Clusters list data source:

1. Expose data sources:
   * Singular: `google_oracle_database_exascale_db_storage_vault`
   * Plural: `google_oracle_database_exascale_db_storage_vaults`
2. Update the existing plural list data source `google_oracle_database_cloud_vm_clusters` to map and expose the `exascale_db_storage_vault` and `storage_management_type` fields.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/28250

### Release Note

```release-note:new-datasource
`google_oracle_database_exascale_db_storage_vault`
```

```release-note:new-list-resource
`google_oracle_database_exascale_db_storage_vaults`
```

```release-note:enhancement
oracledatabase: added `exascale_db_storage_vault` and `storage_management_type` fields to `google_oracle_database_cloud_vm_clusters` data source
```