### PR TITLE
Add google_vertex_ai_persistent_resource

### DIFF
--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -22,23 +22,19 @@ references:
   api: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.persistentResources
 docs:
 base_url: projects/{{project}}/locations/{{location}}/persistentResources
-self_link: projects/{{project}}/locations/{{location}}/persistentResources/{{persistent_resource_id}}
-create_url: projects/{{project}}/locations/{{location}}/persistentResources?persistentResourceId={{persistent_resource_id}}
-update_mask: true
-update_verb: PATCH
+self_link: projects/{{project}}/locations/{{location}}/persistentResources/{{name}}
+create_url: projects/{{project}}/locations/{{location}}/persistentResources?persistentResourceId={{name}}
 import_format:
-  - projects/{{project}}/locations/{{location}}/persistentResources/{{persistent_resource_id}}
+  - projects/{{project}}/locations/{{location}}/persistentResources/{{name}}
 async:
   operation:
     base_url: '{{op_id}}'
   actions:
     - create
-    - update
     - delete
   result:
     resource_inside_response: true
 autogen_status: UGVyc2lzdGVudFJlc291cmNlQXV0b2dlblYyQWdlbnQ=
-autogen_async: true
 samples:
   - name: vertex_ai_persistent_resource
     primary_resource_id: persistent_resource
@@ -47,19 +43,36 @@ samples:
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
         vars:
-          display_name: test-persistent-resource
-      - name: vertex_ai_persistent_resource
+          replica_count: "1"
+  - name: vertex_ai_persistent_resource_full
+    primary_resource_id: persistent_resource
+    external_providers: [time]
+    bootstrap_iam:
+      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+        role: "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+        role: "roles/compute.networkAdmin"
+      - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+        role: "roles/dns.peer"
+    steps:
+      - name: vertex_ai_persistent_resource_full
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
-        vars:
-          display_name: test-persistent-resource-updated
+          network_name: vertex-network
+          address_name: vertex-ip-range
+          network_attachment_name: psc-attachment
+          subnetwork_name: psc-subnetwork
+          kms_key_name: example-key
+        test_vars_overrides:
+          kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-pr-key1").CryptoKey.Name'
 parameters:
   - name: location
     type: String
     description: The location of the PersistentResource. eg us-central1
     url_param_only: true
     immutable: true
-  - name: persistentResourceId
+properties:
+  - name: name
     type: String
     description: |-
       The ID to use for the PersistentResource, which become the final component
@@ -67,13 +80,7 @@ parameters:
 
       The maximum length is 63 characters, and valid characters
       are `/^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/`.
-    immutable: true
-    url_param_only: true
     required: true
-properties:
-  - name: name
-    type: String
-    description: Resource name of a PersistentResource.
     immutable: true
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
   - name: displayName
@@ -96,6 +103,7 @@ properties:
             User can specify it if necessary. Otherwise, it's generated
             automatically.
           immutable: true
+          default_from_api: true
         - name: machineSpec
           type: NestedObject
           required: true
@@ -140,6 +148,7 @@ properties:
             - name: acceleratorCount
               type: Integer
               description: The number of accelerators to attach to the machine.
+              immutable: true
             - name: gpuPartitionSize
               type: String
               description: |-
@@ -170,6 +179,7 @@ properties:
                 A ReservationAffinity can be used to configure a Vertex AI resource (e.g., a
                 DeployedModel) to draw its Compute Engine resources from a Shared
                 Reservation, or exclusively from on-demand capacity.
+              immutable: true
               properties:
                 - name: reservationAffinityType
                   type: String
@@ -180,12 +190,14 @@ properties:
                     NO_RESERVATION
                     ANY_RESERVATION
                     SPECIFIC_RESERVATION
+                  immutable: true
                 - name: key
                   type: String
                   description: |-
                     Corresponds to the label key of a reservation resource. To target a
                     SPECIFIC_RESERVATION by name, use `compute.googleapis.com/reservation-name`
                     as the key and specify the name of your reservation as its value.
+                  immutable: true
                 - name: values
                   type: Array
                   description: |-
@@ -193,6 +205,7 @@ properties:
                     full resource name of the reservation or reservation block.
                   item_type:
                     type: String
+                  immutable: true
         - name: replicaCount
           type: String
           description: The total number of machines to use for this resource pool.
@@ -205,10 +218,14 @@ properties:
         - name: diskSpec
           type: NestedObject
           description: Represents the spec of disk options.
+          default_from_api: true
+          immutable: true
           properties:
             - name: bootDiskSizeGb
               type: Integer
               description: Size in GB of the boot disk (default is 100GB).
+              default_from_api: true
+              immutable: true
             - name: bootDiskType
               type: String
               description: |-
@@ -216,12 +233,16 @@ properties:
                 "pd-ssd", for A3U machines, the default value is "hyperdisk-balanced".
                 Valid values: "pd-ssd" (Persistent Disk Solid State Drive),
                 "pd-standard" (Persistent Disk Hard Disk Drive) or "hyperdisk-balanced".
+              default_from_api: true
+              immutable: true
         - name: autoscalingSpec
           type: NestedObject
           description: The min/max number of replicas allowed if enabling autoscaling
+          immutable: true
           properties:
             - name: minReplicaCount
               type: String
+              immutable: true
               description: |-
                 min replicas in the node pool,
                 must be ≤ replica_count and < max_replica_count or will throw error.
@@ -233,11 +254,13 @@ properties:
                 CreatePersistentResourceRequestValidator.java.
             - name: maxReplicaCount
               type: String
+              immutable: true
               description: |-
                 max replicas in the node pool,
                 must be ≥ replica_count and > min_replica_count or will throw error
   - name: labels
     type: KeyValueLabels
+    immutable: true
     description: |-
       The labels with user-defined metadata to organize PersistentResource.
 
@@ -248,6 +271,7 @@ properties:
       See https://goo.gl/xmQnxf for more information and examples of labels.
   - name: network
     type: String
+    immutable: true
     description: |-
       The full name of the Compute Engine
       [network](/compute/docs/networks-and-firewalls#networks) to peered with
@@ -266,10 +290,12 @@ properties:
       network.
   - name: pscInterfaceConfig
     type: NestedObject
+    immutable: true
     description: Configuration for PSC-I.
     properties:
       - name: networkAttachment
         type: String
+        immutable: true
         description: |-
           The name of the Compute Engine
           [network
@@ -288,15 +314,18 @@ properties:
           on the target project.
         item_type:
           type: NestedObject
+          immutable: true
           properties:
             - name: domain
               type: String
+              immutable: true
               required: true
               description: |-
                 The DNS name suffix of the zone being peered to, e.g.,
                 "my-internal-domain.corp.". Must end with a dot.
             - name: targetNetwork
               type: String
+              immutable: true
               required: true
               description: |-
                 The VPC network name
@@ -304,6 +333,7 @@ properties:
                 visible.
             - name: targetProject
               type: String
+              immutable: true
               required: true
               description: |-
                 The project ID hosting the Cloud DNS managed zone that
@@ -311,6 +341,7 @@ properties:
                 dns.peer role on this project.
   - name: encryptionSpec
     type: NestedObject
+    immutable: true
     description: |-
       Represents a customer-managed encryption key specification that can be
       applied to a Vertex AI resource.
@@ -326,90 +357,27 @@ properties:
           `projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}`.
   - name: resourceRuntimeSpec
     type: NestedObject
+    immutable: true
     description: |-
-      Configuration for the runtime on a PersistentResource instance, including
-      but not limited to:
-
-      * Service accounts used to run the workloads.
-      * Whether to make it a dedicated Ray Cluster.
+      Configuration for the runtime on a PersistentResource instance.
     properties:
       - name: serviceAccountSpec
         type: NestedObject
         description: Configuration for the use of custom service account to run the workloads.
+        immutable: true
         properties:
           - name: enableCustomServiceAccount
             type: Boolean
             required: true
+            immutable: true
             description: |-
               If true, custom user-managed service account is enforced to run any
               workloads (for example, Vertex Jobs) on the resource.
               Otherwise, uses the [Vertex AI Custom Code Service
               Agent](https://cloud.google.com/vertex-ai/docs/general/access-control#service-agents).
-          - name: serviceAccount
-            type: String
-            description: |-
-              Required when all below conditions are met
-               * `enable_custom_service_account` is true;
-               * any runtime is specified via `ResourceRuntimeSpec` on creation time,
-                 for example, Ray
-
-              The users must have `iam.serviceAccounts.actAs` permission on this service
-              account and then the specified runtime containers will run as it.
-
-              Do not set this field if you want to submit jobs using custom service
-              account to this PersistentResource after creation, but only specify the
-              `service_account` inside the job.
-      - name: raySpec
-        type: NestedObject
-        description: |-
-          Configuration information for the Ray cluster.
-          For experimental launch, Ray cluster creation and Persistent
-          cluster creation are 1:1 mapping: We will provision all the nodes within the
-          Persistent cluster as Ray nodes.
-        properties:
-          - name: imageUri
-            type: String
-            description: |-
-              Default image for user to choose a preferred ML framework
-              (for example, TensorFlow or Pytorch) by choosing from [Vertex prebuilt
-              images](https://cloud.google.com/vertex-ai/docs/training/pre-built-containers).
-              Either this or the resource_pool_images is required. Use this field if
-              you need all the resource pools to have the same Ray image. Otherwise, use
-              the `resource_pool_images` field.
-          - name: headNodeResourcePoolId
-            type: String
-            description: |-
-              This will be used to indicate which resource pool will serve as
-              the Ray head node(the first node within that pool). Will use the machine
-              from the first workerpool as the head node by default if this field isn't
-              set.
-          - name: rayMetricSpec
-            type: NestedObject
-            description: Configuration for the Ray metrics.
-            properties:
-              - name: disabled
-                type: Boolean
-                description: Flag to disable the Ray metrics collection.
-          - name: rayLogsSpec
-            type: NestedObject
-            description: Configuration for the Ray OSS Logs.
-            properties:
-              - name: disabled
-                type: Boolean
-                description: Flag to disable the export of Ray OSS logs to Cloud Logging.
-          - name: resourcePoolImages
-            type: KeyValuePairs
-            description: |-
-              Required if image_uri isn't set. A map of resource_pool_id to prebuild Ray
-              image if user need to use different images for different head/worker pools.
-              This map needs to cover all the resource pool ids. Example:
-              {
-              "ray_head_node_pool": "head image"
-              "ray_worker_node_pool1": "worker image"
-              "ray_worker_node_pool2": "another worker image"
-              }
   - name: reservedIpRanges
     type: Array
+    immutable: true
     description: |-
       A list of names for the reserved IP ranges under the VPC network
       that can be used for this persistent resource.

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -45,7 +45,7 @@ samples:
   - name: vertex_ai_persistent_resource_autoscaling
     primary_resource_id: persistent_resource
     steps:
-      - name: vertex_ai_persistent_resource
+      - name: vertex_ai_persistent_resource_autoscaling
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
   - name: vertex_ai_persistent_resource_full

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -161,30 +161,6 @@ properties:
               type: Integer
               description: The number of accelerators to attach to the machine.
               immutable: true
-            - name: gpuPartitionSize
-              type: String
-              description: |-
-                The Nvidia GPU partition size.
-
-                When specified, the requested accelerators will be partitioned into
-                smaller GPU partitions. For example, if the request is for 8 units of
-                NVIDIA A100 GPUs, and gpu_partition_size="1g.10gb", the service will
-                create 8 * 7 = 56 partitioned MIG instances.
-
-                The partition size must be a value supported by the requested accelerator.
-                Refer to
-                [Nvidia GPU
-                Partitioning](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus-multi#multi-instance_gpu_partitions)
-                for the available partition sizes.
-
-                If set, the accelerator_count should be set to 1.
-              immutable: true
-            - name: tpuTopology
-              type: String
-              description: |-
-                The topology of the TPUs. Corresponds to the TPU topologies available from
-                GKE. (Example: tpu_topology: "2x2x1").
-              immutable: true
             - name: reservationAffinity
               type: NestedObject
               description: |-

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -42,8 +42,12 @@ samples:
       - name: vertex_ai_persistent_resource
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
-        vars:
-          replica_count: "1"
+  - name: vertex_ai_persistent_resource_autoscaling
+    primary_resource_id: persistent_resource
+    steps:
+      - name: vertex_ai_persistent_resource
+        resource_id_vars:
+          persistent_resource_id: example-persistent-resource
   - name: vertex_ai_persistent_resource_full
     primary_resource_id: persistent_resource
     external_providers: [time]
@@ -63,6 +67,7 @@ samples:
           network_attachment_name: psc-attachment
           subnetwork_name: psc-subnetwork
           kms_key_name: example-key
+          resource_pool_id: vpr-resource-pool
         test_vars_overrides:
           kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us-central1", "tf-bootstrap-pr-key1").CryptoKey.Name'
 parameters:
@@ -415,15 +420,18 @@ properties:
     properties:
       - name: code
         type: Integer
+        output: true
         description: The status code, which should be an enum value of google.rpc.Code.
       - name: message
         type: String
+        output: true
         description: |-
           A developer-facing error message, which should be in English. Any
           user-facing error message should be localized and sent in the
           google.rpc.Status.details field, or localized by the client.
       - name: details
         type: Array
+        output: true
         description: |-
           A list of messages that carry the error details.  There is a common set of
           message types for APIs to use.

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -48,7 +48,14 @@ samples:
       - name: vertex_ai_persistent_resource_autoscaling
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
-  - name: vertex_ai_persistent_resource_full
+  - name: vertex_ai_persistent_resource_machine_spec
+    exclude_test: true # Requires GPU quota
+    primary_resource_id: persistent_resource
+    steps:
+      - name: vertex_ai_persistent_resource_machine_spec
+        resource_id_vars:
+          persistent_resource_id: example-persistent-resource
+  - name: vertex_ai_persistent_resource_network
     primary_resource_id: persistent_resource
     external_providers: [time]
     bootstrap_iam:
@@ -59,7 +66,7 @@ samples:
       - member: "serviceAccount:service-{project_number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
         role: "roles/dns.peer"
     steps:
-      - name: vertex_ai_persistent_resource_full
+      - name: vertex_ai_persistent_resource_network
         resource_id_vars:
           persistent_resource_id: example-persistent-resource
           network_name: vertex-network

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -161,39 +161,6 @@ properties:
               type: Integer
               description: The number of accelerators to attach to the machine.
               immutable: true
-            - name: reservationAffinity
-              type: NestedObject
-              description: |-
-                A ReservationAffinity can be used to configure a Vertex AI resource (e.g., a
-                DeployedModel) to draw its Compute Engine resources from a Shared
-                Reservation, or exclusively from on-demand capacity.
-              immutable: true
-              properties:
-                - name: reservationAffinityType
-                  type: String
-                  required: true
-                  description: |-
-                    Specifies the reservation affinity type.
-                    Possible values:
-                    NO_RESERVATION
-                    ANY_RESERVATION
-                    SPECIFIC_RESERVATION
-                  immutable: true
-                - name: key
-                  type: String
-                  description: |-
-                    Corresponds to the label key of a reservation resource. To target a
-                    SPECIFIC_RESERVATION by name, use `compute.googleapis.com/reservation-name`
-                    as the key and specify the name of your reservation as its value.
-                  immutable: true
-                - name: values
-                  type: Array
-                  description: |-
-                    Corresponds to the label values of a reservation resource. This must be the
-                    full resource name of the reservation or reservation block.
-                  item_type:
-                    type: String
-                  immutable: true
         - name: replicaCount
           type: String
           description: The total number of machines to use for this resource pool.

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -1,0 +1,501 @@
+# Copyright 2026 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: PersistentResource
+description: |-
+  Represents long-lasting resources that are dedicated to users to runs custom
+  workloads. A PersistentResource can have multiple node pools and each node
+  pool can have its own machine spec.
+references:
+  guides:
+  api: https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.persistentResources
+docs:
+base_url: projects/{{project}}/locations/{{location}}/persistentResources
+self_link: projects/{{project}}/locations/{{location}}/persistentResources/{{persistent_resource_id}}
+create_url: projects/{{project}}/locations/{{location}}/persistentResources?persistentResourceId={{persistent_resource_id}}
+update_mask: true
+update_verb: PATCH
+import_format:
+  - projects/{{project}}/locations/{{location}}/persistentResources/{{persistent_resource_id}}
+async:
+  operation:
+    base_url: '{{op_id}}'
+  actions:
+    - create
+    - update
+    - delete
+  result:
+    resource_inside_response: true
+autogen_status: UGVyc2lzdGVudFJlc291cmNlQXV0b2dlblYyQWdlbnQ=
+autogen_async: true
+samples:
+  - name: vertex_ai_persistent_resource
+    primary_resource_id: persistent_resource
+    steps:
+      - name: vertex_ai_persistent_resource
+        resource_id_vars:
+          persistent_resource_id: example-persistent-resource
+        vars:
+          display_name: test-persistent-resource
+      - name: vertex_ai_persistent_resource
+        resource_id_vars:
+          persistent_resource_id: example-persistent-resource
+        vars:
+          display_name: test-persistent-resource-updated
+parameters:
+  - name: location
+    type: String
+    description: The location of the PersistentResource. eg us-central1
+    url_param_only: true
+    immutable: true
+  - name: persistentResourceId
+    type: String
+    description: |-
+      The ID to use for the PersistentResource, which become the final component
+      of the PersistentResource's resource name.
+
+      The maximum length is 63 characters, and valid characters
+      are `/^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$/`.
+    immutable: true
+    url_param_only: true
+    required: true
+properties:
+  - name: name
+    type: String
+    description: Resource name of a PersistentResource.
+    immutable: true
+    custom_flatten: templates/terraform/custom_flatten/name_from_self_link.tmpl
+  - name: displayName
+    type: String
+    description: |-
+      The display name of the PersistentResource.
+      The name can be up to 128 characters long and can consist of any UTF-8
+      characters.
+  - name: resourcePools
+    type: Array
+    required: true
+    description: The spec of the pools of different resources.
+    item_type:
+      type: NestedObject
+      properties:
+        - name: id
+          type: String
+          description: |-
+            The unique ID in a PersistentResource for referring to this resource pool.
+            User can specify it if necessary. Otherwise, it's generated
+            automatically.
+          immutable: true
+        - name: machineSpec
+          type: NestedObject
+          required: true
+          description: Specification of a single machine.
+          immutable: true
+          properties:
+            - name: machineType
+              type: String
+              description: |-
+                The type of the machine.
+
+                See the [list of machine types supported for
+                prediction](https://cloud.google.com/vertex-ai/docs/predictions/configure-compute#machine-types)
+
+                See the [list of machine types supported for custom
+                training](https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types).
+              immutable: true
+            - name: acceleratorType
+              type: String
+              description: |-
+                The type of accelerator(s) that may be attached to the machine.
+                Possible values:
+                NVIDIA_TESLA_K80
+                NVIDIA_TESLA_P100
+                NVIDIA_TESLA_V100
+                NVIDIA_TESLA_P4
+                NVIDIA_TESLA_T4
+                NVIDIA_TESLA_A100
+                NVIDIA_A100_80GB
+                NVIDIA_L4
+                NVIDIA_H100_80GB
+                NVIDIA_H100_MEGA_80GB
+                NVIDIA_H200_141GB
+                NVIDIA_B200
+                NVIDIA_GB200
+                NVIDIA_RTX_PRO_6000
+                TPU_V2
+                TPU_V3
+                TPU_V4_POD
+                TPU_V5_LITEPOD
+              immutable: true
+            - name: acceleratorCount
+              type: Integer
+              description: The number of accelerators to attach to the machine.
+            - name: gpuPartitionSize
+              type: String
+              description: |-
+                The Nvidia GPU partition size.
+
+                When specified, the requested accelerators will be partitioned into
+                smaller GPU partitions. For example, if the request is for 8 units of
+                NVIDIA A100 GPUs, and gpu_partition_size="1g.10gb", the service will
+                create 8 * 7 = 56 partitioned MIG instances.
+
+                The partition size must be a value supported by the requested accelerator.
+                Refer to
+                [Nvidia GPU
+                Partitioning](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus-multi#multi-instance_gpu_partitions)
+                for the available partition sizes.
+
+                If set, the accelerator_count should be set to 1.
+              immutable: true
+            - name: tpuTopology
+              type: String
+              description: |-
+                The topology of the TPUs. Corresponds to the TPU topologies available from
+                GKE. (Example: tpu_topology: "2x2x1").
+              immutable: true
+            - name: reservationAffinity
+              type: NestedObject
+              description: |-
+                A ReservationAffinity can be used to configure a Vertex AI resource (e.g., a
+                DeployedModel) to draw its Compute Engine resources from a Shared
+                Reservation, or exclusively from on-demand capacity.
+              properties:
+                - name: reservationAffinityType
+                  type: String
+                  required: true
+                  description: |-
+                    Specifies the reservation affinity type.
+                    Possible values:
+                    NO_RESERVATION
+                    ANY_RESERVATION
+                    SPECIFIC_RESERVATION
+                - name: key
+                  type: String
+                  description: |-
+                    Corresponds to the label key of a reservation resource. To target a
+                    SPECIFIC_RESERVATION by name, use `compute.googleapis.com/reservation-name`
+                    as the key and specify the name of your reservation as its value.
+                - name: values
+                  type: Array
+                  description: |-
+                    Corresponds to the label values of a reservation resource. This must be the
+                    full resource name of the reservation or reservation block.
+                  item_type:
+                    type: String
+        - name: replicaCount
+          type: String
+          description: The total number of machines to use for this resource pool.
+        - name: usedReplicaCount
+          type: String
+          description: |-
+            The number of machines currently in use by training jobs for this resource
+            pool. Will replace idle_replica_count.
+          output: true
+        - name: diskSpec
+          type: NestedObject
+          description: Represents the spec of disk options.
+          properties:
+            - name: bootDiskSizeGb
+              type: Integer
+              description: Size in GB of the boot disk (default is 100GB).
+            - name: bootDiskType
+              type: String
+              description: |-
+                Type of the boot disk. For non-A3U machines, the default value is
+                "pd-ssd", for A3U machines, the default value is "hyperdisk-balanced".
+                Valid values: "pd-ssd" (Persistent Disk Solid State Drive),
+                "pd-standard" (Persistent Disk Hard Disk Drive) or "hyperdisk-balanced".
+        - name: autoscalingSpec
+          type: NestedObject
+          description: The min/max number of replicas allowed if enabling autoscaling
+          properties:
+            - name: minReplicaCount
+              type: String
+              description: |-
+                min replicas in the node pool,
+                must be ≤ replica_count and < max_replica_count or will throw error.
+                For autoscaling enabled Ray-on-Vertex, we allow min_replica_count of a
+                resource_pool to be 0 to match the OSS Ray
+                behavior(https://docs.ray.io/en/latest/cluster/vms/user-guides/configuring-autoscaling.html#cluster-config-parameters).
+                As for Persistent Resource, the min_replica_count must be > 0, we added
+                a corresponding validation inside
+                CreatePersistentResourceRequestValidator.java.
+            - name: maxReplicaCount
+              type: String
+              description: |-
+                max replicas in the node pool,
+                must be ≥ replica_count and > min_replica_count or will throw error
+  - name: labels
+    type: KeyValueLabels
+    description: |-
+      The labels with user-defined metadata to organize PersistentResource.
+
+      Label keys and values can be no longer than 64 characters
+      (Unicode codepoints), can only contain lowercase letters, numeric
+      characters, underscores and dashes. International characters are allowed.
+
+      See https://goo.gl/xmQnxf for more information and examples of labels.
+  - name: network
+    type: String
+    description: |-
+      The full name of the Compute Engine
+      [network](/compute/docs/networks-and-firewalls#networks) to peered with
+      Vertex AI to host the persistent resources.
+      For example, `projects/12345/global/networks/myVPC`.
+      [Format](/compute/docs/reference/rest/v1/networks/insert)
+      is of the form `projects/{project}/global/networks/{network}`.
+      Where {project} is a project number, as in `12345`, and {network} is a
+      network name.
+
+      To specify this field, you must have already [configured VPC Network
+      Peering for Vertex
+      AI](https://cloud.google.com/vertex-ai/docs/general/vpc-peering).
+
+      If this field is left unspecified, the resources aren't peered with any
+      network.
+  - name: pscInterfaceConfig
+    type: NestedObject
+    description: Configuration for PSC-I.
+    properties:
+      - name: networkAttachment
+        type: String
+        description: |-
+          The name of the Compute Engine
+          [network
+          attachment](https://cloud.google.com/vpc/docs/about-network-attachments) to
+          attach to the resource within the region and user project.
+          To specify this field, you must have already [created a network attachment]
+          (https://cloud.google.com/vpc/docs/create-manage-network-attachments#create-network-attachments).
+          This field is only used for resources using PSC-I.
+      - name: dnsPeeringConfigs
+        type: Array
+        description: |-
+          DNS peering configurations. When specified, Vertex AI will
+          attempt to configure DNS peering zones in the tenant project VPC
+          to resolve the specified domains using the target network's Cloud DNS.
+          The user must grant the dns.peer role to the Vertex AI Service Agent
+          on the target project.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: domain
+              type: String
+              required: true
+              description: |-
+                The DNS name suffix of the zone being peered to, e.g.,
+                "my-internal-domain.corp.". Must end with a dot.
+            - name: targetNetwork
+              type: String
+              required: true
+              description: |-
+                The VPC network name
+                in the target_project where the DNS zone specified by 'domain' is
+                visible.
+            - name: targetProject
+              type: String
+              required: true
+              description: |-
+                The project ID hosting the Cloud DNS managed zone that
+                contains the 'domain'. The Vertex AI Service Agent requires the
+                dns.peer role on this project.
+  - name: encryptionSpec
+    type: NestedObject
+    description: |-
+      Represents a customer-managed encryption key specification that can be
+      applied to a Vertex AI resource.
+    properties:
+      - name: kmsKeyName
+        type: String
+        required: true
+        description: |-
+          Resource name of the Cloud KMS key used to protect the resource.
+
+          The Cloud KMS key must be in the same region as the resource. It must have
+          the format
+          `projects/{project}/locations/{location}/keyRings/{key_ring}/cryptoKeys/{crypto_key}`.
+  - name: resourceRuntimeSpec
+    type: NestedObject
+    description: |-
+      Configuration for the runtime on a PersistentResource instance, including
+      but not limited to:
+
+      * Service accounts used to run the workloads.
+      * Whether to make it a dedicated Ray Cluster.
+    properties:
+      - name: serviceAccountSpec
+        type: NestedObject
+        description: Configuration for the use of custom service account to run the workloads.
+        properties:
+          - name: enableCustomServiceAccount
+            type: Boolean
+            required: true
+            description: |-
+              If true, custom user-managed service account is enforced to run any
+              workloads (for example, Vertex Jobs) on the resource.
+              Otherwise, uses the [Vertex AI Custom Code Service
+              Agent](https://cloud.google.com/vertex-ai/docs/general/access-control#service-agents).
+          - name: serviceAccount
+            type: String
+            description: |-
+              Required when all below conditions are met
+               * `enable_custom_service_account` is true;
+               * any runtime is specified via `ResourceRuntimeSpec` on creation time,
+                 for example, Ray
+
+              The users must have `iam.serviceAccounts.actAs` permission on this service
+              account and then the specified runtime containers will run as it.
+
+              Do not set this field if you want to submit jobs using custom service
+              account to this PersistentResource after creation, but only specify the
+              `service_account` inside the job.
+      - name: raySpec
+        type: NestedObject
+        description: |-
+          Configuration information for the Ray cluster.
+          For experimental launch, Ray cluster creation and Persistent
+          cluster creation are 1:1 mapping: We will provision all the nodes within the
+          Persistent cluster as Ray nodes.
+        properties:
+          - name: imageUri
+            type: String
+            description: |-
+              Default image for user to choose a preferred ML framework
+              (for example, TensorFlow or Pytorch) by choosing from [Vertex prebuilt
+              images](https://cloud.google.com/vertex-ai/docs/training/pre-built-containers).
+              Either this or the resource_pool_images is required. Use this field if
+              you need all the resource pools to have the same Ray image. Otherwise, use
+              the `resource_pool_images` field.
+          - name: headNodeResourcePoolId
+            type: String
+            description: |-
+              This will be used to indicate which resource pool will serve as
+              the Ray head node(the first node within that pool). Will use the machine
+              from the first workerpool as the head node by default if this field isn't
+              set.
+          - name: rayMetricSpec
+            type: NestedObject
+            description: Configuration for the Ray metrics.
+            properties:
+              - name: disabled
+                type: Boolean
+                description: Flag to disable the Ray metrics collection.
+          - name: rayLogsSpec
+            type: NestedObject
+            description: Configuration for the Ray OSS Logs.
+            properties:
+              - name: disabled
+                type: Boolean
+                description: Flag to disable the export of Ray OSS logs to Cloud Logging.
+          - name: resourcePoolImages
+            type: KeyValuePairs
+            description: |-
+              Required if image_uri isn't set. A map of resource_pool_id to prebuild Ray
+              image if user need to use different images for different head/worker pools.
+              This map needs to cover all the resource pool ids. Example:
+              {
+              "ray_head_node_pool": "head image"
+              "ray_worker_node_pool1": "worker image"
+              "ray_worker_node_pool2": "another worker image"
+              }
+  - name: reservedIpRanges
+    type: Array
+    description: |-
+      A list of names for the reserved IP ranges under the VPC network
+      that can be used for this persistent resource.
+
+      If set, we will deploy the persistent resource within the provided IP
+      ranges. Otherwise, the persistent resource is deployed to any IP
+      ranges under the provided VPC network.
+
+      Example: ['vertex-ai-ip-range'].
+    item_type:
+      type: String
+  - name: state
+    type: String
+    description: |-
+      The detailed state of a PersistentResource.
+      Possible values:
+      PROVISIONING
+      RUNNING
+      STOPPING
+      ERROR
+      REBOOTING
+      UPDATING
+    output: true
+  - name: error
+    type: NestedObject
+    description: |-
+      The `Status` type defines a logical error model that is suitable for
+      different programming environments, including REST APIs and RPC APIs. It is
+      used by [gRPC](https://github.com/grpc). Each `Status` message contains
+      three pieces of data: error code, error message, and error details.
+
+      You can find out more about this error model and how to work with it in the
+      [API Design Guide](https://cloud.google.com/apis/design/errors).
+    output: true
+    properties:
+      - name: code
+        type: Integer
+        description: The status code, which should be an enum value of google.rpc.Code.
+      - name: message
+        type: String
+        description: |-
+          A developer-facing error message, which should be in English. Any
+          user-facing error message should be localized and sent in the
+          google.rpc.Status.details field, or localized by the client.
+      - name: details
+        type: Array
+        description: |-
+          A list of messages that carry the error details.  There is a common set of
+          message types for APIs to use.
+        item_type:
+          type: NestedObject
+          properties: []
+  - name: createTime
+    type: String
+    description: Time when the PersistentResource was created.
+    output: true
+  - name: startTime
+    type: String
+    description: |-
+      Time when the PersistentResource for the first time entered the `RUNNING`
+      state.
+    output: true
+  - name: updateTime
+    type: String
+    description: Time when the PersistentResource was most recently updated.
+    output: true
+  - name: resourceRuntime
+    type: NestedObject
+    description: Persistent Cluster runtime information as output
+    output: true
+    properties:
+      - name: accessUris
+        type: KeyValuePairs
+        description: |-
+          URIs for user to connect to the Cluster.
+          Example:
+          {
+          "RAY_HEAD_NODE_INTERNAL_IP": "head-node-IP:10001"
+          "RAY_DASHBOARD_URI": "ray-dashboard-address:8888"
+          }
+        output: true
+  - name: satisfiesPzs
+    type: Boolean
+    description: Reserved for future use.
+    output: true
+  - name: satisfiesPzi
+    type: Boolean
+    description: Reserved for future use.
+    output: true

--- a/mmv1/products/vertexai/PersistentResource.yaml
+++ b/mmv1/products/vertexai/PersistentResource.yaml
@@ -429,15 +429,6 @@ properties:
           A developer-facing error message, which should be in English. Any
           user-facing error message should be localized and sent in the
           google.rpc.Status.details field, or localized by the client.
-      - name: details
-        type: Array
-        output: true
-        description: |-
-          A list of messages that carry the error details.  There is a common set of
-          message types for APIs to use.
-        item_type:
-          type: NestedObject
-          properties: []
   - name: createTime
     type: String
     description: Time when the PersistentResource was created.

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource.tf.tmpl
@@ -1,13 +1,13 @@
 resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
-  persistent_resource_id = "{{index $.ResourceIdVars "persistent_resource_id"}}"
-  location               = "us-central1"
-  display_name           = "{{index $.Vars "display_name"}}"
+  name         = "{{index $.ResourceIdVars "persistent_resource_id"}}"
+  location     = "us-central1"
+  display_name = "Example persistent resource"
 
   resource_pools {
     machine_spec {
       machine_type = "n1-standard-4"
     }
 
-    replica_count = "1"
+    replica_count = "{{index $.Vars "replica_count"}}"
   }
 }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource.tf.tmpl
@@ -1,0 +1,13 @@
+resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
+  persistent_resource_id = "{{index $.ResourceIdVars "persistent_resource_id"}}"
+  location               = "us-central1"
+  display_name           = "{{index $.Vars "display_name"}}"
+
+  resource_pools {
+    machine_spec {
+      machine_type = "n1-standard-4"
+    }
+
+    replica_count = "1"
+  }
+}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_autoscaling.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_autoscaling.tf.tmpl
@@ -14,4 +14,5 @@ resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
       min_replica_count = 1
       max_replica_count = 2
     }
+  }
 }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_autoscaling.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_autoscaling.tf.tmpl
@@ -9,5 +9,9 @@ resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
     }
 
     replica_count = 1
-  }
+
+    autoscaling_spec {
+      min_replica_count = 1
+      max_replica_count = 2
+    }
 }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_full.tf.tmpl
@@ -30,8 +30,12 @@ resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
   }
 
   resource_pools {
+    id = "{{index $.ResourceIdVars "resource_pool_id"}}"
+
     machine_spec {
-      machine_type = "n1-standard-4"
+      machine_type       = "a3-highgpu-8g"
+      accelerator_count  = 8
+      accelerator_type   = "NVIDIA_H100_80GB"
     }
 
     replica_count = "1"
@@ -96,7 +100,7 @@ resource "google_compute_network_attachment" "psc_attachment" {
   subnetworks = [
     google_compute_subnetwork.psc_subnetwork.id
   ]
-  
+
   lifecycle {
     ignore_changes = [producer_accept_lists]
   }

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_full.tf.tmpl
@@ -1,0 +1,120 @@
+resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
+  name         = "{{index $.ResourceIdVars "persistent_resource_id"}}"
+  location     = "us-central1"
+  display_name = "test-persistent-resource-full"
+
+  labels = {
+    env = "test"
+  }
+
+  # Network peering for Vertex AI
+  network = "projects/${data.google_project.project.number}/global/networks/${google_compute_network.vertex_network.name}"
+
+  # Reserved IP ranges under the VPC for the persistent resource
+  reserved_ip_ranges = [google_compute_global_address.vertex_range.name]
+
+  # Customer-managed encryption key
+  encryption_spec {
+    kms_key_name = "{{index $.ResourceIdVars "kms_key_name"}}"
+  }
+
+  # PSC-I configuration
+  psc_interface_config {
+    network_attachment = google_compute_network_attachment.psc_attachment.id
+
+    dns_peering_configs {
+      domain         = "example.com."
+      target_project = data.google_project.project.project_id
+      target_network = google_compute_network.vertex_network.name
+    }
+  }
+
+  resource_pools {
+    machine_spec {
+      machine_type = "n1-standard-4"
+    }
+
+    replica_count = "1"
+
+    disk_spec {
+      boot_disk_size_gb = 200
+      boot_disk_type    = "pd-ssd"
+    }
+  }
+
+  resource_runtime_spec {
+    service_account_spec {
+      enable_custom_service_account = true
+    }
+  }
+
+  depends_on = [
+    google_service_networking_connection.vertex_vpc_connection,
+    google_kms_crypto_key_iam_member.crypto_key,
+    # Give the google_vertex_ai_persistent_resource a change to fully delete
+    # before deleting other resources.
+    time_sleep.wait_for_deletion,
+  ]
+}
+
+# VPC network for Vertex AI peering
+resource "google_compute_network" "vertex_network" {
+  name                    = "{{index $.ResourceIdVars "network_name"}}"
+  auto_create_subnetworks = false
+}
+
+# Service networking connection for Vertex AI
+resource "google_service_networking_connection" "vertex_vpc_connection" {
+  network                 = google_compute_network.vertex_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.vertex_range.name]
+}
+
+# Reserved IP range for Vertex AI peering
+resource "google_compute_global_address" "vertex_range" {
+  name          = "{{index $.ResourceIdVars "address_name"}}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 24
+  network       = google_compute_network.vertex_network.id
+}
+
+resource "time_sleep" "wait_for_deletion" {
+  depends_on = [
+    google_compute_network_attachment.psc_attachment,
+    google_service_networking_connection.vertex_vpc_connection
+  ]
+  destroy_duration = "300s"
+}
+
+# Network attachment for PSC-I
+resource "google_compute_network_attachment" "psc_attachment" {
+  name                  = "{{index $.ResourceIdVars "network_attachment_name"}}"
+  region                = "us-central1"
+  connection_preference = "ACCEPT_MANUAL"
+
+  subnetworks = [
+    google_compute_subnetwork.psc_subnetwork.id
+  ]
+  
+  lifecycle {
+    ignore_changes = [producer_accept_lists]
+  }
+}
+
+# Subnetwork for the network attachment
+resource "google_compute_subnetwork" "psc_subnetwork" {
+  name          = "{{index $.ResourceIdVars "subnetwork_name"}}"
+  region        = "us-central1"
+  ip_cidr_range = "10.0.0.0/16"
+  network       = google_compute_network.vertex_network.id
+}
+
+# Grant Vertex AI service agent access to the KMS key
+resource "google_kms_crypto_key_iam_member" "crypto_key" {
+  crypto_key_id = "{{index $.ResourceIdVars "kms_key_name"}}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
+}
+
+data "google_project" "project" {}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_machine_spec.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_machine_spec.tf.tmpl
@@ -1,0 +1,19 @@
+resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
+  name         = "{{index $.ResourceIdVars "persistent_resource_id"}}"
+  location     = "us-central1"
+
+  resource_pools {
+    machine_spec {
+      machine_type       = "a3-highgpu-8g"
+      accelerator_count  = 8
+      accelerator_type   = "NVIDIA_H100_80GB"
+    }
+
+    replica_count = "1"
+
+    disk_spec {
+      boot_disk_size_gb = 200
+      boot_disk_type    = "pd-ssd"
+    }
+  }
+}

--- a/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_network.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/vertexai/vertex_ai_persistent_resource_network.tf.tmpl
@@ -32,13 +32,11 @@ resource "google_vertex_ai_persistent_resource" "{{.PrimaryResourceId}}" {
   resource_pools {
     id = "{{index $.ResourceIdVars "resource_pool_id"}}"
 
-    machine_spec {
-      machine_type       = "a3-highgpu-8g"
-      accelerator_count  = 8
-      accelerator_type   = "NVIDIA_H100_80GB"
-    }
-
     replica_count = "1"
+    
+    machine_spec {
+      machine_type = "n1-standard-4"
+    }
 
     disk_spec {
       boot_disk_size_gb = 200


### PR DESCRIPTION
The resource does not include support for updates, which matches [gcloud](https://docs.cloud.google.com/sdk/gcloud/reference/ai/persistent-resources). There is a [PATCH method documented](https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.persistentResources/patch) but after having a bunch of trouble with it I checked the actual API implementation code and it allows only one field in the update mask (`resource_pools.replica_count`) and even that doesn't work.

Tests are passing locally. Fixes https://github.com/hashicorp/terraform-provider-google/issues/17867

```release-note:new-resource
`google_vertex_ai_persistent_resource`
```
