### PR TITLE
Add cpu_utilization and concurrency_utilization to Cloud Run v2 service revision scaling (beta)

### DIFF
--- a/mmv1/products/cloudrunv2/Service.yaml
+++ b/mmv1/products/cloudrunv2/Service.yaml
@@ -439,6 +439,22 @@ properties:
             description: |-
               Maximum number of serving instances that this resource should have. Must not be less than minimum instance count. If absent, Cloud Run will calculate
               a default value based on the project's available container instances quota in the region and specified instance size.
+          - name: 'cpuUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for CPU utilization before scaling begins. Accepted values are between `0.1` and `0.95` (inclusive) or `0.0` to disable
+              CPU utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
+              For more information, visit https://cloud.google.com/run/docs/configuring/scaling-controls.
+            default_from_api: true
+          - name: 'concurrencyUtilization'
+            type: Double
+            min_version: 'beta'
+            description: |-
+              Determines a threshold for concurrency utilization before scaling begins. Accepted values are between `0.1` and `0.95` (inclusive) or `0.0` to disable
+              concurrency utilization as threshold for scaling. CPU and concurrency scaling cannot both be disabled.
+              For more information, visit https://cloud.google.com/run/docs/configuring/scaling-controls.
+            default_from_api: true
       - name: 'vpcAccess'
         type: NestedObject
         description: |-

--- a/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/cloudrunv2/resource_cloud_run_v2_service_test.go.tmpl
@@ -1797,6 +1797,86 @@ resource "google_cloud_run_v2_service" "default" {
 `, context)
 }
 
+{{ if ne $.TargetVersionName `ga` -}}
+func TestAccCloudRunV2Service_cloudrunv2ServiceWithScalingUtilizationTargets(t *testing.T) {
+  t.Parallel()
+  context := map[string]interface{} {
+    "random_suffix" : acctest.RandString(t, 10),
+  }
+  acctest.VcrTest(t, resource.TestCase {
+    PreCheck: func() { acctest.AccTestPreCheck(t)},
+    ProtoV5ProviderFactories: acctest.ProtoV5ProviderBetaFactories(t),
+    CheckDestroy: testAccCheckCloudRunV2ServiceDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceWithScalingUtilizationTargets(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+      {
+        Config: testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithScalingUtilizationTargets(context),
+      },
+      {
+        ResourceName: "google_cloud_run_v2_service.default",
+        ImportState: true,
+        ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"name", "location", "annotations", "labels", "terraform_labels", "launch_stage", "deletion_protection"},
+      },
+    },
+  })
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceWithScalingUtilizationTargets(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider = google-beta
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+  template {
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 5
+      cpu_utilization = 0.5
+      concurrency_utilization = 0.5
+    }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+`, context)
+}
+
+func testAccCloudRunV2Service_cloudrunv2ServiceUpdateWithScalingUtilizationTargets(context map[string]interface{}) string {
+  return acctest.Nprintf(`
+resource "google_cloud_run_v2_service" "default" {
+  provider = google-beta
+  name     = "tf-test-cloudrun-service%{random_suffix}"
+  location = "us-central1"
+  deletion_protection = false
+  ingress = "INGRESS_TRAFFIC_ALL"
+  template {
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 5
+      cpu_utilization = 0.8
+      concurrency_utilization = 0.7
+    }
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello"
+    }
+  }
+}
+`, context)
+}
+{{- end }}
+
 func TestAccCloudRunV2Service_cloudrunv2ServiceWithReadinessProbe(t *testing.T) {
   t.Parallel()
   context := map[string]interface{} {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/28324

Cloud Run added [custom scaling controls](https://docs.cloud.google.com/run/docs/configuring/scaling-controls) in Preview on April 16, 2026 ([release note](https://docs.cloud.google.com/run/docs/release-notes)). The Cloud Run Admin API v2 exposes them as `template.scaling.cpuUtilization` and `template.scaling.concurrencyUtilization` (`GoogleCloudRunV2RevisionScaling`, per the [v2 discovery document](https://run.googleapis.com/$discovery/rest?version=v2)), but the provider's revision `scaling` block only supports `min_instance_count`/`max_instance_count`, and the v2 API rejects the v1-style `run.googleapis.com/scaling-*` annotations — so these targets currently cannot be managed with Terraform at all.

This PR adds both fields to `google_cloud_run_v2_service`:

* `template.scaling.cpu_utilization` (`Double`, beta-only)
* `template.scaling.concurrency_utilization` (`Double`, beta-only)

Design notes for review:

* **`min_version: 'beta'`** — the underlying feature is in Preview (configured via `gcloud beta run services update --scaling-cpu-target/--scaling-concurrency-target`).
* **No `send_empty_value`** — the API uses `0.0` to disable a scaling driver and rejects requests where both drivers are disabled. Sending zero values for unset fields would therefore break every existing configuration that omits them. Consequence: explicitly setting `0.0` in config to disable a driver is not expressible with this change; happy to add custom expand logic if maintainers prefer supporting that case.
* **`default_from_api: true`** — the server controls the effective default (0.6) and the fields are part of an opt-in surface; this avoids permadiffs when unset.
* Fields are scoped to `google_cloud_run_v2_service` only; the gcloud/docs surface for this Preview is services-only (worker pools are not mentioned).
* Added a beta acceptance test (`TestAccCloudRunV2Service_cloudrunv2ServiceWithScalingUtilizationTargets`) covering create (0.5/0.5), update (0.8/0.7), and import, modeled on the existing manual-scaling test in the same file.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrunv2: added `template.scaling.cpu_utilization` and `template.scaling.concurrency_utilization` fields to `google_cloud_run_v2_service` resource (beta)
```
