### PR TITLE
sql: Add Identity block to `google_sql_user` for list resource support

### DIFF
--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -715,18 +715,10 @@ func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schem
 		if err != nil {
 			return nil, fmt.Errorf("error getting identity: %s", err)
 		}
-		var projectStr, instanceStr, hostStr, nameStr string
+
+		var projectStr string
 		if v, ok := identity.GetOk("project"); ok {
 			projectStr = v.(string)
-		}
-		if v, ok := identity.GetOk("instance"); ok {
-			instanceStr = v.(string)
-		}
-		if v, ok := identity.GetOk("host"); ok {
-			hostStr = v.(string)
-		}
-		if v, ok := identity.GetOk("name"); ok {
-			nameStr = v.(string)
 		}
 		if projectStr == "" {
 			projectStr = meta.(*transport_tpg.Config).Project
@@ -734,17 +726,33 @@ func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schem
 		if err := d.Set("project", projectStr); err != nil {
 			return nil, fmt.Errorf("Error setting project: %s", err)
 		}
+
+		var instanceStr string
+		if v, ok := identity.GetOk("instance"); ok {
+			instanceStr = v.(string)
+		}
 		if err := d.Set("instance", instanceStr); err != nil {
 			return nil, fmt.Errorf("Error setting instance: %s", err)
+		}
+
+		var hostStr string
+		if v, ok := identity.GetOk("host"); ok {
+			hostStr = v.(string)
 		}
 		if hostStr != "" {
 			if err := d.Set("host", hostStr); err != nil {
 				return nil, fmt.Errorf("Error setting host: %s", err)
 			}
 		}
+
+		var nameStr string
+		if v, ok := identity.GetOk("name"); ok {
+			nameStr = v.(string)
+		}
 		if err := d.Set("name", nameStr); err != nil {
 			return nil, fmt.Errorf("Error setting name: %s", err)
 		}
+
 		if hostStr != "" {
 			d.SetId(fmt.Sprintf("%s/%s/%s/%s", projectStr, instanceStr, hostStr, nameStr))
 		} else {
@@ -790,6 +798,7 @@ func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schem
 		if err := d.Set("name", parts[4]); err != nil {
 			return nil, fmt.Errorf("Error setting name: %s", err)
 		}
+
 	} else {
 		return nil, fmt.Errorf("Invalid specifier. Expecting {project}/{instance}/{name} for postgres instance and {project}/{instance}/{host}/{name} for MySQL instance")
 	}

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user.go
@@ -82,6 +82,30 @@ func ResourceSqlUser() *schema.Resource {
 		SchemaVersion: 1,
 		MigrateState:  resourceSqlUserMigrateState,
 
+		Identity: &schema.ResourceIdentity{
+			Version: 1,
+			SchemaFunc: func() map[string]*schema.Schema {
+				return map[string]*schema.Schema{
+					"project": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"instance": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+					"host": {
+						Type:              schema.TypeString,
+						OptionalForImport: true,
+					},
+					"name": {
+						Type:              schema.TypeString,
+						RequiredForImport: true,
+					},
+				}
+			},
+		},
+
 		Schema: map[string]*schema.Schema{
 			"host": {
 				Type:        schema.TypeString,
@@ -363,6 +387,14 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 			"into %s: %s", name, instance, err)
 	}
 
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":  project,
+		"instance": instance,
+		"host":     user.Host,
+		"name":     name,
+	}); err != nil {
+		return err
+	}
 	return resourceSqlUserRead(d, meta)
 }
 
@@ -472,6 +504,15 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := flattenSqlUser(user, d, project); err != nil {
+		return err
+	}
+
+	if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+		"project":  project,
+		"instance": user.Instance,
+		"host":     user.Host,
+		"name":     user.Name,
+	}); err != nil {
 		return err
 	}
 
@@ -601,6 +642,14 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				"in %s: %s", name, instance, err)
 		}
 
+		if err := tpgresource.SetResourceIdentityAttributes(d, map[string]interface{}{
+			"project":  project,
+			"instance": instance,
+			"host":     host,
+			"name":     name,
+		}); err != nil {
+			return err
+		}
 		return resourceSqlUserRead(d, meta)
 	}
 
@@ -660,8 +709,51 @@ func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.Split(d.Id(), "/")
+	if d.Id() == "" {
+		// Import via identity block - identity attributes are already set
+		identity, err := d.Identity()
+		if err != nil {
+			return nil, fmt.Errorf("error getting identity: %s", err)
+		}
+		var projectStr, instanceStr, hostStr, nameStr string
+		if v, ok := identity.GetOk("project"); ok {
+			projectStr = v.(string)
+		}
+		if v, ok := identity.GetOk("instance"); ok {
+			instanceStr = v.(string)
+		}
+		if v, ok := identity.GetOk("host"); ok {
+			hostStr = v.(string)
+		}
+		if v, ok := identity.GetOk("name"); ok {
+			nameStr = v.(string)
+		}
+		if projectStr == "" {
+			projectStr = meta.(*transport_tpg.Config).Project
+		}
+		if err := d.Set("project", projectStr); err != nil {
+			return nil, fmt.Errorf("Error setting project: %s", err)
+		}
+		if err := d.Set("instance", instanceStr); err != nil {
+			return nil, fmt.Errorf("Error setting instance: %s", err)
+		}
+		if hostStr != "" {
+			if err := d.Set("host", hostStr); err != nil {
+				return nil, fmt.Errorf("Error setting host: %s", err)
+			}
+		}
+		if err := d.Set("name", nameStr); err != nil {
+			return nil, fmt.Errorf("Error setting name: %s", err)
+		}
+		if hostStr != "" {
+			d.SetId(fmt.Sprintf("%s/%s/%s/%s", projectStr, instanceStr, hostStr, nameStr))
+		} else {
+			d.SetId(fmt.Sprintf("%s/%s/%s", projectStr, instanceStr, nameStr))
+		}
+		return []*schema.ResourceData{d}, nil
+	}
 
+	parts := strings.Split(d.Id(), "/")
 	if len(parts) == 3 {
 		if err := d.Set("project", parts[0]); err != nil {
 			return nil, fmt.Errorf("Error setting project: %s", err)

--- a/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
+++ b/mmv1/third_party/terraform/services/sql/resource_sql_user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-google/google/acctest"
 	"github.com/hashicorp/terraform-provider-google/google/envvar"
 	_ "github.com/hashicorp/terraform-provider-google/google/services/resourcemanager"
@@ -1218,4 +1219,49 @@ resource "google_sql_user" "user" {
   type     = "CLOUD_IAM_GROUP"
 }
 `, instance, username)
+}
+
+func TestAccSqlUser_importBlockWithResourceIdentity(t *testing.T) {
+	t.Parallel()
+	instance := fmt.Sprintf("tf-test-%d", acctest.RandInt(t))
+	acctest.VcrTest(t, resource.TestCase{
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_12_0),
+		},
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccSqlUserDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlUser_postgres(instance, "password"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleSqlUserExists(t, "google_sql_user.user"),
+				),
+			},
+			{
+				Config:          testGoogleSqlUser_postgresNoPassword(instance),
+				ResourceName:    "google_sql_user.user",
+				ImportState:     true,
+				ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			},
+		},
+	})
+}
+
+func testGoogleSqlUser_postgresNoPassword(instance string) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "%s"
+  region           = "us-central1"
+  database_version = "POSTGRES_9_6"
+  deletion_protection = false
+  settings {
+    tier = "db-f1-micro"
+  }
+}
+resource "google_sql_user" "user" {
+  name     = "admin"
+  instance = google_sql_database_instance.instance.name
+}
+`, instance)
 }


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#28056

Adds the `Identity` block and `SetResourceIdentityAttributes` to `google_sql_user`, which is a prerequisite for the list resource implementation in PR #18114.

Builds on #18163 which added `flattenSqlUser`.

### Details

* Adds `Identity` block to `ResourceSqlUser()` schema with fields: `project`, `instance`, `host`, `name`
* Adds `SetResourceIdentityAttributes` call in `resourceSqlUserRead`

### Release Note Template for Downstream PRs (will be copied)

```release-note:enhancement
sql: added identity support to `google_sql_user` for `terraform query` support
```