### PR TITLE
fix: Remove ForceNew from effective_labels

### DIFF
--- a/mmv1/templates/terraform/state_migrations/datastream_private_connection.go.tmpl
+++ b/mmv1/templates/terraform/state_migrations/datastream_private_connection.go.tmpl
@@ -57,7 +57,6 @@ Please refer to the field 'effective_labels' for all of the labels present on th
 			"effective_labels": {
 				Type:        schema.TypeMap,
 				Computed:    true,
-				ForceNew:    true,
 				Description: `All of labels (key/value pairs) present on the resource in GCP, including the labels configured through Terraform, other clients and services.`,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
This change stops the provider from recreating the resource when a resource's labels have changed outside of terraform.

This is relatively straightforward and I believe just fixes a problem with this resource that has gone unnoticed for some time.
The `effective_labels` field is a computed field that returns all labels on a resource, created by terraform, outside of terraform, etc. All sources.

I don't know the history of this provider, but this feels like it never should have been set up this way. I have seen evidence of this in other resources so I wonder if it's a change in behaviour or some other historical issue.

Either way, this should configure the resource to correctly use this value was read-only and no longer replace resources if you modify the tags outside of terraform, or by using the `default_labels` value in the provider config.

For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/28317


**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
datastream: fix issue where `google_datastream_private_connection` resources are replaced when `effective_labels` has changes
```
