### PR TITLE
Securesourcemanager byosa scanning

### DIFF
--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -174,3 +174,25 @@ properties:
         description: |
           README template name.
           Valid values can be viewed at https://cloud.google.com/secure-source-manager/docs/reference/rest/v1/projects.locations.repositories#initialconfig.
+  - name: 'serviceAccount'
+    type: String
+    description: |
+      Repository level service account (BYOSA).
+  - name: 'scanConfig'
+    type: NestedObject
+    description: |
+      Provides configuration for scanning.
+    properties:
+      - name: 'secretScanConfig'
+        type: NestedObject
+        description: |
+          Configuration for secret scanning.
+        properties:
+          - name: 'enabled'
+            type: Boolean
+            description: |
+              Enables secret scanning for the repository.
+          - name: 'inspectTemplate'
+            type: String
+            description: |
+              The DLP inspect template to use for secret scanning.

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -75,6 +75,39 @@ samples:
           deletion_policy: '"DELETE"'
         ignore_read_extra:
           - deletion_policy
+  - name: secure_source_manager_repository_service_account
+    primary_resource_id: default
+    steps:
+      - name: secure_source_manager_repository_service_account
+        resource_id_vars:
+          repository_id: my-repository
+          instance_id: my-instance
+          deletion_policy: PREVENT
+          sa_id: my-sa
+        test_vars_overrides:
+          deletion_policy: '"DELETE"'
+        oics_vars_overrides:
+          deletion_policy: '"DELETE"'
+        ignore_read_extra:
+          - deletion_policy
+  - name: secure_source_manager_repository_secret_scanning
+    primary_resource_id: default
+    steps:
+      - name: secure_source_manager_repository_secret_scanning
+        resource_id_vars:
+          repository_id: my-repository
+          instance_id: my-instance
+          deletion_policy: PREVENT
+        test_env_vars:
+          project: PROJECT_NAME
+        test_vars_overrides:
+          deletion_policy: '"DELETE"'
+        oics_vars_overrides:
+          deletion_policy: '"DELETE"'
+        ignore_read_extra:
+          - deletion_policy
+
+
 parameters:
   - name: location
     type: String
@@ -177,9 +210,10 @@ properties:
   - name: 'serviceAccount'
     type: String
     description: |
-      Repository level service account (BYOSA).
+      Repository level service account.
   - name: 'scanConfig'
     type: NestedObject
+    diff_suppress_func: 'tpgresource.EmptyOrUnsetBlockDiffSuppress'
     description: |
       Provides configuration for scanning.
     properties:

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -106,8 +106,6 @@ samples:
           deletion_policy: '"DELETE"'
         ignore_read_extra:
           - deletion_policy
-
-
 parameters:
   - name: location
     type: String

--- a/mmv1/products/securesourcemanager/Repository.yaml
+++ b/mmv1/products/securesourcemanager/Repository.yaml
@@ -106,6 +106,21 @@ samples:
           deletion_policy: '"DELETE"'
         ignore_read_extra:
           - deletion_policy
+  - name: secure_source_manager_repository_secret_scanning_default
+    primary_resource_id: default
+    steps:
+      - name: secure_source_manager_repository_secret_scanning_default
+        resource_id_vars:
+          repository_id: my-repository
+          instance_id: my-instance
+          deletion_policy: PREVENT
+        test_vars_overrides:
+          deletion_policy: '"DELETE"'
+        oics_vars_overrides:
+          deletion_policy: '"DELETE"'
+        ignore_read_extra:
+          - deletion_policy
+
 parameters:
   - name: location
     type: String
@@ -226,5 +241,6 @@ properties:
               Enables secret scanning for the repository.
           - name: 'inspectTemplate'
             type: String
+            default_from_api: true
             description: |
               The DLP inspect template to use for secret scanning.

--- a/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning.tf.tmpl
@@ -1,0 +1,30 @@
+resource "google_secure_source_manager_instance" "instance" {
+  location = "us-central1"
+  instance_id = "{{index $.ResourceIdVars "instance_id"}}"
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+}
+
+resource "google_data_loss_prevention_inspect_template" "template" {
+  parent       = "projects/{{index $.TestEnvVars "project"}}/locations/us-central1"
+  display_name = "Test Inspect Template"
+
+  inspect_config {
+    info_types {
+      name = "EMAIL_ADDRESS"
+    }
+  }
+}
+
+resource "google_secure_source_manager_repository" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  repository_id = "{{index $.ResourceIdVars "repository_id"}}"
+  instance = google_secure_source_manager_instance.instance.name
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+
+  scan_config {
+    secret_scan_config {
+      enabled          = true
+      inspect_template = google_data_loss_prevention_inspect_template.template.id
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning.tf.tmpl
@@ -15,6 +15,15 @@ resource "google_data_loss_prevention_inspect_template" "template" {
   }
 }
 
+data "google_project" "project" {
+}
+
+resource "google_project_iam_member" "ssm_p4sa_dlp_reader" {
+  project = data.google_project.project.project_id
+  role    = "roles/dlp.inspectTemplatesReader"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-sourcemanager.iam.gserviceaccount.com"
+}
+
 resource "google_secure_source_manager_repository" "{{$.PrimaryResourceId}}" {
   location = "us-central1"
   repository_id = "{{index $.ResourceIdVars "repository_id"}}"
@@ -27,4 +36,8 @@ resource "google_secure_source_manager_repository" "{{$.PrimaryResourceId}}" {
       inspect_template = google_data_loss_prevention_inspect_template.template.id
     }
   }
+
+  depends_on = [
+    google_project_iam_member.ssm_p4sa_dlp_reader,
+  ]
 }

--- a/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning_default.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_secret_scanning_default.tf.tmpl
@@ -1,0 +1,18 @@
+resource "google_secure_source_manager_instance" "instance" {
+  location = "us-central1"
+  instance_id = "{{index $.ResourceIdVars "instance_id"}}"
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+}
+
+resource "google_secure_source_manager_repository" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  repository_id = "{{index $.ResourceIdVars "repository_id"}}"
+  instance = google_secure_source_manager_instance.instance.name
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+
+  scan_config {
+    secret_scan_config {
+      enabled = true
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_service_account.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/securesourcemanager/secure_source_manager_repository_service_account.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_secure_source_manager_instance" "instance" {
+  location = "us-central1"
+  instance_id = "{{index $.ResourceIdVars "instance_id"}}"
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+}
+
+resource "google_service_account" "sa" {
+  account_id   = "{{index $.ResourceIdVars "sa_id"}}"
+  display_name = "Test Service Account"
+}
+
+resource "google_secure_source_manager_repository" "{{$.PrimaryResourceId}}" {
+  location = "us-central1"
+  repository_id = "{{index $.ResourceIdVars "repository_id"}}"
+  instance = google_secure_source_manager_instance.instance.name
+  deletion_policy = "{{index $.ResourceIdVars "deletion_policy"}}"
+
+  service_account = google_service_account.sa.email
+}


### PR DESCRIPTION
This PR adds support for `service_account` and `scan_config` properties to the `google_secure_source_manager_repository` resource.

### Key Changes
- **`service_account`**: Adds repository-level service account support.
- **`scan_config`**: Enables configuring repository scanning settings (e.g., secret scanning via a regional DLP `inspect_template`).
- **Diff Suppression**: Added `diff_suppress_func: 'tpgresource.EmptyOrUnsetBlockDiffSuppress'` to the `scan_config` nested object.
- **Tests & Examples**: Added two new acceptance tests and examples covering these features:
  - `secure_source_manager_repository_service_account`
  - `secure_source_manager_repository_secret_scanning`

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
securesourcemanager: added `service_account` and `scan_config` to `google_secure_source_manager_repository`.
```