### PR TITLE
compute: store `zone` name instead of zone URL in `google_compute_future_reservation`

### DIFF
--- a/mmv1/products/compute/FutureReservation.yaml
+++ b/mmv1/products/compute/FutureReservation.yaml
@@ -120,6 +120,7 @@ parameters:
       The zone where the future reservation is located.
     immutable: true
     default_from_api: true
+    custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.tmpl'
     custom_expand: 'templates/terraform/custom_expand/resourceref_with_validation.go.tmpl'
     resource: 'Zone'
     imports: 'name'


### PR DESCRIPTION
Follow-up to #17417, which made `zone` configurable on `google_compute_future_reservation` (this PR originally carried the same fix and has been rebased on top of it).

Remaining delta: flatten `zone` to the zone name via `name_from_self_link`, matching the `compute.Disk` pattern. Without it, state stores the full zone self link returned by the API (masked by diff suppression); with it, `zone` in state matches what users configure and what `google_compute_disk` exposes, e.g. `us-central1-a`.

Verified against the regenerated `google-beta` provider: schema is unchanged (`Optional + Computed + ForceNew` with self-link diff suppression), the generated flatten now extracts the resource name, and provider schema validation plus compute unit tests pass.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: fixed `zone` in `google_compute_future_reservation` to return the zone name instead of the full zone URL
```
