### PR TITLE
fix deployment timeout values

### DIFF
--- a/mmv1/products/oracledatabase/GoldengateDeployment.yaml
+++ b/mmv1/products/oracledatabase/GoldengateDeployment.yaml
@@ -22,16 +22,16 @@ id_format: projects/{{project}}/locations/{{location}}/goldengateDeployments/{{g
 import_format:
   - projects/{{project}}/locations/{{location}}/goldengateDeployments/{{goldengate_deployment_id}}
 timeouts:
-  insert_minutes: 60
-  update_minutes: 60
-  delete_minutes: 60
+  insert_minutes: 120
+  update_minutes: 120
+  delete_minutes: 120
 async:
   type: OpAsync
   operation:
     timeouts:
-      insert_minutes: 60
-      update_minutes: 60
-      delete_minutes: 60
+      insert_minutes: 120
+      update_minutes: 120
+      delete_minutes: 120
     base_url: '{{op_id}}'
   actions:
     - create


### PR DESCRIPTION
Fixed https://github.com/hashicorp/terraform-provider-google/issues/28068, https://github.com/hashicorp/terraform-provider-google/issues/28293

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
oracledatabase: extended `google_oracle_database_goldengate_deployment` timeouts to 2 hours
```

