### PR TITLE
`container`: set default timeout for `google_container_node_pool` to 2 hours

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -188,9 +188,9 @@ func ResourceContainerNodePool() *schema.Resource {
 		Exists: resourceContainerNodePoolExists,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(60 * time.Minute),
-			Update: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(60 * time.Minute),
+			Create: schema.DefaultTimeout(2 * time.Hour),
+			Update: schema.DefaultTimeout(2 * time.Hour),
+			Delete: schema.DefaultTimeout(2 * time.Hour),
 		},
 
 		SchemaVersion: 1,

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -374,9 +374,9 @@ In addition to the arguments listed above, the following computed attributes are
 `google_container_node_pool` provides the following
 [Timeouts](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/retries-and-customizable-timeouts) configuration options: configuration options:
 
-- `create` - (Default `60 minutes`) Used for adding node pools
-- `update` - (Default `60 minutes`) Used for updates to node pools
-- `delete` - (Default `60 minutes`) Used for removing node pools.
+- `create` - (Default `2 hours`) Used for adding node pools
+- `update` - (Default `2 hours`) Used for updates to node pools
+- `delete` - (Default `2 hours`) Used for removing node pools.
 
 <a name="nested_kubelet_config"></a>The `kubelet_config` block supports:
 

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
@@ -1,6 +1,8 @@
 package container
 
 import (
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -457,6 +459,11 @@ var schemaNodePool = map[string]*schema.Schema{
 
 func ResourceContainerNodePool() *schema.Resource {
 	return &schema.Resource{
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Hour),
+			Update: schema.DefaultTimeout(2 * time.Hour),
+			Delete: schema.DefaultTimeout(2 * time.Hour),
+		},
 		Schema: tpgresource.MergeSchemas(
 			schemaNodePool,
 			map[string]*schema.Schema{

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_node_pool.go
@@ -1,8 +1,6 @@
 package container
 
 import (
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -459,11 +457,6 @@ var schemaNodePool = map[string]*schema.Schema{
 
 func ResourceContainerNodePool() *schema.Resource {
 	return &schema.Resource{
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(2 * time.Hour),
-			Update: schema.DefaultTimeout(2 * time.Hour),
-			Delete: schema.DefaultTimeout(2 * time.Hour),
-		},
 		Schema: tpgresource.MergeSchemas(
 			schemaNodePool,
 			map[string]*schema.Schema{


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27427

when using the following config i found that although it wasn't working as expected on `terraform apply`, checking the state of the node_pool showed node replacement which occurred at 1hr15 minutes, exceeding the 1 hour default timeout that resources have.

```hcl
terraform {
  required_version = ">= 1.6.0"

  required_providers {
    google = {
      source  = "hashicorp/google"
      version = "~> 7.37"
    }
    kubernetes = {
      source  = "hashicorp/kubernetes"
      version = "~> 2.31"
    }
  }
}

provider "google" {
  project = var.project_id
  region  = var.region
}

data "google_client_config" "default" {}

resource "google_container_cluster" "repro" {
  name     = "${var.name_prefix}-cluster"
  location = var.zone

  # Keep the default pool tiny and separate from the pool under test.
  remove_default_node_pool = false
  initial_node_count       = 1

  deletion_protection = false

  network    = "default"
  subnetwork = "default"

  release_channel {
    channel = "REGULAR"
  }
}

resource "google_container_node_pool" "repro" {
  count = var.create_test_pool ? 1 : 0

  name     = "${var.name_prefix}-pool"
  cluster  = google_container_cluster.repro.id
  location = var.zone

  node_count = var.node_count

  autoscaling {
    min_node_count = 1
    max_node_count = var.max_node_count
  }

  node_drain_config {
    respect_pdb_during_node_pool_deletion = false
  }

  management {
    auto_repair  = true
    auto_upgrade = true
  }

  timeouts {
    update = var.node_pool_update_timeout
  }

  node_config {
    machine_type = var.updated_machine_type ? var.updated_machine_type_value : var.machine_type

    oauth_scopes = [
      "https://www.googleapis.com/auth/cloud-platform"
    ]

    labels = {
      repro = "issue-27427"
    }
  }
}

provider "kubernetes" {
  host                   = "https://${google_container_cluster.repro.endpoint}"
  token                  = data.google_client_config.default.access_token
  cluster_ca_certificate = base64decode(google_container_cluster.repro.master_auth[0].cluster_ca_certificate)
}

resource "kubernetes_namespace" "repro" {
  count = var.deploy_pressure_workload ? 1 : 0

  metadata {
    name = "issue-27427"
  }
}

resource "kubernetes_pod_disruption_budget_v1" "pressure" {
  count = var.deploy_pressure_workload ? 1 : 0

  metadata {
    name      = "app-pdb"
    namespace = kubernetes_namespace.repro[0].metadata[0].name
  }

  spec {
    min_available = "1"

    selector {
      match_labels = {
        app = "stateful-pressure"
      }
    }
  }

  depends_on = [google_container_node_pool.repro]
}

resource "kubernetes_stateful_set_v1" "pressure" {
  count = var.deploy_pressure_workload ? 1 : 0

  metadata {
    name      = "stateful-pressure"
    namespace = kubernetes_namespace.repro[0].metadata[0].name
    labels = {
      app = "stateful-pressure"
    }
  }

  spec {
    service_name = "stateful-pressure"
    replicas     = var.pressure_replicas

    selector {
      match_labels = {
        app = "stateful-pressure"
      }
    }

    template {
      metadata {
        labels = {
          app = "stateful-pressure"
        }
      }

      spec {
        node_selector = {
          "cloud.google.com/gke-nodepool" = "${var.name_prefix}-pool"
        }

        termination_grace_period_seconds = 300

        container {
          name  = "burn"
          image = "busybox:1.36"

          command = ["/bin/sh", "-c", "trap : TERM INT; while true; do sleep 5; done"]

          resources {
            requests = {
              cpu    = var.cpu_request
              memory = "64Mi"
            }
            limits = {
              cpu    = var.cpu_limit
              memory = "128Mi"
            }
          }
        }
      }
    }
  }

  depends_on = [google_container_node_pool.repro, kubernetes_pod_disruption_budget_v1.pressure]
}

output "cluster_name" {
  value = google_container_cluster.repro.name
}

output "test_pool_name" {
  value = "${var.name_prefix}-pool"
}

output "zone" {
  value = var.zone
}

```

This should resolve the linked issue while also supporting timeout override since they are only supported on resources that have `Timeouts` set within `schema.Resource`

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: increase default timeout to 2 hours for `google_container_node_pool`
```
