### PR TITLE
refactor: extract flattenServiceAccountKey from Read function

### DIFF
--- a/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_key.go
+++ b/mmv1/third_party/terraform/services/resourcemanager/resource_google_service_account_key.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"google.golang.org/api/iam/v1"
+	iam "google.golang.org/api/iam/v1"
 )
 
 func ResourceGoogleServiceAccountKey() *schema.Resource {
@@ -192,6 +192,10 @@ func resourceGoogleServiceAccountKeyRead(d *schema.ResourceData, meta interface{
 		}
 	}
 
+	return flattenServiceAccountKey(d, config, sak)
+}
+
+func flattenServiceAccountKey(d *schema.ResourceData, config *transport_tpg.Config, sak *iam.ServiceAccountKey) error {
 	if err := d.Set("name", sak.Name); err != nil {
 		return fmt.Errorf("Error setting name: %s", err)
 	}


### PR DESCRIPTION
Extracts the field-setting logic from `resourceGoogleServiceAccountKeyRead` into a shared `flattenServiceAccountKey` function. This enables reuse by the upcoming list resource (#18242) without duplicating code.
No behavior change, pure refactor.
### Details
* Extracts `flattenServiceAccountKey` from the Read function
* Read function now calls the shared flattener
* List resource PR (#18242) will call this same function, eliminating duplicate flatten logic

```release-note:none
```