### PR TITLE
discoveryengine: fix non-refresh plan permadiff on features in google_discovery_engine_search_engine

### DIFF
--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -60,6 +60,7 @@ samples:
           data_store_id: 'data-store-id'
   - name: 'discoveryengine_datastore_kms_key_name'
     primary_resource_id: 'kms_key_name'
+    exclude_test: true
     steps:
       - name: 'discoveryengine_datastore_kms_key_name'
         resource_id_vars:

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -60,14 +60,13 @@ samples:
           data_store_id: 'data-store-id'
   - name: 'discoveryengine_datastore_kms_key_name'
     primary_resource_id: 'kms_key_name'
-    exclude_test: true
     steps:
       - name: 'discoveryengine_datastore_kms_key_name'
         resource_id_vars:
           data_store_id: 'data-store-id'
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "us").CryptoKey.Name'
+          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "global").CryptoKey.Name'
   - name: 'discoveryengine_datastore_document_processing_config'
     primary_resource_id: 'document_processing_config'
     steps:

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -66,7 +66,7 @@ samples:
           data_store_id: 'data-store-id'
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-test-datastore-key").CryptoKey.Name'
+          kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tftest-shared-key-5").CryptoKey.Name'
   - name: 'discoveryengine_datastore_document_processing_config'
     primary_resource_id: 'document_processing_config'
     steps:

--- a/mmv1/products/discoveryengine/DataStore.yaml
+++ b/mmv1/products/discoveryengine/DataStore.yaml
@@ -66,7 +66,7 @@ samples:
           data_store_id: 'data-store-id'
           kms_key_name: 'kms-key'
         test_vars_overrides:
-          kms_key_name: 'kms.BootstrapKMSKeyInLocation(t, "global").CryptoKey.Name'
+          kms_key_name: 'kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tf-test-datastore-key").CryptoKey.Name'
   - name: 'discoveryengine_datastore_document_processing_config'
     primary_resource_id: 'document_processing_config'
     steps:

--- a/mmv1/products/discoveryengine/SearchEngine.yaml
+++ b/mmv1/products/discoveryengine/SearchEngine.yaml
@@ -52,6 +52,7 @@ async:
 autogen_async: false
 custom_code:
   encoder: templates/terraform/encoders/discovery_engine_search_engine_hardcode_solution_type.go.tmpl
+  constants: templates/terraform/constants/discoveryengine_search_engine.go.tmpl
 samples:
   - name: discoveryengine_searchengine_basic
     primary_resource_id: basic
@@ -202,6 +203,7 @@ properties:
   - name: features
     type: KeyValuePairs
     default_from_api: true
+    diff_suppress_func: discoveryEngineSearchEngineFeaturesDiffSuppress
     description: |
       A map of the feature config for the engine to opt in or opt out of features.
   - name: kmsKeyName

--- a/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
@@ -1,0 +1,9 @@
+func discoveryEngineSearchEngineFeaturesDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if strings.HasSuffix(k, ".%") {
+		return true
+	}
+	if new == "" && old != "" {
+		return true
+	}
+	return false
+}

--- a/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
+++ b/mmv1/templates/terraform/constants/discoveryengine_search_engine.go.tmpl
@@ -1,8 +1,8 @@
 func discoveryEngineSearchEngineFeaturesDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if strings.HasSuffix(k, ".%") {
+	if strings.Contains(k, "enable-end-user-sharing-with-groups") && new == "" {
 		return true
 	}
-	if new == "" && old != "" {
+	if strings.HasSuffix(k, ".%") {
 		return true
 	}
 	return false

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "kms_key_name" {
-  location                     = "us"
+  location                     = "global"
   data_store_id                = "{{index $.ResourceIdVars "data_store_id"}}"
   display_name                 = "tf-test-structured-datastore"
   industry_vertical            = "GENERIC"

--- a/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
+++ b/mmv1/templates/terraform/samples/services/discoveryengine/discoveryengine_datastore_kms_key_name.tf.tmpl
@@ -1,5 +1,5 @@
 resource "google_discovery_engine_data_store" "kms_key_name" {
-  location                     = "global"
+  location                     = "us"
   data_store_id                = "{{index $.ResourceIdVars "data_store_id"}}"
   display_name                 = "tf-test-structured-datastore"
   industry_vertical            = "GENERIC"


### PR DESCRIPTION
1. Update `discoveryEngineSearchEngineFeaturesDiffSuppress` to specifically suppress plan diffs for `enable-end-user-sharing-with-groups` when it is not specified in HCL config, preventing non-refresh plan permadiffs caused by server default `FEATURE_STATE_OFF` while keeping API values in state.
2. Update `discoveryengine_datastore_kms_key_name` test override to use `kms.BootstrapKMSKeyWithPurposeInLocationAndName(t, "ENCRYPT_DECRYPT", "us", "tftest-shared-key-5")` in location `us`, utilizing the pre-provisioned bootstrapped KMS key in `tftest-shared-keyring-1`.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/27403
Fixes https://github.com/hashicorp/terraform-provider-google/issues/23515

```release-note:bug
discoveryengine: fixed non-refresh plan permadiff for `features` in `google_discovery_engine_search_engine` 
```