### PR TITLE
dataform: add gitRepositoryLink field to google_dataform_repository

### DIFF
--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -97,6 +97,18 @@ samples:
         test_vars_overrides:
           # for backward compatible
           git_repository_name: '"my/repository" + randomSuffix'
+  - name: dataform_repository_with_developer_connect
+    primary_resource_id: dataform_repository
+    min_version: beta
+    exclude_basic_doc: true
+    exclude_test: true # Can't establish a Github connection in automated tests.
+    steps:
+      - name: dataform_repository_with_developer_connect
+        min_version: beta
+        resource_id_vars:
+          connection_name: my-connection
+          repository_link_name: my-repository
+          dataform_repository_name: dataform_repository
 virtual_fields:
   - name: deletion_policy
     type: Enum
@@ -149,6 +161,7 @@ properties:
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
+          - gitRemoteSettings.0.gitRepositoryLink
       - name: sshAuthenticationConfig
         type: NestedObject
         description: Authentication fields for remote uris using SSH protocol.
@@ -156,6 +169,7 @@ properties:
         exactly_one_of:
           - gitRemoteSettings.0.authenticationTokenSecretVersion
           - gitRemoteSettings.0.sshAuthenticationConfig
+          - gitRemoteSettings.0.gitRepositoryLink
         properties:
           - name: userPrivateKeySecretVersion
             type: String
@@ -167,6 +181,14 @@ properties:
             description: Content of a public SSH key to verify an identity of a remote Git host.
             min_version: beta
             required: true
+      - name: gitRepositoryLink
+        type: String
+        description: The name of the Developer Connect GitRepositoryLink to use for machine credentials. Must be in the format projects/*/locations/*/connections/*/gitRepositoryLinks/*.
+        min_version: beta
+        exactly_one_of:
+          - gitRemoteSettings.0.authenticationTokenSecretVersion
+          - gitRemoteSettings.0.sshAuthenticationConfig
+          - gitRemoteSettings.0.gitRepositoryLink
       - name: tokenStatus
         type: String
         description: |

--- a/mmv1/products/dataform/Repository.yaml
+++ b/mmv1/products/dataform/Repository.yaml
@@ -109,6 +109,8 @@ samples:
           connection_name: my-connection
           repository_link_name: my-repository
           dataform_repository_name: dataform_repository
+        test_env_vars:
+          project_id: PROJECT_NAME
 virtual_fields:
   - name: deletion_policy
     type: Enum

--- a/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_developer_connect.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dataform/dataform_repository_with_developer_connect.tf.tmpl
@@ -1,0 +1,45 @@
+resource "google_project_service_identity" "devconnect_p4sa" {
+  provider = google-beta
+
+  project  = "{{index $.TestEnvVars "project_id"}}"
+  service  = "developerconnect.googleapis.com"
+}
+
+resource "google_project_iam_member" "devconnect_secret" {
+  provider = google-beta
+  project  = "{{index $.TestEnvVars "project_id"}}"
+  role     = "roles/secretmanager.admin"
+  member   = google_project_service_identity.devconnect_p4sa.member
+}
+
+resource "google_developer_connect_connection" "my_connection" {
+  provider = google-beta
+  project  = "{{index $.TestEnvVars "project_id"}}"
+  location = "us-central1"
+  connection_id = "{{index $.ResourceIdVars "connection_name"}}"
+  github_config {
+    github_app = "DEVELOPER_CONNECT"
+  }
+  depends_on = [google_project_iam_member.devconnect_secret]
+}
+
+resource "google_developer_connect_git_repository_link" "my_repository" {
+  provider = google-beta
+  project  = "{{index $.TestEnvVars "project_id"}}"
+  location = "us-central1"
+  git_repository_link_id = "{{index $.ResourceIdVars "repository_link_name"}}"
+  parent_connection = google_developer_connect_connection.my_connection.connection_id
+  clone_uri = "https://github.com/myaccount/myrepository.git"
+}
+
+resource "google_dataform_repository" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
+  display_name = "{{index $.ResourceIdVars "dataform_repository_name"}}"
+
+  git_remote_settings {
+      url = "https://github.com/myaccount/myrepository.git"
+      default_branch = "main"
+      git_repository_link = google_developer_connect_git_repository_link.my_repository.id
+  }
+}


### PR DESCRIPTION
Test excluded for Developer Connect sample because interactive GitHub OAuth is required and cannot be automated in CI.

Proof of Manual Verification:
- Built local beta provider with `go install`.
- Configured `dev_overrides` to use the locally compiled binary.
- Verified using the following `main.tf`:

```hcl
provider "google-beta" {
  project = "cloud-dataform-testing"
  region  = "us-central1"
}

resource "google_project_service_identity" "devconnect_p4sa" {
  provider = google-beta
  project  = "cloud-dataform-testing"
  service  = "developerconnect.googleapis.com"
}

resource "google_project_iam_member" "devconnect_secret" {
  provider = google-beta
  project  = "cloud-dataform-testing"
  role     = "roles/secretmanager.admin"
  member   = google_project_service_identity.devconnect_p4sa.member
}

resource "google_developer_connect_connection" "my_connection" {
  provider = google-beta
  project  = "cloud-dataform-testing"
  location = "us-central1"
  connection_id = "tf-manual-test-conn"
  github_config {
    github_app = "DEVELOPER_CONNECT"
  }
  depends_on = [google_project_iam_member.devconnect_secret]
}

resource "google_developer_connect_git_repository_link" "my_repository" {
  provider = google-beta
  project  = "cloud-dataform-testing"
  location = "us-central1"
  git_repository_link_id = "tf-manual-test-repo-link"
  parent_connection = google_developer_connect_connection.my_connection.connection_id
  clone_uri = "https://github.com/kolina/dataform-example-project-bigquery.git"
}

resource "google_dataform_repository" "dataform_repo" {
  provider = google-beta
  name = "tf-manual-test-dataform-repo"
  display_name = "tf-manual-test-dataform-repo"

  git_remote_settings {
      url = "https://github.com/kolina/dataform-example-project-bigquery.git"
      default_branch = "main"
      git_repository_link = google_developer_connect_git_repository_link.my_repository.id
  }
}
```

- Applied Connection first, authorized interactively, then applied Link and Dataform Repository.
- Verified successful creation and absence of drift via `terraform plan`.
- Verified clean destruction of resources.

<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
dataform: added `git_repository_link` field to `google_dataform_repository` resource (beta)
```
