### PR TITLE
compute: add default_value to consumer_accept_lists fields to prevent…

### DIFF
--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -309,6 +309,7 @@ properties:
       properties:
         - name: 'projectIdOrNum'
           type: String
+          default_value: ""
           # TODO: add exactly_one_of when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
           description: |
             A project that is allowed to connect to this service attachment.
@@ -316,13 +317,16 @@ properties:
           is_missing_in_cai: true
         - name: 'networkUrl'
           type: String
+          default_value: ""
           # TODO: add exactly_one_of when it can be applied to lists (https://github.com/hashicorp/terraform-plugin-sdk/issues/470)
           description: |
             The network that is allowed to connect to this service attachment.
             Only one of project_id_or_num and network_url may be set.
           diff_suppress_func: 'tpgresource.CompareSelfLinkRelativePaths'
+          is_missing_in_cai: true
         - name: 'endpointUrl'
           type: String
+          default_value: ""
           description: |
             The endpoint that is allowed to connect to this service attachment.
             Only one of project_id_or_num, network_url and endpoint_url may be set.

--- a/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_service_attachment_test.go
@@ -1,7 +1,9 @@
 package compute_test
 
 import (
+	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -883,4 +885,179 @@ resource "google_compute_subnetwork" "psc_ilb_nat" {
   ip_cidr_range = "10.1.0.0/16"
 }
 `, context)
+}
+
+func TestAccComputeServiceAttachment_consumerAcceptListsPermadiff(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeServiceAttachmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create the resource with TWO projects in the accept list
+				Config: testAccComputeServiceAttachment_consumerAcceptListsConfig(context, 2),
+			},
+			{
+				// Step 2: Update the resource by adding a THIRD project
+				Config: testAccComputeServiceAttachment_consumerAcceptListsConfig(context, 3),
+
+				// EXPLICIT ASSERTION: Intercept the plan before applying to prove
+				// that only 1 item was added, and 0 items were deleted!
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						expectNoSetDeletions{},
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccComputeServiceAttachment_consumerAcceptListsConfig(context map[string]interface{}, listCount int) string {
+	acceptLists := `
+  consumer_accept_lists {
+    project_id_or_num = "658859330310"
+    connection_limit  = 1
+  }
+  consumer_accept_lists {
+    project_id_or_num = "673497134629"
+    connection_limit  = 1
+  }
+`
+	if listCount == 3 {
+		acceptLists += `
+  consumer_accept_lists {
+    project_id_or_num = "482878270665"
+    connection_limit  = 1
+  }
+`
+	}
+	context["accept_lists"] = acceptLists
+
+	return acctest.Nprintf(`
+resource "google_compute_service_attachment" "psc_ilb_service_attachment" {
+  name                  = "tf-test-sa-%{random_suffix}"
+  region                = "us-west2"
+  enable_proxy_protocol = false
+  connection_preference = "ACCEPT_MANUAL"
+  nat_subnets           = [google_compute_subnetwork.psc_ilb_nat.id]
+  target_service        = google_compute_forwarding_rule.psc_ilb_target_service.id
+
+  %{accept_lists}
+}
+
+resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
+  name                  = "tf-test-fr-%{random_suffix}"
+  region                = "us-west2"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = google_compute_region_backend_service.producer_service_backend.id
+  all_ports             = true
+  network               = google_compute_network.psc_ilb_network.name
+  subnetwork            = google_compute_subnetwork.psc_ilb_producer_subnetwork.name
+}
+
+resource "google_compute_region_backend_service" "producer_service_backend" {
+  name                            = "tf-test-bes-%{random_suffix}"
+  region                          = "us-west2"
+  health_checks                   = [google_compute_health_check.producer_service_health_check.id]
+  connection_draining_timeout_sec = 0
+}
+
+resource "google_compute_health_check" "producer_service_health_check" {
+  name               = "tf-test-hc-%{random_suffix}"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_network" "psc_ilb_network" {
+  name                    = "tf-test-net-%{random_suffix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
+  name          = "tf-test-prod-sub-%{random_suffix}"
+  region        = "us-west2"
+  network       = google_compute_network.psc_ilb_network.id
+  ip_cidr_range = "10.0.0.0/16"
+}
+
+resource "google_compute_subnetwork" "psc_ilb_nat" {
+  name          = "tf-test-nat-sub-%{random_suffix}"
+  region        = "us-west2"
+  network       = google_compute_network.psc_ilb_network.id
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  ip_cidr_range = "10.1.0.0/16"
+}
+`, context)
+}
+
+// expectNoSetDeletions is a custom plan checker that explicitly looks inside
+// the raw terraform plan JSON to ensure that no existing set elements were deleted or replaced.
+type expectNoSetDeletions struct{}
+
+func (e expectNoSetDeletions) CheckPlan(ctx context.Context, req plancheck.CheckPlanRequest, resp *plancheck.CheckPlanResponse) {
+	for _, rc := range req.Plan.ResourceChanges {
+		// Only inspect our specific service attachment resource
+		if rc.Address == "google_compute_service_attachment.psc_ilb_service_attachment" {
+
+			beforeMap, okBefore := rc.Change.Before.(map[string]interface{})
+			afterMap, okAfter := rc.Change.After.(map[string]interface{})
+
+			if !okBefore || !okAfter {
+				return
+			}
+
+			beforeLists, ok1 := beforeMap["consumer_accept_lists"].([]interface{})
+			afterLists, ok2 := afterMap["consumer_accept_lists"].([]interface{})
+
+			if !ok1 || !ok2 {
+				return
+			}
+
+			// 1. Assert exactly 1 item was added (2 -> 3)
+			if len(beforeLists) != 2 {
+				resp.Error = fmt.Errorf("Expected 2 items in before state, got %d", len(beforeLists))
+				return
+			}
+			if len(afterLists) != 3 {
+				resp.Error = fmt.Errorf("Expected 3 items in after state, got %d", len(afterLists))
+				return
+			}
+
+			// 2. Assert NO DELETIONS or RECREATIONS happened
+			// Verify every single object from the 'Before' state still exists IDENTICALLY in the 'After' state.
+			// This proves we didn't do a "delete and recreate" permadiff!
+			for _, bItem := range beforeLists {
+				bMap := bItem.(map[string]interface{})
+
+				foundIdenticalObject := false
+				for _, aItem := range afterLists {
+					aMap := aItem.(map[string]interface{})
+
+					// DeepEqual compares every single key (network_url, endpoint_url, etc.)
+					// and every single value in both objects!
+					if reflect.DeepEqual(bMap, aMap) {
+						foundIdenticalObject = true
+						break
+					}
+				}
+
+				// If the exact object does not appear verbatim in the After array,
+				// Terraform has failed to match it, meaning it will plan to DELETE it!
+				if !foundIdenticalObject {
+					resp.Error = fmt.Errorf("Permadiff Detected! Object %v is being replaced or deleted because of a hash mismatch!", bMap)
+					return
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/26612

This PR adds `default_value: ""` to the string fields inside `consumer_accept_lists` on `google_compute_service_attachment` to prevent noisy permadiffs caused by `null` vs `""` mismatches for unmodified consumers. 

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:bug
compute: Fixed spurious update-in-place permadiffs in `google_compute_service_attachment` when adding or removing elements from `consumer_accept_lists`
```