### PR TITLE
Update PublicDelegatedPrefix description in Address for BYOIPv6 support

### DIFF
--- a/mmv1/products/compute/Address.yaml
+++ b/mmv1/products/compute/Address.yaml
@@ -267,8 +267,9 @@ properties:
     type: String
     diff_suppress_func: 'AddressIpCollectionDiffSuppress'
     description: |
-      Reference to the source of external IPv4 addresses, like a PublicDelegatedPrefix(PDP) for BYOIP.
-      The PDP must support enhanced IPv4 allocations.
+      Reference to the source of external IPv4/IPv6 addresses, like a PublicDelegatedPrefix(PDP) for BYOIP.
+      If an IPv4 PDP is used, the PDP must support enhanced IPv4 allocations.
+      If an IPv6 PDP is used, the PDP must be in EXTERNAL_IPV6_FORWARDING_RULE_CREATION mode.
       Use one of the following formats to specify a PDP when reserving an external IPv4 address using BYOIP.
       Full resource URL, as in:
         * `https://www.googleapis.com/compute/v1/projects/{{projectId}}/regions/{{region}}/publicDelegatedPrefixes/{{pdp-name}}`


### PR DESCRIPTION
Update the description of the `ipCollection` field in the `compute/Address` resource to document support for IPv6 BYOIP addresses via PublicDelegatedPrefix (PDP) in `EXTERNAL_IPV6_FORWARDING_RULE_CREATION` mode.
This updates references from "IPv4" to "IPv4/IPv6" to reflect the newly supported IPv6 capability.

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none
compute: updated documentation for `ip_collection` field on `google_compute_address` to support IPv6 BYOIP addresses
```
