### PR TITLE
add support for node_readiness_config addon to google_container_cluster

### DIFF
--- a/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster.go.tmpl
@@ -112,6 +112,7 @@ var (
 		"addons_config.0.slice_controller_config",
 		"addons_config.0.pod_snapshot_config",
 		"addons_config.0.slurm_operator_config",
+		"addons_config.0.node_readiness_config",
 		"addons_config.0.agent_sandbox_config",
 	{{- if ne $.TargetVersionName "ga" }}
 		"addons_config.0.istio_config",
@@ -702,6 +703,22 @@ func ResourceContainerCluster() *schema.Resource {
 							AtLeastOneOf:  addonsConfigKeys,
 							MaxItems:      1,
 							Description:   `The status of the Slurm Operator addon, which creates slurm related CRDs and KCP pods to manage them. Defaults to disabled for Standard clusters; set enabled = true to enable. It can not be enabled for Autopilot clusters.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"node_readiness_config": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							AtLeastOneOf:  addonsConfigKeys,
+							MaxItems:      1,
+							Description:   `The status of the Node Readiness Controller addon.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
@@ -6127,6 +6144,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
+	if v, ok := config["node_readiness_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.NodeReadinessConfig = &container.NodeReadinessConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 	if v, ok := config["agent_sandbox_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.AgentSandboxConfig = &container.AgentSandboxConfig{
@@ -7914,6 +7939,14 @@ func flattenClusterAddonsConfig(c *container.AddonsConfig) []map[string]interfac
 		result["slurm_operator_config"] = []map[string]interface{}{
 			{
 				"enabled": c.SlurmOperatorConfig.Enabled,
+			},
+		}
+	}
+
+	if c.NodeReadinessConfig != nil {
+		result["node_readiness_config"] = []map[string]interface{}{
+			{
+				"enabled": c.NodeReadinessConfig.Enabled,
 			},
 		}
 	}

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_meta.yaml.tmpl
@@ -45,6 +45,7 @@ fields:
   - api_field: 'addonsConfig.rayOperatorConfig.rayClusterLoggingConfig.enabled'
   - api_field: 'addonsConfig.rayOperatorConfig.rayClusterMonitoringConfig.enabled'
   - api_field: 'addonsConfig.slurmOperatorConfig.enabled'
+  - api_field: 'addonsConfig.nodeReadinessConfig.enabled'
   - api_field: 'addonsConfig.statefulHaConfig.enabled'
   - api_field: 'addonsConfig.sliceControllerConfig.enabled'
   - api_field: 'anonymousAuthenticationConfig.mode'

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_migratev1.go.tmpl
@@ -248,6 +248,22 @@ func resourceContainerClusterResourceV1() *schema.Resource {
 								},
 							},
 						},
+						"node_readiness_config": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							Computed:      true,
+							AtLeastOneOf:  addonsConfigKeys,
+							MaxItems:      1,
+							Description:   `The status of the Node Readiness Controller addon.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
 						{{- if ne $.TargetVersionName "ga" }}
 						"istio_config": {
 							Type:         schema.TypeList,

--- a/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/container/resource_container_cluster_test.go.tmpl
@@ -19374,3 +19374,74 @@ resource "google_container_node_pool" "extra" {
 }
 `, suffix, suffix, clusterName, skipRefresh, poolName)
 }
+
+func TestAccContainerCluster_withNodeReadinessConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-nrc-%s", acctest.RandString(t, 10))
+	networkName := tpgcompute.BootstrapSharedTestNetwork(t, "gke-cluster")
+	subnetworkName := tpgcompute.BootstrapSubnet(t, "gke-cluster", networkName)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_switchNodeReadinessConfig(clusterName, networkName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_nrc_config", "addons_config.0.node_readiness_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_nrc_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_switchNodeReadinessConfig(clusterName, networkName, subnetworkName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_nrc_config", "addons_config.0.node_readiness_config.0.enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_nrc_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccContainerCluster_switchNodeReadinessConfig(clusterName, networkName, subnetworkName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_nrc_config", "addons_config.0.node_readiness_config.0.enabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_container_cluster.with_nrc_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+		},
+	})
+}
+
+func testAccContainerCluster_switchNodeReadinessConfig(clusterName, networkName, subnetworkName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_nrc_config" {
+  name                = "%s"
+  location            = "us-central1-a"
+  initial_node_count  = 1
+  network             = "%s"
+  subnetwork          = "%s"
+  deletion_protection = false
+
+  addons_config {
+    node_readiness_config {
+      enabled = %t
+    }
+  }
+}
+`, clusterName, networkName, subnetworkName, enabled)
+}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -574,6 +574,8 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
     Defaults to disabled for Standard clusters; set `enabled = true` to enable.
     It can not be enabled for Autopilot clusters.
 
+* `node_readiness_config` - (Optional) The status of the Node Readiness Controller addon.
+
 This example `addons_config` disables two addons:
 
 ```hcl

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -574,7 +574,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
     Defaults to disabled for Standard clusters; set `enabled = true` to enable.
     It can not be enabled for Autopilot clusters.
 
-* `node_readiness_config` - (Optional) The status of the Node Readiness Controller addon.
+* `node_readiness_config` - (Optional) The status of the Node Readiness Controller addon. It is disabled by default. Set `enabled = true` to enable.
   Structure is [documented below](#nested_node_readiness_config).
 
 This example `addons_config` disables two addons:

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -575,6 +575,7 @@ Fleet configuration for the cluster. Structure is [documented below](#nested_fle
     It can not be enabled for Autopilot clusters.
 
 * `node_readiness_config` - (Optional) The status of the Node Readiness Controller addon.
+  Structure is [documented below](#nested_node_readiness_config).
 
 This example `addons_config` disables two addons:
 
@@ -589,6 +590,10 @@ addons_config {
   }
 }
 ```
+<a name="nested_node_readiness_config"></a>The `node_readiness_config` block supports:
+
+* `enabled` - (Required) Enable the Node Readiness Controller addon for your cluster.
+
 <a name="nested_binary_authorization"></a>The `binary_authorization` block supports:
 
 * `enabled` - (DEPRECATED) Enable Binary Authorization for this cluster. Deprecated in favor of `evaluation_mode`.

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster.go
@@ -118,6 +118,7 @@ var (
 		"addons_config.0.slice_controller_config",
 		"addons_config.0.pod_snapshot_config",
 		"addons_config.0.slurm_operator_config",
+		"addons_config.0.node_readiness_config",
 	}
 
 	privateClusterConfigKeys = []string{
@@ -649,6 +650,22 @@ func ResourceContainerCluster() *schema.Resource {
 							AtLeastOneOf: addonsConfigKeys,
 							MaxItems:     1,
 							Description:  `The status of the Slurm Operator addon, which creates slurm related CRDs and KCP pods to manage them. Defaults to disabled for Standard clusters; set enabled = true to enable. It can not be enabled for Autopilot clusters.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"node_readiness_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Description:  `The status of the Node Readiness Controller addon.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_cai2hcl.go
@@ -662,6 +662,19 @@ func flattenClusterAddonsConfig(v interface{}, enableAutopilot bool) []map[strin
 		}
 	}
 
+	if val, ok := c["nodeReadinessConfig"].(map[string]interface{}); ok {
+		enabled := false
+		if v, ok := val["enabled"]; ok && v != nil {
+			enabled = v.(bool)
+		}
+
+		result["node_readiness_config"] = []map[string]interface{}{
+			{
+				"enabled": enabled,
+			},
+		}
+	}
+
 	return []map[string]interface{}{result}
 }
 

--- a/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
+++ b/mmv1/third_party/tgc_next/pkg/services/container/resource_container_cluster_tfplan2cai.go
@@ -506,6 +506,14 @@ func expandClusterAddonsConfig(configured interface{}) *container.AddonsConfig {
 		}
 	}
 
+	if v, ok := config["node_readiness_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.NodeReadinessConfig = &container.NodeReadinessConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 	return ac
 }
 


### PR DESCRIPTION
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

Add support for node-readiness-controller GKE cluster addon.

Tested:

```
ajaysundar@ajaysundar-cloudtop:~/workspace/magicmodules/magic-modules$ gcloud container clusters describe tf-test-nrc-rng2v7qlyz --location=us-central1-a | grep -A10 -B10 addonsConfig
addonsConfig:
  dnsCacheConfig:
    enabled: true
  gcePersistentDiskCsiDriverConfig:
    enabled: true
  kubernetesDashboard:
    disabled: true
  networkPolicyConfig:
    disabled: true
  nodeReadinessConfig:
    enabled: true
```

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:enhancement
container: added `addons_config.node_readiness_config` field to `google_container_cluster` resource
```
