### PR TITLE
Make PAB permissions public in Terraform

### DIFF
--- a/mmv1/products/iam3/PrincipalAccessBoundaryPolicy.yaml
+++ b/mmv1/products/iam3/PrincipalAccessBoundaryPolicy.yaml
@@ -171,6 +171,26 @@ properties:
                 The access relationship of principals to the resources in this rule.
                 Possible values: ALLOW
               required: true
+            - name: operation
+              type: NestedObject
+              description: |
+                The operation attributes that determine whether this rule applies to a request.
+                If this field is not specified, the rule applies to all operations.
+              properties:
+                - name: permissions
+                  type: Array
+                  is_set: true
+                  description: |
+                    The permissions that are explicitly affected by this rule.
+                  item_type:
+                    type: String
+                - name: excludedPermissions
+                  type: Array
+                  is_set: true
+                  description: |
+                    Specifies the permissions that this rule excludes from the set of affected permissions.
+                  item_type:
+                    type: String
       - name: enforcementVersion
         type: String
         description: |

--- a/mmv1/third_party/terraform/services/iam3/resource_iam_principal_access_boundary_policy_test.go
+++ b/mmv1/third_party/terraform/services/iam3/resource_iam_principal_access_boundary_policy_test.go
@@ -77,6 +77,10 @@ resource "google_iam_principal_access_boundary_policy" "my-pab-policy" {
       description = "PAB rule%{random_suffix}"
       effect      = "ALLOW"
       resources   = ["//cloudresourcemanager.googleapis.com/projects/${google_project.project.project_id}"]
+      operation {
+        permissions          = ["resourcemanager.projects.get"]
+        excluded_permissions = ["resourcemanager.projects.delete"]
+      }
     }
     enforcement_version = "1"
   }


### PR DESCRIPTION
Make permissions fields available in public and beta Terraform providers.

- Promotes the operation block in PrincipalAccessBoundaryPolicy rules from private to public.
- Companion private override removal CL: cl/944635326

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
iam3: added `operation`, `permissions`, and `excludedPermissions` fields to `google_iam_principal_access_boundary_policy` resource
```
