### PR TITLE
Fix subnetwork and health_check resource names in security_policy_rule_with_body_exclude test

### DIFF
--- a/mmv1/products/compute/SecurityPolicyRule.yaml
+++ b/mmv1/products/compute/SecurityPolicyRule.yaml
@@ -93,6 +93,8 @@ samples:
           sec_policy_name: 'policyruletest'
           backend_name: 'backendpolicy'
           network_name: 'test-network'
+          subnetwork_name: 'test-subnet'
+          health_check_name: 'test-health-check'
         test_vars_overrides:
           # for backward compatible
           sec_policy_name: '"policyruletest" + randomSuffix'

--- a/mmv1/templates/terraform/samples/services/compute/security_policy_rule_with_body_exclude.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/compute/security_policy_rule_with_body_exclude.tf.tmpl
@@ -7,7 +7,7 @@ resource "google_compute_network" "default" {
 
 resource "google_compute_subnetwork" "default" {
   provider      = google-beta
-  name          = "test-subnet"
+  name          = "{{index $.ResourceIdVars "subnetwork_name"}}"
   region        = "us-west2"
   network       = google_compute_network.default.id
   ip_cidr_range = "10.10.0.0/24"
@@ -15,7 +15,7 @@ resource "google_compute_subnetwork" "default" {
 
 resource "google_compute_health_check" "default" {
   provider = google-beta
-  name     = "test-health-check"
+  name     = "{{index $.ResourceIdVars "health_check_name"}}"
 
   http_health_check {
     port = 80


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28273

```release-note:none
```