### PR TITLE
Promote Z4D Terraform SSD partition size changes to public.

### DIFF
--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template.go.tmpl
@@ -59,7 +59,7 @@ var (
 )
 
 var DEFAULT_SCRATCH_DISK_SIZE_GB = 375
-var VALID_SCRATCH_DISK_SIZES_GB [2]int = [2]int{375, 3000}
+var VALID_SCRATCH_DISK_SIZES_GB = []int{375, 3000, 3500, 7000, 14000}
 
 func ResourceComputeInstanceTemplate() *schema.Resource {
 	return &schema.Resource{
@@ -169,7 +169,7 @@ func ResourceComputeInstanceTemplate() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Computed:    true,
-							Description: `The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375 or 3000 GB, with a default of 375 GB.`,
+							Description: `The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375, 3000, 3500, 7000 or 14000 GB, with a default of 375 GB.`,
 						},
 
 						"disk_type": {
@@ -1440,13 +1440,13 @@ func resourceComputeInstanceTemplateScratchDiskCustomizeDiffFunc(diff tpgresourc
 		}
 
 		diskSize := diff.Get(fmt.Sprintf("disk.%d.disk_size_gb", i)).(int)
-		if typee == "SCRATCH" && !(diskSize == 375 || diskSize == 3000) { // see VALID_SCRATCH_DISK_SIZES_GB
+		if typee == "SCRATCH" && !(diskSize == 375 || diskSize == 3000 || diskSize == 3500 || diskSize == 7000 || diskSize == 14000) { // see VALID_SCRATCH_DISK_SIZES_GB
 			return fmt.Errorf("SCRATCH disks must be one of %v GB, disk %d is %d", VALID_SCRATCH_DISK_SIZES_GB, i, diskSize)
 		}
 
 		interfacee := diff.Get(fmt.Sprintf("disk.%d.interface", i)).(string)
-		if typee == "SCRATCH" && diskSize == 3000 && interfacee != "NVME" {
-			return fmt.Errorf("SCRATCH disks with a size of 3000 GB must have an interface of NVME. disk %d has interface %s", i, interfacee)
+		if typee == "SCRATCH" && (diskSize == 3000 || diskSize == 3500 || diskSize == 7000 || diskSize == 14000) && interfacee != "NVME" {
+			return fmt.Errorf("SCRATCH disks with a size of %d GB must have an interface of NVME. disk %d has interface %s", diskSize, i, interfacee)
 		}
 	}
 

--- a/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_instance_template_test.go.tmpl
@@ -1137,6 +1137,25 @@ func TestAccComputeInstanceTemplate_invalidDiskType(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_invalidScratchDiskInterface(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeInstanceTemplate_invalidScratchDiskInterface(acctest.RandString(t, 10), 3500),
+				ExpectError: regexp.MustCompile("SCRATCH disks with a size of 3500 GB must have an interface of NVME"),
+			},
+			{
+				Config:      testAccComputeInstanceTemplate_invalidScratchDiskInterface(acctest.RandString(t, 10), 14000),
+				ExpectError: regexp.MustCompile("SCRATCH disks with a size of 14000 GB must have an interface of NVME"),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_withNamePrefix(t *testing.T) {
 	// Randomness from generated name suffix
 	acctest.SkipIfVcr(t)
@@ -4989,6 +5008,35 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix)
+}
+
+func testAccComputeInstanceTemplate_invalidScratchDiskInterface(suffix string, diskSize int) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-12"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  machine_type   = "n2-standard-64"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.name
+    auto_delete  = true
+    boot         = true
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = %d
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "SCSI"
+  }
+  network_interface {
+    network = "default"
+  }
+}`, suffix, diskSize)
 }
 
 func testAccComputeInstanceTemplate_imageResourceTest(diskName string, imageName string, imageDescription string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template.go.tmpl
@@ -140,7 +140,7 @@ func ResourceComputeRegionInstanceTemplate() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Computed:    true,
-							Description: `The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375 or 3000 GB, with a default of 375 GB.`,
+							Description: `The size of the image in gigabytes. If not specified, it will inherit the size of its base image. For SCRATCH disks, the size must be one of 375, 3000, 3500, 7000 or 14000 GB, with a default of 375 GB.`,
 						},
 
 						"disk_type": {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_instance_template_test.go.tmpl
@@ -1022,6 +1022,25 @@ func TestAccComputeRegionInstanceTemplate_invalidDiskType(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionInstanceTemplate_invalidScratchDiskInterface(t *testing.T) {
+	t.Parallel()
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeRegionInstanceTemplate_invalidScratchDiskInterface(acctest.RandString(t, 10), 3500),
+				ExpectError: regexp.MustCompile("SCRATCH disks with a size of 3500 GB must have an interface of NVME"),
+			},
+			{
+				Config:      testAccComputeRegionInstanceTemplate_invalidScratchDiskInterface(acctest.RandString(t, 10), 14000),
+				ExpectError: regexp.MustCompile("SCRATCH disks with a size of 14000 GB must have an interface of NVME"),
+			},
+		},
+	})
+}
+
 func TestAccComputeRegionInstanceTemplate_withScratchDisk(t *testing.T) {
 	t.Parallel()
 
@@ -4277,6 +4296,36 @@ resource "google_compute_region_instance_template" "foobar" {
   }
 }
 `, suffix)
+}
+
+func testAccComputeRegionInstanceTemplate_invalidScratchDiskInterface(suffix string, diskSize int) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-12"
+	project = "debian-cloud"
+}
+
+resource "google_compute_region_instance_template" "foobar" {
+  name           = "tf-test-instance-template-%s"
+  region         = "us-central1"
+  machine_type   = "n2-standard-64"
+  can_ip_forward = false
+  disk {
+    source_image = data.google_compute_image.my_image.name
+    auto_delete  = true
+    boot         = true
+  }
+  disk {
+    auto_delete  = true
+    disk_size_gb = %d
+    type         = "SCRATCH"
+    disk_type    = "local-ssd"
+    interface    = "SCSI"
+  }
+  network_interface {
+    network = "default"
+  }
+}`, suffix, diskSize)
 }
 
 func testAccComputeRegionInstanceTemplate_imageResourceTest(diskName string, imageName string, imageDescription string) string {


### PR DESCRIPTION
This change promotes the support for 3500GB and 7000GB scratch disk sizes in Compute Instance Template and Compute Region Instance Template from private overrides to the public Magic Modules templates.

The changes were previously applied to `google-nightly` as overrides in b/518876123. This change moves them upstream so that they are included in public `google` and `google-beta` providers.

Link to internal removal CL: cl/947237542

```release-note:enhancement
compute: added 3500GB and 7000GB SSD partition size to `google_compute_instance_template` resource
```