### PR TITLE
Fix async operation waiting on update for discoveryengine resources

### DIFF
--- a/mmv1/products/discoveryengine/ChatEngine.yaml
+++ b/mmv1/products/discoveryengine/ChatEngine.yaml
@@ -44,7 +44,7 @@ async:
   type: OpAsync
   operation:
     base_url: '{{op_id}}'
-  actions: [create, delete]
+  actions: [create, update, delete]
   result:
     resource_inside_response: true
 autogen_async: false

--- a/mmv1/products/discoveryengine/DataConnector.yaml
+++ b/mmv1/products/discoveryengine/DataConnector.yaml
@@ -43,7 +43,7 @@ timeouts:
   delete_minutes: 20
 autogen_async: false
 async:
-  actions: ['create', 'delete']
+  actions: ['create', 'update', 'delete']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -38,7 +38,7 @@ timeouts:
   delete_minutes: 20
 autogen_async: false
 async:
-  actions: ['create', 'delete']
+  actions: ['create', 'update', 'delete']
   type: 'OpAsync'
   operation:
     base_url: '{{op_id}}'

--- a/mmv1/products/discoveryengine/RecommendationEngine.yaml
+++ b/mmv1/products/discoveryengine/RecommendationEngine.yaml
@@ -37,7 +37,7 @@ async:
   type: OpAsync
   operation:
     base_url: '{{op_id}}'
-  actions: [create, delete]
+  actions: [create, update, delete]
   result:
     resource_inside_response: true
 autogen_async: false

--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -46,7 +46,7 @@ async:
   type: OpAsync
   operation:
     base_url: '{{op_id}}'
-  actions: [create, delete]
+  actions: [create, update, delete]
   result:
     resource_inside_response: true
 autogen_async: false


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/27403

Added `update` to `async.actions` configuration for `SearchEngine`, `ChatEngine`, `RecommendationEngine`, `DataStore`, and `DataConnector` in `discoveryengine` product. This ensures that update operations correctly poll and wait for the Long-Running Operation returned by the Google Cloud API before reading the updated state.

```release-note:bug
discoveryengine: fixed missing async operation polling on resource update for `google_discovery_engine_search_engine`, `google_discovery_engine_chat_engine`, `google_discovery_engine_recommendation_engine`, `google_discovery_engine_data_store`, and `google_discovery_engine_data_connector`
```