### PR TITLE
Never consider top-level name fields to be provider-only in metadata

### DIFF
--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -1457,12 +1457,17 @@ func (t *Type) ProviderOnly() bool {
 		return true
 	}
 
+	// top-level `name` fields are never provider-only.
+	parent := t.Parent()
+	if parent == nil && t.Name == "name" {
+		return false
+	}
+
 	if t.UrlParamOnly || t.ClientSide {
 		return true
 	}
 
 	// The type is provider-only if any of its ancestors are provider-only (it is inherited)
-	parent := t.Parent()
 	return parent != nil && parent.ProviderOnly()
 }
 

--- a/mmv1/api/type.go
+++ b/mmv1/api/type.go
@@ -1459,7 +1459,7 @@ func (t *Type) ProviderOnly() bool {
 
 	// top-level `name` fields are never provider-only.
 	parent := t.Parent()
-	if parent == nil && t.Name == "name" {
+	if parent == nil && t.ApiName == "name" {
 		return false
 	}
 

--- a/mmv1/api/type_test.go
+++ b/mmv1/api/type_test.go
@@ -632,6 +632,7 @@ func TestProviderOnly(t *testing.T) {
 			description: "top-level name field (virtual)",
 			obj: Type{
 				Name:       "name",
+				ApiName:    "name",
 				ClientSide: true,
 			},
 			expected: false,
@@ -640,15 +641,35 @@ func TestProviderOnly(t *testing.T) {
 			description: "top-level name field (url param)",
 			obj: Type{
 				Name:         "name",
+				ApiName:      "name",
 				UrlParamOnly: true,
 			},
 			expected: false,
 		},
 		{
+			description: "top-level field with Name different from ApiName",
+			obj: Type{
+				Name:         "custom_name",
+				ApiName:      "name",
+				UrlParamOnly: true,
+			},
+			expected: false,
+		},
+		{
+			description: "top-level field with ApiName different from name",
+			obj: Type{
+				Name:         "name",
+				ApiName:      "something_else",
+				UrlParamOnly: true,
+			},
+			expected: true,
+		},
+		{
 			description: "top-level name field (special labels)",
 			obj: Type{
-				Name: "name",
-				Type: "KeyValueEffectiveLabels",
+				Name:    "name",
+				ApiName: "name",
+				Type:    "KeyValueEffectiveLabels",
 			},
 			expected: true,
 		},

--- a/mmv1/api/type_test.go
+++ b/mmv1/api/type_test.go
@@ -558,6 +558,18 @@ func TestProviderOnly(t *testing.T) {
 	}
 	nested.SetDefault(&Resource{})
 
+	nestedName := Type{
+		Name: "foo",
+		Type: "NestedObject",
+		Properties: []*Type{
+			{
+				Name:       "name",
+				ClientSide: true,
+			},
+		},
+	}
+	nestedName.SetDefault(&Resource{})
+
 	labeled := Resource{
 		BaseUrl: "test",
 		Properties: []*Type{
@@ -615,6 +627,35 @@ func TestProviderOnly(t *testing.T) {
 			// Effective labels are added second
 			obj:      *labeled.Properties[2],
 			expected: true,
+		},
+		{
+			description: "top-level name field (virtual)",
+			obj: Type{
+				Name:       "name",
+				ClientSide: true,
+			},
+			expected: false,
+		},
+		{
+			description: "top-level name field (url param)",
+			obj: Type{
+				Name:         "name",
+				UrlParamOnly: true,
+			},
+			expected: false,
+		},
+		{
+			description: "top-level name field (special labels)",
+			obj: Type{
+				Name: "name",
+				Type: "KeyValueEffectiveLabels",
+			},
+			expected: true,
+		},
+		{
+			description: "nested name field (virtual)",
+			obj:         *nestedName.Properties[0],
+			expected:    true,
 		},
 	}
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Background / discussion at [go/terraform-identifier-field-coverage](http://goto.google.com/terraform-identifier-field-coverage)

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
