### PR TITLE
[v8.0.0] container: convert enable_components to TypeSet on google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -1207,13 +1207,14 @@ func ResourceContainerCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enable_components": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							Description: `GKE components exposing logs. Valid values include SYSTEM_COMPONENTS, APISERVER, CONTROLLER_MANAGER, KCP_CONNECTION, KCP_SSHD, KCP_HPA, KCP_VPA, SCHEDULER, and WORKLOADS.`,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 								ValidateFunc: validation.StringInSlice([]string{"SYSTEM_COMPONENTS", "APISERVER", "CONTROLLER_MANAGER", "KCP_CONNECTION", "KCP_SSHD", "KCP_HPA", "KCP_VPA", "SCHEDULER", "WORKLOADS"}, false),
 							},
+							Set: schema.HashString,
 						},
 					},
 				},
@@ -1534,7 +1535,7 @@ func ResourceContainerCluster() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enable_components": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Computed:    true,
 {{- if eq $.TargetVersionName "ga" }}
@@ -1545,6 +1546,7 @@ func ResourceContainerCluster() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
+							Set: schema.HashString,
 						},
 						"managed_prometheus": {
 							Type:        schema.TypeList,
@@ -7500,7 +7502,7 @@ func expandContainerClusterLoggingConfig(configured interface{}) *container.Logg
 	var components []string
 	if l[0] != nil {
 		config := l[0].(map[string]interface{})
-		components = tpgresource.ConvertStringArr(config["enable_components"].([]interface{}))
+		components = tpgresource.ConvertStringSet(config["enable_components"].(*schema.Set))
 	}
 
 	return &container.LoggingConfig{
@@ -7519,9 +7521,9 @@ func expandMonitoringConfig(configured interface{}) *container.MonitoringConfig 
 	config := l[0].(map[string]interface{})
 {{/* In version == 'ga' enable_components will always be specified. */}}
 	if v, ok := config["enable_components"]; ok {
-		enable_components := v.([]interface{})
+		enable_components := v.(*schema.Set)
 		mc.ComponentConfig = &container.MonitoringComponentConfig{
-			EnableComponents: tpgresource.ConvertStringArr(enable_components),
+			EnableComponents: tpgresource.ConvertStringSet(enable_components),
 		}
 	}
 	if v, ok := config["managed_prometheus"]; ok && len(v.([]interface{})) > 0 {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27247.

Converted `enable_components` inside `logging_config` and `monitoring_config` on `google_container_cluster` from `TypeList` (`schema.TypeList`) to `TypeSet` (`schema.TypeSet` with `schema.HashString`). Since `enable_components` is treated as an unordered set by the GKE API backend (`container.v1`), converting to `TypeSet` eliminates ordering mismatches between configurations and API returns that previously caused continuous permadiff / drift.

Per guidance from provider maintainers, this breaking `TypeList` -> `TypeSet` conversion is targeted for the `v8.0.0` major release branch (`FEATURE-BRANCH-major-release-8.0.0`).

```release-note:breaking-change
container: converted `enable_components` in `logging_config` and `monitoring_config` from `TypeList` to `TypeSet` on `google_container_cluster` to fix element ordering permadiffs
```