### PR TITLE
add support for the DNS output status field

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance.go.tmpl
@@ -711,6 +711,16 @@ API (for read pools, effective_availability_type may differ from availability_ty
                                                                                                                                 Computed:     true,
                                                                                                                                 Description:  `The connection policy status of the consumer network.`,
                                                                                                                         },
+                                                                                                                        "instance_auto_dns_status": {
+                                                                                                                                Type:         schema.TypeString,
+                                                                                                                                Computed:     true,
+                                                                                                                                Description:  `The status of the automated DNS provisioning for the instance.`,
+                                                                                                                        },
+                                                                                                                        "write_endpoint_auto_dns_status": {
+                                                                                                                                Type:         schema.TypeString,
+                                                                                                                                Computed:     true,
+                                                                                                                                Description:  `The status of the automated DNS provisioning for the write endpoint.`,
+                                                                                                                        },
                                                                                                                         "ip_address": {
                                                                                                                                 Type:         schema.TypeString,
                                                                                                                                 Computed:     true,
@@ -3530,6 +3540,8 @@ func flattenPscAutoConnections(pscAutoConnections []*sqladmin.PscAutoConnectionC
                 data := map[string]interface{}{
                         "consumer_network":   flag.ConsumerNetwork,
                         "consumer_network_status":   flag.ConsumerNetworkStatus,
+                        "instance_auto_dns_status":   flag.InstanceAutoDnsStatus,
+                        "write_endpoint_auto_dns_status":   flag.WriteEndpointAutoDnsStatus,
                         "consumer_service_project_id":   flag.ConsumerProject,
                         "ip_address":   flag.IpAddress,
                         "status":   flag.Status,

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_meta.yaml.tmpl
@@ -173,6 +173,8 @@ fields:
   - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.consumerNetworkStatus'
   - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.consumerProject'
     field: 'settings.ip_configuration.psc_config.psc_auto_connections.consumer_service_project_id'
+  - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.instanceAutoDnsStatus'
+  - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.writeEndpointAutoDnsStatus'
   - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.ipAddress'
   - api_field: 'settings.ipConfiguration.pscConfig.pscAutoConnections.status'
   - api_field: 'settings.ipConfiguration.pscConfig.pscAutoDnsEnabled'

--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -7522,6 +7522,14 @@ func verifyPscAutoConnectionsOperation(resourceName string, isPscConfigExpected 
 				if !ok || consumerProject != expectedConsumerProject {
 					return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.psc_auto_connections.0.consumer_service_project_id property is not present or set as expected in state of %s", resourceName)
 				}
+
+				if _, ok = resourceAttributes["settings.0.ip_configuration.0.psc_config.0.psc_auto_connections.0.instance_auto_dns_status"]; !ok {
+					return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.psc_auto_connections.0.instance_auto_dns_status property is not present in state of %s", resourceName)
+				}
+
+				if _, ok = resourceAttributes["settings.0.ip_configuration.0.psc_config.0.psc_auto_connections.0.write_endpoint_auto_dns_status"]; !ok {
+					return fmt.Errorf("settings.0.ip_configuration.0.psc_config.0.psc_auto_connections.0.write_endpoint_auto_dns_status property is not present in state of %s", resourceName)
+				}
 			}
 		}
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -894,6 +894,10 @@ performing filtering in a Terraform config.
 
 * `settings.ip_configuration.psc_config.psc_auto_connections.consumer_network_status` - (Output) The connection policy status of the consumer network.
 
+* `settings.ip_configuration.psc_config.psc_auto_connections.instance_auto_dns_status` - (Output) The status of the automated DNS provisioning for the instance.
+
+* `settings.ip_configuration.psc_config.psc_auto_connections.write_endpoint_auto_dns_status` - (Output) The status of the automated DNS provisioning for the write endpoint.
+
 * `settings.ip_configuration.psc_config.psc_auto_connections.ip_address` - (Output) The IP address of the consumer endpoint.
 
 * `settings.ip_configuration.psc_config.psc_auto_connections.status` - (Output) The connection status of the consumer endpoint.


### PR DESCRIPTION
Adds support for the `instance_auto_dns_status` and `write_endpoint_auto_dns_status` output fields to the `psc_auto_connections` block within `google_sql_database_instance`. 

These output-only fields expose the automated DNS provisioning status for Cloud SQL instances using Private Service Connect (PSC), allowing Terraform users to programmatically verify whether the backend has successfully registered the automated DNS records. 

Modifications include:
* Exposing `instance_auto_dns_status` and `write_endpoint_auto_dns_status` in the Terraform schema.
* Mapping the API fields in the meta YAML configuration.
* Adding verification for these properties in the `psc_auto_connections` integration tests.
* Documenting the new output fields in the resource's markdown page.

```release-note:enhancement
google_sql_database_instance: Added `instance_auto_dns_status` and `write_endpoint_auto_dns_status` output fields to the `psc_auto_connections` block in `google_sql_database_instance`.
```