### PR TITLE
Fix TestAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy in GA provider

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_database_instance_test.go.tmpl
@@ -1272,6 +1272,7 @@ func TestAccSqlDatabaseInstance_updateMCPEnabled(t *testing.T) {
 	})
 }
 
+{{- if ne $.TargetVersionName "ga" }}
 func TestAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -1302,6 +1303,7 @@ func TestAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy(t *testi
 		},
 	})
 }
+{{- end }}
 
 func TestAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(t *testing.T) {
 	t.Parallel()
@@ -7347,6 +7349,7 @@ resource "google_sql_database_instance" "instance" {
 `, projectId, projectId, orgId, billingAccount, instanceName)
 }
 
+{{- if ne $.TargetVersionName "ga" }}
 func testAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy(instanceName string, networkName string, projectId string) string {
 	return fmt.Sprintf(`
 resource "google_project_service_identity" "gcp_sa_cloud_sql" {
@@ -7435,6 +7438,7 @@ resource "google_compute_network" "default" {
 }
 `, projectId, projectId, projectId, projectId, networkName)
 }
+{{- end }}
 
 func testAccSqlDatabaseInstance_withPSCEnabled_withoutAllowedConsumerProjects(instanceName string, projectId string, orgId string, billingAccount string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28288

Fix `TestAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy` failure in GA provider tests.

`google_project_service_identity` is a beta-only resource type. Because this test relies on `google_project_service_identity` in its HCL configuration, running the test in GA builds caused:
```
Error: Invalid resource type
The provider hashicorp/google does not support resource type "google_project_service_identity".
```

Guarding `TestAccSqlDatabaseInstance_withPSCEnabled_withAutoConnectionPolicy` and its helper functions with `{{- if ne $.TargetVersionName "ga" }}` ensures the test is only generated in the beta provider build where `google_project_service_identity` is available.

```release-note:none

```