### PR TITLE
Add google_vertex_ai_agent_anomaly_detection_scope resource (beta)

### DIFF
--- a/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
+++ b/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
@@ -52,8 +52,7 @@ samples:
     min_version: 'beta'
     bootstrap_iam:
       - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
-         role: "roles/logging.configWriter"
-
+        role: "roles/logging.configWriter"
     steps:
       - name: 'vertex_ai_agent_anomaly_detection_scope_basic'
         resource_id_vars:

--- a/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
+++ b/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
@@ -50,6 +50,10 @@ samples:
   - name: 'vertex_ai_agent_anomaly_detection_scope_basic'
     primary_resource_id: 'scope'
     min_version: 'beta'
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+         role: "roles/logging.configWriter"
+
     steps:
       - name: 'vertex_ai_agent_anomaly_detection_scope_basic'
         resource_id_vars:

--- a/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
+++ b/mmv1/products/vertexaiaad/AgentAnomalyDetectionScope.yaml
@@ -1,0 +1,114 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: 'AgentAnomalyDetectionScope'
+min_version: 'beta'
+exclude_tgc: true
+description: |-
+  An Agent Anomaly Detection (AAD) scope defines the Cloud Logging and
+  Observability buckets that AAD monitors for anomalous agent behavior within
+  a location. Creating a scope provisions a dedicated tenant project for
+  detection. Only one scope may exist per location.
+references:
+  guides:
+    'Agent Anomaly Detection': 'https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/'
+  api: 'https://cloud.google.com/vertex-ai/docs/reference/rest/v1beta1/projects.locations.agentAnomalyDetectionScopes'
+base_url: 'projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes'
+self_link: 'projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope_id}}'
+id_format: 'projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope_id}}'
+import_format:
+  - 'projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope_id}}'
+create_url: 'projects/{{project}}/locations/{{region}}/agentAnomalyDetectionScopes?agentAnomalyDetectionScopeId={{agent_anomaly_detection_scope_id}}'
+# The scope has no public update method, so all configurable fields are
+# immutable; changing them requires recreating the scope.
+immutable: true
+timeouts:
+  insert_minutes: 40
+  delete_minutes: 20
+sweeper:
+  url_substitutions:
+    - region: us
+async:
+  actions: ['create', 'delete']
+  type: 'PollAsync'
+  check_response_func_existence: 'PollCheckForScopeActive'
+  check_response_func_absence: 'PollCheckForScopeDeleted'
+  suppress_error: false
+  target_occurrences: 1
+samples:
+  - name: 'vertex_ai_agent_anomaly_detection_scope_basic'
+    primary_resource_id: 'scope'
+    min_version: 'beta'
+    steps:
+      - name: 'vertex_ai_agent_anomaly_detection_scope_basic'
+        resource_id_vars:
+          scope_id: 'agent-anomaly-detection-scope'
+          log_bucket_id: 'aad-log-bucket'
+parameters:
+  - name: 'region'
+    type: String
+    description: The region of the AgentAnomalyDetectionScope, e.g. us-central1.
+    url_param_only: true
+    required: true
+    immutable: true
+  - name: 'agentAnomalyDetectionScopeId'
+    type: String
+    description: |-
+      The ID to use for the AgentAnomalyDetectionScope, which will become the
+      final component of the scope's resource name. This value should be 1-63
+      characters and valid characters are /[a-z][0-9]-/.
+    url_param_only: true
+    required: true
+    immutable: true
+properties:
+  - name: 'name'
+    type: String
+    description: |-
+      The resource name of the AgentAnomalyDetectionScope, in the format
+      projects/{{project}}/locations/{{location}}/agentAnomalyDetectionScopes/{{agent_anomaly_detection_scope}}
+    output: true
+  - name: 'displayName'
+    type: String
+    description: User provided display name of the AgentAnomalyDetectionScope.
+    immutable: true
+  - name: 'logBuckets'
+    type: Array
+    item_type:
+      type: String
+    description: |-
+      Customer owned Cloud Logging bucket resource names attached to this scope.
+      Format: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}.
+    required: true
+    immutable: true
+  - name: 'observabilityBuckets'
+    type: Array
+    item_type:
+      type: String
+    description: |-
+      Customer owned Cloud Observability bucket resource names attached to this
+      scope.
+      Format: projects/{{project}}/locations/{{location}}/buckets/{{bucket}}/datasets/{{dataset}}.
+    required: true
+    immutable: true
+  - name: 'state'
+    type: Enum
+    description: |-
+      The lifecycle state of the scope.
+    output: true
+    enum_values:
+      - 'CREATING'
+      - 'ACTIVE'
+      - 'DELETING'
+      - 'FAILED'
+      - 'UPDATING'

--- a/mmv1/products/vertexaiaad/product.yaml
+++ b/mmv1/products/vertexaiaad/product.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: VertexAiAad
+legacy_name: vertex_ai
+display_name: Vertex AI
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+versions:
+  - name: beta
+    base_url: https://aiplatform.{{region}}.rep.googleapis.com/v1beta1/

--- a/mmv1/templates/terraform/samples/services/vertexaiaad/vertex_ai_agent_anomaly_detection_scope_basic.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexaiaad/vertex_ai_agent_anomaly_detection_scope_basic.tf.tmpl
@@ -1,0 +1,25 @@
+resource "google_logging_project_bucket_config" "{{index $.ResourceIdVars "log_bucket_id"}}" {
+  provider         = google-beta
+  project          = data.google_project.project.project_id
+  location         = "us"
+  retention_days   = 30
+  bucket_id        = "{{index $.ResourceIdVars "log_bucket_id"}}"
+  enable_analytics = true
+}
+
+resource "google_vertex_ai_agent_anomaly_detection_scope" "{{$.PrimaryResourceId}}" {
+  provider                         = google-beta
+  region                           = "us"
+  agent_anomaly_detection_scope_id = "{{index $.ResourceIdVars "scope_id"}}"
+  display_name                     = "Basic AAD scope"
+  log_buckets = [
+    google_logging_project_bucket_config.{{index $.ResourceIdVars "log_bucket_id"}}.id,
+  ]
+  observability_buckets = [
+    "projects/${data.google_project.project.project_id}/locations/us/buckets/_Trace/datasets/Spans",
+  ]
+}
+
+data "google_project" "project" {
+  provider = google-beta
+}

--- a/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
+++ b/mmv1/third_party/terraform/.teamcity/components/inputs/services_beta.kt
@@ -926,6 +926,11 @@ var ServicesListBeta = mapOf(
         "displayName" to "Vertexai",
         "path" to "./google-beta/services/vertexai"
     ),
+    "vertexaiaad" to mapOf(
+        "name" to "vertexaiaad",
+        "displayName" to "Vertexaiaad",
+        "path" to "./google-beta/services/vertexaiaad"
+    ),
     "vmwareengine" to mapOf(
         "name" to "vmwareengine",
         "displayName" to "Vmwareengine",

--- a/mmv1/third_party/terraform/services/vertexaiaad/vertex_ai_aad_polling.go
+++ b/mmv1/third_party/terraform/services/vertexaiaad/vertex_ai_aad_polling.go
@@ -1,0 +1,70 @@
+package vertexaiaad
+
+import (
+	"fmt"
+	"log"
+
+	transport_tpg "github.com/hashicorp/terraform-provider-google/google/transport"
+)
+
+// PollCheckForScopeActive checks the scope's state field during create polling.
+// ACTIVE → done, CREATING/UPDATING → retry, FAILED → error.
+func PollCheckForScopeActive(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+	if respErr != nil {
+		if transport_tpg.IsGoogleApiErrorWithCode(respErr, 404) {
+			log.Printf("[DEBUG] AgentAnomalyDetectionScope poll: not found yet, retrying...")
+			return transport_tpg.PendingStatusPollResult("not found")
+		}
+		log.Printf("[DEBUG] AgentAnomalyDetectionScope poll: error: %s", respErr)
+		return transport_tpg.ErrorPollResult(respErr)
+	}
+
+	state, ok := resp["state"].(string)
+	if !ok {
+		log.Printf("[DEBUG] AgentAnomalyDetectionScope poll: state field not found, retrying...")
+		return transport_tpg.PendingStatusPollResult("state unknown")
+	}
+
+	log.Printf("[DEBUG] AgentAnomalyDetectionScope poll: state=%s", state)
+
+	switch state {
+	case "ACTIVE":
+		return transport_tpg.SuccessPollResult()
+	case "CREATING", "UPDATING":
+		return transport_tpg.PendingStatusPollResult(state)
+	case "FAILED":
+		return transport_tpg.ErrorPollResult(fmt.Errorf("AgentAnomalyDetectionScope reached FAILED state"))
+	default:
+		return transport_tpg.PendingStatusPollResult(state)
+	}
+}
+
+// PollCheckForScopeDeleted checks the scope's state field during delete polling.
+// 404 → done, DELETING → retry, FAILED → error.
+func PollCheckForScopeDeleted(resp map[string]interface{}, respErr error) transport_tpg.PollResult {
+	if respErr != nil {
+		if transport_tpg.IsGoogleApiErrorWithCode(respErr, 404) {
+			log.Printf("[DEBUG] AgentAnomalyDetectionScope delete poll: scope deleted (404)")
+			return transport_tpg.SuccessPollResult()
+		}
+		log.Printf("[DEBUG] AgentAnomalyDetectionScope delete poll: error: %s", respErr)
+		return transport_tpg.ErrorPollResult(respErr)
+	}
+
+	state, ok := resp["state"].(string)
+	if !ok {
+		log.Printf("[DEBUG] AgentAnomalyDetectionScope delete poll: state field not found, retrying...")
+		return transport_tpg.PendingStatusPollResult("state unknown")
+	}
+
+	log.Printf("[DEBUG] AgentAnomalyDetectionScope delete poll: state=%s", state)
+
+	switch state {
+	case "DELETING":
+		return transport_tpg.PendingStatusPollResult("DELETING")
+	case "FAILED":
+		return transport_tpg.ErrorPollResult(fmt.Errorf("AgentAnomalyDetectionScope deletion reached FAILED state"))
+	default:
+		return transport_tpg.PendingStatusPollResult(state)
+	}
+}


### PR DESCRIPTION
Adds a new beta Terraform resource for Vertex AI Agent Anomaly Detection (AAD) scope (`google_vertex_ai_agent_anomaly_detection_scope`).

An AAD scope defines the Cloud Logging and Observability buckets that AAD monitors for anomalous agent behavior in a given location. Creating a scope provisions a dedicated tenant project for detection.

- Create/Delete are async (LRO)
- All configurable fields are immutable (no public Update method)
- Read via standard GET
- Only one scope per location
- 
This is part of the AAD GA launch compliance (b/527074080). The v1 proto surface was promoted in cl/946753365; this resource targets google-beta (v1beta1) first, to be promoted to google (v1) at GA.

```release-note:new-resource
`google_vertex_ai_agent_anomaly_detection_scope` (beta)
```