### PR TITLE
Add allowedServicePatterns to AccessContextManager ServicePerimeter

### DIFF
--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -237,6 +237,45 @@ properties:
             is_set: true
             item_type:
               type: String
+          - name: allowedServicePatterns
+            type: Array
+            description: |
+              Specifies which Google services are allowed to be accessed from
+              VPC networks in the service perimeter.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: service
+                  type: String
+                  description: 'Supported service to allow.'
+                - name: pattern
+                  type: String
+                  description: 'URL pattern to allow.'
+                - name: modifiers
+                  type: Array
+                  description: 'Modifiers to apply to the requests that match the URL pattern.'
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: addRequestHeader
+                        type: NestedObject
+                        description: 'Adds additional HTTP request headers.'
+                        properties:
+                          - name: key
+                            type: String
+                            description: 'HTTP header key.'
+                          - name: value
+                            type: String
+                            description: 'HTTP header value.'
+          - name: servicePatternsEnforcementScopes
+            type: Array
+            description: |
+              Defines the enforcement scopes of service patterns.
+            item_type:
+              type: Enum
+              enum_values:
+                - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
+                - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
       - name: ingressPolicies
         type: Array
         description: |
@@ -606,6 +645,45 @@ properties:
             is_set: true
             item_type:
               type: String
+          - name: allowedServicePatterns
+            type: Array
+            description: |
+              Specifies which Google services are allowed to be accessed from
+              VPC networks in the service perimeter.
+            item_type:
+              type: NestedObject
+              properties:
+                - name: service
+                  type: String
+                  description: 'Supported service to allow.'
+                - name: pattern
+                  type: String
+                  description: 'URL pattern to allow.'
+                - name: modifiers
+                  type: Array
+                  description: 'Modifiers to apply to the requests that match the URL pattern.'
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: addRequestHeader
+                        type: NestedObject
+                        description: 'Adds additional HTTP request headers.'
+                        properties:
+                          - name: key
+                            type: String
+                            description: 'HTTP header key.'
+                          - name: value
+                            type: String
+                            description: 'HTTP header value.'
+          - name: servicePatternsEnforcementScopes
+            type: Array
+            description: |
+              Defines the enforcement scopes of service patterns.
+            item_type:
+              type: Enum
+              enum_values:
+                - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
+                - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
       - name: ingressPolicies
         type: Array
         description: |

--- a/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeter.yaml
@@ -263,9 +263,11 @@ properties:
                         properties:
                           - name: key
                             type: String
+                            required: true
                             description: 'HTTP header key.'
                           - name: value
                             type: String
+                            required: true
                             description: 'HTTP header value.'
           - name: servicePatternsEnforcementScopes
             type: Array
@@ -274,7 +276,6 @@ properties:
             item_type:
               type: Enum
               enum_values:
-                - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
                 - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
       - name: ingressPolicies
         type: Array
@@ -671,9 +672,11 @@ properties:
                         properties:
                           - name: key
                             type: String
+                            required: true
                             description: 'HTTP header key.'
                           - name: value
                             type: String
+                            required: true
                             description: 'HTTP header value.'
           - name: servicePatternsEnforcementScopes
             type: Array
@@ -682,7 +685,6 @@ properties:
             item_type:
               type: Enum
               enum_values:
-                - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
                 - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
       - name: ingressPolicies
         type: Array

--- a/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
@@ -212,6 +212,45 @@ properties:
                   is_set: true
                   item_type:
                     type: String
+                - name: allowedServicePatterns
+                  type: Array
+                  description: |
+                    Specifies which Google services are allowed to be accessed from
+                    VPC networks in the service perimeter.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: service
+                        type: String
+                        description: 'Supported service to allow.'
+                      - name: pattern
+                        type: String
+                        description: 'URL pattern to allow.'
+                      - name: modifiers
+                        type: Array
+                        description: 'Modifiers to apply to the requests that match the URL pattern.'
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: addRequestHeader
+                              type: NestedObject
+                              description: 'Adds additional HTTP request headers.'
+                              properties:
+                                - name: key
+                                  type: String
+                                  description: 'HTTP header key.'
+                                - name: value
+                                  type: String
+                                  description: 'HTTP header value.'
+                - name: servicePatternsEnforcementScopes
+                  type: Array
+                  description: |
+                    Defines the enforcement scopes of service patterns.
+                  item_type:
+                    type: Enum
+                    enum_values:
+                      - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
+                      - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
             - name: ingressPolicies
               type: Array
               description: |
@@ -569,6 +608,45 @@ properties:
                   is_set: true
                   item_type:
                     type: String
+                - name: allowedServicePatterns
+                  type: Array
+                  description: |
+                    Specifies which Google services are allowed to be accessed from
+                    VPC networks in the service perimeter.
+                  item_type:
+                    type: NestedObject
+                    properties:
+                      - name: service
+                        type: String
+                        description: 'Supported service to allow.'
+                      - name: pattern
+                        type: String
+                        description: 'URL pattern to allow.'
+                      - name: modifiers
+                        type: Array
+                        description: 'Modifiers to apply to the requests that match the URL pattern.'
+                        item_type:
+                          type: NestedObject
+                          properties:
+                            - name: addRequestHeader
+                              type: NestedObject
+                              description: 'Adds additional HTTP request headers.'
+                              properties:
+                                - name: key
+                                  type: String
+                                  description: 'HTTP header key.'
+                                - name: value
+                                  type: String
+                                  description: 'HTTP header value.'
+                - name: servicePatternsEnforcementScopes
+                  type: Array
+                  description: |
+                    Defines the enforcement scopes of service patterns.
+                  item_type:
+                    type: Enum
+                    enum_values:
+                      - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
+                      - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
             - name: ingressPolicies
               type: Array
               description: |

--- a/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
+++ b/mmv1/products/accesscontextmanager/ServicePerimeters.yaml
@@ -238,9 +238,11 @@ properties:
                               properties:
                                 - name: key
                                   type: String
+                                  required: true
                                   description: 'HTTP header key.'
                                 - name: value
                                   type: String
+                                  required: true
                                   description: 'HTTP header value.'
                 - name: servicePatternsEnforcementScopes
                   type: Array
@@ -249,7 +251,6 @@ properties:
                   item_type:
                     type: Enum
                     enum_values:
-                      - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
                       - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
             - name: ingressPolicies
               type: Array
@@ -634,9 +635,11 @@ properties:
                               properties:
                                 - name: key
                                   type: String
+                                  required: true
                                   description: 'HTTP header key.'
                                 - name: value
                                   type: String
+                                  required: true
                                   description: 'HTTP header value.'
                 - name: servicePatternsEnforcementScopes
                   type: Array
@@ -645,7 +648,6 @@ properties:
                   item_type:
                     type: Enum
                     enum_values:
-                      - 'SERVICE_PATTERNS_ENFORCEMENT_SCOPE_UNSPECIFIED'
                       - 'GOOGLE_APIS_VIA_PRIVATE_PATH'
             - name: ingressPolicies
               type: Array

--- a/mmv1/products/accesscontextmanager/product.yaml
+++ b/mmv1/products/accesscontextmanager/product.yaml
@@ -24,4 +24,4 @@ scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:
   - name: ga
-    base_url: https://accesscontextmanager.googleapis.com/v1alpha/
+    base_url: https://accesscontextmanager.googleapis.com/v1/

--- a/mmv1/products/accesscontextmanager/product.yaml
+++ b/mmv1/products/accesscontextmanager/product.yaml
@@ -24,4 +24,4 @@ scopes:
   - https://www.googleapis.com/auth/cloud-platform
 versions:
   - name: ga
-    base_url: https://accesscontextmanager.googleapis.com/v1/
+    base_url: https://accesscontextmanager.googleapis.com/v1alpha/

--- a/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
+++ b/mmv1/templates/terraform/custom_flatten/accesscontextmanager_serviceperimeters_custom_flatten.go.tmpl
@@ -126,6 +126,10 @@ func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAcces
 		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesEnableRestriction(original["enableRestriction"], d, config)
 	transformed["allowed_services"] =
 		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServices(original["allowedServices"], d, config)
+	transformed["allowed_service_patterns"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatterns(original["allowedServicePatterns"], d, config)
+	transformed["service_patterns_enforcement_scopes"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesServicePatternsEnforcementScopes(original["servicePatternsEnforcementScopes"], d, config)
 	return []interface{}{transformed}
 }
 func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesEnableRestriction(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
@@ -520,6 +524,10 @@ func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessi
 		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesEnableRestriction(original["enableRestriction"], d, config)
 	transformed["allowed_services"] =
 		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServices(original["allowedServices"], d, config)
+	transformed["allowed_service_patterns"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatterns(original["allowedServicePatterns"], d, config)
+	transformed["service_patterns_enforcement_scopes"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesServicePatternsEnforcementScopes(original["servicePatternsEnforcementScopes"], d, config)
 	return []interface{}{transformed}
 }
 func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesEnableRestriction(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
@@ -926,5 +934,139 @@ func flattenAccessContextManagerServicePerimetersServicePerimetersSpecEgressPoli
 	return []interface{}{transformed}
 }
 func flattenAccessContextManagerServicePerimetersServicePerimetersSpecEgressPoliciesEgressFromSourcesPscEndpointForwardingRule(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatterns(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"service":   flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsService(original["service"], d, config),
+			"pattern":   flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsPattern(original["pattern"], d, config),
+			"modifiers": flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiers(original["modifiers"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsService(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsPattern(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiers(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"add_request_header": flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeader(original["addRequestHeader"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeader(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["key"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderKey(original["key"], d, config)
+	transformed["value"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderValue(original["value"], d, config)
+	return []interface{}{transformed}
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderValue(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersStatusVpcAccessibleServicesServicePatternsEnforcementScopes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatterns(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"service":   flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsService(original["service"], d, config),
+			"pattern":   flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsPattern(original["pattern"], d, config),
+			"modifiers": flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiers(original["modifiers"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsService(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsPattern(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiers(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			continue
+		}
+		transformed = append(transformed, map[string]interface{}{
+			"add_request_header": flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeader(original["addRequestHeader"], d, config),
+		})
+	}
+	return transformed
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeader(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["key"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderKey(original["key"], d, config)
+	transformed["value"] =
+		flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderValue(original["value"], d, config)
+	return []interface{}{transformed}
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderKey(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesAllowedServicePatternsModifiersAddRequestHeaderValue(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
+	return v
+}
+func flattenAccessContextManagerServicePerimetersServicePerimetersSpecVpcAccessibleServicesServicePatternsEnforcementScopes(v interface{}, d *schema.ResourceData, config *transport_tpg.Config) interface{} {
 	return v
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_access_policy_test.go.tmpl
@@ -26,6 +26,8 @@ func TestAccAccessContextManager(t *testing.T) {
 		"access_policy_iam_policy":			testAccAccessContextManagerAccessPolicyIamPolicy,
 		"service_perimeter":				testAccAccessContextManagerServicePerimeter_basicTest,
 		"service_perimeter_update":			testAccAccessContextManagerServicePerimeter_updateTest,
+		"service_perimeter_nongcp_patterns":		testAccAccessContextManagerServicePerimeter_nonGcpServicePatternsTest,
+		"service_perimeters_nongcp_patterns":		testAccAccessContextManagerServicePerimeters_nonGcpServicePatternsTest,
 		"service_perimeter_resource":			testAccAccessContextManagerServicePerimeterResource_basicTest,
 		"service_perimeter_dry_run_resource":		testAccAccessContextManagerServicePerimeterResource_basicTest,
 		"access_level":					testAccAccessContextManagerAccessLevel_basicTest,

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -521,6 +521,25 @@ func (tc *IdentityTypeDiffSuppressFuncDiffSuppressTestCase) Test(t *testing.T) {
 	}
 }
 
+func testAccAccessContextManagerServicePerimeter_nonGcpServicePatternsTest(t *testing.T) {
+	org := envvar.GetTestOrgFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t), // Use standard GA factories (maps to nightly in nightly build)
+		CheckDestroy:             testAccCheckAccessContextManagerServicePerimeterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerServicePerimeter_nonGcpServicePatterns(org, "policy", "level", "perimeter"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
 func testAccAccessContextManagerServicePerimeter_pscEndpointTest(t *testing.T) {
 	org := envvar.GetTestOrgFromEnv(t)
@@ -662,4 +681,121 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
   }
 }
 `, org, policyTitle, perimeterTitleName, perimeterTitleName)
+}
+
+func testAccAccessContextManagerServicePerimeter_nonGcpServicePatterns(org, policyTitle, levelTitleName, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+# Access Policy Title: %s
+
+data "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+}
+
+resource "google_access_context_manager_access_level" "test-access" {
+  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  title    = "%s"
+  basic {
+    conditions {
+      ip_subnetworks = ["1.2.3.4/32"]
+    }
+  }
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title    = "%s"
+  status {
+    access_levels = [google_access_context_manager_access_level.test-access.name]
+    
+    vpc_accessible_services {
+      enable_restriction = true
+      allowed_services   = ["RESTRICTED-SERVICES"]
+      
+      service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
+      allowed_service_patterns {
+        pattern = "maps.googleapis.com/*"
+        modifiers {
+          add_request_header {
+            key   = "X-GoogApps-Allowed-Domains"
+            value = "google.com"
+          }
+        }
+      }
+    }
+  }
+}
+`, policyTitle, org, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
+}
+
+// ----------------- Plural Test Case -----------------
+
+func testAccAccessContextManagerServicePerimeters_nonGcpServicePatternsTest(t *testing.T) {
+	org := envvar.GetTestOrgFromEnv(t)
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t), // Use standard GA factories (maps to nightly in nightly build)
+		CheckDestroy:             testAccCheckAccessContextManagerServicePerimeterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerServicePerimeters_nonGcpServicePatterns(org, "policy", "level", "perimeter"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeters.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccAccessContextManagerServicePerimeters_nonGcpServicePatterns(org, policyTitle, levelTitleName, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+# Access Policy Title: %s
+
+data "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+}
+
+resource "google_access_context_manager_access_level" "test-access" {
+  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  title    = "%s"
+  basic {
+    conditions {
+      ip_subnetworks = ["1.2.3.4/32"]
+    }
+  }
+}
+
+resource "google_access_context_manager_service_perimeters" "test-access" {
+  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
+
+  service_perimeters {
+    name           = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+    title          = "%s"
+    status {
+      access_levels = [google_access_context_manager_access_level.test-access.name]
+      
+      vpc_accessible_services {
+        enable_restriction = true
+        allowed_services   = ["RESTRICTED-SERVICES"]
+        
+        service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
+        allowed_service_patterns {
+          pattern = "maps.googleapis.com/*"
+          modifiers {
+            add_request_header {
+              key   = "X-GoogApps-Allowed-Domains"
+              value = "google.com"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`, policyTitle, org, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
 }

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -717,7 +717,9 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
       
       service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
       allowed_service_patterns {
-        service = "maps.googleapis.com"
+        service = "storage.googleapis.com"
+      }
+      allowed_service_patterns {
         pattern = "maps.googleapis.com/*"
         modifiers {
           add_request_header {
@@ -738,7 +740,9 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
       
       service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
       allowed_service_patterns {
-        service = "maps.googleapis.com"
+        service = "storage.googleapis.com"
+      }
+      allowed_service_patterns {
         pattern = "maps.googleapis.com/*"
         modifiers {
           add_request_header {
@@ -795,12 +799,12 @@ resource "google_access_context_manager_access_level" "test-access" {
 
 resource "google_access_context_manager_service_perimeters" "test-access" {
   parent   = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
-  
-  use_explicit_dry_run_spec = true
 
   service_perimeters {
     name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
     title          = "%s"
+    
+    use_explicit_dry_run_spec = true
 
     spec {
       access_levels = [google_access_context_manager_access_level.test-access.name]
@@ -811,7 +815,9 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
         
         service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
         allowed_service_patterns {
-          service = "maps.googleapis.com"
+          service = "storage.googleapis.com"
+        }
+        allowed_service_patterns {
           pattern = "maps.googleapis.com/*"
           modifiers {
             add_request_header {
@@ -832,7 +838,9 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
         
         service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
         allowed_service_patterns {
-          service = "maps.googleapis.com"
+          service = "storage.googleapis.com"
+        }
+        allowed_service_patterns {
           pattern = "maps.googleapis.com/*"
           modifiers {
             add_request_header {

--- a/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/accesscontextmanager/resource_access_context_manager_service_perimeter_test.go.tmpl
@@ -685,15 +685,14 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 
 func testAccAccessContextManagerServicePerimeter_nonGcpServicePatterns(org, policyTitle, levelTitleName, perimeterTitleName string) string {
 	return fmt.Sprintf(`
-# Access Policy Title: %s
-
-data "google_access_context_manager_access_policy" "test-access" {
+resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
+  title  = "%s"
 }
 
 resource "google_access_context_manager_access_level" "test-access" {
-  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
-  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  parent   = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
   title    = "%s"
   basic {
     conditions {
@@ -703,9 +702,33 @@ resource "google_access_context_manager_access_level" "test-access" {
 }
 
 resource "google_access_context_manager_service_perimeter" "test-access" {
-  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
-  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  parent   = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
   title    = "%s"
+
+  use_explicit_dry_run_spec = true
+
+  spec {
+    access_levels = [google_access_context_manager_access_level.test-access.name]
+    
+    vpc_accessible_services {
+      enable_restriction = true
+      allowed_services   = ["RESTRICTED-SERVICES"]
+      
+      service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
+      allowed_service_patterns {
+        service = "maps.googleapis.com"
+        pattern = "maps.googleapis.com/*"
+        modifiers {
+          add_request_header {
+            key   = "X-GoogApps-Allowed-Domains"
+            value = "google.com"
+          }
+        }
+      }
+    }
+  }
+
   status {
     access_levels = [google_access_context_manager_access_level.test-access.name]
     
@@ -715,6 +738,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
       
       service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
       allowed_service_patterns {
+        service = "maps.googleapis.com"
         pattern = "maps.googleapis.com/*"
         modifiers {
           add_request_header {
@@ -726,7 +750,7 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
     }
   }
 }
-`, policyTitle, org, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
 }
 
 // ----------------- Plural Test Case -----------------
@@ -753,15 +777,14 @@ func testAccAccessContextManagerServicePerimeters_nonGcpServicePatternsTest(t *t
 
 func testAccAccessContextManagerServicePerimeters_nonGcpServicePatterns(org, policyTitle, levelTitleName, perimeterTitleName string) string {
 	return fmt.Sprintf(`
-# Access Policy Title: %s
-
-data "google_access_context_manager_access_policy" "test-access" {
+resource "google_access_context_manager_access_policy" "test-access" {
   parent = "organizations/%s"
+  title  = "%s"
 }
 
 resource "google_access_context_manager_access_level" "test-access" {
-  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
-  name     = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  parent   = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name     = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
   title    = "%s"
   basic {
     conditions {
@@ -771,11 +794,35 @@ resource "google_access_context_manager_access_level" "test-access" {
 }
 
 resource "google_access_context_manager_service_perimeters" "test-access" {
-  parent   = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}"
+  parent   = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  
+  use_explicit_dry_run_spec = true
 
   service_perimeters {
-    name           = "accessPolicies/${data.google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+    name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
     title          = "%s"
+
+    spec {
+      access_levels = [google_access_context_manager_access_level.test-access.name]
+      
+      vpc_accessible_services {
+        enable_restriction = true
+        allowed_services   = ["RESTRICTED-SERVICES"]
+        
+        service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
+        allowed_service_patterns {
+          service = "maps.googleapis.com"
+          pattern = "maps.googleapis.com/*"
+          modifiers {
+            add_request_header {
+              key   = "X-GoogApps-Allowed-Domains"
+              value = "google.com"
+            }
+          }
+        }
+      }
+    }
+
     status {
       access_levels = [google_access_context_manager_access_level.test-access.name]
       
@@ -785,6 +832,7 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
         
         service_patterns_enforcement_scopes = ["GOOGLE_APIS_VIA_PRIVATE_PATH"]
         allowed_service_patterns {
+          service = "maps.googleapis.com"
           pattern = "maps.googleapis.com/*"
           modifiers {
             add_request_header {
@@ -797,5 +845,5 @@ resource "google_access_context_manager_service_perimeters" "test-access" {
     }
   }
 }
-`, policyTitle, org, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
 }


### PR DESCRIPTION

This PR adds support for service patterns in Access Context Manager service perimeters for the GA (`v1`) API.
It introduces the following fields to the `google_access_context_manager_service_perimeter` resource (both in `spec` and `status` blocks):
*   `allowed_service_patterns`: Allows specifying service patterns (e.g., `storage.googleapis.com` or `maps.googleapis.com/*` with modifiers).
*   `service_patterns_enforcement_scopes`: Configures the enforcement scope for these patterns (e.g., `GOOGLE_APIS_VIA_PRIVATE_PATH`).

These fields enable configuring VPC Service Controls for non-GCP APIs.

```release-note:enhancement
accesscontextmanager: added `allowed_service_patterns` and `service_patterns_enforcement_scopes` fields to `google_access_context_manager_service_perimeter` to support VPC Service Controls for non-GCP APIs.
``` 