### PR TITLE
NamedSets GA promotion

### DIFF
--- a/mmv1/products/compute/RouterNamedSet.yaml
+++ b/mmv1/products/compute/RouterNamedSet.yaml
@@ -14,14 +14,13 @@
 ---
 name: 'RouterNamedSet'
 api_resource_type_kind: Router
-min_version: beta
 description: |
   A Named Set is a collection of IP addresses or ranges (for PREFIX type) or
   BGP communities (for COMMUNITY type) that can be used in route policies.
 references:
   guides:
     'Google Cloud Router': 'https://cloud.google.com/router/docs/'
-  api: 'https://cloud.google.com/compute/docs/reference/rest/beta/routers'
+  api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routers'
 docs:
 id_format: '{{project}}/{{region}}/{{router}}/namedSets/{{name}}'
 base_url: 'projects/{{project}}/regions/{{region}}/routers/{{router}}'

--- a/mmv1/templates/terraform/samples/services/compute/router_named_set_community.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/router_named_set_community.tf.tmpl
@@ -1,18 +1,15 @@
 resource "google_compute_network" "net" {
-  provider = google-beta
   name                    = "{{index $.ResourceIdVars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name    = "{{index $.ResourceIdVars "router_name"}}"
   network = google_compute_network.net.name
   region  = "us-central1"
 }
 
 resource "google_compute_router_named_set" "community_set" {
-  provider = google-beta
   name        = "{{index $.ResourceIdVars "named_set_name"}}"
   router      = google_compute_router.router.name
   region      = "us-central1"

--- a/mmv1/templates/terraform/samples/services/compute/router_named_set_prefix.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/router_named_set_prefix.tf.tmpl
@@ -1,18 +1,15 @@
 resource "google_compute_network" "net" {
-  provider = google-beta
   name                    = "{{index $.ResourceIdVars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name    = "{{index $.ResourceIdVars "router_name"}}"
   network = google_compute_network.net.name
   region  = "us-central1"
 }
 
 resource "google_compute_router_named_set" "prefix_set" {
-  provider = google-beta
   name        = "{{index $.ResourceIdVars "named_set_name"}}"
   router      = google_compute_router.router.name
   region      = "us-central1"

--- a/mmv1/templates/terraform/samples/services/compute/router_named_set_route_policy.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/router_named_set_route_policy.tf.tmpl
@@ -1,11 +1,9 @@
 resource "google_compute_network" "my_network" {
-  provider = google-beta
   name                    = "{{index $.ResourceIdVars "network_name"}}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "my_router" {
-  provider = google-beta
   name    = "{{index $.ResourceIdVars "router_name"}}"
   network = google_compute_network.my_network.name
   region  = "us-central1"
@@ -15,7 +13,6 @@ resource "google_compute_router" "my_router" {
 }
 
 resource "google_compute_router_named_set" "my_prefix_set" {
-  provider = google-beta
   name        = "{{index $.ResourceIdVars "named_set_name"}}"
   router      = google_compute_router.my_router.name
   region      = google_compute_router.my_router.region
@@ -38,7 +35,6 @@ resource "google_compute_router_named_set" "my_prefix_set" {
 }
 
 resource "google_compute_router_route_policy" "my_route_policy" {
-  provider = google-beta
   name   = "{{index $.ResourceIdVars "route_policy_name"}}"
   router = google_compute_router.my_router.name
   region = google_compute_router.my_router.region

--- a/mmv1/third_party/terraform/services/compute/resource_compute_router_named_set_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_router_named_set_test.go.tmpl
@@ -1,6 +1,5 @@
 package compute_test
 
-{{ if ne $.TargetVersionName "ga" }}
 import (
     "fmt"
     "log"
@@ -42,7 +41,7 @@ func TestAccComputeRouterNamedSet_updatePrefix(t *testing.T) {
 
     acctest.VcrTest(t, resource.TestCase{
         PreCheck:                 func() { acctest.AccTestPreCheck(t) },
-        ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+        ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),    
         CheckDestroy:             testAccCheckComputeRouterNamedSetsDestroyProducer(t),
         Steps: []resource.TestStep{
             {
@@ -74,20 +73,17 @@ func testAccComputeRouterNamedSet_routerNamedSetPrefix(context map[string]interf
     var b strings.Builder
     b.WriteString(acctest.Nprintf(`
 resource "google_compute_network" "net" {
-  provider = google-beta
   name                    = "tf-test-my-network%{random_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name    = "tf-test-my-router%{random_suffix}"
   network = google_compute_network.net.name
   region  = "us-central1"
 }
 
 resource "google_compute_router_named_set" "prefix_set" {
-  provider = google-beta
   name        = "tf-test-my-prefix-set%{random_suffix}"
   router      = google_compute_router.router.name
   region      = "us-central1"
@@ -158,4 +154,3 @@ func testAccCheckComputeRouterNamedSetsDestroyProducer(t *testing.T) func(s *ter
         return nil
     }
 }
-{{ end }}


### PR DESCRIPTION
b/422038675
Cloud Router NamedSetsTerraform Beta => GA support

**Release Note Template for Downstream PRs (will be copied)**
```release-note:new-resource
`google_compute_router_named_set` (GA promotion)
```

