### PR TITLE
dialogflowcx: update model to gemini-2.5-flash in GenerativeSettings test and sample

### DIFF
--- a/mmv1/templates/terraform/samples/services/dialogflowcx/dialogflowcx_generative_settings_full.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/dialogflowcx/dialogflowcx_generative_settings_full.tf.tmpl
@@ -38,7 +38,7 @@ resource "google_dialogflow_cx_generative_settings" "{{$.PrimaryResourceId}}" {
   language_code = "en"
 
   llm_model_settings {
-    model = "gemini-2.0-flash-001"
+    model = "gemini-2.5-flash"
     prompt_text = "example prompt text"
   }
 }

--- a/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_generative_settings_test.go
+++ b/mmv1/third_party/terraform/services/dialogflowcx/resource_dialogflowcx_generative_settings_test.go
@@ -86,7 +86,7 @@ func testAccDialogflowCXGenerativeSettings_full(context map[string]interface{}) 
     language_code = "en"
 
     llm_model_settings {
-      model = "gemini-2.0-flash-001"
+      model = "gemini-2.5-flash"
       prompt_text = "example prompt text"
     }
   }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27736

Update model to `gemini-2.5-flash` in `GenerativeSettings` acceptance test and sample code to align with Dialogflow CX API behavior.

```release-note:none
```