### PR TITLE
compute: add request_headers and response_headers to log_config on backend service

### DIFF
--- a/mmv1/products/compute/BackendService.yaml
+++ b/mmv1/products/compute/BackendService.yaml
@@ -1652,6 +1652,32 @@ properties:
           For example: orca_load_report, tls.protocol
         item_type:
           type: String
+      - name: 'requestHeaders'
+        api_name: 'loggingHttpRequestHeaders'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of request headers to be logged.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header name to match on for logging.
+              required: true
+      - name: 'responseHeaders'
+        api_name: 'loggingHttpResponseHeaders'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of response headers to be logged.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header name to match on for logging.
+              required: true
   - name: 'serviceLbPolicy'
     type: String
     description: |

--- a/mmv1/products/compute/RegionBackendService.yaml
+++ b/mmv1/products/compute/RegionBackendService.yaml
@@ -1564,6 +1564,32 @@ properties:
         item_type:
           type: String
         default_from_api: true
+      - name: 'requestHeaders'
+        api_name: 'loggingHttpRequestHeaders'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of request headers to be logged.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header name to match on for logging.
+              required: true
+      - name: 'responseHeaders'
+        api_name: 'loggingHttpResponseHeaders'
+        type: Array
+        description: |
+          This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of response headers to be logged.
+        item_type:
+          type: NestedObject
+          properties:
+            - name: 'headerName'
+              type: String
+              description: |
+                The header name to match on for logging.
+              required: true
   - name: 'network'
     type: ResourceRef
     description: |

--- a/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_backend_service_test.go.tmpl
@@ -861,6 +861,37 @@ func TestAccComputeBackendService_withLogConfigMode(t *testing.T) {
 	})
 }
 
+func TestAccComputeBackendService_withLogConfigRequestResponseHeaders(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-lc-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-lc-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, "X-Request-Id", "X-Response-Id"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, "X-Request-Id-Updated", "X-Response-Id-Updated"),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeBackendService_trafficDirectorUpdateBasic(t *testing.T) {
 	t.Parallel()
 
@@ -2522,6 +2553,38 @@ resource "google_compute_health_check" "zero" {
   }
 }
 `, serviceName, enabled, mode, checkName)
+}
+
+func testAccComputeBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, reqHeader, respHeader string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name                  = "%s"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  health_checks         = [google_compute_health_check.zero.self_link]
+
+  log_config {
+    enable      = true
+    sample_rate = 0.5
+    request_headers {
+      header_name = "%s"
+    }
+    response_headers {
+      header_name = "%s"
+    }
+  }
+}
+
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, reqHeader, respHeader, checkName)
 }
 
 func testAccComputeBackendService_withCompressionMode(serviceName, checkName, compressionMode string) string {

--- a/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
+++ b/mmv1/third_party/terraform/services/compute/resource_compute_region_backend_service_test.go.tmpl
@@ -578,6 +578,37 @@ func TestAccComputeRegionBackendService_withLogConfig(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionBackendService_withLogConfigRequestResponseHeaders(t *testing.T) {
+	t.Parallel()
+
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(t, 10))
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, "X-Request-Id", "X-Response-Id"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRegionBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, "X-Request-Id-Updated", "X-Response-Id-Updated"),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeRegionBackendService_zonalILB(t *testing.T) {
 	t.Parallel()
 
@@ -2228,6 +2259,41 @@ resource "google_compute_region_health_check" "health_check" {
   }
 }
 `, serviceName, checkName)
+}
+
+func testAccComputeRegionBackendService_withLogConfigRequestResponseHeaders(serviceName, checkName, reqHeader, respHeader string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  region                = "us-central1"
+  health_checks         = [google_compute_region_health_check.health_check.self_link]
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+  
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+    request_headers {
+      header_name = "%s"
+    }
+    response_headers {
+      header_name = "%s"
+    }
+  }
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  name               = "%s"
+  region             = "us-central1"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, reqHeader, respHeader, checkName)
 }
 
 func testAccComputeRegionBackendService_withTags(serviceName, checkName string, tagKey string, tagValue string) string {


### PR DESCRIPTION
Adds `request_headers` and `response_headers` (containing `header_name`) to `log_config` on `google_compute_backend_service` and `google_compute_region_backend_service` resources to support HTTP request/response header logging for Application Load Balancers.

### REST API Updates
**REST Resource:** [backendService](https://cloud.google.com/compute/docs/reference/rest/v1/backendServices)

| Field | Type | Description |
| :--- | :--- | :--- |
| `logConfig.requestHeaders[]` | `Object` | This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of request headers to be logged. |
| `logConfig.requestHeaders[].headerName` | `String` | The header name to match on for logging. |
| `logConfig.responseHeaders[]` | `Object` | This field can only be specified if logging is enabled for this backend service and if the BackendService protocol is one of HTTP, HTTPS, HTTP2 and GRPC. Contains a list of response headers to be logged. |
| `logConfig.responseHeaders[].headerName` | `String` | The header name to match on for logging. |

```release-note:enhancement
compute: added `request_headers` and `response_headers` fields to `log_config` on `google_compute_backend_service` and `google_compute_region_backend_service` resources
```
