### PR TITLE
Add google_container_node_pool list resource

### DIFF
--- a/mmv1/third_party/terraform/services/container/list_google_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/list_google_container_node_pool.go.tmpl
@@ -40,19 +40,19 @@ type GoogleContainerNodePoolListModel struct {
 }
 
 func NewGoogleContainerNodePoolListResource() list.ListResource {
-	listR := &GoogleContainerNodePoolListResource{}
-	listR.TypeName = "google_container_node_pool"
-	listR.SDKv2Resource = ResourceContainerNodePool()
-	listR.ListConfigFields = []tpgresource.ListConfigField{
+	resource := &GoogleContainerNodePoolListResource{}
+	resource.TypeName = "google_container_node_pool"
+	resource.SDKv2Resource = ResourceContainerNodePool()
+	resource.ListConfigFields = []tpgresource.ListConfigField{
 		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
 		{Name: "location", Kind: tpgresource.ListConfigKindString, Optional: false},
 		{Name: "cluster", Kind: tpgresource.ListConfigKindString, Optional: false},
 	}
-	return listR
+	return resource
 }
 
-func (listR *GoogleContainerNodePoolListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
-	errContainerNodePoolListStreamClosed := errors.New("stream closed")
+func (resource *GoogleContainerNodePoolListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	errStreamClosed := errors.New("stream closed")
 
 	var data GoogleContainerNodePoolListModel
 	diags := listReq.Config.Get(ctx, &data)
@@ -60,7 +60,7 @@ func (listR *GoogleContainerNodePoolListResource) List(ctx context.Context, list
 		stream.Results = list.ListResultsStreamDiagnostics(diags)
 		return
 	}
-	if listR.Client == nil {
+	if resource.Client == nil {
 		diags = append(diags, diag.NewErrorDiagnostic(
 			"Provider not configured",
 			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
@@ -69,24 +69,24 @@ func (listR *GoogleContainerNodePoolListResource) List(ctx context.Context, list
 		return
 	}
 
-	project := listR.GetProject(data.Project)
-	location := listR.GetLocation(data.Location)
+	project := resource.GetProject(data.Project)
+	location := resource.GetLocation(data.Location)
 	cluster := data.Cluster.ValueString()
 
 	stream.Results = func(push func(list.ListResult) bool) {
-		err := ListContainerNodePools(listR.Client, project, location, cluster, func(rd *schema.ResourceData) error {
+		err := ListContainerNodePools(resource.Client, project, location, cluster, func(rd *schema.ResourceData) error {
 			result := listReq.NewListResult(ctx)
 
-			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
+			if err := resource.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
 				return err
 			}
 
 			if !push(result) {
-				return errContainerNodePoolListStreamClosed
+				return errStreamClosed
 			}
 			return nil
 		})
-		if err == nil || errors.Is(err, errContainerNodePoolListStreamClosed) {
+		if err == nil || errors.Is(err, errStreamClosed) {
 			return
 		}
 		diags.AddError("API Error", err.Error())

--- a/mmv1/third_party/terraform/services/container/list_google_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/list_google_container_node_pool.go.tmpl
@@ -1,0 +1,183 @@
+{{- if ne $.TargetVersionName "ga" }}
+// Copyright (c) IBM Corp. 2014, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/list"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	container "google.golang.org/api/container/v1beta1"
+
+	"github.com/hashicorp/terraform-provider-google/google/registry"
+	"github.com/hashicorp/terraform-provider-google/google/tpgresource"
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+func init() {
+	registry.FrameworkListResource{
+		Name:        "google_container_node_pool",
+		ProductName: "container",
+		Func:        NewGoogleContainerNodePoolListResource,
+	}.Register()
+}
+
+type GoogleContainerNodePoolListResource struct {
+	tpgresource.ListResourceMetadata
+}
+
+type GoogleContainerNodePoolListModel struct {
+	Project  types.String `tfsdk:"project"`
+	Location types.String `tfsdk:"location"`
+	Cluster  types.String `tfsdk:"cluster"`
+}
+
+func NewGoogleContainerNodePoolListResource() list.ListResource {
+	listR := &GoogleContainerNodePoolListResource{}
+	listR.TypeName = "google_container_node_pool"
+	listR.SDKv2Resource = ResourceContainerNodePool()
+	listR.ListConfigFields = []tpgresource.ListConfigField{
+		{Name: "project", Kind: tpgresource.ListConfigKindString, Optional: true},
+		{Name: "location", Kind: tpgresource.ListConfigKindString, Optional: false},
+		{Name: "cluster", Kind: tpgresource.ListConfigKindString, Optional: false},
+	}
+	return listR
+}
+
+func (listR *GoogleContainerNodePoolListResource) List(ctx context.Context, listReq list.ListRequest, stream *list.ListResultsStream) {
+	errContainerNodePoolListStreamClosed := errors.New("stream closed")
+
+	var data GoogleContainerNodePoolListModel
+	diags := listReq.Config.Get(ctx, &data)
+	if diags.HasError() {
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+	if listR.Client == nil {
+		diags = append(diags, diag.NewErrorDiagnostic(
+			"Provider not configured",
+			"The Google provider client is not available; ensure the provider is configured (e.g. credentials and default project).",
+		))
+		stream.Results = list.ListResultsStreamDiagnostics(diags)
+		return
+	}
+
+	project := listR.GetProject(data.Project)
+	location := listR.GetLocation(data.Location)
+	cluster := data.Cluster.ValueString()
+
+	stream.Results = func(push func(list.ListResult) bool) {
+		err := ListContainerNodePools(listR.Client, project, location, cluster, func(rd *schema.ResourceData) error {
+			result := listReq.NewListResult(ctx)
+
+			if err := listR.SetResult(ctx, listReq.IncludeResource, &result, rd, "name"); err != nil {
+				return err
+			}
+
+			if !push(result) {
+				return errContainerNodePoolListStreamClosed
+			}
+			return nil
+		})
+		if err == nil || errors.Is(err, errContainerNodePoolListStreamClosed) {
+			return
+		}
+		diags.AddError("API Error", err.Error())
+		result := listReq.NewListResult(ctx)
+		result.Diagnostics = diags
+		push(result)
+	}
+}
+
+func ListContainerNodePools(config *transport_tpg.Config, project, location, cluster string, callback func(*schema.ResourceData) error) error {
+	if config == nil {
+		return fmt.Errorf("provider client is not configured")
+	}
+
+	d := ResourceContainerNodePool().Data(&terraform.InstanceState{})
+
+	if project != "" {
+		if err := d.Set("project", project); err != nil {
+			return fmt.Errorf("error setting project on temporary resource data: %w", err)
+		}
+	}
+	if location != "" {
+		if err := d.Set("location", location); err != nil {
+			return fmt.Errorf("error setting location on temporary resource data: %w", err)
+		}
+	}
+	if cluster != "" {
+		if err := d.Set("cluster", cluster); err != nil {
+			return fmt.Errorf("error setting cluster on temporary resource data: %w", err)
+		}
+	}
+
+	url, err := tpgresource.ReplaceVars(d, config, "{{"{{"}}ContainerBasePath{{"}}"}}projects/{{"{{"}}project{{"}}"}}/locations/{{"{{"}}location{{"}}"}}/clusters/{{"{{"}}cluster{{"}}"}}/nodePools")
+	if err != nil {
+		return err
+	}
+
+	billingProject := project
+	if bp, err := tpgresource.GetBillingProject(d, config); err == nil {
+		billingProject = bp
+	}
+
+	userAgent, err := tpgresource.GenerateUserAgentString(d, config.UserAgent)
+	if err != nil {
+		return err
+	}
+
+	return transport_tpg.ListPages(transport_tpg.ListPagesOptions{
+		Config:         config,
+		TempData:       d,
+		Resource:       ResourceContainerNodePool(),
+		ListURL:        url,
+		BillingProject: billingProject,
+		ItemName:       "nodePools",
+		UserAgent:      userAgent,
+		Flattener: func(res map[string]interface{}, d *schema.ResourceData, config *transport_tpg.Config) error {
+			var np container.NodePool
+			if err := tpgresource.Convert(res, &np); err != nil {
+				return fmt.Errorf("error converting node pool list response: %w", err)
+			}
+			if np.Name == "" {
+				return fmt.Errorf("missing name in node pool list response")
+			}
+
+			if err := d.Set("project", project); err != nil {
+				return err
+			}
+			if err := d.Set("location", location); err != nil {
+				return err
+			}
+			if err := d.Set("cluster", cluster); err != nil {
+				return err
+			}
+			if err := d.Set("name", np.Name); err != nil {
+				return err
+			}
+
+			npMap, err := flattenNodePool(d, config, &np, "")
+			if err != nil {
+				return err
+			}
+			for k, v := range npMap {
+				if err := d.Set(k, v); err != nil {
+					return fmt.Errorf("error setting %s: %s", k, err)
+				}
+			}
+
+			d.SetId(fmt.Sprintf("projects/%s/locations/%s/clusters/%s/nodePools/%s", project, location, cluster, np.Name))
+			return nil
+		},
+		Callback: callback,
+	})
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/container/list_google_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/list_google_container_node_pool_test.go.tmpl
@@ -1,0 +1,100 @@
+{{- if ne $.TargetVersionName "ga" }}
+package container_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/querycheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-google/google/acctest"
+	"github.com/hashicorp/terraform-provider-google/google/envvar"
+	tpgcompute "github.com/hashicorp/terraform-provider-google/google/services/compute"
+	_ "github.com/hashicorp/terraform-provider-google/google/services/container"
+)
+
+func TestAccContainerNodePoolListResource_queryIdentity(t *testing.T) {
+	t.Parallel()
+
+	project := envvar.GetTestProjectFromEnv()
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
+	nodePool := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePoolListResourceBasic(project, cluster, nodePool, networkName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.test", "name", cluster),
+					resource.TestCheckResourceAttr("google_container_cluster.test", "location", "us-central1-a"),
+					resource.TestCheckResourceAttr("google_container_node_pool.test", "name", nodePool),
+				),
+			},
+			{
+				Query:  true,
+				Config: testAccContainerNodePoolListResourceQuery(project, cluster),
+				QueryResultChecks: []querycheck.QueryResultCheck{
+					querycheck.ExpectLengthAtLeast("google_container_node_pool.all", 1),
+					querycheck.ExpectIdentity("google_container_node_pool.all", map[string]knownvalue.Check{
+						"project":  knownvalue.StringExact(project),
+						"location": knownvalue.StringExact("us-central1-a"),
+						"cluster":  knownvalue.StringExact(cluster),
+						"name":     knownvalue.StringExact(nodePool),
+					}),
+				},
+			},
+		},
+	})
+}
+
+func testAccContainerNodePoolListResourceBasic(project, cluster, nodePool, networkName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "test" {
+  name               = %q
+  location           = "us-central1-a"
+  project            = %q
+  initial_node_count = 1
+
+  network    = %q
+  subnetwork = %q
+
+  deletion_protection = false
+}
+
+resource "google_container_node_pool" "test" {
+  name       = %q
+  project    = %q
+  cluster    = google_container_cluster.test.name
+  location   = google_container_cluster.test.location
+  node_count = 1
+}
+`, cluster, project, networkName, subnetworkName, nodePool, project)
+}
+
+func testAccContainerNodePoolListResourceQuery(project, cluster string) string {
+	return fmt.Sprintf(`
+provider "google" {}
+
+list "google_container_node_pool" "all" {
+  provider = google
+  limit    = 1000
+
+  config {
+    project  = %q
+    location = "us-central1-a"
+    cluster  = %q
+  }
+}
+`, project, cluster)
+}
+{{- end }}

--- a/mmv1/third_party/terraform/services/container/list_google_container_node_pool_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/list_google_container_node_pool_test.go.tmpl
@@ -21,7 +21,7 @@ func TestAccContainerNodePoolListResource_queryIdentity(t *testing.T) {
 
 	project := envvar.GetTestProjectFromEnv()
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(t, 10))
-	nodePool := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
+	nodePoolName := fmt.Sprintf("tf-test-nodepool-%s", acctest.RandString(t, 10))
 	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
 	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
 
@@ -33,11 +33,11 @@ func TestAccContainerNodePoolListResource_queryIdentity(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePoolListResourceBasic(project, cluster, nodePool, networkName, subnetworkName),
+				Config: testAccContainerNodePoolListResourceBasic(project, cluster, nodePoolName, networkName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.test", "name", cluster),
 					resource.TestCheckResourceAttr("google_container_cluster.test", "location", "us-central1-a"),
-					resource.TestCheckResourceAttr("google_container_node_pool.test", "name", nodePool),
+					resource.TestCheckResourceAttr("google_container_node_pool.test", "name", nodePoolName),
 				),
 			},
 			{
@@ -49,7 +49,7 @@ func TestAccContainerNodePoolListResource_queryIdentity(t *testing.T) {
 						"project":  knownvalue.StringExact(project),
 						"location": knownvalue.StringExact("us-central1-a"),
 						"cluster":  knownvalue.StringExact(cluster),
-						"name":     knownvalue.StringExact(nodePool),
+						"name":     knownvalue.StringExact(nodePoolName),
 					}),
 				},
 			},

--- a/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_node_pool.go.tmpl
@@ -209,6 +209,30 @@ func ResourceContainerNodePool() *schema.Resource {
 
 		UseJSONNumber: true,
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"location": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"cluster": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"name": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: tpgresource.MergeSchemas(
 			schemaNodePool,
 			map[string]*schema.Schema{
@@ -995,6 +1019,15 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 	
 	if err := tpgresource.DeletionPolicyReadDefault(d, config, "DELETE"); err != nil{
 	    return err
+	}
+
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":  nodePoolInfo.project,
+		"location": nodePoolInfo.location,
+		"cluster":  nodePoolInfo.cluster,
+		"name":     name,
+	}); err != nil {
+		return err
 	}
 	
 

--- a/mmv1/third_party/terraform/website/docs/list-resources/google_container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/list-resources/google_container_node_pool.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Kubernetes (GKE) Engine"
+description: |-
+  List Google Kubernetes Engine node pools in a cluster for use with terraform query
+  and .tfquery.hcl files.
+---
+
+# google_container_node_pool (list)
+
+Lists GKE node pools in a cluster for use with
+[`terraform query`](https://developer.hashicorp.com/terraform/cli/commands/query) and
+`.tfquery.hcl` files. Results correspond to existing
+[`google_container_node_pool`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool)
+managed resources.
+
+For how list resources work in this provider, Terraform version requirements, and shared
+`list` block arguments, refer to the guide
+[Use list resources with terraform query (Google Cloud provider)](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_list_resources_with_terraform_query).
+
+## Example
+
+```hcl
+list "google_container_node_pool" "all" {
+  provider = google
+
+  config {
+    # Optional. Defaults to the provider project when omitted.
+    # project = "my-project"
+    location = "us-central1-a"
+    cluster  = "my-cluster"
+  }
+}
+```
+
+Run `terraform query` from the directory that contains the `.tfquery.hcl` file.
+
+## Configuration (`config` block)
+
+* `project` - (Optional) Project ID containing the cluster. If unset, the provider project is used.
+
+* `location` - (Required) Cluster location (zone or region).
+
+* `cluster` - (Required) Cluster name.
+
+## Results
+
+By default each result includes resource identity for `google_container_node_pool`:
+
+* `project` - Project ID.
+
+* `location` - Cluster location.
+
+* `cluster` - Cluster name.
+
+* `name` - Node pool name.
+
+With `include_resource = true` on the `list` block, results also include the full resource-style
+attributes documented for the managed
+[`google_container_node_pool` resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#attributes-reference).


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28310
Adds a new list resource `google_container_node_pool` for Terraform 1.14+ `terraform query` support. This allows users to list all node pools for a given GKE cluster.
Details
- Adds Identity block and `SetResourceIdentityAttributes` to `google_container_node_pool` resource
- Adds list resource implementation for `google_container_node_pool` using `ListPages`
- Adds acceptance test `TestAccContainerNodePoolListResource_queryIdentity`
- Adds documentation for the list resource
Release Note Template for Downstream PRs (will be copied)

```release-note:enhancement
container: added `google_container_node_pool` list resource for `terraform query` support
```
