### PR TITLE
workbench: suppress server-injected new-proxy-agent-enabled metadata

### DIFF
--- a/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
+++ b/mmv1/templates/terraform/constants/workbench_instance.go.tmpl
@@ -82,6 +82,7 @@ var WorkbenchInstanceProvidedMetadata = []string{
     "enable-guest-attributes",
     "enable-oslogin",
     "proxy-registration-url",
+    "new-proxy-agent-enabled",
 }
 
 func WorkbenchInstanceMetadataDiffSuppress(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
GCP began injecting a server-side metadata key 'new-proxy-agent-enabled' onto Workbench instances, which is not user-settable. Because it was absent from WorkbenchInstanceProvidedMetadata (the allowlist of server-provided keys the diff-suppress ignores), every plan on a running instance showed a perpetual non-empty diff removing the key.

We can see failures occuring on teamcity nightlies due to this. This PR includes a suppress on the new metadata key

[TeamCity Test History](https://hashicorp.teamcity.com/test/8427824793565801075?currentProjectId=TerraformProviders_GoogleCloud_GOOGLE_BETA_NIGHTLYTESTS)
<!--
Complete the self-review checklist to help speed up the review process: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

If your PR is still work in progress, please create it in draft mode.

Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to.
For example: Fixes https://github.com/hashicorp/terraform-provider-google/issues/ISSUE_ID
-->

**Release Note Template for Downstream PRs (will be copied)**

See [Write release notes](https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/) for guidance.

```release-note:none

```
