### PR TITLE
cloudrunv2: add sandbox_launcher to google_cloud_run_v2_service (beta)

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -173,6 +173,16 @@ samples:
           mesh_name: 'network-services-mesh'
         ignore_read_extra:
           - 'deletion_protection'
+  - name: 'cloudrunv2_service_sandbox'
+    primary_resource_id: 'default'
+    min_version: 'beta'
+    steps:
+      - name: 'cloudrunv2_service_sandbox'
+        min_version: 'beta'
+        resource_id_vars:
+          cloud_run_service_name: 'cloudrun-service'
+        ignore_read_extra:
+          - 'deletion_protection'
   - name: 'cloudrunv2_service_invokeriam'
     primary_resource_id: 'default'
     min_version: 'beta'
@@ -517,6 +527,11 @@ properties:
               description: |-
                 URL of the Container image in Google Container Registry or Google Artifact Registry. More info: https://kubernetes.io/docs/concepts/containers/images
               required: true
+            - name: 'sandboxLauncher'
+              type: Boolean
+              min_version: 'beta'
+              description: |-
+                Indicates that this container can act as a sandbox supervisor and launch sandboxes. Requires the second generation execution environment (`EXECUTION_ENVIRONMENT_GEN2`).
             - name: 'command'
               type: Array
               description: |-

--- a/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_sandbox.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/cloudrunv2/cloudrunv2_service_sandbox.tf.tmpl
@@ -1,0 +1,16 @@
+resource "google_cloud_run_v2_service" "{{$.PrimaryResourceId}}" {
+  provider = google-beta
+  name     = "{{index $.ResourceIdVars "cloud_run_service_name"}}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+  launch_stage = "BETA"
+
+  template {
+    execution_environment = "EXECUTION_ENVIRONMENT_GEN2"
+    containers {
+      image            = "us-docker.pkg.dev/cloudrun/container/hello"
+      sandbox_launcher = true
+    }
+  }
+}


### PR DESCRIPTION
Adds the `sandbox_launcher` container field to `google_cloud_run_v2_service` (beta) for [Cloud Run sandboxes](https://cloud.google.com/blog/topics/developers-practitioners/google-cloud-run-sandboxes-are-in-public-preview), which entered public preview on 2026-07-08.

The field is present on the v2 API `Container` message (`sandboxLauncher`, boolean — "Indicates that this container can act as a sandbox supervisor and launch sandboxes") and is enabled via `gcloud beta run deploy --sandbox-launcher`. It requires the second generation execution environment (`EXECUTION_ENVIRONMENT_GEN2`). Gated to `beta` since the feature is pre-GA.

Includes a `cloudrunv2_service_sandbox` beta example exercising the field alongside `execution_environment = "EXECUTION_ENVIRONMENT_GEN2"`.

```release-note:enhancement
cloudrunv2: added `sandbox_launcher` field to `google_cloud_run_v2_service` (beta)
```
