### PR TITLE
discoveryengine: add enable_llm_layout_parsing and enable_get_processed_document to data store

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -317,12 +317,10 @@ properties:
                 type: Boolean
                 description: |
                   If true, the pdf layout will be refined using an LLM.
-                required: false
               - name: 'enableGetProcessedDocument'
                 type: Boolean
                 description: |
                   If true, the processed document will be made available for the GetProcessedDocument API.
-                required: false
               - name: 'structuredContentTypes'
                 type: Array
                 description: |
@@ -415,12 +413,10 @@ properties:
                   type: Boolean
                   description: |
                     If true, the pdf layout will be refined using an LLM.
-                  required: false
                 - name: 'enableGetProcessedDocument'
                   type: Boolean
                   description: |
                     If true, the processed document will be made available for the GetProcessedDocument API.
-                  required: false
                 - name: 'structuredContentTypes'
                   type: Array
                   description: |

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -313,6 +313,16 @@ properties:
                 description: |
                   If true, the LLM based annotation is added to the image during parsing.
                 required: false
+              - name: 'enableLlmLayoutParsing'
+                type: Boolean
+                description: |
+                  If true, the pdf layout will be refined using an LLM.
+                required: false
+              - name: 'enableGetProcessedDocument'
+                type: Boolean
+                description: |
+                  If true, the processed document will be made available for the GetProcessedDocument API.
+                required: false
               - name: 'structuredContentTypes'
                 type: Array
                 description: |
@@ -400,6 +410,16 @@ properties:
                   type: Boolean
                   description: |
                     If true, the LLM based annotation is added to the image during parsing.
+                  required: false
+                - name: 'enableLlmLayoutParsing'
+                  type: Boolean
+                  description: |
+                    If true, the pdf layout will be refined using an LLM.
+                  required: false
+                - name: 'enableGetProcessedDocument'
+                  type: Boolean
+                  description: |
+                    If true, the processed document will be made available for the GetProcessedDocument API.
                   required: false
                 - name: 'structuredContentTypes'
                   type: Array

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_document_processing_config_layout_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_document_processing_config_layout_full.tf.tmpl
@@ -9,12 +9,14 @@ resource "google_discovery_engine_data_store" "document_processing_config_layout
   document_processing_config {
     default_parsing_config {
       layout_parsing_config {
-        enable_table_annotation  = true
-        enable_image_annotation  = true
-        structured_content_types = ["shareholder-structure"]
-        exclude_html_elements    = ["nav", "footer"]
-        exclude_html_classes     = ["overlay", "screenreader"]
-        exclude_html_ids         = ["cookie-banner"]
+        enable_table_annotation       = true
+        enable_image_annotation       = true
+        enable_llm_layout_parsing     = true
+        enable_get_processed_document = true
+        structured_content_types      = ["shareholder-structure"]
+        exclude_html_elements         = ["nav", "footer"]
+        exclude_html_classes          = ["overlay", "screenreader"]
+        exclude_html_ids              = ["cookie-banner"]
       }
     }
     chunking_config {

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_document_processing_config_layout_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_document_processing_config_layout_full.tf.tmpl
@@ -25,5 +25,14 @@ resource "google_discovery_engine_data_store" "document_processing_config_layout
         include_ancestor_headings = true
       }
     }
+    parsing_config_overrides {
+      file_type = "pdf"
+      layout_parsing_config {
+        enable_table_annotation       = true
+        enable_image_annotation       = true
+        enable_llm_layout_parsing     = true
+        enable_get_processed_document = true
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds the two remaining GA `layout_parsing_config` fields to `google_discovery_engine_data_store` so the block matches the v1 API:

- `enable_llm_layout_parsing` — if true, the PDF layout is refined using an LLM.
- `enable_get_processed_document` — if true, the processed document is made available for the GetProcessedDocument API.

Both are added to `default_parsing_config.layout_parsing_config` and the per-file-type `parsing_config_overrides` block, and exercised in the `document_processing_config_layout_full` example. Both fields exist in the `v1` (GA) discovery doc.

```release-note:enhancement
discoveryengine: added `enable_llm_layout_parsing` and `enable_get_processed_document` fields to `google_discovery_engine_data_store`
```
